### PR TITLE
Fix food/ingredient recommender error

### DIFF
--- a/src/components/IngredientRecommender.tsx
+++ b/src/components/IngredientRecommender.tsx
@@ -7,7 +7,6 @@ import { Flame, Droplets, Mountain, Wind, Info, Clock, Tag, Leaf, X, ChevronDown
 import { useChakraInfluencedFood } from '@/hooks/useChakraInfluencedFood';
 import { normalizeChakraKey } from '@/constants/chakraSymbols';
 import { herbsCollection, oilsCollection, vinegarsCollection, grainsCollection, spicesCollection } from '@/data/ingredients';
-import IngredientRecommender from './IngredientRecommender/index';
 
 // Define a styles object for animations and custom styles
 const customStyles = {
@@ -224,25 +223,47 @@ export default function IngredientRecommender() {
   }, [astroLoading, contextChakraEnergies, planetaryPositions, astroError, currentZodiac]);
   
   // Define herb names to improve herb detection
-  const herbNames = useMemo(() => Object.keys(herbsCollection), []);
+  const herbNames = useMemo(() => {
+    try {
+      const keys = Object.keys(herbsCollection || {});
+      return keys.filter(key => typeof key === 'string' && key.length > 0);
+    } catch (error) {
+      console.warn('Error loading herb names:', error);
+      return [];
+    }
+  }, []);
   
   // Define oil types for better oil detection
-  const oilTypes = useMemo(() => 
-    Object.keys(oilsCollection).concat([
-      'oil', 'olive oil', 'vegetable oil', 'sunflower oil', 'sesame oil', 'coconut oil',
-      'avocado oil', 'walnut oil', 'peanut oil', 'grapeseed oil', 'canola oil'
-    ]), 
-  []);
+  const oilTypes = useMemo(() => {
+    try {
+      const baseOils = Object.keys(oilsCollection || {}).filter(key => typeof key === 'string');
+      const additionalOils = [
+        'oil', 'olive oil', 'vegetable oil', 'sunflower oil', 'sesame oil', 'coconut oil',
+        'avocado oil', 'walnut oil', 'peanut oil', 'grapeseed oil', 'canola oil'
+      ];
+      return [...baseOils, ...additionalOils];
+    } catch (error) {
+      console.warn('Error loading oil types:', error);
+      return ['oil', 'olive oil', 'vegetable oil'];
+    }
+  }, []);
   
   // Define vinegar types for better vinegar detection
-  const vinegarTypes = useMemo(() => 
-    Object.keys(vinegarsCollection).concat([
-      'vinegar', 'balsamic vinegar', 'apple cider vinegar', 'rice vinegar', 'red wine vinegar',
-      'white wine vinegar', 'champagne vinegar', 'sherry vinegar', 'malt vinegar', 
-      'distilled vinegar', 'black vinegar', 'rice wine vinegar', 'white balsamic',
-      'balsamic glaze', 'raspberry vinegar', 'fig vinegar', 'coconut vinegar'
-    ]), 
-  []);
+  const vinegarTypes = useMemo(() => {
+    try {
+      const baseVinegars = Object.keys(vinegarsCollection || {}).filter(key => typeof key === 'string');
+      const additionalVinegars = [
+        'vinegar', 'balsamic vinegar', 'apple cider vinegar', 'rice vinegar', 'red wine vinegar',
+        'white wine vinegar', 'champagne vinegar', 'sherry vinegar', 'malt vinegar', 
+        'distilled vinegar', 'black vinegar', 'rice wine vinegar', 'white balsamic',
+        'balsamic glaze', 'raspberry vinegar', 'fig vinegar', 'coconut vinegar'
+      ];
+      return [...baseVinegars, ...additionalVinegars];
+    } catch (error) {
+      console.warn('Error loading vinegar types:', error);
+      return ['vinegar', 'balsamic vinegar', 'apple cider vinegar'];
+    }
+  }, []);
   
   // Helper function to check if an ingredient is an oil
   const isOil = (ingredient: IngredientRecommendation): boolean => {
@@ -250,7 +271,7 @@ export default function IngredientRecommender() {
     if (category === 'oil' || category === 'oils') return true;
     
     const name = ingredient.name.toLowerCase();
-    return oilTypes.some(oil => name.includes(oil.toLowerCase()));
+    return oilTypes.some(oil => typeof oil === 'string' && name.includes(oil.toLowerCase()));
   };
   
   // Helper function to check if an ingredient is a vinegar
@@ -259,7 +280,7 @@ export default function IngredientRecommender() {
     if (category === 'vinegar' || category === 'vinegars') return true;
     
     const name = ingredient.name.toLowerCase();
-    return vinegarTypes.some(vinegar => name.includes(vinegar.toLowerCase()));
+    return vinegarTypes.some(vinegar => typeof vinegar === 'string' && name.includes(vinegar.toLowerCase()));
   };
   
   // Helper function to get normalized category
@@ -407,9 +428,9 @@ export default function IngredientRecommender() {
     }
     
     // Check for known herb names
-    if (herbNames.some(herb => name.includes(herb.toLowerCase()))) {
-        return 'herbs';
-      }
+    if (herbNames.some(herb => typeof herb === 'string' && name.includes(herb.toLowerCase()))) {
+      return 'herbs';
+    }
       
     // Known spices list for more accurate categorization
     const knownSpices = [
@@ -608,7 +629,7 @@ export default function IngredientRecommender() {
           });
         }
         // Herbs
-        else if (ingredient.category === 'herb' || name.includes('herb') || herbNames.some(herb => name.includes(herb.toLowerCase()))) {
+        else if (ingredient.category === 'herb' || name.includes('herb') || herbNames.some(herb => typeof herb === 'string' && name.includes(herb.toLowerCase()))) {
           categories.herbs.push({
             ...ingredient,
             matchScore: ingredient.score || 0.5

--- a/src/components/IngredientRecommender/index.tsx
+++ b/src/components/IngredientRecommender/index.tsx
@@ -148,25 +148,47 @@ export default function IngredientRecommender() {
   }, [astroRecommendations, foodRecommendations]);
   
   // Define herb names to improve herb detection
-  const herbNames = useMemo(() => Object.keys(herbsCollection), []);
+  const herbNames = useMemo(() => {
+    try {
+      const keys = Object.keys(herbsCollection || {});
+      return keys.filter(key => typeof key === 'string' && key.length > 0);
+    } catch (error) {
+      console.warn('Error loading herb names:', error);
+      return [];
+    }
+  }, []);
   
   // Define oil types for better oil detection
-  const oilTypes = useMemo(() => 
-    Object.keys(oilsCollection).concat([
-      'oil', 'olive oil', 'vegetable oil', 'sunflower oil', 'sesame oil', 'coconut oil',
-      'avocado oil', 'walnut oil', 'peanut oil', 'grapeseed oil', 'canola oil'
-    ]), 
-  []);
+  const oilTypes = useMemo(() => {
+    try {
+      const baseOils = Object.keys(oilsCollection || {}).filter(key => typeof key === 'string');
+      const additionalOils = [
+        'oil', 'olive oil', 'vegetable oil', 'sunflower oil', 'sesame oil', 'coconut oil',
+        'avocado oil', 'walnut oil', 'peanut oil', 'grapeseed oil', 'canola oil'
+      ];
+      return [...baseOils, ...additionalOils];
+    } catch (error) {
+      console.warn('Error loading oil types:', error);
+      return ['oil', 'olive oil', 'vegetable oil'];
+    }
+  }, []);
   
   // Define vinegar types for better vinegar detection
-  const vinegarTypes = useMemo(() => 
-    Object.keys(vinegarsCollection).concat([
-      'vinegar', 'balsamic vinegar', 'apple cider vinegar', 'rice vinegar', 'red wine vinegar',
-      'white wine vinegar', 'champagne vinegar', 'sherry vinegar', 'malt vinegar', 
-      'distilled vinegar', 'black vinegar', 'rice wine vinegar', 'white balsamic',
-      'balsamic glaze', 'raspberry vinegar', 'fig vinegar', 'coconut vinegar'
-    ]), 
-  []);
+  const vinegarTypes = useMemo(() => {
+    try {
+      const baseVinegars = Object.keys(vinegarsCollection || {}).filter(key => typeof key === 'string');
+      const additionalVinegars = [
+        'vinegar', 'balsamic vinegar', 'apple cider vinegar', 'rice vinegar', 'red wine vinegar',
+        'white wine vinegar', 'champagne vinegar', 'sherry vinegar', 'malt vinegar', 
+        'distilled vinegar', 'black vinegar', 'rice wine vinegar', 'white balsamic',
+        'balsamic glaze', 'raspberry vinegar', 'fig vinegar', 'coconut vinegar'
+      ];
+      return [...baseVinegars, ...additionalVinegars];
+    } catch (error) {
+      console.warn('Error loading vinegar types:', error);
+      return ['vinegar', 'balsamic vinegar', 'apple cider vinegar'];
+    }
+  }, []);
   
   // Helper function to check if an ingredient is an oil
   const isOil = (ingredient: IngredientRecommendation): boolean => {
@@ -174,7 +196,7 @@ export default function IngredientRecommender() {
     if (category === 'oil' || category === 'oils') return true;
     
     const name = ingredient.name.toLowerCase();
-    return oilTypes.some(oil => name.includes(oil.toLowerCase()));
+    return oilTypes.some(oil => typeof oil === 'string' && name.includes(oil.toLowerCase()));
   };
   
   // Helper function to check if an ingredient is a vinegar
@@ -183,7 +205,7 @@ export default function IngredientRecommender() {
     if (category === 'vinegar' || category === 'vinegars') return true;
     
     const name = ingredient.name.toLowerCase();
-    return vinegarTypes.some(vinegar => name.includes(vinegar.toLowerCase()));
+    return vinegarTypes.some(vinegar => typeof vinegar === 'string' && name.includes(vinegar.toLowerCase()));
   };
   
   // Helper function to get normalized category
@@ -336,7 +358,7 @@ export default function IngredientRecommender() {
     }
     
     // Check for known herb names
-    if (herbNames.some(herb => name.includes(herb.toLowerCase()))) {
+    if (herbNames.some(herb => typeof herb === 'string' && name.includes(herb.toLowerCase()))) {
       return 'herbs';
     }
       
@@ -716,7 +738,7 @@ export default function IngredientRecommender() {
           });
         }
         // Herbs
-        else if (ingredient.category === 'herb' || name.includes('herb') || herbNames.some(herb => name.includes(herb.toLowerCase()))) {
+        else if (ingredient.category === 'herb' || name.includes('herb') || herbNames.some(herb => typeof herb === 'string' && name.includes(herb.toLowerCase()))) {
           categories.herbs.push({
             ...ingredient,
             matchScore: ingredient.score || 0.5


### PR DESCRIPTION
I fixed the "e.toLowerCase is not a function" error in the Food/ingredient recommender.

The root cause was that the `herbNames`, `oilTypes`, and `vinegarTypes` arrays, used for ingredient categorization, sometimes contained non-string values. When iterating over these arrays, the code attempted to call `.toLowerCase()` on these non-string elements, leading to the `TypeError`.

Here are the changes I implemented:

*   **Added robust type safety checks** before calling `.toLowerCase()` on elements within the `herbNames`, `oilTypes`, and `vinegarTypes` arrays.
    *   For example, in `src/components/IngredientRecommender.tsx` and `src/components/IngredientRecommender/index.tsx`, I changed:
        ```typescript
        herbNames.some(herb => name.includes(herb.toLowerCase()))
        ```
        to:
        ```typescript
        herbNames.some(herb => typeof herb === 'string' 