### PR TITLE
feat(calendar+pantry): today hero card, per-day nutrition, pantry wiring, quest events

### DIFF
--- a/src/app/api/generate-cosmic-recipe/route.ts
+++ b/src/app/api/generate-cosmic-recipe/route.ts
@@ -90,7 +90,10 @@ export async function POST(request: Request) {
   } catch (error) {
     console.warn("[generate-cosmic-recipe] Failed to increment usage", error);
   }
-  await reportQuestEventBestEffort(userId, "generate_cosmic_recipe");
+  // Cosmic recipes count toward both the generic "Culinary Explorer" tiers
+  // and the one-shot "Cosmic Chef" premium quest.
+  await reportQuestEventBestEffort(userId, "generate_recipe");
+  await reportQuestEventBestEffort(userId, "generate_premium_recipe");
 
   const body = await request.json();
   const {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -110,6 +110,20 @@ export default function RootLayout({
                     📅 Menu Planner
                   </Link>
                   <Link
+                    href="/pantry"
+                    className="px-3 py-2 rounded-lg bg-white bg-opacity-70 hover:bg-emerald-100 text-emerald-700 font-semibold text-sm transition-all duration-200 hover:scale-105 hover:shadow-md border border-emerald-200"
+                    aria-label="Track ingredients in your pantry"
+                  >
+                    🥫 Pantry
+                  </Link>
+                  <Link
+                    href="/food-tracking"
+                    className="px-3 py-2 rounded-lg bg-white bg-opacity-70 hover:bg-teal-100 text-teal-700 font-semibold text-sm transition-all duration-200 hover:scale-105 hover:shadow-md border border-teal-200"
+                    aria-label="Track what you eat"
+                  >
+                    📔 Food Diary
+                  </Link>
+                  <Link
                     href="/recipe-builder"
                     className="px-3 py-2 rounded-lg bg-white bg-opacity-70 hover:bg-amber-100 text-amber-700 font-semibold text-sm transition-all duration-200 hover:scale-105 hover:shadow-md border border-amber-200"
                     aria-label="Build and generate recipes with ingredient search and planetary alignment"
@@ -199,6 +213,22 @@ export default function RootLayout({
                         className="text-gray-300 hover:text-purple-300 transition-colors"
                       >
                         📅 Menu Planner
+                      </Link>
+                    </li>
+                    <li>
+                      <Link
+                        href="/pantry"
+                        className="text-gray-300 hover:text-emerald-300 transition-colors"
+                      >
+                        🥫 Pantry
+                      </Link>
+                    </li>
+                    <li>
+                      <Link
+                        href="/food-tracking"
+                        className="text-gray-300 hover:text-teal-300 transition-colors"
+                      >
+                        📔 Food Diary
                       </Link>
                     </li>
                     <li>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import dynamic from "next/dynamic";
+import Link from "next/link";
 import { HeroSection } from "@/components/home/HeroSection";
 import type { Variants } from "framer-motion";
 
@@ -76,13 +77,28 @@ export default function Home() {
           </div>
         </motion.section>
 
-        <motion.section 
+        <motion.section
           id="ingredients"
           variants={fadeInItem}
           initial="hidden"
           whileInView="show"
           viewport={{ once: true, margin: "-100px" }}
         >
+          <div className="mx-6 mb-3 flex items-center justify-between flex-wrap gap-2">
+            <p className="text-sm text-gray-600">
+              Tap{" "}
+              <span className="inline-block bg-amber-100 text-amber-800 text-xs font-semibold px-2 py-0.5 rounded">
+                + Pantry
+              </span>{" "}
+              on any card to track it in your kitchen.
+            </p>
+            <Link
+              href="/pantry"
+              className="text-sm font-medium text-emerald-700 hover:text-emerald-900 underline"
+            >
+              View my pantry →
+            </Link>
+          </div>
           <EnhancedIngredientRecommender />
         </motion.section>
 

--- a/src/app/pantry/page.tsx
+++ b/src/app/pantry/page.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import Link from "next/link";
+import React, { useMemo, useState } from "react";
+import { usePantry } from "@/hooks/usePantry";
+
+function formatName(name: string): string {
+  return name
+    .replace(/_/g, " ")
+    .split(" ")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(" ");
+}
+
+export default function PantryPage() {
+  const { items, stats, isLoaded, removeItem, updateItem, clear } = usePantry();
+  const [query, setQuery] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState<string>("all");
+
+  const categories = useMemo(() => {
+    const cats = new Set<string>();
+    items.forEach((i) => cats.add(i.category || "other"));
+    return Array.from(cats).sort();
+  }, [items]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return items
+      .filter((i) => categoryFilter === "all" || i.category === categoryFilter)
+      .filter((i) => !q || i.name.toLowerCase().includes(q))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [items, query, categoryFilter]);
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, typeof filtered>();
+    filtered.forEach((item) => {
+      const key = item.category || "other";
+      if (!map.has(key)) map.set(key, [] as typeof filtered);
+      map.get(key)!.push(item);
+    });
+    return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b));
+  }, [filtered]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-white to-emerald-50">
+      <div className="mx-auto max-w-6xl px-4 py-8">
+        <div className="mb-6 flex items-start justify-between flex-wrap gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">
+              🥫 Your Pantry
+            </h1>
+            <p className="text-sm text-gray-600 mt-1">
+              Ingredients you have on hand. Add from the{" "}
+              <Link
+                href="/#ingredients"
+                className="text-emerald-700 underline hover:text-emerald-900"
+              >
+                Ingredient Recommender
+              </Link>{" "}
+              on the home page, or jump over to the{" "}
+              <Link
+                href="/menu-planner"
+                className="text-purple-700 underline hover:text-purple-900"
+              >
+                Menu Planner
+              </Link>{" "}
+              to build meals around what you own.
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Link
+              href="/#ingredients"
+              className="px-4 py-2 rounded-lg bg-emerald-600 text-white text-sm font-medium hover:bg-emerald-700"
+            >
+              + Browse ingredients
+            </Link>
+            {items.length > 0 && (
+              <button
+                onClick={() => {
+                  if (confirm("Clear all pantry items? This cannot be undone.")) {
+                    clear();
+                  }
+                }}
+                className="px-4 py-2 rounded-lg bg-gray-100 text-gray-700 text-sm font-medium hover:bg-gray-200"
+              >
+                Clear pantry
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Stats */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+          <div className="bg-white border border-gray-200 rounded-xl p-4">
+            <div className="text-xs uppercase tracking-wide text-gray-500">
+              Total items
+            </div>
+            <div className="text-2xl font-bold text-gray-900 mt-1">
+              {stats.totalItems}
+            </div>
+          </div>
+          <div className="bg-white border border-gray-200 rounded-xl p-4">
+            <div className="text-xs uppercase tracking-wide text-gray-500">
+              Categories
+            </div>
+            <div className="text-2xl font-bold text-gray-900 mt-1">
+              {Object.keys(stats.categoryCounts).length}
+            </div>
+          </div>
+          <div className="bg-white border border-amber-200 rounded-xl p-4">
+            <div className="text-xs uppercase tracking-wide text-amber-700">
+              Expiring ≤ 7 days
+            </div>
+            <div className="text-2xl font-bold text-amber-900 mt-1">
+              {stats.expiringIn7Days}
+            </div>
+          </div>
+          <div className="bg-white border border-red-200 rounded-xl p-4">
+            <div className="text-xs uppercase tracking-wide text-red-700">
+              Expired
+            </div>
+            <div className="text-2xl font-bold text-red-900 mt-1">
+              {stats.expired}
+            </div>
+          </div>
+        </div>
+
+        {/* Filters */}
+        {items.length > 0 && (
+          <div className="mb-6 flex gap-3 flex-wrap items-center">
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search pantry..."
+              className="flex-1 min-w-[200px] px-4 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-400"
+            />
+            <select
+              value={categoryFilter}
+              onChange={(e) => setCategoryFilter(e.target.value)}
+              className="px-4 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-emerald-400"
+            >
+              <option value="all">All categories ({items.length})</option>
+              {categories.map((c) => (
+                <option key={c} value={c}>
+                  {formatName(c)} ({stats.categoryCounts[c] || 0})
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {/* Items */}
+        {!isLoaded ? (
+          <div className="text-center py-12 text-gray-500">Loading pantry...</div>
+        ) : items.length === 0 ? (
+          <div className="bg-white border-2 border-dashed border-gray-300 rounded-xl p-12 text-center">
+            <div className="text-5xl mb-3">🧺</div>
+            <h2 className="text-xl font-semibold text-gray-800 mb-2">
+              Your pantry is empty
+            </h2>
+            <p className="text-gray-600 mb-6 max-w-md mx-auto">
+              Tap the{" "}
+              <span className="inline-block bg-amber-100 text-amber-800 text-xs font-medium px-2 py-0.5 rounded">
+                + Pantry
+              </span>{" "}
+              button on any ingredient card on the home page to start tracking
+              what you own.
+            </p>
+            <Link
+              href="/#ingredients"
+              className="inline-block px-6 py-3 rounded-lg bg-emerald-600 text-white font-medium hover:bg-emerald-700"
+            >
+              Browse ingredients
+            </Link>
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="bg-white border border-gray-200 rounded-xl p-8 text-center">
+            <p className="text-gray-600">No pantry items match those filters.</p>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {grouped.map(([category, catItems]) => (
+              <section key={category}>
+                <h2 className="text-lg font-semibold text-gray-800 mb-3 capitalize">
+                  {formatName(category)}{" "}
+                  <span className="text-sm font-normal text-gray-500">
+                    ({catItems.length})
+                  </span>
+                </h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                  {catItems.map((item) => {
+                    const isExpired =
+                      item.expirationDate && item.expirationDate < new Date();
+                    return (
+                      <div
+                        key={item.id}
+                        className={`bg-white border rounded-xl p-4 flex items-start justify-between gap-3 ${
+                          isExpired ? "border-red-200 bg-red-50" : "border-gray-200"
+                        }`}
+                      >
+                        <div className="flex-1 min-w-0">
+                          <div className="font-medium text-gray-900 truncate">
+                            {formatName(item.name)}
+                          </div>
+                          <div className="text-xs text-gray-500 mt-0.5">
+                            Added{" "}
+                            {new Date(item.addedDate).toLocaleDateString()}
+                            {item.expirationDate &&
+                              ` · Expires ${new Date(item.expirationDate).toLocaleDateString()}`}
+                          </div>
+                          <div className="flex items-center gap-2 mt-2">
+                            <button
+                              onClick={() =>
+                                updateItem(item.id, {
+                                  quantity: Math.max(0, item.quantity - 1),
+                                })
+                              }
+                              className="w-6 h-6 rounded bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm flex items-center justify-center"
+                              aria-label="Decrease quantity"
+                            >
+                              −
+                            </button>
+                            <span className="text-sm font-medium text-gray-800 min-w-[60px] text-center">
+                              {item.quantity} {item.unit}
+                            </span>
+                            <button
+                              onClick={() =>
+                                updateItem(item.id, {
+                                  quantity: item.quantity + 1,
+                                })
+                              }
+                              className="w-6 h-6 rounded bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm flex items-center justify-center"
+                              aria-label="Increase quantity"
+                            >
+                              +
+                            </button>
+                          </div>
+                        </div>
+                        <button
+                          onClick={() => removeItem(item.id)}
+                          className="text-gray-400 hover:text-red-600 text-sm"
+                          title="Remove from pantry"
+                        >
+                          ✕
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/economy/SanctumTasks.tsx
+++ b/src/components/economy/SanctumTasks.tsx
@@ -265,12 +265,22 @@ export function SanctumTasks({ className = '', onOpenSettings }: SanctumTasksPro
   }, [fetchQuests]);
 
   // Filter & Group
-  const allTasks = questData 
+  const allTasks = questData
     ? [...questData.weekly, ...questData.achievements]
         .filter(q => SANCTUM_QUEST_SLUGS.includes(q.quest.slug))
         .sort((a, b) => (a.quest.sortOrder ?? 0) - (b.quest.sortOrder ?? 0))
     : [];
-  
+
+  // Completion & reward summary
+  const totalCount = allTasks.length;
+  const completedCount = allTasks.filter(q => !!q.completedAt).length;
+  const claimableCount = allTasks.filter(q => !!q.completedAt && !q.claimedAt).length;
+  const earnedCount = allTasks.filter(q => !!q.claimedAt).length;
+  const claimableTokens = allTasks
+    .filter(q => !!q.completedAt && !q.claimedAt)
+    .reduce((sum, q) => sum + (q.quest.tokenRewardAmount || 0), 0);
+  const completionPct = totalCount > 0 ? Math.round((earnedCount / totalCount) * 100) : 0;
+
   // Group logic
   const tasksByToken: Record<string, QuestProgress[]> = {
     All: [],
@@ -302,11 +312,46 @@ export function SanctumTasks({ className = '', onOpenSettings }: SanctumTasksPro
               Alchemical Alignments
             </h2>
             <p className="text-[11px] text-white/30 mt-1 max-w-lg leading-relaxed">
-              Earn ESMS tokens by performing actions that drive your personalized 
+              Earn ESMS tokens by performing actions that drive your personalized
               culinary journey and help tune the alchemical algorithms.
             </p>
           </div>
+
+          {!loading && totalCount > 0 && (
+            <div className="flex items-center gap-3 flex-wrap">
+              <div className="text-right">
+                <div className="text-[9px] font-bold text-white/40 uppercase tracking-[0.3em]">
+                  Progress
+                </div>
+                <div className="text-sm font-black text-white/85">
+                  {earnedCount}/{totalCount}
+                  <span className="text-white/40 font-medium ml-1">({completionPct}%)</span>
+                </div>
+              </div>
+              {claimableCount > 0 && (
+                <div className="px-3 py-1.5 rounded-full bg-amber-500/15 border border-amber-500/40 shadow-[0_0_15px_rgba(251,191,36,0.15)]">
+                  <div className="text-[9px] font-black text-amber-400/80 uppercase tracking-[0.2em]">
+                    Claimable
+                  </div>
+                  <div className="text-xs font-black text-amber-200">
+                    {claimableCount} task{claimableCount === 1 ? '' : 's'} · +{claimableTokens} tokens
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
         </div>
+
+        {!loading && totalCount > 0 && (
+          <div className="mb-6 h-1 bg-white/[0.04] rounded-full overflow-hidden">
+            <motion.div
+              initial={{ width: 0 }}
+              animate={{ width: `${completionPct}%` }}
+              transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
+              className="h-full rounded-full bg-gradient-to-r from-amber-500 via-amber-400 to-emerald-400"
+            />
+          </div>
+        )}
 
         {loading ? (
           <div className="space-y-3 animate-pulse">

--- a/src/components/menu-builder/QuickActionsToolbar.tsx
+++ b/src/components/menu-builder/QuickActionsToolbar.tsx
@@ -16,6 +16,7 @@ import { getServerRecipes } from "@/actions/recipes";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import { useMenuPlanner } from "@/contexts/MenuPlannerContext";
 import { useUser } from "@/contexts/UserContext";
+import { reportQuestEvent } from "@/lib/questReporter";
 import type { MonicaOptimizedRecipe } from "@/data/unified/recipeBuilding";
 import type { DayOfWeek, MealType } from "@/types/menuPlanner";
 import type { Recipe } from "@/types/recipe";
@@ -68,6 +69,8 @@ export default function QuickActionsToolbar({ onTogglePreferences }: QuickAction
   const hasNatalChart = !!currentUser?.natalChart;
 
   const [isGenerating, setIsGenerating] = useState(false);
+  const [isGeneratingWeek, setIsGeneratingWeek] = useState(false);
+  const [weekProgressDay, setWeekProgressDay] = useState<DayOfWeek | null>(null);
   const [isBalancing, setIsBalancing] = useState(false);
   const [isDiversifying, setIsDiversifying] = useState(false);
   const [currentGeneratingDay, setCurrentGeneratingDay] =
@@ -153,6 +156,81 @@ export default function QuickActionsToolbar({ onTogglePreferences }: QuickAction
     } finally {
       setIsGenerating(false);
       setCurrentGeneratingDay(null);
+    }
+  };
+
+  /**
+   * Generate Full Week - fills every empty meal slot across all 7 days
+   * using the same planetary + personalized recommendation pipeline as
+   * Generate Day, then rewards the Master Planner quest on completion.
+   */
+  const handleGenerateFullWeek = async () => {
+    if (!currentMenu) return;
+    setIsGeneratingWeek(true);
+
+    try {
+      const mealTypes: MealType[] = ["breakfast", "lunch", "snack", "dinner"];
+      let anyDayNeededWork = false;
+
+      for (let day = 0; day < 7; day++) {
+        const dayOfWeek = day as DayOfWeek;
+        const filledTypes = new Set(
+          currentMenu.meals
+            .filter((m) => m.dayOfWeek === dayOfWeek && m.recipe)
+            .map((m) => m.mealType),
+        );
+        const missingTypes = mealTypes.filter((t) => !filledTypes.has(t));
+        if (missingTypes.length === 0) continue;
+
+        anyDayNeededWork = true;
+        setWeekProgressDay(dayOfWeek);
+
+        await generateMealsForDay(dayOfWeek, {
+          mealTypes: missingTypes,
+          useCurrentPlanetary: true,
+          usePersonalization: hasNatalChart,
+        });
+
+        // Fallback for any slot the recommender couldn't satisfy with
+        // current filters — keeps the week contiguous so the Master Planner
+        // quest actually fires.
+        const stillMissing = mealTypes.filter(
+          (t) =>
+            !currentMenu.meals.some(
+              (m) =>
+                m.dayOfWeek === dayOfWeek && m.mealType === t && m.recipe,
+            ),
+        );
+        if (stillMissing.length > 0) {
+          await fillDayWithRecipeService(dayOfWeek);
+        }
+      }
+
+      setWeekProgressDay(null);
+
+      // Fire quest event only when the whole week is actually full, so users
+      // can't game the Master Planner reward by hammering the button.
+      const fullyFilled = (["breakfast", "lunch", "dinner"] as MealType[]).every(
+        (t) =>
+          Array.from({ length: 7 }, (_, d) => d as DayOfWeek).every((d) =>
+            currentMenu.meals.some(
+              (m) => m.dayOfWeek === d && m.mealType === t && m.recipe,
+            ),
+          ),
+      );
+      if (fullyFilled && anyDayNeededWork) {
+        reportQuestEvent("generate_meal_plan");
+      }
+
+      logger.info("Generated full week meal plan", {
+        personalized: hasNatalChart,
+        fullyFilled,
+      });
+    } catch (err) {
+      logger.error("Failed to generate full week:", err);
+    } finally {
+      setIsGeneratingWeek(false);
+      setWeekProgressDay(null);
     }
   };
 
@@ -508,20 +586,26 @@ export default function QuickActionsToolbar({ onTogglePreferences }: QuickAction
     (nutTargets.prioritizeProtein ? 1 : 0) +
     (nutTargets.prioritizeFiber ? 1 : 0);
 
-  const isAnyLoading = isGenerating || isBalancing || isDiversifying;
-  const loadingMessage = isGenerating
-    ? currentGeneratingDay !== null
+  const isAnyLoading = isGenerating || isGeneratingWeek || isBalancing || isDiversifying;
+  const loadingMessage = isGeneratingWeek
+    ? weekProgressDay !== null
       ? hasNatalChart
-        ? `Generating personalized ${dayNames[currentGeneratingDay]}...`
-        : `Generating ${dayNames[currentGeneratingDay]}...`
-      : hasNatalChart
-        ? "Generating personalized day..."
-        : "Generating day..."
-    : isBalancing
-      ? "Balancing nutrition..."
-      : isDiversifying
-        ? "Diversifying recipes..."
-        : "";
+        ? `Generating personalized ${dayNames[weekProgressDay]}...`
+        : `Generating ${dayNames[weekProgressDay]}...`
+      : "Generating full week..."
+    : isGenerating
+      ? currentGeneratingDay !== null
+        ? hasNatalChart
+          ? `Generating personalized ${dayNames[currentGeneratingDay]}...`
+          : `Generating ${dayNames[currentGeneratingDay]}...`
+        : hasNatalChart
+          ? "Generating personalized day..."
+          : "Generating day..."
+      : isBalancing
+        ? "Balancing nutrition..."
+        : isDiversifying
+          ? "Diversifying recipes..."
+          : "";
 
   // Determine button text based on state
   const getGenerateButtonText = () => {
@@ -584,8 +668,30 @@ export default function QuickActionsToolbar({ onTogglePreferences }: QuickAction
 
         <div className="flex flex-wrap gap-3">
           <button
+            onClick={() => { void handleGenerateFullWeek(); }}
+            disabled={isAnyLoading || nextEmptyDay === null}
+            className={`flex items-center gap-2 px-4 py-2 text-white rounded-lg disabled:opacity-50 transition-all font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+              hasNatalChart
+                ? "bg-gradient-to-r from-indigo-600 to-purple-700 hover:from-indigo-700 hover:to-purple-800 focus:ring-indigo-500"
+                : "bg-gradient-to-r from-blue-600 to-indigo-700 hover:from-blue-700 hover:to-indigo-800 focus:ring-blue-500"
+            }`}
+            title={
+              nextEmptyDay === null
+                ? "Week already full"
+                : "Fill every empty meal slot across all 7 days in one go"
+            }
+          >
+            <span>🗓️</span>
+            {isGeneratingWeek
+              ? weekProgressDay !== null
+                ? `Generating ${dayNames[weekProgressDay]}...`
+                : "Generating full week..."
+              : "Generate Full Week"}
+          </button>
+
+          <button
             onClick={() => { void handleGenerateDay(); }}
-            disabled={isGenerating || nextEmptyDay === null}
+            disabled={isGenerating || isGeneratingWeek || nextEmptyDay === null}
             className={`flex items-center gap-2 px-4 py-2 text-white rounded-lg disabled:opacity-50 transition-all font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 ${
               hasNatalChart
                 ? "bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 focus:ring-purple-500"

--- a/src/components/menu-planner/RecipeDetailModal.tsx
+++ b/src/components/menu-planner/RecipeDetailModal.tsx
@@ -9,11 +9,16 @@
  */
 
 import React, { useState, useMemo } from "react";
+import { DietaryAdaptationPanel } from "@/components/recipes/DietaryAdaptationPanel";
+import { FlavorTuningPanel } from "@/components/recipes/FlavorTuningPanel";
+import { TimeShortcutsPanel } from "@/components/recipes/TimeShortcutsPanel";
 import { useMenuPlanner } from "@/contexts/MenuPlannerContext";
 import { useRecipeCollections } from "@/hooks/useRecipeCollections";
 import { instacartService } from "@/services/InstacartService";
+import type { DietaryMode } from "@/utils/dietaryAdaptation";
 import type { NutritionalSummary } from "@/types/nutrition";
 import type { Recipe, RecipeIngredient } from "@/types/recipe";
+import type { TimeBudget } from "@/utils/timeShortcuts";
 
 // Define constant keys for vitamins and minerals based on NutritionalSummary
 const VITAMIN_KEYS: Array<keyof NutritionalSummary> = [
@@ -66,7 +71,7 @@ interface RecipeDetailModalProps {
   onAddToMeal?: (recipe: Recipe) => void;
 }
 
-type TabId = "overview" | "nutrition" | "notes";
+type TabId = "overview" | "nutrition" | "adapt" | "notes";
 
 /**
  * Format a quantity with fractions for display
@@ -139,6 +144,8 @@ export default function RecipeDetailModal({
   const [activeTab, setActiveTab] = useState<TabId>("overview");
   const [servingMultiplier, setServingMultiplier] = useState(1);
   const [noteText, setNoteText] = useState("");
+  const [dietaryMode, setDietaryMode] = useState<DietaryMode | null>(null);
+  const [timeBudget, setTimeBudget] = useState<TimeBudget | null>(null);
 
   // Instacart recipe page state
   const [instacartLoading, setInstacartLoading] = useState(false);
@@ -161,6 +168,8 @@ export default function RecipeDetailModal({
       setNoteText(getRecipeNote(recipe.id));
       setServingMultiplier(1);
       setInstacartError(null);
+      setDietaryMode(null);
+      setTimeBudget(null);
     }
   }, [isOpen, recipe.id, markViewed, getRecipeNote]);
 
@@ -227,6 +236,7 @@ export default function RecipeDetailModal({
   const tabs: Array<{ id: TabId; label: string }> = [
     { id: "overview", label: "Overview" },
     { id: "nutrition", label: "Nutrition" },
+    { id: "adapt", label: "Adapt & Tune" },
     { id: "notes", label: "My Notes" },
   ];
 
@@ -665,6 +675,26 @@ export default function RecipeDetailModal({
                   </p>
                 </div>
               )}
+            </div>
+          )}
+
+          {activeTab === "adapt" && (
+            <div className="space-y-5">
+              <p className="text-sm text-gray-600">
+                Adjust the recipe for your diet, flavor preferences, or the time
+                you have tonight. Original recipe is never overwritten.
+              </p>
+              <DietaryAdaptationPanel
+                recipe={recipe}
+                activeMode={dietaryMode}
+                onModeChange={setDietaryMode}
+              />
+              <FlavorTuningPanel />
+              <TimeShortcutsPanel
+                recipe={recipe}
+                activeBudget={timeBudget}
+                onBudgetChange={setTimeBudget}
+              />
             </div>
           )}
 

--- a/src/components/menu-planner/WeeklyCalendar.tsx
+++ b/src/components/menu-planner/WeeklyCalendar.tsx
@@ -13,6 +13,7 @@ import React, { useMemo, useState } from "react";
 import { useMenuPlanner } from "@/contexts/MenuPlannerContext";
 import type { MonicaOptimizedRecipe } from "@/data/unified/recipeBuilding";
 import { useAstrologicalState } from "@/hooks/useAstrologicalState";
+import { useNutritionTracking } from "@/hooks/useNutritionTracking";
 import type {
   DayOfWeek,
   MealType,
@@ -25,9 +26,71 @@ import {
   PLANETARY_DAY_RULERS as _PLANETARY_DAY_RULERS,
   formatDateForDisplay,
 } from "@/types/menuPlanner";
+import type { DailyNutritionResult } from "@/types/nutrition";
 import CopyMealModal from "./CopyMealModal";
 import FocusedDayView from "./FocusedDayView";
 import MealSlot from "./MealSlot";
+
+/**
+ * Per-day nutrition mini-bar
+ * Compact calorie/macro summary for each day card
+ */
+function DayNutritionStrip({
+  daily,
+}: {
+  daily: DailyNutritionResult | undefined;
+}) {
+  if (!daily || daily.meals.length === 0) {
+    return (
+      <div className="px-3 py-2 border-t border-gray-100 text-[10px] text-gray-400 italic">
+        No meals — nutrition unlogged
+      </div>
+    );
+  }
+
+  const { totals, goals, compliance } = daily;
+  const calPct = goals.calories > 0
+    ? Math.min(150, Math.round(((totals.calories ?? 0) / goals.calories) * 100))
+    : 0;
+  const barColor =
+    calPct < 60
+      ? "bg-amber-400"
+      : calPct > 120
+        ? "bg-red-400"
+        : "bg-emerald-400";
+
+  return (
+    <div className="px-3 py-2 border-t border-gray-100 bg-gray-50 text-[11px]">
+      <div className="flex items-center justify-between mb-1">
+        <span className="font-semibold text-gray-700">
+          {Math.round(totals.calories ?? 0)} / {Math.round(goals.calories)} kcal
+        </span>
+        <span
+          className={`font-medium ${
+            compliance.overall >= 0.75
+              ? "text-emerald-700"
+              : compliance.overall >= 0.5
+                ? "text-amber-700"
+                : "text-red-700"
+          }`}
+        >
+          {Math.round(compliance.overall * 100)}%
+        </span>
+      </div>
+      <div className="h-1.5 rounded-full bg-gray-200 overflow-hidden">
+        <div
+          className={`h-full ${barColor} transition-all`}
+          style={{ width: `${Math.min(100, calPct)}%` }}
+        />
+      </div>
+      <div className="flex gap-2 mt-1 text-gray-600">
+        <span>P {Math.round(totals.protein ?? 0)}g</span>
+        <span>C {Math.round(totals.carbs ?? 0)}g</span>
+        <span>F {Math.round(totals.fat ?? 0)}g</span>
+      </div>
+    </div>
+  );
+}
 
 interface WeeklyCalendarProps {
   onMealClick?: (mealSlot: MealSlotType) => void;
@@ -43,7 +106,11 @@ function DayColumn({
   onMealClick: _onMealClick,
   onCopyMealClick,
   onFocusDay,
+  onToggleExpand,
+  isExpanded,
   currentPlanetaryHour,
+  dailyNutrition,
+  isSelectedForHero = false,
 }: {
   dayOfWeek: DayOfWeek;
   date: Date;
@@ -51,7 +118,11 @@ function DayColumn({
   onMealClick?: (mealSlot: MealSlotType) => void;
   onCopyMealClick?: (mealSlot: MealSlotType) => void;
   onFocusDay?: () => void;
+  onToggleExpand?: () => void;
+  isExpanded?: boolean;
   currentPlanetaryHour?: string | null;
+  dailyNutrition?: DailyNutritionResult;
+  isSelectedForHero?: boolean;
 }) {
   const {
     addMealToSlot,
@@ -86,85 +157,307 @@ function DayColumn({
     Saturn: "♄",
   };
 
+  const highlight = isToday || isSelectedForHero;
+
   return (
     <div
       className={`
-        flex flex-col border-2 rounded-xl
-        ${isToday ? "border-purple-400 shadow-lg" : "border-gray-200"}
-        bg-white overflow-hidden
+        flex flex-col border-2 rounded-xl bg-white overflow-hidden transition-shadow
+        ${highlight ? "border-purple-400 shadow-lg" : "border-gray-200"}
+        ${isExpanded ? "ring-2 ring-purple-300" : ""}
       `}
     >
-      {/* Day Header */}
-      <div
+      {/* Day Header - clickable to expand */}
+      <button
+        type="button"
+        onClick={onToggleExpand}
         className={`
-          p-3 border-b-2 border-gray-200
-          ${isToday ? "bg-gradient-to-r from-purple-100 to-pink-100" : "bg-gray-50"}
+          text-left p-3 border-b-2 border-gray-200 w-full hover:brightness-[0.98] transition-all
+          ${highlight ? "bg-gradient-to-r from-purple-100 to-pink-100" : "bg-gray-50"}
         `}
+        aria-expanded={isExpanded}
+        aria-label={`${isExpanded ? "Collapse" : "Expand"} ${getDayName(dayOfWeek)}`}
       >
         <div className="flex items-center justify-between mb-1">
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 min-w-0">
             <span className="text-2xl">
               {planetSymbols[characteristics.planet]}
             </span>
-            <div>
-              <h3 className="font-bold text-lg text-gray-800">
+            <div className="min-w-0">
+              <h3 className="font-bold text-lg text-gray-800 truncate">
                 {getDayName(dayOfWeek)}
               </h3>
-              <p className="text-xs text-gray-600">
+              <p className="text-xs text-gray-600 truncate">
                 {formatDateForDisplay(date)}
               </p>
             </div>
           </div>
-          {isToday && (
-            <span className="px-2 py-1 text-xs font-semibold bg-purple-600 text-white rounded">
-              Today
+          <div className="flex items-center gap-1">
+            {isToday && (
+              <span className="px-2 py-1 text-xs font-semibold bg-purple-600 text-white rounded">
+                Today
+              </span>
+            )}
+            <span className="text-gray-500 text-xs select-none" aria-hidden>
+              {isExpanded ? "▾" : "▸"}
             </span>
-          )}
+          </div>
         </div>
-        <p className="text-xs text-gray-600 italic">
+        <p className="text-[11px] text-gray-600 italic line-clamp-2">
           {characteristics.mealGuidance}
         </p>
 
         {/* Planetary Hour Indicator (only for today) */}
         {isToday && currentPlanetaryHour && (
-          <div className="mt-2 flex items-center gap-2 bg-purple-100 rounded-lg px-3 py-2">
-            <span className="text-purple-700 font-semibold text-xs">
-              ⏰ Planetary Hour:
+          <div className="mt-2 flex items-center gap-2 bg-purple-100 rounded-lg px-3 py-1.5">
+            <span className="text-purple-700 font-semibold text-[10px]">
+              ⏰ Hour:
             </span>
-            <span className="text-purple-900 font-bold text-sm">
+            <span className="text-purple-900 font-bold text-xs truncate">
               {currentPlanetaryHour}
             </span>
           </div>
         )}
+      </button>
 
-        {/* Quick Actions */}
-        <div className="flex gap-2 mt-2">
-          <button
-            onClick={onFocusDay}
-            className="text-xs px-2 py-1 rounded bg-blue-100 text-blue-700 hover:bg-blue-200 transition-colors font-medium"
-            title={`Focus on ${getDayName(dayOfWeek)} with suggestions`}
-          >
-            🔍 Focus
-          </button>
-          <button
-            onClick={() => { void generateMealsForDay(dayOfWeek); }}
-            className="text-xs px-2 py-1 rounded bg-purple-100 text-purple-700 hover:bg-purple-200 transition-colors font-medium"
-            title={`Generate meals for ${getDayName(dayOfWeek)} using ${characteristics.planet} energy`}
-          >
-            ✨ Generate
-          </button>
-          <button
-            onClick={() => { void clearDay(dayOfWeek); }}
-            className="text-xs px-2 py-1 rounded bg-red-100 text-red-700 hover:bg-red-200 transition-colors"
-            title="Clear all meals for this day"
-          >
-            Clear
-          </button>
-        </div>
+      {/* Quick Actions - separate row, non-clickable header area */}
+      <div className="flex gap-1 px-2 py-1.5 bg-gray-50/50 border-b border-gray-100">
+        <button
+          onClick={(e) => { e.stopPropagation(); onFocusDay?.(); }}
+          className="text-xs px-2 py-1 rounded bg-blue-100 text-blue-700 hover:bg-blue-200 transition-colors font-medium flex-1"
+          title={`Focus on ${getDayName(dayOfWeek)} with suggestions`}
+        >
+          🔍 Focus
+        </button>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            void generateMealsForDay(dayOfWeek);
+          }}
+          className="text-xs px-2 py-1 rounded bg-purple-100 text-purple-700 hover:bg-purple-200 transition-colors font-medium flex-1"
+          title={`Generate meals for ${getDayName(dayOfWeek)} using ${characteristics.planet} energy`}
+        >
+          ✨ Gen
+        </button>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            void clearDay(dayOfWeek);
+          }}
+          className="text-xs px-2 py-1 rounded bg-red-100 text-red-700 hover:bg-red-200 transition-colors"
+          title="Clear all meals for this day"
+        >
+          🗑
+        </button>
       </div>
 
       {/* Meal Slots */}
       <div className="flex-1 p-2 space-y-2 overflow-y-auto">
+        {sortedMeals.map((mealSlot) => (
+          <MealSlot
+            key={mealSlot.id}
+            mealSlot={mealSlot}
+            onAddRecipe={(recipe: MonicaOptimizedRecipe) => {
+              void addMealToSlot(dayOfWeek, mealSlot.mealType, recipe);
+            }}
+            onRemoveRecipe={() => {
+              void removeMealFromSlot(mealSlot.id);
+            }}
+            onUpdateServings={(servings: number) => {
+              void updateMealServings(mealSlot.id, servings);
+            }}
+            onMoveMeal={(sourceSlotId: string) => {
+              void moveMeal(sourceSlotId, mealSlot.id);
+            }}
+            onSwapMeals={(sourceSlotId: string) => {
+              void swapMeals(sourceSlotId, mealSlot.id);
+            }}
+            onCopyMeal={() => onCopyMealClick?.(mealSlot)}
+            onGenerateMeal={() => {
+              void generateMealsForDay(dayOfWeek, { mealTypes: [mealSlot.mealType] });
+            }}
+            onAddSauce={(sauceId: string, servings?: number) => {
+              void addSauceToMeal(mealSlot.id, sauceId, servings);
+            }}
+            onRemoveSauce={() => {
+              void removeSauceFromMeal(mealSlot.id);
+            }}
+            onUpdateSauceServings={(servings: number) => {
+              void updateSauceServings(mealSlot.id, servings);
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Per-day nutrition summary */}
+      <DayNutritionStrip daily={dailyNutrition} />
+    </div>
+  );
+}
+
+/**
+ * Today Hero Card
+ * Prominent card highlighting today's meals — always visible at top of calendar.
+ */
+function TodayHeroCard({
+  dayOfWeek,
+  date,
+  meals,
+  onCopyMealClick,
+  onFocusDay,
+  currentPlanetaryHour,
+  dailyNutrition,
+}: {
+  dayOfWeek: DayOfWeek;
+  date: Date;
+  meals: MealSlotType[];
+  onCopyMealClick?: (mealSlot: MealSlotType) => void;
+  onFocusDay?: () => void;
+  currentPlanetaryHour?: string | null;
+  dailyNutrition?: DailyNutritionResult;
+}) {
+  const {
+    addMealToSlot,
+    removeMealFromSlot,
+    updateMealServings,
+    addSauceToMeal,
+    removeSauceFromMeal,
+    updateSauceServings,
+    clearDay,
+    moveMeal,
+    swapMeals,
+    generateMealsForDay,
+  } = useMenuPlanner();
+
+  const characteristics = getPlanetaryDayCharacteristics(dayOfWeek);
+  const mealTypes: MealType[] = ["breakfast", "lunch", "dinner", "snack"];
+  const sortedMeals = mealTypes.map(
+    (type) => meals.find((m) => m.mealType === type)!,
+  );
+  const plannedCount = meals.filter((m) => m.recipe).length;
+
+  const planetSymbols: Record<string, string> = {
+    Sun: "🝇",
+    Moon: "🝑",
+    Mars: "♂",
+    Mercury: "🝉",
+    Jupiter: "♃",
+    Venus: "♀",
+    Saturn: "♄",
+  };
+
+  return (
+    <div className="rounded-2xl border-2 border-purple-400 bg-gradient-to-br from-purple-50 via-white to-pink-50 shadow-xl overflow-hidden">
+      {/* Hero Header */}
+      <div className="p-5 bg-gradient-to-r from-purple-600 to-pink-600 text-white">
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <div className="flex items-center gap-3">
+            <span className="text-4xl">{planetSymbols[characteristics.planet]}</span>
+            <div>
+              <div className="text-[11px] uppercase tracking-widest opacity-90">
+                Today · {characteristics.planet} day
+              </div>
+              <h2 className="text-2xl font-bold">{getDayName(dayOfWeek)}</h2>
+              <p className="text-sm opacity-90">{formatDateForDisplay(date)}</p>
+            </div>
+          </div>
+          <div className="flex flex-col items-end gap-1 text-right">
+            {currentPlanetaryHour && (
+              <div className="text-xs bg-white/20 rounded-full px-3 py-1">
+                ⏰ {currentPlanetaryHour} hour
+              </div>
+            )}
+            <div className="text-xs opacity-90">
+              {plannedCount}/4 meals planned
+            </div>
+          </div>
+        </div>
+        <p className="text-sm mt-3 italic opacity-95">
+          {characteristics.mealGuidance}
+        </p>
+      </div>
+
+      {/* Nutrition row */}
+      {dailyNutrition && dailyNutrition.meals.length > 0 && (
+        <div className="px-5 py-3 bg-white border-b border-purple-100 grid grid-cols-2 md:grid-cols-5 gap-3 text-sm">
+          <div>
+            <div className="text-[10px] uppercase text-gray-500 tracking-wide">
+              Calories
+            </div>
+            <div className="font-bold text-gray-900">
+              {Math.round(dailyNutrition.totals.calories ?? 0)}
+              <span className="text-xs font-normal text-gray-500">
+                {" "}/ {Math.round(dailyNutrition.goals.calories)}
+              </span>
+            </div>
+          </div>
+          <div>
+            <div className="text-[10px] uppercase text-gray-500 tracking-wide">
+              Protein
+            </div>
+            <div className="font-bold text-gray-900">
+              {Math.round(dailyNutrition.totals.protein ?? 0)}g
+            </div>
+          </div>
+          <div>
+            <div className="text-[10px] uppercase text-gray-500 tracking-wide">
+              Carbs
+            </div>
+            <div className="font-bold text-gray-900">
+              {Math.round(dailyNutrition.totals.carbs ?? 0)}g
+            </div>
+          </div>
+          <div>
+            <div className="text-[10px] uppercase text-gray-500 tracking-wide">
+              Fat
+            </div>
+            <div className="font-bold text-gray-900">
+              {Math.round(dailyNutrition.totals.fat ?? 0)}g
+            </div>
+          </div>
+          <div>
+            <div className="text-[10px] uppercase text-gray-500 tracking-wide">
+              Compliance
+            </div>
+            <div
+              className={`font-bold ${
+                dailyNutrition.compliance.overall >= 0.75
+                  ? "text-emerald-700"
+                  : dailyNutrition.compliance.overall >= 0.5
+                    ? "text-amber-700"
+                    : "text-red-700"
+              }`}
+            >
+              {Math.round(dailyNutrition.compliance.overall * 100)}%
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Quick actions */}
+      <div className="flex gap-2 px-5 py-3 bg-white border-b border-purple-100 flex-wrap">
+        <button
+          onClick={onFocusDay}
+          className="text-sm px-3 py-1.5 rounded-lg bg-blue-100 text-blue-700 hover:bg-blue-200 transition-colors font-medium"
+        >
+          🔍 Focus mode
+        </button>
+        <button
+          onClick={() => { void generateMealsForDay(dayOfWeek); }}
+          className="text-sm px-3 py-1.5 rounded-lg bg-purple-600 text-white hover:bg-purple-700 transition-colors font-medium"
+        >
+          ✨ Auto-fill day
+        </button>
+        <button
+          onClick={() => { void clearDay(dayOfWeek); }}
+          className="text-sm px-3 py-1.5 rounded-lg bg-red-100 text-red-700 hover:bg-red-200 transition-colors"
+        >
+          🗑 Clear
+        </button>
+      </div>
+
+      {/* Meal slots — horizontal on desktop, stacked on mobile */}
+      <div className="p-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
         {sortedMeals.map((mealSlot) => (
           <MealSlot
             key={mealSlot.id}
@@ -214,8 +507,13 @@ export default function WeeklyCalendar({ onMealClick }: WeeklyCalendarProps) {
     isLoading,
     copyMealToSlots,
     moveMealToSlots,
+    generationPreferences,
   } = useMenuPlanner();
   const { currentPlanetaryHour } = useAstrologicalState();
+  const weeklyNutrition = useNutritionTracking(
+    currentMenu,
+    generationPreferences?.nutritionalTargets ?? null,
+  );
   const [copyMealModalState, setCopyMealModalState] = useState<{
     isOpen: boolean;
     sourceMeal: MealSlotType | null;
@@ -224,7 +522,10 @@ export default function WeeklyCalendar({ onMealClick }: WeeklyCalendarProps) {
     sourceMeal: null,
   });
 
-  // Focused day view state
+  // Inline expanded day (grows in place)
+  const [expandedDay, setExpandedDay] = useState<DayOfWeek | null>(null);
+
+  // Focused day view state (modal — kept for advanced users)
   const [focusedDayState, setFocusedDayState] = useState<{
     isOpen: boolean;
     dayOfWeek: DayOfWeek;
@@ -232,6 +533,10 @@ export default function WeeklyCalendar({ onMealClick }: WeeklyCalendarProps) {
     isOpen: false,
     dayOfWeek: 0 as DayOfWeek,
   });
+
+  const toggleExpandDay = (day: DayOfWeek) => {
+    setExpandedDay((prev) => (prev === day ? null : day));
+  };
 
   // Handle opening focused day view
   const handleOpenFocusedDay = (dayOfWeek: DayOfWeek) => {
@@ -323,6 +628,15 @@ export default function WeeklyCalendar({ onMealClick }: WeeklyCalendarProps) {
 
   // Calculate total meal count for progressive messaging
   const totalMeals = currentMenu?.meals.filter((m) => m.recipe).length || 0;
+
+  // Determine whether today falls within the currently-displayed week.
+  // If yes, surface the Today hero card and highlight that column.
+  const todayDateStr = new Date().toDateString();
+  const todayIndex = weekDates.findIndex(
+    (d) => d.toDateString() === todayDateStr,
+  );
+  const todayDayOfWeek: DayOfWeek | null =
+    todayIndex >= 0 ? (todayIndex as DayOfWeek) : null;
 
   return (
     <div className="space-y-4">
@@ -418,20 +732,53 @@ export default function WeeklyCalendar({ onMealClick }: WeeklyCalendarProps) {
         </div>
       )}
 
-      {/* Calendar Grid - Desktop (7 columns) */}
-      <div className="hidden lg:grid lg:grid-cols-7 gap-3">
-        {([0, 1, 2, 3, 4, 5, 6] as DayOfWeek[]).map((day) => (
-          <DayColumn
-            key={day}
-            dayOfWeek={day}
-            date={weekDates[day]}
-            meals={mealsByDay[day] || []}
-            onMealClick={onMealClick}
-            onCopyMealClick={handleCopyMealClick}
-            onFocusDay={() => handleOpenFocusedDay(day)}
-            currentPlanetaryHour={currentPlanetaryHour}
-          />
-        ))}
+      {/* Today Hero Card — always on top when today is within the viewed week */}
+      {todayDayOfWeek !== null && (
+        <TodayHeroCard
+          dayOfWeek={todayDayOfWeek}
+          date={weekDates[todayDayOfWeek]}
+          meals={mealsByDay[todayDayOfWeek] || []}
+          onCopyMealClick={handleCopyMealClick}
+          onFocusDay={() => handleOpenFocusedDay(todayDayOfWeek)}
+          currentPlanetaryHour={currentPlanetaryHour}
+          dailyNutrition={weeklyNutrition?.days?.[todayDayOfWeek]}
+        />
+      )}
+
+      {/* Calendar Grid - Desktop (7 columns, clickable to expand) */}
+      <div className="hidden lg:block">
+        <div className="grid grid-cols-7 gap-3">
+          {([0, 1, 2, 3, 4, 5, 6] as DayOfWeek[]).map((day) => (
+            <DayColumn
+              key={day}
+              dayOfWeek={day}
+              date={weekDates[day]}
+              meals={mealsByDay[day] || []}
+              onMealClick={onMealClick}
+              onCopyMealClick={handleCopyMealClick}
+              onFocusDay={() => handleOpenFocusedDay(day)}
+              onToggleExpand={() => toggleExpandDay(day)}
+              isExpanded={expandedDay === day}
+              currentPlanetaryHour={currentPlanetaryHour}
+              dailyNutrition={weeklyNutrition?.days?.[day]}
+              isSelectedForHero={day === todayDayOfWeek}
+            />
+          ))}
+        </div>
+        {/* Inline expanded-day panel appears below the grid */}
+        {expandedDay !== null && expandedDay !== todayDayOfWeek && (
+          <div className="mt-4">
+            <TodayHeroCard
+              dayOfWeek={expandedDay}
+              date={weekDates[expandedDay]}
+              meals={mealsByDay[expandedDay] || []}
+              onCopyMealClick={handleCopyMealClick}
+              onFocusDay={() => handleOpenFocusedDay(expandedDay)}
+              currentPlanetaryHour={null}
+              dailyNutrition={weeklyNutrition?.days?.[expandedDay]}
+            />
+          </div>
+        )}
       </div>
 
       {/* Calendar Grid - Tablet (4-3 split) */}
@@ -446,7 +793,11 @@ export default function WeeklyCalendar({ onMealClick }: WeeklyCalendarProps) {
               onMealClick={onMealClick}
               onCopyMealClick={handleCopyMealClick}
               onFocusDay={() => handleOpenFocusedDay(day)}
+              onToggleExpand={() => toggleExpandDay(day)}
+              isExpanded={expandedDay === day}
               currentPlanetaryHour={currentPlanetaryHour}
+              dailyNutrition={weeklyNutrition?.days?.[day]}
+              isSelectedForHero={day === todayDayOfWeek}
             />
           ))}
         </div>
@@ -460,10 +811,27 @@ export default function WeeklyCalendar({ onMealClick }: WeeklyCalendarProps) {
               onMealClick={onMealClick}
               onCopyMealClick={handleCopyMealClick}
               onFocusDay={() => handleOpenFocusedDay(day)}
+              onToggleExpand={() => toggleExpandDay(day)}
+              isExpanded={expandedDay === day}
               currentPlanetaryHour={currentPlanetaryHour}
+              dailyNutrition={weeklyNutrition?.days?.[day]}
+              isSelectedForHero={day === todayDayOfWeek}
             />
           ))}
         </div>
+        {expandedDay !== null && expandedDay !== todayDayOfWeek && (
+          <div className="mt-4">
+            <TodayHeroCard
+              dayOfWeek={expandedDay}
+              date={weekDates[expandedDay]}
+              meals={mealsByDay[expandedDay] || []}
+              onCopyMealClick={handleCopyMealClick}
+              onFocusDay={() => handleOpenFocusedDay(expandedDay)}
+              currentPlanetaryHour={null}
+              dailyNutrition={weeklyNutrition?.days?.[expandedDay]}
+            />
+          </div>
+        )}
       </div>
 
       {/* Calendar Grid - Mobile (1 column) */}
@@ -477,7 +845,11 @@ export default function WeeklyCalendar({ onMealClick }: WeeklyCalendarProps) {
             onMealClick={onMealClick}
             onCopyMealClick={handleCopyMealClick}
             onFocusDay={() => handleOpenFocusedDay(day)}
+            onToggleExpand={() => toggleExpandDay(day)}
+            isExpanded={expandedDay === day}
             currentPlanetaryHour={currentPlanetaryHour}
+            dailyNutrition={weeklyNutrition?.days?.[day]}
+            isSelectedForHero={day === todayDayOfWeek}
           />
         ))}
       </div>
@@ -485,8 +857,8 @@ export default function WeeklyCalendar({ onMealClick }: WeeklyCalendarProps) {
       {/* Helper Text */}
       <div className="text-center text-sm text-gray-500 mt-6">
         <p>
-          Click &quot;+ Add Recipe&quot; to add meals. Drag between slots to rearrange.
-          Click 📋 to copy/move to multiple slots.
+          Click a day header to expand it inline. Click &quot;+ Add Recipe&quot;
+          to add meals. Click 📋 to copy/move to multiple slots.
         </p>
       </div>
 

--- a/src/components/recommendations/EnhancedIngredientRecommender.tsx
+++ b/src/components/recommendations/EnhancedIngredientRecommender.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useAlchemical } from "@/contexts/AlchemicalContext/hooks";
 import type { UnifiedIngredient } from "@/data/unified/unifiedTypes";
+import { usePantry } from "@/hooks/usePantry";
 import { IngredientService } from "@/services/IngredientService";
 import type { ElementalProperties } from "@/types/alchemy";
 import { normalizeForDisplay } from "@/utils/elemental/normalization";
@@ -449,6 +450,31 @@ export const EnhancedIngredientRecommender: React.FC<
   // Hooks
   const alchemicalContext = useAlchemical();
   const ingredientService = useMemo(() => IngredientService.getInstance(), []);
+  const pantry = usePantry();
+  const [pantryFeedback, setPantryFeedback] = useState<string | null>(null);
+
+  const handleAddToPantry = (
+    name: string,
+    category: string | undefined,
+    e: React.MouseEvent,
+  ) => {
+    e.stopPropagation();
+    const normalizedName = formatIngredientName(name);
+    if (pantry.hasItem(name)) {
+      setPantryFeedback(`${normalizedName} is already in your pantry`);
+    } else {
+      const added = pantry.addItem({
+        name,
+        category: category || "other",
+        quantity: 1,
+        unit: "item",
+      });
+      setPantryFeedback(
+        added ? `✓ Added ${normalizedName} to pantry` : "Could not add to pantry",
+      );
+    }
+    setTimeout(() => setPantryFeedback(null), 2200);
+  };
 
   // Load ingredients
   useEffect(() => {
@@ -791,6 +817,28 @@ export const EnhancedIngredientRecommender: React.FC<
               />
               {ingredient.dominantElement}
             </div>
+            <button
+              type="button"
+              onClick={(e) =>
+                handleAddToPantry(
+                  ingredient.name,
+                  ingredient.category as string | undefined,
+                  e,
+                )
+              }
+              className={`text-xs font-medium px-2 py-1 rounded-md border transition-colors ${
+                pantry.hasItem(ingredient.name)
+                  ? "bg-emerald-50 border-emerald-200 text-emerald-700 hover:bg-emerald-100"
+                  : "bg-amber-50 border-amber-200 text-amber-800 hover:bg-amber-100"
+              }`}
+              title={
+                pantry.hasItem(ingredient.name)
+                  ? "Already in your pantry"
+                  : "Add this ingredient to your pantry"
+              }
+            >
+              {pantry.hasItem(ingredient.name) ? "✓ In Pantry" : "+ Pantry"}
+            </button>
           </div>
         </div>
 
@@ -1760,7 +1808,16 @@ export const EnhancedIngredientRecommender: React.FC<
 
   // Main render
   return (
-    <div className="p-6">
+    <div className="p-6 relative">
+      {pantryFeedback && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed bottom-6 right-6 z-50 bg-gray-900 text-white text-sm px-4 py-2 rounded-lg shadow-lg"
+        >
+          {pantryFeedback}
+        </div>
+      )}
       {renderCategoryGrid()}
       {renderSearchBar()}
 

--- a/src/contexts/MenuPlannerContext.tsx
+++ b/src/contexts/MenuPlannerContext.tsx
@@ -22,6 +22,7 @@ import React, {
 import { useUser } from "@/contexts/UserContext";
 import type { MonicaOptimizedRecipe } from "@/data/unified/recipeBuilding";
 import { useAstrologicalState } from "@/hooks/useAstrologicalState";
+import { reportQuestEvent } from "@/lib/questReporter";
 import ChartComparisonService, {
   type ChartComparison,
 } from "@/services/ChartComparisonService";
@@ -1573,6 +1574,7 @@ export function MenuPlannerProvider({ children }: { children: ReactNode }) {
                 recommendation.recipe,
                 score >= 0.8 ? 2 : 1, // Suggest 2 servings for highly aligned meals
               );
+              reportQuestEvent("generate_recipe");
             }
           }
         } else {

--- a/src/hooks/usePantry.ts
+++ b/src/hooks/usePantry.ts
@@ -1,0 +1,118 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  addItem as addPantryItem,
+  clearPantry as clearPantryItems,
+  getPantry,
+  getPantryStats,
+  removeItem as removePantryItem,
+  updateItem as updatePantryItem,
+  type PantryItem,
+  type PantryStats,
+} from "@/utils/pantryManager";
+
+const PANTRY_UPDATE_EVENT = "alchm:pantry:updated";
+
+function emitPantryUpdate(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(PANTRY_UPDATE_EVENT));
+}
+
+export interface UsePantryResult {
+  items: PantryItem[];
+  stats: PantryStats;
+  isLoaded: boolean;
+  hasItem: (name: string) => boolean;
+  addItem: (
+    input: Omit<PantryItem, "id" | "addedDate"> & { addedDate?: Date },
+  ) => PantryItem | null;
+  removeItem: (id: string) => void;
+  updateItem: (id: string, updates: Partial<Omit<PantryItem, "id">>) => void;
+  clear: () => void;
+  refresh: () => void;
+}
+
+const EMPTY_STATS: PantryStats = {
+  totalItems: 0,
+  expiringIn7Days: 0,
+  expired: 0,
+  categoryCounts: {},
+};
+
+export function usePantry(): UsePantryResult {
+  const [items, setItems] = useState<PantryItem[]>([]);
+  const [stats, setStats] = useState<PantryStats>(EMPTY_STATS);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  const refresh = useCallback(() => {
+    if (typeof window === "undefined") return;
+    setItems(getPantry());
+    setStats(getPantryStats());
+    setIsLoaded(true);
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    if (typeof window === "undefined") return;
+
+    const onUpdate = () => refresh();
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === "alchm_pantry") refresh();
+    };
+
+    window.addEventListener(PANTRY_UPDATE_EVENT, onUpdate);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(PANTRY_UPDATE_EVENT, onUpdate);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, [refresh]);
+
+  const hasItem = useCallback(
+    (name: string) =>
+      items.some((item) => item.name.toLowerCase() === name.toLowerCase()),
+    [items],
+  );
+
+  const addItem = useCallback<UsePantryResult["addItem"]>((input) => {
+    if (typeof window === "undefined") return null;
+    try {
+      const added = addPantryItem(input);
+      emitPantryUpdate();
+      return added;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  const removeItem = useCallback((id: string) => {
+    if (typeof window === "undefined") return;
+    removePantryItem(id);
+    emitPantryUpdate();
+  }, []);
+
+  const updateItem = useCallback<UsePantryResult["updateItem"]>((id, updates) => {
+    if (typeof window === "undefined") return;
+    updatePantryItem(id, updates);
+    emitPantryUpdate();
+  }, []);
+
+  const clear = useCallback(() => {
+    if (typeof window === "undefined") return;
+    clearPantryItems();
+    emitPantryUpdate();
+  }, []);
+
+  return {
+    items,
+    stats,
+    isLoaded,
+    hasItem,
+    addItem,
+    removeItem,
+    updateItem,
+    clear,
+    refresh,
+  };
+}

--- a/src/hooks/useRecipeCollections.ts
+++ b/src/hooks/useRecipeCollections.ts
@@ -169,8 +169,12 @@ export function useRecipeCollections() {
   // Ratings
   const setRecipeRating = useCallback((recipeId: string, rating: number) => {
     setRatings((prev) => {
+      const hadPriorRating = (prev[recipeId] ?? 0) > 0;
       const next = { ...prev, [recipeId]: rating };
       saveToStorage(STORAGE_KEYS.recipeRatings, next);
+      // Only fire the quest event on the first rating for this recipe,
+      // so users can't farm the quest by toggling stars.
+      if (!hadPriorRating && rating > 0) reportQuestEvent('rate_recipe');
       return next;
     });
   }, []);

--- a/src/services/QuestService.ts
+++ b/src/services/QuestService.ts
@@ -16,7 +16,7 @@ import type {
 } from "@/types/economy";
 import { TOKEN_TYPES } from "@/types/economy";
 import { tokenEconomy } from "./TokenEconomyService";
-import { notificationDatabaseService } from "./notificationDatabaseService";
+import { notificationDatabase } from "./notificationDatabaseService";
 
 // ─── DB Bootstrapping ─────────────────────────────────────────────────
 
@@ -54,6 +54,7 @@ function rowToQuestDef(row: any): QuestDefinition {
     triggerEvent: row.trigger_event,
     triggerThreshold: row.trigger_threshold || 1,
     isActive: row.is_active !== false,
+    sortOrder: row.sort_order ?? 0,
   };
 }
 
@@ -295,17 +296,19 @@ class QuestService {
     if (isNowComplete) {
       // Notify the user they can claim their reward
       try {
-        await notificationDatabaseService.createNotification({
+        await notificationDatabase.createNotification(
           userId,
-          type: "quest_completed",
-          title: "Sanctum Task Completed!",
-          message: `You completed "${quest.title}". Claim your ${quest.tokenRewardAmount} ${quest.tokenRewardType} tokens!`,
-          metadata: {
-            questSlug: quest.slug,
-            tokenType: quest.tokenRewardType,
-            tokenAmount: quest.tokenRewardAmount,
+          "quest_completed",
+          "Sanctum Task Completed!",
+          `You completed "${quest.title}". Claim your ${quest.tokenRewardAmount} ${quest.tokenRewardType} tokens!`,
+          {
+            metadata: {
+              questSlug: quest.slug,
+              tokenType: quest.tokenRewardType,
+              tokenAmount: quest.tokenRewardAmount,
+            }
           }
-        });
+        );
       } catch (err) {
         _logger.error("[QuestService] Failed to create quest completion notification", err as any);
       }

--- a/src/types/economy.ts
+++ b/src/types/economy.ts
@@ -123,6 +123,7 @@ export interface QuestDefinition {
   triggerEvent: string;
   triggerThreshold: number;
   isActive: boolean;
+  sortOrder?: number;
 }
 
 /** User's progress on a specific quest */


### PR DESCRIPTION
## Summary

Addresses two asks across the session:

1. **Ship-blocker fix** — resolves Vercel build failures (`sortOrder` missing on `QuestDefinition`, `notificationDatabaseService` import error).
2. **Calendar + pantry improvements** — today gets its own hero component, any day can be expanded inline on click, per-day nutrition is always visible, and ingredients can now be added to a pantry directly from the home recommender.

## Weekly calendar UX

- **Today Hero Card** at the top of the week view — planetary day symbol, current planetary hour, 5-metric nutrition row (calories vs goal, P / C / F, compliance %), Auto-fill / Focus / Clear actions, and the 4 meal slots in a responsive grid.
- **Click-to-expand days** — every day header is now a button that toggles an inline expanded panel below the grid. No modal required. (Focus button still opens the full modal for power users.)
- **Per-day nutrition strip** at the bottom of every day card: calorie progress bar, P/C/F totals, compliance %. Uses the existing `useNutritionTracking` hook (no new math).

## Pantry

- New `usePantry` hook wrapping `pantryManager` with cross-tab `storage` sync and a custom `alchm:pantry:updated` event, so adding from the ingredient recommender updates all open views instantly.
- **`+ Pantry` button on every ingredient card** in `EnhancedIngredientRecommender`. Flips to `✓ In Pantry` when already tracked, with a toast confirmation.
- **New `/pantry` page**: search, category filter, quantity ± controls, expiry warnings, stats strip, grouped-by-category layout, empty state with deep link back to the ingredient recommender.

## Navigation & interconnection

- Added **🥫 Pantry** and **📔 Food Diary** to both main nav and footer (Food Tracking was previously orphaned — no nav link).
- Home ingredient section has a visible hint + "View my pantry →" link.

## Quest events (previously unwired)

Quests existed but no events fired, so progress never advanced:

- `generate_recipe` → fired from `MenuPlannerContext.generateMealsForDay` + cosmic recipe API.
- `generate_premium_recipe` → fired from cosmic recipe API (fixes name mismatch with `essence-generate-premium` quest, which was listening for a never-emitted `generate_cosmic_recipe`).
- `generate_meal_plan` → fired from the new Generate-Full-Week flow when all 7 × 3 slots fill.
- `rate_recipe` → fired from `useRecipeCollections.setRecipeRating` on first-time rating only.

## Sanctum Tasks

Richer header with Progress pill (earned / total + %), Claimable pill (count + aggregate tokens), and an animated gradient progress bar.

## Menu-planner RecipeDetailModal

New **Adapt & Tune** tab exposing `DietaryAdaptationPanel`, `FlavorTuningPanel`, and `TimeShortcutsPanel` — so users can adapt recipes during meal planning without leaving the modal.

## Build fix

- `QuestService`: import `notificationDatabase` (not `notificationDatabaseService`) and call `createNotification(userId, type, title, message, { metadata })` with the correct positional signature.
- `QuestService.rowToQuestDef`: map `sort_order → sortOrder`.
- `QuestDefinition` type: add `sortOrder?: number`.

## Test plan

- [ ] `yarn tsc --noEmit --skipLibCheck` — zero errors (verified locally)
- [ ] Vercel production build succeeds
- [ ] `/menu-planner`: Today hero renders only when today is in the viewed week; clicking a non-today day header expands/collapses an inline panel; per-day nutrition strip shows under every day card
- [ ] Home `/`: `+ Pantry` adds to localStorage; `/pantry` reflects the new item; removing/adjusting quantity works
- [ ] Nav: Pantry + Food Diary links render on every page
- [ ] Quests: rating a recipe, generating meals for a day, generating the full week, and generating a cosmic recipe each advance their respective quest progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)