### PR TITLE
feat(recipes): adapt, tune, plan — phase 3 & 5

### DIFF
--- a/src/app/api/recipes/[recipeId]/discover/route.ts
+++ b/src/app/api/recipes/[recipeId]/discover/route.ts
@@ -1,0 +1,146 @@
+import { NextResponse } from "next/server";
+import { UnifiedRecipeService } from "@/services/UnifiedRecipeService";
+import type { Recipe } from "@/types/recipe";
+
+export const dynamic = "force-dynamic";
+
+interface ElementalVec {
+  Fire: number;
+  Water: number;
+  Earth: number;
+  Air: number;
+}
+
+interface ESMSVec {
+  spirit: number;
+  essence: number;
+  matter: number;
+  substance: number;
+}
+
+function getElemental(r: Recipe): ElementalVec | null {
+  const e = r.elementalProperties;
+  if (!e) return null;
+  const v = {
+    Fire: e.Fire ?? 0,
+    Water: e.Water ?? 0,
+    Earth: e.Earth ?? 0,
+    Air: e.Air ?? 0,
+  };
+  if (v.Fire === 0 && v.Water === 0 && v.Earth === 0 && v.Air === 0) return null;
+  return v;
+}
+
+function getESMS(r: Recipe): ESMSVec | null {
+  const v = {
+    spirit: r.spirit ?? 0,
+    essence: r.essence ?? 0,
+    matter: r.matter ?? 0,
+    substance: r.substance ?? 0,
+  };
+  if (v.spirit === 0 && v.essence === 0 && v.matter === 0 && v.substance === 0) return null;
+  return v;
+}
+
+function euclideanDistance(a: ElementalVec, b: ElementalVec): number {
+  return Math.sqrt(
+    (a.Fire - b.Fire) ** 2 +
+    (a.Water - b.Water) ** 2 +
+    (a.Earth - b.Earth) ** 2 +
+    (a.Air - b.Air) ** 2,
+  );
+}
+
+function cosineSimilarity(a: ESMSVec, b: ESMSVec): number {
+  const dot = a.spirit * b.spirit + a.essence * b.essence + a.matter * b.matter + a.substance * b.substance;
+  const magA = Math.sqrt(a.spirit ** 2 + a.essence ** 2 + a.matter ** 2 + a.substance ** 2);
+  const magB = Math.sqrt(b.spirit ** 2 + b.essence ** 2 + b.matter ** 2 + b.substance ** 2);
+  if (magA === 0 || magB === 0) return 0;
+  return dot / (magA * magB);
+}
+
+/** Slim a Recipe to the fields the discovery carousel needs. */
+function slim(r: Recipe) {
+  return {
+    id: r.id,
+    name: r.name,
+    description: r.description,
+    cuisine: r.cuisine,
+    elementalProperties: r.elementalProperties,
+    spirit: r.spirit,
+    essence: r.essence,
+    matter: r.matter,
+    substance: r.substance,
+    monicaScore: r.monicaScore,
+    monicaScoreLabel: r.monicaScoreLabel,
+    prepTime: r.prepTime,
+    cookTime: r.cookTime,
+    mealType: r.mealType,
+    season: r.season,
+    isVegetarian: r.isVegetarian,
+    isVegan: r.isVegan,
+    isGlutenFree: r.isGlutenFree,
+  };
+}
+
+export async function GET(_req: Request, props: { params: Promise<{ recipeId: string }> }) {
+  try {
+    const { recipeId } = await props.params;
+    const service = UnifiedRecipeService.getInstance();
+    const recipe = await service.getRecipeById(recipeId);
+    if (!recipe) {
+      return NextResponse.json({ success: false, error: "Recipe not found" }, { status: 404 });
+    }
+
+    const all = await service.getAllRecipes();
+    const others = all.filter((r) => r.id !== recipe.id && r.name !== recipe.name);
+
+    const baseElemental = getElemental(recipe);
+    const baseESMS = getESMS(recipe);
+
+    const similarElemental = baseElemental
+      ? others
+          .map((r) => {
+            const v = getElemental(r);
+            return v ? { r, d: euclideanDistance(baseElemental, v) } : null;
+          })
+          .filter((x): x is { r: Recipe; d: number } => x !== null)
+          .sort((a, b) => a.d - b.d)
+          .slice(0, 6)
+          .map(({ r }) => slim(r))
+      : [];
+
+    const similarAlchemical = baseESMS
+      ? others
+          .map((r) => {
+            const v = getESMS(r);
+            return v ? { r, s: cosineSimilarity(baseESMS, v) } : null;
+          })
+          .filter((x): x is { r: Recipe; s: number } => x !== null)
+          .sort((a, b) => b.s - a.s)
+          .slice(0, 6)
+          .map(({ r }) => slim(r))
+      : [];
+
+    const sameCuisine = recipe.cuisine
+      ? others
+          .filter((r) => r.cuisine && r.cuisine.toLowerCase() === recipe.cuisine!.toLowerCase())
+          .sort((a, b) => (b.monicaScore ?? 0) - (a.monicaScore ?? 0))
+          .slice(0, 3)
+          .map((r) => slim(r))
+      : [];
+
+    return NextResponse.json({
+      success: true,
+      similarElemental,
+      similarAlchemical,
+      sameCuisine,
+    });
+  } catch (err) {
+    console.error("[discover] Error:", err);
+    return NextResponse.json(
+      { success: false, error: "Failed to compute discovery" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/meal-plan/groceries/page.tsx
+++ b/src/app/meal-plan/groceries/page.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import Link from "next/link";
+import React, { useEffect, useMemo, useState } from "react";
+import { useMealPlan, type MealPlanEntry } from "@/hooks/useMealPlan";
+import type { Recipe, RecipeIngredient } from "@/types/recipe";
+
+interface GroceryLine {
+  key: string;
+  name: string;
+  unit: string;
+  amount: number;
+  sources: string[];
+  category?: string;
+}
+
+function normalizeName(name: string): string {
+  return name.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function normalizeUnit(unit: string): string {
+  return unit.trim().toLowerCase();
+}
+
+function getBaseServings(recipe: Recipe): number {
+  return (recipe as { baseServingSize?: number }).baseServingSize
+    || recipe.servingSize
+    || recipe.numberOfServings
+    || (recipe as { servings?: number }).servings
+    || 1;
+}
+
+export default function GroceryListPage() {
+  const { plan } = useMealPlan();
+  const [recipes, setRecipes] = useState<Record<string, Recipe>>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (plan.length === 0) {
+      setRecipes({});
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const uniqueIds = Array.from(new Set(plan.map((e) => e.recipeId)));
+    void Promise.all(
+      uniqueIds.map((id) =>
+        fetch(`/api/recipes/${id}`)
+          .then((r) => r.json())
+          .then((j) => (j?.success && j.recipe ? [id, j.recipe as Recipe] as const : null))
+          .catch(() => null),
+      ),
+    ).then((results) => {
+      if (cancelled) return;
+      const map: Record<string, Recipe> = {};
+      results.forEach((r) => { if (r) map[r[0]] = r[1]; });
+      setRecipes(map);
+      setLoading(false);
+    });
+    return () => { cancelled = true; };
+  }, [plan]);
+
+  const groceries = useMemo<GroceryLine[]>(() => {
+    const lines = new Map<string, GroceryLine>();
+    plan.forEach((entry: MealPlanEntry) => {
+      const recipe = recipes[entry.recipeId];
+      if (!recipe) return;
+      const baseServings = getBaseServings(recipe);
+      const scale = (entry.servings ?? baseServings) / baseServings;
+      recipe.ingredients.forEach((ing: RecipeIngredient) => {
+        const name = normalizeName(ing.name);
+        const unit = normalizeUnit(ing.unit ?? "");
+        const key = `${name}__${unit}`;
+        const scaledAmount = (ing.amount ?? 0) * scale;
+        const existing = lines.get(key);
+        if (existing) {
+          existing.amount += scaledAmount;
+          if (!existing.sources.includes(recipe.name)) existing.sources.push(recipe.name);
+        } else {
+          lines.set(key, {
+            key,
+            name: ing.name,
+            unit: ing.unit ?? "",
+            amount: scaledAmount,
+            sources: [recipe.name],
+            category: ing.category,
+          });
+        }
+      });
+    });
+    return Array.from(lines.values()).sort((a, b) => {
+      const catA = a.category || "zzz";
+      const catB = b.category || "zzz";
+      if (catA !== catB) return catA.localeCompare(catB);
+      return a.name.localeCompare(b.name);
+    });
+  }, [plan, recipes]);
+
+  const grouped = useMemo(() => {
+    const groups = new Map<string, GroceryLine[]>();
+    groceries.forEach((line) => {
+      const cat = line.category || "Other";
+      const arr = groups.get(cat) ?? [];
+      arr.push(line);
+      groups.set(cat, arr);
+    });
+    return Array.from(groups.entries());
+  }, [groceries]);
+
+  const buildPlainList = (): string => {
+    let text = "Grocery List — Alchm.kitchen\n";
+    text += `${"=".repeat(32)}\n\n`;
+    grouped.forEach(([cat, lines]) => {
+      text += `--- ${cat.toUpperCase()} ---\n`;
+      lines.forEach((l) => {
+        const amt = l.amount > 0 ? `${Math.round(l.amount * 100) / 100} ${l.unit}`.trim() : "";
+        text += `${`- ${amt} ${l.name}`.replace(/\s+/g, " ")}\n`;
+      });
+      text += "\n";
+    });
+    return text;
+  };
+
+  const [copied, setCopied] = useState(false);
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(buildPlainList());
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (err) {
+      console.error("Copy failed:", err);
+    }
+  };
+
+  return (
+    <main className="min-h-screen bg-[#08080e] text-white">
+      <div className="max-w-4xl mx-auto px-4 py-10 md:py-14 space-y-6">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <Link href="/meal-plan" className="text-sm text-white/60 hover:text-amber-400">
+              &larr; Back to meal plan
+            </Link>
+            <h1 className="text-3xl md:text-4xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-amber-200 via-orange-300 to-indigo-400 mt-2">
+              Grocery List
+            </h1>
+            <p className="text-white/60 mt-1 text-sm">
+              Aggregated from {plan.length} scheduled meal{plan.length === 1 ? "" : "s"}.
+            </p>
+          </div>
+          {groceries.length > 0 && (
+            <button
+              type="button"
+              onClick={() => { void handleCopy(); }}
+              className="px-4 py-2 rounded-xl bg-amber-500/20 border border-amber-500/50 text-amber-200 text-sm font-medium hover:bg-amber-500/30"
+            >
+              {copied ? "\u2713 Copied!" : "Copy list"}
+            </button>
+          )}
+        </div>
+
+        {loading ? (
+          <div className="glass-card-premium rounded-2xl border border-white/8 p-10 text-center">
+            <div className="w-10 h-10 border-4 border-amber-400/30 border-t-amber-400 rounded-full animate-spin mx-auto mb-4" />
+            <p className="text-white/60">Gathering ingredients...</p>
+          </div>
+        ) : groceries.length === 0 ? (
+          <div className="glass-card-premium rounded-2xl border border-white/8 p-10 text-center">
+            <p className="text-5xl mb-3">{"\u{1F6D2}"}</p>
+            <p className="text-white/70 mb-4">Nothing to buy yet.</p>
+            <Link
+              href="/recipes"
+              className="inline-block px-5 py-2.5 rounded-xl bg-amber-500/20 border border-amber-500/50 text-amber-200 font-medium hover:bg-amber-500/30"
+            >
+              Browse recipes
+            </Link>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {grouped.map(([category, lines]) => (
+              <div key={category} className="glass-card-premium rounded-2xl border border-white/8 p-5">
+                <h2 className="text-sm font-semibold text-amber-300 uppercase tracking-wider mb-3 capitalize">
+                  {category}
+                </h2>
+                <ul className="space-y-1.5">
+                  {lines.map((line) => (
+                    <li key={line.key} className="flex items-start gap-3 p-2 -mx-2 rounded-lg hover:bg-white/5">
+                      <span className="w-1.5 h-1.5 rounded-full bg-amber-400 mt-2 shrink-0" />
+                      <div className="flex-1 min-w-0 text-sm">
+                        <span className="text-white">
+                          {line.amount > 0 && (
+                            <span className="text-amber-300 font-semibold">{Math.round(line.amount * 100) / 100} </span>
+                          )}
+                          {line.unit && <span className="text-white/80">{line.unit} </span>}
+                          <span>{line.name}</span>
+                        </span>
+                        {line.sources.length > 1 && (
+                          <div className="text-xs text-white/50 mt-0.5">
+                            Used in {line.sources.length} recipes: {line.sources.join(", ")}
+                          </div>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/meal-plan/page.tsx
+++ b/src/app/meal-plan/page.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import Link from "next/link";
+import React, { useMemo } from "react";
+import { useMealPlan } from "@/hooks/useMealPlan";
+
+export default function MealPlanPage() {
+  const { plan, removeEntry, clearAll } = useMealPlan();
+
+  const byDate = useMemo(() => {
+    const groups = new Map<string, typeof plan>();
+    [...plan]
+      .sort((a, b) => a.date.localeCompare(b.date) || a.addedAt - b.addedAt)
+      .forEach((e) => {
+        const arr = groups.get(e.date) ?? [];
+        arr.push(e);
+        groups.set(e.date, arr);
+      });
+    return Array.from(groups.entries());
+  }, [plan]);
+
+  return (
+    <main className="min-h-screen bg-[#08080e] text-white">
+      <div className="max-w-4xl mx-auto px-4 py-10 md:py-14 space-y-6">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="text-3xl md:text-4xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-amber-200 via-orange-300 to-indigo-400">
+              Your Meal Plan
+            </h1>
+            <p className="text-white/60 mt-1 text-sm">
+              Scheduled locally in your browser. Sync to your account coming soon.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Link
+              href="/meal-plan/groceries"
+              className="px-4 py-2 rounded-xl bg-amber-500/20 border border-amber-500/50 text-amber-200 text-sm font-medium hover:bg-amber-500/30"
+            >
+              Grocery list &rarr;
+            </Link>
+            {plan.length > 0 && (
+              <button
+                type="button"
+                onClick={clearAll}
+                className="px-3 py-2 rounded-xl bg-white/5 border border-white/10 text-white/60 text-xs hover:text-rose-300"
+              >
+                Clear all
+              </button>
+            )}
+          </div>
+        </div>
+
+        {plan.length === 0 ? (
+          <div className="glass-card-premium rounded-2xl border border-white/8 p-10 text-center">
+            <p className="text-5xl mb-3">{"\u{1F4C5}"}</p>
+            <p className="text-white/70 mb-4">No meals scheduled yet.</p>
+            <Link
+              href="/recipes"
+              className="inline-block px-5 py-2.5 rounded-xl bg-amber-500/20 border border-amber-500/50 text-amber-200 font-medium hover:bg-amber-500/30"
+            >
+              Browse recipes
+            </Link>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {byDate.map(([date, entries]) => (
+              <div key={date} className="glass-card-premium rounded-2xl border border-white/8 p-5">
+                <h2 className="text-sm font-semibold text-amber-300 uppercase tracking-wider mb-3">
+                  {formatDate(date)}
+                </h2>
+                <ul className="space-y-2">
+                  {entries.map((entry) => (
+                    <li
+                      key={entry.id}
+                      className="flex items-center gap-3 p-3 rounded-lg bg-white/5 border border-white/10"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <Link
+                          href={`/recipes/${entry.recipeId}`}
+                          className="text-white hover:text-amber-200 font-medium line-clamp-1"
+                        >
+                          {entry.recipeName ?? entry.recipeId}
+                        </Link>
+                        <div className="text-xs text-white/50 mt-0.5 flex items-center gap-2 flex-wrap">
+                          {entry.mealType && <span className="capitalize">{entry.mealType}</span>}
+                          {entry.servings && <span>&middot; {entry.servings} serving{entry.servings === 1 ? "" : "s"}</span>}
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => removeEntry(entry.id)}
+                        className="text-white/40 hover:text-rose-300 text-sm"
+                        aria-label="Remove from plan"
+                      >
+                        &#x2715;
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(`${iso}T00:00:00`);
+    return d.toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric" });
+  } catch {
+    return iso;
+  }
+}

--- a/src/app/recipes/[recipeId]/page.tsx
+++ b/src/app/recipes/[recipeId]/page.tsx
@@ -2,12 +2,20 @@
 
 import Link from "next/link";
 import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { AddToMealPlanButton } from "@/components/recipes/AddToMealPlanButton";
+import { DietaryAdaptationPanel } from "@/components/recipes/DietaryAdaptationPanel";
+import { DiscoverySection } from "@/components/recipes/DiscoverySection";
+import { FlavorTuningPanel } from "@/components/recipes/FlavorTuningPanel";
 import { IngredientDrawer } from "@/components/recipes/IngredientDrawer";
 import { InteractiveInstruction } from "@/components/recipes/InteractiveInstruction";
 import { NutritionVisualization } from "@/components/recipes/NutritionVisualization";
 import { RecipeCard } from "@/components/recipes/RecipeCard";
+import { SocialSection } from "@/components/recipes/SocialSection";
 import { TechniqueModal } from "@/components/recipes/TechniqueModal";
+import { TimeShortcutsPanel } from "@/components/recipes/TimeShortcutsPanel";
 import type { Recipe } from "@/types/recipe";
+import { adaptRecipe, type DietaryMode } from "@/utils/dietaryAdaptation";
+import { analyzeTimeShortcuts, type TimeBudget } from "@/utils/timeShortcuts";
 
 // ===== Constants =====
 
@@ -670,6 +678,24 @@ export default function RecipePage({ params }: RecipePageProps) {
   const [copied, setCopied] = useState(false);
   const [selectedIngredientIndex, setSelectedIngredientIndex] = useState<number | null>(null);
   const [selectedTechnique, setSelectedTechnique] = useState<string | null>(null);
+  const [dietaryMode, setDietaryMode] = useState<DietaryMode | null>(null);
+  const [timeBudget, setTimeBudget] = useState<TimeBudget | null>(null);
+
+  // Reset interactive modes whenever a new recipe loads
+  useEffect(() => {
+    setDietaryMode(null);
+    setTimeBudget(null);
+  }, [recipeId]);
+
+  const adaptation = useMemo(() => {
+    if (!recipe || !dietaryMode) return null;
+    return adaptRecipe(recipe, dietaryMode);
+  }, [recipe, dietaryMode]);
+
+  const timeAnalysis = useMemo(() => {
+    if (!recipe || !timeBudget) return null;
+    return analyzeTimeShortcuts(recipe, timeBudget);
+  }, [recipe, timeBudget]);
 
   useEffect(() => {
     params.then(p => setRecipeId(p.recipeId)).catch(console.error);
@@ -880,6 +906,8 @@ export default function RecipePage({ params }: RecipePageProps) {
               )}
             </div>
 
+            <AddToMealPlanButton recipe={recipe} servings={servings} />
+
             <button
               onClick={() => {
                 void handleCopyRecipe();
@@ -911,6 +939,19 @@ export default function RecipePage({ params }: RecipePageProps) {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           {/* ===== Left Column: Ingredients + Instructions ===== */}
           <div className="lg:col-span-2 space-y-8">
+            {/* Adapt & Tune — dietary / flavor / time */}
+            <DietaryAdaptationPanel
+              recipe={recipe}
+              activeMode={dietaryMode}
+              onModeChange={setDietaryMode}
+            />
+            <FlavorTuningPanel />
+            <TimeShortcutsPanel
+              recipe={recipe}
+              activeBudget={timeBudget}
+              onBudgetChange={setTimeBudget}
+            />
+
             {/* Ingredients */}
             <SectionCard title="Ingredients" icon="&#x1F9C2;">
               {servings !== baseServings && (
@@ -923,26 +964,53 @@ export default function RecipePage({ params }: RecipePageProps) {
               </p>
               <ul className="space-y-1">
                 {recipe.ingredients.map((ing, index) => {
-                  const scaledAmount = ing.amount ? Math.round(ing.amount * scale * 100) / 100 : null;
+                  const swap = adaptation?.swaps.find((s) => s.index === index) ?? null;
+                  const displayIng = swap ? swap.to : ing;
+                  const scaledAmount = displayIng.amount ? Math.round(displayIng.amount * scale * 100) / 100 : null;
+                  const originalScaled = swap && ing.amount ? Math.round(ing.amount * scale * 100) / 100 : null;
                   return (
                     <li key={index}>
                       <button
                         type="button"
                         onClick={() => setSelectedIngredientIndex(index)}
-                        className="w-full flex items-start gap-3 group text-left px-3 py-2 -mx-3 rounded-lg hover:bg-amber-500/5 border border-transparent hover:border-amber-500/20 transition-colors"
+                        className={`w-full flex items-start gap-3 group text-left px-3 py-2 -mx-3 rounded-lg border transition-colors ${
+                          swap
+                            ? "bg-amber-500/5 border-amber-500/20 hover:bg-amber-500/10"
+                            : "hover:bg-amber-500/5 border-transparent hover:border-amber-500/20"
+                        }`}
                       >
-                        <span className="w-1.5 h-1.5 rounded-full bg-amber-400 mt-2.5 shrink-0 group-hover:bg-amber-300 group-hover:scale-125 transition-transform" />
+                        <span className={`w-1.5 h-1.5 rounded-full mt-2.5 shrink-0 transition-transform ${swap ? "bg-orange-400 group-hover:scale-125" : "bg-amber-400 group-hover:bg-amber-300 group-hover:scale-125"}`} />
                         <div className="flex-1 min-w-0">
-                          <span className="text-white">
-                            {scaledAmount != null && (
-                              <span className="text-amber-300 font-semibold">{scaledAmount} </span>
-                            )}
-                            {ing.unit && <span className="text-white/80">{ing.unit} </span>}
-                            <span className="group-hover:text-amber-200 transition-colors underline decoration-dotted decoration-white/20 underline-offset-4 group-hover:decoration-amber-400/60">
-                              {ing.name}
+                          {swap ? (
+                            <>
+                              <div className="text-white/40 line-through text-sm">
+                                {originalScaled != null && <span>{originalScaled} </span>}
+                                {ing.unit && <span>{ing.unit} </span>}
+                                <span>{ing.name}</span>
+                              </div>
+                              <div className="text-white mt-0.5">
+                                {scaledAmount != null && (
+                                  <span className="text-orange-300 font-semibold">{scaledAmount} </span>
+                                )}
+                                {displayIng.unit && <span className="text-white/80">{displayIng.unit} </span>}
+                                <span className="group-hover:text-amber-200 transition-colors underline decoration-dotted decoration-orange-400/50 underline-offset-4">
+                                  {displayIng.name}
+                                </span>
+                                <span className="ml-2 text-xs text-orange-300/80 italic">({swap.reason})</span>
+                              </div>
+                            </>
+                          ) : (
+                            <span className="text-white">
+                              {scaledAmount != null && (
+                                <span className="text-amber-300 font-semibold">{scaledAmount} </span>
+                              )}
+                              {displayIng.unit && <span className="text-white/80">{displayIng.unit} </span>}
+                              <span className="group-hover:text-amber-200 transition-colors underline decoration-dotted decoration-white/20 underline-offset-4 group-hover:decoration-amber-400/60">
+                                {displayIng.name}
+                              </span>
                             </span>
-                          </span>
-                          {ing.notes && (
+                          )}
+                          {ing.notes && !swap && (
                             <span className="text-sm text-white/60 ml-2 italic">({ing.notes})</span>
                           )}
                         </div>
@@ -962,19 +1030,42 @@ export default function RecipePage({ params }: RecipePageProps) {
                 Highlighted <span className="text-orange-300 underline decoration-dotted decoration-orange-400/50 underline-offset-4">techniques</span> open a deep-dive. Time phrases include a built-in timer.
               </p>
               <ol className="space-y-5">
-                {recipe.instructions.map((instruction, index) => (
-                  <li key={index} className="flex gap-4">
-                    <span className="shrink-0 w-8 h-8 rounded-full bg-gradient-to-br from-amber-500/20 to-orange-500/20 border border-amber-500/30 flex items-center justify-center text-sm font-bold text-amber-300">
-                      {index + 1}
-                    </span>
-                    <p className="text-white/80 leading-relaxed pt-1">
-                      <InteractiveInstruction
-                        text={instruction}
-                        onTechniqueClick={setSelectedTechnique}
-                      />
-                    </p>
-                  </li>
-                ))}
+                {recipe.instructions.map((instruction, index) => {
+                  const analysis = timeAnalysis?.stepAnalyses[index];
+                  const highlight = analysis && (analysis.skippable || analysis.parallelizable || analysis.timeConsuming);
+                  const badge = analysis?.timeConsuming
+                    ? { label: "Long idle", cls: "bg-orange-500/15 text-orange-300 border-orange-500/30" }
+                    : analysis?.parallelizable
+                      ? { label: "Parallelize", cls: "bg-sky-500/15 text-sky-300 border-sky-500/30" }
+                      : analysis?.skippable
+                        ? { label: "Optional", cls: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30" }
+                        : null;
+                  return (
+                    <li key={index} className={`flex gap-4 rounded-lg transition-colors ${highlight ? "bg-amber-500/5 border border-amber-500/20 p-3 -m-3" : ""}`}>
+                      <span className="shrink-0 w-8 h-8 rounded-full bg-gradient-to-br from-amber-500/20 to-orange-500/20 border border-amber-500/30 flex items-center justify-center text-sm font-bold text-amber-300">
+                        {index + 1}
+                      </span>
+                      <div className="flex-1 min-w-0">
+                        {badge && (
+                          <div className="flex flex-wrap items-center gap-2 mb-1.5">
+                            <span className={`text-xs font-medium px-2 py-0.5 rounded border ${badge.cls}`}>
+                              {badge.label}
+                            </span>
+                            {analysis?.reason && (
+                              <span className="text-xs text-white/50 italic">{analysis.reason}</span>
+                            )}
+                          </div>
+                        )}
+                        <p className="text-white/80 leading-relaxed pt-0.5">
+                          <InteractiveInstruction
+                            text={instruction}
+                            onTechniqueClick={setSelectedTechnique}
+                          />
+                        </p>
+                      </div>
+                    </li>
+                  );
+                })}
               </ol>
             </SectionCard>
 
@@ -1333,6 +1424,9 @@ export default function RecipePage({ params }: RecipePageProps) {
                 </div>
               </SectionCard>
             )}
+
+            {/* Community (local-only shell) */}
+            <SocialSection recipeId={recipe.id} />
           </div>
         </div>
 
@@ -1346,7 +1440,7 @@ export default function RecipePage({ params }: RecipePageProps) {
               recipeAmount={scaledAmount}
               recipeUnit={sel?.unit}
               recipeNotes={sel?.notes}
-              currentRecipeId={recipe.id as string}
+              currentRecipeId={recipe.id}
               onClose={() => setSelectedIngredientIndex(null)}
             />
           );
@@ -1358,11 +1452,16 @@ export default function RecipePage({ params }: RecipePageProps) {
           onClose={() => setSelectedTechnique(null)}
         />
 
-        {/* ===== Similar Recipes ===== */}
+        {/* ===== Discovery (elemental / alchemical / cuisine) ===== */}
+        <div className="pt-8">
+          <DiscoverySection recipeId={recipe.id} />
+        </div>
+
+        {/* ===== Similar Recipes (service-recommended fallback) ===== */}
         {recommendedRecipes.length > 0 && (
           <div className="pt-8">
             <h2 className="text-2xl font-bold mb-6 text-transparent bg-clip-text bg-gradient-to-r from-amber-200 to-orange-300">
-              Similar Recipes
+              Also Recommended
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {recommendedRecipes.map((rec) => (

--- a/src/components/recipes/AddToMealPlanButton.tsx
+++ b/src/components/recipes/AddToMealPlanButton.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import Link from "next/link";
+import React, { useEffect, useState } from "react";
+import { useMealPlan } from "@/hooks/useMealPlan";
+import type { Recipe } from "@/types/recipe";
+
+interface Props {
+  recipe: Recipe;
+  servings: number;
+}
+
+const MEAL_TYPES = ["breakfast", "lunch", "dinner", "snack"];
+
+function todayISO(): string {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+export function AddToMealPlanButton({ recipe, servings }: Props) {
+  const { addEntry, entriesForRecipe } = useMealPlan();
+  const [open, setOpen] = useState(false);
+  const [date, setDate] = useState(todayISO());
+  const [mealType, setMealType] = useState<string>("dinner");
+  const [justAdded, setJustAdded] = useState(false);
+
+  const scheduledCount = entriesForRecipe(recipe.id).length;
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setOpen(false); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const handleSave = () => {
+    addEntry({
+      date,
+      recipeId: recipe.id,
+      recipeName: recipe.name,
+      mealType,
+      servings,
+    });
+    setJustAdded(true);
+    setTimeout(() => {
+      setJustAdded(false);
+      setOpen(false);
+    }, 900);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex items-center gap-2 px-5 py-2.5 rounded-xl font-medium transition-all duration-200 bg-white/10/80 border border-white/10/50 text-white/80 hover:bg-amber-500/10 hover:border-amber-500/30 hover:text-amber-300"
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+        </svg>
+        Add to Meal Plan
+        {scheduledCount > 0 && (
+          <span className="px-1.5 py-0.5 text-xs bg-amber-500/20 text-amber-300 rounded-full">
+            {scheduledCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="w-full max-w-md glass-card-premium rounded-2xl border border-white/8 p-6 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-start justify-between mb-4">
+              <div>
+                <h3 className="text-lg font-bold text-transparent bg-clip-text bg-gradient-to-r from-amber-200 to-orange-300">
+                  Schedule {recipe.name}
+                </h3>
+                <p className="text-xs text-white/60 mt-0.5">Saved to your browser&apos;s meal plan.</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="text-white/40 hover:text-white text-xl leading-none"
+                aria-label="Close"
+              >
+                &#x2715;
+              </button>
+            </div>
+
+            <div className="space-y-4">
+              <div>
+                <label className="block text-xs font-semibold text-white/60 uppercase tracking-wider mb-1.5" htmlFor="mp-date">Date</label>
+                <input
+                  id="mp-date"
+                  type="date"
+                  value={date}
+                  onChange={(e) => setDate(e.target.value)}
+                  className="w-full glass-card-premium border border-white/10 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-amber-500 text-sm"
+                />
+              </div>
+
+              <div role="group" aria-label="Meal type">
+                <div className="block text-xs font-semibold text-white/60 uppercase tracking-wider mb-1.5">Meal</div>
+                <div className="flex flex-wrap gap-2">
+                  {MEAL_TYPES.map((m) => (
+                    <button
+                      key={m}
+                      type="button"
+                      onClick={() => setMealType(m)}
+                      className={`px-3 py-1.5 rounded-lg text-sm font-medium border capitalize transition-colors ${
+                        mealType === m
+                          ? "bg-amber-500/20 border-amber-500/50 text-amber-200"
+                          : "bg-white/5 border-white/10 text-white/70 hover:bg-white/10"
+                      }`}
+                    >
+                      {m}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="text-xs text-white/50">
+                Scheduling <span className="text-amber-300 font-semibold">{servings}</span> serving{servings === 1 ? "" : "s"}.
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2 mt-6">
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={justAdded}
+                className={`flex-1 px-4 py-2.5 rounded-lg font-medium transition-colors ${
+                  justAdded
+                    ? "bg-emerald-500/20 border border-emerald-500/50 text-emerald-300"
+                    : "bg-amber-500/20 border border-amber-500/50 text-amber-200 hover:bg-amber-500/30"
+                }`}
+              >
+                {justAdded ? "\u2713 Added!" : "Add to plan"}
+              </button>
+              <Link
+                href="/meal-plan"
+                className="px-4 py-2.5 rounded-lg font-medium bg-white/5 border border-white/10 text-white/70 hover:bg-white/10 text-sm"
+              >
+                View plan
+              </Link>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/recipes/DietaryAdaptationPanel.tsx
+++ b/src/components/recipes/DietaryAdaptationPanel.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import React, { useMemo } from "react";
+import type { Recipe } from "@/types/recipe";
+import {
+  adaptRecipe,
+  isAlreadyCompatible,
+  needsAdaptation,
+  type AdaptationResult,
+  type DietaryMode,
+} from "@/utils/dietaryAdaptation";
+
+const MODES: Array<{ key: DietaryMode; label: string; icon: string }> = [
+  { key: "vegan", label: "Vegan", icon: "\u{1F33F}" },
+  { key: "vegetarian", label: "Vegetarian", icon: "\u{1F957}" },
+  { key: "gluten-free", label: "Gluten-Free", icon: "\u{1F33E}" },
+  { key: "dairy-free", label: "Dairy-Free", icon: "\u{1F95B}" },
+  { key: "keto", label: "Keto", icon: "\u{1F951}" },
+  { key: "low-carb", label: "Low-Carb", icon: "\u{1F366}" },
+];
+
+interface Props {
+  recipe: Recipe;
+  activeMode: DietaryMode | null;
+  onModeChange: (mode: DietaryMode | null) => void;
+}
+
+function formatDelta(n: number, unit = "", digits = 0): string {
+  if (n === 0) return `0${unit}`;
+  const sign = n > 0 ? "+" : "";
+  return `${sign}${n.toFixed(digits)}${unit}`;
+}
+
+export function DietaryAdaptationPanel({ recipe, activeMode, onModeChange }: Props) {
+  const adaptation: AdaptationResult | null = useMemo(() => {
+    if (!activeMode) return null;
+    return adaptRecipe(recipe, activeMode);
+  }, [recipe, activeMode]);
+
+  return (
+    <div className="glass-card-premium rounded-2xl border border-white/8 p-5 md:p-6">
+      <div className="flex items-start justify-between gap-3 mb-3 flex-wrap">
+        <div>
+          <h2 className="text-lg font-bold text-transparent bg-clip-text bg-gradient-to-r from-amber-200 to-orange-300 flex items-center gap-2">
+            <span className="not-italic text-xl">{"\u{1F504}"}</span>
+            Adapt This Recipe
+          </h2>
+          <p className="text-xs text-white/60 mt-1">
+            One-click swap-outs. Original is never overwritten.
+          </p>
+        </div>
+        {activeMode && (
+          <button
+            type="button"
+            onClick={() => onModeChange(null)}
+            className="text-xs text-amber-300 hover:text-amber-200 underline decoration-dotted underline-offset-4"
+          >
+            Reset to original
+          </button>
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {MODES.map(({ key, label, icon }) => {
+          const compatible = isAlreadyCompatible(recipe, key);
+          const wouldSwap = !compatible && needsAdaptation(recipe, key);
+          const isActive = activeMode === key;
+          const disabled = compatible;
+
+          return (
+            <button
+              key={key}
+              type="button"
+              disabled={disabled}
+              onClick={() => onModeChange(isActive ? null : key)}
+              className={`px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors flex items-center gap-1.5 ${
+                disabled
+                  ? "bg-emerald-500/10 border-emerald-500/30 text-emerald-300 cursor-default"
+                  : isActive
+                    ? "bg-amber-500/20 border-amber-500/50 text-amber-200"
+                    : wouldSwap
+                      ? "bg-white/5 border-white/10 text-white/80 hover:bg-amber-500/10 hover:border-amber-500/30 hover:text-amber-200"
+                      : "bg-white/5 border-white/10 text-white/40 hover:text-white/60"
+              }`}
+              title={
+                disabled
+                  ? `Already ${label.toLowerCase()}-compatible`
+                  : wouldSwap
+                    ? `Adapt to ${label.toLowerCase()}`
+                    : `No swap rules triggered for ${label.toLowerCase()}`
+              }
+            >
+              <span className="not-italic">{icon}</span>
+              {label}
+              {disabled && <span className="ml-0.5 text-emerald-300">&#x2713;</span>}
+            </button>
+          );
+        })}
+      </div>
+
+      {adaptation && (
+        <AdaptationBanner adaptation={adaptation} />
+      )}
+    </div>
+  );
+}
+
+function AdaptationBanner({ adaptation }: { adaptation: AdaptationResult }) {
+  const { mode, swaps, nutritionalDelta, elementalDelta, compatible } = adaptation;
+
+  if (compatible) {
+    return (
+      <div className="mt-4 p-3 rounded-lg bg-emerald-500/10 border border-emerald-500/30 text-sm text-emerald-300">
+        Recipe is already {mode}-compatible. No swaps needed.
+      </div>
+    );
+  }
+
+  if (swaps.length === 0) {
+    return (
+      <div className="mt-4 p-3 rounded-lg bg-white/5 border border-white/10 text-sm text-white/60">
+        No ingredients matched {mode} swap rules. Review the full ingredient list for manual adjustments.
+      </div>
+    );
+  }
+
+  const nutritionChips: Array<{ label: string; value: string; cls: string }> = [];
+  if (nutritionalDelta.calories != null && nutritionalDelta.calories !== 0) {
+    nutritionChips.push({
+      label: "cal",
+      value: formatDelta(nutritionalDelta.calories),
+      cls: nutritionalDelta.calories < 0 ? "text-emerald-300" : "text-orange-300",
+    });
+  }
+  if (nutritionalDelta.protein != null && nutritionalDelta.protein !== 0) {
+    nutritionChips.push({ label: "protein", value: formatDelta(nutritionalDelta.protein, "g"), cls: "text-sky-300" });
+  }
+  if (nutritionalDelta.carbs != null && nutritionalDelta.carbs !== 0) {
+    nutritionChips.push({ label: "carbs", value: formatDelta(nutritionalDelta.carbs, "g"), cls: "text-amber-300" });
+  }
+  if (nutritionalDelta.fat != null && nutritionalDelta.fat !== 0) {
+    nutritionChips.push({ label: "fat", value: formatDelta(nutritionalDelta.fat, "g"), cls: "text-rose-300" });
+  }
+
+  const elementalChips: Array<{ el: string; value: string; cls: string }> = [];
+  (["Fire", "Water", "Earth", "Air"] as const).forEach((el) => {
+    const v = elementalDelta[el];
+    if (Math.abs(v) >= 0.005) {
+      elementalChips.push({
+        el,
+        value: formatDelta(v, "", 2),
+        cls: el === "Fire" ? "text-red-300" : el === "Water" ? "text-blue-300" : el === "Earth" ? "text-amber-300" : "text-sky-300",
+      });
+    }
+  });
+
+  return (
+    <div className="mt-4 p-3 rounded-lg bg-amber-500/10 border border-amber-500/30">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
+        <span className="text-amber-200 font-semibold">
+          Adapted for {mode} &middot; {swaps.length} swap{swaps.length === 1 ? "" : "s"}
+        </span>
+        {nutritionChips.length > 0 && (
+          <div className="flex items-center gap-2 flex-wrap">
+            {nutritionChips.map((c) => (
+              <span key={c.label} className={`text-xs ${c.cls}`}>
+                {c.value} {c.label}
+              </span>
+            ))}
+          </div>
+        )}
+        {elementalChips.length > 0 && (
+          <div className="flex items-center gap-2 flex-wrap">
+            {elementalChips.map((c) => (
+              <span key={c.el} className={`text-xs ${c.cls}`}>
+                {c.el} {c.value}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+      <p className="text-xs text-white/50 mt-1.5 italic">
+        Deltas are estimates. ESMS/planetary scores reflect the original recipe.
+      </p>
+    </div>
+  );
+}

--- a/src/components/recipes/DiscoverySection.tsx
+++ b/src/components/recipes/DiscoverySection.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import Link from "next/link";
+import React, { useEffect, useState } from "react";
+
+interface DiscoveryRecipe {
+  id: string;
+  name: string;
+  description?: string;
+  cuisine?: string;
+  elementalProperties?: { Fire?: number; Water?: number; Earth?: number; Air?: number };
+  spirit?: number;
+  essence?: number;
+  matter?: number;
+  substance?: number;
+  monicaScore?: number;
+  monicaScoreLabel?: string;
+  prepTime?: string;
+  cookTime?: string;
+  isVegetarian?: boolean;
+  isVegan?: boolean;
+  isGlutenFree?: boolean;
+}
+
+interface DiscoveryData {
+  similarElemental: DiscoveryRecipe[];
+  similarAlchemical: DiscoveryRecipe[];
+  sameCuisine: DiscoveryRecipe[];
+}
+
+type Lens = "elemental" | "alchemical" | "cuisine";
+
+const LENS_META: Record<Lens, { label: string; icon: string; blurb: string }> = {
+  elemental: {
+    label: "Elemental Kin",
+    icon: "\u2697",
+    blurb: "Closest Fire / Water / Earth / Air signature",
+  },
+  alchemical: {
+    label: "Alchemical Kin",
+    icon: "\u2609",
+    blurb: "Closest Spirit / Essence / Matter / Substance alignment",
+  },
+  cuisine: {
+    label: "Same Cuisine",
+    icon: "\u{1F310}",
+    blurb: "Top rated dishes from this tradition",
+  },
+};
+
+const ELEMENT_DOT: Record<string, string> = {
+  Fire: "bg-red-500",
+  Water: "bg-blue-500",
+  Earth: "bg-amber-500",
+  Air: "bg-sky-400",
+};
+
+function dominantElement(r: DiscoveryRecipe): string | null {
+  const e = r.elementalProperties;
+  if (!e) return null;
+  const entries = [
+    ["Fire", e.Fire ?? 0] as const,
+    ["Water", e.Water ?? 0] as const,
+    ["Earth", e.Earth ?? 0] as const,
+    ["Air", e.Air ?? 0] as const,
+  ];
+  entries.sort((a, b) => b[1] - a[1]);
+  if (entries[0][1] === 0) return null;
+  return entries[0][0];
+}
+
+function DiscoveryCard({ recipe }: { recipe: DiscoveryRecipe }) {
+  const dom = dominantElement(recipe);
+  return (
+    <Link
+      href={`/recipes/${recipe.id}`}
+      className="group block glass-card-premium rounded-xl border border-white/8 p-4 hover:border-amber-500/40 hover:bg-amber-500/5 transition-colors"
+    >
+      <div className="flex items-start justify-between gap-2 mb-1.5">
+        <h3 className="text-sm font-semibold text-white group-hover:text-amber-200 transition-colors line-clamp-2">
+          {recipe.name}
+        </h3>
+        {recipe.monicaScore != null && (
+          <span className="shrink-0 text-xs font-bold text-amber-300">
+            {Math.round(recipe.monicaScore)}
+          </span>
+        )}
+      </div>
+
+      {recipe.description && (
+        <p className="text-xs text-white/60 line-clamp-2 mb-2">{recipe.description}</p>
+      )}
+
+      <div className="flex items-center gap-2 flex-wrap text-xs">
+        {recipe.cuisine && (
+          <span className="text-white/60 capitalize">{recipe.cuisine}</span>
+        )}
+        {dom && (
+          <span className="inline-flex items-center gap-1 text-white/60">
+            <span className={`w-1.5 h-1.5 rounded-full ${ELEMENT_DOT[dom]}`} />
+            {dom}
+          </span>
+        )}
+        {recipe.isVegan && <span className="text-green-400">Vegan</span>}
+        {!recipe.isVegan && recipe.isVegetarian && <span className="text-green-400">Veg</span>}
+        {recipe.isGlutenFree && <span className="text-yellow-400">GF</span>}
+      </div>
+    </Link>
+  );
+}
+
+export function DiscoverySection({ recipeId }: { recipeId: string }) {
+  const [data, setData] = useState<DiscoveryData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [lens, setLens] = useState<Lens>("elemental");
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetch(`/api/recipes/${recipeId}/discover`)
+      .then((r) => r.json())
+      .then((json) => {
+        if (cancelled) return;
+        if (json?.success) {
+          setData({
+            similarElemental: json.similarElemental ?? [],
+            similarAlchemical: json.similarAlchemical ?? [],
+            sameCuisine: json.sameCuisine ?? [],
+          });
+        }
+      })
+      .catch((err) => console.error("Discovery fetch failed:", err))
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [recipeId]);
+
+  if (loading) {
+    return (
+      <div className="glass-card-premium rounded-2xl border border-white/8 p-6">
+        <div className="h-4 w-40 bg-white/5 rounded animate-pulse mb-4" />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="h-24 bg-white/5 rounded-xl animate-pulse" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const lists: Record<Lens, DiscoveryRecipe[]> = {
+    elemental: data.similarElemental,
+    alchemical: data.similarAlchemical,
+    cuisine: data.sameCuisine,
+  };
+
+  const available = (Object.keys(lists) as Lens[]).filter((k) => lists[k].length > 0);
+  if (available.length === 0) return null;
+
+  const activeLens: Lens = lists[lens].length > 0 ? lens : available[0];
+  const items = lists[activeLens];
+
+  return (
+    <div className="glass-card-premium rounded-2xl border border-white/8 p-6">
+      <div className="flex flex-wrap items-start justify-between gap-3 mb-4">
+        <div>
+          <h2 className="text-xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-amber-200 to-orange-300 flex items-center gap-2">
+            <span className="not-italic text-2xl">{"\u{1F52D}"}</span>
+            Discover More
+          </h2>
+          <p className="text-xs text-white/60 mt-1">{LENS_META[activeLens].blurb}</p>
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {available.map((k) => (
+            <button
+              key={k}
+              type="button"
+              onClick={() => setLens(k)}
+              className={`px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                activeLens === k
+                  ? "bg-amber-500/20 border-amber-500/50 text-amber-200"
+                  : "bg-white/5 border-white/10 text-white/60 hover:bg-white/10 hover:text-white"
+              }`}
+            >
+              <span className="mr-1 not-italic">{LENS_META[k].icon}</span>
+              {LENS_META[k].label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {items.map((r) => (
+          <DiscoveryCard key={r.id} recipe={r} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/recipes/FlavorTuningPanel.tsx
+++ b/src/components/recipes/FlavorTuningPanel.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import React, { useState } from "react";
+import { FLAVOR_DIRECTIONS, suggestTweak, type FlavorDirection, type FlavorTweak } from "@/utils/flavorTuning";
+
+const DIRECTION_COLOR: Record<FlavorDirection, { chip: string; label: string }> = {
+  sweeter: { chip: "bg-amber-500/10 border-amber-500/30 text-amber-200",  label: "text-amber-300" },
+  umami:   { chip: "bg-rose-500/10 border-rose-500/30 text-rose-200",     label: "text-rose-300" },
+  acidic:  { chip: "bg-yellow-500/10 border-yellow-500/30 text-yellow-200", label: "text-yellow-300" },
+  spicier: { chip: "bg-red-500/10 border-red-500/30 text-red-200",        label: "text-red-300" },
+  savory:  { chip: "bg-emerald-500/10 border-emerald-500/30 text-emerald-200", label: "text-emerald-300" },
+};
+
+export function FlavorTuningPanel() {
+  const [tweaks, setTweaks] = useState<FlavorTweak[]>([]);
+
+  const addTweak = (direction: FlavorDirection) => {
+    setTweaks((curr) => [...curr, suggestTweak(direction, curr)]);
+  };
+
+  const removeTweak = (id: string) => {
+    setTweaks((curr) => curr.filter((t) => t.id !== id));
+  };
+
+  const clearAll = () => setTweaks([]);
+
+  return (
+    <div className="glass-card-premium rounded-2xl border border-white/8 p-5 md:p-6">
+      <div className="flex items-start justify-between gap-3 mb-3 flex-wrap">
+        <div>
+          <h2 className="text-lg font-bold text-transparent bg-clip-text bg-gradient-to-r from-amber-200 to-orange-300 flex items-center gap-2">
+            <span className="not-italic text-xl">{"\u{1F9C2}"}</span>
+            Flavor Tweaks
+          </h2>
+          <p className="text-xs text-white/60 mt-1">
+            Nudge the dish. Each click stages a micro-adjustment you can pick up at the stove.
+          </p>
+        </div>
+        {tweaks.length > 0 && (
+          <button
+            type="button"
+            onClick={clearAll}
+            className="text-xs text-amber-300 hover:text-amber-200 underline decoration-dotted underline-offset-4"
+          >
+            Clear all
+          </button>
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-2 mb-4">
+        {FLAVOR_DIRECTIONS.map(({ key, label, icon }) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => addTweak(key)}
+            className="px-3 py-1.5 rounded-lg text-sm font-medium bg-white/5 border border-white/10 text-white/80 hover:bg-amber-500/10 hover:border-amber-500/30 hover:text-amber-200 transition-colors flex items-center gap-1.5"
+          >
+            <span className="text-amber-400">+</span>
+            <span className="not-italic">{icon}</span>
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {tweaks.length === 0 ? (
+        <p className="text-xs text-white/40 italic">
+          No tweaks staged. Click a direction to add a suggestion.
+        </p>
+      ) : (
+        <ul className="space-y-1.5">
+          {tweaks.map((t) => {
+            const cfg = DIRECTION_COLOR[t.direction];
+            return (
+              <li
+                key={t.id}
+                className="flex items-start gap-2 p-2 rounded-lg bg-white/5 border border-white/10"
+              >
+                <span className={`shrink-0 text-xs font-medium px-2 py-0.5 rounded border ${cfg.chip} capitalize`}>
+                  {t.direction}
+                </span>
+                <div className="flex-1 min-w-0 text-sm">
+                  <span className={`font-semibold ${cfg.label}`}>+ {t.amount}</span>
+                  <span className="text-white/80"> {t.ingredient}</span>
+                  <span className="text-white/50 italic"> &middot; {t.reason}</span>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => removeTweak(t.id)}
+                  className="shrink-0 text-white/30 hover:text-rose-300 text-xs px-1"
+                  aria-label="Remove tweak"
+                >
+                  &#x2715;
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/recipes/SocialSection.tsx
+++ b/src/components/recipes/SocialSection.tsx
@@ -1,0 +1,197 @@
+// TODO(phase 5.5): wire to /api/users/me/recipes when auth-gated endpoint exists.
+// This component is a pure UX shell backed by localStorage; no user identity, no moderation.
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+
+const STORAGE_PREFIX = "alchm:recipe-social:v1:";
+
+interface LocalSocialState {
+  madeIt: boolean;
+  rating: number;           // 0–5
+  review: string;
+  photoDataUrl?: string;    // base64 preview only
+}
+
+const DEFAULT: LocalSocialState = { madeIt: false, rating: 0, review: "" };
+
+function readState(recipeId: string): LocalSocialState {
+  if (typeof window === "undefined") return DEFAULT;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_PREFIX + recipeId);
+    return raw ? { ...DEFAULT, ...JSON.parse(raw) as Partial<LocalSocialState> } : DEFAULT;
+  } catch {
+    return DEFAULT;
+  }
+}
+
+function writeState(recipeId: string, state: LocalSocialState) {
+  try {
+    window.localStorage.setItem(STORAGE_PREFIX + recipeId, JSON.stringify(state));
+  } catch (err) {
+    console.warn("social state write failed:", err);
+  }
+}
+
+// Mock community tips — read-only. Replace with API data once the backend lands.
+const MOCK_COMMUNITY_TIPS: Array<{ author: string; tip: string; hearts: number }> = [
+  { author: "Kira T.", tip: "Browned the butter instead of just melting it — huge upgrade on the nuttiness.", hearts: 42 },
+  { author: "Marcus L.", tip: "If you chill the dough an extra 20 min it holds shape way better in the pan.", hearts: 28 },
+  { author: "Dana R.", tip: "Swapped half the salt for miso paste. Ten out of ten.", hearts: 17 },
+];
+
+interface Props {
+  recipeId: string;
+}
+
+export function SocialSection({ recipeId }: Props) {
+  const [state, setState] = useState<LocalSocialState>(DEFAULT);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setState(readState(recipeId));
+    setHydrated(true);
+  }, [recipeId]);
+
+  const update = (partial: Partial<LocalSocialState>) => {
+    setState((curr) => {
+      const next = { ...curr, ...partial };
+      writeState(recipeId, next);
+      return next;
+    });
+  };
+
+  // Local-only "made this" count — starts from a mock base + user's own +1 if toggled.
+  const mockBase = useMemo(() => 34 + ((recipeId.charCodeAt(0) ?? 0) % 60), [recipeId]);
+  const madeCount = mockBase + (state.madeIt ? 1 : 0);
+
+  const handlePhoto = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!file.type.startsWith("image/")) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      update({ photoDataUrl: typeof reader.result === "string" ? reader.result : undefined });
+    };
+    reader.readAsDataURL(file);
+  };
+
+  if (!hydrated) {
+    return (
+      <div className="glass-card-premium rounded-2xl border border-white/8 p-6">
+        <div className="h-5 w-32 bg-white/5 rounded animate-pulse" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="glass-card-premium rounded-2xl border border-white/8 p-6 space-y-5">
+      <div className="flex items-start justify-between gap-3 flex-wrap">
+        <div>
+          <h2 className="text-lg font-bold text-transparent bg-clip-text bg-gradient-to-r from-amber-200 to-orange-300 flex items-center gap-2">
+            <span className="not-italic text-xl">{"\u{1F465}"}</span>
+            Community
+          </h2>
+          <p className="text-xs text-white/60 mt-1">
+            <span className="text-amber-300 font-semibold">{madeCount}</span> cooks have made this recipe
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => update({ madeIt: !state.madeIt })}
+          className={`px-4 py-2 rounded-xl text-sm font-medium border transition-colors ${
+            state.madeIt
+              ? "bg-emerald-500/20 border-emerald-500/50 text-emerald-300"
+              : "bg-amber-500/10 border-amber-500/30 text-amber-200 hover:bg-amber-500/20"
+          }`}
+        >
+          {state.madeIt ? "\u2713 You made this" : "I made this!"}
+        </button>
+      </div>
+
+      {/* Rating */}
+      <div>
+        <h3 className="text-xs font-semibold text-white/60 uppercase tracking-wider mb-2">Your rating</h3>
+        <div className="flex items-center gap-1" role="radiogroup" aria-label="Rating">
+          {[1, 2, 3, 4, 5].map((star) => {
+            const filled = star <= state.rating;
+            return (
+              <button
+                key={star}
+                type="button"
+                role="radio"
+                aria-checked={state.rating === star}
+                onClick={() => update({ rating: state.rating === star ? 0 : star })}
+                className={`text-2xl transition-transform hover:scale-110 ${filled ? "text-amber-400" : "text-white/20 hover:text-amber-500/60"}`}
+              >
+                {"\u2605"}
+              </button>
+            );
+          })}
+          {state.rating > 0 && (
+            <span className="ml-2 text-xs text-white/50">{state.rating}/5</span>
+          )}
+        </div>
+      </div>
+
+      {/* Review */}
+      <div>
+        <label htmlFor="review" className="block text-xs font-semibold text-white/60 uppercase tracking-wider mb-2">Short review</label>
+        <textarea
+          id="review"
+          value={state.review}
+          onChange={(e) => update({ review: e.target.value.slice(0, 500) })}
+          placeholder="How did it turn out? (stored locally for now)"
+          rows={3}
+          className="w-full glass-card-premium border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder:text-white/30 focus:outline-none focus:border-amber-500/50 resize-none"
+        />
+        <p className="text-xs text-white/40 mt-1 text-right">{state.review.length}/500</p>
+      </div>
+
+      {/* Photo */}
+      <div>
+        <h3 className="text-xs font-semibold text-white/60 uppercase tracking-wider mb-2">Your photo</h3>
+        {state.photoDataUrl ? (
+          <div className="relative inline-block">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={state.photoDataUrl} alt="Your upload" className="rounded-lg max-h-48 border border-white/10" />
+            <button
+              type="button"
+              onClick={() => update({ photoDataUrl: undefined })}
+              className="absolute top-1 right-1 w-6 h-6 rounded-full bg-black/60 text-white/80 hover:text-rose-300 text-xs"
+              aria-label="Remove photo"
+            >
+              &#x2715;
+            </button>
+          </div>
+        ) : (
+          <label className="flex items-center justify-center gap-2 px-4 py-3 rounded-lg bg-white/5 border border-dashed border-white/15 text-sm text-white/60 hover:text-amber-200 hover:border-amber-500/40 cursor-pointer transition-colors">
+            <span className="text-lg">{"\u{1F4F7}"}</span>
+            Add a photo
+            <input type="file" accept="image/*" onChange={handlePhoto} className="hidden" />
+          </label>
+        )}
+        <p className="text-xs text-white/40 mt-1 italic">Preview only — uploads coming soon.</p>
+      </div>
+
+      {/* Community tips (mock) */}
+      <div>
+        <h3 className="text-xs font-semibold text-white/60 uppercase tracking-wider mb-2">Community Tips</h3>
+        <ul className="space-y-2">
+          {MOCK_COMMUNITY_TIPS.map((t, i) => (
+            <li key={i} className="p-3 rounded-lg bg-white/5 border border-white/10">
+              <div className="flex items-center justify-between gap-2 mb-1">
+                <span className="text-sm font-semibold text-amber-300">{t.author}</span>
+                <span className="text-xs text-white/50 flex items-center gap-1">
+                  <span className="text-rose-400">{"\u2665"}</span> {t.hearts}
+                </span>
+              </div>
+              <p className="text-sm text-white/80 leading-relaxed">{t.tip}</p>
+            </li>
+          ))}
+        </ul>
+        <p className="text-xs text-white/40 mt-2 italic">Mock data — real community feed coming soon.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/recipes/TimeShortcutsPanel.tsx
+++ b/src/components/recipes/TimeShortcutsPanel.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import React, { useMemo } from "react";
+import type { Recipe } from "@/types/recipe";
+import { analyzeTimeShortcuts, type TimeBudget } from "@/utils/timeShortcuts";
+
+const BUDGETS: Array<{ key: TimeBudget; label: string }> = [
+  { key: 15, label: "15 min" },
+  { key: 30, label: "30 min" },
+  { key: 60, label: "1 hour" },
+  { key: "all", label: "All day" },
+];
+
+interface Props {
+  recipe: Recipe;
+  activeBudget: TimeBudget | null;
+  onBudgetChange: (b: TimeBudget | null) => void;
+}
+
+export function TimeShortcutsPanel({ recipe, activeBudget, onBudgetChange }: Props) {
+  const result = useMemo(
+    () => (activeBudget ? analyzeTimeShortcuts(recipe, activeBudget) : null),
+    [recipe, activeBudget],
+  );
+
+  return (
+    <div className="glass-card-premium rounded-2xl border border-white/8 p-5 md:p-6">
+      <div className="flex items-start justify-between gap-3 mb-3 flex-wrap">
+        <div>
+          <h2 className="text-lg font-bold text-transparent bg-clip-text bg-gradient-to-r from-amber-200 to-orange-300 flex items-center gap-2">
+            <span className="not-italic text-xl">{"\u23F1"}</span>
+            How Much Time Do You Have?
+          </h2>
+          <p className="text-xs text-white/60 mt-1">
+            We&apos;ll highlight steps to skip, parallelize, or make ahead.
+          </p>
+        </div>
+        {activeBudget && (
+          <button
+            type="button"
+            onClick={() => onBudgetChange(null)}
+            className="text-xs text-amber-300 hover:text-amber-200 underline decoration-dotted underline-offset-4"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {BUDGETS.map(({ key, label }) => {
+          const active = activeBudget === key;
+          return (
+            <button
+              key={String(key)}
+              type="button"
+              onClick={() => onBudgetChange(active ? null : key)}
+              className={`px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors ${
+                active
+                  ? "bg-amber-500/20 border-amber-500/50 text-amber-200"
+                  : "bg-white/5 border-white/10 text-white/80 hover:bg-amber-500/10 hover:border-amber-500/30 hover:text-amber-200"
+              }`}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {result && <ResultBanner result={result} />}
+    </div>
+  );
+}
+
+function ResultBanner({ result }: { result: ReturnType<typeof analyzeTimeShortcuts> }) {
+  const { fitsBudget, totalRecipeMinutes, budget, shortcutTips, makeAheadTips, equipmentSwaps } = result;
+
+  return (
+    <div className="mt-4 space-y-3">
+      <div
+        className={`p-3 rounded-lg border text-sm ${
+          fitsBudget
+            ? "bg-emerald-500/10 border-emerald-500/30 text-emerald-300"
+            : "bg-orange-500/10 border-orange-500/30 text-orange-300"
+        }`}
+      >
+        {fitsBudget ? (
+          <>
+            <span className="text-emerald-300 mr-1">&#x2713;</span>
+            {totalRecipeMinutes > 0
+              ? `Recipe fits in ${budget === "all" ? "any" : `${budget} min`} budget (est. ${totalRecipeMinutes} min total).`
+              : "No shortcuts required — cook at your pace."}
+          </>
+        ) : (
+          <>Recipe takes about {totalRecipeMinutes} min. Budget is {budget === "all" ? "unlimited" : `${budget} min`}. Use the shortcuts below to close the gap.</>
+        )}
+      </div>
+
+      {shortcutTips.length > 0 && (
+        <ul className="space-y-1 text-xs text-white/70">
+          {shortcutTips.map((t, i) => (
+            <li key={i} className="flex gap-2">
+              <span className="text-amber-400 shrink-0">&#x25B8;</span> {t}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {makeAheadTips.length > 0 && (
+        <div>
+          <h3 className="text-xs font-semibold text-white/60 uppercase tracking-wider mb-1.5">Make-Ahead</h3>
+          <ul className="space-y-1">
+            {makeAheadTips.map((tip, i) => (
+              <li key={i} className="text-sm text-white/80 flex gap-2">
+                <span className="text-sky-400 shrink-0">&#x1F5C3;</span> {tip}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {equipmentSwaps.length > 0 && (
+        <div>
+          <h3 className="text-xs font-semibold text-white/60 uppercase tracking-wider mb-1.5">Equipment Shortcuts</h3>
+          <ul className="space-y-1">
+            {equipmentSwaps.map((swap, i) => (
+              <li key={i} className="text-sm text-white/80 flex gap-2">
+                <span className="text-purple-400 shrink-0">&#x2699;</span> {swap}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useMealPlan.ts
+++ b/src/hooks/useMealPlan.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "alchm:meal-plan:v1";
+
+export interface MealPlanEntry {
+  id: string;
+  date: string;        // YYYY-MM-DD
+  recipeId: string;
+  recipeName?: string;
+  mealType?: string;   // "breakfast" | "lunch" | "dinner" | "snack"
+  servings?: number;
+  addedAt: number;
+}
+
+type Listener = (plan: MealPlanEntry[]) => void;
+const listeners = new Set<Listener>();
+let cached: MealPlanEntry[] | null = null;
+
+function read(): MealPlanEntry[] {
+  if (typeof window === "undefined") return [];
+  if (cached !== null) return cached;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    cached = raw ? (JSON.parse(raw) as MealPlanEntry[]) : [];
+  } catch {
+    cached = [];
+  }
+  return cached;
+}
+
+function write(next: MealPlanEntry[]) {
+  cached = next;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch (err) {
+    console.warn("meal-plan write failed:", err);
+  }
+  listeners.forEach((l) => l(next));
+}
+
+export function useMealPlan() {
+  const [plan, setPlan] = useState<MealPlanEntry[]>(() => read());
+
+  useEffect(() => {
+    const listener: Listener = (next) => setPlan(next);
+    listeners.add(listener);
+    // Cross-tab sync
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) {
+        cached = null;
+        setPlan(read());
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => {
+      listeners.delete(listener);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+
+  const addEntry = useCallback((entry: Omit<MealPlanEntry, "id" | "addedAt">) => {
+    const full: MealPlanEntry = {
+      ...entry,
+      id: `${entry.recipeId}-${entry.date}-${Date.now()}`,
+      addedAt: Date.now(),
+    };
+    write([...read(), full]);
+    return full;
+  }, []);
+
+  const removeEntry = useCallback((id: string) => {
+    write(read().filter((e) => e.id !== id));
+  }, []);
+
+  const clearAll = useCallback(() => {
+    write([]);
+  }, []);
+
+  const entriesForRecipe = useCallback(
+    (recipeId: string) => plan.filter((e) => e.recipeId === recipeId),
+    [plan],
+  );
+
+  return { plan, addEntry, removeEntry, clearAll, entriesForRecipe };
+}

--- a/src/utils/dietaryAdaptation.ts
+++ b/src/utils/dietaryAdaptation.ts
@@ -1,0 +1,430 @@
+import type { Recipe, RecipeIngredient } from "@/types/recipe";
+
+export type DietaryMode = "vegan" | "vegetarian" | "gluten-free" | "dairy-free" | "keto" | "low-carb";
+
+export interface IngredientSwap {
+  index: number;
+  from: RecipeIngredient;
+  to: RecipeIngredient;
+  reason: string;
+}
+
+export interface NutritionalDelta {
+  calories?: number;
+  protein?: number;
+  carbs?: number;
+  fat?: number;
+  fiber?: number;
+  sodium?: number;
+}
+
+export interface ElementalDelta {
+  Fire: number;
+  Water: number;
+  Earth: number;
+  Air: number;
+}
+
+export interface AdaptationResult {
+  mode: DietaryMode;
+  compatible: boolean;
+  swaps: IngredientSwap[];
+  nutritionalDelta: NutritionalDelta;
+  elementalDelta: ElementalDelta;
+  adaptedIngredients: RecipeIngredient[];
+}
+
+interface SwapRule {
+  match: (ing: RecipeIngredient) => boolean;
+  replace: (ing: RecipeIngredient) => { name: string; unit?: string; category?: string; amountScale?: number };
+  reason: string;
+  nutritionDelta?: NutritionalDelta;
+  elementalDelta?: Partial<ElementalDelta>;
+}
+
+const MODE_LABELS: Record<DietaryMode, string> = {
+  "vegan": "vegan",
+  "vegetarian": "vegetarian",
+  "gluten-free": "gluten-free",
+  "dairy-free": "dairy-free",
+  "keto": "keto",
+  "low-carb": "low-carb",
+};
+
+export function getModeLabel(mode: DietaryMode): string {
+  return MODE_LABELS[mode];
+}
+
+/** Match ingredient by lowercase name substring (word-boundary friendly). */
+function nameHas(ing: RecipeIngredient, ...needles: string[]): boolean {
+  const n = ing.name.toLowerCase();
+  return needles.some((s) => n.includes(s.toLowerCase()));
+}
+
+function categoryIs(ing: RecipeIngredient, ...cats: string[]): boolean {
+  const c = (ing.category || "").toLowerCase();
+  return cats.some((x) => c === x.toLowerCase());
+}
+
+// ── Shared swap rules ────────────────────────────────────────────────
+
+const MEAT_NAMES = [
+  "chicken", "beef", "pork", "lamb", "veal", "turkey", "duck",
+  "bacon", "ham", "sausage", "prosciutto", "pancetta", "salami",
+  "steak", "ground meat", "ground beef", "ground pork", "ground turkey", "ground chicken",
+  "ribs", "brisket", "chorizo",
+];
+const FISH_NAMES = ["fish", "salmon", "tuna", "cod", "shrimp", "prawn", "crab", "lobster", "anchov", "scallop", "squid", "octopus", "mussel", "clam", "oyster"];
+const EGG_NAMES = ["egg", "eggs"];
+const HONEY_NAMES = ["honey"];
+
+function meatSwap(ing: RecipeIngredient): { name: string; reason: string } {
+  const n = ing.name.toLowerCase();
+  if (n.includes("ground")) return { name: "crumbled tempeh", reason: "plant-based ground meat swap" };
+  if (n.includes("chicken")) return { name: "firm tofu", reason: "mild plant protein swap" };
+  if (n.includes("pork") || n.includes("bacon") || n.includes("ham")) return { name: "smoked tempeh", reason: "smoky plant protein swap" };
+  if (n.includes("beef") || n.includes("steak") || n.includes("brisket")) return { name: "seitan", reason: "hearty plant protein swap" };
+  if (n.includes("sausage")) return { name: "plant-based sausage", reason: "plant-based sausage swap" };
+  return { name: "jackfruit", reason: "plant-based protein swap" };
+}
+
+function fishSwap(ing: RecipeIngredient): { name: string; reason: string } {
+  const n = ing.name.toLowerCase();
+  if (n.includes("shrimp") || n.includes("prawn")) return { name: "hearts of palm", reason: "plant-based shellfish swap" };
+  if (n.includes("anchov")) return { name: "capers", reason: "briny vegan substitute" };
+  return { name: "marinated tofu", reason: "plant-based seafood swap" };
+}
+
+// ── Rule builders per mode ────────────────────────────────────────────
+
+function veganRules(): SwapRule[] {
+  return [
+    {
+      match: (ing) => nameHas(ing, ...MEAT_NAMES) || categoryIs(ing, "protein") && nameHas(ing, ...MEAT_NAMES),
+      replace: (ing) => {
+        const s = meatSwap(ing);
+        return { name: s.name, unit: ing.unit };
+      },
+      reason: "Replace animal protein",
+      nutritionDelta: { calories: -80, fat: -8, protein: -5 },
+      elementalDelta: { Fire: -0.05, Earth: 0.05 },
+    },
+    {
+      match: (ing) => nameHas(ing, ...FISH_NAMES),
+      replace: (ing) => {
+        const s = fishSwap(ing);
+        return { name: s.name, unit: ing.unit };
+      },
+      reason: "Replace seafood",
+      nutritionDelta: { calories: -40, protein: -10 },
+      elementalDelta: { Water: -0.03, Earth: 0.03 },
+    },
+    {
+      match: (ing) => nameHas(ing, "butter") && !nameHas(ing, "peanut", "almond", "cashew"),
+      replace: (ing) => ({ name: "vegan butter", unit: ing.unit }),
+      reason: "Replace dairy butter",
+      elementalDelta: { Water: -0.02, Earth: 0.02 },
+    },
+    {
+      match: (ing) => nameHas(ing, "milk") && !nameHas(ing, "almond", "oat", "soy", "coconut", "cashew", "rice milk"),
+      replace: (ing) => ({ name: "oat milk", unit: ing.unit }),
+      reason: "Replace dairy milk",
+      nutritionDelta: { calories: -20, fat: -4, protein: -2 },
+      elementalDelta: { Water: -0.02, Earth: 0.02 },
+    },
+    {
+      match: (ing) => nameHas(ing, "cream") && !nameHas(ing, "coconut cream", "cashew cream"),
+      replace: (ing) => ({ name: "coconut cream", unit: ing.unit }),
+      reason: "Replace dairy cream",
+      nutritionDelta: { calories: 20, fat: 4 },
+    },
+    {
+      match: (ing) => nameHas(ing, "yogurt", "yoghurt") && !nameHas(ing, "coconut", "soy", "almond"),
+      replace: (ing) => ({ name: "coconut yogurt", unit: ing.unit }),
+      reason: "Replace dairy yogurt",
+    },
+    {
+      match: (ing) => nameHas(ing, "cheese", "parmesan", "mozzarella", "ricotta", "feta", "cheddar", "gruyere"),
+      replace: (ing) => {
+        if (nameHas(ing, "parmesan")) return { name: "nutritional yeast", unit: ing.unit };
+        if (nameHas(ing, "ricotta")) return { name: "cashew ricotta", unit: ing.unit };
+        return { name: "vegan cheese", unit: ing.unit };
+      },
+      reason: "Replace cheese",
+      nutritionDelta: { calories: -50, fat: -6, protein: -4 },
+    },
+    {
+      match: (ing) => nameHas(ing, ...EGG_NAMES),
+      replace: (ing) => ({ name: "flax egg (1 tbsp ground flax + 3 tbsp water per egg)", unit: ing.unit }),
+      reason: "Replace eggs",
+      nutritionDelta: { calories: -40, protein: -6, fat: -3 },
+    },
+    {
+      match: (ing) => nameHas(ing, ...HONEY_NAMES),
+      replace: (ing) => ({ name: "maple syrup", unit: ing.unit }),
+      reason: "Replace honey",
+    },
+    {
+      match: (ing) => nameHas(ing, "ghee"),
+      replace: (ing) => ({ name: "coconut oil", unit: ing.unit }),
+      reason: "Replace ghee",
+    },
+  ];
+}
+
+function vegetarianRules(): SwapRule[] {
+  return [
+    {
+      match: (ing) => nameHas(ing, ...MEAT_NAMES),
+      replace: (ing) => {
+        const s = meatSwap(ing);
+        return { name: s.name, unit: ing.unit };
+      },
+      reason: "Replace animal protein",
+      nutritionDelta: { calories: -80, fat: -8, protein: -5 },
+      elementalDelta: { Fire: -0.05, Earth: 0.05 },
+    },
+    {
+      match: (ing) => nameHas(ing, ...FISH_NAMES),
+      replace: (ing) => {
+        const s = fishSwap(ing);
+        return { name: s.name, unit: ing.unit };
+      },
+      reason: "Replace seafood",
+      elementalDelta: { Water: -0.03, Earth: 0.03 },
+    },
+  ];
+}
+
+function glutenFreeRules(): SwapRule[] {
+  return [
+    {
+      match: (ing) => nameHas(ing, "flour") && !nameHas(ing, "almond flour", "coconut flour", "rice flour", "chickpea flour", "gluten-free"),
+      replace: (ing) => ({ name: "gluten-free flour blend", unit: ing.unit }),
+      reason: "Gluten-free flour",
+    },
+    {
+      match: (ing) => nameHas(ing, "pasta", "noodle") && !nameHas(ing, "gluten-free", "rice noodle", "shirataki"),
+      replace: (ing) => ({ name: "gluten-free pasta", unit: ing.unit }),
+      reason: "Gluten-free pasta",
+    },
+    {
+      match: (ing) => nameHas(ing, "soy sauce") && !nameHas(ing, "tamari"),
+      replace: (ing) => ({ name: "tamari", unit: ing.unit }),
+      reason: "Gluten-free soy sauce",
+    },
+    {
+      match: (ing) => nameHas(ing, "bread") && !nameHas(ing, "gluten-free"),
+      replace: (ing) => ({ name: "gluten-free bread", unit: ing.unit }),
+      reason: "Gluten-free bread",
+    },
+    {
+      match: (ing) => nameHas(ing, "couscous", "bulgur", "farro", "semolina", "barley", "rye"),
+      replace: (ing) => ({ name: "quinoa", unit: ing.unit }),
+      reason: "Gluten-free grain",
+    },
+    {
+      match: (ing) => nameHas(ing, "seitan"),
+      replace: (ing) => ({ name: "firm tofu", unit: ing.unit }),
+      reason: "Seitan contains gluten",
+    },
+  ];
+}
+
+function dairyFreeRules(): SwapRule[] {
+  return [
+    {
+      match: (ing) => nameHas(ing, "butter") && !nameHas(ing, "peanut", "almond", "cashew"),
+      replace: (ing) => ({ name: "olive oil", unit: ing.unit, amountScale: 0.75 }),
+      reason: "Replace butter with olive oil",
+      nutritionDelta: { fat: -2 },
+    },
+    {
+      match: (ing) => nameHas(ing, "milk") && !nameHas(ing, "almond", "oat", "soy", "coconut", "cashew"),
+      replace: (ing) => ({ name: "almond milk", unit: ing.unit }),
+      reason: "Replace dairy milk",
+    },
+    {
+      match: (ing) => nameHas(ing, "cream") && !nameHas(ing, "coconut", "cashew"),
+      replace: (ing) => ({ name: "coconut cream", unit: ing.unit }),
+      reason: "Replace dairy cream",
+    },
+    {
+      match: (ing) => nameHas(ing, "yogurt", "yoghurt") && !nameHas(ing, "coconut", "soy", "almond"),
+      replace: (ing) => ({ name: "coconut yogurt", unit: ing.unit }),
+      reason: "Replace dairy yogurt",
+    },
+    {
+      match: (ing) => nameHas(ing, "cheese", "parmesan", "mozzarella", "ricotta", "feta", "cheddar"),
+      replace: (ing) => ({ name: "dairy-free cheese", unit: ing.unit }),
+      reason: "Replace cheese",
+    },
+    {
+      match: (ing) => nameHas(ing, "ghee"),
+      replace: (ing) => ({ name: "coconut oil", unit: ing.unit }),
+      reason: "Replace ghee",
+    },
+  ];
+}
+
+function ketoRules(): SwapRule[] {
+  return [
+    {
+      match: (ing) => nameHas(ing, "flour") && !nameHas(ing, "almond flour", "coconut flour"),
+      replace: (ing) => ({ name: "almond flour", unit: ing.unit, amountScale: 0.75 }),
+      reason: "Low-carb flour",
+      nutritionDelta: { carbs: -40, calories: -30 },
+    },
+    {
+      match: (ing) => nameHas(ing, "sugar") && !nameHas(ing, "erythritol", "stevia", "monk fruit"),
+      replace: (ing) => ({ name: "erythritol", unit: ing.unit }),
+      reason: "Low-carb sweetener",
+      nutritionDelta: { carbs: -48, calories: -190 },
+    },
+    {
+      match: (ing) => nameHas(ing, "pasta", "noodle") && !nameHas(ing, "shirataki", "zucchini"),
+      replace: (ing) => ({ name: "zucchini noodles", unit: ing.unit }),
+      reason: "Low-carb noodle",
+      nutritionDelta: { carbs: -40, calories: -150 },
+    },
+    {
+      match: (ing) => nameHas(ing, "rice") && !nameHas(ing, "cauliflower"),
+      replace: (ing) => ({ name: "cauliflower rice", unit: ing.unit }),
+      reason: "Low-carb rice",
+      nutritionDelta: { carbs: -35, calories: -130 },
+    },
+    {
+      match: (ing) => nameHas(ing, "potato") && !nameHas(ing, "sweet potato"),
+      replace: (ing) => ({ name: "turnip", unit: ing.unit }),
+      reason: "Low-carb tuber",
+      nutritionDelta: { carbs: -20, calories: -60 },
+    },
+    {
+      match: (ing) => nameHas(ing, "bread") && !nameHas(ing, "keto"),
+      replace: (ing) => ({ name: "keto bread (almond flour based)", unit: ing.unit }),
+      reason: "Low-carb bread",
+      nutritionDelta: { carbs: -24, calories: -80 },
+    },
+    {
+      match: (ing) => nameHas(ing, "honey", "maple syrup", "agave"),
+      replace: (ing) => ({ name: "monk fruit sweetener", unit: ing.unit }),
+      reason: "Low-carb sweetener",
+      nutritionDelta: { carbs: -16, calories: -60 },
+    },
+  ];
+}
+
+function lowCarbRules(): SwapRule[] {
+  return [
+    {
+      match: (ing) => nameHas(ing, "pasta", "noodle") && !nameHas(ing, "shirataki", "zucchini"),
+      replace: (ing) => ({ name: "zucchini noodles", unit: ing.unit }),
+      reason: "Lower-carb noodle",
+      nutritionDelta: { carbs: -40, calories: -150 },
+    },
+    {
+      match: (ing) => nameHas(ing, "rice") && !nameHas(ing, "cauliflower"),
+      replace: (ing) => ({ name: "cauliflower rice", unit: ing.unit }),
+      reason: "Lower-carb rice",
+      nutritionDelta: { carbs: -35, calories: -130 },
+    },
+    {
+      match: (ing) => nameHas(ing, "potato") && !nameHas(ing, "sweet"),
+      replace: (ing) => ({ name: "cauliflower", unit: ing.unit }),
+      reason: "Lower-carb veg",
+      nutritionDelta: { carbs: -20, calories: -60 },
+    },
+    {
+      match: (ing) => nameHas(ing, "flour") && !nameHas(ing, "almond flour", "coconut flour"),
+      replace: (ing) => ({ name: "almond flour", unit: ing.unit, amountScale: 0.75 }),
+      reason: "Lower-carb flour",
+      nutritionDelta: { carbs: -30, calories: -25 },
+    },
+    {
+      match: (ing) => nameHas(ing, "sugar") && !nameHas(ing, "erythritol", "stevia", "monk"),
+      replace: (ing) => ({ name: "stevia", unit: ing.unit }),
+      reason: "Lower-carb sweetener",
+      nutritionDelta: { carbs: -24, calories: -95 },
+    },
+  ];
+}
+
+function rulesFor(mode: DietaryMode): SwapRule[] {
+  switch (mode) {
+    case "vegan": return veganRules();
+    case "vegetarian": return vegetarianRules();
+    case "gluten-free": return glutenFreeRules();
+    case "dairy-free": return dairyFreeRules();
+    case "keto": return ketoRules();
+    case "low-carb": return lowCarbRules();
+  }
+}
+
+/** Detect whether a recipe is already compatible with a given mode. */
+export function isAlreadyCompatible(recipe: Recipe, mode: DietaryMode): boolean {
+  switch (mode) {
+    case "vegan":       return recipe.isVegan === true;
+    case "vegetarian":  return recipe.isVegetarian === true || recipe.isVegan === true;
+    case "gluten-free": return recipe.isGlutenFree === true;
+    case "dairy-free":  return recipe.isDairyFree === true || recipe.isVegan === true;
+    case "keto":        return recipe.isKeto === true;
+    case "low-carb":    return recipe.isLowCarb === true || recipe.isKeto === true;
+  }
+}
+
+/** Heuristic fallback: scan ingredients to see if any swap would trigger. */
+export function needsAdaptation(recipe: Recipe, mode: DietaryMode): boolean {
+  if (isAlreadyCompatible(recipe, mode)) return false;
+  const rules = rulesFor(mode);
+  return recipe.ingredients.some((ing) => rules.some((r) => r.match(ing)));
+}
+
+/** Pure adaptation: returns swaps + deltas + derived ingredient list. Never mutates. */
+export function adaptRecipe(recipe: Recipe, mode: DietaryMode): AdaptationResult {
+  const compatible = isAlreadyCompatible(recipe, mode);
+  const rules = rulesFor(mode);
+
+  const swaps: IngredientSwap[] = [];
+  const adaptedIngredients: RecipeIngredient[] = [];
+  const nutritionalDelta: NutritionalDelta = {};
+  const elementalDelta: ElementalDelta = { Fire: 0, Water: 0, Earth: 0, Air: 0 };
+
+  recipe.ingredients.forEach((ing, index) => {
+    const rule = rules.find((r) => r.match(ing));
+    if (!rule || compatible) {
+      adaptedIngredients.push(ing);
+      return;
+    }
+    const spec = rule.replace(ing);
+    const newIng: RecipeIngredient = {
+      ...ing,
+      name: spec.name,
+      unit: spec.unit ?? ing.unit,
+      category: spec.category ?? ing.category,
+      amount: spec.amountScale ? ing.amount * spec.amountScale : ing.amount,
+      notes: ing.notes,
+    };
+    adaptedIngredients.push(newIng);
+    swaps.push({ index, from: ing, to: newIng, reason: rule.reason });
+
+    const nd = rule.nutritionDelta ?? {};
+    (Object.keys(nd) as Array<keyof NutritionalDelta>).forEach((k) => {
+      const v = nd[k];
+      if (v != null) nutritionalDelta[k] = (nutritionalDelta[k] ?? 0) + v;
+    });
+    const ed = rule.elementalDelta ?? {};
+    (Object.keys(ed) as Array<keyof ElementalDelta>).forEach((k) => {
+      const v = ed[k];
+      if (v != null) elementalDelta[k] = elementalDelta[k] + v;
+    });
+  });
+
+  return {
+    mode,
+    compatible,
+    swaps,
+    nutritionalDelta,
+    elementalDelta,
+    adaptedIngredients,
+  };
+}

--- a/src/utils/flavorTuning.ts
+++ b/src/utils/flavorTuning.ts
@@ -1,0 +1,73 @@
+export type FlavorDirection = "sweeter" | "umami" | "acidic" | "spicier" | "savory";
+
+export interface FlavorTweak {
+  id: string;
+  direction: FlavorDirection;
+  ingredient: string;
+  amount: string;
+  reason: string;
+}
+
+export const FLAVOR_DIRECTIONS: Array<{ key: FlavorDirection; label: string; icon: string }> = [
+  { key: "sweeter", label: "Sweeter", icon: "\u{1F36F}" },
+  { key: "umami",   label: "Umami",   icon: "\u{1F344}" },
+  { key: "acidic",  label: "Acidic",  icon: "\u{1F34B}" },
+  { key: "spicier", label: "Spicier", icon: "\u{1F336}" },
+  { key: "savory",  label: "Savory",  icon: "\u{1F9C2}" },
+];
+
+const CATALOG: Record<FlavorDirection, Array<Omit<FlavorTweak, "id" | "direction">>> = {
+  sweeter: [
+    { ingredient: "honey", amount: "1 tsp", reason: "Rounds out acidity, deepens caramel notes" },
+    { ingredient: "maple syrup", amount: "1 tsp", reason: "Adds warm sweetness without overpowering" },
+    { ingredient: "brown sugar", amount: "½ tsp", reason: "Brings molasses depth" },
+    { ingredient: "date paste", amount: "1 tsp", reason: "Natural sweetness with fiber" },
+    { ingredient: "roasted carrot purée", amount: "1 tbsp", reason: "Savory sweetness" },
+  ],
+  umami: [
+    { ingredient: "fish sauce", amount: "a dash (¼ tsp)", reason: "Concentrated glutamates" },
+    { ingredient: "soy sauce", amount: "½ tsp", reason: "Rich fermented depth" },
+    { ingredient: "miso paste", amount: "½ tsp", reason: "Mellow umami backbone" },
+    { ingredient: "parmesan rind (simmered)", amount: "1 piece", reason: "Slow-release glutamate" },
+    { ingredient: "dried mushroom powder", amount: "¼ tsp", reason: "Plant-based umami" },
+    { ingredient: "tomato paste", amount: "1 tsp", reason: "Concentrated fruity umami" },
+  ],
+  acidic: [
+    { ingredient: "lemon juice", amount: "½ tsp", reason: "Brightens; add at the end" },
+    { ingredient: "white wine vinegar", amount: "½ tsp", reason: "Clean acidity" },
+    { ingredient: "rice vinegar", amount: "1 tsp", reason: "Mild, slightly sweet acidity" },
+    { ingredient: "yogurt", amount: "1 tbsp", reason: "Creamy tartness" },
+    { ingredient: "capers (chopped)", amount: "1 tsp", reason: "Briny, pickled brightness" },
+  ],
+  spicier: [
+    { ingredient: "cayenne", amount: "¼ tsp", reason: "Clean heat" },
+    { ingredient: "chili flakes", amount: "½ tsp", reason: "Bright, fruity heat" },
+    { ingredient: "fresh chili (sliced)", amount: "½ chili", reason: "Fresh grassy heat" },
+    { ingredient: "hot sauce", amount: "½ tsp", reason: "Vinegar-spiked lift" },
+    { ingredient: "black pepper", amount: "¼ tsp", reason: "Warm, piney heat" },
+    { ingredient: "gochujang", amount: "½ tsp", reason: "Fermented sweet heat" },
+  ],
+  savory: [
+    { ingredient: "kosher salt", amount: "⅛ tsp", reason: "Amplifies existing flavors" },
+    { ingredient: "caramelized onion", amount: "1 tbsp", reason: "Deep sweet-savory note" },
+    { ingredient: "fresh herbs (parsley/thyme)", amount: "1 tbsp", reason: "Green savory lift" },
+    { ingredient: "garlic (grated)", amount: "½ clove", reason: "Pungent foundation" },
+    { ingredient: "anchovy paste", amount: "¼ tsp", reason: "Invisible savory depth" },
+  ],
+};
+
+export function suggestTweak(direction: FlavorDirection, existing: FlavorTweak[]): FlavorTweak {
+  const pool = CATALOG[direction];
+  const usedIngredients = new Set(
+    existing.filter((t) => t.direction === direction).map((t) => t.ingredient),
+  );
+  // Prefer tweaks not yet added; fall back to round-robin if all used.
+  const preferred = pool.find((p) => !usedIngredients.has(p.ingredient)) ?? pool[existing.filter((t) => t.direction === direction).length % pool.length];
+  return {
+    id: `${direction}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    direction,
+    ingredient: preferred.ingredient,
+    amount: preferred.amount,
+    reason: preferred.reason,
+  };
+}

--- a/src/utils/timeShortcuts.ts
+++ b/src/utils/timeShortcuts.ts
@@ -1,0 +1,147 @@
+import type { Recipe } from "@/types/recipe";
+
+export type TimeBudget = 15 | 30 | 60 | "all";
+
+export interface StepAnalysis {
+  index: number;
+  skippable: boolean;
+  parallelizable: boolean;
+  timeConsuming: boolean;
+  reason?: string;
+}
+
+export interface TimeShortcutResult {
+  budget: TimeBudget;
+  totalRecipeMinutes: number;
+  fitsBudget: boolean;
+  stepAnalyses: StepAnalysis[];
+  makeAheadTips: string[];
+  equipmentSwaps: string[];
+  shortcutTips: string[];
+}
+
+const BUDGET_MINUTES: Record<Exclude<TimeBudget, "all">, number> = {
+  15: 15,
+  30: 30,
+  60: 60,
+};
+
+const SKIPPABLE_KEYWORDS = [
+  "optional", "garnish", "to taste", "if desired", "you may", "you can also",
+  "preheat the oven", // technically required but can parallelize with other prep
+];
+const PARALLELIZABLE_KEYWORDS = [
+  "while", "meanwhile", "at the same time", "in parallel", "as the",
+  "preheat", "heat the oven", "bring", "boil",
+];
+const TIME_CONSUMING_KEYWORDS = [
+  "marinate", "marinade", "rest", "chill", "refrigerate", "overnight",
+  "set aside for", "let sit", "proof", "ferment", "cool completely",
+  "simmer for 1", "simmer for 2", "braise", "slow cook", "reduce",
+];
+
+const MAKE_AHEAD_KEYWORDS = [
+  "overnight", "ahead", "day before", "refrigerate", "store", "keeps", "freeze", "prepare in advance", "can be made",
+];
+
+const EQUIPMENT_SHORTCUT_RULES: Array<{ match: RegExp; swap: string }> = [
+  { match: /\bbraise\b|\bslow[\s-]?cook\b|\bstew\b/i, swap: "Use a pressure cooker: reduces braising from hours to 30–40 min" },
+  { match: /\bovernight\b|\bmarinate.*(hour|hr)s?/i,    swap: "Use a vacuum marinator or inject marinade to cut marinating time ~75%" },
+  { match: /\bboil.*potato\b|\bcook.*potato\b/i,       swap: "Microwave-steam potatoes: 5–8 min vs. 20+ min boiling" },
+  { match: /\bwhip\b|\bfold\b|\bbeat/i,                swap: "Use a stand mixer to parallelize hands-free" },
+  { match: /\broast|\bbake\b/i,                        swap: "Air fryer: 25–35% faster than conventional oven for roasting" },
+  { match: /\bsimmer\b.*\b(1|2|3)\s*hour/i,            swap: "Pressure cooker: 15–25 min vs. 1–3 hours simmering" },
+];
+
+function parseMinutesFromString(s: string | undefined): number {
+  if (!s) return 0;
+  let total = 0;
+  const hourMatch = s.match(/(\d+)\s*(?:hour|hr|h\b)/i);
+  if (hourMatch) total += parseInt(hourMatch[1], 10) * 60;
+  const minMatch = s.match(/(\d+)\s*(?:minute|min|m\b)/i);
+  if (minMatch) total += parseInt(minMatch[1], 10);
+  if (total === 0) {
+    const bare = s.match(/\d+/);
+    if (bare) total = parseInt(bare[0], 10);
+  }
+  return total;
+}
+
+function getTotalMinutes(recipe: Recipe): number {
+  const details = (recipe as { details?: { prepTimeMinutes?: number; cookTimeMinutes?: number } }).details;
+  if (details?.prepTimeMinutes != null) {
+    return details.prepTimeMinutes + (details.cookTimeMinutes ?? 0);
+  }
+  return parseMinutesFromString(recipe.prepTime) + parseMinutesFromString(recipe.cookTime);
+}
+
+function matchesAny(text: string, keywords: string[]): boolean {
+  const lower = text.toLowerCase();
+  return keywords.some((k) => lower.includes(k));
+}
+
+function analyzeStep(instruction: string, index: number): StepAnalysis {
+  const skippable = matchesAny(instruction, SKIPPABLE_KEYWORDS);
+  const parallelizable = matchesAny(instruction, PARALLELIZABLE_KEYWORDS);
+  const timeConsuming = matchesAny(instruction, TIME_CONSUMING_KEYWORDS);
+
+  let reason: string | undefined;
+  if (timeConsuming) reason = "Long idle time — prep other steps or skip if pressed";
+  else if (parallelizable) reason = "Can run alongside another step";
+  else if (skippable) reason = "Optional — safe to skip under time pressure";
+
+  return { index, skippable, parallelizable, timeConsuming, reason };
+}
+
+function extractMakeAheadTips(recipe: Recipe): string[] {
+  const buckets = [recipe.tips, recipe.chefNotes, recipe.technicalTips, recipe.variations].filter(Boolean) as string[][];
+  const flat = buckets.flat();
+  return flat.filter((tip) => matchesAny(tip, MAKE_AHEAD_KEYWORDS));
+}
+
+function extractEquipmentSwaps(recipe: Recipe): string[] {
+  const joined = [...recipe.instructions, recipe.prepTime ?? "", recipe.cookTime ?? ""].join(" ");
+  const hits: string[] = [];
+  for (const { match, swap } of EQUIPMENT_SHORTCUT_RULES) {
+    if (match.test(joined) && !hits.includes(swap)) hits.push(swap);
+  }
+  return hits;
+}
+
+export function analyzeTimeShortcuts(recipe: Recipe, budget: TimeBudget): TimeShortcutResult {
+  const totalRecipeMinutes = getTotalMinutes(recipe);
+  const fitsBudget = budget === "all" ? true : totalRecipeMinutes > 0 && totalRecipeMinutes <= BUDGET_MINUTES[budget];
+
+  const stepAnalyses = recipe.instructions.map((inst, i) => analyzeStep(inst, i));
+
+  const makeAheadTips = extractMakeAheadTips(recipe);
+  const equipmentSwaps = budget === "all" ? [] : extractEquipmentSwaps(recipe);
+
+  const shortcutTips: string[] = [];
+  if (budget !== "all" && !fitsBudget) {
+    const longSteps = stepAnalyses.filter((s) => s.timeConsuming).length;
+    const parallelSteps = stepAnalyses.filter((s) => s.parallelizable).length;
+    if (longSteps > 0) {
+      shortcutTips.push(`${longSteps} step${longSteps === 1 ? "" : "s"} involve long idle time. Consider doing those ahead.`);
+    }
+    if (parallelSteps > 0) {
+      shortcutTips.push(`${parallelSteps} step${parallelSteps === 1 ? "" : "s"} can run in parallel to save wall-clock time.`);
+    }
+    if (makeAheadTips.length > 0) {
+      shortcutTips.push(`${makeAheadTips.length} tip${makeAheadTips.length === 1 ? "" : "s"} suggest make-ahead prep.`);
+    }
+    if (equipmentSwaps.length > 0) {
+      shortcutTips.push(`${equipmentSwaps.length} equipment shortcut${equipmentSwaps.length === 1 ? "" : "s"} available.`);
+    }
+  }
+
+  return {
+    budget,
+    totalRecipeMinutes,
+    fitsBudget,
+    stepAnalyses,
+    makeAheadTips,
+    equipmentSwaps,
+    shortcutTips,
+  };
+}


### PR DESCRIPTION
## Summary

Adds five interactive layers to the recipe detail page and two new meal-plan routes, closing out phases 3A–C and 5A–C of the recipe interactivity roadmap. Builds on the phase 1/2/4 work shipped in #344 (interactive ingredients, technique glossary, timers, nutrition viz).

- **Discovery** (`/api/recipes/[id]/discover`): ranks other recipes by Euclidean distance on Fire/Water/Earth/Air, cosine similarity on ESMS, and cuisine+Monica. Three-lens tabbed carousel replaces the prior "Similar Recipes" block.
- **Dietary adaptation**: pure `adaptRecipe()` engine with six modes (vegan, vegetarian, gluten-free, dairy-free, keto, low-carb) and ~40 swap rules. Ingredients list renders inline strikethrough diffs; banner shows swap count plus nutrition (cal/protein/carbs/fat) and elemental deltas. ESMS is never recomputed — planetary scores still reflect the original recipe.
- **Flavor tuning**: five direction buttons (sweeter / umami / acidic / spicier / savory) stage removable micro-suggestions with amount + reason, drawn from a rotating per-direction catalog.
- **Time shortcuts**: budget pills (15 / 30 / 60 min / all day) heuristic-classify each instruction as skippable, parallelizable, or long-idle, and surface make-ahead tips plus equipment swaps (pressure cooker, air fryer, etc.) when the recipe exceeds the budget.
- **Meal planning**: localStorage-backed `useMealPlan` hook (cross-tab sync), "Add to Meal Plan" button with date picker, `/meal-plan` overview page, and `/meal-plan/groceries` that aggregates ingredients across scheduled recipes by name+unit and groups by category.
- **Social shells** (design-only): "I made this" toggle, 5-star rating, 500-char review, photo preview (base64), mock community tips. Pure local state with `TODO(phase 5.5)` for the future auth-gated backend.

## Why

Moves the recipe page from "read this exact recipe" to "adapt this recipe to me" — users can one-click transform a dish for dietary needs, tune its flavor balance, squeeze it into a time budget, schedule it into a weekly plan, or record how their attempt went. The meal-plan + grocery-list pair closes the loop from browsing to shopping.

## Architecture notes

- All adaptation logic is pure (`src/utils/dietaryAdaptation.ts`, `flavorTuning.ts`, `timeShortcuts.ts`) and returns derived data — no recipe mutation.
- Discovery endpoint reuses `UnifiedRecipeService.getAllRecipes()` and performs similarity math in-memory; cheap enough at current catalog size (351 recipes) with no caching layer.
- Meal plan is localStorage-only for now; `useMealPlan` exposes the surface a future `/api/users/me/meal-plan` endpoint can drop into.
- Social component is a UX shell, intentionally not wired to any persistence beyond localStorage — commented `TODO(phase 5.5)` marks the handoff.

## Test plan

- [ ] `npx tsc --noEmit --skipLibCheck` → 0 errors (confirmed)
- [ ] `yarn lint` clean on all touched files (confirmed)
- [ ] Load `/recipes/[id]` — all four new panels render (adapt, tune, time, social)
- [ ] Click "Make Vegan" → ingredients show strikethrough diffs with swap reasons and nutrition/elemental banner
- [ ] Click "Reset to original" → diffs clear
- [ ] Click "+ Sweeter" / "+ Umami" → tweak list populates; individual `×` removes one
- [ ] Click "30 min" budget → long steps get "Long idle" badges, parallelizable steps get "Parallelize" badges
- [ ] Click "Add to Meal Plan" → modal opens, date/meal selectable, saves to localStorage
- [ ] Visit `/meal-plan` → scheduled entries appear grouped by date
- [ ] Visit `/meal-plan/groceries` → ingredients consolidate by name+unit, grouped by category; copy list works
- [ ] Discovery section renders three lenses, each linking to a different recipe
- [ ] Social section: rating persists, review persists, photo preview persists across page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)