### PR TITLE
Implement meal regeneration and improve recipe filtering logic

### DIFF
--- a/src/app/api/instacart/price-estimate/route.ts
+++ b/src/app/api/instacart/price-estimate/route.ts
@@ -4,6 +4,9 @@ import {
   InstacartConfigurationError,
 } from "@/lib/instacart/idpClient";
 import type { InstacartShoppingListRequest } from "@/types/instacart";
+import { createLogger } from "@/utils/logger";
+
+const logger = createLogger("instacart/price-estimate");
 
 /**
  * POST /api/instacart/price-estimate
@@ -65,7 +68,7 @@ export async function POST(req: Request) {
     });
 
   } catch (error) {
-    console.error("Price Probe Error:", error);
+    logger.error("Price probe error", error as Error);
     return NextResponse.json({ confidence: "low", error: "Internal probe failure" }, { status: 500 });
   }
 }

--- a/src/app/api/instacart/shopping-list/route.ts
+++ b/src/app/api/instacart/shopping-list/route.ts
@@ -153,7 +153,7 @@ export async function POST(request: NextRequest) {
       urlObj.searchParams.set("utm_medium", "affiliate");
       urlObj.searchParams.set("utm_campaign", "idp_integration");
       productsLinkUrl = urlObj.toString();
-    } catch (_e) {
+    } catch {
       // fallback if URL parsing fails
       const separator = productsLinkUrl.includes("?") ? "&" : "?";
       productsLinkUrl += `${separator}utm_source=whattoeatnext&utm_medium=affiliate&utm_campaign=idp_integration`;

--- a/src/components/AlchmKitchen.tsx
+++ b/src/components/AlchmKitchen.tsx
@@ -53,8 +53,10 @@ export default function AlchmKitchen() {
   const [displayPositions, setDisplayPositions] = useState<any>(null);
 
   // Get current state from AlchemicalContext
-  const { planetaryPositions, state } = useAlchemical();
+  const { planetaryPositions: rawPositions, state } = useAlchemical();
   const { elementalState, alchemicalValues, astrologicalState } = state;
+  // Cast to a typed shape — context stores positions as Record<string, unknown>
+  const planetaryPositions = rawPositions as Record<string, { sign?: string; degree?: number } | undefined>;
 
   // Current states to use (either global context or custom calculated)
   const currentSign = astrologicalState?.sunSign || 'unknown';

--- a/src/components/AlchmKitchen.tsx
+++ b/src/components/AlchmKitchen.tsx
@@ -53,7 +53,8 @@ export default function AlchmKitchen() {
   const [displayPositions, setDisplayPositions] = useState<any>(null);
 
   // Get current state from AlchemicalContext
-  const { planetaryPositions, elementalState, alchemicalValues, astrologicalState } = useAlchemical();
+  const { planetaryPositions, state } = useAlchemical();
+  const { elementalState, alchemicalValues, astrologicalState } = state;
 
   // Current states to use (either global context or custom calculated)
   const currentSign = astrologicalState?.sunSign || 'unknown';

--- a/src/components/menu-builder/QuickActionsToolbar.tsx
+++ b/src/components/menu-builder/QuickActionsToolbar.tsx
@@ -129,11 +129,16 @@ export default function QuickActionsToolbar() {
         usePersonalization: hasNatalChart,
       });
 
-      // If generateMealsForDay didn't fill slots, try UnifiedRecipeService fallback
-      const dayMeals = currentMenu.meals.filter(
-        (m) => m.dayOfWeek === nextEmptyDay && m.recipe,
+      // If any meal slot is still empty after generation, fill it via fallback
+      const filledTypes = new Set(
+        currentMenu.meals
+          .filter((m) => m.dayOfWeek === nextEmptyDay && m.recipe)
+          .map((m) => m.mealType),
       );
-      if (dayMeals.length === 0) {
+      const allFilled = (["breakfast", "lunch", "dinner"] as MealType[]).every(
+        (t) => filledTypes.has(t),
+      );
+      if (!allFilled) {
         await fillDayWithRecipeService(nextEmptyDay);
       }
 

--- a/src/components/menu-planner/GroceryListModal.tsx
+++ b/src/components/menu-planner/GroceryListModal.tsx
@@ -348,11 +348,10 @@ export default function GroceryListModal({
       await exportGroceryList(groceryList, format);
 
       if (format === "clipboard") {
-        // Show temporary success message
-        console.warn("Grocery list copied to clipboard!");
+        logger.info("Grocery list copied to clipboard");
       }
     } catch (_error) {
-      console.warn("Failed to export grocery list. Please try again.");
+      logger.warn("Failed to export grocery list");
     }
   };
 

--- a/src/components/menu-planner/PossoWidget.tsx
+++ b/src/components/menu-planner/PossoWidget.tsx
@@ -75,7 +75,15 @@ export default function PossoWidget({
           }));
 
           const originalEstimate = calculateRecipeEstimatedCost(normalizedIngs, 4, []);
-          const possoEstimate = calculateRecipeEstimatedCost(normalizedIngs, 4, inventory);
+          // Posso cost = only what the user still needs to buy (exclude inventory items)
+          const possoIngs = normalizedIngs.filter(
+            (ing) => !inventory.some((invItem) => {
+              const ingLower = ing.name.toLowerCase();
+              const invLower = invItem.toLowerCase();
+              return ingLower.includes(invLower) || invLower.includes(ingLower);
+            })
+          );
+          const possoEstimate = calculateRecipeEstimatedCost(possoIngs, 4, []);
 
           return {
             ...recipe,

--- a/src/contexts/MenuPlannerContext.tsx
+++ b/src/contexts/MenuPlannerContext.tsx
@@ -1236,26 +1236,8 @@ export function MenuPlannerProvider({ children }: { children: ReactNode }) {
     [currentMenu],
   );
 
-  /**
-   * Regenerate day with new recommendations
-   * TODO: Implement actual recommendation logic in Phase 3
-   */
-  const regenerateDay = useCallback(
-    async (dayOfWeek: DayOfWeek) => {
-      if (!currentMenu) return;
-
-      try {
-        // For now, just clear the day
-        // In Phase 3, this will call the recommendation engine
-        await clearDay(dayOfWeek);
-        logger.info(`Regenerated day ${dayOfWeek} (placeholder)`);
-      } catch (err) {
-        logger.error("Failed to regenerate day:", err);
-        throw err;
-      }
-    },
-    [currentMenu, clearDay],
-  );
+  // regenerateDay is defined after generateMealsForDay (see below) so it can
+  // call it. Forward-declare the ref so the context value shape stays intact.
 
   // Get user context for personalization
   const natalChart = currentUser?.natalChart;
@@ -1436,6 +1418,30 @@ export function MenuPlannerProvider({ children }: { children: ReactNode }) {
       weeklyBudget,
       syncWithLunarCycle,
     ],
+  );
+
+  /**
+   * Regenerate a day: clears existing meals then re-runs the recommendation
+   * engine for that day.  Defined after generateMealsForDay so the dependency
+   * is always resolved.
+   */
+  const regenerateDay = useCallback(
+    async (dayOfWeek: DayOfWeek) => {
+      if (!currentMenu) return;
+      try {
+        await clearDay(dayOfWeek);
+        await generateMealsForDay(dayOfWeek, {
+          mealTypes: ["breakfast", "lunch", "dinner"],
+          useCurrentPlanetary: true,
+          usePersonalization: !!natalChart,
+        });
+        logger.info(`Regenerated day ${dayOfWeek}`);
+      } catch (err) {
+        logger.error("Failed to regenerate day:", err);
+        throw err;
+      }
+    },
+    [currentMenu, clearDay, generateMealsForDay, natalChart],
   );
 
   /**

--- a/src/utils/instacart/priceEstimator.ts
+++ b/src/utils/instacart/priceEstimator.ts
@@ -72,8 +72,7 @@ export function estimateIngredientCost(
   const TIER_MODIFIER = tier === "premium" ? 1.35 : tier === "pantry" ? 0.05 : 1.0;
   
   if (priceMatch) {
-    const nLow = name.toLowerCase();
-    const isExact = priceMatch.unit === unit || nLow.includes(Object.keys(getPricePoint(name) || {}).find(k => k === nLow) || "###");
+    const isExact = priceMatch.unit === unit;
     const confidence = isExact ? "exact" : ("fuzzy" as const);
     
     // Scale price based on units

--- a/src/utils/menuPlanner/recommendationBridge.ts
+++ b/src/utils/menuPlanner/recommendationBridge.ts
@@ -1019,9 +1019,8 @@ function scoreRecipeForDay(
     reasons.push(`Matches ${dayChar.nutritionalEmphasis} emphasis`);
   }
 
-  // 4. Meal type appropriateness - THIS NEEDS TO BE RE-IMPLEMENTED FOR MONICAOPTIMIZEDRECIPE
-  // For now, setting a placeholder score
-  const mealTypeScore = 0.8; // Placeholder
+  // 4. Meal type appropriateness
+  const mealTypeScore = isSuitableForMealType(recipe, mealType) ? 1.0 : 0.5;
   score += mealTypeScore * weights.mealType;
 
   // 5. Planetary hour alignment — use a gradient instead of binary


### PR DESCRIPTION
## Summary
This PR implements the actual meal regeneration feature for the menu planner and improves recipe filtering and cost estimation logic across multiple components. The changes move from placeholder implementations to functional features that integrate with the recommendation engine.

## Key Changes

- **Regenerate Day Implementation**: Moved `regenerateDay` function to after `generateMealsForDay` definition so it can properly call the recommendation engine. Now clears existing meals and re-generates them with personalization options instead of being a placeholder.

- **Improved Empty Slot Detection**: Enhanced `QuickActionsToolbar` to check which specific meal types are missing rather than just checking if any meals exist, providing more accurate fallback triggering.

- **Posso Cost Calculation Fix**: Updated `PossoWidget` to properly exclude inventory items from cost estimation by filtering ingredients before calculation, ensuring users only see costs for items they need to purchase.

- **Meal Type Appropriateness Scoring**: Replaced placeholder score in `recommendationBridge.ts` with actual `isSuitableForMealType` check, enabling proper recipe-to-meal-type matching.

- **Logger Consistency**: Replaced `console.error` and `console.warn` calls with proper logger instances across `instacart/price-estimate` route and `GroceryListModal` for consistent logging.

- **Type Safety Improvements**: Added proper type casting for `planetaryPositions` in `AlchmKitchen` component to handle context's untyped storage.

- **Code Cleanup**: Simplified price estimation logic in `priceEstimator.ts` by removing unnecessary string matching logic and fixed unused variable in `shopping-list` route.

## Implementation Details

The `regenerateDay` callback now properly depends on `generateMealsForDay` and `natalChart` to ensure personalization is applied during regeneration. The function follows the same pattern as the initial meal generation, maintaining consistency across the codebase.

https://claude.ai/code/session_01TtEUSvFfUSCQhuA7veRetj