### PR TITLE
Add Cloudflare Workers compatibility for edge deployment

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -113,7 +113,10 @@ const nextConfig = {
       "date-fns",
       "lodash",
     ],
-    serverExternalPackages: ["astronomy-engine", "pg"],
+    // astronomy-engine is pure JS — must be bundled into the worker bundle
+    // so the edge /api/astrologize route can use it as a fallback.
+    // pg uses TCP sockets and is handled by nodejs_compat in the Worker.
+    serverExternalPackages: ["pg"],
   },
 
   webpack: (config, { isServer, nextRuntime }) => {

--- a/src/app/api/food-lab/upload/route.ts
+++ b/src/app/api/food-lab/upload/route.ts
@@ -54,7 +54,10 @@ export async function POST(request: NextRequest) {
   }
 
   const bytes = await file.arrayBuffer();
-  const base64 = Buffer.from(bytes).toString("base64");
+  // Use Web API for base64 encoding — Buffer is not available in Edge runtime
+  const uint8Array = new Uint8Array(bytes);
+  const binary = Array.from(uint8Array, (b) => String.fromCharCode(b)).join("");
+  const base64 = btoa(binary);
   const dataUrl = `data:${file.type};base64,${base64}`;
 
   return NextResponse.json({

--- a/src/lib/database/connection.ts
+++ b/src/lib/database/connection.ts
@@ -108,22 +108,27 @@ export function initializeDatabase(): Pool {
     });
   });
 
-  // Graceful shutdown handling
-  process.on("SIGINT", () => {
-    void (async () => {
-      void logger.info("Received SIGINT, closing database pool...");
-      await closeDatabase();
-      process.exit(0);
-    })();
-  });
+  // Graceful shutdown handling — guarded because Cloudflare Workers
+  // don't support process signal events (process.on throws there).
+  try {
+    process.on("SIGINT", () => {
+      void (async () => {
+        void logger.info("Received SIGINT, closing database pool...");
+        await closeDatabase();
+        process.exit(0);
+      })();
+    });
 
-  process.on("SIGTERM", () => {
-    void (async () => {
-      void logger.info("Received SIGTERM, closing database pool...");
-      await closeDatabase();
-      process.exit(0);
-    })();
-  });
+    process.on("SIGTERM", () => {
+      void (async () => {
+        void logger.info("Received SIGTERM, closing database pool...");
+        await closeDatabase();
+        process.exit(0);
+      })();
+    });
+  } catch {
+    // Cloudflare Workers / Edge environments don't support process signals
+  }
 
   void logger.info("Database connection pool initialized", {
     database: config.database,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,12 +1,23 @@
 {
   "name": "alchm-kitchen",
   "main": ".open-next/worker.js",
-  "compatibility_date": "2024-09-23",
+  // Update to 2025-01-01 for improved nodejs_compat TCP socket support
+  // (required for pg to open connections via cloudflare:sockets polyfill).
+  "compatibility_date": "2025-01-01",
   "compatibility_flags": [
     "nodejs_compat"
   ],
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"
+  },
+  // Enable built-in observability for tail workers / logpush
+  "observability": {
+    "enabled": true
   }
+  // To use Cloudflare Hyperdrive for efficient PostgreSQL connection pooling,
+  // create a Hyperdrive config in the dashboard and uncomment:
+  // "hyperdrive": [
+  //   { "binding": "HYPERDRIVE", "id": "<your-hyperdrive-config-id>" }
+  // ]
 }


### PR DESCRIPTION
## Summary
This PR adds support for deploying the application to Cloudflare Workers and edge environments by addressing runtime incompatibilities and updating the worker configuration.

## Key Changes

- **Database connection graceful shutdown**: Wrapped `process.on()` signal handlers in a try-catch block since Cloudflare Workers don't support process signal events. This allows the database initialization to succeed in edge environments while maintaining graceful shutdown in Node.js environments.

- **Worker configuration updates**: Updated `wrangler.jsonc` to use compatibility date `2025-01-01` for improved `nodejs_compat` TCP socket support (required for PostgreSQL connections via the cloudflare:sockets polyfill). Also enabled observability for tail workers and added documentation for optional Hyperdrive integration.

- **Build configuration**: Removed `astronomy-engine` from `serverExternalPackages` since it's pure JavaScript and needs to be bundled into the worker for the edge `/api/astrologize` route. Kept `pg` as external since it's handled by `nodejs_compat` in the Worker runtime.

- **Edge runtime compatibility**: Updated the file upload endpoint to use Web APIs (`btoa`) instead of Node.js `Buffer` for base64 encoding, ensuring compatibility with Edge runtime where Buffer is unavailable.

## Implementation Details

The changes maintain backward compatibility with Node.js deployments while enabling edge deployment scenarios. The graceful shutdown handling degrades gracefully in environments that don't support process signals, and the base64 encoding uses a standard Web API that works across all JavaScript runtimes.

https://claude.ai/code/session_01WqDqiwBWCDZoWpGmhfeowa