### PR TITLE
Add nutrition aggregation and recipe indexing for performance

### DIFF
--- a/src/actions/recipes.ts
+++ b/src/actions/recipes.ts
@@ -2,14 +2,56 @@
 
 import { primaryCuisines } from "@/data/cuisines/index";
 import type { Recipe } from "@/types/recipe";
+import type { IndexedRecipe, RecipeIndex } from "@/types/indexedRecipe";
+import { computeRecipeNutritionFromIngredients } from "@/utils/ingredientNutritionAggregation";
+import {
+  hasNutritionData,
+  normalizeRecipeNutrition,
+} from "@/utils/recipeNutrition";
+
+interface NutritionCoverageStats {
+  total: number;
+  fromSource: number; // had usable nutritionPerServing / nutrition / nutritionalProfile
+  fromIngredients: number; // filled via UnifiedIngredientService fallback
+  missing: number; // still zero after both paths
+  missingNames: string[];
+}
+
+let _cachedRecipes: IndexedRecipe[] | null = null;
+let _cachedIndex: RecipeIndex | null = null;
+let _nutritionStats: NutritionCoverageStats = {
+  total: 0,
+  fromSource: 0,
+  fromIngredients: 0,
+  missing: 0,
+  missingNames: [],
+};
+
+function lowerArray(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) {
+    const out = value
+      .filter((v): v is string => typeof v === "string")
+      .map((v) => v.toLowerCase());
+    return out.length ? out : undefined;
+  }
+  if (typeof value === "string") return [value.toLowerCase()];
+  return undefined;
+}
 
 /**
  * Extract and normalize recipes from the static cuisine data files.
  * This is the authoritative source for the 351 recipes.
  */
-function extractRecipesFromCuisines(): Recipe[] {
-  const recipes: Recipe[] = [];
+function extractRecipesFromCuisines(): IndexedRecipe[] {
+  const recipes: IndexedRecipe[] = [];
   const seen = new Set<string>();
+  const stats: NutritionCoverageStats = {
+    total: 0,
+    fromSource: 0,
+    fromIngredients: 0,
+    missing: 0,
+    missingNames: [],
+  };
 
   for (const [cuisineName, cuisine] of Object.entries(primaryCuisines)) {
     if (!cuisine?.dishes) continue;
@@ -33,22 +75,33 @@ function extractRecipesFromCuisines(): Recipe[] {
           if (seen.has(key)) continue;
           seen.add(key);
 
-          const alchemical = (dish.alchemicalProfile ?? {}) as Record<string, unknown>;
-          const nutritional = (dish.nutritionalProfile ?? dish.nutrition ?? {}) as Record<string, unknown>;
+          const alchemical = (dish.alchemicalProfile ?? {}) as Record<
+            string,
+            unknown
+          >;
           const prepTime = Number(dish.prepTimeMinutes ?? 0);
           const cookTime = Number(dish.cookTimeMinutes ?? 0);
 
           const dietaryTags: string[] = [];
-          if (dish.isVegetarian || alchemical.vegetarian) dietaryTags.push("vegetarian");
+          if (dish.isVegetarian || alchemical.vegetarian)
+            dietaryTags.push("vegetarian");
           if (dish.isVegan || alchemical.vegan) dietaryTags.push("vegan");
-          if (dish.isGlutenFree || alchemical.glutenFree) dietaryTags.push("glutenFree");
-          if (dish.isDairyFree || alchemical.dairyFree) dietaryTags.push("dairyFree");
+          if (dish.isGlutenFree || alchemical.glutenFree)
+            dietaryTags.push("glutenFree");
+          if (dish.isDairyFree || alchemical.dairyFree)
+            dietaryTags.push("dairyFree");
 
-          const recipe: Recipe = {
-            id: (dish.id as string) ?? `${cuisineName.toLowerCase()}-${key.replace(/\s+/g, "-")}`,
+          const recipe: IndexedRecipe = {
+            id:
+              (dish.id as string) ??
+              `${cuisineName.toLowerCase()}-${key.replace(/\s+/g, "-")}`,
             name: dish.name,
             description: (dish.description as string) ?? "",
-            cuisine: (dish.cuisine as string) ?? (dish.alchemicalProfile as Record<string, unknown>)?.cuisine as string ?? cuisineName,
+            cuisine:
+              (dish.cuisine as string) ??
+              ((dish.alchemicalProfile as Record<string, unknown>)
+                ?.cuisine as string) ??
+              cuisineName,
             ingredients: Array.isArray(dish.ingredients)
               ? dish.ingredients.map((ing: unknown) => {
                   if (typeof ing === "string") {
@@ -68,7 +121,12 @@ function extractRecipesFromCuisines(): Recipe[] {
               ? dish.instructions.map((step: unknown) => {
                   if (typeof step === "string") return step;
                   const s = step as Record<string, unknown>;
-                  return (s.instruction as string) ?? (s.text as string) ?? (s.step as string) ?? String(step);
+                  return (
+                    (s.instruction as string) ??
+                    (s.text as string) ??
+                    (s.step as string) ??
+                    String(step)
+                  );
                 })
               : [],
             prepTime: String(prepTime),
@@ -82,14 +140,57 @@ function extractRecipesFromCuisines(): Recipe[] {
             isVegan: dietaryTags.includes("vegan"),
             isGlutenFree: dietaryTags.includes("glutenFree"),
             isDairyFree: dietaryTags.includes("dairyFree"),
-            nutrition: nutritional as any, // nutritional is complex and fits the interface loosely
-            elementalProperties: (dish.elementalProfile ?? dish.elementalProperties ?? {
-              Fire: 0.25,
-              Water: 0.25,
-              Earth: 0.25,
-              Air: 0.25,
-            }),
+            numberOfServings:
+              Number(
+                (dish as { numberOfServings?: unknown }).numberOfServings ??
+                  (dish as { servings?: unknown }).servings,
+              ) || undefined,
+            nutrition: undefined,
+            elementalProperties:
+              (dish.elementalProfile ?? dish.elementalProperties ?? {
+                Fire: 0.25,
+                Water: 0.25,
+                Earth: 0.25,
+                Air: 0.25,
+              }) as Recipe["elementalProperties"],
           };
+
+          // ── Nutrition pipeline ──
+          //
+          // 1. Try the canonical field-name mapping (reads
+          //    nutritionPerServing / nutritionalProfile / nutrition).
+          // 2. If that produces nothing, compute from the ingredient list
+          //    via UnifiedIngredientService.
+          // 3. If both fail, log a dev-only warning and leave nutrition
+          //    undefined so the counter gracefully skips this recipe.
+          stats.total++;
+          const normalized = normalizeRecipeNutrition(
+            dish as Record<string, unknown>,
+          );
+          if (normalized && hasNutritionData(normalized)) {
+            recipe.nutrition = normalized as Recipe["nutrition"];
+            stats.fromSource++;
+          } else {
+            const computed = computeRecipeNutritionFromIngredients(recipe);
+            if (computed && hasNutritionData(computed)) {
+              recipe.nutrition = computed as Recipe["nutrition"];
+              stats.fromIngredients++;
+            } else {
+              stats.missing++;
+              if (stats.missingNames.length < 20) {
+                stats.missingNames.push(recipe.name);
+              }
+            }
+          }
+
+          // ── Precomputed lowercased fields for perf in the bridge ──
+          recipe._lcCuisine = recipe.cuisine?.toLowerCase() ?? "";
+          recipe._lcTags = lowerArray(recipe.tags);
+          recipe._lcCookingMethod = lowerArray(
+            (recipe as { cookingMethod?: unknown }).cookingMethod,
+          );
+          recipe._lcSeasons = lowerArray(recipe.season);
+          recipe._lcMealTypes = lowerArray(recipe.mealType);
 
           recipes.push(recipe);
         }
@@ -97,11 +198,58 @@ function extractRecipesFromCuisines(): Recipe[] {
     }
   }
 
+  _nutritionStats = stats;
+
+  // Dev-only visibility for any recipes that couldn't be filled by either
+  // path. Silent in production to avoid flooding logs.
+  if (process.env.NODE_ENV !== "production" && stats.missing > 0) {
+    console.warn(
+      `[getServerRecipes] ${stats.missing}/${stats.total} recipes have no usable nutrition. ` +
+        `Sample: ${stats.missingNames.slice(0, 5).join(", ")}`,
+    );
+  }
+
   return recipes;
 }
 
-// Server-side in-memory cache
-let _cachedRecipes: Recipe[] | null = null;
+/** Build the mealType × season lookup index from a flat recipe array. */
+function buildRecipeIndex(recipes: IndexedRecipe[]): RecipeIndex {
+  const index: RecipeIndex = new Map();
+  const mealTypes = ["breakfast", "lunch", "dinner", "dessert"] as const;
+  const seasons = ["spring", "summer", "autumn", "winter", "all"] as const;
+
+  for (const mt of mealTypes) {
+    for (const s of seasons) {
+      index.set(`${mt}-${s}`, []);
+    }
+  }
+
+  for (const r of recipes) {
+    const recipeMealTypes =
+      r._lcMealTypes && r._lcMealTypes.length > 0
+        ? r._lcMealTypes
+        : ["breakfast", "lunch", "dinner"];
+    const recipeSeasons =
+      r._lcSeasons && r._lcSeasons.length > 0 ? r._lcSeasons : ["all"];
+
+    for (const mt of mealTypes) {
+      const mtMatches =
+        recipeMealTypes.includes(mt) ||
+        recipeMealTypes.some((m) => m.includes(mt));
+      if (!mtMatches) continue;
+
+      for (const s of recipeSeasons) {
+        const seasonKey =
+          s === "fall" ? "autumn" : s === "all" ? "all" : s;
+        const bucketKey = `${mt}-${seasonKey}`;
+        const bucket = index.get(bucketKey);
+        if (bucket) bucket.push(r);
+      }
+    }
+  }
+
+  return index;
+}
 
 /**
  * Server action to fetch all recipes from the static cuisine data files.
@@ -114,10 +262,38 @@ export async function getServerRecipes(): Promise<Recipe[]> {
     }
     const recipes = extractRecipesFromCuisines();
     _cachedRecipes = recipes;
-    console.log(`[getServerRecipes] Loaded ${recipes.length} recipes from static cuisine data`);
+    _cachedIndex = buildRecipeIndex(recipes);
+    console.log(
+      `[getServerRecipes] Loaded ${recipes.length} recipes from static cuisine data ` +
+        `(nutrition: ${_nutritionStats.fromSource} from source, ${_nutritionStats.fromIngredients} computed, ${_nutritionStats.missing} missing)`,
+    );
     return recipes;
   } catch (error) {
     console.error("Failed to load recipes from cuisine data:", error);
     return [];
   }
+}
+
+/**
+ * Return the prebuilt mealType × season index, building it on demand if
+ * `getServerRecipes` hasn't been called yet. Used by the recommendation
+ * bridge to avoid scanning all 351 recipes on every generation request.
+ */
+export async function getServerRecipeIndex(): Promise<RecipeIndex> {
+  if (!_cachedIndex) {
+    await getServerRecipes();
+  }
+  return _cachedIndex ?? new Map();
+}
+
+/**
+ * Diagnostics: how many of the cached recipes have real nutrition data and
+ * from which source. Returned as a plain object so it can be serialized to
+ * a diagnostics page.
+ */
+export async function getNutritionCoverageStats(): Promise<NutritionCoverageStats> {
+  if (!_cachedRecipes) {
+    await getServerRecipes();
+  }
+  return { ..._nutritionStats };
 }

--- a/src/app/api/recommendations/generate/route.ts
+++ b/src/app/api/recommendations/generate/route.ts
@@ -32,6 +32,74 @@ interface RetryGrant {
 const RETRY_WINDOW_MS = 5 * 60 * 1000;
 const retryGrants = new Map<string, RetryGrant>();
 
+// ── TTL memo cache for generation results ──────────────────────────────
+//
+// Identical (dayOfWeek, astroState, options) payloads are common on this
+// route: users frequently click Generate multiple times in quick succession
+// while exploring suggestions. Caching results for a few minutes lets those
+// repeat clicks return in <5 ms instead of rerunning the full filter+score
+// pipeline.
+interface MemoEntry {
+  recommendations: unknown;
+  expiresAt: number;
+}
+const MEMO_TTL_MS = 3 * 60 * 1000;
+const MEMO_MAX_ENTRIES = 64;
+const generationMemo = new Map<string, MemoEntry>();
+
+/**
+ * Deterministic JSON serialization. Built-in JSON.stringify is not stable
+ * because object key order is not guaranteed. We need a key for the memo
+ * cache that is identical across clicks with the same logical payload.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys
+    .map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`)
+    .join(",")}}`;
+}
+
+function memoKey(
+  userId: string,
+  dayOfWeek: number,
+  astroState: unknown,
+  options: unknown,
+): string {
+  return `${userId}|${dayOfWeek}|${stableStringify({ astroState, options })}`;
+}
+
+function lookupMemo(key: string): unknown | null {
+  const entry = generationMemo.get(key);
+  if (!entry) return null;
+  if (entry.expiresAt <= Date.now()) {
+    generationMemo.delete(key);
+    return null;
+  }
+  // Refresh insertion order so LRU-style eviction keeps the hottest entries.
+  generationMemo.delete(key);
+  generationMemo.set(key, entry);
+  return entry.recommendations;
+}
+
+function storeMemo(key: string, recommendations: unknown): void {
+  if (generationMemo.size >= MEMO_MAX_ENTRIES) {
+    // Map iteration order is insertion order — drop the oldest entry.
+    const oldestKey = generationMemo.keys().next().value;
+    if (oldestKey !== undefined) generationMemo.delete(oldestKey);
+  }
+  generationMemo.set(key, {
+    recommendations,
+    expiresAt: Date.now() + MEMO_TTL_MS,
+  });
+}
+
 function cleanupExpiredRetryGrants(now = Date.now()): void {
   for (const [token, grant] of retryGrants.entries()) {
     if (grant.expiresAt <= now) {
@@ -88,6 +156,7 @@ interface GenerateRequestBody {
 }
 
 export async function POST(request: NextRequest) {
+  const tStart = Date.now();
   const userId = await getUserIdFromRequest(request);
   if (!userId) {
     return NextResponse.json(
@@ -117,6 +186,34 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(
       { success: false, message: "Invalid request payload" },
       { status: 400 },
+    );
+  }
+
+  // ── Memo cache hit: return immediately without charging tokens ──
+  //
+  // We key on (userId, dayOfWeek, astroState, options). When the user
+  // clicks Generate repeatedly with the same payload, we return the
+  // previously computed result. No token charge on a cache hit.
+  const cacheKey = memoKey(userId, dayOfWeek, astroState, options);
+  const cachedRecommendations = lookupMemo(cacheKey);
+  if (cachedRecommendations !== null) {
+    const totalMs = Date.now() - tStart;
+    return NextResponse.json(
+      {
+        success: true,
+        recommendations: cachedRecommendations,
+        charged: false,
+        usedRetryWindow: false,
+        cached: true,
+        emptyResult:
+          Array.isArray(cachedRecommendations) &&
+          cachedRecommendations.length === 0,
+      },
+      {
+        headers: {
+          "Server-Timing": `cache;desc="hit";dur=${totalMs}, total;dur=${totalMs}`,
+        },
+      },
     );
   }
 
@@ -191,10 +288,12 @@ export async function POST(request: NextRequest) {
 
   try {
     // Keep below maxDuration to ensure timeout handling can return retry token.
+    const tGen = Date.now();
     const recommendations = await withTimeout(
       generateDayRecommendations(dayOfWeek, astroState, options),
       55_000,
     );
+    const genMs = Date.now() - tGen;
 
     // Success: the retry grant (if any) has delivered a recipe and must be
     // consumed so it cannot be reused to bypass future payments.
@@ -202,14 +301,25 @@ export async function POST(request: NextRequest) {
       deleteRetryGrant(retryToken);
     }
 
-    return NextResponse.json({
-      success: true,
-      recommendations,
-      charged,
-      usedRetryWindow,
-      // Tokens are intentionally charged even when recommendations are empty.
-      emptyResult: recommendations.length === 0,
-    });
+    // Cache the result for the TTL window so repeat clicks are instant.
+    storeMemo(cacheKey, recommendations);
+
+    const totalMs = Date.now() - tStart;
+    return NextResponse.json(
+      {
+        success: true,
+        recommendations,
+        charged,
+        usedRetryWindow,
+        // Tokens are intentionally charged even when recommendations are empty.
+        emptyResult: recommendations.length === 0,
+      },
+      {
+        headers: {
+          "Server-Timing": `generate;dur=${genMs}, total;dur=${totalMs}`,
+        },
+      },
+    );
   } catch (error) {
     if (error instanceof Error && error.message === "GENERATION_TIMEOUT") {
       // Issue or refresh a retry grant so the caller keeps the full

--- a/src/types/indexedRecipe.ts
+++ b/src/types/indexedRecipe.ts
@@ -1,0 +1,25 @@
+// src/types/indexedRecipe.ts
+//
+// Type-only module that is safe to import from any runtime (Edge, Node,
+// server actions). Next.js `"use server"` files may only export async
+// functions, so these type definitions live outside `src/actions/recipes.ts`
+// and are imported from both the server action and the recommendation
+// bridge.
+
+import type { Recipe } from "@/types/recipe";
+
+/**
+ * Internal shape for the pre-indexed recipe cache. The extra lowercased
+ * fields are attached on each recipe so the recommendation bridge can
+ * score without repeated toLowerCase() calls.
+ */
+export interface IndexedRecipe extends Recipe {
+  _lcCuisine?: string;
+  _lcTags?: string[];
+  _lcCookingMethod?: string[];
+  _lcSeasons?: string[];
+  _lcMealTypes?: string[];
+}
+
+/** Precomputed lookup buckets keyed by `${mealType}-${season}`. */
+export type RecipeIndex = Map<string, IndexedRecipe[]>;

--- a/src/utils/ingredientNutritionAggregation.ts
+++ b/src/utils/ingredientNutritionAggregation.ts
@@ -1,0 +1,358 @@
+// src/utils/ingredientNutritionAggregation.ts
+//
+// Fallback path for recipes that arrive without a populated
+// `nutritionPerServing`. Looks each recipe ingredient up by name in the
+// UnifiedIngredientService, scales the ingredient's nutritional profile to
+// the recipe's actual amount, sums the results, and divides by the recipe's
+// serving count to produce a per-serving nutrition payload.
+//
+// The aggregator is intentionally forgiving: missing or unrecognised
+// ingredients are skipped. When fewer than half of the ingredients resolve,
+// the aggregator declines to produce a result (returns `null`) rather than
+// report a misleadingly low total.
+
+import { UnifiedIngredientService } from "@/services/UnifiedIngredientService";
+import type { Recipe, RecipeIngredient } from "@/types/recipe";
+
+import type { NormalizedRecipeNutrition } from "./recipeNutrition";
+import { UNIT_CONVERSIONS, convertToGrams } from "./unitConversion";
+
+const DEFAULT_SERVING_GRAMS = 100;
+const DEFAULT_RECIPE_SERVINGS = 4;
+
+/**
+ * Extract the grams-per-serving value from a human-readable serving size
+ * string like "1 cup (148g)" or "1 tbsp (14g)".
+ *
+ * When the explicit grams annotation is missing, falls back to parsing the
+ * leading amount + unit ("1 cup") and multiplying by UNIT_CONVERSIONS.
+ */
+export function parseServingSizeGrams(
+  servingSize: string | undefined | null,
+): number | null {
+  if (!servingSize) return null;
+
+  // Prefer the explicit grams annotation — `(148g)` / `(148 g)` / `(1.5g)`.
+  const explicit = servingSize.match(/\((\d+(?:\.\d+)?)\s*g\)/i);
+  if (explicit) {
+    const grams = Number(explicit[1]);
+    if (Number.isFinite(grams) && grams > 0) return grams;
+  }
+
+  // Fall back to a leading amount + unit ("1 cup", "2 tbsp", "100 g").
+  const leading = servingSize.match(/^\s*(\d+(?:\.\d+)?)\s*([a-z ]+?)\b/i);
+  if (leading) {
+    const amount = Number(leading[1]);
+    const unit = leading[2]?.toLowerCase().trim();
+    const grams = convertToGrams(amount, unit ?? "");
+    if (grams != null && grams > 0) return grams;
+  }
+
+  return null;
+}
+
+type IngredientLike = {
+  nutritionalProfile?: unknown;
+};
+
+type NutritionalMacros = {
+  protein?: number;
+  carbs?: number;
+  fat?: number;
+  fiber?: number;
+  sugar?: number;
+  sodium?: number;
+  saturatedFat?: number;
+};
+
+type NutritionalProfileShape = {
+  calories?: number;
+  macros?: NutritionalMacros;
+  protein?: number;
+  carbs?: number;
+  fat?: number;
+  fiber?: number;
+  sugar?: number;
+  sodium?: number;
+  vitamins?: Record<string, number> | string[];
+  minerals?: Record<string, number> | string[];
+  serving_size?: string;
+};
+
+function readNum(value: unknown): number {
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function emptyNutrition(): NormalizedRecipeNutrition {
+  return {
+    calories: 0,
+    protein: 0,
+    carbs: 0,
+    fat: 0,
+    fiber: 0,
+    sugar: 0,
+    sodium: 0,
+  };
+}
+
+/**
+ * Add numeric nutrition fields from `b` onto `a` in place. Preserves
+ * untouched fields.
+ */
+function addNutrition(
+  a: NormalizedRecipeNutrition,
+  b: NormalizedRecipeNutrition,
+): void {
+  a.calories += b.calories;
+  a.protein += b.protein;
+  a.carbs += b.carbs;
+  a.fat += b.fat;
+  a.fiber += b.fiber;
+  a.sugar += b.sugar;
+  a.sodium += b.sodium;
+  if (b.saturatedFat != null) {
+    a.saturatedFat = (a.saturatedFat ?? 0) + b.saturatedFat;
+  }
+  const microKeys: (keyof NormalizedRecipeNutrition)[] = [
+    "vitaminA",
+    "vitaminC",
+    "vitaminD",
+    "vitaminE",
+    "vitaminK",
+    "thiamin",
+    "riboflavin",
+    "niacin",
+    "vitaminB6",
+    "vitaminB12",
+    "folate",
+    "calcium",
+    "iron",
+    "magnesium",
+    "phosphorus",
+    "potassium",
+    "zinc",
+    "copper",
+    "manganese",
+    "selenium",
+  ];
+  for (const k of microKeys) {
+    const bv = (b as unknown as Record<string, unknown>)[k];
+    if (typeof bv === "number" && Number.isFinite(bv)) {
+      const prev = (a as unknown as Record<string, unknown>)[k];
+      (a as unknown as Record<string, unknown>)[k] =
+        (typeof prev === "number" ? prev : 0) + bv;
+    }
+  }
+}
+
+function scaleNutrition(
+  n: NormalizedRecipeNutrition,
+  factor: number,
+): NormalizedRecipeNutrition {
+  if (!Number.isFinite(factor) || factor <= 0) return emptyNutrition();
+  const out: NormalizedRecipeNutrition = {
+    calories: n.calories * factor,
+    protein: n.protein * factor,
+    carbs: n.carbs * factor,
+    fat: n.fat * factor,
+    fiber: n.fiber * factor,
+    sugar: n.sugar * factor,
+    sodium: n.sodium * factor,
+  };
+  if (n.saturatedFat != null) out.saturatedFat = n.saturatedFat * factor;
+
+  const microKeys: (keyof NormalizedRecipeNutrition)[] = [
+    "vitaminA",
+    "vitaminC",
+    "vitaminD",
+    "vitaminE",
+    "vitaminK",
+    "thiamin",
+    "riboflavin",
+    "niacin",
+    "vitaminB6",
+    "vitaminB12",
+    "folate",
+    "calcium",
+    "iron",
+    "magnesium",
+    "phosphorus",
+    "potassium",
+    "zinc",
+    "copper",
+    "manganese",
+    "selenium",
+  ];
+  for (const k of microKeys) {
+    const v = (n as unknown as Record<string, unknown>)[k];
+    if (typeof v === "number" && Number.isFinite(v)) {
+      (out as unknown as Record<string, unknown>)[k] = v * factor;
+    }
+  }
+  return out;
+}
+
+/**
+ * Convert an ingredient's nutritionalProfile (which may use USDA-style
+ * nested `macros` or a flat shape) into our canonical NormalizedRecipeNutrition.
+ * The values represent one serving, i.e. the `serving_size` field on the
+ * profile.
+ */
+function profileToNutrition(
+  profile: NutritionalProfileShape,
+): NormalizedRecipeNutrition {
+  const out = emptyNutrition();
+  out.calories = readNum(profile.calories);
+
+  if (profile.macros) {
+    out.protein = readNum(profile.macros.protein);
+    out.carbs = readNum(profile.macros.carbs);
+    out.fat = readNum(profile.macros.fat);
+    out.fiber = readNum(profile.macros.fiber);
+    out.sugar = readNum(profile.macros.sugar);
+    out.sodium = readNum(profile.macros.sodium);
+    if (profile.macros.saturatedFat != null) {
+      out.saturatedFat = readNum(profile.macros.saturatedFat);
+    }
+  } else {
+    // Flat shape
+    out.protein = readNum(profile.protein);
+    out.carbs = readNum(profile.carbs);
+    out.fat = readNum(profile.fat);
+    out.fiber = readNum(profile.fiber);
+    out.sugar = readNum(profile.sugar);
+    out.sodium = readNum(profile.sodium);
+  }
+
+  // Copy numeric vitamin/mineral records when present.
+  if (profile.vitamins && !Array.isArray(profile.vitamins)) {
+    const vits = profile.vitamins as Record<string, number>;
+    const pick = (
+      target: keyof NormalizedRecipeNutrition,
+      ...keys: string[]
+    ) => {
+      for (const k of keys) {
+        if (typeof vits[k] === "number") {
+          (out as unknown as Record<string, unknown>)[target] = vits[k];
+          return;
+        }
+      }
+    };
+    pick("vitaminA", "A", "a", "vitaminA");
+    pick("vitaminC", "C", "c", "vitaminC");
+    pick("vitaminD", "D", "d", "vitaminD");
+    pick("vitaminE", "E", "e", "vitaminE");
+    pick("vitaminK", "K", "k", "vitaminK");
+    pick("vitaminB6", "B6", "b6", "vitaminB6");
+    pick("vitaminB12", "B12", "b12", "vitaminB12");
+    pick("folate", "folate", "Folate");
+    pick("thiamin", "B1", "b1", "thiamin");
+    pick("riboflavin", "B2", "b2", "riboflavin");
+    pick("niacin", "B3", "b3", "niacin");
+  }
+  if (profile.minerals && !Array.isArray(profile.minerals)) {
+    const min = profile.minerals as Record<string, number>;
+    for (const key of [
+      "calcium",
+      "iron",
+      "magnesium",
+      "phosphorus",
+      "potassium",
+      "zinc",
+      "copper",
+      "manganese",
+      "selenium",
+    ] as const) {
+      if (typeof min[key] === "number") {
+        (out as unknown as Record<string, unknown>)[key] = min[key];
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Compute the nutrition contribution of a single recipe ingredient, scaled
+ * to the amount + unit actually used in the recipe. Returns `null` when the
+ * ingredient isn't recognised or has no usable nutritional profile.
+ */
+export function computeIngredientNutrition(
+  ingredient: IngredientLike | undefined | null,
+  amount: number,
+  unit: string,
+): NormalizedRecipeNutrition | null {
+  if (!ingredient) return null;
+  const profile = ingredient.nutritionalProfile as
+    | NutritionalProfileShape
+    | undefined;
+  if (!profile) return null;
+
+  const perServing = profileToNutrition(profile);
+  if (
+    perServing.calories === 0 &&
+    perServing.protein === 0 &&
+    perServing.carbs === 0 &&
+    perServing.fat === 0
+  ) {
+    return null;
+  }
+
+  const servingGrams =
+    parseServingSizeGrams(profile.serving_size) ?? DEFAULT_SERVING_GRAMS;
+
+  const recipeGrams =
+    convertToGrams(amount, unit) ?? amount * (UNIT_CONVERSIONS["each"] ?? 50);
+  if (!Number.isFinite(recipeGrams) || recipeGrams <= 0) return null;
+
+  const factor = recipeGrams / servingGrams;
+  return scaleNutrition(perServing, factor);
+}
+
+/**
+ * Compute recipe-level nutrition from the ingredients list. Returns `null`
+ * when fewer than half of the ingredients resolved against the unified
+ * ingredient DB — at that point the total would be misleadingly incomplete.
+ *
+ * The resulting nutrition is expressed per serving (divided by
+ * `recipe.numberOfServings`, defaulting to 4 when the recipe doesn't state
+ * one).
+ */
+export function computeRecipeNutritionFromIngredients(
+  recipe: Pick<Recipe, "ingredients" | "numberOfServings"> & {
+    servings?: number;
+  },
+): NormalizedRecipeNutrition | null {
+  const ingredients = recipe.ingredients;
+  if (!Array.isArray(ingredients) || ingredients.length === 0) return null;
+
+  const service = UnifiedIngredientService.getInstance();
+  const total = emptyNutrition();
+  let resolved = 0;
+
+  for (const ing of ingredients as RecipeIngredient[]) {
+    if (!ing?.name) continue;
+    const found = service.getIngredientByName(ing.name);
+    if (!found) continue;
+
+    const amount = Number(ing.amount) || 1;
+    const unit = (ing.unit ?? "").toString();
+    const contribution = computeIngredientNutrition(found, amount, unit);
+    if (!contribution) continue;
+
+    addNutrition(total, contribution);
+    resolved++;
+  }
+
+  if (resolved === 0) return null;
+  // Require at least half of the ingredients to resolve — otherwise the
+  // total under-counts the recipe and would be more misleading than useful.
+  if (resolved * 2 < ingredients.length) return null;
+
+  const servings =
+    (recipe as { numberOfServings?: number }).numberOfServings ??
+    (recipe as { servings?: number }).servings ??
+    DEFAULT_RECIPE_SERVINGS;
+
+  return scaleNutrition(total, 1 / Math.max(1, servings));
+}

--- a/src/utils/menuPlanner/recommendationBridge.ts
+++ b/src/utils/menuPlanner/recommendationBridge.ts
@@ -8,7 +8,11 @@
  * @updated 2026-02-03 - Added user chart personalization support
  */
 
-import { getServerRecipes } from "@/actions/recipes";
+import {
+  getServerRecipeIndex,
+  getServerRecipes,
+} from "@/actions/recipes";
+import type { IndexedRecipe } from "@/types/indexedRecipe";
 import type { AlchemicalProfile } from "@/contexts/UserContext";
 import {
     type MonicaOptimizedRecipe,
@@ -685,8 +689,12 @@ async function searchRecipesForDay(
       recommendedCuisines: dayChar.recommendedCuisines,
     });
 
+    // Pull the prebuilt mealType × season index rather than scanning all
+    // 351 recipes on every generation request. The `recipes` variable is
+    // kept around for the relaxed-filter fallback paths below.
+    const recipeIndex = await getServerRecipeIndex();
     const allRecipes = await getServerRecipes();
-    const recipes = allRecipes as unknown as Recipe[];
+    const recipes = allRecipes as unknown as IndexedRecipe[];
     const currentSeason = getCurrentSeason();
     const existingMeals = options.existingMeals || [];
     const existingRecipeIds = new Set(existingMeals.map((m) => m.recipeId));
@@ -702,16 +710,29 @@ async function searchRecipesForDay(
       PLANET_CULINARY_PROFILES["Sun"];
 
     // ── Step 1: Filter pipeline ──
+    //
+    // Start from the `${mealType}-${season}` bucket (+ season-agnostic
+    // "all" bucket) in the prebuilt index instead of scanning every recipe.
+    const primaryBucket = recipeIndex.get(`${mealType}-${currentSeason}`) ?? [];
+    const allSeasonBucket = recipeIndex.get(`${mealType}-all`) ?? [];
+    const seed: IndexedRecipe[] = [];
+    const seedSeen = new Set<string>();
+    for (const r of primaryBucket) {
+      if (r.id && !seedSeen.has(r.id)) {
+        seed.push(r);
+        seedSeen.add(r.id);
+      }
+    }
+    for (const r of allSeasonBucket) {
+      if (r.id && !seedSeen.has(r.id)) {
+        seed.push(r);
+        seedSeen.add(r.id);
+      }
+    }
 
-    let candidates = recipes.filter((recipe) => {
+    let candidates = seed.filter((recipe) => {
       // Hard-exclude recipes already in the weekly plan
       if (existingRecipeIds.has(recipe.id)) return false;
-
-      // Meal type suitability
-      if (!isSuitableForMealType(recipe, mealType)) return false;
-
-      // Season match
-      if (!matchesSeason(recipe, currentSeason)) return false;
 
       // Dietary restrictions
       if (
@@ -742,7 +763,7 @@ async function searchRecipesForDay(
     // ── Step 2: Progressive fallback if filters are too restrictive ──
 
     if (candidates.length === 0) {
-      // Relax: drop season filter
+      // Relax: drop season filter (scan any season for this meal type)
       candidates = recipes.filter((recipe) => {
         if (existingRecipeIds.has(recipe.id)) return false;
         if (!isSuitableForMealType(recipe, mealType)) return false;
@@ -784,6 +805,17 @@ async function searchRecipesForDay(
       c.toLowerCase(),
     );
 
+    // Precompute lowercased planetary cooking methods once per call rather
+    // than once per candidate-per-method inside the inner loops.
+    const planetCookingMethodsLc = planetProfile.cookingMethods.map((pm) =>
+      pm.toLowerCase(),
+    );
+    const preferredCookingMethodsLc = (options.preferredCookingMethods ?? []).map(
+      (pm) => pm.toLowerCase(),
+    );
+    const budget = options.budgetPerMeal;
+    const budgetEnabled = typeof budget === "number" && budget > 0;
+
     const scored = candidates.map((recipe) => {
       let score = 0;
 
@@ -797,8 +829,9 @@ async function searchRecipesForDay(
       }
 
       // Cuisine match with day's recommended cuisines (weight: 0.2)
-      const recipeCuisine = recipe.cuisine?.toLowerCase() || "";
+      const recipeCuisine = recipe._lcCuisine ?? recipe.cuisine?.toLowerCase() ?? "";
       if (
+        recipeCuisine &&
         recommendedCuisinesLower.some(
           (c) => recipeCuisine.includes(c) || c.includes(recipeCuisine),
         )
@@ -807,17 +840,17 @@ async function searchRecipesForDay(
       }
 
       // Cooking method alignment with planetary profile (weight: 0.15)
-      if (recipe.cookingMethod && recipe.cookingMethod.length > 0) {
-        const methodMatch = recipe.cookingMethod.some((m) =>
-          planetProfile.cookingMethods.some((pm) =>
-            m.toLowerCase().includes(pm.toLowerCase()),
-          ),
+      const lcCookingMethods = recipe._lcCookingMethod;
+      if (lcCookingMethods && lcCookingMethods.length > 0) {
+        const methodMatch = lcCookingMethods.some((m) =>
+          planetCookingMethodsLc.some((pm) => m.includes(pm)),
         );
         if (methodMatch) score += 0.15;
       }
 
       // Preferred cuisine match (weight: 0.1)
       if (
+        recipeCuisine &&
         preferredCuisinesLower.length > 0 &&
         preferredCuisinesLower.some(
           (c) => recipeCuisine.includes(c) || c.includes(recipeCuisine),
@@ -828,16 +861,13 @@ async function searchRecipesForDay(
 
       // Preferred cooking methods match (weight: 0.05)
       if (
-        options.preferredCookingMethods &&
-        options.preferredCookingMethods.length > 0 &&
-        recipe.cookingMethod
+        preferredCookingMethodsLc.length > 0 &&
+        lcCookingMethods &&
+        lcCookingMethods.some((m) =>
+          preferredCookingMethodsLc.some((pm) => m.includes(pm)),
+        )
       ) {
-        const prefMethodMatch = recipe.cookingMethod.some((m) =>
-          options.preferredCookingMethods!.some((pm) =>
-            m.toLowerCase().includes(pm.toLowerCase()),
-          ),
-        );
-        if (prefMethodMatch) score += 0.05;
+        score += 0.05;
       }
 
       // Weekly variety penalties
@@ -858,8 +888,11 @@ async function searchRecipesForDay(
       }
 
       // ── Budget-aware scoring (weight: ±0.2) ──
+      // Early return when no budget is set — avoids the per-recipe call to
+      // `calculateRecipeEstimatedCost`, which is the hottest branch in this
+      // loop when pricing is enabled.
       let costPerServing = 0;
-      if (options.budgetPerMeal && options.budgetPerMeal > 0) {
+      if (budgetEnabled) {
         const ingredients = recipe.ingredients.map((ing: any) => ({
           name: typeof ing === "string" ? ing : ing.name ?? "",
           amount: typeof ing === "string" ? 1 : ing.amount ?? 1,
@@ -867,20 +900,25 @@ async function searchRecipesForDay(
           category: typeof ing === "string" ? undefined : ing.category,
           optional: typeof ing === "string" ? false : ing.optional,
         }));
-        const estimate = calculateRecipeEstimatedCost(ingredients, (recipe as any).servings ?? 4);
+        const estimate = calculateRecipeEstimatedCost(
+          ingredients,
+          (recipe as { servings?: number }).servings ?? 4,
+        );
         costPerServing = estimate.costPerServing;
 
-        const budgetRatio = costPerServing / options.budgetPerMeal;
+        const budgetRatio = costPerServing / (budget as number);
 
         if (budgetRatio > 1.5) {
           // Way over budget → heavy penalty
           score -= 0.25;
         } else if (budgetRatio > 1.0) {
           // Slightly over budget → moderate penalty
-          score -= 0.15 * (budgetRatio - 1.0) / 0.5;
+          score -= (0.15 * (budgetRatio - 1.0)) / 0.5;
         } else if (budgetRatio < 0.6) {
           // Well under budget → bonus for value
-          const nutrition = (recipe as any).nutrition ?? (recipe as any).nutritionalProfile;
+          const nutrition =
+            (recipe as any).nutrition ??
+            (recipe as any).nutritionalProfile;
           const bfb = calculateBangForBuck(nutrition, costPerServing);
           score += Math.min(0.2, bfb.score / 500);
         }
@@ -902,7 +940,8 @@ async function searchRecipesForDay(
     for (const entry of scored) {
       if (selected.length >= maxCandidates) break;
 
-      const recipeCuisine = entry.recipe.cuisine?.toLowerCase() || "";
+      const recipeCuisine =
+        entry.recipe._lcCuisine ?? entry.recipe.cuisine?.toLowerCase() ?? "";
       const recipeProtein = entry.protein || "";
 
       // Prefer recipes that don't duplicate protein or cuisine within this batch

--- a/src/utils/quantityScaling.ts
+++ b/src/utils/quantityScaling.ts
@@ -8,55 +8,11 @@ import type {
   QuantityScaledProperties,
   ThermodynamicMetrics,
 } from "@/types/alchemy";
+import { UNIT_CONVERSIONS } from "./unitConversion";
 
-/**
- * Unit conversion mappings for ingredient quantities
- * Maps various units to grams (base unit for calculations)
- */
-const UNIT_CONVERSIONS: Record<string, number> = {
-  // Weight units
-  g: 1,
-  gram: 1,
-  grams: 1,
-  kg: 1000,
-  kilogram: 1000,
-  kilograms: 1000,
-  oz: 28.35,
-  ounce: 28.35,
-  ounces: 28.35,
-  lb: 453.59,
-  pound: 453.59,
-  pounds: 453.59,
-
-  // Volume units (approximate conversions using water density)
-  ml: 1,
-  milliliter: 1,
-  milliliters: 1,
-  l: 1000,
-  liter: 1000,
-  liters: 1000,
-  cup: 240,
-  cups: 240,
-  tbsp: 15,
-  tablespoon: 15,
-  tablespoons: 15,
-  tsp: 5,
-  teaspoon: 5,
-  teaspoons: 5,
-  "fl oz": 29.57,
-  "fluid ounce": 29.57,
-  "fluid ounces": 29.57,
-
-  // Piece/count units (context-dependent, using approximate averages)
-  piece: 50, // Average piece weight
-  pieces: 50,
-  clove: 6, // Garlic clove
-  cloves: 6,
-  slice: 30, // Average slice
-  slices: 30,
-  head: 200, // Average head (e.g., garlic, lettuce)
-  heads: 200,
-};
+// Re-export for backwards compatibility with any consumers that imported
+// UNIT_CONVERSIONS directly from this module.
+export { UNIT_CONVERSIONS };
 
 /**
  * Calculate quantity scaling factor with logarithmic diminishing returns

--- a/src/utils/recipeNutrition.ts
+++ b/src/utils/recipeNutrition.ts
@@ -1,0 +1,253 @@
+// src/utils/recipeNutrition.ts
+//
+// Normalizes the different nutrition shapes we see in cuisine dish data down
+// to the flat shape that NutritionTrackingService.extractMealNutrition reads
+// (calories / protein / carbs / fat / fiber / sodium / sugar / ...).
+//
+// Cuisine files follow the AlchemicalRecipe schema and store nutrition under
+// `nutritionPerServing` with gram-suffixed keys (proteinG, carbsG, ...).
+// Legacy dishes may use `nutritionalProfile` or `nutrition`. This helper
+// accepts all three and produces a single canonical object.
+
+/**
+ * Flat nutrition shape consumed by NutritionTrackingService.extractMealNutrition.
+ * Only the fields we actually read from recipes are declared here; anything
+ * else on the object is tolerated.
+ */
+export interface NormalizedRecipeNutrition {
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  fiber: number;
+  sugar: number;
+  sodium: number;
+  saturatedFat?: number;
+
+  // Micronutrients — included when available on the source.
+  vitaminA?: number;
+  vitaminC?: number;
+  vitaminD?: number;
+  vitaminE?: number;
+  vitaminK?: number;
+  thiamin?: number;
+  riboflavin?: number;
+  niacin?: number;
+  vitaminB6?: number;
+  vitaminB12?: number;
+  folate?: number;
+  calcium?: number;
+  iron?: number;
+  magnesium?: number;
+  phosphorus?: number;
+  potassium?: number;
+  zinc?: number;
+  copper?: number;
+  manganese?: number;
+  selenium?: number;
+
+  // Raw tags for downstream display (some callers show the literal
+  // vitamin/mineral lists unchanged).
+  vitamins?: string[];
+  minerals?: string[];
+}
+
+/**
+ * Map common vitamin/mineral display names to the NutritionalSummary field
+ * name. When a dish only lists vitamins by string (no numeric amount), we
+ * can't attach a real quantity, but we can still surface the presence flag
+ * so downstream UI knows the micronutrient is in the recipe.
+ */
+const VITAMIN_KEY_MAP: Record<string, keyof NormalizedRecipeNutrition> = {
+  a: "vitaminA",
+  "vitamin a": "vitaminA",
+  c: "vitaminC",
+  "vitamin c": "vitaminC",
+  d: "vitaminD",
+  "vitamin d": "vitaminD",
+  e: "vitaminE",
+  "vitamin e": "vitaminE",
+  k: "vitaminK",
+  "vitamin k": "vitaminK",
+  b1: "thiamin",
+  thiamin: "thiamin",
+  b2: "riboflavin",
+  riboflavin: "riboflavin",
+  b3: "niacin",
+  niacin: "niacin",
+  b6: "vitaminB6",
+  "vitamin b6": "vitaminB6",
+  b12: "vitaminB12",
+  "vitamin b12": "vitaminB12",
+  folate: "folate",
+};
+
+const MINERAL_KEY_MAP: Record<string, keyof NormalizedRecipeNutrition> = {
+  calcium: "calcium",
+  iron: "iron",
+  magnesium: "magnesium",
+  phosphorus: "phosphorus",
+  potassium: "potassium",
+  sodium: "sodium",
+  zinc: "zinc",
+  copper: "copper",
+  manganese: "manganese",
+  selenium: "selenium",
+};
+
+function num(value: unknown): number {
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) {
+    const strs = value.filter((v): v is string => typeof v === "string");
+    return strs.length ? strs : undefined;
+  }
+  if (value && typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>);
+  }
+  return undefined;
+}
+
+/**
+ * Pull numeric vitamin/mineral values from a record that may be keyed by
+ * symbol ("A", "K"), name ("Vitamin C"), or short form ("b12").
+ */
+function applyMicroMap(
+  source: Record<string, unknown> | null | undefined,
+  keyMap: Record<string, keyof NormalizedRecipeNutrition>,
+  target: NormalizedRecipeNutrition,
+): void {
+  if (!source) return;
+  for (const [rawKey, rawValue] of Object.entries(source)) {
+    const lc = rawKey.toLowerCase().trim();
+    const mapped = keyMap[lc];
+    if (!mapped) continue;
+    const n = typeof rawValue === "number" ? rawValue : Number(rawValue);
+    if (Number.isFinite(n) && n > 0) {
+      (target as unknown as Record<string, unknown>)[mapped] = n;
+    }
+  }
+}
+
+/**
+ * Normalize a dish's nutrition payload to the canonical shape.
+ *
+ * Accepts any of:
+ *  - `dish.nutritionPerServing` with gram-suffixed keys (canonical AlchemicalRecipe)
+ *  - `dish.nutritionalProfile` with nested `macros` (USDA-style ingredient profile)
+ *  - `dish.nutrition` already in flat shape (legacy)
+ *
+ * Returns `null` if no source produces any non-zero macros, so callers can
+ * trigger an ingredient-based fallback.
+ */
+export function normalizeRecipeNutrition(
+  dish: Record<string, unknown> | null | undefined,
+): NormalizedRecipeNutrition | null {
+  if (!dish) return null;
+
+  const out: NormalizedRecipeNutrition = {
+    calories: 0,
+    protein: 0,
+    carbs: 0,
+    fat: 0,
+    fiber: 0,
+    sugar: 0,
+    sodium: 0,
+  };
+
+  // --- Source 1: canonical AlchemicalRecipe.nutritionPerServing -----------
+  const perServing = asRecord(dish.nutritionPerServing);
+  if (perServing) {
+    out.calories = num(perServing.calories);
+    out.protein = num(perServing.proteinG ?? perServing.protein);
+    out.carbs = num(perServing.carbsG ?? perServing.carbs);
+    out.fat = num(perServing.fatG ?? perServing.fat);
+    out.fiber = num(perServing.fiberG ?? perServing.fiber);
+    out.sugar = num(perServing.sugarG ?? perServing.sugar);
+    out.sodium = num(perServing.sodiumMg ?? perServing.sodium);
+    if (perServing.saturatedFatG != null || perServing.saturatedFat != null) {
+      out.saturatedFat = num(
+        perServing.saturatedFatG ?? perServing.saturatedFat,
+      );
+    }
+    out.vitamins = asStringArray(perServing.vitamins);
+    out.minerals = asStringArray(perServing.minerals);
+  }
+
+  // --- Source 2: legacy flat `dish.nutrition` -----------------------------
+  const flat = asRecord(dish.nutrition);
+  if (flat && out.calories === 0) {
+    out.calories = num(flat.calories);
+    out.protein = num(flat.protein ?? flat.proteinG);
+    out.carbs = num(flat.carbs ?? flat.carbsG);
+    out.fat = num(flat.fat ?? flat.fatG);
+    out.fiber = num(flat.fiber ?? flat.fiberG);
+    out.sugar = num(flat.sugar ?? flat.sugarG);
+    out.sodium = num(flat.sodium ?? flat.sodiumMg);
+    if (flat.saturatedFat != null) out.saturatedFat = num(flat.saturatedFat);
+    out.vitamins ??= asStringArray(flat.vitamins);
+    out.minerals ??= asStringArray(flat.minerals);
+    applyMicroMap(asRecord(flat.vitamins), VITAMIN_KEY_MAP, out);
+    applyMicroMap(asRecord(flat.minerals), MINERAL_KEY_MAP, out);
+  }
+
+  // --- Source 3: USDA-style `dish.nutritionalProfile.macros` --------------
+  const profile = asRecord(dish.nutritionalProfile);
+  if (profile && out.calories === 0) {
+    out.calories = num(profile.calories);
+    const macros = asRecord(profile.macros);
+    if (macros) {
+      out.protein = num(macros.protein);
+      out.carbs = num(macros.carbs);
+      out.fat = num(macros.fat);
+      out.fiber = num(macros.fiber);
+      if (macros.sugar != null) out.sugar = num(macros.sugar);
+      if (macros.sodium != null) out.sodium = num(macros.sodium);
+      if (macros.saturatedFat != null) {
+        out.saturatedFat = num(macros.saturatedFat);
+      }
+    }
+    out.vitamins ??= asStringArray(profile.vitamins);
+    out.minerals ??= asStringArray(profile.minerals);
+    applyMicroMap(asRecord(profile.vitamins), VITAMIN_KEY_MAP, out);
+    applyMicroMap(asRecord(profile.minerals), MINERAL_KEY_MAP, out);
+  }
+
+  // If every macro is still zero we have no meaningful data — tell the
+  // caller so it can try the ingredient-based fallback path.
+  if (
+    out.calories === 0 &&
+    out.protein === 0 &&
+    out.carbs === 0 &&
+    out.fat === 0
+  ) {
+    return null;
+  }
+
+  return out;
+}
+
+/**
+ * Cheap predicate used by callers that just want to know whether a recipe
+ * has *any* meaningful nutrition data attached.
+ */
+export function hasNutritionData(
+  nutrition: Partial<NormalizedRecipeNutrition> | null | undefined,
+): boolean {
+  if (!nutrition) return false;
+  return Boolean(
+    (nutrition.calories ?? 0) > 0 ||
+      (nutrition.protein ?? 0) > 0 ||
+      (nutrition.carbs ?? 0) > 0 ||
+      (nutrition.fat ?? 0) > 0,
+  );
+}

--- a/src/utils/unitConversion.ts
+++ b/src/utils/unitConversion.ts
@@ -1,0 +1,71 @@
+// src/utils/unitConversion.ts
+// Shared unit-to-grams conversion table used by both the quantity scaling
+// engine (elemental calculations) and the ingredient-based nutrition
+// aggregator. Keeping a single table avoids drift between the two.
+
+/**
+ * Unit conversion mappings for ingredient quantities.
+ * Maps various units to grams (base unit for calculations).
+ *
+ * Volume units assume water density as an approximation; acceptable for
+ * elemental scoring and nutrition estimation when a per-ingredient density
+ * is not available.
+ */
+export const UNIT_CONVERSIONS: Record<string, number> = {
+  // Weight units
+  g: 1,
+  gram: 1,
+  grams: 1,
+  kg: 1000,
+  kilogram: 1000,
+  kilograms: 1000,
+  oz: 28.35,
+  ounce: 28.35,
+  ounces: 28.35,
+  lb: 453.59,
+  pound: 453.59,
+  pounds: 453.59,
+
+  // Volume units (approximate conversions using water density)
+  ml: 1,
+  milliliter: 1,
+  milliliters: 1,
+  l: 1000,
+  liter: 1000,
+  liters: 1000,
+  cup: 240,
+  cups: 240,
+  tbsp: 15,
+  tablespoon: 15,
+  tablespoons: 15,
+  tsp: 5,
+  teaspoon: 5,
+  teaspoons: 5,
+  "fl oz": 29.57,
+  "fluid ounce": 29.57,
+  "fluid ounces": 29.57,
+
+  // Piece/count units (context-dependent, using approximate averages)
+  piece: 50,
+  pieces: 50,
+  clove: 6,
+  cloves: 6,
+  slice: 30,
+  slices: 30,
+  head: 200,
+  heads: 200,
+  each: 50,
+  "": 50,
+};
+
+/**
+ * Convert an amount in a given unit to grams. Returns `null` when the unit is
+ * unrecognised, allowing callers to decide how to handle ambiguous inputs.
+ */
+export function convertToGrams(amount: number, unit: string): number | null {
+  if (!Number.isFinite(amount) || amount <= 0) return null;
+  const key = (unit ?? "").toLowerCase().trim();
+  const factor = UNIT_CONVERSIONS[key];
+  if (factor == null) return null;
+  return amount * factor;
+}


### PR DESCRIPTION
## Summary

This PR adds two major features to improve nutrition data coverage and recommendation generation performance:

1. **Ingredient-based nutrition fallback**: When recipes lack explicit nutrition data, compute it from the ingredient list using the UnifiedIngredientService
2. **Recipe indexing by meal type and season**: Pre-compute a lookup index to avoid scanning all 351 recipes on every generation request

## Key Changes

### Nutrition Pipeline
- **New `src/utils/recipeNutrition.ts`**: Normalizes nutrition data from multiple sources (canonical `nutritionPerServing`, legacy `nutrition`, USDA-style `nutritionalProfile`) into a flat `NormalizedRecipeNutrition` shape
- **New `src/utils/ingredientNutritionAggregation.ts`**: Fallback aggregator that:
  - Looks up each recipe ingredient by name in UnifiedIngredientService
  - Scales nutritional profiles to actual recipe amounts using unit conversions
  - Sums contributions and divides by serving count
  - Returns `null` if fewer than half of ingredients resolve (to avoid misleading incomplete totals)
- **New `src/utils/unitConversion.ts`**: Extracted shared unit-to-grams conversion table (previously duplicated in `quantityScaling.ts`)

### Recipe Indexing & Performance
- **New `src/types/indexedRecipe.ts`**: Type definitions for indexed recipes with precomputed lowercased fields (`_lcCuisine`, `_lcTags`, `_lcCookingMethod`, `_lcSeasons`, `_lcMealTypes`)
- **Updated `src/actions/recipes.ts`**:
  - Extracts recipes as `IndexedRecipe[]` with lowercased fields attached
  - Builds a `RecipeIndex` (Map keyed by `${mealType}-${season}`) for O(1) bucket lookups
  - Applies nutrition pipeline: tries source data first, falls back to ingredient aggregation
  - Tracks nutrition coverage stats (fromSource, fromIngredients, missing)
- **Updated `src/utils/menuPlanner/recommendationBridge.ts`**:
  - Uses prebuilt recipe index to seed candidates instead of scanning all recipes
  - Eliminates redundant `isSuitableForMealType()` and `matchesSeason()` checks (already filtered by index)
  - Precomputes lowercased cooking methods and cuisines once per call instead of per-candidate

### Caching & Optimization
- **Updated `src/app/api/recommendations/generate/route.ts`**:
  - Added TTL memo cache (3 minutes, max 64 entries) for identical generation requests
  - Implements deterministic `stableStringify()` for cache key generation
  - Cache hits return instantly without charging tokens
  - Includes Server-Timing headers for observability

## Implementation Details

- The nutrition aggregator is intentionally forgiving: missing/unrecognized ingredients are skipped, but requires ≥50% resolution to return a result
- Lowercased fields are computed once during recipe extraction and reused throughout the recommendation pipeline, eliminating repeated `toLowerCase()` calls
- The memo cache uses LRU-style eviction (oldest entry dropped when full) and refreshes insertion order on hits to keep hot entries
- Unit conversions use water density approximations for volume units when per-ingredient density is unavailable
- Nutrition coverage stats are logged in dev mode to surface any recipes that couldn't be filled by either path

https://claude.ai/code/session_01ELSPqE4V7icUfbjWF9aKCV