### PR TITLE
Expand social features: friendships, saved charts, dual-track companions

### DIFF
--- a/database/init/10-social-schema.sql
+++ b/database/init/10-social-schema.sql
@@ -1,0 +1,74 @@
+-- database/init/10-social-schema.sql
+-- Social Features: Friendships, Saved Charts, Cosmic Identities
+-- Migration for expanding user social data ecosystem
+
+-- ==========================================
+-- SAVED CHARTS (decoupled from user_profiles JSONB)
+-- ==========================================
+
+CREATE TABLE IF NOT EXISTS saved_charts (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  owner_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  label VARCHAR(255) NOT NULL,                     -- e.g. "Personal", "Career/Mundane"
+  chart_type VARCHAR(50) NOT NULL DEFAULT 'manual', -- 'primary' | 'cosmic_identity' | 'manual'
+  birth_data JSONB NOT NULL,                        -- BirthData object
+  natal_chart JSONB NOT NULL,                       -- NatalChart object
+  is_primary BOOLEAN NOT NULL DEFAULT false,        -- true for the user's main birth chart
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Enforce at most one primary chart per user
+CREATE UNIQUE INDEX IF NOT EXISTS idx_saved_charts_primary
+  ON saved_charts (owner_id) WHERE is_primary = true;
+
+CREATE INDEX IF NOT EXISTS idx_saved_charts_owner ON saved_charts (owner_id);
+CREATE INDEX IF NOT EXISTS idx_saved_charts_type ON saved_charts (chart_type);
+
+-- Trigger for updated_at
+CREATE TRIGGER update_saved_charts_updated_at
+  BEFORE UPDATE ON saved_charts
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ==========================================
+-- FRIENDSHIPS (many-to-many between registered users)
+-- ==========================================
+
+CREATE TYPE friendship_status AS ENUM ('pending', 'accepted', 'blocked');
+
+CREATE TABLE IF NOT EXISTS friendships (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  requester_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  addressee_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  status friendship_status NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+
+  -- Prevent duplicate friend requests in either direction
+  CONSTRAINT friendships_unique_pair UNIQUE (requester_id, addressee_id),
+  CONSTRAINT friendships_no_self CHECK (requester_id <> addressee_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_friendships_requester ON friendships (requester_id);
+CREATE INDEX IF NOT EXISTS idx_friendships_addressee ON friendships (addressee_id);
+CREATE INDEX IF NOT EXISTS idx_friendships_status ON friendships (status);
+
+-- Composite index for looking up accepted friends for a user
+CREATE INDEX IF NOT EXISTS idx_friendships_accepted_requester
+  ON friendships (requester_id) WHERE status = 'accepted';
+CREATE INDEX IF NOT EXISTS idx_friendships_accepted_addressee
+  ON friendships (addressee_id) WHERE status = 'accepted';
+
+-- Trigger for updated_at
+CREATE TRIGGER update_friendships_updated_at
+  BEFORE UPDATE ON friendships
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- ==========================================
+-- COMMENTS
+-- ==========================================
+
+COMMENT ON TABLE saved_charts IS 'Decoupled birth charts: primary, cosmic identities, and manual companion charts';
+COMMENT ON TABLE friendships IS 'Many-to-many friendship relationships between registered users';
+COMMENT ON COLUMN saved_charts.chart_type IS 'primary = user main chart, cosmic_identity = alternate persona, manual = companion without account';
+COMMENT ON COLUMN friendships.status IS 'pending = awaiting acceptance, accepted = mutual friends, blocked = rejected/blocked';

--- a/src/app/api/friends/accept/route.ts
+++ b/src/app/api/friends/accept/route.ts
@@ -1,0 +1,44 @@
+/**
+ * Accept Friend Request API Route
+ * POST /api/friends/accept - Accept a pending friend request
+ */
+
+import { NextResponse } from "next/server";
+import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { socialDatabase } from "@/services/socialDatabaseService";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(request: NextRequest) {
+  const userId = await getUserIdFromRequest(request);
+  if (!userId) {
+    return NextResponse.json({ success: false, message: "Authentication required" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { friendshipId } = body as { friendshipId?: string };
+
+  if (!friendshipId) {
+    return NextResponse.json(
+      { success: false, message: "friendshipId is required" },
+      { status: 400 },
+    );
+  }
+
+  const friendship = await socialDatabase.updateFriendshipStatus(
+    friendshipId,
+    "accepted",
+    userId,
+  );
+
+  if (!friendship) {
+    return NextResponse.json(
+      { success: false, message: "Could not accept request. You may not be the addressee, or it may already be processed." },
+      { status: 400 },
+    );
+  }
+
+  return NextResponse.json({ success: true, friendship });
+}

--- a/src/app/api/friends/reject/route.ts
+++ b/src/app/api/friends/reject/route.ts
@@ -1,0 +1,57 @@
+/**
+ * Reject / Remove Friend API Route
+ * POST /api/friends/reject - Reject a pending request or unfriend an accepted friend
+ * Body: { friendshipId, block?: boolean }
+ */
+
+import { NextResponse } from "next/server";
+import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { socialDatabase } from "@/services/socialDatabaseService";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(request: NextRequest) {
+  const userId = await getUserIdFromRequest(request);
+  if (!userId) {
+    return NextResponse.json({ success: false, message: "Authentication required" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { friendshipId, block } = body as { friendshipId?: string; block?: boolean };
+
+  if (!friendshipId) {
+    return NextResponse.json(
+      { success: false, message: "friendshipId is required" },
+      { status: 400 },
+    );
+  }
+
+  if (block) {
+    // Block instead of delete
+    const friendship = await socialDatabase.updateFriendshipStatus(
+      friendshipId,
+      "blocked",
+      userId,
+    );
+    if (!friendship) {
+      return NextResponse.json(
+        { success: false, message: "Could not block. You may not be a party to this friendship." },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json({ success: true, friendship });
+  }
+
+  // Delete the friendship (reject or unfriend)
+  const deleted = await socialDatabase.deleteFriendship(friendshipId, userId);
+  if (!deleted) {
+    return NextResponse.json(
+      { success: false, message: "Could not reject/remove. Friendship not found." },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/friends/request/route.ts
+++ b/src/app/api/friends/request/route.ts
@@ -1,0 +1,56 @@
+/**
+ * Friend Request API Route
+ * POST /api/friends/request - Send a friend request by email
+ */
+
+import { NextResponse } from "next/server";
+import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { userDatabase } from "@/services/userDatabaseService";
+import { socialDatabase } from "@/services/socialDatabaseService";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(request: NextRequest) {
+  const userId = await getUserIdFromRequest(request);
+  if (!userId) {
+    return NextResponse.json({ success: false, message: "Authentication required" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { email } = body as { email?: string };
+
+  if (!email || typeof email !== "string") {
+    return NextResponse.json(
+      { success: false, message: "email is required" },
+      { status: 400 },
+    );
+  }
+
+  // Look up addressee by email
+  const addressee = await userDatabase.getUserByEmail(email.trim().toLowerCase());
+  if (!addressee) {
+    return NextResponse.json(
+      { success: false, message: "No user found with that email" },
+      { status: 404 },
+    );
+  }
+
+  if (addressee.id === userId) {
+    return NextResponse.json(
+      { success: false, message: "You cannot send a friend request to yourself" },
+      { status: 400 },
+    );
+  }
+
+  const friendship = await socialDatabase.createFriendRequest(userId, addressee.id);
+  if (!friendship) {
+    return NextResponse.json(
+      { success: false, message: "Could not create friend request. It may already exist or be blocked." },
+      { status: 409 },
+    );
+  }
+
+  return NextResponse.json({ success: true, friendship }, { status: 201 });
+}

--- a/src/app/api/friends/route.ts
+++ b/src/app/api/friends/route.ts
@@ -1,0 +1,42 @@
+/**
+ * Friends API Route
+ * GET /api/friends - List all friendships (pending, accepted, blocked) for the authenticated user
+ */
+
+import { NextResponse } from "next/server";
+import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { socialDatabase } from "@/services/socialDatabaseService";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  const userId = await getUserIdFromRequest(request);
+  if (!userId) {
+    return NextResponse.json({ success: false, message: "Authentication required" }, { status: 401 });
+  }
+
+  const friendships = await socialDatabase.getFriendshipsForUser(userId);
+  const linkedFriends = await socialDatabase.getLinkedFriendsForUser(userId);
+
+  // Separate into categories
+  const incoming = friendships.filter(
+    (f) => f.addresseeId === userId && f.status === "pending",
+  );
+  const outgoing = friendships.filter(
+    (f) => f.requesterId === userId && f.status === "pending",
+  );
+  const accepted = friendships.filter((f) => f.status === "accepted");
+  const blocked = friendships.filter((f) => f.status === "blocked");
+
+  return NextResponse.json({
+    success: true,
+    friendships,
+    incoming,
+    outgoing,
+    accepted,
+    blocked,
+    linkedFriends,
+  });
+}

--- a/src/app/api/group-recommendations/route.ts
+++ b/src/app/api/group-recommendations/route.ts
@@ -10,6 +10,7 @@ import { NextResponse } from "next/server";
 import { CUISINES } from "@/data/cuisines/index";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { userDatabase } from "@/services/userDatabaseService";
+import { socialDatabase } from "@/services/socialDatabaseService";
 import type { Element, Modality } from "@/types/celestial";
 import type { GroupMember, CompositeNatalChart } from "@/types/natalChart";
 import type { NextRequest } from "next/server";
@@ -134,32 +135,53 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: false, message: "User not found" }, { status: 404 });
   }
 
-  // Resolve member list
+  // Resolve member list from group or explicit IDs
   let memberIds: string[] = commensalIds ?? [];
-  if (!memberIds.length && groupId) {
+  const { linkedUserIds } = body as { linkedUserIds?: string[] };
+  let linkedIds: string[] = linkedUserIds ?? [];
+
+  if (!memberIds.length && !linkedIds.length && groupId) {
     const group = (user.profile.diningGroups ?? []).find((g) => g.id === groupId);
     if (!group) {
       return NextResponse.json({ success: false, message: "Dining group not found" }, { status: 404 });
     }
     memberIds = group.memberIds;
+    // If this is an ExtendedDiningGroup, also pull linked user IDs
+    linkedIds = (group as any).linkedUserIds ?? [];
   }
 
-  if (!memberIds.length) {
+  if (!memberIds.length && !linkedIds.length) {
     return NextResponse.json(
-      { success: false, message: "Provide commensalIds or a valid groupId" },
+      { success: false, message: "Provide commensalIds, linkedUserIds, or a valid groupId" },
       { status: 400 },
     );
   }
 
+  // Resolve manual commensals
   const allMembers = user.profile.groupMembers ?? [];
   const selectedMembers = allMembers.filter((m) => memberIds.includes(m.id));
 
-  if (selectedMembers.length === 0) {
-    return NextResponse.json({ success: false, message: "No valid commensals found" }, { status: 400 });
+  // Resolve linked friends (registered users with accepted friendships)
+  const allLinkedFriends = await socialDatabase.getLinkedFriendsForUser(userId);
+  const selectedLinked: GroupMember[] = allLinkedFriends
+    .filter((lf) => linkedIds.includes(lf.userId))
+    .map((lf) => ({
+      id: lf.userId,
+      name: lf.name,
+      relationship: "friend" as const,
+      birthData: lf.birthData,
+      natalChart: lf.natalChart,
+      createdAt: lf.syncedAt,
+    }));
+
+  const combinedMembers = [...selectedMembers, ...selectedLinked];
+
+  if (combinedMembers.length === 0) {
+    return NextResponse.json({ success: false, message: "No valid commensals or linked friends found" }, { status: 400 });
   }
 
   // Include the requesting user as a member if they have a natal chart
-  const membersForCalc: GroupMember[] = [...selectedMembers];
+  const membersForCalc: GroupMember[] = [...combinedMembers];
   if (user.profile.natalChart && user.profile.birthData) {
     membersForCalc.unshift({
       id: userId,

--- a/src/app/api/user/charts/route.ts
+++ b/src/app/api/user/charts/route.ts
@@ -1,0 +1,151 @@
+/**
+ * User Charts (Cosmic Identities) API Route
+ * GET  /api/user/charts - List all saved charts for the user
+ * POST /api/user/charts - Create a new cosmic identity chart
+ */
+
+import { NextResponse } from "next/server";
+import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { socialDatabase } from "@/services/socialDatabaseService";
+import { getPlanetaryPositionsForDateTime } from "@/services/astrologizeApi";
+import { calculateAlchemicalFromPlanets } from "@/utils/planetaryAlchemyMapping";
+import type { Planet, ZodiacSignType, Element, Modality } from "@/types/celestial";
+import type { BirthData, NatalChart, PlanetInfo } from "@/types/natalChart";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const SIGN_TO_ELEMENT: Record<ZodiacSignType, Element> = {
+  aries: "Fire", leo: "Fire", sagittarius: "Fire",
+  taurus: "Earth", virgo: "Earth", capricorn: "Earth",
+  gemini: "Air", libra: "Air", aquarius: "Air",
+  cancer: "Water", scorpio: "Water", pisces: "Water",
+};
+
+const SIGN_TO_MODALITY: Record<ZodiacSignType, Modality> = {
+  aries: "Cardinal", cancer: "Cardinal", libra: "Cardinal", capricorn: "Cardinal",
+  taurus: "Fixed", leo: "Fixed", scorpio: "Fixed", aquarius: "Fixed",
+  gemini: "Mutable", virgo: "Mutable", sagittarius: "Mutable", pisces: "Mutable",
+};
+
+function calcDominantElement(positions: Record<Planet, ZodiacSignType>): Element {
+  const counts: Record<Element, number> = { Fire: 0, Water: 0, Earth: 0, Air: 0 };
+  Object.values(positions).forEach((sign) => {
+    const el = SIGN_TO_ELEMENT[sign];
+    if (el) counts[el]++;
+  });
+  return Object.entries(counts).sort(([, a], [, b]) => b - a)[0][0] as Element;
+}
+
+function calcDominantModality(positions: Record<Planet, ZodiacSignType>): Modality {
+  const counts: Record<string, number> = { Cardinal: 0, Fixed: 0, Mutable: 0 };
+  Object.values(positions).forEach((sign) => {
+    const m = SIGN_TO_MODALITY[sign];
+    if (m) counts[m]++;
+  });
+  return Object.entries(counts).sort(([, a], [, b]) => b - a)[0][0] as Modality;
+}
+
+function calcElementalBalance(positions: Record<Planet, ZodiacSignType>) {
+  const counts: Record<Element, number> = { Fire: 0, Water: 0, Earth: 0, Air: 0 };
+  Object.values(positions).forEach((sign) => {
+    const el = SIGN_TO_ELEMENT[sign];
+    if (el) counts[el]++;
+  });
+  const total = Object.values(counts).reduce((a, b) => a + b, 0) || 1;
+  return {
+    Fire: counts.Fire / total,
+    Water: counts.Water / total,
+    Earth: counts.Earth / total,
+    Air: counts.Air / total,
+  };
+}
+
+/** GET /api/user/charts */
+export async function GET(request: NextRequest) {
+  const userId = await getUserIdFromRequest(request);
+  if (!userId) {
+    return NextResponse.json({ success: false, message: "Authentication required" }, { status: 401 });
+  }
+
+  const charts = await socialDatabase.getSavedChartsForUser(userId);
+  return NextResponse.json({ success: true, charts });
+}
+
+/** POST /api/user/charts - Create a new cosmic identity */
+export async function POST(request: NextRequest) {
+  const userId = await getUserIdFromRequest(request);
+  if (!userId) {
+    return NextResponse.json({ success: false, message: "Authentication required" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { label, birthData } = body as {
+    label?: string;
+    birthData?: BirthData;
+  };
+
+  if (!label || !birthData?.dateTime || birthData.latitude === undefined || birthData.longitude === undefined) {
+    return NextResponse.json(
+      { success: false, message: "label, birthData.dateTime, latitude, and longitude are required" },
+      { status: 400 },
+    );
+  }
+
+  // Calculate natal chart
+  const birthDate = new Date(birthData.dateTime);
+  const rawPositions = await getPlanetaryPositionsForDateTime(birthDate, {
+    latitude: birthData.latitude,
+    longitude: birthData.longitude,
+  });
+
+  const positions: Record<Planet, ZodiacSignType> = {
+    Sun: rawPositions.Sun?.sign,
+    Moon: rawPositions.Moon?.sign,
+    Mercury: rawPositions.Mercury?.sign,
+    Venus: rawPositions.Venus?.sign,
+    Mars: rawPositions.Mars?.sign,
+    Jupiter: rawPositions.Jupiter?.sign,
+    Saturn: rawPositions.Saturn?.sign,
+    Uranus: rawPositions.Uranus?.sign,
+    Neptune: rawPositions.Neptune?.sign,
+    Pluto: rawPositions.Pluto?.sign,
+    Ascendant: rawPositions.Ascendant?.sign || "aries",
+  };
+
+  const planets: PlanetInfo[] = Object.entries(positions).map(([pname, sign]) => ({
+    name: pname as Planet,
+    sign,
+    position: rawPositions[pname]?.exactLongitude ?? 0,
+  }));
+
+  const natalChart: NatalChart = {
+    birthData: { dateTime: birthData.dateTime, latitude: birthData.latitude, longitude: birthData.longitude, timezone: birthData.timezone },
+    planets,
+    ascendant: positions.Ascendant,
+    planetaryPositions: positions,
+    dominantElement: calcDominantElement(positions),
+    dominantModality: calcDominantModality(positions),
+    elementalBalance: calcElementalBalance(positions),
+    alchemicalProperties: calculateAlchemicalFromPlanets(positions),
+    calculatedAt: new Date().toISOString(),
+  };
+
+  const chart = await socialDatabase.createSavedChart({
+    ownerId: userId,
+    label,
+    chartType: "cosmic_identity",
+    birthData: natalChart.birthData,
+    natalChart,
+  });
+
+  if (!chart) {
+    return NextResponse.json(
+      { success: false, message: "Failed to save chart" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ success: true, chart }, { status: 201 });
+}

--- a/src/app/api/users/search/route.ts
+++ b/src/app/api/users/search/route.ts
@@ -1,0 +1,34 @@
+/**
+ * User Search API Route
+ * GET /api/users/search?q=email - Search registered users by email
+ * Returns basic info only (id, name, email) for friend request UI.
+ */
+
+import { NextResponse } from "next/server";
+import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { socialDatabase } from "@/services/socialDatabaseService";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  const userId = await getUserIdFromRequest(request);
+  if (!userId) {
+    return NextResponse.json({ success: false, message: "Authentication required" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get("q");
+
+  if (!query || query.length < 3) {
+    return NextResponse.json(
+      { success: false, message: "Query must be at least 3 characters" },
+      { status: 400 },
+    );
+  }
+
+  const users = await socialDatabase.searchUsersByEmail(query, userId, 10);
+
+  return NextResponse.json({ success: true, users });
+}

--- a/src/components/dashboard/CommensalManager.tsx
+++ b/src/components/dashboard/CommensalManager.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import type { GroupMember, DiningGroup, CompositeNatalChart } from '@/types/natalChart';
+import type { GroupMember, DiningGroup, CompositeNatalChart, LinkedFriend } from '@/types/natalChart';
 import { LocationSearch } from '@/components/onboarding/LocationSearch';
 
 /* ─── Types ────────────────────────────────────────────── */
@@ -21,6 +21,12 @@ interface GroupRecommendationResult {
   recommendations: CuisineRec[];
   memberCount: number;
   strategy: string;
+}
+
+interface SearchResult {
+  id: string;
+  name: string;
+  email: string;
 }
 
 /* ─── Constants ─────────────────────────────────────────── */
@@ -57,7 +63,169 @@ function ScoreBar({ value, color = 'purple' }: { value: number; color?: string }
   );
 }
 
-/* ─── Add Commensal Form ─────────────────────────────────── */
+/* ─── Add Mode Toggle ────────────────────────────────────── */
+
+type AddMode = 'manual' | 'email';
+
+function AddModeToggle({ mode, onModeChange }: { mode: AddMode; onModeChange: (m: AddMode) => void }) {
+  return (
+    <div className="flex rounded-lg border border-gray-200 overflow-hidden mb-4">
+      <button
+        type="button"
+        onClick={() => onModeChange('manual')}
+        className={`flex-1 px-4 py-2 text-sm font-medium transition-colors ${
+          mode === 'manual'
+            ? 'bg-purple-600 text-white'
+            : 'bg-white text-gray-600 hover:bg-gray-50'
+        }`}
+      >
+        Add Manual Chart
+      </button>
+      <button
+        type="button"
+        onClick={() => onModeChange('email')}
+        className={`flex-1 px-4 py-2 text-sm font-medium transition-colors ${
+          mode === 'email'
+            ? 'bg-purple-600 text-white'
+            : 'bg-white text-gray-600 hover:bg-gray-50'
+        }`}
+      >
+        Search by Email
+      </button>
+    </div>
+  );
+}
+
+/* ─── Email Search Form ──────────────────────────────────── */
+
+function AddByEmailForm({
+  onRequestSent,
+  onCancel,
+}: {
+  onRequestSent: () => void;
+  onCancel: () => void;
+}) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [sending, setSending] = useState<string | null>(null);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  const handleSearch = useCallback(async () => {
+    if (query.length < 3) {
+      setResults([]);
+      return;
+    }
+    setSearching(true);
+    setMessage(null);
+    try {
+      const res = await fetch(`/api/users/search?q=${encodeURIComponent(query)}`, {
+        credentials: 'include',
+      });
+      const data = await res.json();
+      if (data.success) setResults(data.users ?? []);
+    } catch {
+      setMessage({ type: 'error', text: 'Search failed' });
+    } finally {
+      setSearching(false);
+    }
+  }, [query]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (query.length >= 3) void handleSearch();
+      else setResults([]);
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [query, handleSearch]);
+
+  const handleSendRequest = async (email: string) => {
+    setSending(email);
+    setMessage(null);
+    try {
+      const res = await fetch('/api/friends/request', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ email }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        setMessage({ type: 'success', text: `Friend request sent to ${email}` });
+        onRequestSent();
+      } else {
+        setMessage({ type: 'error', text: data.message || 'Failed to send request' });
+      }
+    } catch {
+      setMessage({ type: 'error', text: 'Failed to send request' });
+    } finally {
+      setSending(null);
+    }
+  };
+
+  return (
+    <div className="space-y-3 bg-gray-50 border border-gray-200 rounded-xl p-4">
+      <h4 className="text-sm font-semibold text-gray-800">Find a Friend on Alchm.kitchen</h4>
+      <p className="text-xs text-gray-500">
+        Search by their email. When they accept, their birth chart syncs automatically.
+      </p>
+
+      {message && (
+        <div className={`text-sm px-3 py-2 rounded-lg border ${
+          message.type === 'success'
+            ? 'text-green-700 bg-green-50 border-green-200'
+            : 'text-red-600 bg-red-50 border-red-200'
+        }`}>
+          {message.text}
+        </div>
+      )}
+
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search by email (min 3 characters)..."
+        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-400"
+      />
+
+      {searching && <p className="text-xs text-gray-400">Searching...</p>}
+
+      {results.length > 0 && (
+        <div className="space-y-1.5">
+          {results.map((u) => (
+            <div key={u.id} className="flex items-center justify-between p-2 bg-white rounded-lg border border-gray-100">
+              <div>
+                <span className="text-sm font-medium text-gray-800">{u.name || 'User'}</span>
+                <span className="text-xs text-gray-400 ml-2">{u.email}</span>
+              </div>
+              <button
+                onClick={() => handleSendRequest(u.email)}
+                disabled={sending === u.email}
+                className="px-3 py-1 text-xs bg-purple-600 text-white rounded-lg font-medium hover:bg-purple-700 disabled:opacity-60 transition-colors"
+              >
+                {sending === u.email ? 'Sending...' : 'Add Friend'}
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {query.length >= 3 && !searching && results.length === 0 && (
+        <p className="text-xs text-gray-400 italic">No users found matching that email.</p>
+      )}
+
+      <button
+        type="button"
+        onClick={onCancel}
+        className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg text-sm font-medium hover:bg-gray-200 transition-colors"
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}
+
+/* ─── Add Commensal Form (Manual Chart) ───────────────────── */
 
 function AddCommensalForm({
   onAdded,
@@ -113,7 +281,10 @@ function AddCommensalForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4 bg-gray-50 border border-gray-200 rounded-xl p-4">
-      <h4 className="text-sm font-semibold text-gray-800">New Dining Companion</h4>
+      <h4 className="text-sm font-semibold text-gray-800">New Manual Chart</h4>
+      <p className="text-xs text-gray-500">
+        For friends/family who do NOT have an alchm.kitchen account.
+      </p>
 
       {error && (
         <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
@@ -155,7 +326,7 @@ function AddCommensalForm({
         </div>
         <div className="sm:col-span-1">
           <label className="block text-xs text-gray-500 mb-1">Birth Location *</label>
-          <LocationSearch 
+          <LocationSearch
             onLocationSelect={(loc) => {
               setLatitude(loc.latitude.toString());
               setLongitude(loc.longitude.toString());
@@ -192,7 +363,7 @@ function AddCommensalForm({
           disabled={saving}
           className="px-4 py-2 bg-purple-600 text-white rounded-lg text-sm font-medium hover:bg-purple-700 disabled:opacity-60 transition-colors"
         >
-          {saving ? 'Calculating chart…' : 'Add Companion'}
+          {saving ? 'Calculating chart...' : 'Add Companion'}
         </button>
         <button
           type="button"
@@ -208,19 +379,22 @@ function AddCommensalForm({
 
 /* ─── Commensal Card ─────────────────────────────────────── */
 
-function CommensalCard({
-  member,
-  selected,
-  onToggle,
-  onDelete,
-}: {
-  member: GroupMember;
+interface CompanionCardProps {
+  name: string;
+  element: string;
+  modality?: string;
+  ascendant?: string;
+  relationship?: string;
+  isLinked?: boolean;
   selected: boolean;
   onToggle: () => void;
-  onDelete: () => void;
-}) {
-  const el = member.natalChart?.dominantElement ?? 'Fire';
-  const colorClass = ELEMENT_COLORS[el] ?? ELEMENT_COLORS.Fire;
+  onDelete?: () => void;
+}
+
+const CompanionCard: React.FC<CompanionCardProps> = ({
+  name, element, modality, ascendant, relationship, isLinked, selected, onToggle, onDelete,
+}) => {
+  const colorClass = ELEMENT_COLORS[element] ?? ELEMENT_COLORS.Fire;
 
   return (
     <div
@@ -238,60 +412,69 @@ function CommensalCard({
       />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-semibold text-gray-800">{member.name}</span>
-          {member.relationship && (
-            <span className="text-xs text-gray-400 capitalize">{member.relationship}</span>
+          <span className="text-sm font-semibold text-gray-800">{name}</span>
+          {relationship && (
+            <span className="text-xs text-gray-400 capitalize">{relationship}</span>
+          )}
+          {isLinked && (
+            <span className="text-xs px-1.5 py-0.5 rounded bg-green-50 text-green-600 border border-green-200 font-medium">
+              Linked
+            </span>
           )}
         </div>
         <div className="flex items-center gap-2 mt-0.5">
           <span className={`text-xs px-2 py-0.5 rounded-full border font-medium ${colorClass}`}>
-            {ELEMENT_EMOJI[el]} {el}
+            {ELEMENT_EMOJI[element]} {element}
           </span>
-          <span className="text-xs text-gray-400 capitalize">
-            {member.natalChart?.dominantModality}
-          </span>
-          {member.natalChart?.ascendant && (
-            <span className="text-xs text-gray-400 capitalize">
-              {member.natalChart.ascendant} rising
-            </span>
+          {modality && (
+            <span className="text-xs text-gray-400 capitalize">{modality}</span>
+          )}
+          {ascendant && (
+            <span className="text-xs text-gray-400 capitalize">{ascendant} rising</span>
           )}
         </div>
       </div>
-      <button
-        onClick={(e) => { e.stopPropagation(); onDelete(); }}
-        className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
-        title="Remove companion"
-      >
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-        </svg>
-      </button>
+      {onDelete && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onDelete(); }}
+          className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
+          title="Remove companion"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      )}
     </div>
   );
-}
+};
 
 /* ─── Group Recommendations Panel ────────────────────────── */
 
 function GroupRecommendationsPanel({
   commensalIds,
+  linkedUserIds,
   allMembers,
+  linkedFriends,
 }: {
   commensalIds: string[];
+  linkedUserIds: string[];
   allMembers: GroupMember[];
+  linkedFriends: LinkedFriend[];
 }) {
   const [result, setResult] = useState<GroupRecommendationResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [strategy, setStrategy] = useState<'average' | 'minimum' | 'consensus'>('average');
 
   const fetchRecs = useCallback(async () => {
-    if (!commensalIds.length) return;
+    if (!commensalIds.length && !linkedUserIds.length) return;
     setLoading(true);
     try {
       const res = await fetch('/api/group-recommendations', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ commensalIds, strategy }),
+        body: JSON.stringify({ commensalIds, linkedUserIds, strategy }),
       });
       const data = await res.json();
       if (data.success) setResult(data);
@@ -300,18 +483,22 @@ function GroupRecommendationsPanel({
     } finally {
       setLoading(false);
     }
-  }, [commensalIds, strategy]);
+  }, [commensalIds, linkedUserIds, strategy]);
 
   useEffect(() => {
-    if (commensalIds.length > 0) void fetchRecs();
+    if (commensalIds.length > 0 || linkedUserIds.length > 0) void fetchRecs();
     else setResult(null);
-  }, [commensalIds, fetchRecs]);
+  }, [commensalIds, linkedUserIds, fetchRecs]);
 
-  if (!commensalIds.length) return null;
+  if (!commensalIds.length && !linkedUserIds.length) return null;
 
-  const selectedNames = allMembers
+  const manualNames = allMembers
     .filter((m) => commensalIds.includes(m.id))
     .map((m) => m.name);
+  const linkedNames = linkedFriends
+    .filter((f) => linkedUserIds.includes(f.userId))
+    .map((f) => f.name);
+  const selectedNames = [...manualNames, ...linkedNames];
 
   return (
     <div className="bg-white border border-gray-200 rounded-xl p-4 space-y-4">
@@ -339,14 +526,14 @@ function GroupRecommendationsPanel({
             disabled={loading}
             className="px-3 py-1.5 bg-purple-600 text-white rounded-lg text-xs font-medium hover:bg-purple-700 disabled:opacity-60 transition-colors"
           >
-            {loading ? '…' : 'Refresh'}
+            {loading ? '...' : 'Refresh'}
           </button>
         </div>
       </div>
 
       {loading && (
         <div className="text-center py-6 text-sm text-gray-400">
-          Calculating group harmony…
+          Calculating group harmony...
         </div>
       )}
 
@@ -401,21 +588,28 @@ function GroupRecommendationsPanel({
 function DiningGroupSection({
   groups,
   members,
+  linkedFriends,
   onGroupCreated,
   onGroupDeleted,
   onGetRecs,
 }: {
   groups: DiningGroup[];
   members: GroupMember[];
+  linkedFriends: LinkedFriend[];
   onGroupCreated: (g: DiningGroup) => void;
   onGroupDeleted: (id: string) => void;
-  onGetRecs: (ids: string[]) => void;
+  onGetRecs: (manualIds: string[], linkedIds: string[]) => void;
 }) {
   const [showCreate, setShowCreate] = useState(false);
   const [groupName, setGroupName] = useState('');
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const allCompanions = [
+    ...members.map((m) => ({ id: m.id, name: m.name, element: m.natalChart?.dominantElement, isLinked: false })),
+    ...linkedFriends.map((f) => ({ id: f.userId, name: f.name, element: f.natalChart?.dominantElement, isLinked: true })),
+  ];
 
   const toggleMember = (id: string) =>
     setSelectedIds((prev) => prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]);
@@ -427,12 +621,22 @@ function DiningGroupSection({
     }
     setSaving(true);
     setError(null);
+
+    // Separate manual vs linked IDs
+    const manualMemberIds = new Set(members.map((m) => m.id));
+    const groupManualIds = selectedIds.filter((id) => manualMemberIds.has(id));
+    const groupLinkedIds = selectedIds.filter((id) => !manualMemberIds.has(id));
+
     try {
       const res = await fetch('/api/user/dining-groups', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ name: groupName.trim(), memberIds: selectedIds }),
+        body: JSON.stringify({
+          name: groupName.trim(),
+          memberIds: groupManualIds,
+          linkedUserIds: groupLinkedIds,
+        }),
       });
       const data = await res.json();
       if (!data.success) throw new Error(data.message);
@@ -487,19 +691,22 @@ function DiningGroupSection({
           />
           <div className="space-y-1.5">
             <span className="text-xs text-gray-500">Select members:</span>
-            {members.length === 0 && (
+            {allCompanions.length === 0 && (
               <p className="text-xs text-gray-400 italic">No companions added yet.</p>
             )}
-            {members.map((m) => (
-              <label key={m.id} className="flex items-center gap-2 cursor-pointer">
+            {allCompanions.map((c) => (
+              <label key={c.id} className="flex items-center gap-2 cursor-pointer">
                 <input
                   type="checkbox"
-                  checked={selectedIds.includes(m.id)}
-                  onChange={() => toggleMember(m.id)}
+                  checked={selectedIds.includes(c.id)}
+                  onChange={() => toggleMember(c.id)}
                   className="accent-purple-600"
                 />
-                <span className="text-sm text-gray-700">{m.name}</span>
-                <span className="text-xs text-gray-400 capitalize">{m.natalChart?.dominantElement}</span>
+                <span className="text-sm text-gray-700">{c.name}</span>
+                <span className="text-xs text-gray-400 capitalize">{c.element}</span>
+                {c.isLinked && (
+                  <span className="text-[10px] text-green-600 font-medium">Linked</span>
+                )}
               </label>
             ))}
           </div>
@@ -508,7 +715,7 @@ function DiningGroupSection({
             disabled={saving}
             className="px-4 py-2 bg-purple-600 text-white rounded-lg text-sm font-medium hover:bg-purple-700 disabled:opacity-60 transition-colors"
           >
-            {saving ? 'Creating…' : 'Create Group'}
+            {saving ? 'Creating...' : 'Create Group'}
           </button>
         </div>
       )}
@@ -523,20 +730,23 @@ function DiningGroupSection({
         const groupMemberNames = members
           .filter((m) => group.memberIds.includes(m.id))
           .map((m) => m.name);
+        const groupLinkedNames = linkedFriends
+          .filter((f) => ((group as any).linkedUserIds ?? []).includes(f.userId))
+          .map((f) => f.name);
+        const allNames = [...groupMemberNames, ...groupLinkedNames];
+
         return (
           <div key={group.id} className="bg-white border border-gray-200 rounded-xl p-3">
             <div className="flex items-center justify-between">
               <div>
                 <span className="text-sm font-semibold text-gray-800">{group.name}</span>
                 <p className="text-xs text-gray-400 mt-0.5">
-                  {groupMemberNames.length > 0
-                    ? groupMemberNames.join(', ')
-                    : 'No members'}
+                  {allNames.length > 0 ? allNames.join(', ') : 'No members'}
                 </p>
               </div>
               <div className="flex gap-2">
                 <button
-                  onClick={() => onGetRecs(group.memberIds)}
+                  onClick={() => onGetRecs(group.memberIds, (group as any).linkedUserIds ?? [])}
                   className="px-3 py-1.5 text-xs bg-orange-50 text-orange-700 border border-orange-200 rounded-lg font-medium hover:bg-orange-100 transition-colors"
                 >
                   Recommend
@@ -562,23 +772,29 @@ function DiningGroupSection({
 
 export const CommensalManager: React.FC = () => {
   const [commensals, setCommensals] = useState<GroupMember[]>([]);
+  const [linkedFriends, setLinkedFriends] = useState<LinkedFriend[]>([]);
   const [groups, setGroups] = useState<DiningGroup[]>([]);
   const [loading, setLoading] = useState(true);
   const [showAddForm, setShowAddForm] = useState(false);
-  const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const [activeGroupIds, setActiveGroupIds] = useState<string[]>([]);
+  const [addMode, setAddMode] = useState<AddMode>('manual');
+  const [selectedManualIds, setSelectedManualIds] = useState<string[]>([]);
+  const [selectedLinkedIds, setSelectedLinkedIds] = useState<string[]>([]);
+  const [activeManualIds, setActiveManualIds] = useState<string[]>([]);
+  const [activeLinkedIds, setActiveLinkedIds] = useState<string[]>([]);
 
-  // Load commensals + groups
+  // Load commensals + groups + linked friends
   useEffect(() => {
     const load = async () => {
       try {
-        const [cRes, gRes] = await Promise.all([
+        const [cRes, gRes, fRes] = await Promise.all([
           fetch('/api/user/commensals', { credentials: 'include' }),
           fetch('/api/user/dining-groups', { credentials: 'include' }),
+          fetch('/api/friends', { credentials: 'include' }),
         ]);
-        const [cData, gData] = await Promise.all([cRes.json(), gRes.json()]);
+        const [cData, gData, fData] = await Promise.all([cRes.json(), gRes.json(), fRes.json()]);
         if (cData.success) setCommensals(cData.commensals ?? []);
         if (gData.success) setGroups(gData.diningGroups ?? []);
+        if (fData.success) setLinkedFriends(fData.linkedFriends ?? []);
       } catch {
         // ignore
       } finally {
@@ -588,32 +804,50 @@ export const CommensalManager: React.FC = () => {
     void load();
   }, []);
 
-  const handleDelete = async (commensalId: string) => {
+  const refreshLinkedFriends = async () => {
+    try {
+      const res = await fetch('/api/friends', { credentials: 'include' });
+      const data = await res.json();
+      if (data.success) setLinkedFriends(data.linkedFriends ?? []);
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleDeleteCommensal = async (commensalId: string) => {
     try {
       await fetch(`/api/user/commensals/${commensalId}`, {
         method: 'DELETE',
         credentials: 'include',
       });
       setCommensals((prev) => prev.filter((m) => m.id !== commensalId));
-      setSelectedIds((prev) => prev.filter((id) => id !== commensalId));
+      setSelectedManualIds((prev) => prev.filter((id) => id !== commensalId));
     } catch {
       // ignore
     }
   };
 
-  const toggleSelect = (id: string) =>
-    setSelectedIds((prev) => prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]);
+  const toggleManualSelect = (id: string) =>
+    setSelectedManualIds((prev) => prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]);
 
-  // IDs to show in recommendation panel: from group or manual selection
-  const recIds = activeGroupIds.length > 0 ? activeGroupIds : selectedIds;
+  const toggleLinkedSelect = (id: string) =>
+    setSelectedLinkedIds((prev) => prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]);
+
+  // IDs for recommendation panel
+  const recManualIds = activeManualIds.length > 0 ? activeManualIds : selectedManualIds;
+  const recLinkedIds = activeLinkedIds.length > 0 ? activeLinkedIds : selectedLinkedIds;
+  const hasSelection = recManualIds.length > 0 || recLinkedIds.length > 0;
+  const totalSelected = selectedManualIds.length + selectedLinkedIds.length;
 
   if (loading) {
     return (
       <div className="text-center py-10 text-sm text-gray-400">
-        Loading companions…
+        Loading companions...
       </div>
     );
   }
+
+  const totalCompanions = commensals.length + linkedFriends.length;
 
   return (
     <div className="space-y-5">
@@ -637,44 +871,52 @@ export const CommensalManager: React.FC = () => {
         </div>
       </div>
 
-      {/* Add form */}
+      {/* Dual-track add form */}
       {showAddForm && (
         <div className="bg-white rounded-xl shadow-sm p-5">
-          <AddCommensalForm
-            onAdded={(c) => {
-              setCommensals((prev) => [...prev, c]);
-              setShowAddForm(false);
-            }}
-            onCancel={() => setShowAddForm(false)}
-          />
+          <AddModeToggle mode={addMode} onModeChange={setAddMode} />
+          {addMode === 'manual' ? (
+            <AddCommensalForm
+              onAdded={(c) => {
+                setCommensals((prev) => [...prev, c]);
+                setShowAddForm(false);
+              }}
+              onCancel={() => setShowAddForm(false)}
+            />
+          ) : (
+            <AddByEmailForm
+              onRequestSent={refreshLinkedFriends}
+              onCancel={() => setShowAddForm(false)}
+            />
+          )}
         </div>
       )}
 
-      {/* Commensals list */}
+      {/* Companions list (manual + linked) */}
       <div className="bg-white rounded-xl shadow-sm p-5">
         <div className="flex items-center justify-between mb-3">
           <h4 className="text-sm font-semibold text-gray-800">
             Your Companions
-            {commensals.length > 0 && (
+            {totalCompanions > 0 && (
               <span className="ml-2 text-xs text-gray-400 font-normal">
-                ({commensals.length})
+                ({totalCompanions})
               </span>
             )}
           </h4>
-          {selectedIds.length > 0 && (
+          {totalSelected > 0 && (
             <button
               onClick={() => {
-                setActiveGroupIds([]);
-                // Trigger recs via the recIds derived state
+                setActiveManualIds([]);
+                setActiveLinkedIds([]);
               }}
               className="text-xs text-orange-600 font-medium hover:text-orange-800"
             >
-              Get Recs for {selectedIds.length} selected
+              Get Recs for {totalSelected} selected
             </button>
           )}
         </div>
 
-        {commensals.length === 0 ? (
+        {totalCompanions === 0 ? (
           <div className="text-center py-8">
             <div className="text-3xl mb-2">👨‍👩‍👧‍👦</div>
             <p className="text-sm text-gray-500">No companions yet.</p>
@@ -684,18 +926,38 @@ export const CommensalManager: React.FC = () => {
           </div>
         ) : (
           <div className="space-y-2">
+            {/* Manual commensals */}
             {commensals.map((m) => (
-              <CommensalCard
+              <CompanionCard
                 key={m.id}
-                member={m}
-                selected={selectedIds.includes(m.id)}
-                onToggle={() => toggleSelect(m.id)}
-                onDelete={() => handleDelete(m.id)}
+                name={m.name}
+                element={m.natalChart?.dominantElement ?? 'Fire'}
+                modality={m.natalChart?.dominantModality}
+                ascendant={m.natalChart?.ascendant}
+                relationship={m.relationship}
+                selected={selectedManualIds.includes(m.id)}
+                onToggle={() => { toggleManualSelect(m.id); }}
+                onDelete={() => { void handleDeleteCommensal(m.id); }}
               />
             ))}
-            {selectedIds.length > 0 && (
+
+            {/* Linked friends */}
+            {linkedFriends.map((f) => (
+              <CompanionCard
+                key={f.userId}
+                name={f.name}
+                element={f.natalChart?.dominantElement ?? 'Fire'}
+                modality={f.natalChart?.dominantModality}
+                ascendant={f.natalChart?.ascendant}
+                isLinked
+                selected={selectedLinkedIds.includes(f.userId)}
+                onToggle={() => { toggleLinkedSelect(f.userId); }}
+              />
+            ))}
+
+            {totalSelected > 0 && (
               <p className="text-xs text-gray-400 text-center pt-1">
-                {selectedIds.length} companion{selectedIds.length > 1 ? 's' : ''} selected
+                {totalSelected} companion{totalSelected > 1 ? 's' : ''} selected
                 &mdash; see recommendations below
               </p>
             )}
@@ -704,11 +966,13 @@ export const CommensalManager: React.FC = () => {
       </div>
 
       {/* Group recommendations (auto-shown when selection exists) */}
-      {recIds.length > 0 && (
+      {hasSelection && (
         <div className="bg-white rounded-xl shadow-sm p-5">
           <GroupRecommendationsPanel
-            commensalIds={recIds}
+            commensalIds={recManualIds}
+            linkedUserIds={recLinkedIds}
             allMembers={commensals}
+            linkedFriends={linkedFriends}
           />
         </div>
       )}
@@ -718,11 +982,14 @@ export const CommensalManager: React.FC = () => {
         <DiningGroupSection
           groups={groups}
           members={commensals}
+          linkedFriends={linkedFriends}
           onGroupCreated={(g) => setGroups((prev) => [...prev, g])}
           onGroupDeleted={(id) => setGroups((prev) => prev.filter((g) => g.id !== id))}
-          onGetRecs={(ids) => {
-            setActiveGroupIds(ids);
-            setSelectedIds([]);
+          onGetRecs={(manualIds, linkedIds) => {
+            setActiveManualIds(manualIds);
+            setActiveLinkedIds(linkedIds);
+            setSelectedManualIds([]);
+            setSelectedLinkedIds([]);
           }}
         />
       </div>

--- a/src/components/dashboard/SocialManager.tsx
+++ b/src/components/dashboard/SocialManager.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import type { Friendship } from '@/types/natalChart';
+
+/* ─── Social Manager Component ─────────────────────────── */
+
+export const SocialManager: React.FC = () => {
+  const [friendships, setFriendships] = useState<Friendship[]>([]);
+  const [incoming, setIncoming] = useState<Friendship[]>([]);
+  const [outgoing, setOutgoing] = useState<Friendship[]>([]);
+  const [accepted, setAccepted] = useState<Friendship[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [actionInProgress, setActionInProgress] = useState<string | null>(null);
+
+  const loadFriendships = useCallback(async () => {
+    try {
+      const res = await fetch('/api/friends', { credentials: 'include' });
+      const data = await res.json();
+      if (data.success) {
+        setFriendships(data.friendships ?? []);
+        setIncoming(data.incoming ?? []);
+        setOutgoing(data.outgoing ?? []);
+        setAccepted(data.accepted ?? []);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadFriendships();
+  }, [loadFriendships]);
+
+  const handleAccept = async (friendshipId: string) => {
+    setActionInProgress(friendshipId);
+    try {
+      const res = await fetch('/api/friends/accept', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ friendshipId }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        await loadFriendships();
+      }
+    } catch {
+      // ignore
+    } finally {
+      setActionInProgress(null);
+    }
+  };
+
+  const handleReject = async (friendshipId: string, block = false) => {
+    setActionInProgress(friendshipId);
+    try {
+      await fetch('/api/friends/reject', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ friendshipId, block }),
+      });
+      await loadFriendships();
+    } catch {
+      // ignore
+    } finally {
+      setActionInProgress(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="text-center py-10 text-sm text-gray-400">
+        Loading social connections...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      {/* Incoming Requests */}
+      <div className="bg-white rounded-xl shadow-sm p-5">
+        <h3 className="text-sm font-bold text-gray-800 mb-3">
+          Incoming Friend Requests
+          {incoming.length > 0 && (
+            <span className="ml-2 text-xs bg-purple-100 text-purple-700 px-2 py-0.5 rounded-full font-medium">
+              {incoming.length}
+            </span>
+          )}
+        </h3>
+        {incoming.length === 0 ? (
+          <p className="text-sm text-gray-400 italic">No pending requests.</p>
+        ) : (
+          <div className="space-y-2">
+            {incoming.map((f) => (
+              <div key={f.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg border border-gray-100">
+                <div>
+                  <span className="text-sm font-semibold text-gray-800">
+                    {f.requesterName || 'User'}
+                  </span>
+                  <span className="text-xs text-gray-400 ml-2">{f.requesterEmail}</span>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => handleAccept(f.id)}
+                    disabled={actionInProgress === f.id}
+                    className="px-3 py-1.5 text-xs bg-green-600 text-white rounded-lg font-medium hover:bg-green-700 disabled:opacity-60 transition-colors"
+                  >
+                    Accept
+                  </button>
+                  <button
+                    onClick={() => handleReject(f.id)}
+                    disabled={actionInProgress === f.id}
+                    className="px-3 py-1.5 text-xs bg-gray-200 text-gray-700 rounded-lg font-medium hover:bg-gray-300 disabled:opacity-60 transition-colors"
+                  >
+                    Decline
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Outgoing Requests */}
+      {outgoing.length > 0 && (
+        <div className="bg-white rounded-xl shadow-sm p-5">
+          <h3 className="text-sm font-bold text-gray-800 mb-3">Sent Requests</h3>
+          <div className="space-y-2">
+            {outgoing.map((f) => (
+              <div key={f.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg border border-gray-100">
+                <div>
+                  <span className="text-sm font-semibold text-gray-800">
+                    {f.addresseeName || 'User'}
+                  </span>
+                  <span className="text-xs text-gray-400 ml-2">{f.addresseeEmail}</span>
+                  <span className="text-xs text-yellow-600 ml-2 font-medium">Pending</span>
+                </div>
+                <button
+                  onClick={() => handleReject(f.id)}
+                  disabled={actionInProgress === f.id}
+                  className="px-3 py-1.5 text-xs bg-gray-200 text-gray-700 rounded-lg font-medium hover:bg-gray-300 disabled:opacity-60 transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Accepted Friends */}
+      <div className="bg-white rounded-xl shadow-sm p-5">
+        <h3 className="text-sm font-bold text-gray-800 mb-3">
+          Friends ({accepted.length})
+        </h3>
+        {accepted.length === 0 ? (
+          <div className="text-center py-6">
+            <p className="text-sm text-gray-400">No friends yet.</p>
+            <p className="text-xs text-gray-400 mt-1">
+              Use the Companions tab to search by email and send friend requests.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {accepted.map((f) => {
+              // Determine which side is the friend (not the current user)
+              // We don't know currentUserId here, so show both sides
+              const friendName = f.requesterName || f.addresseeName || 'Friend';
+              const friendEmail = f.requesterEmail || f.addresseeEmail || '';
+
+              return (
+                <div key={f.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg border border-gray-100">
+                  <div>
+                    <span className="text-sm font-semibold text-gray-800">{friendName}</span>
+                    <span className="text-xs text-gray-400 ml-2">{friendEmail}</span>
+                    <span className="text-xs text-green-600 ml-2 font-medium">Connected</span>
+                  </div>
+                  <button
+                    onClick={() => handleReject(f.id)}
+                    disabled={actionInProgress === f.id}
+                    className="px-3 py-1.5 text-xs text-gray-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
+                    title="Remove friend"
+                  >
+                    Remove
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/dashboard/UserDashboard.tsx
+++ b/src/components/dashboard/UserDashboard.tsx
@@ -10,6 +10,7 @@ import { DashboardOverview } from './DashboardOverview';
 import { FoodLabBook } from './FoodLabBook';
 import { NatalTransitChart } from './NatalTransitChart';
 import { RecommendationsPanel } from './RecommendationsPanel';
+import { SocialManager } from './SocialManager';
 
 export interface UserPreferences {
   dietaryRestrictions: string[];
@@ -29,7 +30,7 @@ interface UserDashboardProps {
   onEditPreferences: () => void;
 }
 
-type DashboardTab = 'overview' | 'transits' | 'chart' | 'recommendations' | 'commensals' | 'labbook' | 'settings';
+type DashboardTab = 'overview' | 'transits' | 'chart' | 'recommendations' | 'commensals' | 'social' | 'labbook' | 'settings';
 
 const TAB_CONFIG: Array<{ key: DashboardTab; label: string; icon: string }> = [
   { key: 'overview', label: 'Overview', icon: '\u2728' },
@@ -37,6 +38,7 @@ const TAB_CONFIG: Array<{ key: DashboardTab; label: string; icon: string }> = [
   { key: 'chart', label: 'My Chart', icon: '\uD83D\uDD2E' },
   { key: 'recommendations', label: 'Recommendations', icon: '\uD83C\uDF7D\uFE0F' },
   { key: 'commensals', label: 'Companions', icon: '\uD83D\uDC65' },
+  { key: 'social', label: 'Social', icon: '\uD83E\uDD1D' },
   { key: 'labbook', label: 'Lab Book', icon: '\uD83E\uDDEA' },
   { key: 'settings', label: 'Settings', icon: '\u2699\uFE0F' },
 ];
@@ -229,6 +231,10 @@ export const UserDashboard: React.FC<UserDashboardProps> = ({
 
       {activeTab === 'commensals' && (
         <CommensalManager />
+      )}
+
+      {activeTab === 'social' && (
+        <SocialManager />
       )}
 
       {activeTab === 'labbook' && (

--- a/src/contexts/UserContext/index.tsx
+++ b/src/contexts/UserContext/index.tsx
@@ -13,6 +13,9 @@ import type {
   NatalChart,
   GroupMember,
   DiningGroup,
+  Friendship,
+  LinkedFriend,
+  SavedChart,
 } from "@/types/natalChart";
 import { calculateAlchemicalProfile } from "@/utils/astrology/natalAlchemy";
 import { logger } from "@/utils/logger";
@@ -38,7 +41,7 @@ interface AlchemicalProfile {
   monicaConstant: number;
 }
 
-// Extended UserProfile interface with natal chart and group support
+// Extended UserProfile interface with natal chart, group, and social support
 interface UserProfile {
   userId: string;
   name?: string;
@@ -49,6 +52,11 @@ interface UserProfile {
   groupMembers?: GroupMember[];
   diningGroups?: DiningGroup[];
   stats?: AlchemicalProfile;
+  // Social features
+  friendships?: Friendship[];
+  linkedFriends?: LinkedFriend[];
+  // Multi-chart cosmic identities
+  savedCharts?: SavedChart[];
 }
 
 // Keys for localStorage
@@ -139,6 +147,9 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
                 groupMembers: data.profile.groupMembers || [],
                 diningGroups: data.profile.diningGroups || [],
                 stats: data.profile.stats,
+                friendships: data.profile.friendships || [],
+                linkedFriends: data.profile.linkedFriends || [],
+                savedCharts: data.profile.savedCharts || [],
               };
               setCurrentUser(profile);
               checkProfileCompleteness(profile);
@@ -191,6 +202,9 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
             groupMembers: data.profile.groupMembers || [],
             diningGroups: data.profile.diningGroups || [],
             stats: data.profile.stats,
+            friendships: data.profile.friendships || [],
+            linkedFriends: data.profile.linkedFriends || [],
+            savedCharts: data.profile.savedCharts || [],
           };
           setCurrentUser(profile);
           checkProfileCompleteness(profile);
@@ -253,6 +267,9 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
               groupMembers: result.profile.groupMembers || [],
               diningGroups: result.profile.diningGroups || [],
               stats: result.profile.stats,
+              friendships: result.profile.friendships || [],
+              linkedFriends: result.profile.linkedFriends || [],
+              savedCharts: result.profile.savedCharts || [],
             };
             setCurrentUser(serverProfile);
             checkProfileCompleteness(serverProfile);

--- a/src/services/socialDatabaseService.ts
+++ b/src/services/socialDatabaseService.ts
@@ -1,0 +1,463 @@
+/**
+ * Social Database Service
+ * Manages friendships, saved charts, and user search for the social features.
+ * Uses PostgreSQL with in-memory fallback (same pattern as userDatabaseService).
+ */
+
+import { _logger } from "@/lib/logger";
+import type {
+  Friendship,
+  FriendshipStatus,
+  SavedChart,
+  LinkedFriend,
+  BirthData,
+  NatalChart,
+} from "@/types/natalChart";
+
+const isServerWithDB = (): boolean => {
+  return typeof window === "undefined" && !!process.env.DATABASE_URL;
+};
+
+let dbModule: typeof import("@/lib/database") | null = null;
+const getDbModule = async () => {
+  if (!dbModule && isServerWithDB()) {
+    try {
+      dbModule = await import("@/lib/database");
+    } catch {
+      _logger.warn("Database module not available for social service");
+    }
+  }
+  return dbModule;
+};
+
+// ─── In-memory fallback stores ───────────────────────────
+const friendshipsStore: Map<string, Friendship> = new Map();
+const savedChartsStore: Map<string, SavedChart> = new Map();
+
+class SocialDatabaseService {
+  // ─── User Search ─────────────────────────────────────────
+
+  /**
+   * Search for registered users by email (partial match).
+   * Returns basic info only (no sensitive data).
+   */
+  async searchUsersByEmail(
+    query: string,
+    excludeUserId: string,
+    limit = 10,
+  ): Promise<Array<{ id: string; name: string; email: string }>> {
+    const db = await getDbModule();
+    if (!db) return [];
+
+    try {
+      const result = await db.executeQuery(
+        `SELECT u.id, COALESCE(up.name, u.name, '') as name, u.email
+         FROM users u
+         LEFT JOIN user_profiles up ON u.id = up.user_id
+         WHERE u.email ILIKE $1
+           AND u.id != $2
+           AND u.is_active = true
+         ORDER BY u.email
+         LIMIT $3`,
+        [`%${query}%`, excludeUserId, limit],
+      );
+      return result.rows.map((r: any) => ({
+        id: r.id,
+        name: r.name || "",
+        email: r.email,
+      }));
+    } catch (error) {
+      _logger.error("searchUsersByEmail failed:", error as any);
+      return [];
+    }
+  }
+
+  // ─── Friendships ─────────────────────────────────────────
+
+  /**
+   * Send a friend request from requester to addressee.
+   * Prevents duplicates and self-requests.
+   */
+  async createFriendRequest(
+    requesterId: string,
+    addresseeId: string,
+  ): Promise<Friendship | null> {
+    if (requesterId === addresseeId) return null;
+
+    const db = await getDbModule();
+    const id = `friendship_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`;
+    const now = new Date().toISOString();
+
+    const friendship: Friendship = {
+      id,
+      requesterId,
+      addresseeId,
+      status: "pending",
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    if (db) {
+      try {
+        // Check for existing friendship in either direction
+        const existing = await db.executeQuery(
+          `SELECT id, status FROM friendships
+           WHERE (requester_id = $1 AND addressee_id = $2)
+              OR (requester_id = $2 AND addressee_id = $1)`,
+          [requesterId, addresseeId],
+        );
+
+        if (existing.rows.length > 0) {
+          const row = existing.rows[0];
+          if (row.status === "blocked") return null;
+          // Already exists — return existing
+          return this.getFriendshipById(row.id);
+        }
+
+        await db.executeQuery(
+          `INSERT INTO friendships (id, requester_id, addressee_id, status)
+           VALUES ($1, $2, $3, 'pending')`,
+          [id, requesterId, addresseeId],
+        );
+
+        // Fetch with names
+        return this.getFriendshipById(id);
+      } catch (error) {
+        _logger.error("createFriendRequest failed:", error as any);
+        return null;
+      }
+    }
+
+    // In-memory fallback
+    friendshipsStore.set(id, friendship);
+    return friendship;
+  }
+
+  /**
+   * Update friendship status (accept, block).
+   * Only the addressee can accept; either party can block.
+   */
+  async updateFriendshipStatus(
+    friendshipId: string,
+    newStatus: FriendshipStatus,
+    actingUserId: string,
+  ): Promise<Friendship | null> {
+    const db = await getDbModule();
+
+    if (db) {
+      try {
+        // Verify the acting user is a party to the friendship
+        const check = await db.executeQuery(
+          `SELECT requester_id, addressee_id, status FROM friendships WHERE id = $1`,
+          [friendshipId],
+        );
+        if (check.rows.length === 0) return null;
+
+        const { requester_id, addressee_id, status } = check.rows[0];
+        const isParty = actingUserId === requester_id || actingUserId === addressee_id;
+        if (!isParty) return null;
+
+        // Only addressee can accept
+        if (newStatus === "accepted" && actingUserId !== addressee_id) return null;
+        // Can't accept if already blocked
+        if (status === "blocked" && newStatus === "accepted") return null;
+
+        await db.executeQuery(
+          `UPDATE friendships SET status = $2::friendship_status, updated_at = CURRENT_TIMESTAMP WHERE id = $1`,
+          [friendshipId, newStatus],
+        );
+
+        return this.getFriendshipById(friendshipId);
+      } catch (error) {
+        _logger.error("updateFriendshipStatus failed:", error as any);
+        return null;
+      }
+    }
+
+    // In-memory fallback
+    const f = friendshipsStore.get(friendshipId);
+    if (!f) return null;
+    f.status = newStatus;
+    f.updatedAt = new Date().toISOString();
+    return f;
+  }
+
+  /**
+   * Delete a friendship (reject / unfriend).
+   */
+  async deleteFriendship(
+    friendshipId: string,
+    actingUserId: string,
+  ): Promise<boolean> {
+    const db = await getDbModule();
+
+    if (db) {
+      try {
+        const result = await db.executeQuery(
+          `DELETE FROM friendships
+           WHERE id = $1 AND (requester_id = $2 OR addressee_id = $2)`,
+          [friendshipId, actingUserId],
+        );
+        return (result.rowCount ?? 0) > 0;
+      } catch (error) {
+        _logger.error("deleteFriendship failed:", error as any);
+        return false;
+      }
+    }
+
+    friendshipsStore.delete(friendshipId);
+    return true;
+  }
+
+  /**
+   * Get all friendships for a user (both directions).
+   */
+  async getFriendshipsForUser(userId: string): Promise<Friendship[]> {
+    const db = await getDbModule();
+
+    if (db) {
+      try {
+        const result = await db.executeQuery(
+          `SELECT f.id, f.requester_id, f.addressee_id, f.status,
+                  f.created_at, f.updated_at,
+                  COALESCE(up_req.name, u_req.name, '') as requester_name,
+                  u_req.email as requester_email,
+                  COALESCE(up_adr.name, u_adr.name, '') as addressee_name,
+                  u_adr.email as addressee_email
+           FROM friendships f
+           JOIN users u_req ON f.requester_id = u_req.id
+           JOIN users u_adr ON f.addressee_id = u_adr.id
+           LEFT JOIN user_profiles up_req ON f.requester_id = up_req.user_id
+           LEFT JOIN user_profiles up_adr ON f.addressee_id = up_adr.user_id
+           WHERE f.requester_id = $1 OR f.addressee_id = $1
+           ORDER BY f.updated_at DESC`,
+          [userId],
+        );
+
+        return result.rows.map((r: any) => this.rowToFriendship(r));
+      } catch (error) {
+        _logger.error("getFriendshipsForUser failed:", error as any);
+        return [];
+      }
+    }
+
+    // In-memory fallback
+    return Array.from(friendshipsStore.values()).filter(
+      (f) => f.requesterId === userId || f.addresseeId === userId,
+    );
+  }
+
+  /**
+   * Get accepted friends with their natal chart data (for dining companion sync).
+   */
+  async getLinkedFriendsForUser(userId: string): Promise<LinkedFriend[]> {
+    const db = await getDbModule();
+    if (!db) return [];
+
+    try {
+      const result = await db.executeQuery(
+        `SELECT
+            CASE WHEN f.requester_id = $1 THEN f.addressee_id ELSE f.requester_id END as friend_id,
+            CASE WHEN f.requester_id = $1 THEN COALESCE(up_adr.name, u_adr.name, '') ELSE COALESCE(up_req.name, u_req.name, '') END as friend_name,
+            CASE WHEN f.requester_id = $1 THEN u_adr.email ELSE u_req.email END as friend_email,
+            CASE WHEN f.requester_id = $1 THEN up_adr.natal_chart ELSE up_req.natal_chart END as natal_chart,
+            CASE WHEN f.requester_id = $1 THEN up_adr.birth_data ELSE up_req.birth_data END as birth_data,
+            f.id as friendship_id,
+            f.updated_at as synced_at
+         FROM friendships f
+         JOIN users u_req ON f.requester_id = u_req.id
+         JOIN users u_adr ON f.addressee_id = u_adr.id
+         LEFT JOIN user_profiles up_req ON f.requester_id = up_req.user_id
+         LEFT JOIN user_profiles up_adr ON f.addressee_id = up_adr.user_id
+         WHERE (f.requester_id = $1 OR f.addressee_id = $1)
+           AND f.status = 'accepted'`,
+        [userId],
+      );
+
+      return result.rows
+        .filter((r: any) => {
+          // Only include friends who have completed onboarding (have natal chart)
+          const chart = typeof r.natal_chart === "string" ? JSON.parse(r.natal_chart) : r.natal_chart;
+          return chart && Object.keys(chart).length > 0;
+        })
+        .map((r: any) => {
+          const natalChart = typeof r.natal_chart === "string" ? JSON.parse(r.natal_chart) : r.natal_chart;
+          const birthData = typeof r.birth_data === "string" ? JSON.parse(r.birth_data) : r.birth_data;
+          return {
+            userId: r.friend_id,
+            name: r.friend_name,
+            email: r.friend_email,
+            natalChart,
+            birthData,
+            friendshipId: r.friendship_id,
+            syncedAt: r.synced_at?.toISOString?.() ?? new Date().toISOString(),
+          } as LinkedFriend;
+        });
+    } catch (error) {
+      _logger.error("getLinkedFriendsForUser failed:", error as any);
+      return [];
+    }
+  }
+
+  private async getFriendshipById(id: string): Promise<Friendship | null> {
+    const db = await getDbModule();
+    if (!db) return friendshipsStore.get(id) || null;
+
+    try {
+      const result = await db.executeQuery(
+        `SELECT f.id, f.requester_id, f.addressee_id, f.status,
+                f.created_at, f.updated_at,
+                COALESCE(up_req.name, u_req.name, '') as requester_name,
+                u_req.email as requester_email,
+                COALESCE(up_adr.name, u_adr.name, '') as addressee_name,
+                u_adr.email as addressee_email
+         FROM friendships f
+         JOIN users u_req ON f.requester_id = u_req.id
+         JOIN users u_adr ON f.addressee_id = u_adr.id
+         LEFT JOIN user_profiles up_req ON f.requester_id = up_req.user_id
+         LEFT JOIN user_profiles up_adr ON f.addressee_id = up_adr.user_id
+         WHERE f.id = $1`,
+        [id],
+      );
+      if (result.rows.length === 0) return null;
+      return this.rowToFriendship(result.rows[0]);
+    } catch {
+      return null;
+    }
+  }
+
+  private rowToFriendship(row: any): Friendship {
+    return {
+      id: row.id,
+      requesterId: row.requester_id,
+      requesterName: row.requester_name || undefined,
+      requesterEmail: row.requester_email || undefined,
+      addresseeId: row.addressee_id,
+      addresseeName: row.addressee_name || undefined,
+      addresseeEmail: row.addressee_email || undefined,
+      status: row.status as FriendshipStatus,
+      createdAt: row.created_at?.toISOString?.() ?? row.created_at,
+      updatedAt: row.updated_at?.toISOString?.() ?? row.updated_at,
+    };
+  }
+
+  // ─── Saved Charts (Cosmic Identities) ───────────────────
+
+  /**
+   * Get all saved charts for a user.
+   */
+  async getSavedChartsForUser(userId: string): Promise<SavedChart[]> {
+    const db = await getDbModule();
+
+    if (db) {
+      try {
+        const result = await db.executeQuery(
+          `SELECT * FROM saved_charts WHERE owner_id = $1 ORDER BY is_primary DESC, created_at ASC`,
+          [userId],
+        );
+        return result.rows.map((r: any) => this.rowToSavedChart(r));
+      } catch (error) {
+        _logger.error("getSavedChartsForUser failed:", error as any);
+        return [];
+      }
+    }
+
+    return Array.from(savedChartsStore.values()).filter((c) => c.ownerId === userId);
+  }
+
+  /**
+   * Create a new saved chart (cosmic identity or manual companion chart).
+   */
+  async createSavedChart(data: {
+    ownerId: string;
+    label: string;
+    chartType: SavedChart["chartType"];
+    birthData: BirthData;
+    natalChart: NatalChart;
+    isPrimary?: boolean;
+  }): Promise<SavedChart | null> {
+    const db = await getDbModule();
+    const id = `chart_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`;
+    const now = new Date().toISOString();
+
+    const chart: SavedChart = {
+      id,
+      ownerId: data.ownerId,
+      label: data.label,
+      chartType: data.chartType,
+      birthData: data.birthData,
+      natalChart: data.natalChart,
+      isPrimary: data.isPrimary ?? false,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    if (db) {
+      try {
+        await db.executeQuery(
+          `INSERT INTO saved_charts (id, owner_id, label, chart_type, birth_data, natal_chart, is_primary)
+           VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+          [
+            id,
+            data.ownerId,
+            data.label,
+            data.chartType,
+            JSON.stringify(data.birthData),
+            JSON.stringify(data.natalChart),
+            data.isPrimary ?? false,
+          ],
+        );
+        return chart;
+      } catch (error) {
+        _logger.error("createSavedChart failed:", error as any);
+        return null;
+      }
+    }
+
+    savedChartsStore.set(id, chart);
+    return chart;
+  }
+
+  /**
+   * Delete a saved chart (only if owned by the user and not the primary chart).
+   */
+  async deleteSavedChart(chartId: string, userId: string): Promise<boolean> {
+    const db = await getDbModule();
+
+    if (db) {
+      try {
+        const result = await db.executeQuery(
+          `DELETE FROM saved_charts WHERE id = $1 AND owner_id = $2 AND is_primary = false`,
+          [chartId, userId],
+        );
+        return (result.rowCount ?? 0) > 0;
+      } catch (error) {
+        _logger.error("deleteSavedChart failed:", error as any);
+        return false;
+      }
+    }
+
+    const chart = savedChartsStore.get(chartId);
+    if (chart && chart.ownerId === userId && !chart.isPrimary) {
+      savedChartsStore.delete(chartId);
+      return true;
+    }
+    return false;
+  }
+
+  private rowToSavedChart(row: any): SavedChart {
+    return {
+      id: row.id,
+      ownerId: row.owner_id,
+      label: row.label,
+      chartType: row.chart_type,
+      birthData: typeof row.birth_data === "string" ? JSON.parse(row.birth_data) : row.birth_data,
+      natalChart: typeof row.natal_chart === "string" ? JSON.parse(row.natal_chart) : row.natal_chart,
+      isPrimary: row.is_primary,
+      createdAt: row.created_at?.toISOString?.() ?? row.created_at,
+      updatedAt: row.updated_at?.toISOString?.() ?? row.updated_at,
+    };
+  }
+}
+
+export const socialDatabase = new SocialDatabaseService();

--- a/src/types/natalChart.ts
+++ b/src/types/natalChart.ts
@@ -132,3 +132,70 @@ export interface GroupScoringStrategy {
   weights?: Record<string, number>; // Optional member weights (memberId -> weight)
   minimumConsensus?: number; // For consensus strategy (0-1)
 }
+
+// ─── Social & Multi-Chart Types ──────────────────────────
+
+/**
+ * Friendship status between two registered users
+ */
+export type FriendshipStatus = "pending" | "accepted" | "blocked";
+
+/**
+ * Friendship record between two registered users
+ */
+export interface Friendship {
+  id: string;
+  requesterId: string;
+  requesterName?: string;
+  requesterEmail?: string;
+  addresseeId: string;
+  addresseeName?: string;
+  addresseeEmail?: string;
+  status: FriendshipStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * A saved birth chart — can be a primary chart, cosmic identity, or manual companion chart.
+ * Decoupled from the monolithic user_profiles JSONB for easier querying and sharing.
+ */
+export interface SavedChart {
+  id: string;
+  ownerId: string;
+  label: string;
+  chartType: "primary" | "cosmic_identity" | "manual";
+  birthData: BirthData;
+  natalChart: NatalChart;
+  isPrimary: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * A linked friend in the dining companions list.
+ * When a friendship is accepted, the friend's chart data is synced here.
+ */
+export interface LinkedFriend {
+  userId: string;
+  name: string;
+  email: string;
+  natalChart: NatalChart;
+  birthData: BirthData;
+  friendshipId: string;
+  syncedAt: string;
+}
+
+/**
+ * Union type for dining companion entries — either a manual GroupMember or a LinkedFriend
+ */
+export type DiningCompanion =
+  | ({ type: "manual" } & GroupMember)
+  | ({ type: "linked" } & LinkedFriend);
+
+/**
+ * Extended DiningGroup that supports a mix of manual and linked members
+ */
+export interface ExtendedDiningGroup extends DiningGroup {
+  linkedUserIds?: string[]; // IDs of linked registered users in this group
+}


### PR DESCRIPTION
## Summary

- **Database**: New `friendships` and `saved_charts` PostgreSQL tables (migration `10-social-schema.sql`) with proper indexes, constraints, and triggers
- **Friendships**: Full request/accept/reject/block flow via `/api/friends/*` endpoints, with many-to-many user relationships and automatic natal chart sharing on acceptance
- **Saved Charts**: Decoupled birth charts from monolithic `user_profiles` JSONB into queryable `saved_charts` table, supporting primary charts, cosmic identities, and manual companion charts via `/api/user/charts`
- **Mixed Dining Groups**: `group-recommendations` API now resolves both manual `GroupMember` commensals and `LinkedFriend` registered users seamlessly for unified recipe scoring
- **Dual-Track UI**: CommensalManager now offers [Add Manual Chart] | [Search by Email] toggle — manual charts for non-users, email search + friend request for registered users
- **Social Dashboard Tab**: New Social tab with incoming/outgoing request management and accepted friends list

## New Files

| File | Purpose |
|------|---------|
| `database/init/10-social-schema.sql` | friendships + saved_charts tables |
| `src/services/socialDatabaseService.ts` | Friendship CRUD, user search, linked friend resolution |
| `src/app/api/friends/route.ts` | GET all friendships for user |
| `src/app/api/friends/request/route.ts` | POST send friend request by email |
| `src/app/api/friends/accept/route.ts` | POST accept pending request |
| `src/app/api/friends/reject/route.ts` | POST reject/block/unfriend |
| `src/app/api/users/search/route.ts` | GET search users by email |
| `src/app/api/user/charts/route.ts` | GET/POST cosmic identity charts |
| `src/components/dashboard/SocialManager.tsx` | Friend request management UI |

## Modified Files

| File | Change |
|------|--------|
| `src/types/natalChart.ts` | Added Friendship, SavedChart, LinkedFriend, DiningCompanion, ExtendedDiningGroup types |
| `src/contexts/UserContext/index.tsx` | Extended UserProfile with friendships, linkedFriends, savedCharts |
| `src/app/api/group-recommendations/route.ts` | Support mixed manual + linked members |
| `src/components/dashboard/CommensalManager.tsx` | Dual-track add, linked friend display, mixed group support |
| `src/components/dashboard/UserDashboard.tsx` | Added Social tab |

## Test plan

- [ ] Verify manual chart addition still works end-to-end (name + birth data + location -> natal chart calculated)
- [ ] Verify email search returns registered users (requires 2+ test accounts)
- [ ] Verify friend request/accept flow creates linked friend with synced natal chart
- [ ] Verify group recommendations work with a mix of manual commensals and linked friends
- [ ] Verify Social tab shows incoming/outgoing/accepted friendships
- [ ] Run `yarn tsc --noEmit --skipLibCheck` — zero new TypeScript errors
- [ ] Run database migration on test PostgreSQL instance

https://claude.ai/code/session_01MEqpDzC7xLVtTwRk5yBBkJ