### PR TITLE
feat(recipes): interactive ingredients, technique glossary, timers, nutrition viz

### DIFF
--- a/NEXT_SESSION_PROMPT.md
+++ b/NEXT_SESSION_PROMPT.md
@@ -1,0 +1,145 @@
+# Next Session Prompt — Recipe Page Phases 3 & 5
+
+Use this as the opening message of a fresh Claude Code session to continue the recipe-page transformation.
+
+---
+
+## Context — What's Already Built (Phases 1, 2, 4)
+
+The recipe page at `src/app/recipes/[recipeId]/page.tsx` has been upgraded from read-only to interactive. Completed work:
+
+**Phase 1 — Interactive ingredients** *(shipped)*
+- `src/app/api/ingredients/[name]/route.ts` — returns full ingredient profile + recipes containing it + substitution suggestions from `pairingRecommendations.complementary`
+- `src/components/recipes/IngredientDrawer.tsx` — slide-in right drawer (full-screen on mobile) showing qualities, elemental signature, ESMS + Kalchm/Monica, taste profile, nutrition macros + vitamins/minerals, seasonality, origin, storage, cooking methods, ruling planets/zodiac, pairings (complements/contrasts/avoid), substitutions, and "More recipes with this ingredient" list
+- Every ingredient on the recipe page is now a clickable button that opens the drawer with the scaled per-recipe amount
+
+**Phase 2 — Technique & timer layer** *(shipped)*
+- `src/app/api/techniques/[name]/route.ts` — looks up `allCookingMethods` from `src/data/cooking/methods`; includes a `VERB_ALIASES` map (roast→roasting, sauté→stir-frying, etc.)
+- `src/components/recipes/TechniqueModal.tsx` — centered modal with overview, elemental signature, science/principles, benefits, optimal temperatures (F + C), doneness indicators, common mistakes, expert tips, tools, best-for chips
+- `src/components/recipes/InteractiveInstruction.tsx` — parses each instruction string and renders:
+  - Technique verbs as clickable orange dotted-underline tokens (opens `TechniqueModal`)
+  - Time phrases ("15 minutes", "1-2 hours") with an inline countdown timer that beeps on completion (WebAudio)
+  - Temperatures with Celsius/Fahrenheit conversion tooltips
+
+**Phase 4 — Nutrition visualization** *(shipped)*
+- `src/components/recipes/NutritionVisualization.tsx` — replaces the old macro grid with:
+  - Headline calories + % of 2000-cal DV
+  - Recharts `PieChart` showing macro split (calories from protein/carbs/fat) with custom tooltip
+  - %DV bars for protein/carbs/fat/fiber/sugar/sodium (turns red when >100%)
+  - Micronutrient coverage label + chip grid
+- Removed the now-dead `NutritionGrid` helper from the page
+
+**Build status:** `npx tsc --noEmit --skipLibCheck` → exit 0. ESLint on all touched files → 0 errors.
+
+---
+
+## Your Mission — Phases 3 & 5
+
+### Phase 3: Dynamic Recipe Customization
+
+Transform the recipe page from "read this exact recipe" to "adapt this recipe to me." Users should be able to one-click transform a dish while the app intelligently swaps ingredients and updates nutrition + alchemical scores.
+
+**3A. Dietary Adaptation Engine**
+
+Add a row of transform buttons above the ingredients section:
+- "Make Vegan" · "Make Vegetarian" · "Gluten-Free" · "Dairy-Free" · "Keto" · "Low-Carb"
+
+When clicked:
+- Build a substitution map (meat → jackfruit/tofu/seitan with context; butter → olive oil or vegan butter; flour → almond flour for keto, etc.)
+- Display ingredient swaps inline with strikethrough + replacement, e.g. ~~2 tbsp butter~~ → **2 tbsp olive oil**
+- Show a diff banner: "Adapted for vegan — 3 swaps, -180 cal, elemental Fire -0.08"
+- Add a "Reset to original" button
+- Disable the transform if it's already compatible (e.g., recipe is already vegan → show ✓ chip instead)
+
+Architecture suggestion:
+- New file: `src/utils/dietaryAdaptation.ts` — pure functions `adaptRecipe(recipe, mode)` returning `{ swaps: Array<{index, from, to, reason}>, nutritionalDelta, elementalDelta }`
+- Swap rules keyed by category + name substring. Draw substitution targets from `src/data/ingredients/` where possible (same category, different dietary tags). Hard-code a `COMMON_SWAPS` map for the 40-50 most frequent conversions.
+- Don't mutate the recipe. Return a derived "adapted recipe" object consumed by the render layer.
+
+**3B. Flavor Profile Tuning**
+
+Add a small inline control panel:
+- "+ Sweeter" · "+ Umami" · "+ Acidic" · "+ Spicier" · "+ Savory"
+
+Each click adds a micro-adjustment suggestion (e.g., "+ 1 tsp honey", "+ dash of fish sauce", "+ squeeze of lemon", "+ ¼ tsp cayenne"). Collect suggestions into a sidebar "Flavor Tweaks" list the user can toggle individually.
+
+Architecture:
+- `src/utils/flavorTuning.ts` with pure function `suggestTweaks(direction, currentFlavorProfile)` → `{ ingredient, amount, reason }`
+- Avoid the rabbit hole of computing new ESMS/elemental values for these small additions; just show the additive suggestions.
+
+**3C. Time-Constraint Shortcuts**
+
+Add a "How much time do you have?" pill row: 15 min · 30 min · 60 min · All day.
+
+When a shorter time is selected:
+- Highlight steps that can be skipped, simplified, or parallelized
+- Surface make-ahead tips: "Prep the onions the night before to save 10 min"
+- Suggest equipment swaps: "Use a pressure cooker: braise 4h → 35 min"
+- If recipe's total time already fits, show a green ✓
+
+This one is primarily presentational — use `recipe.tips`, `recipe.variations`, `recipe.makeAheadTips` (check the Recipe type for exact field names) plus a small heuristic parser over the instruction strings to identify skippable/parallelizable steps (keywords: "marinate", "rest", "chill").
+
+### Phase 5: Social, Discovery & Meal Planning
+
+**5A. Meal Planning Integration**
+
+- Add "Add to Meal Plan" button in the recipe header (next to Copy Recipe)
+- Check for existing meal-plan infrastructure first: `src/app/menu-planner/`, `src/services/`, and any API route under `src/app/api/` referencing "plan" or "menu" — integrate rather than rebuild
+- If missing: build a simple `useMealPlan` hook backed by `localStorage` (key: `alchm:meal-plan:v1`) with shape `{ date: string, recipeId: string, mealType?: string }[]`
+- Add a date-picker mini-modal for scheduling
+- Build a "Grocery List" aggregator: a new route `/meal-plan/groceries` that sums ingredients across all scheduled recipes, consolidating by name+unit
+
+**5B. Discovery Enhancements**
+
+On the recipe page, add new discovery surfaces:
+- **"Recipes with similar elemental profile"** — API: new GET endpoint that ranks all recipes by Euclidean distance on Fire/Water/Earth/Air, returns top 6 excluding current. Use `elementalProperties` on recipes from `UnifiedRecipeService.getAllRecipes()`
+- **"Recipes with similar planetary alignment"** — rank by cosine similarity on ESMS (spirit/essence/matter/substance)
+- **"Try next in [cuisine]"** — 3 other recipes from the same cuisine, ordered by `monicaScore` descending
+
+These can live in one endpoint: `src/app/api/recipes/[recipeId]/discover/route.ts` returning `{ similarElemental, similarAlchemical, sameCuisine }`.
+
+**5C. Social UX (Design Only — No Backend)**
+
+Build the UI shell for user contributions, wired to placeholder state (no persistence yet). The goal is to lock in UX patterns so a future session can bolt on backend/auth.
+- "Made this" counter + button (optimistic update, localStorage for now)
+- Star rating (1-5) with optional short review textarea
+- Photo upload stub (file input → base64 preview, no upload yet)
+- Community tips section — read-only mock data; display as if sourced from other users
+
+Add a comment at the top of each placeholder component: `// TODO(phase 5.5): wire to /api/users/me/recipes when auth-gated endpoint exists`.
+
+---
+
+## Working Rules (Non-negotiable)
+
+1. **Preserve zero TypeScript errors.** Run `npx tsc --noEmit --skipLibCheck` after each major change. Exit 0 or fix immediately.
+2. **Dark glass aesthetic.** Follow the established visual language: `glass-card-premium`, `border-white/8`, amber/orange for primary, gradient text `bg-gradient-to-r from-amber-200 to-orange-300` for headings.
+3. **Client components** must include `"use client"` directive at the top.
+4. **ESMS only from planetary positions** — never recompute ESMS from elementals. For diet adaptations, just show nutritional/elemental deltas, not ESMS deltas.
+5. **Elemental casing**: `Fire` `Water` `Earth` `Air` (capitalized). Zodiac signs lowercase (`aries`).
+6. **No new `as any` casts** unless following documented patterns in CLAUDE.md.
+7. **Component location**: `src/components/recipes/*.tsx` for recipe-specific UI.
+8. **If using `<style jsx>`** wrap with `{/* eslint-disable react/no-unknown-property */}` and `{/* eslint-enable */}`.
+
+## Key Existing Infrastructure
+
+- `UnifiedRecipeService.getInstance()` — `getAllRecipes()`, `getRecipeById(id)`
+- `IngredientService.getInstance()` — `getIngredientByName(name)`, `getAllIngredientsFlat()`, `getIngredientsByCategory(cat)`
+- Recipe type: `src/types/recipe.ts` — has `ingredients: RecipeIngredient[]`, `elementalProperties`, `spirit/essence/matter/substance`, `monicaScore`, dietary booleans (`isVegan` etc.), `allergens`, `substitutions`
+- Ingredient data lives in `src/data/ingredients/{category}/*.ts`; each file exports an object keyed by normalized name, with the schema shown in `src/types/ingredient.ts` and `src/data/unified/unifiedTypes.ts`
+- Recharts 3.8.1 is installed. Framer Motion 12.38 is installed if you want transitions.
+- Recipe page at `src/app/recipes/[recipeId]/page.tsx` already imports `IngredientDrawer`, `InteractiveInstruction`, `NutritionVisualization`, `TechniqueModal` from `src/components/recipes/`.
+
+## Suggested Build Order
+
+1. **Start with Phase 5B discovery endpoint** — quick win, reuses existing data, gives immediate new surface on the page
+2. **Phase 3A dietary adaptation** — highest user-facing impact, most complex logic
+3. **Phase 3B/3C** — layer in after 3A infrastructure is stable
+4. **Phase 5A meal plan** — requires localStorage + small new route
+5. **Phase 5C social shells** — last; pure UX, unblocks a future backend session
+
+Commit after each phase lands green. Confirm with the user before opening a PR.
+
+## First Step
+
+Read the current state of `src/app/recipes/[recipeId]/page.tsx` to understand what's already wired. Then run `npx tsc --noEmit --skipLibCheck` to confirm the zero-error baseline. Then ask the user which phase to prioritize if they haven't already specified.

--- a/src/app/api/ingredients/[name]/route.ts
+++ b/src/app/api/ingredients/[name]/route.ts
@@ -1,0 +1,132 @@
+import { NextResponse } from "next/server";
+import { IngredientService } from "@/services/IngredientService";
+import { UnifiedRecipeService } from "@/services/UnifiedRecipeService";
+import type { UnifiedIngredient } from "@/data/unified/unifiedTypes";
+import type { Recipe } from "@/types/recipe";
+
+export const dynamic = "force-dynamic";
+
+function normalizeName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Tokenized match: does `candidate` contain `target` as a word/substring?
+ * We normalize both sides so "Basil, fresh" matches "basil".
+ */
+function ingredientMatches(candidate: string, target: string): boolean {
+  const c = normalizeName(candidate);
+  const t = normalizeName(target);
+  if (!c || !t) return false;
+  return c.includes(t) || t.includes(c);
+}
+
+interface RelatedRecipe {
+  id: string;
+  name: string;
+  cuisine?: string;
+  description?: string;
+  prepTime?: number;
+  cookTime?: number;
+  servings?: number;
+  amount?: number;
+  unit?: string;
+}
+
+function extractTime(recipe: Recipe, kind: "prep" | "cook"): number | undefined {
+  const details = (recipe as { details?: { prepTimeMinutes?: number; cookTimeMinutes?: number } }).details;
+  if (details) {
+    const v = kind === "prep" ? details.prepTimeMinutes : details.cookTimeMinutes;
+    if (typeof v === "number") return v;
+  }
+  const raw = kind === "prep" ? recipe.prepTime : recipe.cookTime;
+  if (typeof raw === "string") {
+    const m = raw.match(/(\d+)/);
+    if (m) return parseInt(m[1], 10);
+  }
+  return undefined;
+}
+
+function buildSubstitutions(
+  ingredient: UnifiedIngredient | undefined,
+): Array<{ name: string; rationale: string; type: "complementary" | "direct" }> {
+  if (!ingredient) return [];
+  const subs: Array<{ name: string; rationale: string; type: "complementary" | "direct" }> = [];
+
+  const pairing = (ingredient as { pairingRecommendations?: { complementary?: string[]; contrasting?: string[] } })
+    .pairingRecommendations;
+
+  if (pairing?.complementary) {
+    for (const alt of pairing.complementary.slice(0, 5)) {
+      subs.push({
+        name: alt,
+        rationale: `Shares flavor affinity with ${ingredient.name} — works well in similar contexts.`,
+        type: "complementary",
+      });
+    }
+  }
+
+  return subs;
+}
+
+export async function GET(
+  _request: Request,
+  props: { params: Promise<{ name: string }> },
+) {
+  try {
+    const { name } = await props.params;
+    const ingredientName = decodeURIComponent(name);
+
+    const ingredientService = IngredientService.getInstance();
+    const ingredient = ingredientService.getIngredientByName(ingredientName);
+
+    // Find recipes using this ingredient
+    const recipeService = UnifiedRecipeService.getInstance();
+    const allRecipes = await recipeService.getAllRecipes();
+
+    const relatedRecipes: RelatedRecipe[] = [];
+    for (const recipe of allRecipes) {
+      if (!Array.isArray(recipe.ingredients)) continue;
+      const match = recipe.ingredients.find((ing) =>
+        ing?.name ? ingredientMatches(ing.name, ingredientName) : false,
+      );
+      if (match) {
+        relatedRecipes.push({
+          id: recipe.id as string,
+          name: recipe.name,
+          cuisine: recipe.cuisine,
+          description: recipe.description,
+          prepTime: extractTime(recipe, "prep"),
+          cookTime: extractTime(recipe, "cook"),
+          servings:
+            (recipe as { baseServingSize?: number }).baseServingSize ||
+            recipe.servingSize ||
+            recipe.numberOfServings,
+          amount: match.amount,
+          unit: match.unit,
+        });
+      }
+      if (relatedRecipes.length >= 24) break;
+    }
+
+    const substitutions = buildSubstitutions(ingredient);
+
+    return NextResponse.json({
+      success: true,
+      ingredient: ingredient ?? null,
+      relatedRecipes,
+      substitutions,
+      totalRecipeMatches: relatedRecipes.length,
+    });
+  } catch (error) {
+    console.error("[ingredients/:name] Error:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to fetch ingredient details" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/techniques/[name]/route.ts
+++ b/src/app/api/techniques/[name]/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse } from "next/server";
+import { allCookingMethods } from "@/data/cooking/methods";
+
+export const dynamic = "force-dynamic";
+
+function normalize(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, "").trim();
+}
+
+// Common verb → canonical cooking method name
+const VERB_ALIASES: Record<string, string> = {
+  roast: "roasting",
+  roasted: "roasting",
+  bake: "roasting",
+  baked: "roasting",
+  baking: "roasting",
+  saute: "stirfrying",
+  sauteed: "stirfrying",
+  sear: "stirfrying",
+  seared: "stirfrying",
+  stirfry: "stirfrying",
+  stirfried: "stirfrying",
+  fry: "frying",
+  fried: "frying",
+  deepfry: "frying",
+  grill: "grilling",
+  grilled: "grilling",
+  broil: "broiling",
+  broiled: "broiling",
+  boil: "boiling",
+  boiled: "boiling",
+  simmer: "simmering",
+  simmered: "simmering",
+  poach: "poaching",
+  poached: "poaching",
+  steam: "steaming",
+  steamed: "steaming",
+  braise: "braising",
+  braised: "braising",
+  stew: "stewing",
+  stewed: "stewing",
+  sousvide: "sousvide",
+  pressurecook: "pressurecooking",
+  ferment: "fermentation",
+  fermented: "fermentation",
+  pickle: "pickling",
+  pickled: "pickling",
+  cure: "curing",
+  cured: "curing",
+  smoke: "smoking",
+  smoked: "smoking",
+  dehydrate: "dehydrating",
+  dehydrated: "dehydrating",
+  marinate: "marinating",
+  marinated: "marinating",
+  infuse: "infusing",
+  infused: "infusing",
+  raw: "raw",
+};
+
+export async function GET(
+  _request: Request,
+  props: { params: Promise<{ name: string }> },
+) {
+  try {
+    const { name } = await props.params;
+    const queryRaw = decodeURIComponent(name);
+    const query = normalize(queryRaw);
+
+    // Try direct key match first
+    const keys = Object.keys(allCookingMethods);
+    let match = keys.find((k) => normalize(k) === query);
+
+    // Try alias
+    if (!match && VERB_ALIASES[query]) {
+      const aliasTarget = VERB_ALIASES[query];
+      match = keys.find((k) => normalize(k) === aliasTarget);
+    }
+
+    // Try substring
+    if (!match) {
+      match = keys.find((k) => normalize(k).includes(query) || query.includes(normalize(k)));
+    }
+
+    if (!match) {
+      return NextResponse.json(
+        { success: false, error: "Technique not found", query: queryRaw },
+        { status: 404 },
+      );
+    }
+
+    const method = (allCookingMethods as Record<string, unknown>)[match];
+    return NextResponse.json({ success: true, technique: method, canonicalKey: match });
+  } catch (error) {
+    console.error("[techniques/:name] Error:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to fetch technique" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/recipes/[recipeId]/page.tsx
+++ b/src/app/recipes/[recipeId]/page.tsx
@@ -2,7 +2,11 @@
 
 import Link from "next/link";
 import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { IngredientDrawer } from "@/components/recipes/IngredientDrawer";
+import { InteractiveInstruction } from "@/components/recipes/InteractiveInstruction";
+import { NutritionVisualization } from "@/components/recipes/NutritionVisualization";
 import { RecipeCard } from "@/components/recipes/RecipeCard";
+import { TechniqueModal } from "@/components/recipes/TechniqueModal";
 import type { Recipe } from "@/types/recipe";
 
 // ===== Constants =====
@@ -650,31 +654,6 @@ function AlchemicalScoreSection({ recipe }: { recipe: Recipe }) {
   );
 }
 
-function NutritionGrid({ nutrition }: { nutrition: NormalizedNutrition }) {
-  const macros = [
-    { label: "Calories", value: nutrition.calories, unit: "", color: "text-amber-400" },
-    { label: "Protein", value: nutrition.protein, unit: "g", color: "text-emerald-400" },
-    { label: "Carbs", value: nutrition.carbs, unit: "g", color: "text-blue-400" },
-    { label: "Fat", value: nutrition.fat, unit: "g", color: "text-orange-400" },
-    { label: "Fiber", value: nutrition.fiber, unit: "g", color: "text-green-400" },
-    { label: "Sodium", value: nutrition.sodium, unit: "mg", color: "text-purple-400" },
-    { label: "Sugar", value: nutrition.sugar, unit: "g", color: "text-pink-400" },
-  ].filter((m) => m.value != null && m.value !== 0);
-
-  return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-      {macros.map((m) => (
-        <div key={m.label} className="glass-card-premium rounded-xl border border-white/8 p-3 text-center">
-          <div className={`text-xl font-bold ${m.color}`}>
-            {m.value}{m.unit}
-          </div>
-          <div className="text-xs text-white/60 mt-1">{m.label}</div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
 // ===== Main Component =====
 
 interface RecipePageProps {
@@ -689,6 +668,8 @@ export default function RecipePage({ params }: RecipePageProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [servings, setServings] = useState(1);
   const [copied, setCopied] = useState(false);
+  const [selectedIngredientIndex, setSelectedIngredientIndex] = useState<number | null>(null);
+  const [selectedTechnique, setSelectedTechnique] = useState<string | null>(null);
 
   useEffect(() => {
     params.then(p => setRecipeId(p.recipeId)).catch(console.error);
@@ -937,24 +918,38 @@ export default function RecipePage({ params }: RecipePageProps) {
                   Scaled from {baseServings} to {servings} servings
                 </p>
               )}
-              <ul className="space-y-3">
+              <p className="text-xs text-white/40 mb-3">
+                Click any ingredient to explore its profile, pairings, and related recipes.
+              </p>
+              <ul className="space-y-1">
                 {recipe.ingredients.map((ing, index) => {
                   const scaledAmount = ing.amount ? Math.round(ing.amount * scale * 100) / 100 : null;
                   return (
-                    <li key={index} className="flex items-start gap-3 group">
-                      <span className="w-1.5 h-1.5 rounded-full bg-amber-400 mt-2.5 shrink-0 group-hover:bg-amber-300 transition-colors" />
-                      <div>
-                        <span className="text-white">
-                          {scaledAmount != null && (
-                            <span className="text-amber-300 font-semibold">{scaledAmount} </span>
+                    <li key={index}>
+                      <button
+                        type="button"
+                        onClick={() => setSelectedIngredientIndex(index)}
+                        className="w-full flex items-start gap-3 group text-left px-3 py-2 -mx-3 rounded-lg hover:bg-amber-500/5 border border-transparent hover:border-amber-500/20 transition-colors"
+                      >
+                        <span className="w-1.5 h-1.5 rounded-full bg-amber-400 mt-2.5 shrink-0 group-hover:bg-amber-300 group-hover:scale-125 transition-transform" />
+                        <div className="flex-1 min-w-0">
+                          <span className="text-white">
+                            {scaledAmount != null && (
+                              <span className="text-amber-300 font-semibold">{scaledAmount} </span>
+                            )}
+                            {ing.unit && <span className="text-white/80">{ing.unit} </span>}
+                            <span className="group-hover:text-amber-200 transition-colors underline decoration-dotted decoration-white/20 underline-offset-4 group-hover:decoration-amber-400/60">
+                              {ing.name}
+                            </span>
+                          </span>
+                          {ing.notes && (
+                            <span className="text-sm text-white/60 ml-2 italic">({ing.notes})</span>
                           )}
-                          {ing.unit && <span className="text-white/80">{ing.unit} </span>}
-                          {ing.name}
+                        </div>
+                        <span className="text-white/20 group-hover:text-amber-400 transition-colors text-sm shrink-0 mt-1" aria-hidden="true">
+                          &#x2192;
                         </span>
-                        {ing.notes && (
-                          <span className="text-sm text-white/60 ml-2 italic">({ing.notes})</span>
-                        )}
-                      </div>
+                      </button>
                     </li>
                   );
                 })}
@@ -963,13 +958,21 @@ export default function RecipePage({ params }: RecipePageProps) {
 
             {/* Instructions */}
             <SectionCard title="Instructions" icon="&#x1F4DD;">
+              <p className="text-xs text-white/40 mb-4">
+                Highlighted <span className="text-orange-300 underline decoration-dotted decoration-orange-400/50 underline-offset-4">techniques</span> open a deep-dive. Time phrases include a built-in timer.
+              </p>
               <ol className="space-y-5">
                 {recipe.instructions.map((instruction, index) => (
                   <li key={index} className="flex gap-4">
                     <span className="shrink-0 w-8 h-8 rounded-full bg-gradient-to-br from-amber-500/20 to-orange-500/20 border border-amber-500/30 flex items-center justify-center text-sm font-bold text-amber-300">
                       {index + 1}
                     </span>
-                    <p className="text-white/80 leading-relaxed pt-1">{instruction}</p>
+                    <p className="text-white/80 leading-relaxed pt-1">
+                      <InteractiveInstruction
+                        text={instruction}
+                        onTechniqueClick={setSelectedTechnique}
+                      />
+                    </p>
                   </li>
                 ))}
               </ol>
@@ -1176,31 +1179,7 @@ export default function RecipePage({ params }: RecipePageProps) {
             {/* Nutrition */}
             {nutrition && (
               <SectionCard title="Nutrition Per Serving" icon="&#x1F4CA;">
-                <NutritionGrid nutrition={nutrition} />
-                {(nutrition.vitamins?.length && nutrition.vitamins.length > 0) || (nutrition.minerals?.length && nutrition.minerals.length > 0) ? (
-                  <div className="mt-4 space-y-3">
-                    {nutrition.vitamins?.length && nutrition.vitamins.length > 0 && (
-                      <div>
-                        <h3 className="text-xs font-semibold text-white/60 uppercase tracking-wider mb-1.5">Vitamins</h3>
-                        <div className="flex flex-wrap gap-1.5">
-                          {nutrition.vitamins.map((v: string) => (
-                            <span key={v} className="px-2 py-0.5 bg-emerald-500/10 rounded text-xs text-emerald-400">{v}</span>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                    {nutrition.minerals?.length && nutrition.minerals.length > 0 && (
-                      <div>
-                        <h3 className="text-xs font-semibold text-white/60 uppercase tracking-wider mb-1.5">Minerals</h3>
-                        <div className="flex flex-wrap gap-1.5">
-                          {nutrition.minerals.map((m: string) => (
-                            <span key={m} className="px-2 py-0.5 bg-sky-500/10 rounded text-xs text-sky-400">{m}</span>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                ) : null}
+                <NutritionVisualization nutrition={nutrition} />
               </SectionCard>
             )}
 
@@ -1356,6 +1335,28 @@ export default function RecipePage({ params }: RecipePageProps) {
             )}
           </div>
         </div>
+
+        {/* ===== Ingredient Drawer ===== */}
+        {(() => {
+          const sel = selectedIngredientIndex != null ? recipe.ingredients[selectedIngredientIndex] : null;
+          const scaledAmount = sel && sel.amount ? Math.round(sel.amount * scale * 100) / 100 : undefined;
+          return (
+            <IngredientDrawer
+              ingredientName={sel?.name ?? null}
+              recipeAmount={scaledAmount}
+              recipeUnit={sel?.unit}
+              recipeNotes={sel?.notes}
+              currentRecipeId={recipe.id as string}
+              onClose={() => setSelectedIngredientIndex(null)}
+            />
+          );
+        })()}
+
+        {/* ===== Technique Modal ===== */}
+        <TechniqueModal
+          techniqueName={selectedTechnique}
+          onClose={() => setSelectedTechnique(null)}
+        />
 
         {/* ===== Similar Recipes ===== */}
         {recommendedRecipes.length > 0 && (

--- a/src/components/recipes/IngredientDrawer.tsx
+++ b/src/components/recipes/IngredientDrawer.tsx
@@ -1,0 +1,875 @@
+"use client";
+
+import Link from "next/link";
+import React, { useEffect, useState, useCallback } from "react";
+
+// ===== Types =====
+
+interface IngredientData {
+  name: string;
+  category?: string;
+  subCategory?: string;
+  subcategory?: string;
+  description?: string;
+  qualities?: string[];
+  origin?: string[] | string;
+  elementalProperties?: { Fire?: number; Water?: number; Earth?: number; Air?: number };
+  alchemicalProperties?: { Spirit?: number; Essence?: number; Matter?: number; Substance?: number };
+  kalchm?: number;
+  monica?: number;
+  flavorProfile?: Record<string, number>;
+  sensoryProfile?: {
+    taste?: Record<string, number>;
+    aroma?: Record<string, number> | string[];
+    texture?: Record<string, number> | string[];
+  };
+  nutritionalProfile?: {
+    serving_size?: string;
+    calories?: number;
+    macros?: { protein?: number; carbs?: number; fat?: number; fiber?: number };
+    vitamins?: Record<string, number>;
+    minerals?: Record<string, number>;
+    antioxidants?: Record<string, string>;
+    source?: string;
+  };
+  storage?:
+    | string
+    | {
+        container?: string;
+        duration?: string;
+        temperature?: string | { fahrenheit: number; celsius: number };
+        notes?: string;
+      };
+  seasonality?: string[] | string;
+  season?: string[] | string;
+  pairingRecommendations?: {
+    complementary?: string[];
+    contrasting?: string[];
+    toAvoid?: string[];
+  };
+  astrologicalProfile?: {
+    elementalAffinity?: { base?: string; secondary?: string };
+    rulingPlanets?: string[];
+    zodiacAffinity?: string[];
+  };
+  recommendedCookingMethods?: Array<string | { name?: string }>;
+  quantityBase?: { amount?: number; unit?: string };
+}
+
+interface RelatedRecipe {
+  id: string;
+  name: string;
+  cuisine?: string;
+  description?: string;
+  prepTime?: number;
+  cookTime?: number;
+  servings?: number;
+  amount?: number;
+  unit?: string;
+}
+
+interface Substitution {
+  name: string;
+  rationale: string;
+  type: "complementary" | "direct";
+}
+
+interface ApiResponse {
+  success: boolean;
+  ingredient: IngredientData | null;
+  relatedRecipes: RelatedRecipe[];
+  substitutions: Substitution[];
+  totalRecipeMatches: number;
+  error?: string;
+}
+
+interface IngredientDrawerProps {
+  ingredientName: string | null;
+  recipeAmount?: number;
+  recipeUnit?: string;
+  recipeNotes?: string;
+  currentRecipeId?: string;
+  onClose: () => void;
+}
+
+// ===== Constants =====
+
+const ELEMENT_COLORS: Record<string, { bar: string; text: string }> = {
+  Fire: { bar: "bg-red-500", text: "text-red-400" },
+  Water: { bar: "bg-blue-500", text: "text-blue-400" },
+  Earth: { bar: "bg-amber-600", text: "text-amber-400" },
+  Air: { bar: "bg-sky-400", text: "text-sky-400" },
+};
+
+const ELEMENT_ICONS: Record<string, string> = {
+  Fire: "\u{1F525}",
+  Water: "\u{1F4A7}",
+  Earth: "\u{1F30D}",
+  Air: "\u{1F4A8}",
+};
+
+const ESMS_COLORS: Record<string, { color: string; text: string }> = {
+  Spirit: { color: "#f59e0b", text: "text-amber-400" },
+  Essence: { color: "#6366f1", text: "text-indigo-400" },
+  Matter: { color: "#10b981", text: "text-emerald-400" },
+  Substance: { color: "#a855f7", text: "text-purple-400" },
+};
+
+// ===== Helpers =====
+
+function formatMinutes(m?: number): string {
+  if (!m) return "";
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  const mins = m % 60;
+  return mins > 0 ? `${h}h ${mins}m` : `${h}h`;
+}
+
+function normalizeSeasons(seasons?: string[] | string): string[] {
+  if (!seasons) return [];
+  return Array.isArray(seasons) ? seasons : [seasons];
+}
+
+function normalizeOrigin(origin?: string[] | string): string[] {
+  if (!origin) return [];
+  return Array.isArray(origin) ? origin : [origin];
+}
+
+function normalizeMethods(methods?: Array<string | { name?: string }>): string[] {
+  if (!methods) return [];
+  return methods
+    .map((m) => (typeof m === "string" ? m : m?.name || ""))
+    .filter(Boolean);
+}
+
+function storageToText(storage: IngredientData["storage"]): string | null {
+  if (!storage) return null;
+  if (typeof storage === "string") return storage;
+  const parts: string[] = [];
+  if (storage.container) parts.push(storage.container);
+  if (storage.duration) parts.push(`for ${storage.duration}`);
+  if (storage.temperature) {
+    const t = storage.temperature;
+    if (typeof t === "string") parts.push(`at ${t}`);
+    else parts.push(`at ${t.fahrenheit}\u00B0F / ${t.celsius}\u00B0C`);
+  }
+  if (storage.notes) parts.push(`— ${storage.notes}`);
+  return parts.join(" ");
+}
+
+// ===== Small UI primitives =====
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="px-5 py-4 border-b border-white/5 last:border-b-0">
+      <h3 className="text-[11px] uppercase tracking-[0.14em] text-white/50 font-semibold mb-3">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function Bar({
+  label,
+  value,
+  max = 1,
+  barClass,
+  labelClass = "text-white/60",
+  showPct = true,
+  icon,
+}: {
+  label: string;
+  value: number;
+  max?: number;
+  barClass: string;
+  labelClass?: string;
+  showPct?: boolean;
+  icon?: string;
+}) {
+  const pct = Math.min(100, Math.max(0, (value / max) * 100));
+  return (
+    <div className="flex items-center gap-3">
+      {icon && <span className="w-5 text-center text-base leading-none">{icon}</span>}
+      <span className={`w-16 text-xs font-medium capitalize ${labelClass}`}>{label}</span>
+      <div className="flex-1 h-2 bg-white/5 rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full ${barClass} transition-all duration-500`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      {showPct && (
+        <span className="w-10 text-right text-xs text-white/50 tabular-nums">
+          {Math.round(pct)}%
+        </span>
+      )}
+    </div>
+  );
+}
+
+function Chip({
+  label,
+  tone = "default",
+}: {
+  label: string;
+  tone?: "default" | "good" | "warn" | "bad" | "info";
+}) {
+  const tones: Record<string, string> = {
+    default: "bg-white/5 border-white/10 text-white/70",
+    good: "bg-emerald-500/10 border-emerald-500/30 text-emerald-300",
+    warn: "bg-amber-500/10 border-amber-500/30 text-amber-300",
+    bad: "bg-red-500/10 border-red-500/30 text-red-300",
+    info: "bg-indigo-500/10 border-indigo-500/30 text-indigo-300",
+  };
+  return (
+    <span
+      className={`inline-block px-2.5 py-1 rounded-full border text-xs capitalize ${tones[tone]}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+// ===== Drawer =====
+
+export function IngredientDrawer({
+  ingredientName,
+  recipeAmount,
+  recipeUnit,
+  recipeNotes,
+  currentRecipeId,
+  onClose,
+}: IngredientDrawerProps) {
+  const open = Boolean(ingredientName);
+  const [data, setData] = useState<ApiResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!ingredientName) {
+      setData(null);
+      return;
+    }
+    const controller = new AbortController();
+    const fetchData = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(
+          `/api/ingredients/${encodeURIComponent(ingredientName)}`,
+          { signal: controller.signal },
+        );
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const json = (await res.json()) as ApiResponse;
+        setData(json);
+      } catch (err) {
+        if ((err as { name?: string })?.name === "AbortError") return;
+        setError("Couldn't load ingredient details");
+        setData(null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    void fetchData();
+    return () => controller.abort();
+  }, [ingredientName]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  // Lock body scroll
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) onClose();
+    },
+    [onClose],
+  );
+
+  if (!open) return null;
+
+  const ingredient = data?.ingredient;
+  const relatedRecipes = data?.relatedRecipes ?? [];
+  const substitutions = data?.substitutions ?? [];
+
+  const displayName = ingredient?.name ?? ingredientName ?? "";
+  const category = ingredient?.category ?? "";
+  const subcategory = ingredient?.subCategory ?? ingredient?.subcategory ?? "";
+
+  const elemental = ingredient?.elementalProperties;
+  const hasElemental =
+    elemental &&
+    ((elemental.Fire ?? 0) +
+      (elemental.Water ?? 0) +
+      (elemental.Earth ?? 0) +
+      (elemental.Air ?? 0)) >
+      0;
+
+  const alch = ingredient?.alchemicalProperties;
+  const hasAlch =
+    alch &&
+    ((alch.Spirit ?? 0) + (alch.Essence ?? 0) + (alch.Matter ?? 0) + (alch.Substance ?? 0)) >
+      0;
+
+  const taste =
+    ingredient?.sensoryProfile?.taste ?? (ingredient?.flavorProfile as Record<string, number> | undefined);
+  const tasteEntries = taste
+    ? Object.entries(taste).filter(([, v]) => typeof v === "number" && (v as number) > 0)
+    : [];
+
+  const nut = ingredient?.nutritionalProfile;
+  const seasons = normalizeSeasons(ingredient?.seasonality ?? ingredient?.season);
+  const origins = normalizeOrigin(ingredient?.origin);
+  const methods = normalizeMethods(ingredient?.recommendedCookingMethods);
+  const storageText = storageToText(ingredient?.storage);
+  const pairing = ingredient?.pairingRecommendations;
+  const rulingPlanets = ingredient?.astrologicalProfile?.rulingPlanets ?? [];
+  const zodiacs = ingredient?.astrologicalProfile?.zodiacAffinity ?? [];
+
+  const filteredRelated = currentRecipeId
+    ? relatedRecipes.filter((r) => r.id !== currentRecipeId)
+    : relatedRecipes;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex justify-end"
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${displayName} details`}
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm animate-[fadeIn_0.2s_ease-out]"
+        aria-hidden="true"
+      />
+
+      {/* Drawer panel */}
+      <aside
+        className="relative h-full w-full sm:max-w-lg md:max-w-xl bg-[#0a0a12] border-l border-white/10 overflow-y-auto animate-[slideInRight_0.28s_cubic-bezier(0.2,0.9,0.3,1)] shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <header className="sticky top-0 z-10 backdrop-blur-xl bg-[#0a0a12]/90 border-b border-white/10">
+          <div className="flex items-start justify-between gap-4 px-5 py-4">
+            <div className="min-w-0 flex-1">
+              <h2 className="text-2xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-amber-200 to-orange-300 leading-tight truncate">
+                {displayName || "Ingredient"}
+              </h2>
+              <div className="flex items-center gap-2 mt-1 text-xs">
+                {category && (
+                  <span className="text-white/60 capitalize">{category}</span>
+                )}
+                {subcategory && (
+                  <>
+                    <span className="text-white/30">•</span>
+                    <span className="text-white/60 capitalize">
+                      {subcategory.replace(/_/g, " ")}
+                    </span>
+                  </>
+                )}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="shrink-0 w-9 h-9 flex items-center justify-center rounded-full bg-white/5 hover:bg-white/10 text-white/60 hover:text-white transition-colors"
+            >
+              <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M6 6l12 12M6 18L18 6" strokeLinecap="round" />
+              </svg>
+            </button>
+          </div>
+
+          {/* In this recipe banner */}
+          {(recipeAmount != null || recipeUnit || recipeNotes) && (
+            <div className="px-5 pb-4">
+              <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-amber-500/10 border border-amber-500/20">
+                <span className="text-[10px] uppercase tracking-widest text-amber-400/80 font-semibold">
+                  In this recipe
+                </span>
+                <span className="text-sm text-amber-100">
+                  {recipeAmount != null && (
+                    <span className="font-semibold">{recipeAmount} </span>
+                  )}
+                  {recipeUnit && <span>{recipeUnit}</span>}
+                  {recipeNotes && (
+                    <span className="text-amber-200/70 italic"> ({recipeNotes})</span>
+                  )}
+                </span>
+              </div>
+            </div>
+          )}
+        </header>
+
+        {/* Loading */}
+        {isLoading && (
+          <div className="flex flex-col items-center justify-center py-16 gap-3">
+            <div className="w-8 h-8 border-2 border-amber-400/30 border-t-amber-400 rounded-full animate-spin" />
+            <p className="text-sm text-white/40">Loading ingredient…</p>
+          </div>
+        )}
+
+        {/* Error */}
+        {!isLoading && error && (
+          <div className="px-5 py-8 text-center">
+            <p className="text-sm text-red-300">{error}</p>
+          </div>
+        )}
+
+        {/* No ingredient data — show related recipes only */}
+        {!isLoading && !error && !ingredient && (
+          <div className="px-5 py-6 text-sm text-white/50">
+            <p>No detailed profile available for this ingredient yet.</p>
+            {filteredRelated.length > 0 && (
+              <p className="mt-2">
+                Found in {filteredRelated.length} other recipe
+                {filteredRelated.length === 1 ? "" : "s"} — see below.
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Body */}
+        {!isLoading && !error && (
+          <div className="pb-6">
+            {/* Qualities */}
+            {ingredient?.qualities && ingredient.qualities.length > 0 && (
+              <Section title="Qualities">
+                <div className="flex flex-wrap gap-1.5">
+                  {ingredient.qualities.map((q) => (
+                    <Chip key={q} label={q} />
+                  ))}
+                </div>
+              </Section>
+            )}
+
+            {/* Elemental Signature */}
+            {hasElemental && elemental && (
+              <Section title="Elemental Signature">
+                <div className="space-y-2">
+                  {(["Fire", "Water", "Earth", "Air"] as const).map((el) => (
+                    <Bar
+                      key={el}
+                      label={el}
+                      value={elemental[el] ?? 0}
+                      barClass={ELEMENT_COLORS[el].bar}
+                      labelClass={ELEMENT_COLORS[el].text}
+                      icon={ELEMENT_ICONS[el]}
+                    />
+                  ))}
+                </div>
+              </Section>
+            )}
+
+            {/* Alchemical (ESMS) */}
+            {hasAlch && alch && (
+              <Section title="Alchemical Properties">
+                <div className="grid grid-cols-2 gap-2">
+                  {(["Spirit", "Essence", "Matter", "Substance"] as const).map((key) => {
+                    const v = alch[key] ?? 0;
+                    if (v === 0) return null;
+                    const cfg = ESMS_COLORS[key];
+                    return (
+                      <div
+                        key={key}
+                        className="flex items-center justify-between px-3 py-2 rounded-lg bg-white/[0.03] border border-white/5"
+                      >
+                        <div className="flex items-center gap-2">
+                          <span
+                            className="w-2 h-2 rounded-full"
+                            style={{ background: cfg.color }}
+                          />
+                          <span className="text-xs text-white/70">{key}</span>
+                        </div>
+                        <span className={`text-sm font-semibold tabular-nums ${cfg.text}`}>
+                          {v.toFixed(2)}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+                {(ingredient?.kalchm != null || ingredient?.monica != null) && (
+                  <div className="flex gap-4 mt-3 text-xs text-white/50">
+                    {ingredient?.kalchm != null && (
+                      <span>
+                        K<sub>alchm</sub>:{" "}
+                        <span className="text-amber-300 font-semibold tabular-nums">
+                          {ingredient.kalchm.toFixed(3)}
+                        </span>
+                      </span>
+                    )}
+                    {ingredient?.monica != null && (
+                      <span>
+                        Monica:{" "}
+                        <span className="text-indigo-300 font-semibold tabular-nums">
+                          {ingredient.monica.toFixed(3)}
+                        </span>
+                      </span>
+                    )}
+                  </div>
+                )}
+              </Section>
+            )}
+
+            {/* Flavor / Taste */}
+            {tasteEntries.length > 0 && (
+              <Section title="Flavor Profile">
+                <div className="space-y-2">
+                  {tasteEntries.map(([k, v]) => (
+                    <Bar
+                      key={k}
+                      label={k}
+                      value={v as number}
+                      max={1}
+                      barClass="bg-gradient-to-r from-amber-500 to-orange-500"
+                    />
+                  ))}
+                </div>
+              </Section>
+            )}
+
+            {/* Nutrition */}
+            {nut && (nut.calories != null || nut.macros) && (
+              <Section title="Nutrition">
+                {nut.serving_size && (
+                  <p className="text-xs text-white/40 mb-3 italic">
+                    Per {nut.serving_size}
+                  </p>
+                )}
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                  {nut.calories != null && (
+                    <NutriStat label="Calories" value={nut.calories} color="text-amber-400" />
+                  )}
+                  {nut.macros?.protein != null && (
+                    <NutriStat
+                      label="Protein"
+                      value={nut.macros.protein}
+                      unit="g"
+                      color="text-emerald-400"
+                    />
+                  )}
+                  {nut.macros?.carbs != null && (
+                    <NutriStat
+                      label="Carbs"
+                      value={nut.macros.carbs}
+                      unit="g"
+                      color="text-blue-400"
+                    />
+                  )}
+                  {nut.macros?.fat != null && (
+                    <NutriStat
+                      label="Fat"
+                      value={nut.macros.fat}
+                      unit="g"
+                      color="text-orange-400"
+                    />
+                  )}
+                  {nut.macros?.fiber != null && (
+                    <NutriStat
+                      label="Fiber"
+                      value={nut.macros.fiber}
+                      unit="g"
+                      color="text-green-400"
+                    />
+                  )}
+                </div>
+
+                {nut.vitamins && Object.keys(nut.vitamins).length > 0 && (
+                  <div className="mt-4">
+                    <div className="text-[10px] uppercase tracking-wider text-white/40 mb-1.5">
+                      Vitamins
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {Object.entries(nut.vitamins).map(([v, _]) => (
+                        <span
+                          key={v}
+                          className="px-2 py-0.5 bg-emerald-500/10 rounded text-xs text-emerald-300"
+                        >
+                          {v}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {nut.minerals && Object.keys(nut.minerals).length > 0 && (
+                  <div className="mt-3">
+                    <div className="text-[10px] uppercase tracking-wider text-white/40 mb-1.5">
+                      Minerals
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {Object.entries(nut.minerals).map(([m, _]) => (
+                        <span
+                          key={m}
+                          className="px-2 py-0.5 bg-sky-500/10 rounded text-xs text-sky-300"
+                        >
+                          {m}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {nut.source && (
+                  <p className="text-[10px] text-white/30 mt-3 italic">Source: {nut.source}</p>
+                )}
+              </Section>
+            )}
+
+            {/* Seasonality / Origin */}
+            {(seasons.length > 0 || origins.length > 0) && (
+              <Section title="Seasonality & Origin">
+                {seasons.length > 0 && (
+                  <div className="mb-3">
+                    <div className="text-[10px] uppercase tracking-wider text-white/40 mb-1.5">
+                      Peak seasons
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {seasons.map((s) => (
+                        <Chip key={s} label={s} tone="good" />
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {origins.length > 0 && (
+                  <div>
+                    <div className="text-[10px] uppercase tracking-wider text-white/40 mb-1.5">
+                      Origin
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {origins.map((o) => (
+                        <Chip key={o} label={o} />
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </Section>
+            )}
+
+            {/* Storage */}
+            {storageText && (
+              <Section title="Storage">
+                <p className="text-sm text-white/70 leading-relaxed">{storageText}</p>
+              </Section>
+            )}
+
+            {/* Cooking Methods */}
+            {methods.length > 0 && (
+              <Section title="Recommended Cooking Methods">
+                <div className="flex flex-wrap gap-1.5">
+                  {methods.map((m) => (
+                    <Chip key={m} label={m} tone="info" />
+                  ))}
+                </div>
+              </Section>
+            )}
+
+            {/* Astrological */}
+            {(rulingPlanets.length > 0 || zodiacs.length > 0) && (
+              <Section title="Astrological Affinities">
+                {rulingPlanets.length > 0 && (
+                  <div className="mb-2">
+                    <div className="text-[10px] uppercase tracking-wider text-white/40 mb-1.5">
+                      Ruling planets
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {rulingPlanets.map((p) => (
+                        <Chip key={p} label={p} tone="info" />
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {zodiacs.length > 0 && (
+                  <div>
+                    <div className="text-[10px] uppercase tracking-wider text-white/40 mb-1.5">
+                      Zodiac
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {zodiacs.map((z) => (
+                        <Chip key={z} label={z} />
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </Section>
+            )}
+
+            {/* Pairings */}
+            {pairing && (pairing.complementary?.length || pairing.contrasting?.length || pairing.toAvoid?.length) && (
+              <Section title="Pairings">
+                {pairing.complementary && pairing.complementary.length > 0 && (
+                  <div className="mb-3">
+                    <div className="text-[10px] uppercase tracking-wider text-emerald-400/80 mb-1.5">
+                      Complements
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {pairing.complementary.map((p) => (
+                        <Chip key={p} label={p} tone="good" />
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {pairing.contrasting && pairing.contrasting.length > 0 && (
+                  <div className="mb-3">
+                    <div className="text-[10px] uppercase tracking-wider text-amber-400/80 mb-1.5">
+                      Contrasts (bold)
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {pairing.contrasting.map((p) => (
+                        <Chip key={p} label={p} tone="warn" />
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {pairing.toAvoid && pairing.toAvoid.length > 0 && (
+                  <div>
+                    <div className="text-[10px] uppercase tracking-wider text-red-400/80 mb-1.5">
+                      Avoid
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {pairing.toAvoid.map((p) => (
+                        <Chip key={p} label={p} tone="bad" />
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </Section>
+            )}
+
+            {/* Substitutions */}
+            {substitutions.length > 0 && (
+              <Section title="Substitution Ideas">
+                <ul className="space-y-2">
+                  {substitutions.map((s) => (
+                    <li
+                      key={s.name}
+                      className="px-3 py-2 rounded-lg bg-white/[0.03] border border-white/5"
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="text-amber-300 font-medium capitalize">{s.name}</span>
+                        <span className="text-[10px] uppercase tracking-wider text-white/40 px-1.5 py-0.5 rounded bg-white/5">
+                          {s.type}
+                        </span>
+                      </div>
+                      <p className="text-xs text-white/50 mt-0.5 leading-relaxed">
+                        {s.rationale}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              </Section>
+            )}
+
+            {/* Related recipes */}
+            {filteredRelated.length > 0 && (
+              <Section
+                title={`More recipes with ${displayName} (${filteredRelated.length})`}
+              >
+                <ul className="space-y-2">
+                  {filteredRelated.slice(0, 8).map((r) => (
+                    <li key={r.id}>
+                      <Link
+                        href={`/recipes/${encodeURIComponent(r.id)}`}
+                        onClick={onClose}
+                        className="block px-3 py-2.5 rounded-lg bg-white/[0.03] border border-white/5 hover:border-amber-500/30 hover:bg-amber-500/5 transition-colors group"
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0 flex-1">
+                            <div className="text-sm font-medium text-white group-hover:text-amber-200 truncate">
+                              {r.name}
+                            </div>
+                            <div className="flex items-center gap-2 mt-0.5 text-[11px] text-white/40">
+                              {r.cuisine && (
+                                <span className="capitalize">{r.cuisine}</span>
+                              )}
+                              {(r.prepTime || r.cookTime) && (
+                                <>
+                                  <span>•</span>
+                                  <span>
+                                    {formatMinutes((r.prepTime ?? 0) + (r.cookTime ?? 0))}
+                                  </span>
+                                </>
+                              )}
+                              {r.amount != null && r.unit && (
+                                <>
+                                  <span>•</span>
+                                  <span>
+                                    {r.amount} {r.unit}
+                                  </span>
+                                </>
+                              )}
+                            </div>
+                          </div>
+                          <span className="text-amber-400/60 group-hover:text-amber-300 text-sm shrink-0">
+                            →
+                          </span>
+                        </div>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+                {filteredRelated.length > 8 && (
+                  <p className="text-xs text-white/40 mt-3 text-center">
+                    +{filteredRelated.length - 8} more
+                  </p>
+                )}
+              </Section>
+            )}
+          </div>
+        )}
+      </aside>
+
+      {/* eslint-disable react/no-unknown-property */}
+      <style jsx>{`
+        @keyframes fadeIn {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+        @keyframes slideInRight {
+          from { transform: translateX(100%); }
+          to { transform: translateX(0); }
+        }
+      `}</style>
+      {/* eslint-enable react/no-unknown-property */}
+    </div>
+  );
+}
+
+// ===== Sub-components =====
+
+function NutriStat({
+  label,
+  value,
+  unit = "",
+  color,
+}: {
+  label: string;
+  value: number;
+  unit?: string;
+  color: string;
+}) {
+  return (
+    <div className="px-3 py-2 rounded-lg bg-white/[0.03] border border-white/5 text-center">
+      <div className={`text-base font-bold ${color} tabular-nums`}>
+        {value}
+        {unit}
+      </div>
+      <div className="text-[10px] uppercase tracking-wider text-white/40 mt-0.5">{label}</div>
+    </div>
+  );
+}

--- a/src/components/recipes/InteractiveInstruction.tsx
+++ b/src/components/recipes/InteractiveInstruction.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+// ===== Known technique verbs → canonical form =====
+// Keep this list broad; the API resolves to cookingMethod data.
+const TECHNIQUE_TERMS: Array<{ pattern: RegExp; canonical: string }> = [
+  { pattern: /\b(roast(?:ed|ing)?)\b/i, canonical: "roasting" },
+  { pattern: /\b(bak(?:e|ed|ing))\b/i, canonical: "roasting" },
+  { pattern: /\b(saut(?:e|é|ed|éed|ing|éing))\b/i, canonical: "stir-frying" },
+  { pattern: /\b(sear(?:ed|ing)?)\b/i, canonical: "stir-frying" },
+  { pattern: /\b(stir[- ]?fry(?:ing|ed)?|stir[- ]?fried)\b/i, canonical: "stir-frying" },
+  { pattern: /\b(fry(?:ing)?|fried|deep[- ]?fry(?:ing)?)\b/i, canonical: "frying" },
+  { pattern: /\b(grill(?:ed|ing)?)\b/i, canonical: "grilling" },
+  { pattern: /\b(broil(?:ed|ing)?)\b/i, canonical: "broiling" },
+  { pattern: /\b(boil(?:ed|ing)?)\b/i, canonical: "boiling" },
+  { pattern: /\b(simmer(?:ed|ing)?)\b/i, canonical: "simmering" },
+  { pattern: /\b(poach(?:ed|ing)?)\b/i, canonical: "poaching" },
+  { pattern: /\b(steam(?:ed|ing)?)\b/i, canonical: "steaming" },
+  { pattern: /\b(brais(?:e|ed|ing))\b/i, canonical: "braising" },
+  { pattern: /\b(stew(?:ed|ing)?)\b/i, canonical: "stewing" },
+  { pattern: /\b(sous[- ]?vide)\b/i, canonical: "sous-vide" },
+  { pattern: /\b(pressure[- ]?cook(?:ed|ing)?)\b/i, canonical: "pressure-cooking" },
+  { pattern: /\b(ferment(?:ed|ing)?)\b/i, canonical: "fermentation" },
+  { pattern: /\b(pickl(?:e|ed|ing))\b/i, canonical: "pickling" },
+  { pattern: /\b(cur(?:e|ed|ing))\b/i, canonical: "curing" },
+  { pattern: /\b(smok(?:e|ed|ing))\b/i, canonical: "smoking" },
+  { pattern: /\b(dehydrat(?:e|ed|ing))\b/i, canonical: "dehydrating" },
+  { pattern: /\b(marinat(?:e|ed|ing))\b/i, canonical: "marinating" },
+  { pattern: /\b(infus(?:e|ed|ing))\b/i, canonical: "infusing" },
+];
+
+// Time phrase: "15 minutes", "1 hour", "30-45 seconds", "2 hours 30 minutes"
+const TIME_RE =
+  /\b(\d+(?:\.\d+)?)(?:\s*(?:-|to|–)\s*(\d+(?:\.\d+)?))?\s*(hours?|hrs?|minutes?|mins?|seconds?|secs?)\b/gi;
+
+// Temperature phrase: "350°F", "180°C", "350 degrees", "350 F"
+const TEMP_RE = /\b(\d{2,3})\s*(?:°|degrees?)\s*(F|C|Fahrenheit|Celsius)?\b/gi;
+
+// ===== Token types =====
+
+interface TextToken { type: "text"; value: string; }
+interface TechniqueToken { type: "technique"; value: string; canonical: string; }
+interface TimeToken { type: "time"; value: string; seconds: number; label: string; }
+interface TempToken { type: "temp"; value: string; f?: number; c?: number; }
+
+type Token = TextToken | TechniqueToken | TimeToken | TempToken;
+
+interface Match {
+  start: number;
+  end: number;
+  token: Token;
+}
+
+function unitToSeconds(qty: number, unit: string): number {
+  const u = unit.toLowerCase();
+  if (u.startsWith("h")) return Math.round(qty * 3600);
+  if (u.startsWith("min")) return Math.round(qty * 60);
+  return Math.round(qty);
+}
+
+function buildMatches(text: string): Match[] {
+  const matches: Match[] = [];
+
+  // Techniques
+  for (const { pattern, canonical } of TECHNIQUE_TERMS) {
+    const g = new RegExp(pattern.source, pattern.flags.includes("g") ? pattern.flags : pattern.flags + "g");
+    let m: RegExpExecArray | null;
+    while ((m = g.exec(text)) !== null) {
+      matches.push({
+        start: m.index,
+        end: m.index + m[0].length,
+        token: { type: "technique", value: m[0], canonical },
+      });
+      if (m[0].length === 0) g.lastIndex++;
+    }
+  }
+
+  // Times
+  {
+    const g = new RegExp(TIME_RE.source, TIME_RE.flags);
+    let m: RegExpExecArray | null;
+    while ((m = g.exec(text)) !== null) {
+      const qty1 = parseFloat(m[1]);
+      const qty2 = m[2] ? parseFloat(m[2]) : undefined;
+      const unit = m[3];
+      // Use the upper bound if range, else single quantity
+      const qty = qty2 ?? qty1;
+      const seconds = unitToSeconds(qty, unit);
+      matches.push({
+        start: m.index,
+        end: m.index + m[0].length,
+        token: {
+          type: "time",
+          value: m[0],
+          seconds,
+          label: qty2 ? `${qty2} ${unit}` : `${qty1} ${unit}`,
+        },
+      });
+    }
+  }
+
+  // Temperatures
+  {
+    const g = new RegExp(TEMP_RE.source, TEMP_RE.flags);
+    let m: RegExpExecArray | null;
+    while ((m = g.exec(text)) !== null) {
+      const v = parseInt(m[1], 10);
+      const unit = m[2]?.toUpperCase().startsWith("C") ? "C" : "F";
+      const f = unit === "F" ? v : Math.round((v * 9) / 5 + 32);
+      const c = unit === "C" ? v : Math.round(((v - 32) * 5) / 9);
+      matches.push({
+        start: m.index,
+        end: m.index + m[0].length,
+        token: { type: "temp", value: m[0], f, c },
+      });
+    }
+  }
+
+  // Resolve overlaps: sort by start, drop overlapping later matches
+  matches.sort((a, b) => (a.start - b.start) || (b.end - b.start) - (a.end - a.start));
+  const resolved: Match[] = [];
+  let cursor = 0;
+  for (const m of matches) {
+    if (m.start < cursor) continue;
+    resolved.push(m);
+    cursor = m.end;
+  }
+  return resolved;
+}
+
+function tokenize(text: string): Token[] {
+  const matches = buildMatches(text);
+  if (matches.length === 0) return [{ type: "text", value: text }];
+  const out: Token[] = [];
+  let cursor = 0;
+  for (const m of matches) {
+    if (m.start > cursor) {
+      out.push({ type: "text", value: text.slice(cursor, m.start) });
+    }
+    out.push(m.token);
+    cursor = m.end;
+  }
+  if (cursor < text.length) out.push({ type: "text", value: text.slice(cursor) });
+  return out;
+}
+
+// ===== Inline Timer =====
+
+function formatSeconds(s: number): string {
+  if (s < 0) s = 0;
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  if (h > 0) return `${h}:${m.toString().padStart(2, "0")}:${sec.toString().padStart(2, "0")}`;
+  return `${m}:${sec.toString().padStart(2, "0")}`;
+}
+
+function InlineTimer({ totalSeconds, label }: { totalSeconds: number; label: string }) {
+  const [remaining, setRemaining] = useState(totalSeconds);
+  const [running, setRunning] = useState(false);
+  const [done, setDone] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!running) {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      return;
+    }
+    intervalRef.current = setInterval(() => {
+      setRemaining((r) => {
+        if (r <= 1) {
+          setRunning(false);
+          setDone(true);
+          // Audible beep using WebAudio (best-effort)
+          try {
+            const Ctor = (window as unknown as { AudioContext?: typeof AudioContext; webkitAudioContext?: typeof AudioContext }).AudioContext
+              ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+            if (Ctor) {
+              const ctx = new Ctor();
+              const o = ctx.createOscillator();
+              const gain = ctx.createGain();
+              o.connect(gain);
+              gain.connect(ctx.destination);
+              o.frequency.value = 880;
+              gain.gain.setValueAtTime(0.2, ctx.currentTime);
+              o.start();
+              o.stop(ctx.currentTime + 0.4);
+            }
+          } catch {
+            // ignore audio failures
+          }
+          return 0;
+        }
+        return r - 1;
+      });
+    }, 1000);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [running]);
+
+  const reset = () => {
+    setRunning(false);
+    setDone(false);
+    setRemaining(totalSeconds);
+  };
+
+  if (!running && remaining === totalSeconds && !done) {
+    return (
+      <button
+        type="button"
+        onClick={() => setRunning(true)}
+        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-amber-500/10 border border-amber-500/30 text-amber-300 hover:bg-amber-500/20 transition-colors text-xs font-medium align-baseline"
+        title={`Start ${label} timer`}
+      >
+        <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M8 5v14l11-7z" />
+        </svg>
+        {label}
+      </button>
+    );
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md border text-xs font-medium align-baseline tabular-nums ${
+        done
+          ? "bg-emerald-500/15 border-emerald-500/40 text-emerald-300"
+          : "bg-amber-500/15 border-amber-500/40 text-amber-200"
+      }`}
+    >
+      <span className={done ? "" : "animate-pulse"}>
+        {done ? "✓ Done!" : formatSeconds(remaining)}
+      </span>
+      {!done && (
+        <button
+          type="button"
+          onClick={() => setRunning((r) => !r)}
+          className="text-amber-300/70 hover:text-amber-200"
+          aria-label={running ? "Pause" : "Resume"}
+        >
+          {running ? "⏸" : "▶"}
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={reset}
+        className="text-white/50 hover:text-white"
+        aria-label="Reset timer"
+        title="Reset"
+      >
+        ↺
+      </button>
+    </span>
+  );
+}
+
+// ===== Main interactive renderer =====
+
+interface InteractiveInstructionProps {
+  text: string;
+  onTechniqueClick: (canonical: string) => void;
+}
+
+export function InteractiveInstruction({ text, onTechniqueClick }: InteractiveInstructionProps) {
+  const tokens = useMemo(() => tokenize(text), [text]);
+
+  return (
+    <span className="leading-relaxed">
+      {tokens.map((t, i) => {
+        if (t.type === "text") return <React.Fragment key={i}>{t.value}</React.Fragment>;
+        if (t.type === "technique") {
+          return (
+            <button
+              key={i}
+              type="button"
+              onClick={() => onTechniqueClick(t.canonical)}
+              className="inline px-1 -mx-0.5 rounded text-orange-300 hover:text-orange-200 hover:bg-orange-500/10 underline decoration-dotted decoration-orange-400/50 hover:decoration-orange-300 underline-offset-4 transition-colors cursor-pointer"
+              title={`Learn about ${t.canonical}`}
+            >
+              {t.value}
+            </button>
+          );
+        }
+        if (t.type === "time") {
+          return (
+            <React.Fragment key={i}>
+              <span className="text-white/80">{t.value}</span>
+              {" "}
+              <InlineTimer totalSeconds={t.seconds} label={t.label} />
+            </React.Fragment>
+          );
+        }
+        if (t.type === "temp") {
+          const alt = t.f != null && t.c != null ? `${t.f}°F / ${t.c}°C` : t.value;
+          return (
+            <span
+              key={i}
+              className="text-sky-300 border-b border-dotted border-sky-500/40 cursor-help"
+              title={alt}
+            >
+              {t.value}
+            </span>
+          );
+        }
+        return null;
+      })}
+    </span>
+  );
+}

--- a/src/components/recipes/NutritionVisualization.tsx
+++ b/src/components/recipes/NutritionVisualization.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import React from "react";
+import {
+  Cell,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+} from "recharts";
+
+export interface NutritionData {
+  calories?: number;
+  protein?: number;
+  carbs?: number;
+  fat?: number;
+  fiber?: number;
+  sodium?: number;
+  sugar?: number;
+  vitamins?: string[];
+  minerals?: string[];
+}
+
+// 2000-calorie reference daily values (FDA)
+const DAILY_VALUES = {
+  protein: 50,   // g
+  carbs: 275,    // g
+  fat: 78,       // g
+  fiber: 28,     // g
+  sodium: 2300,  // mg
+  sugar: 50,     // g (added sugar limit)
+};
+
+// Calories per gram
+const CAL_PER_G = { protein: 4, carbs: 4, fat: 9 };
+
+const MACRO_COLORS = {
+  protein: "#10b981",
+  carbs:   "#3b82f6",
+  fat:     "#f97316",
+};
+
+function DvBar({
+  label,
+  grams,
+  unit = "g",
+  pct,
+  colorClass,
+}: {
+  label: string;
+  grams: number;
+  unit?: string;
+  pct: number;
+  colorClass: string;
+}) {
+  const clamped = Math.min(150, pct);
+  const over = pct > 100;
+  return (
+    <div className="flex items-center gap-3">
+      <span className="w-16 text-xs text-white/60 capitalize">{label}</span>
+      <div className="flex-1 h-2 bg-white/5 rounded-full overflow-hidden relative">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${over ? "bg-red-500" : colorClass}`}
+          style={{ width: `${Math.min(100, clamped)}%` }}
+        />
+      </div>
+      <span className="text-xs text-white/70 tabular-nums w-16 text-right">
+        {grams}{unit}
+      </span>
+      <span className={`text-xs tabular-nums w-10 text-right ${over ? "text-red-400" : "text-white/40"}`}>
+        {Math.round(pct)}%
+      </span>
+    </div>
+  );
+}
+
+interface MacroTooltipPayload {
+  name?: string;
+  value?: number;
+  payload?: { grams?: number; calories?: number };
+}
+
+function MacroTooltip({ active, payload }: {
+  active?: boolean;
+  payload?: MacroTooltipPayload[];
+}) {
+  if (!active || !payload || !payload.length) return null;
+  const p = payload[0];
+  const name = p.name ?? "";
+  const cals = p.value ?? 0;
+  const grams = p.payload?.grams ?? 0;
+  return (
+    <div className="glass-card-premium rounded-lg border border-white/10 px-3 py-2 text-xs">
+      <div className="text-white font-semibold capitalize mb-1">{name}</div>
+      <div className="text-white/70 tabular-nums">
+        {grams}g · {cals} cal
+      </div>
+    </div>
+  );
+}
+
+export function NutritionVisualization({ nutrition }: { nutrition: NutritionData }) {
+  const protein = nutrition.protein ?? 0;
+  const carbs = nutrition.carbs ?? 0;
+  const fat = nutrition.fat ?? 0;
+
+  const proteinCal = protein * CAL_PER_G.protein;
+  const carbsCal = carbs * CAL_PER_G.carbs;
+  const fatCal = fat * CAL_PER_G.fat;
+  const derivedTotal = proteinCal + carbsCal + fatCal;
+
+  const stated = nutrition.calories ?? 0;
+  // Use stated calories when available, else derived
+  const totalCal = stated > 0 ? stated : derivedTotal;
+
+  const macroData = [
+    { name: "protein", value: proteinCal, grams: protein, color: MACRO_COLORS.protein },
+    { name: "carbs",   value: carbsCal,   grams: carbs,   color: MACRO_COLORS.carbs },
+    { name: "fat",     value: fatCal,     grams: fat,     color: MACRO_COLORS.fat },
+  ].filter((d) => d.value > 0);
+
+  const hasMacros = macroData.length > 0;
+
+  const caloriePct = stated ? (stated / 2000) * 100 : 0;
+
+  const vitamins = nutrition.vitamins ?? [];
+  const minerals = nutrition.minerals ?? [];
+  const microCount = vitamins.length + minerals.length;
+  // Heuristic "coverage" label
+  const microLabel =
+    microCount === 0 ? "None listed"
+      : microCount <= 3 ? "Low"
+      : microCount <= 6 ? "Moderate"
+      : microCount <= 10 ? "High"
+      : "Exceptional";
+
+  return (
+    <div className="space-y-5">
+      {/* Headline calories */}
+      {stated > 0 && (
+        <div className="flex items-baseline justify-between pb-3 border-b border-white/5">
+          <div>
+            <div className="text-3xl font-bold text-amber-300 tabular-nums">
+              {stated}
+              <span className="text-sm text-white/40 font-normal ml-1">cal</span>
+            </div>
+            <div className="text-[10px] uppercase tracking-wider text-white/40 mt-1">
+              Per serving
+            </div>
+          </div>
+          <div className="text-right">
+            <div className="text-xs text-white/40">% Daily Value</div>
+            <div className="text-base font-semibold text-white/80 tabular-nums">
+              {Math.round(caloriePct)}%
+            </div>
+            <div className="text-[10px] text-white/30">of 2000 cal</div>
+          </div>
+        </div>
+      )}
+
+      {/* Macro pie */}
+      {hasMacros && (
+        <div className="flex items-center gap-4">
+          <div className="w-32 h-32 shrink-0">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={macroData}
+                  dataKey="value"
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={36}
+                  outerRadius={60}
+                  paddingAngle={2}
+                  strokeWidth={0}
+                  isAnimationActive
+                >
+                  {macroData.map((entry) => (
+                    <Cell key={entry.name} fill={entry.color} />
+                  ))}
+                </Pie>
+                <Tooltip content={<MacroTooltip />} />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="flex-1 space-y-1.5">
+            {macroData.map((m) => {
+              const pct = totalCal > 0 ? Math.round((m.value / totalCal) * 100) : 0;
+              return (
+                <div key={m.name} className="flex items-center gap-2 text-xs">
+                  <span
+                    className="w-2.5 h-2.5 rounded-full shrink-0"
+                    style={{ background: m.color }}
+                  />
+                  <span className="capitalize text-white/70 w-14">{m.name}</span>
+                  <span className="text-white/50 tabular-nums w-14">{m.grams}g</span>
+                  <span className="text-white/80 font-semibold tabular-nums ml-auto">{pct}%</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Daily Value bars */}
+      <div className="space-y-2">
+        <div className="text-[10px] uppercase tracking-wider text-white/40 mb-1">
+          % Daily Value
+        </div>
+        {protein > 0 && (
+          <DvBar
+            label="Protein"
+            grams={protein}
+            pct={(protein / DAILY_VALUES.protein) * 100}
+            colorClass="bg-emerald-500"
+          />
+        )}
+        {carbs > 0 && (
+          <DvBar
+            label="Carbs"
+            grams={carbs}
+            pct={(carbs / DAILY_VALUES.carbs) * 100}
+            colorClass="bg-blue-500"
+          />
+        )}
+        {fat > 0 && (
+          <DvBar
+            label="Fat"
+            grams={fat}
+            pct={(fat / DAILY_VALUES.fat) * 100}
+            colorClass="bg-orange-500"
+          />
+        )}
+        {nutrition.fiber != null && nutrition.fiber > 0 && (
+          <DvBar
+            label="Fiber"
+            grams={nutrition.fiber}
+            pct={(nutrition.fiber / DAILY_VALUES.fiber) * 100}
+            colorClass="bg-green-500"
+          />
+        )}
+        {nutrition.sugar != null && nutrition.sugar > 0 && (
+          <DvBar
+            label="Sugar"
+            grams={nutrition.sugar}
+            pct={(nutrition.sugar / DAILY_VALUES.sugar) * 100}
+            colorClass="bg-pink-500"
+          />
+        )}
+        {nutrition.sodium != null && nutrition.sodium > 0 && (
+          <DvBar
+            label="Sodium"
+            grams={nutrition.sodium}
+            unit="mg"
+            pct={(nutrition.sodium / DAILY_VALUES.sodium) * 100}
+            colorClass="bg-purple-500"
+          />
+        )}
+      </div>
+
+      {/* Micronutrient coverage */}
+      {(vitamins.length > 0 || minerals.length > 0) && (
+        <div className="pt-3 border-t border-white/5">
+          <div className="flex items-center justify-between mb-3">
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-white/40">
+                Micronutrient Coverage
+              </div>
+              <div className="text-sm text-white/80 font-semibold mt-0.5">
+                {microLabel}
+                <span className="text-white/40 font-normal ml-2 text-xs">
+                  ({microCount} identified)
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {vitamins.length > 0 && (
+            <div className="mb-2">
+              <div className="text-[10px] uppercase tracking-wider text-emerald-400/70 mb-1.5">
+                Vitamins · {vitamins.length}
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {vitamins.map((v) => (
+                  <span
+                    key={v}
+                    className="px-2 py-0.5 bg-emerald-500/10 border border-emerald-500/20 rounded text-xs text-emerald-300"
+                  >
+                    {v}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+          {minerals.length > 0 && (
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-sky-400/70 mb-1.5">
+                Minerals · {minerals.length}
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {minerals.map((m) => (
+                  <span
+                    key={m}
+                    className="px-2 py-0.5 bg-sky-500/10 border border-sky-500/20 rounded text-xs text-sky-300"
+                  >
+                    {m}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/recipes/TechniqueModal.tsx
+++ b/src/components/recipes/TechniqueModal.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+import React, { useEffect, useState, useCallback } from "react";
+
+interface TechniqueData {
+  name?: string;
+  description?: string;
+  shortDescription?: string;
+  culinaryArchetype?: string;
+  elementalEffect?: { Fire?: number; Water?: number; Earth?: number; Air?: number };
+  duration?: { min?: number; max?: number };
+  suitable_for?: string[];
+  benefits?: string[];
+  toolsRequired?: string[];
+  commonMistakes?: string[];
+  pairingSuggestions?: string[];
+  chemicalChanges?: Record<string, boolean>;
+  optimalTemperatures?: Record<string, number>;
+  nutrientRetention?: Record<string, number>;
+  history?: string;
+  modernVariations?: string[];
+  scientificPrinciples?: string[];
+  expertTips?: string[];
+  doneness_indicators?: Record<string, string>;
+  timingConsiderations?: Record<string, string>;
+  astrologicalInfluences?: {
+    dominantPlanets?: string[];
+    favorableZodiac?: string[];
+  };
+}
+
+interface ApiResponse {
+  success: boolean;
+  technique?: TechniqueData;
+  canonicalKey?: string;
+  error?: string;
+}
+
+interface TechniqueModalProps {
+  techniqueName: string | null;
+  onClose: () => void;
+}
+
+const ELEMENT_COLORS: Record<string, { bar: string; text: string; icon: string }> = {
+  Fire:  { bar: "bg-red-500",  text: "text-red-400",  icon: "\u{1F525}" },
+  Water: { bar: "bg-blue-500", text: "text-blue-400", icon: "\u{1F4A7}" },
+  Earth: { bar: "bg-amber-600", text: "text-amber-400", icon: "\u{1F30D}" },
+  Air:   { bar: "bg-sky-400",  text: "text-sky-400",   icon: "\u{1F4A8}" },
+};
+
+function formatDuration(d?: { min?: number; max?: number }): string {
+  if (!d || d.min == null || d.max == null) return "";
+  const fmt = (m: number) => {
+    if (m < 60) return `${m}m`;
+    const h = Math.floor(m / 60);
+    const rem = m % 60;
+    return rem > 0 ? `${h}h ${rem}m` : `${h}h`;
+  };
+  if (d.min === d.max) return fmt(d.min);
+  return `${fmt(d.min)} – ${fmt(d.max)}`;
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="px-5 py-4 border-b border-white/5 last:border-b-0">
+      <h3 className="text-[11px] uppercase tracking-[0.14em] text-white/50 font-semibold mb-3">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+export function TechniqueModal({ techniqueName, onClose }: TechniqueModalProps) {
+  const open = Boolean(techniqueName);
+  const [data, setData] = useState<ApiResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!techniqueName) {
+      setData(null);
+      return;
+    }
+    const controller = new AbortController();
+    const fetchData = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(
+          `/api/techniques/${encodeURIComponent(techniqueName)}`,
+          { signal: controller.signal },
+        );
+        const json = (await res.json()) as ApiResponse;
+        if (!res.ok || !json.success) {
+          setError(json.error || "Technique not found");
+          setData(null);
+          return;
+        }
+        setData(json);
+      } catch (err) {
+        if ((err as { name?: string })?.name === "AbortError") return;
+        setError("Couldn't load technique details");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    void fetchData();
+    return () => controller.abort();
+  }, [techniqueName]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) onClose();
+    },
+    [onClose],
+  );
+
+  if (!open) return null;
+
+  const t = data?.technique;
+  const displayName = t?.name ?? techniqueName ?? "Technique";
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center p-4"
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${displayName} technique details`}
+    >
+      <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" aria-hidden="true" />
+
+      <div
+        className="relative w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-2xl bg-[#0a0a12] border border-white/10 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="sticky top-0 z-10 backdrop-blur-xl bg-[#0a0a12]/90 border-b border-white/10">
+          <div className="flex items-start justify-between gap-4 px-5 py-4">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 mb-1">
+                <span className="text-[10px] uppercase tracking-[0.18em] text-amber-400/70 font-bold">
+                  Technique
+                </span>
+                {t?.culinaryArchetype && (
+                  <span className="text-[10px] text-white/40 italic">
+                    • {t.culinaryArchetype}
+                  </span>
+                )}
+              </div>
+              <h2 className="text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-amber-200 to-orange-300 capitalize leading-tight">
+                {displayName}
+              </h2>
+              {t?.shortDescription && (
+                <p className="text-sm text-white/60 mt-1.5 italic">{t.shortDescription}</p>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="shrink-0 w-9 h-9 flex items-center justify-center rounded-full bg-white/5 hover:bg-white/10 text-white/60 hover:text-white transition-colors"
+            >
+              <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M6 6l12 12M6 18L18 6" strokeLinecap="round" />
+              </svg>
+            </button>
+          </div>
+        </header>
+
+        {isLoading && (
+          <div className="flex flex-col items-center justify-center py-16 gap-3">
+            <div className="w-8 h-8 border-2 border-amber-400/30 border-t-amber-400 rounded-full animate-spin" />
+            <p className="text-sm text-white/40">Loading technique…</p>
+          </div>
+        )}
+
+        {!isLoading && error && (
+          <div className="px-5 py-10 text-center">
+            <p className="text-sm text-white/50">{error}</p>
+          </div>
+        )}
+
+        {!isLoading && !error && t && (
+          <div className="pb-4">
+            {t.description && (
+              <Section title="Overview">
+                <p className="text-sm text-white/75 leading-relaxed">{t.description}</p>
+                {t.duration && (
+                  <p className="text-xs text-white/40 mt-3">
+                    Typical duration:{" "}
+                    <span className="text-amber-300 font-medium">
+                      {formatDuration(t.duration)}
+                    </span>
+                  </p>
+                )}
+              </Section>
+            )}
+
+            {t.elementalEffect && (
+              <Section title="Elemental Signature">
+                <div className="space-y-2">
+                  {(["Fire", "Water", "Earth", "Air"] as const).map((el) => {
+                    const v = t.elementalEffect?.[el] ?? 0;
+                    const cfg = ELEMENT_COLORS[el];
+                    const pct = Math.round(Math.min(100, Math.max(0, v * 100)));
+                    return (
+                      <div key={el} className="flex items-center gap-3">
+                        <span className="w-5 text-center text-base">{cfg.icon}</span>
+                        <span className={`w-14 text-xs font-medium ${cfg.text}`}>{el}</span>
+                        <div className="flex-1 h-2 bg-white/5 rounded-full overflow-hidden">
+                          <div
+                            className={`h-full rounded-full ${cfg.bar}`}
+                            style={{ width: `${pct}%` }}
+                          />
+                        </div>
+                        <span className="w-10 text-right text-xs text-white/50 tabular-nums">
+                          {pct}%
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </Section>
+            )}
+
+            {t.scientificPrinciples && t.scientificPrinciples.length > 0 && (
+              <Section title="Science">
+                <ul className="space-y-1.5">
+                  {t.scientificPrinciples.map((p, i) => (
+                    <li key={i} className="text-sm text-white/70 flex gap-2">
+                      <span className="text-blue-400 shrink-0">◆</span>
+                      <span>{p}</span>
+                    </li>
+                  ))}
+                </ul>
+              </Section>
+            )}
+
+            {t.benefits && t.benefits.length > 0 && (
+              <Section title="Benefits">
+                <ul className="space-y-1.5">
+                  {t.benefits.map((b, i) => (
+                    <li key={i} className="text-sm text-white/70 flex gap-2">
+                      <span className="text-emerald-400 shrink-0">✓</span>
+                      <span>{b}</span>
+                    </li>
+                  ))}
+                </ul>
+              </Section>
+            )}
+
+            {t.optimalTemperatures && Object.keys(t.optimalTemperatures).length > 0 && (
+              <Section title="Optimal Temperatures">
+                <div className="grid grid-cols-2 gap-2">
+                  {Object.entries(t.optimalTemperatures).map(([k, v]) => (
+                    <div
+                      key={k}
+                      className="px-3 py-2 rounded-lg bg-white/[0.03] border border-white/5"
+                    >
+                      <div className="text-xs text-white/50 capitalize">{k.replace(/_/g, " ")}</div>
+                      <div className="text-base font-bold text-amber-300 tabular-nums">
+                        {v}°F
+                        <span className="text-xs text-white/40 ml-1">
+                          / {Math.round(((v - 32) * 5) / 9)}°C
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </Section>
+            )}
+
+            {t.doneness_indicators && Object.keys(t.doneness_indicators).length > 0 && (
+              <Section title="Doneness Indicators">
+                <dl className="space-y-2">
+                  {Object.entries(t.doneness_indicators).map(([k, v]) => (
+                    <div key={k}>
+                      <dt className="text-xs text-white/50 capitalize font-semibold">
+                        {k.replace(/_/g, " ")}
+                      </dt>
+                      <dd className="text-sm text-white/70 mt-0.5">{v}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </Section>
+            )}
+
+            {t.commonMistakes && t.commonMistakes.length > 0 && (
+              <Section title="Common Mistakes to Avoid">
+                <ul className="space-y-1.5">
+                  {t.commonMistakes.slice(0, 8).map((m, i) => (
+                    <li key={i} className="text-sm text-white/70 flex gap-2">
+                      <span className="text-red-400 shrink-0">⚠</span>
+                      <span>{m}</span>
+                    </li>
+                  ))}
+                </ul>
+              </Section>
+            )}
+
+            {t.expertTips && t.expertTips.length > 0 && (
+              <Section title="Expert Tips">
+                <ul className="space-y-1.5">
+                  {t.expertTips.slice(0, 8).map((tip, i) => (
+                    <li key={i} className="text-sm text-white/70 flex gap-2">
+                      <span className="text-amber-400 shrink-0">★</span>
+                      <span>{tip}</span>
+                    </li>
+                  ))}
+                </ul>
+              </Section>
+            )}
+
+            {t.toolsRequired && t.toolsRequired.length > 0 && (
+              <Section title="Tools & Equipment">
+                <div className="flex flex-wrap gap-1.5">
+                  {t.toolsRequired.slice(0, 12).map((tool) => (
+                    <span
+                      key={tool}
+                      className="px-2 py-1 rounded-full bg-white/5 border border-white/10 text-xs text-white/60"
+                    >
+                      {tool}
+                    </span>
+                  ))}
+                </div>
+              </Section>
+            )}
+
+            {t.suitable_for && t.suitable_for.length > 0 && (
+              <Section title="Best For">
+                <div className="flex flex-wrap gap-1.5">
+                  {t.suitable_for.map((s) => (
+                    <span
+                      key={s}
+                      className="px-2 py-1 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-xs text-emerald-300 capitalize"
+                    >
+                      {s}
+                    </span>
+                  ))}
+                </div>
+              </Section>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Transforms the recipe detail page (`src/app/recipes/[recipeId]/page.tsx`) from a read-only display into an interactive culinary exploration surface. Ships **Phases 1, 2, and 4** of the recipe-page roadmap; Phases 3 & 5 are scoped in `NEXT_SESSION_PROMPT.md` for a follow-up session.

## What Changed

### Phase 1 — Interactive ingredients
- **New endpoint** `GET /api/ingredients/[name]` — full ingredient profile, recipes containing the ingredient (across all 351), and substitution suggestions derived from `pairingRecommendations.complementary`
- **New component** `IngredientDrawer` — slide-in panel (right on desktop, full-screen on mobile) rendering qualities, elemental signature, ESMS + Kalchm/Monica, taste profile, nutrition macros + vitamin/mineral chips, seasonality, origin, storage, recommended cooking methods, ruling planets, pairings (complements/contrasts/avoid), substitutions, and related recipes
- Ingredient list items on the recipe page are now buttons with hover affordances; scaled per-recipe amounts flow through to the drawer

### Phase 2 — Technique glossary & inline timers
- **New endpoint** `GET /api/techniques/[name]` — resolves verbs (roast, sauté, braise, ferment, etc.) via an alias map against the existing `allCookingMethods` dataset
- **New component** `TechniqueModal` — overview, elemental signature, science principles, benefits, optimal temperatures (F + C), doneness indicators, common mistakes, expert tips, tools, best-for chips
- **New component** `InteractiveInstruction` — tokenizes each instruction string to render:
  - Technique verbs as clickable orange dotted-underline tokens (opens `TechniqueModal`)
  - Time phrases (`"15 minutes"`, `"1–2 hours"`) with an inline countdown timer that beeps on completion via WebAudio
  - Temperatures with Celsius/Fahrenheit conversion tooltips

### Phase 4 — Nutrition visualization
- **New component** `NutritionVisualization` replaces the old macro grid with a Recharts `PieChart` showing macro calorie split, %DV bars (turns red when >100%), and a micronutrient coverage summary
- Dead `NutritionGrid` helper removed from the page

## Why

The recipe page shipped comprehensive data (ESMS, thermodynamic metrics, full nutrition, cultural context) as static display. To fulfill the project's "culinary intelligence platform" vision, users need to *explore* that data — click an ingredient to see why it's in the dish, click a technique to learn the science, and start a timer without leaving the recipe. This PR lays the interactive foundation.

## Files

**New**
- `src/app/api/ingredients/[name]/route.ts`
- `src/app/api/techniques/[name]/route.ts`
- `src/components/recipes/IngredientDrawer.tsx`
- `src/components/recipes/TechniqueModal.tsx`
- `src/components/recipes/InteractiveInstruction.tsx`
- `src/components/recipes/NutritionVisualization.tsx`
- `NEXT_SESSION_PROMPT.md` — detailed follow-up brief for Phases 3 & 5

**Modified**
- `src/app/recipes/[recipeId]/page.tsx` — wires up the new components; removes dead `NutritionGrid`

## Verification

- `npx tsc --noEmit --skipLibCheck` → **exit 0** (zero TS errors preserved)
- ESLint on all 7 touched files → **0 errors** (7 benign warnings: resolver/unnecessary-assertion)
- No existing features touched or regressed

## Test plan

- [ ] Load a recipe with diverse ingredients and confirm each ingredient opens the drawer with a populated profile
- [ ] Confirm scaled amounts flow into the drawer "In this recipe" banner when serving size is changed
- [ ] Click a technique verb in an instruction step (e.g., "sear", "simmer") and verify the technique modal loads
- [ ] Click the play button on a time phrase; confirm countdown ticks, pause/reset works, and completion beep fires
- [ ] Hover a temperature to verify F/C conversion tooltip
- [ ] Inspect the nutrition card: pie chart renders, %DV bars color-code correctly, micronutrient chips display
- [ ] Test mobile layout — drawer should be full-screen; modal should be centered with scroll
- [ ] `make check` or `npx tsc --noEmit --skipLibCheck` still exits 0

## Follow-up

`NEXT_SESSION_PROMPT.md` scopes Phase 3 (dietary adaptation, flavor tuning, time-constraint shortcuts) and Phase 5 (meal planning, discovery endpoints, social UX shells) with architecture notes and suggested build order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)