### PR TITLE
Fix alchemize function calls and refactor alchmWeight scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: yarn

--- a/src/app/api/alchm-quantities/trends/route.ts
+++ b/src/app/api/alchm-quantities/trends/route.ts
@@ -62,7 +62,7 @@ export async function GET() {
         // Calculate alchemical properties for this moment.
         // CRITICAL: pass timePoint so the sect (day/night) is correct for
         // that historical moment, not always "now".
-        const alchemicalResult = alchemize(planetaryPositions, timePoint);
+        const alchemicalResult = alchemize(planetaryPositions, null, timePoint);
 
         // Format time label
         const timeLabel =

--- a/src/lib/economy/livePricing.ts
+++ b/src/lib/economy/livePricing.ts
@@ -50,7 +50,7 @@ export async function getLivePricingContext(now = new Date()): Promise<LivePrici
     positions = getFallbackPlanetaryPositions();
   }
 
-  const alch = alchemize(asPlanetaryPositions(positions), now);
+  const alch = alchemize(asPlanetaryPositions(positions), null, now);
   const aNumber =
     Number(alch.esms.Spirit || 0) +
     Number(alch.esms.Essence || 0) +

--- a/src/services/RealAlchemizeService.ts
+++ b/src/services/RealAlchemizeService.ts
@@ -48,6 +48,7 @@ export interface PlanetaryPosition {
   degree: number;
   minute: number;
   isRetrograde: boolean;
+  exactLongitude?: number;
 }
 export interface ThermodynamicProperties {
   heat: number;
@@ -246,14 +247,15 @@ export function alchemize(
   for (const [planet, position] of Object.entries(planetaryPositions)) {
     // Get planetary alchemical properties
     const alchemy = planetaryAlchemy[planet];
+    // Alchm weighting: orbital period (slower = deeper alchemical tide)
+    // SPECIAL CASE: The Ascendant is the "Physical Vessel" grounding constant (weight = 1.0)
+    // Declared here (outside if-alchemy) so alchmWeight is in scope for momentum calc below.
+    const period = PLANET_ALCHM_PERIODS[planet] ?? 1.0;
+    const alchmWeight = planet === "Ascendant" ? 1.0 : normalizeAlchmWeight(period);
     if (alchemy) {
       // Apply dignity modifier (existing ±0.15/level scale kept for RealAlchemize compat)
       const dignity = getPlanetaryDignity(planet, position.sign);
       const dignityMultiplier = Math.max(0.5, 1.0 + dignity * 0.15);
-      // Alchm weighting: orbital period (slower = deeper alchemical tide)
-      // SPECIAL CASE: The Ascendant is the "Physical Vessel" grounding constant (weight = 1.0)
-      const period = PLANET_ALCHM_PERIODS[planet] ?? 1.0;
-      const alchmWeight = planet === "Ascendant" ? 1.0 : normalizeAlchmWeight(period);
       totals.Spirit    += alchemy.Spirit    * dignityMultiplier * alchmWeight;
       totals.Essence   += alchemy.Essence   * dignityMultiplier * alchmWeight;
       totals.Matter    += alchemy.Matter    * dignityMultiplier * alchmWeight;


### PR DESCRIPTION
## Summary
This PR fixes function signature mismatches in alchemize calls and refactors the alchemical weighting calculation to ensure proper variable scope for momentum calculations.

## Key Changes
- **Fixed alchemize function calls**: Updated calls in `trends/route.ts` and `livePricing.ts` to pass `null` as the second parameter, matching the expected function signature
- **Refactored alchmWeight calculation**: Moved `period` and `alchmWeight` variable declarations outside the `if (alchemy)` block in `RealAlchemizeService.ts` to ensure they're in scope for subsequent momentum calculations
- **Added exactLongitude field**: Extended `PlanetaryPosition` interface with optional `exactLongitude` property for more precise positional data
- **Updated CI workflow**: Downgraded `actions/setup-node` from v6 to v4 for Node.js setup

## Implementation Details
The alchmWeight refactoring is particularly important as it ensures the alchemical weighting (based on orbital period) is calculated once and available for all downstream calculations, including momentum computations that may depend on this value. The special case for the Ascendant (weight = 1.0) is preserved and now properly documented with inline comments explaining the "Physical Vessel" grounding constant concept.

https://claude.ai/code/session_012kxNs2pHnhHgf69ekrPr8G