### PR TITLE
feat: dark theme, ingredient enrichment & cuisine card redesign

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import NavAuthLink from "@/components/nav/NavAuthLink";
 import NotificationBell from "@/components/nav/NotificationBell";
 import PremiumLink from "@/components/nav/PremiumLink";
 import PayPalButton from "@/components/PayPalButton";
+import ThemeToggle from "@/components/ThemeToggle";
 import ClientProviders from "./ClientProviders";
 import type { Metadata } from "next";
 import "./globals.css";
@@ -75,6 +76,7 @@ export default function RootLayout({
                 {/* Right Side: Navigation & Icons */}
                 <div className="flex flex-col items-center xl:items-end flex-grow w-full xl:w-2/3">
                   <div className="flex items-center gap-3 w-full justify-end mb-4 xl:mb-6">
+                    <ThemeToggle compact />
                     <NotificationBell />
                     {/* Hamburger toggle for mobile */}
                     <MobileNavToggle>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -85,16 +85,16 @@ export default function Home() {
           viewport={{ once: true, margin: "-100px" }}
         >
           <div className="mx-6 mb-3 flex items-center justify-between flex-wrap gap-2">
-            <p className="text-sm text-gray-600">
+            <p className="text-sm text-gray-600 dark:text-slate-300">
               Tap{" "}
-              <span className="inline-block bg-amber-100 text-amber-800 text-xs font-semibold px-2 py-0.5 rounded">
+              <span className="inline-block bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 text-xs font-semibold px-2 py-0.5 rounded">
                 + Pantry
               </span>{" "}
               on any card to track it in your kitchen.
             </p>
             <Link
               href="/pantry"
-              className="text-sm font-medium text-emerald-700 hover:text-emerald-900 underline"
+              className="text-sm font-medium text-emerald-700 dark:text-emerald-300 hover:text-emerald-900 dark:hover:text-emerald-100 underline"
             >
               View my pantry →
             </Link>

--- a/src/app/profile/day-night-effects/page.tsx
+++ b/src/app/profile/day-night-effects/page.tsx
@@ -9,7 +9,7 @@ import { PLANETARY_SECTARIAN_ELEMENTS, PLANETARY_SECTARIAN_ESMS, isSectDiurnal, 
 
 export default function DayNightEffectsPage() {
   const { profileData, isLoading } = useProfile();
-  const { isDiurnal: appIsDiurnal, setThemeBase } = useTheme();
+  const { isDiurnal: appIsDiurnal, setPreference } = useTheme();
   
   // Local state to toggle views independent of the global theme, though we can sync them
   const [viewDiurnal, setViewDiurnal] = useState(appIsDiurnal);
@@ -55,7 +55,7 @@ export default function DayNightEffectsPage() {
   const toggleView = () => {
     setViewDiurnal(!viewDiurnal);
     // Sync with app theme to show visual change across app if desired
-    setThemeBase(!viewDiurnal);
+    setPreference(!viewDiurnal ? 'light' : 'dark');
   };
 
   const getHighestESMS = (esms: any) => {

--- a/src/components/IngredientCard.tsx
+++ b/src/components/IngredientCard.tsx
@@ -138,32 +138,53 @@ const styles = `
   margin-bottom: 16px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: all 0.3s ease;
+  color: #f1f5f9;
+  background-color: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(99, 102, 241, 0.2);
+}
+
+[data-theme="light"] .ingredient-card {
+  color: #1e293b;
+  background-color: #ffffff;
+  border: 1px solid rgba(15, 23, 42, 0.1);
 }
 
 .ingredient-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
 }
 
 .ingredient-name {
   margin-top: 0;
   margin-bottom: 8px;
   font-size: 1.2rem;
+  color: inherit;
+  font-weight: 600;
 }
 
 .ingredient-amount {
   font-size: 1rem;
   margin-bottom: 12px;
+  color: inherit;
 }
 
 .ingredient-prep {
   font-style: italic;
+  color: rgba(241, 245, 249, 0.75);
+}
+
+[data-theme="light"] .ingredient-prep {
+  color: #475569;
 }
 
 .ingredient-optional {
   font-style: italic;
-  color: #666;
+  color: rgba(241, 245, 249, 0.65);
   margin-top: 8px;
+}
+
+[data-theme="light"] .ingredient-optional {
+  color: #64748b;
 }
 
 .element-bars {
@@ -179,12 +200,14 @@ const styles = `
 .element-label {
   width: 50px;
   font-size: 0.8rem;
+  color: inherit;
 }
 
 .element-value {
   margin-left: 8px;
   font-size: 0.8rem;
   width: 40px;
+  color: inherit;
 }
 
 .bar {
@@ -210,27 +233,53 @@ const styles = `
   background: linear-gradient(to right, #f0f8ff, #b0c4de);
 }
 
+/* Dark theme: subtle tinted backgrounds with bright accent borders */
 .element-fire {
+  background-color: rgba(127, 29, 29, 0.35);
+  border-left: 4px solid #f97316;
+}
+
+.element-water {
+  background-color: rgba(30, 58, 138, 0.35);
+  border-left: 4px solid #38bdf8;
+}
+
+.element-earth {
+  background-color: rgba(20, 83, 45, 0.35);
+  border-left: 4px solid #84cc16;
+}
+
+.element-air {
+  background-color: rgba(15, 23, 42, 0.45);
+  border-left: 4px solid #cbd5e1;
+}
+
+.element-balanced {
+  background-color: rgba(30, 41, 59, 0.45);
+  border-left: 4px solid #a1a1aa;
+}
+
+[data-theme="light"] .element-fire {
   background-color: #fff0e8;
   border-left: 4px solid #ff4500;
 }
 
-.element-water {
+[data-theme="light"] .element-water {
   background-color: #e8f4ff;
   border-left: 4px solid #1e90ff;
 }
 
-.element-earth {
+[data-theme="light"] .element-earth {
   background-color: #f0f2e8;
   border-left: 4px solid #556b2f;
 }
 
-.element-air {
+[data-theme="light"] .element-air {
   background-color: #f8faff;
   border-left: 4px solid #b0c4de;
 }
 
-.element-balanced {
+[data-theme="light"] .element-balanced {
   background-color: #f9f9f9;
   border-left: 4px solid #a9a9a9;
 }
@@ -239,19 +288,25 @@ const styles = `
   font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  color: #666;
+  color: rgba(241, 245, 249, 0.7);
   margin-top: 12px;
+}
+
+[data-theme="light"] .ingredient-category {
+  color: #64748b;
 }
 
 .ingredient-qualities {
   font-size: 0.9rem;
   margin-top: 8px;
   font-style: italic;
+  color: inherit;
 }
 
 .ingredient-seasonality {
   font-size: 0.9rem;
   margin-top: 8px;
+  color: inherit;
 }
 `;
 

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import React from 'react';
+import { useTheme, type ThemePreference } from '@/contexts/ThemeContext';
+
+interface ThemeToggleProps {
+  /** Compact icon-only mode for header */
+  compact?: boolean;
+  className?: string;
+}
+
+const OPTIONS: Array<{ value: ThemePreference; label: string; icon: string; aria: string }> = [
+  { value: 'light', label: 'Light', icon: '☀️', aria: 'Use light theme (day)' },
+  { value: 'dark', label: 'Dark', icon: '🌙', aria: 'Use dark theme (night)' },
+  { value: 'system', label: 'Auto', icon: '🌗', aria: 'Follow time of day' },
+];
+
+/**
+ * Theme toggle borrowed from ondeck (next-themes pattern), adapted to our
+ * day/night alchemical theme system. "Auto" mode reflects the diurnal/nocturnal
+ * sectarian split — light during local day (06:00–18:00), dark at night.
+ */
+export const ThemeToggle: React.FC<ThemeToggleProps> = ({ compact = false, className = '' }) => {
+  const { preference, theme, isDiurnal, setPreference, cycleTheme } = useTheme();
+
+  if (compact) {
+    const current = OPTIONS.find((o) => o.value === preference) ?? OPTIONS[2];
+    const tooltip =
+      preference === 'system'
+        ? `Auto (currently ${theme}, ${isDiurnal ? 'day' : 'night'})`
+        : `${current.label} theme`;
+    return (
+      <button
+        type="button"
+        onClick={cycleTheme}
+        title={tooltip}
+        aria-label={`Theme: ${tooltip}. Click to cycle.`}
+        className={`inline-flex items-center justify-center h-10 w-10 rounded-xl border border-purple-500/30 bg-purple-900/40 text-purple-100 hover:bg-purple-800/60 hover:text-white hover:scale-105 transition-all duration-200 shadow-md ${className}`}
+      >
+        <span className="text-lg leading-none" aria-hidden="true">{current.icon}</span>
+      </button>
+    );
+  }
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Theme preference"
+      className={`inline-flex items-center gap-1 rounded-xl border border-purple-500/30 bg-purple-900/30 p-1 ${className}`}
+    >
+      {OPTIONS.map((opt) => {
+        const active = preference === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            aria-label={opt.aria}
+            onClick={() => setPreference(opt.value)}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-all ${
+              active
+                ? 'bg-purple-700/80 text-white shadow-sm'
+                : 'text-purple-200 hover:bg-purple-800/50 hover:text-white'
+            }`}
+          >
+            <span aria-hidden="true">{opt.icon}</span>
+            <span>{opt.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ThemeToggle;

--- a/src/components/home/CuisineCard.tsx
+++ b/src/components/home/CuisineCard.tsx
@@ -2,39 +2,109 @@
 
 import Link from "next/link";
 import React, { useState } from "react";
+import { getCuisineProfile } from "@/data/cuisineFlavorProfiles";
 
-// Optional callback for double-click-to-queue integration
 type OnDoubleClickCuisine = (cuisineName: string) => void;
 
 const PLANET_ICONS: Record<string, string> = {
-  Sun: "\u2609",
-  Moon: "\u263D",
-  Mercury: "\u263F",
-  Venus: "\u2640",
-  Mars: "\u2642",
-  Jupiter: "\u2643",
-  Saturn: "\u2644",
+  Sun: "☉",
+  Moon: "☽",
+  Mercury: "☿",
+  Venus: "♀",
+  Mars: "♂",
+  Jupiter: "♃",
+  Saturn: "♄",
 };
 
+// Dark-theme planet badge styles
 const PLANET_COLORS: Record<string, string> = {
-  Sun: "text-yellow-600 bg-yellow-50 border-yellow-200",
-  Moon: "text-blue-400 bg-blue-50 border-blue-200",
-  Mercury: "text-gray-600 bg-gray-50 border-gray-200",
-  Venus: "text-pink-500 bg-pink-50 border-pink-200",
-  Mars: "text-red-600 bg-red-50 border-red-200",
-  Jupiter: "text-orange-500 bg-orange-50 border-orange-200",
-  Saturn: "text-gray-700 bg-gray-50 border-gray-300",
+  Sun: "text-yellow-300 bg-yellow-900/30 border-yellow-700/50",
+  Moon: "text-blue-300 bg-blue-900/30 border-blue-700/50",
+  Mercury: "text-slate-300 bg-slate-800/50 border-slate-600/50",
+  Venus: "text-pink-300 bg-pink-900/30 border-pink-700/50",
+  Mars: "text-red-300 bg-red-900/30 border-red-700/50",
+  Jupiter: "text-orange-300 bg-orange-900/30 border-orange-700/50",
+  Saturn: "text-slate-400 bg-slate-800/50 border-slate-500/50",
 };
 
+// Gradient header tones — still vibrant but shifted darker
 const GRADIENT_COLORS: Record<string, string> = {
-  Sun: "from-yellow-400 to-amber-500",
-  Moon: "from-blue-400 to-indigo-500",
-  Mercury: "from-gray-400 to-slate-500",
-  Venus: "from-pink-400 to-rose-500",
-  Mars: "from-red-500 to-orange-600",
-  Jupiter: "from-orange-400 to-amber-600",
-  Saturn: "from-gray-500 to-slate-600",
+  Sun: "from-yellow-700 to-amber-900",
+  Moon: "from-blue-800 to-indigo-900",
+  Mercury: "from-slate-700 to-slate-900",
+  Venus: "from-pink-800 to-rose-900",
+  Mars: "from-red-800 to-orange-900",
+  Jupiter: "from-orange-800 to-amber-900",
+  Saturn: "from-slate-700 to-gray-900",
 };
+
+const FLAVOR_LABELS: Record<string, { label: string; color: string }> = {
+  spicy:  { label: "Spicy",  color: "bg-red-500" },
+  sweet:  { label: "Sweet",  color: "bg-amber-400" },
+  sour:   { label: "Sour",   color: "bg-lime-500" },
+  bitter: { label: "Bitter", color: "bg-emerald-600" },
+  salty:  { label: "Salty",  color: "bg-sky-500" },
+  umami:  { label: "Umami",  color: "bg-purple-500" },
+};
+
+const FLAVOR_ORDER = ["spicy", "umami", "salty", "sweet", "sour", "bitter"] as const;
+
+function FlavorBars({ cuisineName }: { cuisineName: string }) {
+  const profile = getCuisineProfile(cuisineName);
+  if (!profile) return null;
+  const fp = profile.flavorProfiles;
+
+  return (
+    <div className="space-y-1 mt-2">
+      {FLAVOR_ORDER.map((key) => {
+        const value = fp[key as keyof typeof fp] ?? 0;
+        const meta = FLAVOR_LABELS[key];
+        return (
+          <div key={key} className="flex items-center gap-2">
+            <span className="text-[10px] text-slate-400 w-9 shrink-0">{meta.label}</span>
+            <div className="flex-1 h-1.5 rounded-full bg-slate-700/60">
+              <div
+                className={`h-1.5 rounded-full ${meta.color} opacity-85`}
+                style={{ width: `${Math.round(value * 100)}%` }}
+              />
+            </div>
+            <span className="text-[10px] text-slate-500 w-6 text-right">
+              {Math.round(value * 100)}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function TopFlavorPills({ cuisineName }: { cuisineName: string }) {
+  const profile = getCuisineProfile(cuisineName);
+  if (!profile) return null;
+  const fp = profile.flavorProfiles;
+
+  const sorted = FLAVOR_ORDER
+    .map((k) => ({ key: k, val: fp[k as keyof typeof fp] ?? 0 }))
+    .sort((a, b) => b.val - a.val)
+    .slice(0, 3)
+    .filter((x) => x.val >= 0.35);
+
+  return (
+    <div className="flex flex-wrap gap-1 mt-1">
+      {sorted.map(({ key }) => {
+        const meta = FLAVOR_LABELS[key];
+        return (
+          <span
+            key={key}
+            className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${meta.color} text-white/90`}
+          >
+            {meta.label}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
 
 export interface DynamicCuisineRecommendation {
   cuisine: string;
@@ -57,16 +127,16 @@ interface CuisineCardProps {
 export function CuisineCard({ cuisine, rank, compact, onDoubleClickCuisine }: CuisineCardProps) {
   const [showPreview, setShowPreview] = useState(false);
 
-  const icon = PLANET_ICONS[cuisine.planet] || "\u2609";
+  const icon = PLANET_ICONS[cuisine.planet] || "☉";
   const colorClass = PLANET_COLORS[cuisine.planet] || PLANET_COLORS.Sun;
   const gradient = GRADIENT_COLORS[cuisine.planet] || GRADIENT_COLORS.Sun;
 
   const scoreColor =
     cuisine.score >= 85
-      ? "bg-green-500"
+      ? "bg-emerald-600"
       : cuisine.score >= 70
-        ? "bg-amber-500"
-        : "bg-gray-400";
+        ? "bg-amber-600"
+        : "bg-slate-600";
 
   if (compact) {
     return (
@@ -79,33 +149,25 @@ export function CuisineCard({ cuisine, rank, compact, onDoubleClickCuisine }: Cu
           }
         }}
       >
-        <div className="bg-white rounded-lg shadow-sm hover:shadow-md transition-all duration-200 overflow-hidden border border-gray-200 hover:border-amber-300 cursor-pointer p-4">
+        <div className="bg-slate-900/80 rounded-lg transition-all duration-200 overflow-hidden border border-purple-500/20 hover:border-purple-400/40 hover:bg-slate-800/80 cursor-pointer p-4">
           <div className="flex items-center justify-between mb-2">
             <div className="flex items-center gap-2">
-              <span className="text-lg">{icon}</span>
-              <h3 className="font-semibold text-gray-900">{cuisine.cuisine}</h3>
+              <span className="text-lg opacity-80">{icon}</span>
+              <h3 className="font-semibold text-slate-100">{cuisine.cuisine}</h3>
               {cuisine.isRetrograde && (
-                <span
-                  className="text-xs text-amber-600"
-                  title={`${cuisine.planet} retrograde`}
-                >
+                <span className="text-xs text-amber-400" title={`${cuisine.planet} retrograde`}>
                   Rx
                 </span>
               )}
             </div>
-            <div
-              className={`px-2 py-0.5 ${scoreColor} text-white rounded-full text-xs font-bold`}
-            >
+            <div className={`px-2 py-0.5 ${scoreColor} text-white rounded-full text-xs font-bold`}>
               {cuisine.score}%
             </div>
           </div>
-          <p className="text-xs text-gray-600 line-clamp-2">
-            {cuisine.reasoning}
-          </p>
-          <div className="flex items-center justify-between mt-2 text-xs text-gray-500">
-            {cuisine.recipeCount > 0 && (
-              <span>{cuisine.recipeCount} recipes</span>
-            )}
+          <p className="text-xs text-slate-400 line-clamp-2">{cuisine.reasoning}</p>
+          <TopFlavorPills cuisineName={cuisine.cuisine} />
+          <div className="flex items-center justify-between mt-2 text-xs text-slate-500">
+            {cuisine.recipeCount > 0 && <span>{cuisine.recipeCount} recipes</span>}
             <span>{cuisine.optimalTiming}</span>
           </div>
         </div>
@@ -125,55 +187,44 @@ export function CuisineCard({ cuisine, rank, compact, onDoubleClickCuisine }: Cu
         }
       }}
     >
-      <Link
-        href={`/recipes?cuisine=${encodeURIComponent(cuisine.cuisine.toLowerCase())}`}
-      >
-        <div className="bg-white rounded-xl shadow-md hover:shadow-xl transition-all duration-300 overflow-hidden border border-gray-200 hover:border-amber-300 cursor-pointer transform hover:-translate-y-1">
+      <Link href={`/recipes?cuisine=${encodeURIComponent(cuisine.cuisine.toLowerCase())}`}>
+        <div className="bg-slate-900/80 rounded-xl transition-all duration-300 overflow-hidden border border-purple-500/20 hover:border-purple-400/50 hover:bg-slate-800/80 cursor-pointer transform hover:-translate-y-1 hover:shadow-lg hover:shadow-purple-900/20">
           {/* Rank Badge */}
           <div className="absolute top-3 left-3 z-10">
-            <div className="w-8 h-8 bg-amber-600 text-white rounded-full flex items-center justify-center font-bold text-sm shadow-lg">
+            <div className="w-8 h-8 bg-purple-700 text-white rounded-full flex items-center justify-center font-bold text-sm shadow-lg">
               #{rank}
             </div>
           </div>
 
           {/* Score Badge */}
           <div className="absolute top-3 right-3 z-10">
-            <div
-              className={`px-3 py-1 ${scoreColor} text-white rounded-full font-bold text-sm shadow-lg`}
-            >
+            <div className={`px-3 py-1 ${scoreColor} text-white rounded-full font-bold text-sm shadow-lg`}>
               {cuisine.score}%
             </div>
           </div>
 
           {/* Header with gradient */}
-          <div
-            className={`h-32 bg-gradient-to-br ${gradient} relative overflow-hidden`}
-          >
+          <div className={`h-32 bg-gradient-to-br ${gradient} relative overflow-hidden`}>
             <div className="absolute inset-0 flex items-center justify-center opacity-20">
               <span className="text-8xl text-white">{icon}</span>
             </div>
+            <div className="absolute inset-0 bg-black/30" />
             <div className="absolute bottom-4 left-4 right-4">
-              <h3 className="text-2xl font-bold text-white drop-shadow-lg">
-                {cuisine.cuisine}
-              </h3>
+              <h3 className="text-2xl font-bold text-white drop-shadow-lg">{cuisine.cuisine}</h3>
             </div>
           </div>
 
           {/* Content */}
           <div className="p-5 space-y-3">
-            {/* Planetary indicator */}
+            {/* Planetary badge */}
             <div className="flex items-center gap-2">
-              <div
-                className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full border ${colorClass}`}
-              >
+              <div className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full border ${colorClass}`}>
                 <span className="text-lg">{icon}</span>
-                <span className="text-sm font-semibold">
-                  {cuisine.planet} Ruled
-                </span>
+                <span className="text-sm font-semibold">{cuisine.planet} Ruled</span>
               </div>
               {cuisine.isRetrograde && (
                 <span
-                  className="inline-flex items-center px-2 py-1 text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-full"
+                  className="inline-flex items-center px-2 py-1 text-xs font-medium text-amber-300 bg-amber-900/30 border border-amber-700/50 rounded-full"
                   title={`${cuisine.planet} is retrograde`}
                 >
                   Rx
@@ -182,46 +233,43 @@ export function CuisineCard({ cuisine, rank, compact, onDoubleClickCuisine }: Cu
             </div>
 
             {/* Reasoning */}
-            <p className="text-sm text-gray-700 leading-relaxed">
-              {cuisine.reasoning}
-            </p>
+            <p className="text-sm text-slate-300 leading-relaxed">{cuisine.reasoning}</p>
+
+            {/* Flavor Profile */}
+            <div className="pt-1">
+              <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-500 mb-1">
+                Flavor Profile
+              </p>
+              <FlavorBars cuisineName={cuisine.cuisine} />
+            </div>
 
             {/* Stats */}
-            <div className="flex items-center justify-between pt-2 border-t border-gray-100">
-              <div className="flex items-center gap-2 text-sm text-gray-600">
+            <div className="flex items-center justify-between pt-2 border-t border-slate-700/50">
+              <div className="flex items-center gap-2 text-sm text-slate-400">
                 {cuisine.recipeCount > 0 ? (
                   <span>{cuisine.recipeCount} recipes</span>
                 ) : (
                   <span>Explore cuisine</span>
                 )}
               </div>
-              <div className="text-xs text-gray-500">
-                {cuisine.optimalTiming}
-              </div>
+              <div className="text-xs text-slate-500">{cuisine.optimalTiming}</div>
             </div>
           </div>
 
           {/* Hover Preview */}
           {showPreview && cuisine.topRecipes.length > 0 && (
-            <div className="absolute inset-0 bg-white bg-opacity-95 backdrop-blur-sm p-5 flex flex-col justify-center rounded-xl">
-              <h4 className="font-semibold text-gray-900 mb-3">Top Recipes:</h4>
+            <div className="absolute inset-0 bg-slate-900/95 backdrop-blur-sm p-5 flex flex-col justify-center rounded-xl border border-purple-500/30">
+              <h4 className="font-semibold text-slate-100 mb-3">Top Recipes:</h4>
               <div className="space-y-2">
                 {cuisine.topRecipes.map((recipe, idx) => (
-                  <div
-                    key={idx}
-                    className="flex items-center justify-between text-sm"
-                  >
-                    <span className="text-gray-700">{recipe.name}</span>
-                    <span className="text-amber-600 font-medium">
-                      {recipe.matchScore}%
-                    </span>
+                  <div key={idx} className="flex items-center justify-between text-sm">
+                    <span className="text-slate-300">{recipe.name}</span>
+                    <span className="text-amber-400 font-medium">{recipe.matchScore}%</span>
                   </div>
                 ))}
               </div>
               <div className="mt-4 text-center">
-                <span className="text-amber-600 font-medium text-sm">
-                  Click to explore &rarr;
-                </span>
+                <span className="text-purple-400 font-medium text-sm">Click to explore &rarr;</span>
               </div>
             </div>
           )}
@@ -233,15 +281,23 @@ export function CuisineCard({ cuisine, rank, compact, onDoubleClickCuisine }: Cu
 
 export function CuisineCardSkeleton() {
   return (
-    <div className="bg-white rounded-xl shadow-md overflow-hidden border border-gray-200 animate-pulse">
-      <div className="h-32 bg-gray-200" />
+    <div className="bg-slate-900/80 rounded-xl overflow-hidden border border-purple-500/20 animate-pulse">
+      <div className="h-32 bg-slate-800" />
       <div className="p-5 space-y-3">
-        <div className="h-8 bg-gray-200 rounded w-3/4" />
-        <div className="h-4 bg-gray-200 rounded w-full" />
-        <div className="h-4 bg-gray-200 rounded w-5/6" />
+        <div className="h-8 bg-slate-800 rounded w-3/4" />
+        <div className="h-4 bg-slate-800 rounded w-full" />
+        <div className="h-4 bg-slate-800 rounded w-5/6" />
+        <div className="space-y-1.5 pt-1">
+          {[...Array(6)].map((_, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <div className="h-2 bg-slate-800 rounded w-9" />
+              <div className="flex-1 h-1.5 bg-slate-800 rounded" />
+            </div>
+          ))}
+        </div>
         <div className="flex justify-between pt-2">
-          <div className="h-4 bg-gray-200 rounded w-1/3" />
-          <div className="h-4 bg-gray-200 rounded w-1/4" />
+          <div className="h-4 bg-slate-800 rounded w-1/3" />
+          <div className="h-4 bg-slate-800 rounded w-1/4" />
         </div>
       </div>
     </div>

--- a/src/components/home/DynamicCuisineRecommender.tsx
+++ b/src/components/home/DynamicCuisineRecommender.tsx
@@ -341,22 +341,22 @@ export default function DynamicCuisineRecommender({ onDoubleClickCuisine }: Dyna
       <div className="text-center mb-8">
         <h2
           id="dynamic-cuisine-heading"
-          className="text-3xl font-bold text-gray-900 mb-3"
+          className="text-3xl font-bold text-white mb-3"
         >
           Cuisines Aligned with the Cosmos
         </h2>
-        <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+        <p className="text-lg text-slate-400 max-w-2xl mx-auto">
           Recommendations powered by real-time planetary positions. Updated{" "}
           {getTimeAgo(lastUpdated)}.
         </p>
 
         {/* Live indicator */}
-        <div className="mt-4 inline-flex items-center gap-2 px-4 py-2 bg-green-50 border border-green-200 rounded-full">
+        <div className="mt-4 inline-flex items-center gap-2 px-4 py-2 bg-emerald-900/30 border border-emerald-700/50 rounded-full">
           <span className="relative flex h-3 w-3">
-            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
-            <span className="relative inline-flex rounded-full h-3 w-3 bg-green-500" />
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+            <span className="relative inline-flex rounded-full h-3 w-3 bg-emerald-500" />
           </span>
-          <span className="text-sm font-medium text-green-800">
+          <span className="text-sm font-medium text-emerald-300">
             Live planetary scoring
           </span>
         </div>
@@ -387,7 +387,7 @@ export default function DynamicCuisineRecommender({ onDoubleClickCuisine }: Dyna
             <div className="mt-8">
               <button
                 onClick={() => setShowAllCuisines(!showAllCuisines)}
-                className="mx-auto flex items-center gap-2 px-5 py-2.5 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
+                className="mx-auto flex items-center gap-2 px-5 py-2.5 text-sm font-medium text-slate-300 bg-slate-800/60 hover:bg-slate-700/60 border border-slate-700/50 rounded-lg transition-colors"
               >
                 {showAllCuisines
                   ? "Show fewer"
@@ -421,7 +421,7 @@ export default function DynamicCuisineRecommender({ onDoubleClickCuisine }: Dyna
         <button
           onClick={() => { void loadRecommendations(); }}
           disabled={isLoading}
-          className="px-6 py-3 bg-amber-600 hover:bg-amber-700 disabled:bg-gray-400 text-white rounded-lg font-medium transition-colors inline-flex items-center gap-2"
+          className="px-6 py-3 bg-purple-700 hover:bg-purple-600 disabled:bg-slate-700 text-white rounded-lg font-medium transition-colors inline-flex items-center gap-2"
         >
           <span className={isLoading ? "animate-spin inline-block" : ""}>
             &#x21bb;

--- a/src/components/recommendations/EnhancedIngredientRecommender.tsx
+++ b/src/components/recommendations/EnhancedIngredientRecommender.tsx
@@ -203,14 +203,131 @@ function isIngredientInSeason(
 }
 
 /**
- * Score breakdown interface for detailed compatibility info
+ * Score breakdown interface for detailed compatibility info.
+ * Each dimension is 0..1 representing how well the ingredient matches the
+ * current astrological / sectarian / seasonal moment.
  */
 interface ScoreBreakdown {
   elemental: number;
   thermodynamic: number;
   kinetic: number;
   seasonal: number;
+  astrological: number;
+  lunar: number;
+  diurnal: number;
   final: number;
+}
+
+interface AstroContext {
+  zodiacSign?: string;
+  lunarPhase?: string;
+  planetaryPositions?: Record<string, unknown>;
+  isDaytime?: boolean;
+}
+
+/**
+ * Score how well the ingredient's astrological profile matches the current
+ * zodiac sign and active planetary positions. Combines:
+ *   • favorable-zodiac match (binary 1.0 / 0.5 baseline)
+ *   • ruling-planet activity (1.0 if any ruler currently has a position; else 0.5)
+ *   • sub-element decan affinity bonus when present
+ */
+function calculateAstrologicalScore(
+  astroProfile: any,
+  ctx: AstroContext,
+): number {
+  if (!astroProfile || typeof astroProfile !== "object") return 0.5;
+
+  let zodiacScore = 0.5;
+  if (Array.isArray(astroProfile.favorableZodiac) && ctx.zodiacSign) {
+    const sign = String(ctx.zodiacSign).toLowerCase();
+    const favored = astroProfile.favorableZodiac.map((z: string) =>
+      String(z).toLowerCase(),
+    );
+    if (favored.includes(sign)) zodiacScore = 1.0;
+    else zodiacScore = 0.45; // off-favor penalty
+  }
+
+  let planetScore = 0.5;
+  if (Array.isArray(astroProfile.rulingPlanets)) {
+    const positions = ctx.planetaryPositions || {};
+    const activeRulers = astroProfile.rulingPlanets.filter(
+      (p: string) => positions[p] !== undefined,
+    ).length;
+    if (astroProfile.rulingPlanets.length > 0) {
+      planetScore = 0.5 + 0.5 * (activeRulers / astroProfile.rulingPlanets.length);
+    }
+  }
+
+  return zodiacScore * 0.6 + planetScore * 0.4;
+}
+
+/**
+ * Score how well the current lunar phase aligns with the ingredient's
+ * lunarPhaseModifiers. If the current phase has a registered potencyMultiplier,
+ * apply it; otherwise return a neutral baseline.
+ */
+function calculateLunarScore(astroProfile: any, lunarPhase?: string): number {
+  if (!astroProfile?.lunarPhaseModifiers || !lunarPhase) return 0.5;
+  const phase = String(lunarPhase).toLowerCase().replace(/\s+/g, "_");
+  const modifiers = astroProfile.lunarPhaseModifiers;
+  // Try several key shapes
+  const match =
+    modifiers[phase] ||
+    modifiers[lunarPhase as string] ||
+    modifiers[String(lunarPhase).toLowerCase()];
+  if (!match) return 0.5;
+  const potency = typeof match.potencyMultiplier === "number"
+    ? Math.min(1, Math.max(0, match.potencyMultiplier))
+    : undefined;
+  if (potency != null) return 0.5 + 0.5 * potency;
+  // If a phase entry exists at all, give a moderate bonus.
+  return 0.8;
+}
+
+/**
+ * Score the ingredient against the current sectarian (diurnal/nocturnal) state.
+ * Day favors warming, drying, fire-leaning ingredients; night favors cooling,
+ * moistening, water-leaning ingredients. Reads:
+ *   • kineticsImpact.thermalDirection (numeric, +warm / -cool)
+ *   • qualities array (warming / cooling / grounding / drying / moistening)
+ */
+function calculateDiurnalScore(
+  qualities: string[] | undefined,
+  kineticsImpact: any,
+  isDaytime: boolean | undefined,
+): number {
+  if (isDaytime == null) return 0.5;
+
+  let thermalScore = 0.5;
+  if (kineticsImpact && typeof kineticsImpact.thermalDirection === "number") {
+    const dir = kineticsImpact.thermalDirection;
+    // Map: dir > 0 (warming) ⇒ aligns with day; dir < 0 (cooling) ⇒ aligns with night
+    if (isDaytime) {
+      thermalScore = dir >= 0 ? 0.5 + Math.min(0.5, dir * 2) : 0.5 + dir; // dir<0 reduces score
+    } else {
+      thermalScore = dir <= 0 ? 0.5 + Math.min(0.5, -dir * 2) : 0.5 - dir;
+    }
+    thermalScore = Math.max(0, Math.min(1, thermalScore));
+  }
+
+  let qualityScore = 0.5;
+  if (Array.isArray(qualities) && qualities.length > 0) {
+    const tags = qualities.map((q) => String(q).toLowerCase());
+    const warming = tags.some((q) => /warm|hot|pungent|drying/.test(q));
+    const cooling = tags.some((q) => /cool|cold|moisten|hydrating/.test(q));
+    if (isDaytime) {
+      if (warming && !cooling) qualityScore = 1.0;
+      else if (cooling && !warming) qualityScore = 0.4;
+      else qualityScore = 0.7; // mixed or grounding ⇒ slight bonus
+    } else {
+      if (cooling && !warming) qualityScore = 1.0;
+      else if (warming && !cooling) qualityScore = 0.4;
+      else qualityScore = 0.7;
+    }
+  }
+
+  return thermalScore * 0.55 + qualityScore * 0.45;
 }
 
 /**
@@ -230,6 +347,12 @@ function calculateCompatibilityScore(
     Matter: number;
     Substance: number;
   } | null,
+  ingredientExtras?: {
+    astrologicalProfile?: any;
+    qualities?: string[];
+    kineticsImpact?: any;
+  },
+  astroCtx?: AstroContext,
 ): { score: number; breakdown: ScoreBreakdown } {
   // Calculate elemental compatibility using exponential decay for better spread
   const fireCompat = exponentialCompatibility(
@@ -336,29 +459,51 @@ function calculateCompatibilityScore(
 
   const kineticScore = powerCompat * 0.6 + forceCompat * 0.4;
 
-  // Final score: Blend elemental, thermodynamic, and kinetic
-  // Using geometric mean for better differentiation (penalizes imbalanced scores)
+  // Astrological / lunar / sectarian dimensions — leverage all of the
+  // ingredient's metadata against the current astrological moment.
+  const astrologicalScore = calculateAstrologicalScore(
+    ingredientExtras?.astrologicalProfile,
+    astroCtx || {},
+  );
+  const lunarScore = calculateLunarScore(
+    ingredientExtras?.astrologicalProfile,
+    astroCtx?.lunarPhase,
+  );
+  const diurnalScore = calculateDiurnalScore(
+    ingredientExtras?.qualities,
+    ingredientExtras?.kineticsImpact,
+    astroCtx?.isDaytime,
+  );
+
+  // Final score: blend the alchemical/thermodynamic core with astrological
+  // alignment. Geometric mean penalizes imbalance; weighted mean rewards
+  // partial matches. We blend the two for a stable distribution.
   const geometricMean = Math.pow(
-    elementalScore * thermoScore * kineticScore,
+    Math.max(elementalScore, 0.05) *
+      Math.max(thermoScore, 0.05) *
+      Math.max(kineticScore, 0.05),
     1 / 3,
   );
 
-  // Blend geometric mean with weighted average for final score
   const weightedScore =
-    elementalScore * 0.35 + thermoScore * 0.4 + kineticScore * 0.25;
-  let finalScore = geometricMean * 0.5 + weightedScore * 0.5;
+    elementalScore * 0.22 +
+    thermoScore * 0.22 +
+    kineticScore * 0.13 +
+    astrologicalScore * 0.18 +
+    lunarScore * 0.1 +
+    diurnalScore * 0.15;
 
-  // Seasonal boosting - ingredients in season get a boost
+  let finalScore = geometricMean * 0.4 + weightedScore * 0.6;
+
+  // Seasonal boost — ingredients currently in season get a multiplicative bump.
   const currentSeason = getCurrentSeason();
   const inSeason = isIngredientInSeason(seasonality, currentSeason);
   const seasonalScore = inSeason ? 1.0 : 0.5;
-
-  // Apply seasonal boost (5% boost for in-season ingredients)
   if (inSeason) {
     finalScore = Math.min(1.0, finalScore * 1.05);
   }
 
-  // Apply power function to expand the range (creates more variation)
+  // Power function expands range for more visible differentiation.
   const adjustedScore = Math.pow(finalScore, 0.85);
 
   return {
@@ -368,6 +513,9 @@ function calculateCompatibilityScore(
       thermodynamic: thermoScore,
       kinetic: kineticScore,
       seasonal: seasonalScore,
+      astrological: astrologicalScore,
+      lunar: lunarScore,
+      diurnal: diurnalScore,
       final: adjustedScore,
     },
   };
@@ -386,16 +534,34 @@ function getDominantElement(elementals: ElementalProperties): string {
 const TASTE_CONFIG: Record<string, { emoji: string; color: string }> = {
   sweet: {
     emoji: "🍬",
-    color: "bg-yellow-100 text-yellow-800 border-yellow-200",
+    color:
+      "bg-yellow-100 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-200 border-yellow-200 dark:border-yellow-700/50",
   },
-  salty: { emoji: "🧂", color: "bg-sky-100 text-sky-800 border-sky-200" },
-  sour: { emoji: "🍋", color: "bg-lime-100 text-lime-800 border-lime-200" },
+  salty: {
+    emoji: "🧂",
+    color:
+      "bg-sky-100 dark:bg-sky-900/40 text-sky-800 dark:text-sky-200 border-sky-200 dark:border-sky-700/50",
+  },
+  sour: {
+    emoji: "🍋",
+    color:
+      "bg-lime-100 dark:bg-lime-900/40 text-lime-800 dark:text-lime-200 border-lime-200 dark:border-lime-700/50",
+  },
   bitter: {
     emoji: "🌿",
-    color: "bg-emerald-100 text-emerald-800 border-emerald-200",
+    color:
+      "bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200 border-emerald-200 dark:border-emerald-700/50",
   },
-  umami: { emoji: "🍄", color: "bg-amber-100 text-amber-800 border-amber-200" },
-  spicy: { emoji: "🌶️", color: "bg-red-100 text-red-800 border-red-200" },
+  umami: {
+    emoji: "🍄",
+    color:
+      "bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200 border-amber-200 dark:border-amber-700/50",
+  },
+  spicy: {
+    emoji: "🌶️",
+    color:
+      "bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200 border-red-200 dark:border-red-700/50",
+  },
 };
 
 // Extract calories + macros from the several different nutritionalProfile shapes used across ingredient files
@@ -525,6 +691,17 @@ export const EnhancedIngredientRecommender: React.FC<
       );
     }
 
+    // Build the astrological context once per render — every ingredient is
+    // scored against the same current moment.
+    const astroCtx: AstroContext = {
+      zodiacSign: alchemicalContext?.zodiacSign as string | undefined,
+      lunarPhase: alchemicalContext?.lunarPhase as string | undefined,
+      planetaryPositions: alchemicalContext?.planetaryPositions as
+        | Record<string, unknown>
+        | undefined,
+      isDaytime: alchemicalContext?.isDaytime,
+    };
+
     // Calculate scores and sort
     return filtered
       .map((ing) => {
@@ -537,6 +714,12 @@ export const EnhancedIngredientRecommender: React.FC<
               currentElementals,
               seasonData,
               ing.alchemicalProperties as any,
+              {
+                astrologicalProfile: (ing as any).astrologicalProfile,
+                qualities: ing.qualities as string[] | undefined,
+                kineticsImpact: (ing as any).kineticsImpact,
+              },
+              astroCtx,
             )
           : {
               score: 0.5,
@@ -545,6 +728,9 @@ export const EnhancedIngredientRecommender: React.FC<
                 thermodynamic: 0.5,
                 kinetic: 0.5,
                 seasonal: 0.5,
+                astrological: 0.5,
+                lunar: 0.5,
+                diurnal: 0.5,
                 final: 0.5,
               },
             };
@@ -560,7 +746,16 @@ export const EnhancedIngredientRecommender: React.FC<
         };
       })
       .sort((a, b) => b.compatibilityScore - a.compatibilityScore);
-  }, [ingredients, selectedCategory, searchQuery, currentElementals]);
+  }, [
+    ingredients,
+    selectedCategory,
+    searchQuery,
+    currentElementals,
+    alchemicalContext?.zodiacSign,
+    alchemicalContext?.lunarPhase,
+    alchemicalContext?.planetaryPositions,
+    alchemicalContext?.isDaytime,
+  ]);
 
   // Handlers
   const handleCategorySelect = (categoryId: string) => {
@@ -626,7 +821,7 @@ export const EnhancedIngredientRecommender: React.FC<
   // Render category grid
   const renderCategoryGrid = () => (
     <div className="mb-6">
-      <h3 className="mb-3 text-lg font-semibold text-gray-800">
+      <h3 className="mb-3 text-lg font-semibold text-gray-800 dark:text-slate-100">
         Browse by Category
       </h3>
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
@@ -636,12 +831,12 @@ export const EnhancedIngredientRecommender: React.FC<
             onClick={() => handleCategorySelect(category.id)}
             className={`rounded-lg border-2 p-4 transition-all ${
               selectedCategory === category.id
-                ? "border-indigo-500 bg-indigo-50 shadow-md"
-                : "border-gray-200 bg-white hover:border-indigo-300 hover:shadow-sm"
+                ? "border-indigo-500 dark:border-indigo-400 bg-indigo-50 dark:bg-indigo-950/40 shadow-md"
+                : "border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900/80 hover:border-indigo-300 dark:hover:border-indigo-500 hover:shadow-sm"
             }`}
           >
             <div className="mb-2 text-3xl">{category.icon}</div>
-            <div className="text-sm font-medium text-gray-800">
+            <div className="text-sm font-medium text-gray-800 dark:text-slate-100">
               {category.name}
             </div>
           </button>
@@ -658,7 +853,7 @@ export const EnhancedIngredientRecommender: React.FC<
         value={searchQuery}
         onChange={(e) => setSearchQuery(e.target.value)}
         placeholder="Search ingredients..."
-        className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        className="w-full rounded-lg border border-gray-300 dark:border-slate-700 bg-white dark:bg-slate-900/80 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-slate-500 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400"
       />
     </div>
   );
@@ -684,18 +879,18 @@ export const EnhancedIngredientRecommender: React.FC<
           return (
             <div key={name} className="flex items-center gap-2">
               <span className="text-lg">{icon}</span>
-              <span className="w-16 text-sm font-medium text-gray-700">
+              <span className="w-16 text-sm font-medium text-gray-700 dark:text-slate-200">
                 {name}
               </span>
               <div className="flex-1">
-                <div className="h-2 w-full rounded-full bg-gray-200">
+                <div className="h-2 w-full rounded-full bg-gray-200 dark:bg-slate-700">
                   <div
                     className={`h-2 rounded-full ${colorClass}`}
                     style={{ width: `${percentage}%` }}
                   />
                 </div>
               </div>
-              <span className="w-12 text-right text-sm text-gray-600">
+              <span className="w-12 text-right text-sm text-gray-600 dark:text-slate-300">
                 {percentage}%
               </span>
             </div>
@@ -706,39 +901,55 @@ export const EnhancedIngredientRecommender: React.FC<
   };
 
   // Render score breakdown tooltip
-  const renderScoreBreakdown = (breakdown: ScoreBreakdown) => (
-    <div className="mt-2 rounded-md bg-gray-50 p-3 text-xs">
-      <div className="mb-1 font-semibold text-gray-700">Score Breakdown</div>
-      <div className="grid grid-cols-2 gap-2">
-        <div className="flex justify-between">
-          <span className="text-gray-600">Elemental:</span>
-          <span className="font-medium">
-            {Math.round(breakdown.elemental * 100)}%
-          </span>
+  const renderScoreBreakdown = (breakdown: ScoreBreakdown) => {
+    const Row = ({
+      label,
+      value,
+      icon,
+    }: {
+      label: string;
+      value: number;
+      icon: string;
+    }) => (
+      <div className="flex justify-between">
+        <span className="text-gray-600 dark:text-slate-300">
+          <span aria-hidden="true">{icon}</span> {label}:
+        </span>
+        <span className="font-medium text-gray-900 dark:text-white">
+          {Math.round(value * 100)}%
+        </span>
+      </div>
+    );
+    return (
+      <div className="mt-2 rounded-md bg-gray-50 dark:bg-slate-900/50 p-3 text-xs border border-gray-100 dark:border-slate-800">
+        <div className="mb-1 font-semibold text-gray-700 dark:text-slate-200">
+          Score Breakdown
         </div>
-        <div className="flex justify-between">
-          <span className="text-gray-600">Thermodynamic:</span>
-          <span className="font-medium">
-            {Math.round(breakdown.thermodynamic * 100)}%
-          </span>
-        </div>
-        <div className="flex justify-between">
-          <span className="text-gray-600">Kinetic:</span>
-          <span className="font-medium">
-            {Math.round(breakdown.kinetic * 100)}%
-          </span>
-        </div>
-        <div className="flex justify-between">
-          <span className="text-gray-600">Seasonal:</span>
-          <span
-            className={`font-medium ${breakdown.seasonal === 1.0 ? "text-green-600" : ""}`}
-          >
-            {breakdown.seasonal === 1.0 ? "In Season!" : "Off Season"}
-          </span>
+        <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+          <Row label="Elemental" value={breakdown.elemental} icon="🜂" />
+          <Row label="Thermodynamic" value={breakdown.thermodynamic} icon="🌡️" />
+          <Row label="Kinetic" value={breakdown.kinetic} icon="⚡" />
+          <Row label="Astrological" value={breakdown.astrological} icon="✨" />
+          <Row label="Lunar" value={breakdown.lunar} icon="🌙" />
+          <Row label="Diurnal" value={breakdown.diurnal} icon="☀️" />
+          <div className="flex justify-between col-span-2">
+            <span className="text-gray-600 dark:text-slate-300">
+              <span aria-hidden="true">🗓️</span> Seasonal:
+            </span>
+            <span
+              className={`font-medium ${
+                breakdown.seasonal === 1.0
+                  ? "text-green-600 dark:text-green-300"
+                  : "text-gray-900 dark:text-white"
+              }`}
+            >
+              {breakdown.seasonal === 1.0 ? "In Season!" : "Off Season"}
+            </span>
+          </div>
         </div>
       </div>
-    </div>
-  );
+    );
+  };
 
   // Render ingredient card
   const renderIngredientCard = (ingredient: (typeof scoredIngredients)[0]) => {
@@ -763,31 +974,31 @@ export const EnhancedIngredientRecommender: React.FC<
         }}
         className={`cursor-pointer rounded-lg border-2 p-4 transition-all ${
           isSelected
-            ? "border-indigo-500 bg-indigo-50 shadow-lg"
-            : "border-gray-200 bg-white hover:border-indigo-300 hover:shadow-md"
+            ? "border-indigo-500 dark:border-indigo-400 bg-indigo-50 dark:bg-indigo-950/40 shadow-lg dark:shadow-indigo-500/10"
+            : "border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900/80 hover:border-indigo-300 dark:hover:border-indigo-500 hover:shadow-md dark:hover:shadow-indigo-500/10"
         }`}
       >
         {/* Header */}
         <div className="mb-3 flex items-start justify-between">
           <div className="flex-1">
             <div className="flex items-center gap-2">
-              <h4 className="text-lg font-semibold text-gray-900">
+              <h4 className="text-lg font-semibold text-gray-900 dark:text-white">
                 {displayName}
               </h4>
               {ingredient.isInSeason && (
-                <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+                <span className="rounded-full bg-green-100 dark:bg-green-900/40 px-2 py-0.5 text-xs font-medium text-green-700 dark:text-green-300">
                   In Season
                 </span>
               )}
             </div>
             <div className="mt-1 flex flex-wrap gap-1">
-              <span className="text-xs text-gray-500 capitalize">
+              <span className="text-xs text-gray-500 dark:text-slate-400 capitalize">
                 {formatIngredientName(ingredient.category)}
               </span>
               {ingredient.subcategory && (
                 <>
-                  <span className="text-xs text-gray-400">•</span>
-                  <span className="text-xs text-gray-500 capitalize">
+                  <span className="text-xs text-gray-400 dark:text-slate-500">•</span>
+                  <span className="text-xs text-gray-500 dark:text-slate-400 capitalize">
                     {formatIngredientName(ingredient.subcategory)}
                   </span>
                 </>
@@ -796,12 +1007,12 @@ export const EnhancedIngredientRecommender: React.FC<
           </div>
           <div className="flex flex-col items-end gap-2">
             <div
-              className="group relative rounded-full bg-indigo-100 px-3 py-1 text-sm font-medium text-indigo-800 cursor-help"
+              className="group relative rounded-full bg-indigo-100 dark:bg-indigo-900/50 px-3 py-1 text-sm font-medium text-indigo-800 dark:text-indigo-200 cursor-help"
               title="Click for score breakdown"
             >
               {Math.round(ingredient.compatibilityScore * 100)}%
             </div>
-            <div className="flex items-center gap-1 text-xs text-gray-500">
+            <div className="flex items-center gap-1 text-xs text-gray-500 dark:text-slate-400">
               <span
                 className={`inline-block h-2 w-2 rounded-full ${
                   ingredient.dominantElement === "Fire"
@@ -828,8 +1039,8 @@ export const EnhancedIngredientRecommender: React.FC<
               }
               className={`text-xs font-medium px-2 py-1 rounded-md border transition-colors ${
                 pantry.hasItem(ingredient.name)
-                  ? "bg-emerald-50 border-emerald-200 text-emerald-700 hover:bg-emerald-100"
-                  : "bg-amber-50 border-amber-200 text-amber-800 hover:bg-amber-100"
+                  ? "bg-emerald-50 dark:bg-emerald-950/40 border-emerald-200 dark:border-emerald-700/50 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-100 dark:hover:bg-emerald-900/50"
+                  : "bg-amber-50 dark:bg-amber-950/40 border-amber-200 dark:border-amber-700/50 text-amber-800 dark:text-amber-200 hover:bg-amber-100 dark:hover:bg-amber-900/50"
               }`}
               title={
                 pantry.hasItem(ingredient.name)
@@ -844,7 +1055,7 @@ export const EnhancedIngredientRecommender: React.FC<
 
         {/* Summary Blurb */}
         {ingredient.description && (
-          <div className="mb-3 text-sm text-gray-700 bg-blue-50/30 p-3 rounded-md border border-blue-100/50">
+          <div className="mb-3 text-sm text-gray-700 dark:text-slate-200 bg-blue-50/30 dark:bg-blue-950/30 p-3 rounded-md border border-blue-100/50 dark:border-blue-900/40">
             {ingredient.description.split("\n\n").map((paragraph, i) => (
               <p
                 key={i}
@@ -867,13 +1078,13 @@ export const EnhancedIngredientRecommender: React.FC<
               {ingredient.qualities.slice(0, 4).map((quality, idx) => (
                 <span
                   key={idx}
-                  className="rounded-md bg-green-100 px-2 py-1 text-xs text-green-700"
+                  className="rounded-md bg-green-100 dark:bg-green-900/40 px-2 py-1 text-xs text-green-700 dark:text-green-300"
                 >
                   {quality}
                 </span>
               ))}
               {ingredient.qualities.length > 4 && (
-                <span className="rounded-md bg-gray-100 px-2 py-1 text-xs text-gray-600">
+                <span className="rounded-md bg-gray-100 dark:bg-slate-800 px-2 py-1 text-xs text-gray-600 dark:text-slate-300">
                   +{ingredient.qualities.length - 4} more
                 </span>
               )}
@@ -891,14 +1102,15 @@ export const EnhancedIngredientRecommender: React.FC<
           if (active.length === 0) return null;
           return (
             <div className="mb-3">
-              <div className="mb-1 text-xs font-medium text-gray-500">
+              <div className="mb-1 text-xs font-medium text-gray-500 dark:text-slate-400">
                 Taste profile
               </div>
               <div className="flex flex-wrap gap-1">
                 {active.map(([name, value]) => {
                   const cfg = TASTE_CONFIG[name] ?? {
                     emoji: "•",
-                    color: "bg-gray-100 text-gray-700 border-gray-200",
+                    color:
+                      "bg-gray-100 dark:bg-slate-800 text-gray-700 dark:text-slate-200 border-gray-200 dark:border-slate-700",
                   };
                   const dots = value > 0.7 ? "●●●" : value > 0.4 ? "●●" : "●";
                   return (
@@ -922,24 +1134,24 @@ export const EnhancedIngredientRecommender: React.FC<
           return (
             <div className="mb-3">
               {n.servingSize && (
-                <div className="mb-0.5 text-xs text-gray-400">
+                <div className="mb-0.5 text-xs text-gray-400 dark:text-slate-500">
                   Per {n.servingSize}
                 </div>
               )}
               <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs">
                 {n.calories != null && (
-                  <span className="font-semibold text-gray-700">
+                  <span className="font-semibold text-gray-700 dark:text-slate-200">
                     🔥 {n.calories} cal
                   </span>
                 )}
                 {n.protein != null && n.protein > 0 && (
-                  <span className="text-blue-600">💪 {n.protein}g protein</span>
+                  <span className="text-blue-600 dark:text-blue-300">💪 {n.protein}g protein</span>
                 )}
                 {n.carbs != null && n.carbs > 0 && (
-                  <span className="text-amber-600">🌾 {n.carbs}g carbs</span>
+                  <span className="text-amber-600 dark:text-amber-300">🌾 {n.carbs}g carbs</span>
                 )}
                 {n.fat != null && n.fat > 0 && (
-                  <span className="text-orange-600">🫒 {n.fat}g fat</span>
+                  <span className="text-orange-600 dark:text-orange-300">🫒 {n.fat}g fat</span>
                 )}
               </div>
             </div>
@@ -949,14 +1161,14 @@ export const EnhancedIngredientRecommender: React.FC<
         {/* ── SMOKE POINT (oils) ────────────────────────────── */}
         {(ingredient as any).smokePoint && (
           <div className="mb-3 text-xs">
-            <span className="font-medium text-orange-600">
+            <span className="font-medium text-orange-600 dark:text-orange-300">
               🌡️ Smoke point:{" "}
             </span>
-            <span className="text-gray-700">
+            <span className="text-gray-700 dark:text-slate-200">
               {(ingredient as any).smokePoint.fahrenheit}°F /{" "}
               {(ingredient as any).smokePoint.celsius}°C
             </span>
-            <span className="ml-1 text-gray-400">
+            <span className="ml-1 text-gray-400 dark:text-slate-500">
               {(ingredient as any).smokePoint.fahrenheit >= 400
                 ? "(high-heat ok)"
                 : (ingredient as any).smokePoint.fahrenheit >= 350
@@ -971,7 +1183,7 @@ export const EnhancedIngredientRecommender: React.FC<
           Array.isArray((ingredient as any).culinaryApplications.commonUses) &&
           (ingredient as any).culinaryApplications.commonUses.length > 0 && (
             <div className="mb-3">
-              <div className="mb-1 text-xs font-medium text-gray-500">
+              <div className="mb-1 text-xs font-medium text-gray-500 dark:text-slate-400">
                 👨‍🍳 Used in
               </div>
               <div className="flex flex-wrap gap-1">
@@ -980,14 +1192,14 @@ export const EnhancedIngredientRecommender: React.FC<
                   .map((use: string, idx: number) => (
                     <span
                       key={idx}
-                      className="rounded-md border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs text-amber-700"
+                      className="rounded-md border border-amber-200 dark:border-amber-700/50 bg-amber-50 dark:bg-amber-950/40 px-2 py-0.5 text-xs text-amber-700 dark:text-amber-300"
                     >
                       {use}
                     </span>
                   ))}
                 {(ingredient as any).culinaryApplications.commonUses.length >
                   4 && (
-                  <span className="text-xs text-gray-400">
+                  <span className="text-xs text-gray-400 dark:text-slate-500">
                     +
                     {(ingredient as any).culinaryApplications.commonUses
                       .length - 4}{" "}
@@ -1007,8 +1219,8 @@ export const EnhancedIngredientRecommender: React.FC<
           if (!methods || !Array.isArray(methods) || methods.length === 0)
             return null;
           return (
-            <div className="mb-3 text-xs text-gray-600">
-              <span className="font-medium text-gray-500">🍳 Methods: </span>
+            <div className="mb-3 text-xs text-gray-600 dark:text-slate-300">
+              <span className="font-medium text-gray-500 dark:text-slate-400">🍳 Methods: </span>
               {methods.slice(0, 4).join(", ")}
             </div>
           );
@@ -1024,8 +1236,8 @@ export const EnhancedIngredientRecommender: React.FC<
             pr.complementary.length > 0
           ) {
             return (
-              <div className="mb-2 text-xs text-gray-600">
-                <span className="font-medium text-gray-500">
+              <div className="mb-2 text-xs text-gray-600 dark:text-slate-300">
+                <span className="font-medium text-gray-500 dark:text-slate-400">
                   🤝 Pairs with:{" "}
                 </span>
                 {pr.complementary.slice(0, 4).join(", ")}
@@ -1035,8 +1247,8 @@ export const EnhancedIngredientRecommender: React.FC<
           // Simple string array format
           if (Array.isArray(pr) && pr.length > 0) {
             return (
-              <div className="mb-2 text-xs text-gray-600">
-                <span className="font-medium text-gray-500">
+              <div className="mb-2 text-xs text-gray-600 dark:text-slate-300">
+                <span className="font-medium text-gray-500 dark:text-slate-400">
                   🤝 Pairs with:{" "}
                 </span>
                 {(pr as string[]).slice(0, 4).join(", ")}
@@ -1047,8 +1259,8 @@ export const EnhancedIngredientRecommender: React.FC<
           const affinities = (ingredient as any).affinities;
           if (Array.isArray(affinities) && affinities.length > 0) {
             return (
-              <div className="mb-2 text-xs text-gray-600">
-                <span className="font-medium text-gray-500">
+              <div className="mb-2 text-xs text-gray-600 dark:text-slate-300">
+                <span className="font-medium text-gray-500 dark:text-slate-400">
                   🤝 Pairs with:{" "}
                 </span>
                 {(affinities as string[]).slice(0, 4).join(", ")}
@@ -1059,7 +1271,7 @@ export const EnhancedIngredientRecommender: React.FC<
         })()}
 
         {/* ── ORIGIN + SEASONALITY ──────────────────────────── */}
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-gray-400">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-gray-400 dark:text-slate-500">
           {ingredient.origin && ingredient.origin.length > 0 && (
             <span>📍 {ingredient.origin.slice(0, 2).join(", ")}</span>
           )}
@@ -1078,14 +1290,14 @@ export const EnhancedIngredientRecommender: React.FC<
 
         {/* ── HERB / SPICE TIMING TIP ───────────────────────── */}
         {(ingredient as any).timing?.notes && (
-          <div className="mt-2 rounded-md bg-indigo-50 px-2 py-1.5 text-xs text-indigo-700">
+          <div className="mt-2 rounded-md bg-indigo-50 dark:bg-indigo-950/40 px-2 py-1.5 text-xs text-indigo-700 dark:text-indigo-300">
             ⏱️ {(ingredient as any).timing.notes}
           </div>
         )}
 
         {/* Expanded details */}
         {isSelected && (
-          <div className="mt-4 space-y-4 border-t border-gray-200 pt-4">
+          <div className="mt-4 space-y-4 border-t border-gray-200 dark:border-slate-700 pt-4">
             {/* Score Breakdown */}
             {ingredient.scoreBreakdown &&
               renderScoreBreakdown(ingredient.scoreBreakdown)}
@@ -1093,10 +1305,10 @@ export const EnhancedIngredientRecommender: React.FC<
             {/* Origin */}
             {ingredient.origin && ingredient.origin.length > 0 && (
               <div>
-                <div className="mb-1 text-sm font-semibold text-gray-800">
+                <div className="mb-1 text-sm font-semibold text-gray-800 dark:text-slate-100">
                   Origin
                 </div>
-                <div className="text-sm text-gray-600">
+                <div className="text-sm text-gray-600 dark:text-slate-300">
                   {ingredient.origin.join(", ")}
                 </div>
               </div>
@@ -1106,7 +1318,7 @@ export const EnhancedIngredientRecommender: React.FC<
             {(ingredient as any).sensoryProfile &&
               typeof (ingredient as any).sensoryProfile === "object" && (
                 <div>
-                  <div className="mb-2 text-sm font-semibold text-gray-800">
+                  <div className="mb-2 text-sm font-semibold text-gray-800 dark:text-slate-100">
                     Sensory Profile
                   </div>
                   <div className="space-y-2 text-sm">
@@ -1115,7 +1327,7 @@ export const EnhancedIngredientRecommender: React.FC<
                       typeof (ingredient as any).sensoryProfile.taste ===
                         "object" && (
                         <div>
-                          <span className="font-medium text-gray-700">
+                          <span className="font-medium text-gray-700 dark:text-slate-200">
                             Taste:{" "}
                           </span>
                           <div className="mt-1 flex flex-wrap gap-1">
@@ -1129,7 +1341,7 @@ export const EnhancedIngredientRecommender: React.FC<
                               .map(([taste, value]) => (
                                 <span
                                   key={taste}
-                                  className="rounded-md bg-purple-100 px-2 py-1 text-xs text-purple-700"
+                                  className="rounded-md bg-purple-100 dark:bg-purple-900/40 px-2 py-1 text-xs text-purple-700 dark:text-purple-300"
                                 >
                                   {taste} ({Math.round((value as number) * 10)}
                                   /10)
@@ -1144,7 +1356,7 @@ export const EnhancedIngredientRecommender: React.FC<
                       typeof (ingredient as any).sensoryProfile.aroma ===
                         "object" && (
                         <div>
-                          <span className="font-medium text-gray-700">
+                          <span className="font-medium text-gray-700 dark:text-slate-200">
                             Aroma:{" "}
                           </span>
                           <div className="mt-1 flex flex-wrap gap-1">
@@ -1158,7 +1370,7 @@ export const EnhancedIngredientRecommender: React.FC<
                               .map(([aroma, value]) => (
                                 <span
                                   key={aroma}
-                                  className="rounded-md bg-pink-100 px-2 py-1 text-xs text-pink-700"
+                                  className="rounded-md bg-pink-100 dark:bg-pink-900/40 px-2 py-1 text-xs text-pink-700 dark:text-pink-300"
                                 >
                                   {aroma} ({Math.round((value as number) * 10)}
                                   /10)
@@ -1173,7 +1385,7 @@ export const EnhancedIngredientRecommender: React.FC<
                       typeof (ingredient as any).sensoryProfile.texture ===
                         "object" && (
                         <div>
-                          <span className="font-medium text-gray-700">
+                          <span className="font-medium text-gray-700 dark:text-slate-200">
                             Texture:{" "}
                           </span>
                           <div className="mt-1 flex flex-wrap gap-1">
@@ -1187,7 +1399,7 @@ export const EnhancedIngredientRecommender: React.FC<
                               .map(([texture, value]) => (
                                 <span
                                   key={texture}
-                                  className="rounded-md bg-orange-100 px-2 py-1 text-xs text-orange-700"
+                                  className="rounded-md bg-orange-100 dark:bg-orange-900/40 px-2 py-1 text-xs text-orange-700 dark:text-orange-300"
                                 >
                                   {texture} (
                                   {Math.round((value as number) * 10)}
@@ -1204,7 +1416,7 @@ export const EnhancedIngredientRecommender: React.FC<
             {/* Astrological Profile */}
             {ingredient.astrologicalProfile && (
               <div>
-                <div className="mb-2 text-sm font-semibold text-gray-800">
+                <div className="mb-2 text-sm font-semibold text-gray-800 dark:text-slate-100">
                   Astrological Profile
                 </div>
                 <div className="space-y-1 text-sm">
@@ -1213,10 +1425,10 @@ export const EnhancedIngredientRecommender: React.FC<
                       ingredient.astrologicalProfile.rulingPlanets,
                     ) && (
                       <div>
-                        <span className="font-medium text-gray-700">
+                        <span className="font-medium text-gray-700 dark:text-slate-200">
                           Ruling Planets:{" "}
                         </span>
-                        <span className="text-gray-600">
+                        <span className="text-gray-600 dark:text-slate-300">
                           {ingredient.astrologicalProfile.rulingPlanets.join(
                             ", ",
                           )}
@@ -1228,10 +1440,10 @@ export const EnhancedIngredientRecommender: React.FC<
                       ingredient.astrologicalProfile.favorableZodiac,
                     ) && (
                       <div>
-                        <span className="font-medium text-gray-700">
+                        <span className="font-medium text-gray-700 dark:text-slate-200">
                           Favorable Signs:{" "}
                         </span>
-                        <span className="text-gray-600 capitalize">
+                        <span className="text-gray-600 dark:text-slate-300 capitalize">
                           {ingredient.astrologicalProfile.favorableZodiac.join(
                             ", ",
                           )}
@@ -1243,10 +1455,10 @@ export const EnhancedIngredientRecommender: React.FC<
                       (ingredient.astrologicalProfile as any).seasonalAffinity,
                     ) && (
                       <div>
-                        <span className="font-medium text-gray-700">
+                        <span className="font-medium text-gray-700 dark:text-slate-200">
                           Seasonal Affinity:{" "}
                         </span>
-                        <span className="text-gray-600 capitalize">
+                        <span className="text-gray-600 dark:text-slate-300 capitalize">
                           {(
                             ingredient.astrologicalProfile as any
                           ).seasonalAffinity.join(", ")}
@@ -1262,7 +1474,7 @@ export const EnhancedIngredientRecommender: React.FC<
               Array.isArray((ingredient as any).healthBenefits) &&
               (ingredient as any).healthBenefits.length > 0 && (
                 <div>
-                  <div className="mb-1 text-sm font-semibold text-gray-800">
+                  <div className="mb-1 text-sm font-semibold text-gray-800 dark:text-slate-100">
                     Health Benefits
                   </div>
                   <div className="flex flex-wrap gap-1">
@@ -1270,7 +1482,7 @@ export const EnhancedIngredientRecommender: React.FC<
                       (benefit: string, idx: number) => (
                         <span
                           key={idx}
-                          className="rounded-md bg-teal-100 px-2 py-1 text-xs text-teal-700"
+                          className="rounded-md bg-teal-100 dark:bg-teal-900/40 px-2 py-1 text-xs text-teal-700 dark:text-teal-300"
                         >
                           {benefit}
                         </span>
@@ -1283,7 +1495,7 @@ export const EnhancedIngredientRecommender: React.FC<
             {/* Pairing Recommendations */}
             {ingredient.pairingRecommendations && (
               <div>
-                <div className="mb-2 text-sm font-semibold text-gray-800">
+                <div className="mb-2 text-sm font-semibold text-gray-800 dark:text-slate-100">
                   Pairings
                 </div>
                 {(() => {
@@ -1293,10 +1505,10 @@ export const EnhancedIngredientRecommender: React.FC<
                     return (
                       <div className="space-y-1 text-sm">
                         <div>
-                          <span className="font-medium text-green-700">
+                          <span className="font-medium text-green-700 dark:text-green-300">
                             Pairs well with:{" "}
                           </span>
-                          <span className="text-gray-600">
+                          <span className="text-gray-600 dark:text-slate-300">
                             {(pr as string[]).join(", ")}
                           </span>
                         </div>
@@ -1308,30 +1520,30 @@ export const EnhancedIngredientRecommender: React.FC<
                     <div className="space-y-1 text-sm">
                       {pr?.complementary && Array.isArray(pr.complementary) && (
                         <div>
-                          <span className="font-medium text-green-700">
+                          <span className="font-medium text-green-700 dark:text-green-300">
                             Complementary:{" "}
                           </span>
-                          <span className="text-gray-600">
+                          <span className="text-gray-600 dark:text-slate-300">
                             {pr.complementary.join(", ")}
                           </span>
                         </div>
                       )}
                       {pr?.contrasting && Array.isArray(pr.contrasting) && (
                         <div>
-                          <span className="font-medium text-orange-700">
+                          <span className="font-medium text-orange-700 dark:text-orange-300">
                             Contrasting:{" "}
                           </span>
-                          <span className="text-gray-600">
+                          <span className="text-gray-600 dark:text-slate-300">
                             {pr.contrasting.join(", ")}
                           </span>
                         </div>
                       )}
                       {pr?.toAvoid && Array.isArray(pr.toAvoid) && (
                         <div>
-                          <span className="font-medium text-red-700">
+                          <span className="font-medium text-red-700 dark:text-red-300">
                             Avoid:{" "}
                           </span>
-                          <span className="text-gray-600">
+                          <span className="text-gray-600 dark:text-slate-300">
                             {pr.toAvoid.join(", ")}
                           </span>
                         </div>
@@ -1345,7 +1557,7 @@ export const EnhancedIngredientRecommender: React.FC<
             {/* Elemental Properties */}
             {ingredient.elementalProperties && (
               <div>
-                <div className="mb-2 text-sm font-semibold text-gray-800">
+                <div className="mb-2 text-sm font-semibold text-gray-800 dark:text-slate-100">
                   Elemental Balance
                 </div>
                 {renderElementalProperties(ingredient.elementalProperties)}
@@ -1355,17 +1567,17 @@ export const EnhancedIngredientRecommender: React.FC<
             {/* Alchemical Properties + KAlchm */}
             {ingredient.alchemicalProperties && (
               <div>
-                <div className="mb-2 text-sm font-semibold text-gray-800">
+                <div className="mb-2 text-sm font-semibold text-gray-800 dark:text-slate-100">
                   Alchemical Properties
                 </div>
                 <div className="grid grid-cols-2 gap-2 text-sm">
                   {Object.entries(ingredient.alchemicalProperties).map(
                     ([prop, value]) => (
                       <div key={prop} className="flex justify-between">
-                        <span className="font-medium text-gray-700">
+                        <span className="font-medium text-gray-700 dark:text-slate-200">
                           {prop}:
                         </span>
-                        <span className="text-gray-600">
+                        <span className="text-gray-600 dark:text-slate-300">
                           {Number(value).toFixed(3)}
                         </span>
                       </div>
@@ -1387,11 +1599,11 @@ export const EnhancedIngredientRecommender: React.FC<
                       : null);
                   if (kalchmValue == null) return null;
                   return (
-                    <div className="mt-2 flex items-center justify-between rounded-md bg-indigo-50 px-3 py-2">
-                      <span className="text-sm font-semibold text-indigo-800">
+                    <div className="mt-2 flex items-center justify-between rounded-md bg-indigo-50 dark:bg-indigo-950/40 px-3 py-2">
+                      <span className="text-sm font-semibold text-indigo-800 dark:text-indigo-200">
                         K<sub>alchm</sub>
                       </span>
-                      <span className="text-sm font-bold text-indigo-700">
+                      <span className="text-sm font-bold text-indigo-700 dark:text-indigo-300">
                         {Number(kalchmValue).toFixed(4)}
                       </span>
                     </div>
@@ -1410,14 +1622,14 @@ export const EnhancedIngredientRecommender: React.FC<
                 return null;
               return (
                 <div>
-                  <div className="mb-1 text-sm font-semibold text-gray-800">
+                  <div className="mb-1 text-sm font-semibold text-gray-800 dark:text-slate-100">
                     Cooking Methods
                   </div>
                   <div className="flex flex-wrap gap-1">
                     {methods.map((method: string, idx: number) => (
                       <span
                         key={idx}
-                        className="rounded-md bg-blue-100 px-2 py-1 text-xs text-blue-700"
+                        className="rounded-md bg-blue-100 px-2 py-1 text-xs text-blue-700 dark:text-blue-300"
                       >
                         {method}
                       </span>
@@ -1431,30 +1643,30 @@ export const EnhancedIngredientRecommender: React.FC<
             {(ingredient as any).storage &&
               typeof (ingredient as any).storage === "object" && (
                 <div>
-                  <div className="mb-1 text-sm font-semibold text-gray-800">
+                  <div className="mb-1 text-sm font-semibold text-gray-800 dark:text-slate-100">
                     Storage
                   </div>
-                  <div className="space-y-1 text-sm text-gray-600">
+                  <div className="space-y-1 text-sm text-gray-600 dark:text-slate-300">
                     {(ingredient as any).storage.temperature && (
                       <div>
-                        <span className="font-medium text-gray-700">🌡️ </span>
+                        <span className="font-medium text-gray-700 dark:text-slate-200">🌡️ </span>
                         {(ingredient as any).storage.temperature}
                       </div>
                     )}
                     {(ingredient as any).storage.duration && (
                       <div>
-                        <span className="font-medium text-gray-700">⏱️ </span>
+                        <span className="font-medium text-gray-700 dark:text-slate-200">⏱️ </span>
                         {(ingredient as any).storage.duration}
                       </div>
                     )}
                     {(ingredient as any).storage.container && (
                       <div>
-                        <span className="font-medium text-gray-700">📦 </span>
+                        <span className="font-medium text-gray-700 dark:text-slate-200">📦 </span>
                         {(ingredient as any).storage.container}
                       </div>
                     )}
                     {(ingredient as any).storage.notes && (
-                      <div className="text-xs text-gray-500 italic">
+                      <div className="text-xs text-gray-500 dark:text-slate-400 italic">
                         {(ingredient as any).storage.notes}
                       </div>
                     )}
@@ -1466,17 +1678,17 @@ export const EnhancedIngredientRecommender: React.FC<
             {(ingredient as any).preparation &&
               typeof (ingredient as any).preparation === "object" && (
                 <div>
-                  <div className="mb-1 text-sm font-semibold text-gray-800">
+                  <div className="mb-1 text-sm font-semibold text-gray-800 dark:text-slate-100">
                     Preparation
                   </div>
-                  <div className="space-y-1 text-sm text-gray-600">
+                  <div className="space-y-1 text-sm text-gray-600 dark:text-slate-300">
                     {typeof (ingredient as any).preparation === "object" &&
                       !Array.isArray((ingredient as any).preparation) && (
                         <>
                           {(ingredient as any).preparation.washing !==
                             undefined && (
                             <div>
-                              <span className="font-medium text-gray-700">
+                              <span className="font-medium text-gray-700 dark:text-slate-200">
                                 Washing:{" "}
                               </span>
                               {(ingredient as any).preparation.washing
@@ -1486,7 +1698,7 @@ export const EnhancedIngredientRecommender: React.FC<
                           )}
                           {(ingredient as any).preparation.peeling && (
                             <div>
-                              <span className="font-medium text-gray-700">
+                              <span className="font-medium text-gray-700 dark:text-slate-200">
                                 Peeling:{" "}
                               </span>
                               {(ingredient as any).preparation.peeling}
@@ -1494,7 +1706,7 @@ export const EnhancedIngredientRecommender: React.FC<
                           )}
                           {(ingredient as any).preparation.cutting && (
                             <div>
-                              <span className="font-medium text-gray-700">
+                              <span className="font-medium text-gray-700 dark:text-slate-200">
                                 Cutting:{" "}
                               </span>
                               {(ingredient as any).preparation.cutting}
@@ -1502,7 +1714,7 @@ export const EnhancedIngredientRecommender: React.FC<
                           )}
                           {(ingredient as any).preparation.selection && (
                             <div>
-                              <span className="font-medium text-gray-700">
+                              <span className="font-medium text-gray-700 dark:text-slate-200">
                                 Selection:{" "}
                               </span>
                               {(ingredient as any).preparation.selection}
@@ -1511,7 +1723,7 @@ export const EnhancedIngredientRecommender: React.FC<
                           {(ingredient as any).preparation.notes &&
                             typeof (ingredient as any).preparation.notes ===
                               "string" && (
-                              <div className="text-xs text-gray-500 italic">
+                              <div className="text-xs text-gray-500 dark:text-slate-400 italic">
                                 {(ingredient as any).preparation.notes}
                               </div>
                             )}
@@ -1520,10 +1732,10 @@ export const EnhancedIngredientRecommender: React.FC<
                               (ingredient as any).preparation.tips,
                             ) && (
                               <div className="mt-1">
-                                <span className="font-medium text-gray-700">
+                                <span className="font-medium text-gray-700 dark:text-slate-200">
                                   Tips:{" "}
                                 </span>
-                                <ul className="ml-4 list-disc text-xs text-gray-500">
+                                <ul className="ml-4 list-disc text-xs text-gray-500 dark:text-slate-400">
                                   {(
                                     (ingredient as any).preparation
                                       .tips as string[]
@@ -1548,18 +1760,18 @@ export const EnhancedIngredientRecommender: React.FC<
               const macros = np.macros || {};
               return (
                 <div>
-                  <div className="mb-1 text-sm font-semibold text-gray-800">
+                  <div className="mb-1 text-sm font-semibold text-gray-800 dark:text-slate-100">
                     Nutritional Details
                   </div>
                   {np.serving_size && (
-                    <div className="mb-1 text-xs text-gray-400">
+                    <div className="mb-1 text-xs text-gray-400 dark:text-slate-500">
                       Per {np.serving_size}
                     </div>
                   )}
                   <div className="grid grid-cols-2 gap-1 text-sm">
                     {np.calories != null && (
                       <div className="flex justify-between">
-                        <span className="text-gray-600">Calories:</span>
+                        <span className="text-gray-600 dark:text-slate-300">Calories:</span>
                         <span className="font-medium">
                           {Math.round(np.calories)}
                         </span>
@@ -1567,7 +1779,7 @@ export const EnhancedIngredientRecommender: React.FC<
                     )}
                     {(macros.protein ?? np.protein) != null && (
                       <div className="flex justify-between">
-                        <span className="text-gray-600">Protein:</span>
+                        <span className="text-gray-600 dark:text-slate-300">Protein:</span>
                         <span className="font-medium">
                           {macros.protein ?? np.protein}g
                         </span>
@@ -1575,7 +1787,7 @@ export const EnhancedIngredientRecommender: React.FC<
                     )}
                     {(macros.carbs ?? np.carbs) != null && (
                       <div className="flex justify-between">
-                        <span className="text-gray-600">Carbs:</span>
+                        <span className="text-gray-600 dark:text-slate-300">Carbs:</span>
                         <span className="font-medium">
                           {macros.carbs ?? np.carbs}g
                         </span>
@@ -1583,7 +1795,7 @@ export const EnhancedIngredientRecommender: React.FC<
                     )}
                     {(macros.fat ?? np.fat) != null && (
                       <div className="flex justify-between">
-                        <span className="text-gray-600">Fat:</span>
+                        <span className="text-gray-600 dark:text-slate-300">Fat:</span>
                         <span className="font-medium">
                           {macros.fat ?? np.fat}g
                         </span>
@@ -1591,13 +1803,13 @@ export const EnhancedIngredientRecommender: React.FC<
                     )}
                     {macros.fiber != null && macros.fiber > 0 && (
                       <div className="flex justify-between">
-                        <span className="text-gray-600">Fiber:</span>
+                        <span className="text-gray-600 dark:text-slate-300">Fiber:</span>
                         <span className="font-medium">{macros.fiber}g</span>
                       </div>
                     )}
                     {macros.sugar != null && macros.sugar > 0 && (
                       <div className="flex justify-between">
-                        <span className="text-gray-600">Sugar:</span>
+                        <span className="text-gray-600 dark:text-slate-300">Sugar:</span>
                         <span className="font-medium">{macros.sugar}g</span>
                       </div>
                     )}
@@ -1606,8 +1818,8 @@ export const EnhancedIngredientRecommender: React.FC<
                     typeof np.vitamins === "object" &&
                     Object.keys(np.vitamins).length > 0 &&
                     !Array.isArray(np.vitamins) && (
-                      <div className="mt-1 text-xs text-gray-500">
-                        <span className="font-medium text-gray-600">
+                      <div className="mt-1 text-xs text-gray-500 dark:text-slate-400">
+                        <span className="font-medium text-gray-600 dark:text-slate-300">
                           Vitamins:{" "}
                         </span>
                         {Object.keys(np.vitamins).join(", ").toUpperCase()}
@@ -1617,8 +1829,8 @@ export const EnhancedIngredientRecommender: React.FC<
                     typeof np.minerals === "object" &&
                     Object.keys(np.minerals).length > 0 &&
                     !Array.isArray(np.minerals) && (
-                      <div className="text-xs text-gray-500">
-                        <span className="font-medium text-gray-600">
+                      <div className="text-xs text-gray-500 dark:text-slate-400">
+                        <span className="font-medium text-gray-600 dark:text-slate-300">
                           Minerals:{" "}
                         </span>
                         {Object.keys(np.minerals).join(", ")}
@@ -1631,7 +1843,7 @@ export const EnhancedIngredientRecommender: React.FC<
             {/* Thermodynamic Properties */}
             {(ingredient as any).thermodynamicProperties && (
               <div>
-                <div className="mb-2 text-sm font-semibold text-gray-800">
+                <div className="mb-2 text-sm font-semibold text-gray-800 dark:text-slate-100">
                   Thermodynamic Properties
                 </div>
                 <div className="grid grid-cols-2 gap-2 text-sm">
@@ -1639,10 +1851,10 @@ export const EnhancedIngredientRecommender: React.FC<
                     (ingredient as any).thermodynamicProperties,
                   ).map(([prop, value]: [string, any]) => (
                     <div key={prop} className="flex justify-between">
-                      <span className="font-medium text-gray-700 capitalize">
+                      <span className="font-medium text-gray-700 dark:text-slate-200 capitalize">
                         {prop}:
                       </span>
-                      <span className="text-gray-600">
+                      <span className="text-gray-600 dark:text-slate-300">
                         {typeof value === "number"
                           ? Number(value).toFixed(3)
                           : value}
@@ -1658,7 +1870,7 @@ export const EnhancedIngredientRecommender: React.FC<
               Array.isArray((ingredient as any).parts_used) &&
               (ingredient as any).parts_used.length > 0 && (
                 <div>
-                  <div className="mb-1 text-sm font-semibold text-gray-800">
+                  <div className="mb-1 text-sm font-semibold text-gray-800 dark:text-slate-100">
                     Parts Used
                   </div>
                   <div className="flex flex-wrap gap-1">
@@ -1666,7 +1878,7 @@ export const EnhancedIngredientRecommender: React.FC<
                       (part: string, idx: number) => (
                         <span
                           key={idx}
-                          className="rounded-md bg-violet-100 px-2 py-1 text-xs text-violet-700"
+                          className="rounded-md bg-violet-100 dark:bg-violet-900/40 px-2 py-1 text-xs text-violet-700 dark:text-violet-300"
                         >
                           {part}
                         </span>
@@ -1682,7 +1894,7 @@ export const EnhancedIngredientRecommender: React.FC<
               !Array.isArray((ingredient as any).properties) &&
               Object.keys((ingredient as any).properties).length > 0 && (
                 <div>
-                  <div className="mb-1 text-sm font-semibold text-gray-800">
+                  <div className="mb-1 text-sm font-semibold text-gray-800 dark:text-slate-100">
                     Medicinal Properties
                   </div>
                   <div className="space-y-1 text-sm">
@@ -1690,10 +1902,10 @@ export const EnhancedIngredientRecommender: React.FC<
                       (ingredient as any).properties as Record<string, string>,
                     ).map(([key, val]) => (
                       <div key={key}>
-                        <span className="font-medium capitalize text-teal-700">
+                        <span className="font-medium capitalize text-teal-700 dark:text-teal-300">
                           {key.replace(/_/g, " ")}:{" "}
                         </span>
-                        <span className="text-gray-600">{String(val)}</span>
+                        <span className="text-gray-600 dark:text-slate-300">{String(val)}</span>
                       </div>
                     ))}
                   </div>
@@ -1705,7 +1917,7 @@ export const EnhancedIngredientRecommender: React.FC<
               Array.isArray((ingredient as any).affinities) &&
               (ingredient as any).affinities.length > 0 && (
                 <div>
-                  <div className="mb-1 text-sm font-semibold text-gray-800">
+                  <div className="mb-1 text-sm font-semibold text-gray-800 dark:text-slate-100">
                     Affinities
                   </div>
                   <div className="flex flex-wrap gap-1">
@@ -1713,7 +1925,7 @@ export const EnhancedIngredientRecommender: React.FC<
                       (affinity: string, idx: number) => (
                         <span
                           key={idx}
-                          className="rounded-md bg-green-50 border border-green-200 px-2 py-0.5 text-xs text-green-700"
+                          className="rounded-md bg-green-50 border border-green-200 px-2 py-0.5 text-xs text-green-700 dark:text-green-300"
                         >
                           {affinity}
                         </span>
@@ -1732,10 +1944,10 @@ export const EnhancedIngredientRecommender: React.FC<
               if (!desc || typeof desc !== "string") return null;
               return (
                 <div>
-                  <div className="mb-1 text-sm font-semibold text-gray-800">
+                  <div className="mb-1 text-sm font-semibold text-gray-800 dark:text-slate-100">
                     Flavor Notes
                   </div>
-                  <p className="text-sm italic text-gray-600">{desc}</p>
+                  <p className="text-sm italic text-gray-600 dark:text-slate-300">{desc}</p>
                 </div>
               );
             })()}
@@ -1749,14 +1961,14 @@ export const EnhancedIngredientRecommender: React.FC<
                 return null;
               return (
                 <div>
-                  <div className="mb-1 text-sm font-semibold text-gray-800">
+                  <div className="mb-1 text-sm font-semibold text-gray-800 dark:text-slate-100">
                     Culinary Uses
                   </div>
                   <div className="flex flex-wrap gap-1">
                     {uses.map((use: string, idx: number) => (
                       <span
                         key={idx}
-                        className="rounded-md border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs text-amber-700"
+                        className="rounded-md border border-amber-200 dark:border-amber-700/50 bg-amber-50 dark:bg-amber-950/40 px-2 py-0.5 text-xs text-amber-700 dark:text-amber-300"
                       >
                         {use}
                       </span>
@@ -1771,7 +1983,7 @@ export const EnhancedIngredientRecommender: React.FC<
               typeof (ingredient as any).varieties === "object" &&
               Object.keys((ingredient as any).varieties).length > 0 && (
                 <div>
-                  <div className="mb-1 text-sm font-semibold text-gray-800">
+                  <div className="mb-1 text-sm font-semibold text-gray-800 dark:text-slate-100">
                     Varieties
                   </div>
                   <div className="flex flex-wrap gap-1">
@@ -1779,7 +1991,7 @@ export const EnhancedIngredientRecommender: React.FC<
                       (v, idx) => (
                         <span
                           key={idx}
-                          className="rounded-md bg-sky-100 px-2 py-0.5 text-xs capitalize text-sky-700"
+                          className="rounded-md bg-sky-100 dark:bg-sky-900/40 px-2 py-0.5 text-xs capitalize text-sky-700 dark:text-sky-300"
                         >
                           {v.replace(/_/g, " ")}
                         </span>
@@ -1800,7 +2012,7 @@ export const EnhancedIngredientRecommender: React.FC<
       <div className="flex items-center justify-center p-12">
         <div className="text-center">
           <div className="mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-b-4 border-indigo-600" />
-          <p className="text-gray-600">Loading ingredients...</p>
+          <p className="text-gray-600 dark:text-slate-300">Loading ingredients...</p>
         </div>
       </div>
     );
@@ -1824,8 +2036,8 @@ export const EnhancedIngredientRecommender: React.FC<
       {/* Selected category indicator */}
       {selectedCategory && (
         <div className="mb-4 flex items-center gap-2">
-          <span className="text-sm text-gray-600">Showing:</span>
-          <span className="rounded-full bg-indigo-100 px-3 py-1 text-sm font-medium text-indigo-800">
+          <span className="text-sm text-gray-600 dark:text-slate-300">Showing:</span>
+          <span className="rounded-full bg-indigo-100 dark:bg-indigo-900/50 px-3 py-1 text-sm font-medium text-indigo-800 dark:text-indigo-200">
             {CATEGORIES.find((c) => c.id === selectedCategory)?.name}
           </span>
           <button
@@ -1841,7 +2053,7 @@ export const EnhancedIngredientRecommender: React.FC<
       )}
 
       {/* Results count */}
-      <div className="mb-4 text-sm text-gray-600">
+      <div className="mb-4 text-sm text-gray-600 dark:text-slate-300">
         Showing {displayedIngredients.length}
         {remainingCount > 0 ? ` of ${scoredIngredients.length}` : ""} ingredient
         {scoredIngredients.length !== 1 ? "s" : ""} (sorted by compatibility)
@@ -1859,7 +2071,7 @@ export const EnhancedIngredientRecommender: React.FC<
             onClick={() =>
               handleToggleExpand(selectedCategory || ALL_INGREDIENTS_KEY)
             }
-            className="group flex items-center gap-2 rounded-lg border-2 border-indigo-200 bg-white px-6 py-3 text-indigo-700 transition-all hover:border-indigo-400 hover:bg-indigo-50 hover:shadow-md"
+            className="group flex items-center gap-2 rounded-lg border-2 border-indigo-200 dark:border-indigo-700/60 bg-white dark:bg-slate-900 px-6 py-3 text-indigo-700 dark:text-indigo-300 transition-all hover:border-indigo-400 hover:bg-indigo-50 hover:shadow-md"
           >
             {currentCategoryExpanded ? (
               <>
@@ -1904,7 +2116,7 @@ export const EnhancedIngredientRecommender: React.FC<
       )}
 
       {displayedIngredients.length === 0 && (
-        <div className="py-12 text-center text-gray-500">
+        <div className="py-12 text-center text-gray-500 dark:text-slate-400">
           {searchQuery || selectedCategory
             ? "No ingredients match your filters."
             : "No ingredients available at this time."}

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,48 +1,107 @@
 'use client';
 
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import type { ReactNode } from 'react';
 
+export type ThemePreference = 'light' | 'dark' | 'system';
+export type ResolvedTheme = 'light' | 'dark';
+
 interface ThemeContextType {
-  theme: 'light' | 'dark';
-  isDiurnal: boolean; // True during daytime, false during nighttime
-  toggleTheme: () => void;
-  setThemeBase: (isDiurnal: boolean) => void;
+  /** User-selected preference: explicit light, explicit dark, or "system" (= follow time of day) */
+  preference: ThemePreference;
+  /** The actual resolved theme being applied to the DOM */
+  theme: ResolvedTheme;
+  /** True during local daytime (06:00–18:00). Drives diurnal/nocturnal alchemy quantity bias. */
+  isDiurnal: boolean;
+  /** Set the user's explicit preference. 'system' falls back to day/night auto-switching. */
+  setPreference: (pref: ThemePreference) => void;
+  /** Quick toggle: cycles light → dark → system → light. */
+  cycleTheme: () => void;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+const STORAGE_KEY = 'alchm-theme-preference';
+
+function computeDiurnal(date = new Date()): boolean {
+  const hour = date.getHours();
+  return hour >= 6 && hour < 18;
+}
+
+function resolveTheme(preference: ThemePreference, isDiurnal: boolean): ResolvedTheme {
+  if (preference === 'system') return isDiurnal ? 'light' : 'dark';
+  return preference;
+}
 
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
-  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  // SSR-safe defaults: assume dark + nighttime; client effect corrects on mount
+  const [preference, setPreferenceState] = useState<ThemePreference>('system');
+  const [isDiurnal, setIsDiurnal] = useState<boolean>(false);
+  const [theme, setTheme] = useState<ResolvedTheme>('dark');
 
+  // Hydrate preference from localStorage + initial diurnal calc
   useEffect(() => {
-    // Automatically set theme based on user's current local hour (Diurnal vs Nocturnal)
-    const hour = new Date().getHours();
-    const isDayTime = hour >= 6 && hour < 18;
-    setTheme(isDayTime ? 'light' : 'dark');
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY) as ThemePreference | null;
+      const initialPref: ThemePreference =
+        stored === 'light' || stored === 'dark' || stored === 'system' ? stored : 'system';
+      const diurnal = computeDiurnal();
+      setPreferenceState(initialPref);
+      setIsDiurnal(diurnal);
+      setTheme(resolveTheme(initialPref, diurnal));
+    } catch {
+      // localStorage may be unavailable (SSR fallback / private mode)
+    }
   }, []);
 
-  const toggleTheme = () => {
-    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
-  };
-
-  const setThemeBase = (isDiurnal: boolean) => {
-    setTheme(isDiurnal ? 'light' : 'dark');
-  };
-
+  // Re-check time of day every 5 minutes so 'system' theme flips at sunrise/sunset
   useEffect(() => {
-    // Apply theme to document
-    document.documentElement.setAttribute('data-theme', theme);
-    if (theme === 'dark') {
-      document.documentElement.classList.add('dark');
-    } else {
-      document.documentElement.classList.remove('dark');
-    }
+    const interval = setInterval(() => {
+      const next = computeDiurnal();
+      setIsDiurnal((prev) => (prev === next ? prev : next));
+    }, 5 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Recompute resolved theme whenever preference or isDiurnal changes
+  useEffect(() => {
+    setTheme(resolveTheme(preference, isDiurnal));
+  }, [preference, isDiurnal]);
+
+  // Apply resolved theme to DOM
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    root.setAttribute('data-theme', theme);
+    root.classList.toggle('dark', theme === 'dark');
+    root.style.colorScheme = theme;
   }, [theme]);
 
-  const isDiurnal = theme === 'light';
+  const setPreference = useCallback((pref: ThemePreference) => {
+    setPreferenceState(pref);
+    try {
+      localStorage.setItem(STORAGE_KEY, pref);
+    } catch {
+      /* ignore */
+    }
+  }, []);
 
-  return <ThemeContext.Provider value={{ theme, isDiurnal, toggleTheme, setThemeBase }}>{children}</ThemeContext.Provider>;
+  const cycleTheme = useCallback(() => {
+    setPreferenceState((prev) => {
+      const next: ThemePreference = prev === 'light' ? 'dark' : prev === 'dark' ? 'system' : 'light';
+      try {
+        localStorage.setItem(STORAGE_KEY, next);
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ preference, theme, isDiurnal, setPreference, cycleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
 };
 
 export const useTheme = () => {

--- a/src/data/ingredients/beverages/beverages.ts
+++ b/src/data/ingredients/beverages/beverages.ts
@@ -6,6 +6,8 @@ const rawBeverages: Record<string, Partial<IngredientMapping>> = {
   red_wine_vinaigrette: {
       description: "An alcoholic beverage fermented from the juice of grapes (*Vitis vinifera*), functioning as a crucial source of acid, aroma, and complexity in cooking. Dry white wines contribute bright tartness and fruit notes to seafood and poultry pan sauces, while robust red wines provide tannins and deep fruit flavors essential for long-simmered beef or lamb braises. Alcohol serves as a solvent, releasing flavor compounds in foods that are insoluble in water or fat.",
     name: "red wine vinaigrette",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.4, Earth: 0.1, Air: 0.3 },
     scaledElemental: { Fire: 0.2, Water: 0.4, Earth: 0.1, Air: 0.3 },
     quantityBase: { amount: 30, unit: "ml" },
@@ -47,6 +49,8 @@ const rawBeverages: Record<string, Partial<IngredientMapping>> = {
   clam_juice: {
       description: "A bivalve mollusk providing a briny, chewy, and distinctly oceanic flavor. Hard-shell clams (like littlenecks or cherrystones) are perfect for eating raw or tossing into pastas, while softer-shelled varieties (like steamers) are excellent for frying or broths.\n\n**Selection & Storage:** Buy clams that are tightly closed; if slightly open, they should snap shut when tapped. Store them in a breathable bag or bowl covered with a damp cloth in the refrigerator.",
     name: "clam juice",
+    origin: ["Worldwide coastal waters"],
+    season: ["fall", "winter", "spring"],
     elementalProperties: { Fire: 0.1, Water: 0.6, Earth: 0.2, Air: 0.1 },
     scaledElemental: { Fire: 0.1, Water: 0.6, Earth: 0.2, Air: 0.1 },
     quantityBase: { amount: 240, unit: "ml" },
@@ -88,6 +92,8 @@ const rawBeverages: Record<string, Partial<IngredientMapping>> = {
   white_wine: {
       description: "A fermented beverage made from light-colored grapes. In cooking, its sharp acidity (tartaric and malic acids) tenderizes proteins, its alcohol dissolves complex flavor compounds, and it provides a bright, fruity foundation for classic sauces like beurre blanc or pan deglazing.",
     name: "white wine",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.5, Earth: 0.1, Air: 0.3 },
     scaledElemental: { Fire: 0.1, Water: 0.5, Earth: 0.1, Air: 0.3 },
     quantityBase: { amount: 148, unit: "ml" },
@@ -129,6 +135,8 @@ const rawBeverages: Record<string, Partial<IngredientMapping>> = {
   red_wine: {
       description: "A fermented beverage made from dark-colored grapes, fermented with their skins. It imparts deep color, robust fruit flavors, and astringent tannins, making it the essential braising liquid for hearty, slow-cooked beef dishes like Boeuf Bourguignon.",
     name: "red wine",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.4, Earth: 0.2, Air: 0.2 },
     scaledElemental: { Fire: 0.2, Water: 0.4, Earth: 0.2, Air: 0.2 },
     quantityBase: { amount: 148, unit: "ml" },
@@ -170,6 +178,8 @@ const rawBeverages: Record<string, Partial<IngredientMapping>> = {
   turkey_stock: {
       description: "A large poultry bird (*Meleagris gallopavo*) that yields exceptionally lean, mildly flavored meat. Due to the stark structural differences between its white breast meat (which cooks quickly and dries out) and dark leg meat (which requires longer cooking to break down collagen), it often requires careful heat management or brining.\n\n**Selection & Storage:** Fresh turkey meat should look plump, firm, and slightly pink with no off-odors. Keep fresh turkey refrigerated at 40°F (4°C) or below and use within two days.",
     name: "turkey stock",
+    origin: ["Mesoamerica"],
+    season: ["fall", "winter"],
     elementalProperties: { Fire: 0.1, Water: 0.5, Earth: 0.3, Air: 0.1 },
     scaledElemental: { Fire: 0.1, Water: 0.5, Earth: 0.3, Air: 0.1 },
     quantityBase: { amount: 240, unit: "ml" },
@@ -211,6 +221,8 @@ const rawBeverages: Record<string, Partial<IngredientMapping>> = {
   water: {
       description: "The universal solvent and culinary liquid — mineral content and temperature both matter more than is usually recognized. Hard water (high calcium, magnesium) inhibits yeast and affects coffee extraction; filtered or bottled water produces cleaner stock and clearer broth. Ice-cold water relaxes doughs; just-off-boil water extracts tea; room-temperature water shortens rest times in pastry. Recipe measurements assume volumetric consistency — weigh water (1 mL = 1 g) for precision in baking.",
     name: "Water",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.0, Water: 0.8, Earth: 0.1, Air: 0.1 },
     scaledElemental: { Fire: 0.0, Water: 0.8, Earth: 0.1, Air: 0.1 },
     quantityBase: { amount: 240, unit: "ml" },
@@ -252,6 +264,8 @@ const rawBeverages: Record<string, Partial<IngredientMapping>> = {
   baking_soda: {
       description: "Pure sodium bicarbonate, a chemical base that requires the addition of an acidic ingredient (like buttermilk, yogurt, or lemon juice) to react and produce carbon dioxide gas. In addition to leavening, it dramatically accelerates browning (the Maillard reaction) by raising the pH of the batter.",
     name: "baking soda",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.1, Earth: 0.6, Air: 0.2 },
     scaledElemental: { Fire: 0.1, Water: 0.1, Earth: 0.6, Air: 0.2 },
     quantityBase: { amount: 4.6, unit: "g" },
@@ -293,6 +307,8 @@ const rawBeverages: Record<string, Partial<IngredientMapping>> = {
   coffee: {
       description: "Coffee is a liquid culinary ingredient used for hydration, extraction, and flavor transport. Temperature and dilution directly affect aroma release and mouthfeel, so tune handling to the dish rather than treating it as neutral water. Store as directed and keep containers sealed between uses to preserve freshness.",
     name: "coffee",
+    origin: ["Ethiopia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.3, Earth: 0.1, Air: 0.3 },
     scaledElemental: { Fire: 0.3, Water: 0.3, Earth: 0.1, Air: 0.3 },
     quantityBase: { amount: 240, unit: "ml" },
@@ -334,6 +350,8 @@ const rawBeverages: Record<string, Partial<IngredientMapping>> = {
   dry_white_wine: {
       description: "An alcoholic beverage fermented from the juice of grapes (*Vitis vinifera*), functioning as a crucial source of acid, aroma, and complexity in cooking. Dry white wines contribute bright tartness and fruit notes to seafood and poultry pan sauces, while robust red wines provide tannins and deep fruit flavors essential for long-simmered beef or lamb braises. Alcohol serves as a solvent, releasing flavor compounds in foods that are insoluble in water or fat.",
     name: "dry white wine",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.5, Earth: 0.1, Air: 0.3 },
     scaledElemental: { Fire: 0.1, Water: 0.5, Earth: 0.1, Air: 0.3 },
     quantityBase: { amount: 148, unit: "ml" },
@@ -375,6 +393,8 @@ const rawBeverages: Record<string, Partial<IngredientMapping>> = {
   white_wine_vinegar: {
       description: "A bright, moderately sharp vinegar made by fermenting white wine. It is significantly less assertive and tannic than red wine vinegar, offering a delicate, slightly floral acidity that perfectly balances lighter dishes like chicken salads, delicate fish, or hollandaise sauce.",
     name: "white wine vinegar",
+    origin: ["Europe"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.4, Earth: 0.1, Air: 0.3 },
     scaledElemental: { Fire: 0.2, Water: 0.4, Earth: 0.1, Air: 0.3 },
     quantityBase: { amount: 15, unit: "ml" },
@@ -416,6 +436,8 @@ const rawBeverages: Record<string, Partial<IngredientMapping>> = {
   tea_bags: {
       description: "Tea Bags is a liquid culinary ingredient used for hydration, extraction, and flavor transport. Temperature and dilution directly affect aroma release and mouthfeel, so tune handling to the dish rather than treating it as neutral water. Store as directed and keep containers sealed between uses to preserve freshness.",
     name: "tea bags",
+    origin: ["Southwest China"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.4, Earth: 0.1, Air: 0.4 },
     scaledElemental: { Fire: 0.1, Water: 0.4, Earth: 0.1, Air: 0.4 },
     quantityBase: { amount: 240, unit: "ml" },
@@ -457,6 +479,8 @@ const rawBeverages: Record<string, Partial<IngredientMapping>> = {
   rose_water: {
       description: "The universal solvent and culinary liquid — mineral content and temperature both matter more than is usually recognized. Hard water (high calcium, magnesium) inhibits yeast and affects coffee extraction; filtered or bottled water produces cleaner stock and clearer broth. Ice-cold water relaxes doughs; just-off-boil water extracts tea; room-temperature water shortens rest times in pastry. Recipe measurements assume volumetric consistency — weigh water (1 mL = 1 g) for precision in baking.",
     name: "rose water",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.0, Water: 0.6, Earth: 0.0, Air: 0.4 },
     scaledElemental: { Fire: 0.0, Water: 0.6, Earth: 0.0, Air: 0.4 },
     quantityBase: { amount: 15, unit: "ml" },
@@ -498,6 +522,8 @@ const rawBeverages: Record<string, Partial<IngredientMapping>> = {
   water_chestnuts: {
       description: "An aquatic tuber (*Eleocharis dulcis*) grown in marshes, prized for a structural uniqueness: it retains a profound, apple-like crispness even after prolonged cooking. Its mild sweetness provides essential textural contrast in rich stir-fries and dim sum fillings.\n\n**Selection & Storage:** Fresh water chestnuts are superior but difficult to find; look for firm, unwrinkled tubers. Canned ones are widely available; rinse well to remove any tinny flavor before using.",
     name: "water chestnuts",
+    origin: ["Europe"],
+    season: ["fall"],
     elementalProperties: { Fire: 0.0, Water: 0.4, Earth: 0.4, Air: 0.2 },
     scaledElemental: { Fire: 0.0, Water: 0.4, Earth: 0.4, Air: 0.2 },
     quantityBase: { amount: 62, unit: "g" },

--- a/src/data/ingredients/dairy/dairy.ts
+++ b/src/data/ingredients/dairy/dairy.ts
@@ -7,6 +7,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   milk: {
       description: "An opaque, nutrient-rich emulsion of butterfat globules suspended in a water-based fluid containing dissolved carbohydrates (lactose) and proteins (casein and whey). It acts as a foundational binder and tenderizer in baking, while its lactose sugars promote browning and crust formation.",
     name: "milk",
+    origin: ["Worldwide pastoral cultures"],
+    season: ["all"],
     elementalProperties: { Fire: 0.05, Water: 0.6, Earth: 0.2, Air: 0.15 },
     alchemicalProperties: { Spirit: 0.06, Essence: 0.38, Matter: 0.27, Substance: 0.29 },
     quantityBase: { amount: 244, unit: "g" },
@@ -79,6 +81,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   whole_milk: {
       description: "Dairy milk with its naturally occurring ~3.25% butterfat retained after standardization. The fat carries flavor and fat-soluble vitamins (A, D, E, K), contributes richness and body, and gives whole milk a rounder mouthfeel than reduced-fat versions. Indispensable in café culture for steaming a stable microfoam, in baking for tender crumb, and in homemade cheese-making where fat content affects yield and texture. Ultra-pasteurized whole milk has a longer shelf life but slightly cooked flavor.",
     name: "whole milk",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.08, Water: 0.55, Earth: 0.25, Air: 0.12 },
     alchemicalProperties: { Spirit: 0.08, Essence: 0.75, Matter: 0.35, Substance: 0.30 },
     quantityBase: { amount: 244, unit: "g" },
@@ -151,6 +155,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   buttermilk: {
       description: "Buttermilk is a dairy ingredient that contributes richness, body, and protein structure to both savory and sweet preparations. Heat and acid can quickly shift texture from smooth to curdled, so gentle temperature control is important in sauces and custards. Keep refrigerated and handle with clean tools to maintain shelf life and flavor.",
     name: "buttermilk",
+    origin: ["Western Asia (originated)", "Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.05, Water: 0.55, Earth: 0.15, Air: 0.25 },
     alchemicalProperties: { Spirit: 0.18, Essence: 0.32, Matter: 0.26, Substance: 0.24 },
     quantityBase: { amount: 245, unit: "g" },
@@ -220,6 +226,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   evaporated_milk: {
       description: "Fresh liquid from lactating dairy cattle, standardized to a fat percentage (whole ~3.25%, 2% reduced-fat, 1%, or skim) and typically pasteurized and homogenized. Beyond drinking, milk is structural in baking (gluten development, tender crumb), enriches sauces (béchamel, bread pudding), and tenderizes meats via slow protein digestion (*milk-braised pork*). Heat above 180°F denatures whey proteins and can cause skin formation; acid or long reduction curdles it. Store sealed at 35–40°F.",
     name: "evaporated milk",
+    origin: ["Worldwide pastoral cultures"],
+    season: ["all"],
     elementalProperties: { Fire: 0.12, Water: 0.45, Earth: 0.3, Air: 0.13 },
     alchemicalProperties: { Spirit: 0.1, Essence: 0.26, Matter: 0.35, Substance: 0.29 },
     quantityBase: { amount: 126, unit: "g" },
@@ -284,6 +292,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   skim_milk: {
       description: "Fresh liquid from lactating dairy cattle, standardized to a fat percentage (whole ~3.25%, 2% reduced-fat, 1%, or skim) and typically pasteurized and homogenized. Beyond drinking, milk is structural in baking (gluten development, tender crumb), enriches sauces (béchamel, bread pudding), and tenderizes meats via slow protein digestion (*milk-braised pork*). Heat above 180°F denatures whey proteins and can cause skin formation; acid or long reduction curdles it. Store sealed at 35–40°F.",
     name: "skim milk",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.02, Water: 0.7, Earth: 0.1, Air: 0.18 },
     alchemicalProperties: { Spirit: 0.06, Essence: 0.44, Matter: 0.23, Substance: 0.27 },
     quantityBase: { amount: 245, unit: "g" },
@@ -348,6 +358,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   oat_milk: {
       description: "Fresh liquid from lactating dairy cattle, standardized to a fat percentage (whole ~3.25%, 2% reduced-fat, 1%, or skim) and typically pasteurized and homogenized. Beyond drinking, milk is structural in baking (gluten development, tender crumb), enriches sauces (béchamel, bread pudding), and tenderizes meats via slow protein digestion (*milk-braised pork*). Heat above 180°F denatures whey proteins and can cause skin formation; acid or long reduction curdles it. Store sealed at 35–40°F.",
     name: "oat milk",
+    origin: ["Fertile Crescent", "Northern Europe"],
+    season: ["all"],
     elementalProperties: { Fire: 0.08, Water: 0.5, Earth: 0.28, Air: 0.14 },
     alchemicalProperties: { Spirit: 0.09, Essence: 0.31, Matter: 0.3, Substance: 0.3 },
     quantityBase: { amount: 240, unit: "g" },
@@ -412,6 +424,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   almond_milk: {
       description: "A popular plant-based milk alternative created by blending almonds with water and straining out the solids. It offers a very thin, watery texture and a subtly sweet, distinctly nutty flavor, but it lacks the protein structure to properly foam or emulsify in hot sauces without chemical stabilizers.",
     name: "almond milk",
+    origin: ["Western Asia (Iran, Levant)"],
+    season: ["fall"],
     elementalProperties: { Fire: 0.1, Water: 0.52, Earth: 0.22, Air: 0.16 },
     alchemicalProperties: { Spirit: 0.1, Essence: 0.34, Matter: 0.27, Substance: 0.29 },
     quantityBase: { amount: 240, unit: "g" },
@@ -476,6 +490,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   coconut_milk: {
       description: "Fresh liquid from lactating dairy cattle, standardized to a fat percentage (whole ~3.25%, 2% reduced-fat, 1%, or skim) and typically pasteurized and homogenized. Beyond drinking, milk is structural in baking (gluten development, tender crumb), enriches sauces (béchamel, bread pudding), and tenderizes meats via slow protein digestion (*milk-braised pork*). Heat above 180°F denatures whey proteins and can cause skin formation; acid or long reduction curdles it. Store sealed at 35–40°F.",
     name: "coconut milk",
+    origin: ["Indo-Pacific"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.45, Earth: 0.28, Air: 0.12 },
     alchemicalProperties: { Spirit: 0.11, Essence: 0.31, Matter: 0.29, Substance: 0.29 },
     quantityBase: { amount: 240, unit: "g" },
@@ -542,6 +558,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   heavy_cream: {
       description: "The high-fat layer (at least 36% milk fat) skimmed from the top of milk before homogenization. Because of its high fat content, it is highly stable—it can be whipped into a foam to hold air, and it won't curdle or \"break\" when boiled or reduced with acidic ingredients.",
     name: "heavy cream",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.18, Water: 0.38, Earth: 0.35, Air: 0.09 },
     alchemicalProperties: { Spirit: 0.1, Essence: 0.31, Matter: 0.3, Substance: 0.29 },
     quantityBase: { amount: 120, unit: "g" },
@@ -608,6 +626,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   sour_cream: {
       description: "A thick, rich dairy product created by fermenting regular cream with lactic acid bacteria, which thickens the liquid and imparts a distinctively tart, acidic tang. It acts as an excellent tenderizer in baked goods and a cooling, rich garnish for spicy dishes.",
     name: "sour cream",
+    origin: ["Eastern Europe"],
+    season: ["all"],
     elementalProperties: { Fire: 0.08, Water: 0.42, Earth: 0.28, Air: 0.22 },
     alchemicalProperties: { Spirit: 0.12, Essence: 0.55, Matter: 0.50, Substance: 0.40 },
     quantityBase: { amount: 115, unit: "g" },
@@ -672,6 +692,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   creme_fraiche: {
       description: "Crème Fraîche is a dairy ingredient that contributes richness, body, and protein structure to both savory and sweet preparations. Heat and acid can quickly shift texture from smooth to curdled, so gentle temperature control is important in sauces and custards. Keep refrigerated and handle with clean tools to maintain shelf life and flavor.",
     name: "crème fraîche",
+    origin: ["France"],
+    season: ["all"],
     elementalProperties: { Fire: 0.12, Water: 0.4, Earth: 0.32, Air: 0.16 },
     alchemicalProperties: { Spirit: 0.12, Essence: 0.60, Matter: 0.50, Substance: 0.42 },
     quantityBase: { amount: 110, unit: "g" },
@@ -742,6 +764,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   mascarpone: {
       description: "An Italian cream cheese coagulated through the addition of an acidic substance (like lemon juice or citric acid) rather than rennet. It boasts an exceptionally high butterfat content (up to 75%), yielding an unimaginably rich, velvety texture and a sweet, milky flavor crucial for tiramisu.",
     name: "mascarpone",
+    origin: ["Italy (Lombardy)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.32, Earth: 0.42, Air: 0.11 },
     alchemicalProperties: { Spirit: 0.10, Essence: 0.55, Matter: 0.62, Substance: 0.48 },
     quantityBase: { amount: 112, unit: "g" },
@@ -812,6 +836,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   clotted_cream: {
       description: "Clotted Cream is a dairy ingredient that contributes richness, body, and protein structure to both savory and sweet preparations. Heat and acid can quickly shift texture from smooth to curdled, so gentle temperature control is important in sauces and custards. Keep refrigerated and handle with clean tools to maintain shelf life and flavor.",
     name: "clotted cream",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.22, Water: 0.28, Earth: 0.42, Air: 0.08 },
     alchemicalProperties: { Spirit: 0.12, Essence: 0.26, Matter: 0.32, Substance: 0.3 },
     quantityBase: { amount: 56, unit: "g" },
@@ -877,6 +903,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   butter: {
       description: "A dairy emulsion created by churning cream until the butterfat separates from the buttermilk, containing about 80% fat, 15% water, and 5% milk proteins. Its low melting point gives it an unparalleled mouthfeel, while its milk solids undergo the Maillard reaction to create complex, nutty flavors when browned.",
     name: "butter",
+    origin: ["Western Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.25, Water: 0.15, Earth: 0.5, Air: 0.1 },
     alchemicalProperties: { Spirit: 0.15, Essence: 0.50, Matter: 0.78, Substance: 0.60 },
     quantityBase: { amount: 14, unit: "g" },
@@ -936,6 +964,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   unsalted_butter: {
       description: "Pure dairy fat (~80%) churned from cream without added salt — the baker's default for precise seasoning control, since salt levels in salted butter vary by brand. Its flavor is pure cream without the distraction of salt, letting the cook decide exact seasoning. Freshness matters more than in salted versions, since salt is a preservative; store unsalted butter refrigerated 1–2 months or frozen up to 6 months. Softened to cool room temperature (65°F), it creams air into cakes and cookies.",
     name: "unsalted butter",
+    origin: ["Western Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.23, Water: 0.16, Earth: 0.52, Air: 0.09 },
     alchemicalProperties: { Spirit: 0.15, Essence: 0.12, Matter: 0.44, Substance: 0.29 },
     quantityBase: { amount: 14, unit: "g" },
@@ -993,6 +1023,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   cold_butter: {
       description: "Cultured or sweet-cream dairy fat churned until the butterfat separates from buttermilk, yielding a ~80% fat emulsion. European-style butters have higher fat (82–86%) and richer flavor from cultured cream; American-style is typically 80% fat with a cleaner profile. Salted butter extends shelf life; unsalted is the baker's standard for precise seasoning control. Cold butter laminates pastry; soft butter creams into cakes; melted butter binds doughs; browned butter (*beurre noisette*) adds toasted-hazelnut depth.",
     name: "cold butter",
+    origin: ["Western Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.12, Earth: 0.58, Air: 0.1 },
     alchemicalProperties: { Spirit: 0.13, Essence: 0.1, Matter: 0.47, Substance: 0.3 },
     quantityBase: { amount: 14, unit: "g" },
@@ -1057,6 +1089,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   french_butter: {
       description: "Premium butter cultured with lactic acid bacteria before churning, and required by French law to contain at least 82% butterfat (compared to the US standard of 80%). The culturing process provides a distinct, complex tanginess, while the higher fat content yields flakier pastries and richer sauces.",
     name: "French butter",
+    origin: ["Western Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.26, Water: 0.14, Earth: 0.48, Air: 0.12 },
     alchemicalProperties: { Spirit: 0.18, Essence: 0.13, Matter: 0.41, Substance: 0.28 },
     quantityBase: { amount: 14, unit: "g" },
@@ -1121,6 +1155,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   clarified_butter: {
       description: "Cultured or sweet-cream dairy fat churned until the butterfat separates from buttermilk, yielding a ~80% fat emulsion. European-style butters have higher fat (82–86%) and richer flavor from cultured cream; American-style is typically 80% fat with a cleaner profile. Salted butter extends shelf life; unsalted is the baker's standard for precise seasoning control. Cold butter laminates pastry; soft butter creams into cakes; melted butter binds doughs; browned butter (*beurre noisette*) adds toasted-hazelnut depth.",
     name: "clarified butter",
+    origin: ["Western Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.35, Water: 0.05, Earth: 0.55, Air: 0.05 },
     alchemicalProperties: { Spirit: 0.19, Essence: 0.1, Matter: 0.43, Substance: 0.28 },
     quantityBase: { amount: 14, unit: "g" },
@@ -1190,6 +1226,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   ghee: {
       description: "A class of clarified butter originating in ancient India, created by simmering butter until the water evaporates and the milk solids toast and sink to the bottom. Once strained, the resulting pure butterfat boasts an intensely nutty, caramel-like flavor and a massive smoke point (482°F / 250°C), making it ideal for high-heat frying.",
     name: "ghee",
+    origin: ["South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.4, Water: 0.03, Earth: 0.52, Air: 0.05 },
     alchemicalProperties: { Spirit: 0.38, Essence: 0.48, Matter: 0.75, Substance: 0.65 },
     quantityBase: { amount: 14, unit: "g" },
@@ -1254,6 +1292,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   brown_butter: {
       description: "Cultured or sweet-cream dairy fat churned until the butterfat separates from buttermilk, yielding a ~80% fat emulsion. European-style butters have higher fat (82–86%) and richer flavor from cultured cream; American-style is typically 80% fat with a cleaner profile. Salted butter extends shelf life; unsalted is the baker's standard for precise seasoning control. Cold butter laminates pastry; soft butter creams into cakes; melted butter binds doughs; browned butter (*beurre noisette*) adds toasted-hazelnut depth.",
     name: "brown butter",
+    origin: ["Western Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.45, Water: 0.08, Earth: 0.4, Air: 0.07 },
     alchemicalProperties: { Spirit: 0.26, Essence: 0.14, Matter: 0.36, Substance: 0.24 },
     quantityBase: { amount: 14, unit: "g" },
@@ -1319,6 +1359,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   cream_cheese: {
       description: "A soft, highly spreadable fresh cheese made from milk and cream, stabilized with lactic acid bacteria to provide a signature, mild tanginess. Because of its high fat content and stable emulsion, it blends seamlessly into both dense, rich frostings and velvety savory dips.",
     name: "cream cheese",
+    origin: ["United States"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.38, Earth: 0.42, Air: 0.1 },
     alchemicalProperties: { Spirit: 0.08, Essence: 0.50, Matter: 0.55, Substance: 0.45 },
     quantityBase: { amount: 28, unit: "g" },
@@ -1391,6 +1433,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   ricotta: {
       description: "An incredibly soft, fluffy Italian whey cheese made by reheating the whey left over from producing other cheeses. It has a mild, subtly sweet, and milky flavor profile that makes it a versatile foundational ingredient in both savory pastas (like lasagna) and sweet pastries (like cannoli).",
     name: "ricotta",
+    origin: ["Italy"],
+    season: ["all"],
     elementalProperties: { Fire: 0.06, Water: 0.5, Earth: 0.32, Air: 0.12 },
     alchemicalProperties: { Spirit: 0.08, Essence: 0.62, Matter: 0.45, Substance: 0.40 },
     quantityBase: { amount: 124, unit: "g" },
@@ -1455,6 +1499,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   cottage_cheese: {
       description: "A fresh, unaged cheese consisting of loose, mild curds suspended in a small amount of cream or whey. Its high protein content and very mild, slightly acidic flavor make it a popular base for both savory additions (like black pepper and tomatoes) and sweet pairings (like fruit).",
     name: "cottage cheese",
+    origin: ["Northern Europe"],
+    season: ["all"],
     elementalProperties: { Fire: 0.05, Water: 0.55, Earth: 0.28, Air: 0.12 },
     alchemicalProperties: { Spirit: 0.08, Essence: 0.58, Matter: 0.42, Substance: 0.45 },
     quantityBase: { amount: 113, unit: "g" },
@@ -1519,6 +1565,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   quark: {
       description: "Quark is a dairy ingredient that contributes richness, body, and protein structure to both savory and sweet preparations. Heat and acid can quickly shift texture from smooth to curdled, so gentle temperature control is important in sauces and custards. Keep refrigerated and handle with clean tools to maintain shelf life and flavor.",
     name: "quark",
+    origin: ["Worldwide pastoral cultures"],
+    season: ["all"],
     elementalProperties: { Fire: 0.04, Water: 0.58, Earth: 0.26, Air: 0.12 },
     alchemicalProperties: { Spirit: 0.1, Essence: 0.3, Matter: 0.32, Substance: 0.28 },
     quantityBase: { amount: 100, unit: "g" },
@@ -1583,6 +1631,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   labneh: {
       description: "Labneh is a dairy ingredient that contributes richness, body, and protein structure to both savory and sweet preparations. Heat and acid can quickly shift texture from smooth to curdled, so gentle temperature control is important in sauces and custards. Keep refrigerated and handle with clean tools to maintain shelf life and flavor.",
     name: "labneh",
+    origin: ["Worldwide pastoral cultures"],
+    season: ["all"],
     elementalProperties: { Fire: 0.07, Water: 0.45, Earth: 0.35, Air: 0.13 },
     alchemicalProperties: { Spirit: 0.18, Essence: 0.55, Matter: 0.52, Substance: 0.48 },
     quantityBase: { amount: 100, unit: "g" },
@@ -1647,6 +1697,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   paneer: {
       description: "A fresh, unaged, non-melting cheese common in the Indian subcontinent, made by curdling heated milk with lemon juice or vinegar. Because it doesn't melt, its firm, spongy texture is perfect for absorbing the complex, spicy gravies of dishes like Saag Paneer or Matar Paneer.",
     name: "paneer",
+    origin: ["South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.42, Air: 0.08 },
     alchemicalProperties: { Spirit: 0.08, Essence: 0.45, Matter: 0.65, Substance: 0.60 },
     quantityBase: { amount: 100, unit: "g" },
@@ -1712,6 +1764,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   goat_cheese: {
       description: "A tart, earthy cheese made from goat's milk (*Capra hircus*), known as chèvre. It contains different fatty acids (caproic, caprylic, and capric acids) than cow's milk, giving it a distinctive tang and a dense, crumbly texture that softens but doesn't melt into strings when heated.",
     name: "goat cheese",
+    origin: ["Western Asia", "Africa"],
+    season: ["all"],
     elementalProperties: { Fire: 0.12, Water: 0.4, Earth: 0.35, Air: 0.13 },
     alchemicalProperties: { Spirit: 0.40, Essence: 0.52, Matter: 0.55, Substance: 0.50 },
     quantityBase: { amount: 28, unit: "g" },
@@ -1776,6 +1830,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   brie: {
       description: "A soft-ripened, bloomy-rind cheese originally from the French region of Brie. The edible white rind (a mold called *Penicillium camemberti*) breaks down the fats and proteins in the cheese from the outside in, creating a luxurious, runny, and buttery paste with notes of mushroom and earth.",
     name: "brie",
+    origin: ["France (Île-de-France)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.42, Earth: 0.32, Air: 0.11 },
     alchemicalProperties: { Spirit: 0.42, Essence: 0.52, Matter: 0.58, Substance: 0.50 },
     quantityBase: { amount: 28, unit: "g" },
@@ -1840,6 +1896,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   camembert: {
       description: "A soft, bloomy-rind cheese from Normandy, France. It is chemically similar to Brie but typically features a slightly deeper, more robust flavor profile with pronounced notes of earth, mushrooms, and truffles due to its specific *Penicillium camemberti* mold and production methods.",
     name: "camembert",
+    origin: ["France (Normandy)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.18, Water: 0.4, Earth: 0.3, Air: 0.12 },
     alchemicalProperties: { Spirit: 0.48, Essence: 0.50, Matter: 0.55, Substance: 0.48 },
     quantityBase: { amount: 28, unit: "g" },
@@ -1904,6 +1962,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   feta: {
       description: "A brined curd cheese traditionally made in Greece from sheep's milk (or a mixture of sheep and goat's milk). Its extended aging in salt brine gives it a profound, sharp saltiness and a crumbly, grainy texture that acts as a bright, acidic counterpoint to rich roasted meats or sweet summer fruits.",
     name: "feta",
+    origin: ["Greece"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.45, Earth: 0.32, Air: 0.13 },
     alchemicalProperties: { Spirit: 0.30, Essence: 0.50, Matter: 0.60, Substance: 0.55 },
     quantityBase: { amount: 28, unit: "g" },
@@ -1968,6 +2028,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   burrata: {
       description: "An artisanal Italian cheese consisting of a solid outer shell of fresh mozzarella that is hand-tied around a luscious, creamy center of stracciatella (shredded mozzarella curds mixed with heavy cream). Breaking it open reveals an incredibly rich, buttery texture that elevates simple salads.",
     name: "burrata",
+    origin: ["Italy (Apulia)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.12, Water: 0.48, Earth: 0.3, Air: 0.1 },
     alchemicalProperties: { Spirit: 0.15, Essence: 0.68, Matter: 0.45, Substance: 0.42 },
     quantityBase: { amount: 56, unit: "g" },
@@ -2033,6 +2095,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   mozzarella: {
       description: "A southern Italian pasta filata (spun paste) cheese made by stretching heated curds, resulting in a unique, elastic, and stringy texture. Fresh mozzarella is incredibly delicate, milky, and high in moisture, while low-moisture (block) mozzarella is ideal for baking and melting (like on pizza) due to its superior stretch.",
     name: "mozzarella",
+    origin: ["Italy (Campania)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.14, Water: 0.46, Earth: 0.28, Air: 0.12 },
     alchemicalProperties: { Spirit: 0.10, Essence: 0.60, Matter: 0.55, Substance: 0.50 },
     quantityBase: { amount: 28, unit: "g" },
@@ -2099,6 +2163,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   havarti: {
       description: "A semi-soft, buttery cow's milk cheese from Denmark. It features small, irregular holes ('eyes') and a remarkably smooth, sweet, and slightly acidic flavor that melts beautifully, making it an upgraded choice for sophisticated grilled cheese sandwiches.",
     name: "havarti",
+    origin: ["Worldwide pastoral cultures"],
+    season: ["all"],
     elementalProperties: { Fire: 0.16, Water: 0.38, Earth: 0.35, Air: 0.11 },
     alchemicalProperties: { Spirit: 0.12, Essence: 0.22, Matter: 0.31, Substance: 0.35 },
     quantityBase: { amount: 28, unit: "g" },
@@ -2163,6 +2229,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   monterey_jack: {
       description: "A semi-hard, highly meltable cow's milk cheese originating in California. Because its flavor is exceptionally mild and neutral, it acts as the perfect structural melting cheese for dishes that rely on other ingredients for flavor, such as nachos, quesadillas, and spicy dips.",
     name: "monterey jack",
+    origin: ["United States (California)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.4, Earth: 0.33, Air: 0.12 },
     alchemicalProperties: { Spirit: 0.11, Essence: 0.22, Matter: 0.31, Substance: 0.36 },
     quantityBase: { amount: 28, unit: "g" },
@@ -2227,6 +2295,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   fontina: {
       description: "A classic Italian cow's milk cheese boasting a pungent, earthy aroma but a surprisingly mild, sweet, and nutty flavor. Its high fat content and semi-soft texture make it one of the premier melting cheeses in the world, essential for fondue and rich gratins.",
     name: "fontina",
+    origin: ["Italy (Aosta Valley)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.35, Earth: 0.35, Air: 0.1 },
     alchemicalProperties: { Spirit: 0.13, Essence: 0.21, Matter: 0.31, Substance: 0.35 },
     quantityBase: { amount: 28, unit: "g" },
@@ -2291,6 +2361,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   halloumi: {
       description: "A semi-hard, unripened, brined cheese from Cyprus made from a mixture of goat's and sheep's milk. Its unique chemical structure allows it to withstand incredibly high heat without melting, making it the premier cheese for grilling or pan-frying to a crispy, squeaky golden-brown.",
     name: "halloumi",
+    origin: ["Cyprus"],
+    season: ["all"],
     elementalProperties: { Fire: 0.28, Water: 0.32, Earth: 0.32, Air: 0.08 },
     alchemicalProperties: { Spirit: 0.18, Essence: 0.42, Matter: 0.75, Substance: 0.70 },
     quantityBase: { amount: 56, unit: "g" },
@@ -2356,6 +2428,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   cheddar_cheese: {
       description: "A relatively hard, off-white to orange cow's milk cheese that undergoes a unique \"cheddaring\" process—stacking slabs of curds to press out whey. As it ages, enzymes break down proteins and fats into complex amino acids, transforming its flavor from mild and creamy to sharp, crumbly, and deeply savory.\n\n**Selection & Storage:** Look for solid blocks without surface mold or dry, cracked edges. Store wrapped tightly in parchment or wax paper, then placed in a loosely closed plastic bag in the cheese drawer.",
     name: "cheddar cheese",
+    origin: ["Western Asia (Fertile Crescent)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.22, Water: 0.25, Earth: 0.42, Air: 0.11 },
     alchemicalProperties: { Spirit: 0.35, Essence: 0.40, Matter: 0.80, Substance: 0.75 },
     quantityBase: { amount: 28, unit: "g" },
@@ -2422,6 +2496,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   gruy_re_cheese: {
       description: "Gruyère Cheese is a dairy ingredient that contributes richness, body, and protein structure to both savory and sweet preparations. Heat and acid can quickly shift texture from smooth to curdled, so gentle temperature control is important in sauces and custards. Keep refrigerated and handle with clean tools to maintain shelf life and flavor.",
     name: "Gruyère cheese",
+    origin: ["Western Asia (Fertile Crescent)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.24, Water: 0.22, Earth: 0.44, Air: 0.1 },
     alchemicalProperties: { Spirit: 0.14, Essence: 0.17, Matter: 0.31, Substance: 0.38 },
     quantityBase: { amount: 28, unit: "g" },
@@ -2486,6 +2562,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   parmesan: {
       description: "An iconic, hard, granular Italian cheese (*Parmigiano-Reggiano*) made from raw cow's milk and aged for at least 12 months. This long aging process creates an intensely savory, umami-rich flavor and forms crystalline crunches of tyrosine (an amino acid), making it a powerful natural flavor enhancer.",
     name: "parmesan",
+    origin: ["Italy"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.1, Earth: 0.5, Air: 0.1 },
     alchemicalProperties: { Spirit: 0.17, Essence: 0.13, Matter: 0.32, Substance: 0.38 },
     quantityBase: { amount: 28, unit: "g" },
@@ -2559,6 +2637,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   pecorino_romano: {
       description: "A family of hard, salty Italian cheeses made specifically from sheep's milk (*pecora* meaning sheep). Pecorino Romano is the most famous—heavily salted, sharply pungent, and granular—serving as the foundational flavor for classic Roman pastas like Cacio e Pepe.\n\n**Selection & Storage:** Purchase in blocks rather than pre-grated. Store wrapped tightly in parchment paper and plastic wrap in the cheese drawer, where it will last for months.",
     name: "pecorino romano",
+    origin: ["Italy"],
+    season: ["all"],
     elementalProperties: { Fire: 0.32, Water: 0.08, Earth: 0.52, Air: 0.08 },
     alchemicalProperties: { Spirit: 0.17, Essence: 0.13, Matter: 0.32, Substance: 0.38 },
     quantityBase: { amount: 28, unit: "g" },
@@ -2623,6 +2703,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   manchego: {
       description: "A firm, buttery sheep's milk cheese from the La Mancha region of Spain. Depending on its age (from semi-curado to añejo), it offers a complex, zesty, and slightly piquante flavor with a distinctly crystalline texture, making it the classic pairing for sweet quince paste (membrillo).",
     name: "manchego",
+    origin: ["Spain (La Mancha)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.26, Water: 0.18, Earth: 0.46, Air: 0.1 },
     alchemicalProperties: { Spirit: 0.15, Essence: 0.16, Matter: 0.31, Substance: 0.38 },
     quantityBase: { amount: 28, unit: "g" },
@@ -2687,6 +2769,8 @@ const rawDairy: Record<string, Partial<IngredientMapping>> = {
   asiago: {
       description: "A northern Italian cow's milk cheese that dramatically changes with age. Fresh Asiago (Pressato) is smooth, sweet, and meltable, while aged Asiago (d'Allevo) develops a crumbly texture and an incredibly sharp, savory, and complex flavor profile similar to a young Parmesan.",
     name: "asiago",
+    origin: ["Worldwide pastoral cultures"],
+    season: ["all"],
     elementalProperties: { Fire: 0.25, Water: 0.2, Earth: 0.45, Air: 0.1 },
     alchemicalProperties: { Spirit: 0.14, Essence: 0.16, Matter: 0.31, Substance: 0.39 },
     quantityBase: { amount: 28, unit: "g" },

--- a/src/data/ingredients/fruits/berries.ts
+++ b/src/data/ingredients/fruits/berries.ts
@@ -159,6 +159,7 @@ const rawBerries: Record<string, Partial<IngredientMapping>> = {
   raspberry: {
       description: "A delicate, aggregate fruit (*Rubus idaeus*) composed of tightly packed drupelets around a hollow core. They are highly aromatic and naturally tart, meaning their bright flavor holds up beautifully against intense, rich counterparts like dark chocolate or heavy cream.",
     name: "Raspberry",
+    origin: ["Europe", "North America"],
     elementalProperties: { Water: 0.4, Air: 0.3, Fire: 0.2, Earth: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Venus", "Moon"],
@@ -236,6 +237,7 @@ const rawBerries: Record<string, Partial<IngredientMapping>> = {
   strawberry: {
       description: "A fragrant, deeply red accessory fruit (*Fragaria × ananassa*) bearing its seeds on the outside. Known for a perfect balance of malic acid and natural sugars, they soften quickly when cooked and release their vibrant juices, making them ideal for macerating, purees, and delicate desserts.",
     name: "Strawberry",
+    origin: ["Europe", "Americas"],
     elementalProperties: { Water: 0.4, Air: 0.3, Fire: 0.2, Earth: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Venus", "Moon"],
@@ -307,6 +309,7 @@ const rawBerries: Record<string, Partial<IngredientMapping>> = {
   blackberry: {
       description: "An aggregate fruit (*Rubus*) composed of many tiny, juice-filled drupelets. They provide a complex, earthy, and slightly tart flavor with a noticeable seed crunch, cooking down beautifully into rich, dark jams and reductions that pair surprisingly well with game meats.",
     name: "Blackberry",
+    origin: ["Europe", "North America"],
     elementalProperties: { Water: 0.4, Earth: 0.3, Air: 0.2, Fire: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Venus", "Saturn"],
@@ -379,6 +382,7 @@ const rawBerries: Record<string, Partial<IngredientMapping>> = {
   cranberry: {
       description: "A small, exceptionally tart, and astringent berry (*Vaccinium macrocarpon*) native to North American bogs. Because of their intense acidity and low sugar content, they are rarely eaten raw; instead, they are cooked with sugar to create brightly colored, pectin-rich sauces that cut through rich holiday roasts.",
     name: "Cranberry",
+    origin: ["North America"],
     elementalProperties: { Water: 0.4, Air: 0.3, Fire: 0.2, Earth: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Mars", "Saturn"],
@@ -451,6 +455,7 @@ const rawBerries: Record<string, Partial<IngredientMapping>> = {
   gooseberry: {
       description: "A small, tart berry (*Ribes uva-crispa*) with translucent skin, often green or pale red, featuring faint vertical striping. Their sharp acidity makes them a classic ingredient in traditional British baking (like fools and crumbles) and a sharp, pectin-rich pairing for fatty fish like mackerel.",
     name: "Gooseberry",
+    origin: ["Europe", "Western Asia"],
     elementalProperties: { Water: 0.4, Air: 0.3, Fire: 0.2, Earth: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Venus", "Mercury"],
@@ -516,6 +521,7 @@ const rawBerries: Record<string, Partial<IngredientMapping>> = {
   elderberry: {
       description: "The tiny, dark purple-black berries of the *Sambucus* tree. They are mildly toxic when raw and must be cooked, which transforms their astringent, earthy flavor into a deeply complex, floral, and rich syrup utilized in cordials, jams, and medicinal tinctures.",
     name: "Elderberry",
+    origin: ["Europe", "North America"],
     elementalProperties: { Water: 0.3, Air: 0.3, Earth: 0.3, Fire: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Venus", "Moon"],
@@ -581,6 +587,7 @@ const rawBerries: Record<string, Partial<IngredientMapping>> = {
   mulberry: {
       description: "A highly perishable, elongated berry (*Morus*) resembling an elongated blackberry. They offer an intensely sweet, earthy, and slightly woodsy flavor without the sharp tartness of other berries, though their delicate structure makes them difficult to transport commercially.",
     name: "Mulberry",
+    origin: ["Cultivated worldwide"],
     elementalProperties: { Water: 0.5, Air: 0.2, Earth: 0.2, Fire: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Mercury", "Venus"],
@@ -646,6 +653,7 @@ const rawBerries: Record<string, Partial<IngredientMapping>> = {
   goji_berry: {
       description: "The bright red-orange fruit of the *Lycium barbarum* shrub, typically sold dried. They possess a complex, slightly sour, and earthy sweetness (reminiscent of a cross between a cranberry and a cherry tomato), commonly steeped in Chinese healing broths or used as a nutrient-dense topping for oatmeal.",
     name: "Goji Berry",
+    origin: ["China"],
     elementalProperties: { Water: 0.3, Fire: 0.3, Air: 0.2, Earth: 0.2 },
     astrologicalProfile: {
       rulingPlanets: ["Sun", "Mars"],
@@ -718,6 +726,7 @@ const rawBerries: Record<string, Partial<IngredientMapping>> = {
   acai_berry: {
       description: "A small, dark purple fruit (*Euterpe oleracea*) native to the Amazon rainforest. Highly perishable when fresh, it is usually sold as a frozen puree or freeze-dried powder, providing an earthy, unsweetened flavor profile with deep notes of blackberry and dark, unsweetened chocolate.",
     name: "Acai Berry",
+    origin: ["South America (Amazon)"],
     elementalProperties: { Water: 0.4, Earth: 0.3, Air: 0.2, Fire: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Moon", "Venus"],
@@ -790,6 +799,7 @@ const rawBerries: Record<string, Partial<IngredientMapping>> = {
   currant_red: {
       description: "Tiny, intensely flavored berries (*Ribes*) available in red, black, and white varieties. Blackcurrants are incredibly musky, earthy, and tart (often made into cassis), while red and white currants are brighter, more acidic, and commonly used to make crystal-clear, pectin-heavy jellies.\n\n**Selection & Storage:** Choose firm, plump clusters attached to their stems. Store unwashed in the refrigerator and use within a few days.",
     name: "Red Currant",
+    origin: ["Europe"],
     elementalProperties: { Water: 0.4, Air: 0.3, Fire: 0.2, Earth: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Mars", "Venus"],
@@ -855,6 +865,7 @@ const rawBerries: Record<string, Partial<IngredientMapping>> = {
   currant_black: {
       description: "Tiny, intensely flavored berries (*Ribes*) available in red, black, and white varieties. Blackcurrants are incredibly musky, earthy, and tart (often made into cassis), while red and white currants are brighter, more acidic, and commonly used to make crystal-clear, pectin-heavy jellies.\n\n**Selection & Storage:** Choose firm, plump clusters attached to their stems. Store unwashed in the refrigerator and use within a few days.",
     name: "Black Currant",
+    origin: ["Europe"],
     elementalProperties: { Water: 0.3, Earth: 0.4, Air: 0.2, Fire: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Saturn", "Venus"],

--- a/src/data/ingredients/fruits/citrus.ts
+++ b/src/data/ingredients/fruits/citrus.ts
@@ -5,6 +5,7 @@ const rawCitrus: Record<string, Partial<IngredientMapping>> = {
   lemon: {
       description: "An intensely sour, acidic citrus fruit (*Citrus limon*) that serves as a fundamental culinary brightener. Its juice provides citric acid to balance rich fats and tenderize proteins, while its zest (the yellow outer skin) contains essential oils that deliver pure floral-citrus aroma without the tartness.",
     name: "Lemon",
+    origin: ["South Asia", "Mediterranean (cultivated)"],
 
     // Base elemental properties (unscaled)
     elementalProperties: { Water: 0.4, Air: 0.3, Fire: 0.2, Earth: 0.1 },
@@ -71,6 +72,7 @@ const rawCitrus: Record<string, Partial<IngredientMapping>> = {
   orange: {
       description: "A sweet citrus fruit (*Citrus × sinensis*) prized for its balanced sweetness and acidity. Its juice adds bright, floral sugar to marinades and sauces, while its zest, rich in essential oils, provides pure orange aroma without altering the liquid balance of baked goods.",
     name: "Orange",
+    origin: ["Southern China", "Southeast Asia"],
 
     // Base elemental properties (unscaled)
     elementalProperties: { Water: 0.4, Fire: 0.3, Air: 0.2, Earth: 0.1 },
@@ -137,6 +139,7 @@ const rawCitrus: Record<string, Partial<IngredientMapping>> = {
   lime: {
       description: "A highly acidic, tropical citrus fruit (*Citrus × aurantiifolia*) whose juice provides a sharper, more floral acidity than lemon. It is essential in cuisines around the equator (Latin American, Southeast Asian) as its bright acidity 'cooks' raw fish in ceviche and balances intense chili heat.",
     name: "Lime",
+    origin: ["Southeast Asia", "India"],
 
     // Base elemental properties (unscaled)
     elementalProperties: { Water: 0.5, Air: 0.2, Fire: 0.2, Earth: 0.1 },
@@ -203,6 +206,7 @@ const rawCitrus: Record<string, Partial<IngredientMapping>> = {
   grapefruit: {
       description: "A large, somewhat bitter citrus fruit (*Citrus × paradisi*) that is a hybrid of the sweet orange and the pomelo. It is highly valued for its sharp acidity and distinctively astringent, floral flavor, which cuts through heavy, rich fats and brightens complex salads and ceviches.",
     name: "Grapefruit",
+    origin: ["Caribbean (Barbados)"],
 
     // Base elemental properties (unscaled)
     elementalProperties: { Water: 0.4, Air: 0.3, Fire: 0.2, Earth: 0.1 },
@@ -271,6 +275,7 @@ const rawCitrus: Record<string, Partial<IngredientMapping>> = {
   mandarin: {
       description: "A small, loose-skinned citrus fruit (*Citrus reticulata*) considered one of the core ancestral species of modern citrus. They are incredibly sweet, far less acidic than a standard orange, and distinctly floral, making them perfect for eating out of hand or sectioning into delicate salads.",
     name: "Mandarin",
+    origin: ["China"],
 
     // Base elemental properties (unscaled)
     elementalProperties: { Water: 0.4, Fire: 0.3, Air: 0.2, Earth: 0.1 },
@@ -331,6 +336,7 @@ const rawCitrus: Record<string, Partial<IngredientMapping>> = {
   clementine: {
       description: "A small, exceptionally sweet, and generally seedless citrus fruit (*Citrus × clementina*) resulting from a cross between a sweet orange and a willowleaf mandarin. Its skin is incredibly loose and easy to peel, making it a perfect raw snack, though its juice is also excellent for bright, acidic vinaigrettes.",
     name: "Clementine",
+    origin: ["North Africa", "Mediterranean"],
 
     // Base elemental properties (unscaled)
     elementalProperties: { Water: 0.4, Fire: 0.3, Air: 0.2, Earth: 0.1 },
@@ -397,6 +403,7 @@ const rawCitrus: Record<string, Partial<IngredientMapping>> = {
   pomelo: {
       description: "The massive, thick-rinded ancestor of the grapefruit (*Citrus maxima*). It lacks the aggressive, sharp bitterness of a grapefruit, offering instead a milder, highly floral sweetness and large, firm juice vesicles that separate cleanly, making it the perfect structural addition to Southeast Asian salads.",
     name: "Pomelo",
+    origin: ["Southeast Asia"],
 
     // Base elemental properties (unscaled)
     elementalProperties: { Water: 0.5, Air: 0.2, Fire: 0.2, Earth: 0.1 },
@@ -493,6 +500,7 @@ const rawCitrus: Record<string, Partial<IngredientMapping>> = {
   yuzu: {
       description: "A highly aromatic, bumpy, and tart citrus fruit (*Citrus junos*) native to East Asia. It produces very little juice, but its intensely fragrant zest offers a profoundly complex, floral aroma that tastes like a hybrid of lemon, mandarin, and grapefruit, famously used to flavor ponzu sauce.",
     name: "Yuzu",
+    origin: ["East Asia"],
     elementalProperties: { Water: 0.4, Air: 0.4, Fire: 0.1, Earth: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Mercury", "Moon"],
@@ -564,6 +572,7 @@ const rawCitrus: Record<string, Partial<IngredientMapping>> = {
   bergamot: {
       description: "A highly aromatic, bitter citrus fruit (*Citrus bergamia*) primarily cultivated for its essential oils extracted from the rind. This intensely fragrant, floral, and slightly spicy oil is the defining flavor of Earl Grey tea and adds a profoundly sophisticated, perfumed note to marmalades and delicate pastries.",
     name: "Bergamot",
+    origin: ["Mediterranean (Calabria)"],
     elementalProperties: { Water: 0.3, Air: 0.4, Fire: 0.2, Earth: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Mercury", "Venus"],
@@ -635,6 +644,7 @@ const rawCitrus: Record<string, Partial<IngredientMapping>> = {
   kumquat: {
       description: "A tiny, bite-sized citrus fruit (*Citrus japonica*) possessing a unique biological inversion: its rind is incredibly sweet and floral, while its juice and flesh are sharply, intensely sour. This contrast makes them perfect for eating whole (raw) or boiling down into deeply complex, sweet-and-sour marmalades.",
     name: "Kumquat",
+    origin: ["Southern China"],
     elementalProperties: { Water: 0.4, Fire: 0.3, Air: 0.2, Earth: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Sun", "Mercury"],
@@ -706,6 +716,7 @@ const rawCitrus: Record<string, Partial<IngredientMapping>> = {
   finger_lime: {
       description: "A highly unusual micro-citrus (*Citrus australasica*) native to Australia. When the thin, elongated fruit is cut open, it reveals hundreds of tiny, spherical juice vesicles that resemble caviar; when bitten, they explode with an intense, tart, and floral lime flavor.",
     name: "Finger Lime",
+    origin: ["Southeast Asia", "India"],
     elementalProperties: { Water: 0.5, Air: 0.3, Fire: 0.1, Earth: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Moon", "Mercury"],
@@ -777,6 +788,7 @@ const rawCitrus: Record<string, Partial<IngredientMapping>> = {
   blood_orange: {
       description: "A visually striking citrus fruit (*Citrus × sinensis*) characterized by its deep crimson flesh, which results from the presence of anthocyanins (antioxidants rare in citrus). They offer a complex flavor profile that combines traditional bright orange sweetness with distinct notes of raspberry and tart cherry.",
     name: "Blood Orange",
+    origin: ["Mediterranean (Sicily)"],
     elementalProperties: { Water: 0.4, Fire: 0.3, Air: 0.2, Earth: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Mars", "Sun"],
@@ -848,6 +860,7 @@ const rawCitrus: Record<string, Partial<IngredientMapping>> = {
   tangerine: {
       description: "A specific variety of mandarin orange (*Citrus tangerina*) characterized by its deep red-orange hue and pebbly skin. It is exceptionally sweet, juicy, and highly aromatic, with a more pronounced, complex citrus bite than standard navel oranges.",
     name: "Tangerine",
+    origin: ["Southeast Asia"],
     elementalProperties: { Water: 0.4, Fire: 0.3, Air: 0.2, Earth: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Sun", "Mercury"],

--- a/src/data/ingredients/fruits/exotic.ts
+++ b/src/data/ingredients/fruits/exotic.ts
@@ -5,6 +5,7 @@ const rawExoticFruits: Record<string, Partial<IngredientMapping>> = {
   pomegranate: {
     description: "A tough-skinned fruit (*Punica granatum*) containing hundreds of jewel-like, juice-filled arils surrounding a tiny seed. The arils provide a bright, tart-sweet crunch and brilliant ruby color, acting as a stunning garnish or a deeply flavorful reduction (pomegranate molasses) in Middle Eastern cooking.",
     name: "Pomegranate",
+    origin: ["Persia", "Northern India"],
     elementalProperties: { Water: 0.4, Fire: 0.3, Earth: 0.2, Air: 0.1 },
     quantityBase: { amount: 87, unit: "g" },
     scaledElemental: { Water: 0.4, Fire: 0.3, Air: 0.2, Earth: 0.1 },
@@ -78,6 +79,7 @@ const rawExoticFruits: Record<string, Partial<IngredientMapping>> = {
   fig: {
     description: "A unique, inverted flower structure (*Ficus carica*) containing hundreds of tiny seeds within a soft, fleshy exterior. Fresh figs are incredibly delicate and offer a profound, honeyed sweetness with an earthy, jammy texture that pairs flawlessly with salty, cured meats (like prosciutto) or sharp blue cheeses.",
     name: "Fig",
+    origin: ["Western Asia", "Mediterranean"],
     elementalProperties: { Water: 0.4, Earth: 0.3, Fire: 0.2, Air: 0.1 },
     quantityBase: { amount: 50, unit: "g" },
     scaledElemental: { Water: 0.4, Earth: 0.3, Fire: 0.2, Air: 0.1 },
@@ -157,6 +159,7 @@ const rawExoticFruits: Record<string, Partial<IngredientMapping>> = {
   grape: {
     description: "Small, spherical berries (*Vitis vinifera*) that grow in clusters, offering a crisp snap and a burst of sweet-tart juice. With a high ratio of skin-to-flesh, they provide complex tannins and sugars that make them perfect for eating raw, roasting to concentrate their flavor, or fermenting into wine.",
     name: "Grape",
+    origin: ["Western Asia", "Mediterranean"],
     elementalProperties: { Water: 0.5, Air: 0.2, Fire: 0.2, Earth: 0.1 },
     quantityBase: { amount: 151, unit: "g" },
     scaledElemental: { Water: 0.5, Air: 0.2, Fire: 0.2, Earth: 0.1 },
@@ -230,6 +233,7 @@ const rawExoticFruits: Record<string, Partial<IngredientMapping>> = {
   date: {
     description: "The profoundly sweet, chewy fruit of the date palm tree (*Phoenix dactylifera*), typically consumed in its dried or semi-dried state (like the Medjool variety). Consisting of nearly 80% sugar, they provide deep, complex notes of caramel, toffee, and molasses, acting as a powerful natural sweetener and binder in raw desserts.",
     name: "Date",
+    origin: ["Middle East", "North Africa"],
     elementalProperties: { Earth: 0.5, Fire: 0.3, Water: 0.1, Air: 0.1 },
     quantityBase: { amount: 24, unit: "g" },
     scaledElemental: { Earth: 0.5, Fire: 0.3, Water: 0.1, Air: 0.1 },
@@ -303,6 +307,7 @@ const rawExoticFruits: Record<string, Partial<IngredientMapping>> = {
   kiwano: {
     description: "A sweet edible plant product, kiwano delivers natural sugars, acid, aromatic volatiles, and fiber. Ripeness dramatically changes its flavor, texture, and use.",
     name: "Kiwano (Horned Melon)",
+    origin: ["Cultivated worldwide"],
     elementalProperties: { Water: 0.5, Air: 0.2, Earth: 0.2, Fire: 0.1 },
     quantityBase: { amount: 100, unit: "g" },
     scaledElemental: { Water: 0.5, Air: 0.2, Earth: 0.2, Fire: 0.1 },
@@ -376,6 +381,7 @@ const rawExoticFruits: Record<string, Partial<IngredientMapping>> = {
   feijoa: {
     description: "A sweet edible plant product, feijoa delivers natural sugars, acid, aromatic volatiles, and fiber. Ripeness dramatically changes its flavor, texture, and use.",
     name: "Feijoa (Pineapple Guava)",
+    origin: ["Cultivated worldwide"],
     elementalProperties: { Water: 0.4, Air: 0.3, Earth: 0.2, Fire: 0.1 },
     quantityBase: { amount: 100, unit: "g" },
     scaledElemental: { Water: 0.4, Air: 0.3, Earth: 0.2, Fire: 0.1 },
@@ -449,6 +455,7 @@ const rawExoticFruits: Record<string, Partial<IngredientMapping>> = {
   tamarind: {
     description: "The sticky, highly acidic pulp extracted from the seed pods of the *Tamarindus indica* tree. It provides a profoundly complex, fruity, and intensely tart flavor profile that acts as the primary souring agent in Pad Thai, Indian chutneys, and Worcestershire sauce.",
     name: "Tamarind",
+    origin: ["Cultivated worldwide"],
     elementalProperties: { Earth: 0.4, Fire: 0.3, Water: 0.2, Air: 0.1 },
     quantityBase: { amount: 120, unit: "g" },
     scaledElemental: { Earth: 0.4, Fire: 0.3, Water: 0.2, Air: 0.1 },
@@ -522,6 +529,7 @@ const rawExoticFruits: Record<string, Partial<IngredientMapping>> = {
   loquat_exotic: {
     description: "A small, oval, orange fruit (*Eriobotrya japonica*) native to China, featuring a tart, slightly sweet flavor reminiscent of a cross between a peach, citrus, and mild apricot. Its high pectin content and bright acidity make it exceptionally well-suited for traditional jams, jellies, and savory chutneys.\n\n**Selection & Storage:** They are highly delicate and bruise easily. Choose bright orange fruit that gives slightly to pressure. Store in the refrigerator and eat quickly.",
     name: "Loquat",
+    origin: ["Cultivated worldwide"],
     elementalProperties: { Water: 0.4, Earth: 0.3, Fire: 0.2, Air: 0.1 },
     quantityBase: { amount: 149, unit: "g" },
     scaledElemental: { Water: 0.4, Earth: 0.3, Fire: 0.2, Air: 0.1 },
@@ -595,6 +603,7 @@ const rawExoticFruits: Record<string, Partial<IngredientMapping>> = {
   cactus_pear: {
     description: "A delicate pome fruit (*Pyrus communis*) that ripens from the inside out, transforming from crunchy to buttery-soft. Its high sugar content and delicate floral notes make it excellent for eating raw, poaching in wine, or pairing with sharp blue cheeses.\n\n**Selection & Storage:** Purchase pears while still firm; they are ripe when the flesh yields slightly to gentle pressure at the stem end. Ripen at room temperature, then transfer to the refrigerator to pause the ripening process.",
     name: "Cactus Pear (Prickly Pear)",
+    origin: ["Central Asia", "Western Europe"],
     elementalProperties: { Water: 0.5, Earth: 0.2, Fire: 0.2, Air: 0.1 },
     quantityBase: { amount: 103, unit: "g" },
     scaledElemental: { Water: 0.5, Earth: 0.2, Fire: 0.2, Air: 0.1 },
@@ -668,6 +677,7 @@ const rawExoticFruits: Record<string, Partial<IngredientMapping>> = {
   quince_exotic: {
     description: "An ancient, highly structured pome fruit (*Cydonia oblonga*) resembling a lumpy yellow pear. It is essentially inedible raw due to its extreme tartness and astringent tannins, but when slow-cooked with sugar, it magically transforms into a soft, deeply floral, and bright ruby-red paste (membrillo).\n\n**Selection & Storage:** Choose firm, bright yellow fruit that emits a powerful, floral, and rosy aroma. Store at room temperature for several days, or in the refrigerator for up to a month.",
     name: "Quince",
+    origin: ["Caucasus", "Western Asia"],
     elementalProperties: { Earth: 0.6, Air: 0.2, Water: 0.2, Fire: 0.0 },
     quantityBase: { amount: 100, unit: "g" },
     scaledElemental: { Earth: 0.6, Air: 0.2, Water: 0.2, Fire: 0.0 },
@@ -741,6 +751,7 @@ const rawExoticFruits: Record<string, Partial<IngredientMapping>> = {
   passion_fruit_exotic: {
     description: "A sweet edible plant product, passion fruit exotic delivers natural sugars, acid, aromatic volatiles, and fiber. Ripeness dramatically changes its flavor, texture, and use.",
     name: "Passion Fruit",
+    origin: ["South America"],
     elementalProperties: { Water: 0.4, Air: 0.3, Fire: 0.2, Earth: 0.1 },
     quantityBase: { amount: 100, unit: "g" },
     scaledElemental: { Water: 0.4, Air: 0.3, Fire: 0.2, Earth: 0.1 },
@@ -814,6 +825,7 @@ const rawExoticFruits: Record<string, Partial<IngredientMapping>> = {
   custard_apple: {
     description: "A crisp, versatile pome fruit (*Malus domestica*) containing high levels of pectin, which gives it a satisfying snap and thickens sauces naturally. Their flavor profiles range wildly from the tart, baking-friendly Granny Smith to the sweet, floral Honeycrisp or Fuji.\n\n**Selection & Storage:** Look for firm apples with vibrant coloring and smooth skin that feel heavy for their size. Store them in the crisper drawer of the refrigerator to maintain their crispness, as they soften ten times faster at room temperature.",
     name: "Custard Apple (Cherimoya)",
+    origin: ["Central Asia (Kazakhstan)"],
     elementalProperties: { Water: 0.4, Earth: 0.3, Air: 0.2, Fire: 0.1 },
     quantityBase: { amount: 100, unit: "g" },
     scaledElemental: { Water: 0.4, Earth: 0.3, Air: 0.2, Fire: 0.1 },
@@ -887,6 +899,7 @@ const rawExoticFruits: Record<string, Partial<IngredientMapping>> = {
   sapote: {
     description: "A sweet edible plant product, sapote delivers natural sugars, acid, aromatic volatiles, and fiber. Ripeness dramatically changes its flavor, texture, and use.",
     name: "Sapote (Mamey)",
+    origin: ["Cultivated worldwide"],
     elementalProperties: { Water: 0.3, Earth: 0.4, Fire: 0.2, Air: 0.1 },
     quantityBase: { amount: 100, unit: "g" },
     scaledElemental: { Water: 0.3, Earth: 0.4, Fire: 0.2, Air: 0.1 },
@@ -960,6 +973,7 @@ const rawExoticFruits: Record<string, Partial<IngredientMapping>> = {
   plantain: {
     description: "A large, starchy member of the banana family (*Musa paradisiaca*) that is treated strictly as a vegetable. When green, it is hard and starchy, ideal for savory frying (tostones); as it blackens, its starches convert to sugar, becoming incredibly sweet and soft when caramelized (maduros).",
     name: "Plantain",
+    origin: ["Southeast Asia"],
     elementalProperties: { Earth: 0.4, Water: 0.3, Fire: 0.2, Air: 0.1 },
     quantityBase: { amount: 179, unit: "g" },
     scaledElemental: { Earth: 0.4, Water: 0.3, Fire: 0.2, Air: 0.1 },
@@ -1033,6 +1047,7 @@ const rawExoticFruits: Record<string, Partial<IngredientMapping>> = {
   breadfruit: {
     description: "A massive, starchy, tropical fruit (*Artocarpus altilis*) related to the jackfruit. When unripe and green, its flesh is hard and starchy, tasting remarkably like freshly baked bread or potatoes when roasted; as it ripens, the starches convert to sugar, becoming soft, sweet, and custard-like.",
     name: "Breadfruit",
+    origin: ["Cultivated worldwide"],
     elementalProperties: { Earth: 0.5, Water: 0.2, Fire: 0.2, Air: 0.1 },
     quantityBase: { amount: 220, unit: "g" },
     scaledElemental: { Earth: 0.5, Water: 0.2, Fire: 0.2, Air: 0.1 },
@@ -1106,6 +1121,7 @@ const rawExoticFruits: Record<string, Partial<IngredientMapping>> = {
   cloudberry: {
     description: "A highly prized, rare wild berry (*Rubus chamaemorus*) native to alpine and arctic tundras, resembling an amber-colored raspberry. They possess a completely unique, tart flavor profile reminiscent of baked apples and floral honey, most commonly preserved in jams or served warm over Swedish cheese.",
     name: "Cloudberry",
+    origin: ["Cultivated worldwide"],
     elementalProperties: { Water: 0.4, Air: 0.3, Earth: 0.2, Fire: 0.1 },
     quantityBase: { amount: 100, unit: "g" },
     scaledElemental: { Water: 0.4, Air: 0.3, Earth: 0.2, Fire: 0.1 },
@@ -1179,6 +1195,7 @@ const rawExoticFruits: Record<string, Partial<IngredientMapping>> = {
   boysenberry: {
     description: "A large, highly perishable aggregate fruit that is a complex cross between a European raspberry, a European blackberry, an American dewberry, and a loganberry. It offers a spectacular balance of sweet and tart flavors with a softer, juicier texture than a standard blackberry, making it unparalleled for jams and pies.",
     name: "Boysenberry",
+    origin: ["Cultivated worldwide"],
     elementalProperties: { Water: 0.4, Earth: 0.3, Air: 0.2, Fire: 0.1 },
     quantityBase: { amount: 132, unit: "g" },
     scaledElemental: { Water: 0.4, Earth: 0.3, Air: 0.2, Fire: 0.1 },

--- a/src/data/ingredients/fruits/fruits.ts
+++ b/src/data/ingredients/fruits/fruits.ts
@@ -6,6 +6,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   avocado: {
       description: "A unique fruit (*Persea americana*) characterized by its extraordinarily high fat content (mostly monounsaturated oleic acid) and creamy, buttery texture. Its mild, slightly nutty flavor acts as a perfect canvas for acids and salts, making it a staple in both savory dishes and vegan baking.",
     name: "avocado",
+    origin: ["Cultivated worldwide"],
+    season: ["varies by variety"],
     elementalProperties: { Fire: 0.2, Water: 0.4, Earth: 0.15, Air: 0.25 },
     qualities: ["creamy", "rich", "nutritious", "versatile"],
     category: "fruit",
@@ -43,6 +45,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   lemon_juice: {
       description: "The oval yellow citrus fruit (*Citrus × limon*) delivering 5–6% citric acid plus fragrant d-limonene in the peel — essentially a complete seasoning of acid, aroma, and brightness in one package. Meyer lemons are sweeter with floral notes; Eureka and Lisbon are standard supermarket varieties. Use the whole fruit: zest for aroma (before juicing — the tool ruins the peel otherwise), juice for acid, rind for preserved lemons. Rolling the lemon before cutting breaks internal membranes and yields more juice.",
     name: "lemon juice",
+    origin: ["South Asia", "Mediterranean (cultivated)"],
+    season: ["winter", "spring"],
     elementalProperties: { Fire: 0.3, Water: 0.45, Earth: 0.05, Air: 0.2 },
     qualities: ["acidic", "bright", "refreshing", "versatile"],
     category: "fruit",
@@ -75,6 +79,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   banana: {
       description: "A tropical, starch-rich berry (*Musa spp.*) that converts its starches to easily digestible sugars as it ripens, indicated by its skin turning from green to yellow to spotted brown. This enzymatic transformation drastically alters its culinary use, moving from a firm snack to a sweet, mushy base for baking.",
     name: "banana",
+    origin: ["Southeast Asia", "Papua New Guinea"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.45, Earth: 0.25, Air: 0.15 },
     qualities: ["sweet", "creamy", "nutritious", "energizing"],
     category: "fruit",
@@ -107,6 +113,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   orange_zest: {
       description: "A sweet citrus fruit (*Citrus × sinensis*) prized for its balanced sweetness and acidity. Its juice adds bright, floral sugar to marinades and sauces, while its zest, rich in essential oils, provides pure orange aroma without altering the liquid balance of baked goods.\n\n**Selection & Storage:** Look for oranges that feel heavy for their size with smooth, firm, and vibrantly colored skin. They can be kept at room temperature for a few days, but will last up to a month loose in the refrigerator.",
     name: "orange zest",
+    origin: ["Southern China", "Southeast Asia"],
+    season: ["winter"],
     elementalProperties: { Fire: 0.35, Water: 0.25, Earth: 0.1, Air: 0.3 },
     qualities: ["aromatic", "citrusy", "bright", "versatile"],
     category: "fruit",
@@ -139,6 +147,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   lemon_zest: {
       description: "The oval yellow citrus fruit (*Citrus × limon*) delivering 5–6% citric acid plus fragrant d-limonene in the peel — essentially a complete seasoning of acid, aroma, and brightness in one package. Meyer lemons are sweeter with floral notes; Eureka and Lisbon are standard supermarket varieties. Use the whole fruit: zest for aroma (before juicing — the tool ruins the peel otherwise), juice for acid, rind for preserved lemons. Rolling the lemon before cutting breaks internal membranes and yields more juice.",
     name: "lemon zest",
+    origin: ["South Asia", "Mediterranean (cultivated)"],
+    season: ["winter", "spring"],
     elementalProperties: { Fire: 0.35, Water: 0.25, Earth: 0.1, Air: 0.3 },
     qualities: ["aromatic", "citrusy", "bright", "versatile"],
     category: "fruit",
@@ -171,6 +181,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   lemon: {
       description: "An intensely sour, acidic citrus fruit (*Citrus limon*) that serves as a fundamental culinary brightener. Its juice provides citric acid to balance rich fats and tenderize proteins, while its zest (the yellow outer skin) contains essential oils that deliver pure floral-citrus aroma without the tartness.",
     name: "lemon",
+    origin: ["South Asia", "Mediterranean (cultivated)"],
+    season: ["winter", "spring"],
     elementalProperties: { Fire: 0.25, Water: 0.45, Earth: 0.05, Air: 0.25 },
     qualities: ["sour", "bright", "refreshing", "cleansing"],
     category: "fruit",
@@ -203,6 +215,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   apples: {
       description: "A crisp, versatile pome fruit (*Malus domestica*) containing high levels of pectin, which gives it a satisfying snap and thickens sauces naturally. Their flavor profiles range wildly from the tart, baking-friendly Granny Smith to the sweet, floral Honeycrisp or Fuji.\n\n**Selection & Storage:** Look for firm apples with vibrant coloring and smooth skin that feel heavy for their size. Store them in the crisper drawer of the refrigerator to maintain their crispness, as they soften ten times faster at room temperature.",
     name: "apples",
+    origin: ["Central Asia (Kazakhstan)"],
+    season: ["fall"],
     elementalProperties: { Fire: 0.1, Water: 0.5, Earth: 0.2, Air: 0.2 },
     qualities: ["sweet", "crisp", "juicy", "versatile"],
     category: "fruit",
@@ -235,6 +249,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   ripe_mangoes: {
       description: "A sweet edible plant product, ripe mangoes delivers natural sugars, acid, aromatic volatiles, and fiber. Ripeness dramatically changes its flavor, texture, and use.",
     name: "ripe mangoes",
+    origin: ["Cultivated worldwide"],
+    season: ["varies by variety"],
     elementalProperties: { Fire: 0.25, Water: 0.45, Earth: 0.1, Air: 0.2 },
     qualities: ["sweet", "tropical", "juicy", "aromatic"],
     category: "fruit",
@@ -267,6 +283,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   strawberry_preserves: {
       description: "A fragrant, deeply red accessory fruit (*Fragaria × ananassa*) bearing its seeds on the outside. Known for a perfect balance of malic acid and natural sugars, they soften quickly when cooked and release their vibrant juices, making them ideal for macerating, purees, and delicate desserts.\n\n**Selection & Storage:** Choose plump, uniformly red berries with fresh, bright green caps; they do not ripen after being picked. Store unwashed in the refrigerator in a container lined with paper towels, and consume within two to three days.",
     name: "strawberry preserves",
+    origin: ["Europe", "Americas"],
+    season: ["spring", "summer"],
     elementalProperties: { Fire: 0.2, Water: 0.4, Earth: 0.15, Air: 0.25 },
     qualities: ["sweet", "fruity", "spreadable"],
     category: "fruit",
@@ -299,6 +317,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   ni_oise_olives: {
       description: "A sweet edible plant product, ni oise olives delivers natural sugars, acid, aromatic volatiles, and fiber. Ripeness dramatically changes its flavor, texture, and use.",
     name: "Niçoise olives",
+    origin: ["Cultivated worldwide"],
+    season: ["varies by variety"],
     elementalProperties: { Fire: 0.15, Water: 0.3, Earth: 0.35, Air: 0.2 },
     qualities: ["briny", "savory", "Mediterranean"],
     category: "fruit",
@@ -331,6 +351,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   olive_oil: {
       description: "A liquid fat extracted by pressing whole olives (*Olea europaea*). Extra-virgin olive oil (EVOO) is mechanically extracted without heat or chemicals, retaining high levels of antioxidants and an intensely grassy, peppery, and fruity flavor best reserved for finishing dishes or low-heat cooking.",
     name: "olive oil",
+    origin: ["Mediterranean"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.1, Earth: 0.4, Air: 0.2 },
     qualities: ["rich", "fruity", "versatile", "healthy"],
     category: "fruit",
@@ -363,6 +385,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   grape_leaves: {
       description: "Small, spherical berries (*Vitis vinifera*) that grow in clusters, offering a crisp snap and a burst of sweet-tart juice. With a high ratio of skin-to-flesh, they provide complex tannins and sugars that make them perfect for eating raw, roasting to concentrate their flavor, or fermenting into wine.\n\n**Selection & Storage:** Look for plump, firm grapes tightly attached to pliable, green stems. Store unwashed in a perforated plastic bag in the refrigerator crisper drawer.",
     name: "grape leaves",
+    origin: ["Western Asia", "Mediterranean"],
+    season: ["fall"],
     elementalProperties: { Fire: 0.15, Water: 0.3, Earth: 0.3, Air: 0.25 },
     qualities: ["tangy", "tender", "Mediterranean"],
     category: "fruit",
@@ -396,6 +420,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   coconut_chutney: {
       description: "A large, hard-shelled seed (*Cocos nucifera*) containing sweet, clear water and rich, fatty white meat. Its high concentration of saturated lauric acid gives coconut milk, cream, and oil a uniquely rich, tropical flavor that forms the creamy base of many Southeast Asian and Indian curries.\n\n**Selection & Storage:** Shake whole coconuts to ensure they sound full of water; avoid any with cracks or damp eyes. Store whole coconuts at room temperature, but refrigerate any extracted meat or water.",
     name: "coconut chutney",
+    origin: ["Indo-Pacific"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.35, Earth: 0.25, Air: 0.2 },
     qualities: ["creamy", "tangy", "aromatic", "Indian"],
     category: "fruit",
@@ -428,6 +454,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   lime_juice: {
       description: "A highly acidic, tropical citrus fruit (*Citrus × aurantiifolia*) whose juice provides a sharper, more floral acidity than lemon. It is essential in cuisines around the equator (Latin American, Southeast Asian) as its bright acidity 'cooks' raw fish in ceviche and balances intense chili heat.\n\n**Selection & Storage:** Select limes that are dark green, heavy for their size, and give slightly when squeezed; hard limes will yield little juice. Store them loose in the refrigerator crisper drawer for up to a month.",
     name: "lime juice",
+    origin: ["Southeast Asia", "India"],
+    season: ["summer", "fall"],
     elementalProperties: { Fire: 0.3, Water: 0.45, Earth: 0.05, Air: 0.2 },
     qualities: ["acidic", "bright", "refreshing", "tropical"],
     category: "fruit",
@@ -460,6 +488,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   coconut_milk: {
       description: "Fresh liquid from lactating dairy cattle, standardized to a fat percentage (whole ~3.25%, 2% reduced-fat, 1%, or skim) and typically pasteurized and homogenized. Beyond drinking, milk is structural in baking (gluten development, tender crumb), enriches sauces (béchamel, bread pudding), and tenderizes meats via slow protein digestion (*milk-braised pork*). Heat above 180°F denatures whey proteins and can cause skin formation; acid or long reduction curdles it. Store sealed at 35–40°F.",
     name: "coconut milk",
+    origin: ["Indo-Pacific"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.4, Earth: 0.25, Air: 0.15 },
     qualities: ["creamy", "rich", "tropical", "versatile"],
     category: "fruit",
@@ -497,6 +527,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   ripe_bananas: {
       description: "A tropical, starch-rich berry (*Musa spp.*) that converts its starches to easily digestible sugars as it ripens, indicated by its skin turning from green to yellow to spotted brown. This enzymatic transformation drastically alters its culinary use, moving from a firm snack to a sweet, mushy base for baking.\n\n**Selection & Storage:** Choose bananas based on your immediate need: green for later, yellow for eating, or heavily spotted for baking. Store at room temperature; refrigerating will turn the skin black but keep the flesh firm longer.",
     name: "ripe bananas",
+    origin: ["Cultivated worldwide"],
+    season: ["varies by variety"],
     elementalProperties: { Fire: 0.15, Water: 0.45, Earth: 0.25, Air: 0.15 },
     qualities: ["sweet", "soft", "nutritious", "energizing"],
     category: "fruit",
@@ -529,6 +561,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   lime: {
       description: "A highly acidic, tropical citrus fruit (*Citrus × aurantiifolia*) whose juice provides a sharper, more floral acidity than lemon. It is essential in cuisines around the equator (Latin American, Southeast Asian) as its bright acidity 'cooks' raw fish in ceviche and balances intense chili heat.",
     name: "lime",
+    origin: ["Southeast Asia", "India"],
+    season: ["summer", "fall"],
     elementalProperties: { Fire: 0.25, Water: 0.45, Earth: 0.05, Air: 0.25 },
     qualities: ["sour", "bright", "refreshing", "tropical"],
     category: "fruit",
@@ -561,6 +595,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   lemongrass: {
       description: "A tall, fibrous tropical grass (*Cymbopogon citratus*) with a tough outer stalk and a tender, highly aromatic inner core. It provides a complex, bright, and floral citrus flavor without the sharp acidity of lemon juice, making it indispensable in Southeast Asian curries and soups.",
     name: "lemongrass",
+    origin: ["South and Southeast Asia"],
+    season: ["summer"],
     elementalProperties: { Fire: 0.3, Water: 0.25, Earth: 0.15, Air: 0.3 },
     qualities: ["aromatic", "citrusy", "tropical", "fragrant"],
     category: "fruit",
@@ -593,6 +629,8 @@ const rawFruits: Record<string, Partial<IngredientMapping>> = {
   banana_flower: {
       description: "The massive, tear-shaped, purplish-red blossom that hangs at the end of a cluster of bananas. Commonly used in Southeast Asian and Indian cuisines, its tender inner bracts provide a crunchy, flaky texture and a mild, slightly bitter, and highly astringent flavor that mimics the texture of artichoke hearts or fish.",
     name: "banana flower",
+    origin: ["Southeast Asia", "Papua New Guinea"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.4, Earth: 0.3, Air: 0.2 },
     qualities: ["tender", "mild", "nutritious", "tropical"],
     category: "fruit",

--- a/src/data/ingredients/fruits/melons.ts
+++ b/src/data/ingredients/fruits/melons.ts
@@ -5,6 +5,7 @@ const rawMelons = {
   watermelon: {
       description: "A massive, vining fruit (*Citrullus lanatus*) that is roughly 92% water, known for its crisp, refreshing, and subtly sweet pink or red flesh. Its extremely high water content and delicate flavor make it best suited for raw applications, from fruit salads to chilled soups like gazpacho.",
     name: "Watermelon",
+    origin: ["Africa (Sudan)"],
     elementalProperties: {
       Water: 0.8,
       Fire: 0.1,
@@ -195,6 +196,7 @@ const rawMelons = {
   cantaloupe: {
       description: "A highly aromatic, orange-fleshed melon (*Cucumis melo var. cantalupensis*) characterized by its rough, webbed rind. Its high water content and sweet, slightly musky floral flavor make it a refreshing raw snack, pairing classically with salty cured meats like prosciutto.",
     name: "Cantaloupe",
+    origin: ["South Asia", "Africa"],
     elementalProperties: {
       Water: 0.6,
       Earth: 0.2,
@@ -348,6 +350,7 @@ const rawMelons = {
   honeydew: {
       description: "A smooth-skinned, pale green melon (*Cucumis melo inodorus*) with a crisp texture and a mild, exceptionally sweet flavor. While less aggressively aromatic than cantaloupe, its clean, honey-like sweetness makes it a versatile base for chilled soups and fruit salads.",
     name: "Honeydew",
+    origin: ["Western Asia", "Africa"],
     elementalProperties: {
       Water: 0.7,
       Air: 0.2,
@@ -509,6 +512,7 @@ const rawMelons = {
   casaba: {
       description: "A sweet edible plant product, casaba delivers natural sugars, acid, aromatic volatiles, and fiber. Ripeness dramatically changes its flavor, texture, and use.",
     name: "Casaba",
+    origin: ["Cultivated worldwide"],
     elementalProperties: {
       Water: 0.6,
       Earth: 0.3,
@@ -648,6 +652,7 @@ const rawMelons = {
   crenshaw: {
       description: "A sweet edible plant product, crenshaw delivers natural sugars, acid, aromatic volatiles, and fiber. Ripeness dramatically changes its flavor, texture, and use.",
     name: "Crenshaw",
+    origin: ["Cultivated worldwide"],
     elementalProperties: {
       Water: 0.5,
       Earth: 0.3,
@@ -778,6 +783,7 @@ const rawMelons = {
   persian_melon: {
       description: "A large, ancient variety of melon (*Cucumis melo*) closely related to the cantaloupe, featuring a dark green, un-netted rind. It offers an intensely sweet, dense, and floral orange flesh that is profoundly fragrant, requiring no accompaniment beyond a squeeze of fresh lime juice.",
     name: "Persian Melon",
+    origin: ["Cultivated worldwide"],
     elementalProperties: {
       Water: 0.6,
       Earth: 0.2,
@@ -917,6 +923,7 @@ const rawMelons = {
   winter_melon: {
       description: "A massive, vine-grown fruit (*Benincasa hispida*) covered in a waxy, chalky coating that allows it to be stored for many months. While technically a fruit, it is treated strictly as a vegetable in Asian cooking, featuring a dense, stark-white flesh that absorbs profound amounts of broth in long-simmering soups.",
     name: "Winter Melon",
+    origin: ["Cultivated worldwide"],
     elementalProperties: {
       Water: 0.6,
       Earth: 0.3,
@@ -1066,6 +1073,7 @@ const rawMelons = {
   galia: {
       description: "A sweet edible plant product, galia delivers natural sugars, acid, aromatic volatiles, and fiber. Ripeness dramatically changes its flavor, texture, and use.",
     name: "Galia Melon",
+    origin: ["Israel"],
     elementalProperties: {
       Water: 0.6,
       Air: 0.2,

--- a/src/data/ingredients/fruits/pome.ts
+++ b/src/data/ingredients/fruits/pome.ts
@@ -5,6 +5,7 @@ const rawPome = {
   apple: {
       description: "A crisp, versatile pome fruit (*Malus domestica*) containing high levels of pectin, which gives it a satisfying snap and thickens sauces naturally. Their flavor profiles range wildly from the tart, baking-friendly Granny Smith to the sweet, floral Honeycrisp or Fuji.",
     name: "Apple",
+    origin: ["Central Asia (Kazakhstan)"],
     elementalProperties: {
       Earth: 0.5,
       Water: 0.3,
@@ -187,6 +188,7 @@ const rawPome = {
   pear: {
       description: "A delicate pome fruit (*Pyrus communis*) that ripens from the inside out, transforming from crunchy to buttery-soft. Its high sugar content and delicate floral notes make it excellent for eating raw, poaching in wine, or pairing with sharp blue cheeses.",
     name: "Pear",
+    origin: ["Central Asia", "Western Europe"],
     elementalProperties: {
       Water: 0.4,
       Earth: 0.4,
@@ -362,6 +364,7 @@ const rawPome = {
   quince: {
       description: "An ancient, highly structured pome fruit (*Cydonia oblonga*) resembling a lumpy yellow pear. It is essentially inedible raw due to its extreme tartness and astringent tannins, but when slow-cooked with sugar, it magically transforms into a soft, deeply floral, and bright ruby-red paste (membrillo).",
     name: "Quince",
+    origin: ["Caucasus", "Western Asia"],
     elementalProperties: {
       Earth: 0.6,
       Air: 0.2,
@@ -522,6 +525,7 @@ const rawPome = {
   asian_pear: {
       description: "A crisp, exceptionally juicy fruit (*Pyrus pyrifolia*) that looks like a round apple but retains the delicate, floral sweetness of a pear. Unlike European pears, they do not soften after picking; their granular, water-dense texture makes them perfect for eating raw or grating into Korean meat marinades to tenderize beef.",
     name: "Asian Pear",
+    origin: ["Central Asia", "Western Europe"],
     elementalProperties: {
       Water: 0.5,
       Earth: 0.3,
@@ -667,6 +671,7 @@ const rawPome = {
   medlar: {
       description: "A sweet edible plant product, medlar delivers natural sugars, acid, aromatic volatiles, and fiber. Ripeness dramatically changes its flavor, texture, and use.",
     name: "Medlar",
+    origin: ["Cultivated worldwide"],
     elementalProperties: {
       Earth: 0.7,
       Water: 0.2,
@@ -809,6 +814,7 @@ const rawPome = {
   loquat: {
       description: "A small, oval, orange fruit (*Eriobotrya japonica*) native to China, featuring a tart, slightly sweet flavor reminiscent of a cross between a peach, citrus, and mild apricot. Its high pectin content and bright acidity make it exceptionally well-suited for traditional jams, jellies, and savory chutneys.",
     name: "Loquat",
+    origin: ["Cultivated worldwide"],
     elementalProperties: {
       Water: 0.4,
       Earth: 0.3,

--- a/src/data/ingredients/fruits/stoneFruit.ts
+++ b/src/data/ingredients/fruits/stoneFruit.ts
@@ -5,6 +5,7 @@ const rawStoneFruit = {
   peach: {
       description: "A velvety stone fruit (*Prunus persica*) known for its juicy, fragrant, and profoundly sweet flesh balanced by a subtle acidity. When cooked, its natural sugars caramelize beautifully, making it an ideal candidate for both rustic baked cobblers and grilling to pair with savory meats.",
     name: "Peach",
+    origin: ["China"],
     elementalProperties: { Water: 0.4, Fire: 0.2, Air: 0.2, Earth: 0.2 },
     alchemicalProperties: {
       Spirit: 0.38,
@@ -64,6 +65,7 @@ const rawStoneFruit = {
   plum: {
       description: "A smooth-skinned stone fruit (*Prunus domestica*) that comes in a wide variety of colors and sizes. The skin provides a sharp, tannic tartness that perfectly balances the incredibly sweet, jammy interior, making it excellent for reductions, sauces, and raw eating.",
     name: "Plum",
+    origin: ["Eurasia"],
     elementalProperties: { Water: 0.4, Fire: 0.2, Air: 0.2, Earth: 0.2 },
     alchemicalProperties: {
       Spirit: 0.32,
@@ -123,6 +125,7 @@ const rawStoneFruit = {
   apricot: {
       description: "A small, golden-orange stone fruit (*Prunus armeniaca*) with a velvety skin and a delicate, sweet-tart flavor profile. Because fresh apricots have a very short shelf life and subtle flavor, they are frequently dried, which concentrates their natural sugars and bright acidity, making them a staple in Middle Eastern tagines and baking.",
     name: "Apricot",
+    origin: ["Central Asia (Armenia)"],
     elementalProperties: { Water: 0.3, Fire: 0.3, Air: 0.2, Earth: 0.2 },
     alchemicalProperties: {
       Spirit: 0.42,
@@ -175,6 +178,7 @@ const rawStoneFruit = {
   cherry: {
       description: "A small, fleshy drupe (*Prunus avium*) that ranges from bright red and tart to dark mahogany and intensely sweet. Because they retain their structure well when heated, they are versatile in both sweet applications (pies, jams) and savory reductions (pairing classically with duck or pork).",
     name: "Cherry",
+    origin: ["Western Asia", "Europe"],
     elementalProperties: { Water: 0.3, Fire: 0.3, Air: 0.2, Earth: 0.2 },
     alchemicalProperties: {
       Spirit: 0.35,
@@ -227,6 +231,7 @@ const rawStoneFruit = {
   nectarine: {
       description: "A smooth-skinned, genetic mutation of the peach (*Prunus persica var. nucipersica*). Lacking the fuzzy trichomes of a peach, nectarines often have a slightly firmer texture and a sharper, more pronounced acidity, making them excellent candidates for raw slicing, salads, or high-heat grilling.",
     name: "Nectarine",
+    origin: ["China"],
     elementalProperties: { Water: 0.4, Fire: 0.2, Air: 0.2, Earth: 0.2 },
     alchemicalProperties: {
       Spirit: 0.36,
@@ -279,6 +284,7 @@ const rawStoneFruit = {
   greengage: {
       description: "A cultivar of plum (*Prunus domestica subsp. italica*) featuring a pale, green-yellow skin even when fully ripe. They are widely considered to be the finest dessert plum in the world, boasting an unimaginably rich, honeyed sweetness and a dense, jammy texture.",
     name: "Greengage",
+    origin: ["Cultivated worldwide"],
     elementalProperties: { Water: 0.4, Fire: 0.1, Air: 0.2, Earth: 0.3 },
     alchemicalProperties: {
       Spirit: 0.25,
@@ -331,6 +337,7 @@ const rawStoneFruit = {
   damson: {
       description: "A small, oval plum (*Prunus insititia*) with dark blue-black skin and yellow-green flesh. Because it is highly astringent and tart when raw, it is almost exclusively cooked down into intensely flavored, deeply colored jams, jellies, and traditional fruit cheeses.",
     name: "Damson",
+    origin: ["Cultivated worldwide"],
     elementalProperties: { Water: 0.3, Fire: 0.2, Air: 0.2, Earth: 0.3 },
     alchemicalProperties: {
       Spirit: 0.28,

--- a/src/data/ingredients/fruits/tropical.ts
+++ b/src/data/ingredients/fruits/tropical.ts
@@ -102,6 +102,7 @@ const rawTropicalFruits: Record<string, Partial<IngredientMapping>> = {
   pineapple: {
       description: "A large, spiky tropical fruit (*Ananas comosus*) characterized by its intensely sweet, tart, and vibrant yellow flesh. It contains the enzyme bromelain, which actively breaks down proteins, making fresh pineapple an incredibly effective (and sometimes overpowering) meat tenderizer in marinades.",
     name: "Pineapple",
+    origin: ["South America"],
     elementalProperties: { Water: 0.4, Fire: 0.3, Air: 0.2, Earth: 0.1 },
     quantityBase: { amount: 165, unit: "g" },
     scaledElemental: { Water: 0.4, Fire: 0.3, Air: 0.2, Earth: 0.1 },
@@ -175,6 +176,7 @@ const rawTropicalFruits: Record<string, Partial<IngredientMapping>> = {
   papaya: {
       description: "A large, tropical berry (*Carica papaya*) featuring vibrant orange flesh and a central cavity filled with peppery, edible black seeds. It contains papain, a powerful proteolytic enzyme used globally as a meat tenderizer, and offers a sweet, slightly musky, and floral flavor.",
     name: "Papaya",
+    origin: ["Mesoamerica"],
     elementalProperties: { Water: 0.5, Fire: 0.2, Air: 0.2, Earth: 0.1 },
     quantityBase: { amount: 145, unit: "g" },
     scaledElemental: { Water: 0.5, Fire: 0.2, Air: 0.2, Earth: 0.1 },
@@ -248,6 +250,7 @@ const rawTropicalFruits: Record<string, Partial<IngredientMapping>> = {
   passion_fruit: {
       description: "The small, tough-skinned fruit of a climbing vine (*Passiflora edulis*), filled with a gelatinous, intensely aromatic, and sharply acidic yellow pulp containing crunchy black seeds. Its explosive, tropical tartness makes it an unparalleled flavor enhancer for sweet meringues, curds, and cocktails.",
     name: "Passion Fruit",
+    origin: ["South America"],
     elementalProperties: { Water: 0.4, Air: 0.3, Fire: 0.2, Earth: 0.1 },
     quantityBase: { amount: 18, unit: "g" },
     scaledElemental: { Water: 0.4, Air: 0.3, Fire: 0.2, Earth: 0.1 },
@@ -328,6 +331,7 @@ const rawTropicalFruits: Record<string, Partial<IngredientMapping>> = {
   guava: {
       description: "A highly aromatic tropical fruit (*Psidium guajava*) with an edible rind, ranging in interior color from white to deep pink. It provides an intense, perfumed sweetness and a distinctively gritty texture from its small, edible seeds, making it a favorite for purees, jams, and Latin American pastries (pastelitos).",
     name: "Guava",
+    origin: ["Central America"],
     elementalProperties: { Water: 0.4, Earth: 0.3, Air: 0.2, Fire: 0.1 },
     quantityBase: { amount: 55, unit: "g" },
     scaledElemental: { Water: 0.4, Earth: 0.3, Air: 0.2, Fire: 0.1 },
@@ -401,6 +405,7 @@ const rawTropicalFruits: Record<string, Partial<IngredientMapping>> = {
   dragon_fruit: {
       description: "Also known as pitaya (*Selenicereus undatus*), this striking fruit of a cactus features bright pink or yellow skin with green, leafy scales. Despite its dramatic appearance, its white or magenta flesh offers a very mild, subtly sweet flavor—similar to a cross between a pear and a kiwi—with a crunchy texture from its tiny black seeds.",
     name: "Dragon Fruit",
+    origin: ["Mesoamerica"],
     elementalProperties: { Water: 0.5, Air: 0.2, Earth: 0.2, Fire: 0.1 },
     quantityBase: { amount: 227, unit: "g" },
     scaledElemental: { Water: 0.5, Air: 0.2, Earth: 0.2, Fire: 0.1 },
@@ -474,6 +479,7 @@ const rawTropicalFruits: Record<string, Partial<IngredientMapping>> = {
   lychee: {
       description: "A small tropical fruit (*Litchi chinensis*) native to China, encased in a rough, pinkish-red rind. Peeling the rind reveals a translucent, pearl-white flesh that is incredibly juicy, crisp, and boasts a profound, floral sweetness reminiscent of rosewater and muscat grapes.",
     name: "Lychee",
+    origin: ["Southern China"],
     elementalProperties: { Water: 0.5, Air: 0.3, Fire: 0.1, Earth: 0.1 },
     quantityBase: { amount: 190, unit: "g" },
     scaledElemental: { Water: 0.5, Air: 0.3, Fire: 0.1, Earth: 0.1 },
@@ -547,6 +553,7 @@ const rawTropicalFruits: Record<string, Partial<IngredientMapping>> = {
   rambutan: {
       description: "A tropical fruit (*Nephelium lappaceum*) covered in a striking, hairy, bright red rind. The translucent white flesh inside is similar to a lychee but is generally sweeter, creamier, and slightly less acidic, making it a highly refreshing raw snack.",
     name: "Rambutan",
+    origin: ["Southeast Asia"],
     elementalProperties: { Water: 0.5, Air: 0.2, Fire: 0.2, Earth: 0.1 },
     quantityBase: { amount: 100, unit: "g" },
     scaledElemental: { Water: 0.5, Air: 0.2, Fire: 0.2, Earth: 0.1 },
@@ -620,6 +627,7 @@ const rawTropicalFruits: Record<string, Partial<IngredientMapping>> = {
   longan: {
       description: "A small tropical fruit (*Dimocarpus longan*) closely related to the lychee, often referred to as 'dragon eye' due to the appearance of its translucent flesh encasing a single black seed. It offers a deeply sweet, slightly musky, and floral flavor profile that is less acidic and more earthy than a lychee.",
     name: "Longan",
+    origin: ["Southern China"],
     elementalProperties: { Water: 0.5, Air: 0.3, Earth: 0.1, Fire: 0.1 },
     quantityBase: { amount: 100, unit: "g" },
     scaledElemental: { Water: 0.5, Air: 0.3, Earth: 0.1, Fire: 0.1 },
@@ -693,6 +701,7 @@ const rawTropicalFruits: Record<string, Partial<IngredientMapping>> = {
   starfruit: {
       description: "Also known as carambola (*Averrhoa carambola*), a uniquely shaped tropical fruit that forms a perfect five-pointed star when sliced horizontally. Its crisp, watery texture and mild, sweet-tart flavor (reminiscent of green apples and citrus) make it a beautiful, refreshing garnish or addition to fruit salads.",
     name: "Starfruit",
+    origin: ["Southeast Asia"],
     elementalProperties: { Water: 0.5, Air: 0.3, Earth: 0.1, Fire: 0.1 },
     quantityBase: { amount: 108, unit: "g" },
     scaledElemental: { Water: 0.5, Air: 0.3, Earth: 0.1, Fire: 0.1 },
@@ -766,6 +775,7 @@ const rawTropicalFruits: Record<string, Partial<IngredientMapping>> = {
   persimmon: {
       description: "A vibrant orange fruit (*Diospyros kaki*) that must be fully understood before eating. The Hachiya variety is highly astringent (due to tannins) until it becomes entirely soft and jelly-like, while the Fuyu variety is non-astringent, crisp like an apple, and mildly sweet with notes of honey and cinnamon.",
     name: "Persimmon",
+    origin: ["East Asia"],
     elementalProperties: { Water: 0.4, Earth: 0.3, Fire: 0.2, Air: 0.1 },
     quantityBase: { amount: 168, unit: "g" },
     scaledElemental: { Water: 0.4, Earth: 0.3, Fire: 0.2, Air: 0.1 },
@@ -839,6 +849,7 @@ const rawTropicalFruits: Record<string, Partial<IngredientMapping>> = {
   kiwi: {
       description: "A small, fuzzy brown fruit (*Actinidia deliciosa*) harboring bright green flesh and tiny, edible black seeds. It delivers a uniquely tart, sweet flavor—reminiscent of strawberries and melon—and, like pineapple, contains actinidain, an enzyme that tenderizes meat and prevents gelatin from setting.",
     name: "Kiwi",
+    origin: ["China", "New Zealand (cultivated)"],
     elementalProperties: { Water: 0.5, Air: 0.2, Earth: 0.2, Fire: 0.1 },
     quantityBase: { amount: 69, unit: "g" },
     scaledElemental: { Water: 0.5, Air: 0.2, Earth: 0.2, Fire: 0.1 },
@@ -912,6 +923,7 @@ const rawTropicalFruits: Record<string, Partial<IngredientMapping>> = {
   jackfruit: {
       description: "The largest tree-borne fruit in the world (*Artocarpus heterophyllus*). When ripe, the golden bulbs are intensely sweet and taste like a blend of mango, banana, and pineapple; when unripe (green), the flesh is neutral, stringy, and fibrous, acting as an incredibly popular vegan substitute for pulled pork or braised chicken.",
     name: "Jackfruit",
+    origin: ["South India", "Southeast Asia"],
     elementalProperties: { Water: 0.4, Earth: 0.3, Air: 0.2, Fire: 0.1 },
     quantityBase: { amount: 165, unit: "g" },
     scaledElemental: { Water: 0.4, Earth: 0.3, Air: 0.2, Fire: 0.1 },
@@ -985,6 +997,7 @@ const rawTropicalFruits: Record<string, Partial<IngredientMapping>> = {
   durian: {
       description: "A massive, spiky tropical fruit native to Southeast Asia, famously known for its overpowering, highly divisive odor (often compared to rotting onions or raw sewage). However, the custard-like flesh inside is incredibly rich, buttery, and profoundly sweet, tasting of almond, caramel, and complex savory notes.",
     name: "Durian",
+    origin: ["Southeast Asia (Borneo, Sumatra)"],
     elementalProperties: { Water: 0.3, Earth: 0.4, Fire: 0.2, Air: 0.1 },
     quantityBase: { amount: 100, unit: "g" },
     scaledElemental: { Water: 0.3, Earth: 0.4, Fire: 0.2, Air: 0.1 },
@@ -1058,6 +1071,7 @@ const rawTropicalFruits: Record<string, Partial<IngredientMapping>> = {
   coconut: {
       description: "A large, hard-shelled seed (*Cocos nucifera*) containing sweet, clear water and rich, fatty white meat. Its high concentration of saturated lauric acid gives coconut milk, cream, and oil a uniquely rich, tropical flavor that forms the creamy base of many Southeast Asian and Indian curries.",
     name: "Coconut",
+    origin: ["Indo-Pacific"],
     elementalProperties: { Water: 0.4, Earth: 0.3, Air: 0.2, Fire: 0.1 },
     quantityBase: { amount: 80, unit: "g" },
     scaledElemental: { Water: 0.4, Earth: 0.3, Air: 0.2, Fire: 0.1 },

--- a/src/data/ingredients/grains/grains.ts
+++ b/src/data/ingredients/grains/grains.ts
@@ -6,6 +6,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   flour: {
       description: "A powder made by grinding raw grains, roots, beans, nuts, or seeds, though most commonly refers to wheat. Its specific culinary use is dictated by its protein content: high-protein bread flour forms strong gluten networks for chewy breads, while low-protein cake flour yields tender, delicate crumb structures.",
     name: "flour",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -49,6 +51,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "rice",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -81,6 +85,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   all_purpose_flour: {
       description: "A mid-protein (10–12%) wheat flour blended from hard and soft varieties to perform acceptably across most baked goods — the Swiss Army knife of American baking. Less chewy than bread flour and less tender than cake flour, it sits in the middle of the gluten spectrum. Bleached versions cook more predictably in cakes; unbleached has slightly more protein and a mellower cream color. Store airtight in cool, dry conditions; refrigerate for long-term use to deter pantry pests.",
     name: "all-purpose flour",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -113,6 +119,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   whole_grain_bread: {
       description: "A staple food prepared from a dough of flour and water, usually baked. The inclusion of leavening agents (like yeast or sourdough starter) traps carbon dioxide gases within a gluten network, transforming a dense paste into a light, aerated, and highly absorbent sponge.\n\n**Selection & Storage:** Fresh artisanal bread should have a hard, shatteringly crisp crust and a soft interior. Store fresh bread in a paper bag at room temperature for a day or two, or slice and freeze it; never refrigerate bread, as the cold accelerates the staling (retrogradation) process.",
     name: "whole grain bread",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -145,6 +153,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   steel_cut_oats: {
       description: "A resilient cereal grain (*Avena sativa*) valued for its high soluble fiber (beta-glucan), which creates a creamy, viscous texture when boiled in liquids. Rolled oats are steamed and flattened for quicker cooking, while steel-cut oats retain more texture and require longer simmering.\n\n**Selection & Storage:** Look for oats that smell slightly sweet and toasty. Because they contain natural fats that can go rancid, store them in a cool, dark pantry in an airtight container, or refrigerate for long-term storage.",
     name: "steel-cut oats",
+    origin: ["Northern Europe"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -183,6 +193,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   breadcrumbs: {
       description: "Breadcrumbs is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "breadcrumbs",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -215,6 +227,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   arborio_rice: {
       description: "An Italian short-grain rice (*Oryza sativa*) named after the town of Arborio in the Po Valley. Its exterior is rich in amylopectin starch, which dissolves slowly during constant stirring to create the signature, creamy, suspension characteristic of classic risotto, while the interior maintains a firm 'al dente' bite.",
     name: "arborio rice",
+    origin: ["Italy (Po Valley)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -247,6 +261,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   bread_stuffing: {
       description: "A staple food prepared from a dough of flour and water, usually baked. The inclusion of leavening agents (like yeast or sourdough starter) traps carbon dioxide gases within a gluten network, transforming a dense paste into a light, aerated, and highly absorbent sponge.\n\n**Selection & Storage:** Fresh artisanal bread should have a hard, shatteringly crisp crust and a soft interior. Store fresh bread in a paper bag at room temperature for a day or two, or slice and freeze it; never refrigerate bread, as the cold accelerates the staling (retrogradation) process.",
     name: "bread stuffing",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -279,6 +295,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   cheong_fun__rice_noodle_rolls_: {
       description: "A broad category of unleavened dough stretched, rolled, or cut into long, thin strips, prevalent in Asian cuisines. Unlike Italian pasta, which is almost exclusively wheat-based, Asian noodles are often made from rice, mung beans, sweet potatoes, or buckwheat, dramatically altering their cooking times and chewy textures.\n\n**Selection & Storage:** Dried rice or glass noodles require only a quick soak in hot water, while fresh wheat noodles require boiling. Store dried noodles in the pantry, and keep fresh noodles tightly wrapped in the refrigerator.",
     name: "cheong fun (rice noodle rolls)",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -311,6 +329,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   glutinous_rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "glutinous rice",
+    origin: ["Southeast Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -343,6 +363,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   rustic_bread: {
       description: "A staple food prepared from a dough of flour and water, usually baked. The inclusion of leavening agents (like yeast or sourdough starter) traps carbon dioxide gases within a gluten network, transforming a dense paste into a light, aerated, and highly absorbent sponge.\n\n**Selection & Storage:** Fresh artisanal bread should have a hard, shatteringly crisp crust and a soft interior. Store fresh bread in a paper bag at room temperature for a day or two, or slice and freeze it; never refrigerate bread, as the cold accelerates the staling (retrogradation) process.",
     name: "rustic bread",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -375,6 +397,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   white_sandwich_bread: {
       description: "A staple food prepared from a dough of flour and water, usually baked. The inclusion of leavening agents (like yeast or sourdough starter) traps carbon dioxide gases within a gluten network, transforming a dense paste into a light, aerated, and highly absorbent sponge.\n\n**Selection & Storage:** Fresh artisanal bread should have a hard, shatteringly crisp crust and a soft interior. Store fresh bread in a paper bag at room temperature for a day or two, or slice and freeze it; never refrigerate bread, as the cold accelerates the staling (retrogradation) process.",
     name: "white sandwich bread",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -407,6 +431,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   idli_rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "idli rice",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -439,6 +465,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   flattened_rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "flattened rice",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -471,6 +499,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   basmati_rice: {
       description: "A highly aromatic, extra-long-grain rice originating from the Indian subcontinent. It undergoes an aging process before milling to reduce its moisture content, ensuring that when cooked, the grains elongate dramatically and remain completely separate, fluffy, and dry—perfect for biryanis.",
     name: "basmati rice",
+    origin: ["South Asia (Punjab region)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -503,6 +533,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   steamed_rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "steamed rice",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -535,6 +567,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   sushi_rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "sushi rice",
+    origin: ["Japan"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -567,6 +601,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   short_grain_rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "short grain rice",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -599,6 +635,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   sliced_rice_cakes: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "sliced rice cakes",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -631,6 +669,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   rice_cakes: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "rice cakes",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -663,6 +703,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   rice_flour: {
       description: "The powder produced by milling raw grains, roots, beans, nuts, or seeds — most commonly wheat (*Triticum aestivum*). Its behavior in baking is governed by protein content: high-protein bread flour (12–14%) develops strong gluten networks for chewy yeasted breads, while low-protein cake flour (7–9%) yields tender, delicate crumb. Whole-grain flours include the bran and germ, adding fiber, fat, and perishability that demands cool storage to prevent rancidity.",
     name: "rice flour",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -695,6 +737,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   flatbread: {
       description: "Flatbread is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "flatbread",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -727,6 +771,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   jasmine_rice: {
       description: "A fragrant, long-grain rice (*Oryza sativa*) primarily cultivated in Thailand. It contains the aromatic compound 2-acetyl-1-pyrroline, which gives it a deeply floral, pandan-like, and slightly buttery aroma that perfectly complements the rich coconut curries of Southeast Asia.",
     name: "jasmine rice",
+    origin: ["Thailand"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -759,6 +805,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   glass_noodles: {
       description: "A broad category of unleavened dough stretched, rolled, or cut into long, thin strips, prevalent in Asian cuisines. Unlike Italian pasta, which is almost exclusively wheat-based, Asian noodles are often made from rice, mung beans, sweet potatoes, or buckwheat, dramatically altering their cooking times and chewy textures.\n\n**Selection & Storage:** Dried rice or glass noodles require only a quick soak in hot water, while fresh wheat noodles require boiling. Store dried noodles in the pantry, and keep fresh noodles tightly wrapped in the refrigerator.",
     name: "glass noodles",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -791,6 +839,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   rice_noodles: {
       description: "A broad category of unleavened dough stretched, rolled, or cut into long, thin strips, prevalent in Asian cuisines. Unlike Italian pasta, which is almost exclusively wheat-based, Asian noodles are often made from rice, mung beans, sweet potatoes, or buckwheat, dramatically altering their cooking times and chewy textures.\n\n**Selection & Storage:** Dried rice or glass noodles require only a quick soak in hot water, while fresh wheat noodles require boiling. Store dried noodles in the pantry, and keep fresh noodles tightly wrapped in the refrigerator.",
     name: "rice noodles",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -823,6 +873,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   sticky_rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "sticky rice",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -855,6 +907,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   tapioca_flour: {
       description: "The powder produced by milling raw grains, roots, beans, nuts, or seeds — most commonly wheat (*Triticum aestivum*). Its behavior in baking is governed by protein content: high-protein bread flour (12–14%) develops strong gluten networks for chewy yeasted breads, while low-protein cake flour (7–9%) yields tender, delicate crumb. Whole-grain flours include the bran and germ, adding fiber, fat, and perishability that demands cool storage to prevent rancidity.",
     name: "tapioca flour",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -887,6 +941,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   glutinous_rice_flour: {
       description: "The powder produced by milling raw grains, roots, beans, nuts, or seeds — most commonly wheat (*Triticum aestivum*). Its behavior in baking is governed by protein content: high-protein bread flour (12–14%) develops strong gluten networks for chewy yeasted breads, while low-protein cake flour (7–9%) yields tender, delicate crumb. Whole-grain flours include the bran and germ, adding fiber, fat, and perishability that demands cool storage to prevent rancidity.",
     name: "glutinous rice flour",
+    origin: ["Southeast Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -919,6 +975,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   thick_rice_noodles: {
       description: "A broad category of unleavened dough stretched, rolled, or cut into long, thin strips, prevalent in Asian cuisines. Unlike Italian pasta, which is almost exclusively wheat-based, Asian noodles are often made from rice, mung beans, sweet potatoes, or buckwheat, dramatically altering their cooking times and chewy textures.\n\n**Selection & Storage:** Dried rice or glass noodles require only a quick soak in hot water, while fresh wheat noodles require boiling. Store dried noodles in the pantry, and keep fresh noodles tightly wrapped in the refrigerator.",
     name: "thick rice noodles",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -951,6 +1009,8 @@ const rawGrains: Record<string, Partial<IngredientMapping>> = {
   broken_rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "broken rice",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",

--- a/src/data/ingredients/grains/pseudoGrains/amaranth.ts
+++ b/src/data/ingredients/grains/pseudoGrains/amaranth.ts
@@ -5,6 +5,7 @@ const rawAmaranth = {
   amaranth: {
       description: "An ancient, tiny pseudocereal seed (*Amaranthus*) that was a staple of the Aztec diet. It has a peppery, deeply earthy flavor and never entirely softens when boiled, retaining a gelatinous, caviar-like crunch that thickens porridges and soups.",
     name: "Amaranth",
+    season: ["all"],
     elementalProperties: { Earth: 0.3, Fire: 0.3, Air: 0.2, Water: 0.2 },
     astrologicalProfile: {
       rulingPlanets: ["Mars", "Venus"],

--- a/src/data/ingredients/grains/pseudoGrains/buckwheat.ts
+++ b/src/data/ingredients/grains/pseudoGrains/buckwheat.ts
@@ -5,6 +5,7 @@ const rawBuckwheat = {
   buckwheat: {
       description: "A nutrient-dense pseudocereal (*Fagopyrum esculentum*) that is completely unrelated to wheat and naturally gluten-free. It provides an aggressively earthy, nutty, and slightly bitter flavor, and is the essential ingredient in Japanese soba noodles and French Breton galettes (crepes).",
     name: "Buckwheat",
+    season: ["all"],
     elementalProperties: { Earth: 0.4, Water: 0.1, Air: 0.2, Fire: 0.3 },
     astrologicalProfile: {
       rulingPlanets: ["Saturn", "Mars"],

--- a/src/data/ingredients/grains/pseudoGrains/chia.ts
+++ b/src/data/ingredients/grains/pseudoGrains/chia.ts
@@ -5,6 +5,7 @@ const rawChia: Record<string, Partial<IngredientMapping>> = {
   chia: {
       description: "Chia Seeds is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "Chia Seeds",
+    season: ["all"],
     elementalProperties: { Water: 0.4, Earth: 0.3, Air: 0.2, Fire: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Neptune", "Moon"],

--- a/src/data/ingredients/grains/pseudoGrains/flaxseed.ts
+++ b/src/data/ingredients/grains/pseudoGrains/flaxseed.ts
@@ -5,6 +5,7 @@ const rawFlaxseed = {
   flaxseed: {
       description: "A small, flat, teardrop-shaped seed (*Linum usitatissimum*) known for its high concentration of alpha-linolenic acid (an omega-3) and mucilaginous fiber. When ground and mixed with water, it forms a thick, gel-like paste that is heavily utilized as a vegan egg substitute in baking.",
     name: "Flaxseed",
+    season: ["all"],
     elementalProperties: { Water: 0.3, Earth: 0.3, Air: 0.3, Fire: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Moon", "Venus"],

--- a/src/data/ingredients/grains/pseudoGrains/quinoa.ts
+++ b/src/data/ingredients/grains/pseudoGrains/quinoa.ts
@@ -5,6 +5,7 @@ const rawQuinoa = {
   quinoa: {
       description: "A pseudocereal seed (*Chenopodium quinoa*) from the amaranth family, revered for containing all nine essential amino acids (a complete protein). It cooks quickly, yielding a fluffy, slightly crunchy texture and a distinctively earthy, nutty flavor that works perfectly in salads and grain bowls.",
     name: "Quinoa",
+    season: ["all"],
     elementalProperties: { Earth: 0.3, Water: 0.2, Air: 0.3, Fire: 0.2 },
     astrologicalProfile: {
       rulingPlanets: ["Mercury"],

--- a/src/data/ingredients/grains/refinedGrains.ts
+++ b/src/data/ingredients/grains/refinedGrains.ts
@@ -5,6 +5,8 @@ const rawRefinedGrains = {
   white_rice: {
       description: "A starchy cereal grain (*Oryza sativa*) that has been milled to remove its husk, bran, and germ. Because only the starchy endosperm remains, it cooks quickly, has a mild, clean flavor, and yields a fluffy, soft texture that acts as a neutral sponge for rich sauces and curries.",
     name: "White Rice",
+    origin: ["East Asia"],
+    season: ["all"],
     elementalProperties: { Air: 0.4, Earth: 0.3, Water: 0.2, Fire: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Moon", "Mercury"],
@@ -102,6 +104,8 @@ const rawRefinedGrains = {
   semolina: {
       description: "A coarse, pale-yellow flour milled from hard durum wheat (*Triticum durum*). Its extraordinarily high protein content and coarse grind make it the international standard for creating structured, resilient dried pasta, and it provides a gritty, satisfying crunch when dusted on pizza peels.",
     name: "Semolina",
+    origin: ["Mediterranean"],
+    season: ["all"],
     elementalProperties: { Fire: 0.18, Water: 0.09, Earth: 0.37, Air: 0.36 },
     astrologicalProfile: {
       rulingPlanets: ["Mercury", "Saturn"],
@@ -211,6 +215,8 @@ const rawRefinedGrains = {
   pearl_barley: {
       description: "A form of barley (*Hordeum vulgare*) that has been scoured (pearled) to remove both its inedible outer hull and its bran layer. This processing significantly reduces its cooking time and allows it to release massive amounts of viscous starches, perfectly thickening heavy winter beef stews and risottos.",
     name: "Pearl Barley",
+    origin: ["Fertile Crescent"],
+    season: ["all"],
     elementalProperties: { Earth: 0.4, Water: 0.3, Air: 0.2, Fire: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Moon", "Saturn"],
@@ -312,6 +318,8 @@ const rawRefinedGrains = {
   polished_farro: {
       description: "An ancient wheat grain (*Triticum dicoccum*) that has undergone 'pearling' to completely remove its tough bran layer. While this reduces its nutritional density compared to whole farro, it drastically cuts the cooking time to under 20 minutes, yielding a soft, starchy grain perfect for quick risottos (farrotto).",
     name: "Polished Farro",
+    origin: ["Fertile Crescent", "Italy"],
+    season: ["all"],
     elementalProperties: { Earth: 0.4, Air: 0.3, Fire: 0.2, Water: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Saturn", "Mercury"],
@@ -414,6 +422,8 @@ const rawRefinedGrains = {
   white_cornmeal: {
       description: "A coarse flour milled from dried white dent corn. Compared to yellow cornmeal, it offers a more delicate, less aggressively sweet, and slightly more floral flavor profile, serving as the foundational ingredient for Southern US staples like grits and traditional cornbread.",
     name: "White Cornmeal",
+    origin: ["Mesoamerica"],
+    season: ["all"],
     elementalProperties: { Earth: 0.4, Fire: 0.3, Air: 0.2, Water: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Sun", "Jupiter"],
@@ -517,6 +527,8 @@ const rawRefinedGrains = {
   all_purpose_flour: {
       description: "A mid-protein (10–12%) wheat flour blended from hard and soft varieties to perform acceptably across most baked goods — the Swiss Army knife of American baking. Less chewy than bread flour and less tender than cake flour, it sits in the middle of the gluten spectrum. Bleached versions cook more predictably in cakes; unbleached has slightly more protein and a mellower cream color. Store airtight in cool, dry conditions; refrigerate for long-term use to deter pantry pests.",
     name: "All-Purpose Flour",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Earth: 0.4, Air: 0.4, Water: 0.1, Fire: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Mercury", "Venus"],

--- a/src/data/ingredients/grains/wholeGrains.ts
+++ b/src/data/ingredients/grains/wholeGrains.ts
@@ -379,6 +379,8 @@ const rawWholeGrains = {
   quinoa: {
       description: "A pseudocereal seed (*Chenopodium quinoa*) from the amaranth family, revered for containing all nine essential amino acids (a complete protein). It cooks quickly, yielding a fluffy, slightly crunchy texture and a distinctively earthy, nutty flavor that works perfectly in salads and grain bowls.",
     name: "Quinoa",
+    origin: ["Andes (Peru, Bolivia, Ecuador)"],
+    season: ["all"],
     elementalProperties: { Earth: 0.4, Air: 0.4, Water: 0.2, Fire: 0 },
     astrologicalProfile: {
       rulingPlanets: ["Moon", "Mercury"],
@@ -411,6 +413,8 @@ const rawWholeGrains = {
   kamut: {
       description: "A trademarked name for Khorasan wheat (*Triticum turgidum turanicum*), an ancient grain characterized by kernels twice the size of modern wheat. It has a rich, buttery, and slightly sweet flavor, providing exceptional chew when boiled for salads or milled into a golden-hued pasta dough.",
     name: "Kamut",
+    origin: ["Fertile Crescent"],
+    season: ["all"],
     elementalProperties: { Earth: 0.5, Fire: 0.2, Air: 0.2, Water: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Saturn", "Earth"],
@@ -462,6 +466,8 @@ const rawWholeGrains = {
   spelt_berries: {
       description: "The whole, unprocessed grains of an ancient wheat subspecies (*Triticum spelta*). They possess a tough outer hull that must be mechanically removed before cooking, yielding a grain with a satisfying, popping chew and a distinctly sweet, intensely nutty flavor profile that is more complex than standard wheat berries.",
     name: "Spelt Berries",
+    origin: ["Fertile Crescent"],
+    season: ["all"],
     elementalProperties: { Earth: 0.5, Fire: 0.2, Air: 0.2, Water: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Saturn", "Earth"],
@@ -513,6 +519,8 @@ const rawWholeGrains = {
   einkorn: {
       description: "An ancient species of wheat (*Triticum monococcum*), considered the first domesticated wheat in human history. It has a significantly simpler gluten structure than modern wheat (making it easier for some to digest) and offers a profoundly rich, nutty, and slightly sweet flavor when baked into dense, rustic breads.",
     name: "Einkorn",
+    origin: ["Fertile Crescent"],
+    season: ["all"],
     elementalProperties: { Earth: 0.5, Fire: 0.2, Air: 0.2, Water: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Saturn", "Venus"],
@@ -564,6 +572,8 @@ const rawWholeGrains = {
   rye_berries: {
       description: "The whole, unprocessed grain of rye (*Secale cereale*), containing the bran, germ, and endosperm. They require long soaking and simmering to soften but offer a profoundly chewy, dense texture and a distinctively sour, earthy, and complex flavor that makes an incredibly hearty grain salad.",
     name: "Rye Berries",
+    origin: ["Western Asia"],
+    season: ["all"],
     elementalProperties: { Earth: 0.5, Water: 0.2, Air: 0.1, Fire: 0.2 },
     astrologicalProfile: {
       rulingPlanets: ["Saturn", "Venus"],
@@ -615,6 +625,8 @@ const rawWholeGrains = {
   wild_rice: {
       description: "Not a true rice, but rather the long, dark seed of a marsh grass (*Zizania*) native to North America. It offers a distinctly intense, woodsy, and toasted tea-like flavor, and features a tough outer sheath that pops open to reveal a tender interior when boiled.",
     name: "Wild Rice",
+    origin: ["North America (Great Lakes)"],
+    season: ["all"],
     elementalProperties: { Water: 0.4, Earth: 0.3, Air: 0.2, Fire: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Saturn", "Venus"],
@@ -665,6 +677,8 @@ const rawWholeGrains = {
   triticale: {
       description: "A hybrid grain created by crossing wheat (*Triticum*) and rye (*Secale*), aiming to combine the yield potential and grain quality of wheat with the disease and environmental tolerance of rye. It offers a dense, chewy texture and a flavor that is sweeter than rye but more complex and earthy than standard wheat.",
     name: "Triticale",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Earth: 0.5, Fire: 0.2, Air: 0.2, Water: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Saturn", "Venus"],
@@ -716,6 +730,8 @@ const rawWholeGrains = {
   oats: {
       description: "A resilient cereal grain (*Avena sativa*) valued for its high soluble fiber (beta-glucan), which creates a creamy, viscous texture when boiled in liquids. Rolled oats are steamed and flattened for quicker cooking, while steel-cut oats retain more texture and require longer simmering.\n\n**Selection & Storage:** Look for oats that smell slightly sweet and toasty. Because they contain natural fats that can go rancid, store them in a cool, dark pantry in an airtight container, or refrigerate for long-term storage.",
     name: "Oats",
+    origin: ["Northern Europe"],
+    season: ["all"],
     elementalProperties: { Earth: 0.4, Water: 0.3, Air: 0.2, Fire: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Moon", "Venus"],
@@ -769,6 +785,8 @@ const rawWholeGrains = {
   barley: {
       description: "A hardy cereal grain (*Hordeum vulgare*) with a tough hull. It contains high levels of soluble beta-glucan fiber, which causes it to release a thick, gelatinous starch when simmered, naturally thickening hearty beef stews and winter soups.",
     name: "Barley",
+    origin: ["Fertile Crescent"],
+    season: ["all"],
     astrologicalProfile: {
       rulingPlanets: ["Venus", "Moon"],
       favorableZodiac: ["cancer", "taurus"] as any[],
@@ -818,6 +836,8 @@ const rawWholeGrains = {
   flour: {
       description: "A powder made by grinding raw grains, roots, beans, nuts, or seeds, though most commonly refers to wheat. Its specific culinary use is dictated by its protein content: high-protein bread flour forms strong gluten networks for chewy breads, while low-protein cake flour yields tender, delicate crumb structures.",
     name: "flour",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -835,6 +855,8 @@ const rawWholeGrains = {
   rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "rice",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -852,6 +874,8 @@ const rawWholeGrains = {
   all_purpose_flour: {
       description: "A mid-protein (10–12%) wheat flour blended from hard and soft varieties to perform acceptably across most baked goods — the Swiss Army knife of American baking. Less chewy than bread flour and less tender than cake flour, it sits in the middle of the gluten spectrum. Bleached versions cook more predictably in cakes; unbleached has slightly more protein and a mellower cream color. Store airtight in cool, dry conditions; refrigerate for long-term use to deter pantry pests.",
     name: "all-purpose flour",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -869,6 +893,8 @@ const rawWholeGrains = {
   whole_grain_bread: {
       description: "A staple food prepared from a dough of flour and water, usually baked. The inclusion of leavening agents (like yeast or sourdough starter) traps carbon dioxide gases within a gluten network, transforming a dense paste into a light, aerated, and highly absorbent sponge.\n\n**Selection & Storage:** Fresh artisanal bread should have a hard, shatteringly crisp crust and a soft interior. Store fresh bread in a paper bag at room temperature for a day or two, or slice and freeze it; never refrigerate bread, as the cold accelerates the staling (retrogradation) process.",
     name: "whole grain bread",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -886,6 +912,8 @@ const rawWholeGrains = {
   steel_cut_oats: {
       description: "A resilient cereal grain (*Avena sativa*) valued for its high soluble fiber (beta-glucan), which creates a creamy, viscous texture when boiled in liquids. Rolled oats are steamed and flattened for quicker cooking, while steel-cut oats retain more texture and require longer simmering.\n\n**Selection & Storage:** Look for oats that smell slightly sweet and toasty. Because they contain natural fats that can go rancid, store them in a cool, dark pantry in an airtight container, or refrigerate for long-term storage.",
     name: "steel-cut oats",
+    origin: ["Northern Europe"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -903,6 +931,8 @@ const rawWholeGrains = {
   breadcrumbs: {
       description: "Breadcrumbs is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "breadcrumbs",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -920,6 +950,8 @@ const rawWholeGrains = {
   arborio_rice: {
       description: "An Italian short-grain rice (*Oryza sativa*) named after the town of Arborio in the Po Valley. Its exterior is rich in amylopectin starch, which dissolves slowly during constant stirring to create the signature, creamy, suspension characteristic of classic risotto, while the interior maintains a firm 'al dente' bite.",
     name: "arborio rice",
+    origin: ["Italy (Po Valley)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -937,6 +969,8 @@ const rawWholeGrains = {
   bread_stuffing: {
       description: "A staple food prepared from a dough of flour and water, usually baked. The inclusion of leavening agents (like yeast or sourdough starter) traps carbon dioxide gases within a gluten network, transforming a dense paste into a light, aerated, and highly absorbent sponge.\n\n**Selection & Storage:** Fresh artisanal bread should have a hard, shatteringly crisp crust and a soft interior. Store fresh bread in a paper bag at room temperature for a day or two, or slice and freeze it; never refrigerate bread, as the cold accelerates the staling (retrogradation) process.",
     name: "bread stuffing",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -954,6 +988,8 @@ const rawWholeGrains = {
   cheong_fun__rice_noodle_rolls_: {
       description: "A broad category of unleavened dough stretched, rolled, or cut into long, thin strips, prevalent in Asian cuisines. Unlike Italian pasta, which is almost exclusively wheat-based, Asian noodles are often made from rice, mung beans, sweet potatoes, or buckwheat, dramatically altering their cooking times and chewy textures.\n\n**Selection & Storage:** Dried rice or glass noodles require only a quick soak in hot water, while fresh wheat noodles require boiling. Store dried noodles in the pantry, and keep fresh noodles tightly wrapped in the refrigerator.",
     name: "cheong fun (rice noodle rolls)",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -971,6 +1007,8 @@ const rawWholeGrains = {
   glutinous_rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "glutinous rice",
+    origin: ["Southeast Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -988,6 +1026,8 @@ const rawWholeGrains = {
   rustic_bread: {
       description: "A staple food prepared from a dough of flour and water, usually baked. The inclusion of leavening agents (like yeast or sourdough starter) traps carbon dioxide gases within a gluten network, transforming a dense paste into a light, aerated, and highly absorbent sponge.\n\n**Selection & Storage:** Fresh artisanal bread should have a hard, shatteringly crisp crust and a soft interior. Store fresh bread in a paper bag at room temperature for a day or two, or slice and freeze it; never refrigerate bread, as the cold accelerates the staling (retrogradation) process.",
     name: "rustic bread",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1005,6 +1045,8 @@ const rawWholeGrains = {
   white_sandwich_bread: {
       description: "A staple food prepared from a dough of flour and water, usually baked. The inclusion of leavening agents (like yeast or sourdough starter) traps carbon dioxide gases within a gluten network, transforming a dense paste into a light, aerated, and highly absorbent sponge.\n\n**Selection & Storage:** Fresh artisanal bread should have a hard, shatteringly crisp crust and a soft interior. Store fresh bread in a paper bag at room temperature for a day or two, or slice and freeze it; never refrigerate bread, as the cold accelerates the staling (retrogradation) process.",
     name: "white sandwich bread",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1022,6 +1064,8 @@ const rawWholeGrains = {
   idli_rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "idli rice",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1039,6 +1083,8 @@ const rawWholeGrains = {
   flattened_rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "flattened rice",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1056,6 +1102,8 @@ const rawWholeGrains = {
   basmati_rice: {
       description: "A highly aromatic, extra-long-grain rice originating from the Indian subcontinent. It undergoes an aging process before milling to reduce its moisture content, ensuring that when cooked, the grains elongate dramatically and remain completely separate, fluffy, and dry—perfect for biryanis.",
     name: "basmati rice",
+    origin: ["South Asia (Punjab region)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1073,6 +1121,8 @@ const rawWholeGrains = {
   steamed_rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "steamed rice",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1090,6 +1140,8 @@ const rawWholeGrains = {
   sushi_rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "sushi rice",
+    origin: ["Japan"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1107,6 +1159,8 @@ const rawWholeGrains = {
   short_grain_rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "short grain rice",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1124,6 +1178,8 @@ const rawWholeGrains = {
   sliced_rice_cakes: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "sliced rice cakes",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1141,6 +1197,8 @@ const rawWholeGrains = {
   rice_cakes: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "rice cakes",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1158,6 +1216,8 @@ const rawWholeGrains = {
   rice_flour: {
       description: "The powder produced by milling raw grains, roots, beans, nuts, or seeds — most commonly wheat (*Triticum aestivum*). Its behavior in baking is governed by protein content: high-protein bread flour (12–14%) develops strong gluten networks for chewy yeasted breads, while low-protein cake flour (7–9%) yields tender, delicate crumb. Whole-grain flours include the bran and germ, adding fiber, fat, and perishability that demands cool storage to prevent rancidity.",
     name: "rice flour",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1175,6 +1235,8 @@ const rawWholeGrains = {
   flatbread: {
       description: "Flatbread is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "flatbread",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1192,6 +1254,8 @@ const rawWholeGrains = {
   jasmine_rice: {
       description: "A fragrant, long-grain rice (*Oryza sativa*) primarily cultivated in Thailand. It contains the aromatic compound 2-acetyl-1-pyrroline, which gives it a deeply floral, pandan-like, and slightly buttery aroma that perfectly complements the rich coconut curries of Southeast Asia.",
     name: "jasmine rice",
+    origin: ["Thailand"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1209,6 +1273,8 @@ const rawWholeGrains = {
   glass_noodles: {
       description: "A broad category of unleavened dough stretched, rolled, or cut into long, thin strips, prevalent in Asian cuisines. Unlike Italian pasta, which is almost exclusively wheat-based, Asian noodles are often made from rice, mung beans, sweet potatoes, or buckwheat, dramatically altering their cooking times and chewy textures.\n\n**Selection & Storage:** Dried rice or glass noodles require only a quick soak in hot water, while fresh wheat noodles require boiling. Store dried noodles in the pantry, and keep fresh noodles tightly wrapped in the refrigerator.",
     name: "glass noodles",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1226,6 +1292,8 @@ const rawWholeGrains = {
   rice_noodles: {
       description: "A broad category of unleavened dough stretched, rolled, or cut into long, thin strips, prevalent in Asian cuisines. Unlike Italian pasta, which is almost exclusively wheat-based, Asian noodles are often made from rice, mung beans, sweet potatoes, or buckwheat, dramatically altering their cooking times and chewy textures.\n\n**Selection & Storage:** Dried rice or glass noodles require only a quick soak in hot water, while fresh wheat noodles require boiling. Store dried noodles in the pantry, and keep fresh noodles tightly wrapped in the refrigerator.",
     name: "rice noodles",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1243,6 +1311,8 @@ const rawWholeGrains = {
   sticky_rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "sticky rice",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1260,6 +1330,8 @@ const rawWholeGrains = {
   tapioca_flour: {
       description: "The powder produced by milling raw grains, roots, beans, nuts, or seeds — most commonly wheat (*Triticum aestivum*). Its behavior in baking is governed by protein content: high-protein bread flour (12–14%) develops strong gluten networks for chewy yeasted breads, while low-protein cake flour (7–9%) yields tender, delicate crumb. Whole-grain flours include the bran and germ, adding fiber, fat, and perishability that demands cool storage to prevent rancidity.",
     name: "tapioca flour",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1277,6 +1349,8 @@ const rawWholeGrains = {
   glutinous_rice_flour: {
       description: "The powder produced by milling raw grains, roots, beans, nuts, or seeds — most commonly wheat (*Triticum aestivum*). Its behavior in baking is governed by protein content: high-protein bread flour (12–14%) develops strong gluten networks for chewy yeasted breads, while low-protein cake flour (7–9%) yields tender, delicate crumb. Whole-grain flours include the bran and germ, adding fiber, fat, and perishability that demands cool storage to prevent rancidity.",
     name: "glutinous rice flour",
+    origin: ["Southeast Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1294,6 +1368,8 @@ const rawWholeGrains = {
   thick_rice_noodles: {
       description: "A broad category of unleavened dough stretched, rolled, or cut into long, thin strips, prevalent in Asian cuisines. Unlike Italian pasta, which is almost exclusively wheat-based, Asian noodles are often made from rice, mung beans, sweet potatoes, or buckwheat, dramatically altering their cooking times and chewy textures.\n\n**Selection & Storage:** Dried rice or glass noodles require only a quick soak in hot water, while fresh wheat noodles require boiling. Store dried noodles in the pantry, and keep fresh noodles tightly wrapped in the refrigerator.",
     name: "thick rice noodles",
+    origin: ["Cultivated worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",
@@ -1311,6 +1387,8 @@ const rawWholeGrains = {
   broken_rice: {
       description: "The edible starchy seed of *Oryza sativa* (Asian rice) or *O. glaberrima* (African rice), domesticated over 10,000 years ago and now feeding more than half the global population. Its culinary behavior depends on amylose-to-amylopectin starch ratio: long-grain varieties stay separate and fluffy; medium and short-grain grow creamy or sticky; glutinous rice turns fully chewy. Technique matters — rinse until water runs clear, then use the appropriate water ratio and resting period for the target texture.",
     name: "broken rice",
+    origin: ["East and South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
     qualities: ["carbohydrate-rich", "sustaining", "versatile"],
     category: "grain",

--- a/src/data/ingredients/herbs/aromatic.ts
+++ b/src/data/ingredients/herbs/aromatic.ts
@@ -5,6 +5,8 @@ const rawAromaticHerbs = {
   thyme: {
       description: "A resilient, woody-stemmed herb (*Thymus vulgaris*) featuring tiny leaves packed with the essential oil thymol. Its earthy, slightly floral, and sharp flavor holds up exceptionally well to long, slow cooking, making it a foundational aromatic for stocks, stews, and roasted meats.",
     name: "Thyme",
+    origin: ["Mediterranean"],
+    season: ["spring", "summer", "fall"],
     category: "culinary_herb",
     subCategory: "aromatic",
     elementalProperties: { Air: 0.5, Fire: 0.3, Earth: 0.1, Water: 0.1 },
@@ -60,6 +62,8 @@ const rawAromaticHerbs = {
   rosemary: {
       description: "A fragrant, evergreen shrub (*Salvia rosmarinus*) of the mint family known for its needle-like leaves and robust, pine-and-citrus aroma. Its essential oils contain rosmarinic acid, a powerful antioxidant that helps preserve the flavor and freshness of the foods it's cooked with, making it a classic pairing for roasted meats and root vegetables.\\n\\n",
     name: "Rosemary",
+    origin: ["Mediterranean"],
+    season: ["all"],
     category: "culinary_herb",
     subCategory: "aromatic",
     elementalProperties: { Fire: 0.6, Air: 0.2, Earth: 0.1, Water: 0.1 },
@@ -128,6 +132,8 @@ const rawAromaticHerbs = {
   basil: {
       description: "A tender, aromatic herb (*Ocimum basilicum*) of the mint family, defined by its bright green, delicate leaves. Its complex flavor profile includes notes of anise, clove, and sweet citrus; because its volatile oils evaporate quickly, it should be added at the very end of cooking or used raw.",
     name: "Basil",
+    origin: ["South Asia (India)", "Southeast Asia"],
+    season: ["summer"],
     category: "culinary_herb",
     subCategory: "aromatic",
     elementalProperties: { Air: 0.5, Fire: 0.3, Earth: 0.2, Water: 0 },

--- a/src/data/ingredients/herbs/driedHerbs.ts
+++ b/src/data/ingredients/herbs/driedHerbs.ts
@@ -7,6 +7,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_basil: {
       description: "The dehydrated leaves of the sweet basil plant (*Ocimum basilicum*). Unlike oregano or thyme, basil loses almost all of its complex, sweet, and anise-like volatile oils during the drying process, leaving behind a muted, slightly minty flavor that requires long simmering in tomato sauces to rehydrate and extract.",
     name: "Dried Basil",
+    origin: ["South Asia (India)", "Southeast Asia"],
     elementalProperties: { Air: 0.4, Water: 0.3, Fire: 0.2, Earth: 0.1 },
     alchemicalProperties: { Spirit: 0.60, Essence: 0.35, Matter: 0.15, Substance: 0.18 },
     astrologicalProfile: {
@@ -50,6 +51,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_oregano: {
       description: "The dehydrated leaves of *Origanum vulgare*. It is one of the few herbs that is generally considered superior when dried rather than fresh; the drying process tames its aggressive bitterness and concentrates its pungent, earthy, and peppery flavor, making it the defining herb of Mediterranean pizza and pasta sauces.",
     name: "Dried Oregano",
+    origin: ["Mediterranean (Greece)"],
     elementalProperties: { Fire: 0.5, Air: 0.2, Earth: 0.2, Water: 0.1 },
     alchemicalProperties: { Spirit: 0.72, Essence: 0.30, Matter: 0.15, Substance: 0.20 },
     astrologicalProfile: {
@@ -98,6 +100,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_thyme: {
       description: "The dehydrated leaves of *Thymus vulgaris*. Because thyme is a woody, resinous herb, it dries exceptionally well, concentrating its sharp, earthy, and distinctly floral/minty flavor. It is a workhorse pantry staple, providing the aromatic backbone for countless stocks, stews, and roasted meats.",
     name: "Dried Thyme",
+    origin: ["Mediterranean"],
     elementalProperties: { Fire: 0.4, Air: 0.3, Earth: 0.2, Water: 0.1 },
     alchemicalProperties: { Spirit: 0.70, Essence: 0.32, Matter: 0.15, Substance: 0.18 },
     astrologicalProfile: {
@@ -140,6 +143,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_rosemary: {
       description: "The dehydrated, needle-like leaves of *Salvia rosmarinus*. Because the leaves are tough and resinous, they retain their powerful pine, wood, and citrus flavor flawlessly when dried. Due to their sharp, brittle texture, they should be minced finely or crushed in a mortar before being added to roasted meats or breads.",
     name: "Dried Rosemary",
+    origin: ["Mediterranean"],
     elementalProperties: { Fire: 0.5, Air: 0.2, Earth: 0.2, Water: 0.1 },
     alchemicalProperties: { Spirit: 0.75, Essence: 0.30, Matter: 0.18, Substance: 0.22 },
     astrologicalProfile: {
@@ -182,6 +186,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_sage: {
       description: "The dehydrated leaves of *Salvia officinalis*. Drying significantly amplifies its already assertive, earthy, slightly astringent, and musky flavor profile. It is incredibly potent and must be used with a light hand, acting as the foundational seasoning for Thanksgiving stuffing and heavy pork sausages.",
     name: "Dried Sage",
+    origin: ["Mediterranean"],
     elementalProperties: { Earth: 0.4, Fire: 0.3, Air: 0.2, Water: 0.1 },
     alchemicalProperties: { Spirit: 0.65, Essence: 0.28, Matter: 0.20, Substance: 0.22 },
     astrologicalProfile: {
@@ -228,6 +233,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_bay_leaves: {
       description: "The dehydrated leaves of the sweet bay tree (*Laurus nobilis*). While fresh bay leaves can be overwhelmingly astringent and menthol-heavy, drying them mellows their bite and concentrates their complex, woody, and floral notes, which release slowly during long braises and stews.",
     name: "Dried Bay Leaves",
+    origin: ["Cultivated worldwide"],
     elementalProperties: { Earth: 0.4, Fire: 0.3, Air: 0.2, Water: 0.1 },
     alchemicalProperties: { Spirit: 0.68, Essence: 0.25, Matter: 0.22, Substance: 0.25 },
     astrologicalProfile: {
@@ -270,6 +276,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_marjoram: {
       description: "The dehydrated leaves of *Origanum majorana*. It is closely related to oregano but is significantly sweeter, more floral, and less aggressive. Drying concentrates its mild, pine-and-citrus flavor, making it a staple in traditional German sausages and delicate poultry seasonings.",
     name: "Dried Marjoram",
+    origin: ["Mediterranean", "Western Asia"],
     elementalProperties: { Air: 0.4, Fire: 0.3, Earth: 0.2, Water: 0.1 },
     alchemicalProperties: { Spirit: 0.65, Essence: 0.32, Matter: 0.14, Substance: 0.18 },
     astrologicalProfile: {
@@ -311,6 +318,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_savory: {
       description: "The dehydrated leaves of the *Satureja* plant, specifically Winter Savory or Summer Savory. It offers a highly pungent, peppery, and robust flavor profile—somewhere between thyme and mint—and is historically famous for its ability to flavor and aid in the digestion of heavy bean stews.",
     name: "Dried Savory",
+    origin: ["Mediterranean"],
     elementalProperties: { Fire: 0.4, Earth: 0.3, Air: 0.2, Water: 0.1 },
     alchemicalProperties: { Spirit: 0.60, Essence: 0.30, Matter: 0.18, Substance: 0.20 },
     astrologicalProfile: {
@@ -352,6 +360,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_chervil: {
       description: "The dried version of the delicate spring herb (*Anthriscus cerefolium*). Because its subtle parsley-anise flavor is extremely fragile, it survives the drying process poorly; it is best used in large quantities in light, cream-based sauces where it won't be overpowered by other ingredients.",
     name: "Dried Chervil",
+    origin: ["Caucasus"],
     elementalProperties: { Air: 0.5, Earth: 0.2, Water: 0.2, Fire: 0.1 },
     alchemicalProperties: { Spirit: 0.55, Essence: 0.35, Matter: 0.10, Substance: 0.14 },
     astrologicalProfile: {
@@ -393,6 +402,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_tarragon: {
       description: "The dehydrated leaves of *Artemisia dracunculus*. While it loses some of the bright, fresh nuance of the raw herb, it retains its distinct, sweet anise and licorice flavor reasonably well, making it a convenient pantry staple for classic French cream sauces and chicken salads.",
     name: "Dried Tarragon",
+    origin: ["Eurasia"],
     elementalProperties: { Air: 0.4, Fire: 0.3, Earth: 0.2, Water: 0.1 },
     alchemicalProperties: { Spirit: 0.70, Essence: 0.32, Matter: 0.12, Substance: 0.16 },
     astrologicalProfile: {
@@ -434,6 +444,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_dill: {
       description: "The dehydrated, feathery fronds of *Anethum graveolens*. It retains its signature sweet, grassy, and slightly anise-like flavor reasonably well when dried, making it a reliable addition to long-simmering fish chowders, yogurt sauces, and potato salads.",
     name: "Dried Dill",
+    origin: ["Mediterranean", "Russia"],
     elementalProperties: { Air: 0.5, Water: 0.2, Earth: 0.2, Fire: 0.1 },
     alchemicalProperties: { Spirit: 0.62, Essence: 0.35, Matter: 0.10, Substance: 0.14 },
     astrologicalProfile: {
@@ -475,6 +486,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_mint: {
       description: "The dehydrated leaves of various *Mentha* species, most commonly spearmint. While it loses the sharp, cooling 'freshness' of raw mint, it develops a deeper, sweeter, and more earthy profile that is absolutely essential for traditional Middle Eastern lamb meatballs (kofta) and yogurt sauces.",
     name: "Dried Mint",
+    origin: ["Mediterranean", "Western Asia"],
     elementalProperties: { Air: 0.5, Water: 0.2, Fire: 0.2, Earth: 0.1 },
     alchemicalProperties: { Spirit: 0.78, Essence: 0.38, Matter: 0.08, Substance: 0.12 },
     astrologicalProfile: {
@@ -521,6 +533,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_fennel: {
       description: "The dehydrated fronds (leaves) of the fennel plant (*Foeniculum vulgare*), not to be confused with fennel seeds. They offer a very mild, sweet licorice/anise flavor that is exceptionally delicate, typically used to lightly season fish broths or delicate pork dishes.",
     name: "Dried Fennel",
+    origin: ["Mediterranean"],
     elementalProperties: { Fire: 0.3, Air: 0.3, Earth: 0.2, Water: 0.2 },
     alchemicalProperties: { Spirit: 0.65, Essence: 0.30, Matter: 0.18, Substance: 0.20 },
     astrologicalProfile: {
@@ -567,6 +580,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_parsley: {
       description: "The dehydrated leaves of *Petroselinum crispum*. Much like dried basil or cilantro, parsley loses almost all of its bright, fresh, and mineral-heavy flavor during the drying process, functioning primarily as a mild, slightly grassy visual garnish.",
     name: "Dried Parsley",
+    origin: ["Mediterranean"],
     elementalProperties: { Air: 0.4, Earth: 0.3, Water: 0.2, Fire: 0.1 },
     alchemicalProperties: { Spirit: 0.45, Essence: 0.30, Matter: 0.15, Substance: 0.18 },
     astrologicalProfile: {
@@ -608,6 +622,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_cilantro: {
       description: "The dehydrated leaves of the coriander plant (*Coriandrum sativum*). The drying process almost completely destroys the bright, citrusy, and pungent volatile oils that define fresh cilantro, leaving a very subtle, grassy herb that functions mostly as a visual garnish rather than a primary flavoring agent.",
     name: "Dried Cilantro",
+    origin: ["Mediterranean", "Western Asia"],
     elementalProperties: { Air: 0.4, Fire: 0.3, Earth: 0.2, Water: 0.1 },
     alchemicalProperties: { Spirit: 0.58, Essence: 0.28, Matter: 0.12, Substance: 0.15 },
     astrologicalProfile: {
@@ -649,6 +664,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_chives: {
       description: "The dehydrated hollow stalks of the smallest onion species (*Allium schoenoprasum*). Drying preserves their distinctively mild, sweet onion flavor surprisingly well, making them a convenient stir-in for sour cream dips, baked potatoes, and savory scones.",
     name: "Dried Chives",
+    origin: ["Europe", "Asia"],
     elementalProperties: { Air: 0.4, Water: 0.3, Fire: 0.2, Earth: 0.1 },
     alchemicalProperties: { Spirit: 0.50, Essence: 0.32, Matter: 0.10, Substance: 0.14 },
     astrologicalProfile: {
@@ -690,6 +706,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_lemon_balm: {
       description: "The dehydrated leaves of *Melissa officinalis*, a member of the mint family. It retains a bright, distinctively sweet lemon aroma and a mild minty undertone, making it a soothing, aromatic addition to herbal teas, delicate fruit salads, and light chicken marinades.",
     name: "Dried Lemon Balm",
+    origin: ["Mediterranean", "Western Asia"],
     elementalProperties: { Air: 0.4, Water: 0.3, Fire: 0.2, Earth: 0.1 },
     alchemicalProperties: { Spirit: 0.65, Essence: 0.40, Matter: 0.08, Substance: 0.12 },
     astrologicalProfile: {
@@ -736,6 +753,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_lavender: {
       description: "The dehydrated, highly aromatic flowers of the *Lavandula* plant, most commonly *Lavandula angustifolia* (English lavender) for culinary use. It imparts a profoundly strong, perfumed, and sweet floral flavor that must be used incredibly sparingly to avoid making food taste like soap.",
     name: "Dried Lavender",
+    origin: ["Mediterranean"],
     elementalProperties: { Air: 0.5, Fire: 0.2, Earth: 0.2, Water: 0.1 },
     alchemicalProperties: { Spirit: 0.80, Essence: 0.42, Matter: 0.08, Substance: 0.10 },
     astrologicalProfile: {
@@ -782,6 +800,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_summer_savory: {
       description: "Dried Summer Savory is an aromatic herb used to brighten savory dishes with fresh, volatile flavor compounds. Add early for mellow infusion or late for sharper aromatic lift, depending on the recipe goal. Because aroma degrades quickly with heat and air, keep it cold and dry, and chop just before use when possible.",
     name: "Dried Summer Savory",
+    origin: ["Mediterranean"],
     elementalProperties: { Fire: 0.4, Earth: 0.3, Air: 0.2, Water: 0.1 },
     alchemicalProperties: { Spirit: 0.58, Essence: 0.30, Matter: 0.18, Substance: 0.20 },
     astrologicalProfile: {
@@ -823,6 +842,7 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   dried_lovage: {
       description: "The dehydrated leaves of *Levisticum officinale*, an herb that tastes like an intense, highly concentrated cross between celery and parsley. Because its flavor is so robust and meaty, it survives the drying process exceptionally well and is a powerhouse addition to beef stews and heavy broths.",
     name: "Dried Lovage",
+    origin: ["Cultivated worldwide"],
     elementalProperties: { Earth: 0.4, Water: 0.3, Air: 0.2, Fire: 0.1 },
     alchemicalProperties: { Spirit: 0.11, Essence: 0.19, Matter: 0.39, Substance: 0.31 },
     astrologicalProfile: {
@@ -864,6 +884,8 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   chervil: {
       description: "A delicate, highly perishable spring herb (*Anthriscus cerefolium*) featuring lacy, fern-like leaves. It is a cornerstone of the classic French *fines herbes* blend, offering a subtle, refined flavor profile combining parsley and faint anise, which must be added at the absolute last second to avoid destroying its volatile oils.",
     name: "Chervil",
+    origin: ["Caucasus"],
+    season: ["spring", "fall"],
     elementalProperties: {
       Air: 0.4,
       Fire: 0.3,
@@ -896,6 +918,8 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   bay_leaf: {
       description: "The aromatic leaf of the sweet bay tree (*Laurus nobilis*), typically used dried. When simmered in liquid for an extended period, it releases complex, woodsy, floral, and slightly menthol notes that add essential savory depth to soups, stews, and braises.",
     name: "Bay Leaf",
+    origin: ["Mediterranean (Asia Minor)"],
+    season: ["all"],
     elementalProperties: {
       Air: 0.4,
       Fire: 0.3,
@@ -929,6 +953,8 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
   anise: {
       description: "The seed of the *Pimpinella anisum* plant, yielding a distinctively sweet, highly aromatic, and slightly spicy licorice flavor. It shares the volatile compound anethole with fennel and star anise, making it a foundational flavoring for classic Mediterranean spirits like Ouzo, Sambuca, and Absinthe.",
     name: "Anise",
+    origin: ["Eastern Mediterranean", "Western Asia"],
+    season: ["all"],
     elementalProperties: {
       Air: 0.4,
       Fire: 0.3,

--- a/src/data/ingredients/herbs/freshHerbs.ts
+++ b/src/data/ingredients/herbs/freshHerbs.ts
@@ -5,6 +5,7 @@ const rawFreshHerbs = {
   basil: {
       description: "A tender, aromatic herb (*Ocimum basilicum*) of the mint family, defined by its bright green, delicate leaves. Its complex flavor profile includes notes of anise, clove, and sweet citrus; because its volatile oils evaporate quickly, it should be added at the very end of cooking or used raw.",
     name: "Basil",
+    season: ["summer"],
     category: "culinary_herb",
     subCategory: "fresh_herb",
 
@@ -315,6 +316,8 @@ const rawFreshHerbs = {
   pork_sausage: {
       description: "A remarkably broad category of ground meat (usually pork) mixed with salt, spices, and fat, typically stuffed into a casing. Fresh sausages (like bratwurst or Italian sausage) require cooking, while cured or smoked sausages (like andouille or kielbasa) are preserved and often ready to eat.\n\n**Selection & Storage:** Fresh sausages must be kept in the coldest part of the refrigerator and cooked within 1-2 days, or frozen for long-term storage.",
     name: "pork sausage",
+    origin: ["East Asia (domestication)"],
+    season: ["all"],
     // Corrected: pork sausage is a cured meat, not an herb.
     // Fire-dominant (high heat cooking), secondary Earth (rich, dense).
     elementalProperties: { Fire: 0.5, Water: 0.1, Earth: 0.35, Air: 0.05 },
@@ -334,6 +337,8 @@ const rawFreshHerbs = {
   thyme: {
       description: "A resilient, woody-stemmed herb (*Thymus vulgaris*) featuring tiny leaves packed with the essential oil thymol. Its earthy, slightly floral, and sharp flavor holds up exceptionally well to long, slow cooking, making it a foundational aromatic for stocks, stews, and roasted meats.",
     name: "thyme",
+    origin: ["Mediterranean"],
+    season: ["spring", "summer", "fall"],
     // Warm, earthy Mediterranean herb. Fire (warming thymol), Air (volatile aromatics), Earth (woody stem).
     elementalProperties: { Fire: 0.30, Water: 0.10, Earth: 0.20, Air: 0.40 },
     qualities: ["aromatic", "warming", "earthy", "culinary", "medicinal"],
@@ -352,6 +357,8 @@ const rawFreshHerbs = {
   fresh_thyme: {
       description: "A resilient, woody-stemmed herb (*Thymus vulgaris*) featuring tiny leaves packed with the essential oil thymol. Its earthy, slightly floral, and sharp flavor holds up exceptionally well to long, slow cooking, making it a foundational aromatic for stocks, stews, and roasted meats.\n\n**Selection & Storage:** Look for bright green, fragrant sprigs without woody or dried-out tips. Store fresh thyme wrapped loosely in a damp paper towel inside a plastic bag in the refrigerator's crisper drawer.",
     name: "fresh thyme",
+    origin: ["Mediterranean"],
+    season: ["spring", "summer", "fall"],
     // Similar to dried thyme but slightly more Water (moisture in fresh leaves).
     elementalProperties: { Fire: 0.25, Water: 0.15, Earth: 0.18, Air: 0.42 },
     qualities: ["aromatic", "fresh", "warming", "culinary", "medicinal"],
@@ -370,6 +377,8 @@ const rawFreshHerbs = {
   sage: {
       description: "A hardy herb (*Salvia officinalis*) with velvety, grey-green leaves and a highly assertive, pine-like, and slightly astringent aroma. Because its flavor is so robust and somewhat resinous, it pairs perfectly with fatty meats like pork and sausage, or browned butter sauces.",
     name: "sage",
+    origin: ["Mediterranean"],
+    season: ["spring", "summer", "fall"],
     // Warm, pungent, slightly bitter. Strong Fire (warming oils), Air (volatile compounds), Earth (grounding).
     elementalProperties: { Fire: 0.35, Water: 0.10, Earth: 0.20, Air: 0.35 },
     qualities: ["warming", "pungent", "savory", "medicinal", "culinary"],
@@ -388,6 +397,8 @@ const rawFreshHerbs = {
   fresh_mint: {
       description: "A rapidly spreading, aromatic herb (*Mentha*) characterized by the cooling compound menthol. It provides a sharp, refreshing contrast to rich or spicy dishes, and is utilized globally in everything from Middle Eastern lamb marinades to Southeast Asian salads and sweet desserts.\n\n**Selection & Storage:** Look for perky, bright green leaves without dark spots or wilting. Store unwashed mint wrapped in a lightly damp paper towel inside a plastic bag in the crisper drawer.",
     name: "fresh mint",
+    origin: ["Mediterranean", "Western Asia"],
+    season: ["spring", "summer", "fall"],
     // Cooling menthol creates a paradoxical sensation: Water (cooling), Air (volatile menthol), minimal Fire/Earth.
     elementalProperties: { Fire: 0.05, Water: 0.40, Earth: 0.05, Air: 0.50 },
     qualities: ["cooling", "refreshing", "menthol", "aromatic", "culinary", "medicinal"],
@@ -406,6 +417,8 @@ const rawFreshHerbs = {
   fresh_sage: {
       description: "A hardy herb (*Salvia officinalis*) with velvety, grey-green leaves and a highly assertive, pine-like, and slightly astringent aroma. Because its flavor is so robust and somewhat resinous, it pairs perfectly with fatty meats like pork and sausage, or browned butter sauces.\n\n**Selection & Storage:** Look for fresh, pliable leaves that are fuzzy and aromatic; avoid dried-out or black-spotted leaves. Store wrapped in a slightly damp paper towel in a plastic bag in the refrigerator.",
     name: "fresh sage",
+    origin: ["Mediterranean"],
+    season: ["spring", "summer", "fall"],
     // Fresh sage: slightly more Water than dried, warm pungent oils still dominate.
     elementalProperties: { Fire: 0.30, Water: 0.15, Earth: 0.20, Air: 0.35 },
     qualities: ["warming", "pungent", "fresh", "savory", "culinary"],
@@ -424,6 +437,8 @@ const rawFreshHerbs = {
   bay_leaf: {
       description: "The aromatic leaf of the sweet bay tree (*Laurus nobilis*), typically used dried. When simmered in liquid for an extended period, it releases complex, woodsy, floral, and slightly menthol notes that add essential savory depth to soups, stews, and braises.",
     name: "bay leaf",
+    origin: ["Mediterranean (Asia Minor)"],
+    season: ["all"],
     // Subtle, woody background note. Earth (woody structure), Air (slow-release aromatics), mild Fire.
     elementalProperties: { Fire: 0.15, Water: 0.10, Earth: 0.35, Air: 0.40 },
     qualities: ["aromatic", "woody", "subtle", "earthy", "culinary"],
@@ -442,6 +457,8 @@ const rawFreshHerbs = {
   flat_leaf_parsley: {
       description: "A mild, grassy, and slightly bitter herb (*Petroselinum crispum*) available in curly (best for garnishing) and flat-leaf (best for cooking) varieties. Its clean, mineral-rich flavor acts as a culinary palate cleanser, cutting through heavy fats and brightening rich stews and sauces.\n\n**Selection & Storage:** Choose bunches with vibrant, dark green leaves and firm stems. Store it by trimming the ends and placing the stems in a jar of water in the refrigerator, covered loosely with a plastic bag.",
     name: "flat-leaf parsley",
+    origin: ["Mediterranean"],
+    season: ["spring", "summer", "fall"],
     // Bright, fresh, green. Air (fresh volatile compounds), Water (high moisture, fresh green), minimal Fire/Earth.
     elementalProperties: { Fire: 0.10, Water: 0.35, Earth: 0.10, Air: 0.45 },
     qualities: ["fresh", "bright", "green", "clean", "culinary", "medicinal"],
@@ -460,6 +477,8 @@ const rawFreshHerbs = {
   oregano: {
       description: "A robust, highly aromatic herb (*Origanum vulgare*) essential to Mediterranean and Mexican cuisines. Unlike delicate herbs, its pungent, slightly bitter, and peppery flavor actually deepens and improves when dried, making it a powerful seasoning for tomato sauces and grilled meats.",
     name: "oregano",
+    origin: ["Mediterranean (Greece)"],
+    season: ["summer", "fall"],
     // Robust Mediterranean herb. Strong Fire (warming carvacrol), Air (pungent aromatics), Earth (robust drying).
     elementalProperties: { Fire: 0.40, Water: 0.10, Earth: 0.15, Air: 0.35 },
     qualities: ["pungent", "warming", "robust", "aromatic", "culinary", "medicinal"],
@@ -478,6 +497,8 @@ const rawFreshHerbs = {
   parsley: {
       description: "A mild, grassy, and slightly bitter herb (*Petroselinum crispum*) available in curly (best for garnishing) and flat-leaf (best for cooking) varieties. Its clean, mineral-rich flavor acts as a culinary palate cleanser, cutting through heavy fats and brightening rich stews and sauces.",
     name: "parsley",
+    origin: ["Mediterranean"],
+    season: ["spring", "summer", "fall"],
     // Classic culinary parsley. Air dominant (fresh aromatics), Water (moisture-rich leaves).
     elementalProperties: { Fire: 0.10, Water: 0.35, Earth: 0.12, Air: 0.43 },
     qualities: ["fresh", "bright", "mild", "versatile", "culinary", "medicinal"],
@@ -496,6 +517,8 @@ const rawFreshHerbs = {
   mint: {
       description: "A rapidly spreading, aromatic herb (*Mentha*) characterized by the cooling compound menthol. It provides a sharp, refreshing contrast to rich or spicy dishes, and is utilized globally in everything from Middle Eastern lamb marinades to Southeast Asian salads and sweet desserts.",
     name: "mint",
+    origin: ["Mediterranean", "Western Asia"],
+    season: ["spring", "summer", "fall"],
     // Cooling, menthol-dominant. Water (cooling effect), Air (extremely volatile menthol compounds).
     elementalProperties: { Fire: 0.05, Water: 0.40, Earth: 0.08, Air: 0.47 },
     qualities: ["cooling", "refreshing", "menthol", "aromatic", "medicinal", "culinary"],
@@ -514,6 +537,8 @@ const rawFreshHerbs = {
   dill: {
       description: "A feathery, delicate herb (*Anethum graveolens*) with a distinctively clean, grassy flavor featuring notes of anise and celery. It pairs classicly with mild, sweet ingredients like seafood, cucumbers, and yogurt, and its seeds are essential for pickling.",
     name: "dill",
+    origin: ["Mediterranean", "Russia"],
+    season: ["summer"],
     // Feathery, delicate, anise-like. Very Air dominant (extremely aromatic, feathery texture), Water (fresh green).
     elementalProperties: { Fire: 0.05, Water: 0.30, Earth: 0.10, Air: 0.55 },
     qualities: ["delicate", "feathery", "anise-like", "fresh", "aromatic", "culinary"],
@@ -532,6 +557,8 @@ const rawFreshHerbs = {
   bay_leaves: {
       description: "Bay Leaves is an aromatic herb used to brighten savory dishes with fresh, volatile flavor compounds. Add early for mellow infusion or late for sharper aromatic lift, depending on the recipe goal. Because aroma degrades quickly with heat and air, keep it cold and dry, and chop just before use when possible.",
     name: "bay leaves",
+    origin: ["Cultivated worldwide"],
+    season: ["spring", "summer"],
     // Same profile as bay_leaf (plural form, same ingredient).
     elementalProperties: { Fire: 0.15, Water: 0.10, Earth: 0.35, Air: 0.40 },
     qualities: ["aromatic", "woody", "subtle", "earthy", "culinary"],
@@ -550,6 +577,8 @@ const rawFreshHerbs = {
   rosemary: {
       description: "A fragrant, evergreen shrub (*Salvia rosmarinus*) of the mint family known for its needle-like leaves and robust, pine-and-citrus aroma. Its essential oils contain rosmarinic acid, a powerful antioxidant that helps preserve the flavor and freshness of the foods it's cooked with, making it a classic pairing for roasted meats and root vegetables.\\n\\n",
     name: "rosemary",
+    origin: ["Mediterranean"],
+    season: ["all"],
     // Piney, resinous, powerful. Fire dominant (warming terpenes, resinous oils), Air (piney volatile aroma).
     elementalProperties: { Fire: 0.45, Water: 0.10, Earth: 0.15, Air: 0.30 },
     qualities: ["piney", "resinous", "warming", "robust", "aromatic", "medicinal", "culinary"],
@@ -568,6 +597,8 @@ const rawFreshHerbs = {
   mint_leaves: {
       description: "A rapidly spreading, aromatic herb (*Mentha*) characterized by the cooling compound menthol. It provides a sharp, refreshing contrast to rich or spicy dishes, and is utilized globally in everything from Middle Eastern lamb marinades to Southeast Asian salads and sweet desserts.\n\n**Selection & Storage:** Look for perky, bright green leaves without dark spots or wilting. Store unwashed mint wrapped in a lightly damp paper towel inside a plastic bag in the crisper drawer.",
     name: "mint leaves",
+    origin: ["Mediterranean", "Western Asia"],
+    season: ["spring", "summer", "fall"],
     // Mint leaves — same cooling profile as mint.
     elementalProperties: { Fire: 0.05, Water: 0.40, Earth: 0.08, Air: 0.47 },
     qualities: ["cooling", "refreshing", "aromatic", "culinary", "medicinal"],
@@ -586,6 +617,8 @@ const rawFreshHerbs = {
   fresh_basil: {
       description: "A tender, aromatic herb (*Ocimum basilicum*) of the mint family, defined by its bright green, delicate leaves. Its complex flavor profile includes notes of anise, clove, and sweet citrus; because its volatile oils evaporate quickly, it should be added at the very end of cooking or used raw.\n\n**Selection & Storage:** Choose vibrant, unblemished leaves; avoid any with black spots. Store fresh basil like a bouquet of flowers: stems in a glass of water at room temperature, loosely covered with a plastic bag.",
     name: "fresh basil",
+    origin: ["South Asia (India)", "Southeast Asia"],
+    season: ["summer"],
     // Fresh basil shares the profile of the detailed basil entry above: Air dominant, sweet/warm.
     elementalProperties: { Fire: 0.22, Water: 0.27, Earth: 0.08, Air: 0.43 },
     qualities: ["aromatic", "sweet", "fresh", "warm", "culinary"],
@@ -604,6 +637,8 @@ const rawFreshHerbs = {
   cilantro: {
       description: "A delicate, leafy green herb (*Coriandrum sativum*) known for its bright, citrusy, and slightly peppery flavor (though a genetic trait makes it taste like soap to some). It loses its flavor entirely when cooked, so it is used exclusively as a fresh garnish or pounded into raw salsas and chutneys.",
     name: "cilantro",
+    origin: ["Mediterranean", "Western Asia"],
+    season: ["spring", "fall"],
     // Bright, citrusy-soapy. Air very dominant (highly volatile aldehydes), Water (fresh green moisture).
     elementalProperties: { Fire: 0.08, Water: 0.32, Earth: 0.10, Air: 0.50 },
     qualities: ["citrusy", "fresh", "aromatic", "bright", "culinary", "medicinal"],

--- a/src/data/ingredients/herbs/herbs.ts
+++ b/src/data/ingredients/herbs/herbs.ts
@@ -7,6 +7,8 @@ const rawHerbs: Record<string, Partial<IngredientMapping>> = {
   thyme: {
       description: "A resilient, woody-stemmed herb (*Thymus vulgaris*) featuring tiny leaves packed with the essential oil thymol. Its earthy, slightly floral, and sharp flavor holds up exceptionally well to long, slow cooking, making it a foundational aromatic for stocks, stews, and roasted meats.",
     name: "thyme",
+    origin: ["Mediterranean"],
+    season: ["spring", "summer", "fall"],
     elementalProperties: { Fire: 0.15, Water: 0.25, Earth: 0.15, Air: 0.45 },
     qualities: ["aromatic", "earthy", "culinary", "medicinal"],
     category: "culinary_herb",
@@ -39,6 +41,8 @@ const rawHerbs: Record<string, Partial<IngredientMapping>> = {
   fresh_thyme: {
       description: "A resilient, woody-stemmed herb (*Thymus vulgaris*) featuring tiny leaves packed with the essential oil thymol. Its earthy, slightly floral, and sharp flavor holds up exceptionally well to long, slow cooking, making it a foundational aromatic for stocks, stews, and roasted meats.\n\n**Selection & Storage:** Look for bright green, fragrant sprigs without woody or dried-out tips. Store fresh thyme wrapped loosely in a damp paper towel inside a plastic bag in the refrigerator's crisper drawer.",
     name: "fresh thyme",
+    origin: ["Mediterranean"],
+    season: ["spring", "summer", "fall"],
     elementalProperties: { Fire: 0.15, Water: 0.25, Earth: 0.15, Air: 0.45 },
     qualities: ["aromatic", "fresh", "culinary", "medicinal"],
     category: "culinary_herb",
@@ -69,6 +73,8 @@ const rawHerbs: Record<string, Partial<IngredientMapping>> = {
   sage: {
       description: "A hardy herb (*Salvia officinalis*) with velvety, grey-green leaves and a highly assertive, pine-like, and slightly astringent aroma. Because its flavor is so robust and somewhat resinous, it pairs perfectly with fatty meats like pork and sausage, or browned butter sauces.",
     name: "sage",
+    origin: ["Mediterranean"],
+    season: ["spring", "summer", "fall"],
     elementalProperties: { Fire: 0.15, Water: 0.25, Earth: 0.15, Air: 0.45 },
     qualities: ["aromatic", "fresh", "culinary", "medicinal"],
     category: "culinary_herb",
@@ -99,6 +105,8 @@ const rawHerbs: Record<string, Partial<IngredientMapping>> = {
   fresh_mint: {
       description: "A rapidly spreading, aromatic herb (*Mentha*) characterized by the cooling compound menthol. It provides a sharp, refreshing contrast to rich or spicy dishes, and is utilized globally in everything from Middle Eastern lamb marinades to Southeast Asian salads and sweet desserts.\n\n**Selection & Storage:** Look for perky, bright green leaves without dark spots or wilting. Store unwashed mint wrapped in a lightly damp paper towel inside a plastic bag in the crisper drawer.",
     name: "fresh mint",
+    origin: ["Mediterranean", "Western Asia"],
+    season: ["spring", "summer", "fall"],
     elementalProperties: { Fire: 0.15, Water: 0.25, Earth: 0.15, Air: 0.45 },
     qualities: ["aromatic", "fresh", "culinary", "medicinal"],
     category: "culinary_herb",
@@ -129,6 +137,8 @@ const rawHerbs: Record<string, Partial<IngredientMapping>> = {
   fresh_sage: {
       description: "A hardy herb (*Salvia officinalis*) with velvety, grey-green leaves and a highly assertive, pine-like, and slightly astringent aroma. Because its flavor is so robust and somewhat resinous, it pairs perfectly with fatty meats like pork and sausage, or browned butter sauces.\n\n**Selection & Storage:** Look for fresh, pliable leaves that are fuzzy and aromatic; avoid dried-out or black-spotted leaves. Store wrapped in a slightly damp paper towel in a plastic bag in the refrigerator.",
     name: "fresh sage",
+    origin: ["Mediterranean"],
+    season: ["spring", "summer", "fall"],
     elementalProperties: { Fire: 0.15, Water: 0.25, Earth: 0.15, Air: 0.45 },
     qualities: ["aromatic", "fresh", "culinary", "medicinal"],
     category: "culinary_herb",
@@ -159,6 +169,8 @@ const rawHerbs: Record<string, Partial<IngredientMapping>> = {
   bay_leaf: {
       description: "The aromatic leaf of the sweet bay tree (*Laurus nobilis*), typically used dried. When simmered in liquid for an extended period, it releases complex, woodsy, floral, and slightly menthol notes that add essential savory depth to soups, stews, and braises.",
     name: "bay leaf",
+    origin: ["Mediterranean (Asia Minor)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.25, Earth: 0.15, Air: 0.45 },
     qualities: ["aromatic", "fresh", "culinary", "medicinal"],
     category: "culinary_herb",
@@ -189,6 +201,8 @@ const rawHerbs: Record<string, Partial<IngredientMapping>> = {
   flat_leaf_parsley: {
       description: "A mild, grassy, and slightly bitter herb (*Petroselinum crispum*) available in curly (best for garnishing) and flat-leaf (best for cooking) varieties. Its clean, mineral-rich flavor acts as a culinary palate cleanser, cutting through heavy fats and brightening rich stews and sauces.\n\n**Selection & Storage:** Choose bunches with vibrant, dark green leaves and firm stems. Store it by trimming the ends and placing the stems in a jar of water in the refrigerator, covered loosely with a plastic bag.",
     name: "flat-leaf parsley",
+    origin: ["Mediterranean"],
+    season: ["spring", "summer", "fall"],
     elementalProperties: { Fire: 0.15, Water: 0.25, Earth: 0.15, Air: 0.45 },
     qualities: ["aromatic", "fresh", "culinary", "medicinal"],
     category: "culinary_herb",
@@ -219,6 +233,8 @@ const rawHerbs: Record<string, Partial<IngredientMapping>> = {
   oregano: {
       description: "A robust, highly aromatic herb (*Origanum vulgare*) essential to Mediterranean and Mexican cuisines. Unlike delicate herbs, its pungent, slightly bitter, and peppery flavor actually deepens and improves when dried, making it a powerful seasoning for tomato sauces and grilled meats.",
     name: "oregano",
+    origin: ["Mediterranean (Greece)"],
+    season: ["summer", "fall"],
     elementalProperties: { Fire: 0.15, Water: 0.25, Earth: 0.15, Air: 0.45 },
     qualities: ["aromatic", "peppery", "Mediterranean"],
     category: "culinary_herb",
@@ -251,6 +267,8 @@ const rawHerbs: Record<string, Partial<IngredientMapping>> = {
   parsley: {
       description: "A mild, grassy, and slightly bitter herb (*Petroselinum crispum*) available in curly (best for garnishing) and flat-leaf (best for cooking) varieties. Its clean, mineral-rich flavor acts as a culinary palate cleanser, cutting through heavy fats and brightening rich stews and sauces.",
     name: "parsley",
+    origin: ["Mediterranean"],
+    season: ["spring", "summer", "fall"],
     elementalProperties: { Fire: 0.15, Water: 0.25, Earth: 0.15, Air: 0.45 },
     qualities: ["fresh", "bright", "versatile"],
     category: "culinary_herb",
@@ -283,6 +301,8 @@ const rawHerbs: Record<string, Partial<IngredientMapping>> = {
   mint: {
       description: "A rapidly spreading, aromatic herb (*Mentha*) characterized by the cooling compound menthol. It provides a sharp, refreshing contrast to rich or spicy dishes, and is utilized globally in everything from Middle Eastern lamb marinades to Southeast Asian salads and sweet desserts.",
     name: "mint",
+    origin: ["Mediterranean", "Western Asia"],
+    season: ["spring", "summer", "fall"],
     elementalProperties: { Fire: 0.15, Water: 0.25, Earth: 0.15, Air: 0.45 },
     qualities: ["aromatic", "fresh", "culinary", "medicinal"],
     category: "culinary_herb",
@@ -313,6 +333,8 @@ const rawHerbs: Record<string, Partial<IngredientMapping>> = {
   dill: {
       description: "A feathery, delicate herb (*Anethum graveolens*) with a distinctively clean, grassy flavor featuring notes of anise and celery. It pairs classicly with mild, sweet ingredients like seafood, cucumbers, and yogurt, and its seeds are essential for pickling.",
     name: "dill",
+    origin: ["Mediterranean", "Russia"],
+    season: ["summer"],
     elementalProperties: { Fire: 0.15, Water: 0.25, Earth: 0.15, Air: 0.45 },
     qualities: ["aromatic", "fresh", "culinary", "medicinal"],
     category: "culinary_herb",
@@ -344,6 +366,8 @@ const rawHerbs: Record<string, Partial<IngredientMapping>> = {
   rosemary: {
       description: "A fragrant, evergreen shrub (*Salvia rosmarinus*) of the mint family known for its needle-like leaves and robust, pine-and-citrus aroma. Its essential oils contain rosmarinic acid, a powerful antioxidant that helps preserve the flavor and freshness of the foods it's cooked with, making it a classic pairing for roasted meats and root vegetables.\\n\\n",
     name: "rosemary",
+    origin: ["Mediterranean"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.25, Earth: 0.15, Air: 0.45 },
     qualities: ["aromatic", "piney", "robust"],
     category: "culinary_herb",
@@ -377,6 +401,8 @@ const rawHerbs: Record<string, Partial<IngredientMapping>> = {
   fresh_basil: {
       description: "A tender, aromatic herb (*Ocimum basilicum*) of the mint family, defined by its bright green, delicate leaves. Its complex flavor profile includes notes of anise, clove, and sweet citrus; because its volatile oils evaporate quickly, it should be added at the very end of cooking or used raw.\n\n**Selection & Storage:** Choose vibrant, unblemished leaves; avoid any with black spots. Store fresh basil like a bouquet of flowers: stems in a glass of water at room temperature, loosely covered with a plastic bag.",
     name: "fresh basil",
+    origin: ["South Asia (India)", "Southeast Asia"],
+    season: ["summer"],
     elementalProperties: { Fire: 0.15, Water: 0.25, Earth: 0.15, Air: 0.45 },
     qualities: ["aromatic", "sweet", "Italian"],
     category: "culinary_herb",
@@ -409,6 +435,8 @@ const rawHerbs: Record<string, Partial<IngredientMapping>> = {
   cilantro: {
       description: "A delicate, leafy green herb (*Coriandrum sativum*) known for its bright, citrusy, and slightly peppery flavor (though a genetic trait makes it taste like soap to some). It loses its flavor entirely when cooked, so it is used exclusively as a fresh garnish or pounded into raw salsas and chutneys.",
     name: "cilantro",
+    origin: ["Mediterranean", "Western Asia"],
+    season: ["spring", "fall"],
     elementalProperties: { Fire: 0.15, Water: 0.25, Earth: 0.15, Air: 0.45 },
     qualities: ["aromatic", "citrusy", "fresh"],
     category: "culinary_herb",

--- a/src/data/ingredients/herbs/medicinalHerbs.ts
+++ b/src/data/ingredients/herbs/medicinalHerbs.ts
@@ -5,6 +5,7 @@ const rawMedicinalHerbs = {
   echinacea: {
       description: "A genus of herbaceous flowering plants in the daisy family, traditionally used by Native Americans for its purported immune-boosting properties. When brewed as a tea or tincture, it provides an earthy, slightly floral, and numbing sensation on the tongue due to its high concentration of alkamides.",
     name: "Echinacea",
+    season: ["spring", "summer"],
     elementalProperties: { Earth: 0.3, Fire: 0.4, Air: 0.2, Water: 0.1 },
     alchemicalProperties: { Spirit: 0.32, Essence: 0.21, Matter: 0.24, Substance: 0.23 },
     astrologicalProfile: {
@@ -331,6 +332,8 @@ const rawMedicinalHerbs = {
   elderberry: {
       description: "The tiny, dark purple-black berries of the *Sambucus* tree. They are mildly toxic when raw and must be cooked, which transforms their astringent, earthy flavor into a deeply complex, floral, and rich syrup utilized in cordials, jams, and medicinal tinctures.",
     name: "Elderberry",
+    origin: ["Europe", "North America"],
+    season: ["late summer"],
     elementalProperties: { Fire: 0.09, Water: 0.37, Earth: 0.27, Air: 0.27 },
     alchemicalProperties: { Spirit: 0.16, Essence: 0.26, Matter: 0.29, Substance: 0.29 },
     astrologicalProfile: {
@@ -369,6 +372,8 @@ const rawMedicinalHerbs = {
   chamomile: {
       description: "The delicate, daisy-like flowers of the *Matricaria* family, most commonly dried and consumed as a tisane (herbal tea). They impart a remarkably gentle, floral, and distinctively apple-like sweetness that infuses beautifully into light custards, panna cottas, and clear broths.",
     name: "Chamomile",
+    origin: ["Cultivated worldwide"],
+    season: ["spring", "summer"],
     elementalProperties: { Fire: 0.09, Water: 0.37, Earth: 0.18, Air: 0.36 },
     alchemicalProperties: { Spirit: 0.20, Essence: 0.29, Matter: 0.25, Substance: 0.26 },
     astrologicalProfile: {

--- a/src/data/ingredients/misc/misc.ts
+++ b/src/data/ingredients/misc/misc.ts
@@ -8,6 +8,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   sugar: {
       description: "Refined sucrose crystallized from sugarcane (*Saccharum officinarum*) or sugar beets (*Beta vulgaris*) — the default sweetener of Western cooking and a critical functional ingredient beyond taste. In baking sugar tenderizes by competing for water, stabilizes foams, browns via Maillard and caramelization, and preserves by binding water activity. Granulated, superfine (caster), confectioners', turbinado, and demerara differ in crystal size, moisture, and residual molasses — each behaving differently in creaming, dissolving, or finishing.",
     name: "sugar",
+    origin: ["South and Southeast Asia"],
+    season: ["all"],
     // Refined sweetener: Earth (crystalline structure), Fire (quick energy), minimal Water/Air
     elementalProperties: { Fire: 0.35, Water: 0.1, Earth: 0.45, Air: 0.1 },
     qualities: ["versatile", "culinary"],
@@ -33,6 +35,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   maple_syrup: {
       description: "A complex, earthy sweetener created by boiling down the sap of sugar maple trees (*Acer saccharum*). As the sap reduces, intense caramelization occurs, creating a rich flavor profile featuring notes of vanilla, caramel, and wood that pairs perfectly with both sweet breakfast foods and savory glazed meats.",
     name: "maple syrup",
+    origin: ["Northeastern North America"],
+    season: ["spring"],
     // Tree sap liquid sweetener: Water (liquid), Earth (from trees), Fire (sweet energy)
     elementalProperties: { Fire: 0.3, Water: 0.4, Earth: 0.25, Air: 0.05 },
     qualities: ["versatile", "culinary"],
@@ -58,6 +62,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   baking_powder: {
       description: "A complete chemical leavening agent containing both a base (sodium bicarbonate) and a weak acid. \"Double-acting\" baking powder reacts twice: first when it dissolves in liquid, and again when exposed to heat, providing a reliable, sustained lift to cakes and quick breads.",
     name: "baking powder",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.24, Water: 0.14, Earth: 0.33, Air: 0.29 },
     qualities: ["versatile", "culinary"],
     category: "seasoning",
@@ -82,6 +88,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   microgreens: {
       description: "Microgreens is a seasoning ingredient used to adjust balance, aroma, and perceived intensity across savory and sweet cooking. Add in stages so you can control extraction during cooking and precision at the finish. Keep sealed and dry to preserve potency and prevent clumping or flavor drift.",
     name: "microgreens",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.18, Water: 0.32, Earth: 0.18, Air: 0.32 },
     qualities: ["versatile", "culinary"],
     category: "seasoning",
@@ -106,6 +114,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   fresh_herbs: {
       description: "Fresh Herbs is an aromatic herb used to brighten savory dishes with fresh, volatile flavor compounds. Add early for mellow infusion or late for sharper aromatic lift, depending on the recipe goal. Because aroma degrades quickly with heat and air, keep it cold and dry, and chop just before use when possible.",
     name: "fresh herbs",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.18, Water: 0.32, Earth: 0.18, Air: 0.32 },
     qualities: ["aromatic", "fresh"],
     category: "culinary_herb",
@@ -130,6 +140,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   mixed_berries: {
       description: "Mixed Berries is a fruit ingredient used for sweetness, acidity, aroma, and moisture balance. Ripeness and processing method meaningfully change flavor concentration and texture, so adjust sugar and acid around the ingredient's current state. Use chilled for freshness-driven dishes or cooked to concentrate body and flavor.",
     name: "mixed berries",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.45, Earth: 0.15, Air: 0.2 },
     qualities: ["sweet", "tart"],
     category: "fruit",
@@ -154,6 +166,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   honey: {
       description: "A viscous, supersaturated sugar solution produced by bees from floral nectar. In addition to sweetness, it provides complex floral notes, humectant properties (retaining moisture in baked goods), and promotes rapid browning due to its high fructose and glucose content.",
     name: "honey",
+    origin: ["Worldwide (apiculture)"],
+    season: ["all"],
     // Thick liquid sweetener from bees: Water (liquid), Earth (thick/grounding), Fire (energy)
     elementalProperties: { Fire: 0.3, Water: 0.35, Earth: 0.3, Air: 0.05 },
     qualities: ["versatile", "culinary"],
@@ -179,6 +193,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   granola: {
       description: "Granola is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "granola",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.05, Earth: 0.5, Air: 0.25 },
     qualities: ["crunchy", "sweet"],
     category: "grain",
@@ -203,6 +219,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   pumpkin_puree: {
       description: "A large, thick-skinned winter squash (*Cucurbita pepo*) prized for its sweet, earthy flesh and edible seeds. While large field pumpkins are bred for carving, smaller \"sugar\" or \"pie\" pumpkins have dense, less watery flesh ideal for roasting, pureeing, and baking.\n\n**Selection & Storage:** For cooking, select small pie pumpkins that feel dense and heavy with hard, unblemished rinds and an intact stem. Store whole in a cool, dark, dry place for several months.",
     name: "pumpkin puree",
+    origin: ["North America"],
+    season: ["fall"],
     elementalProperties: { Fire: 0.15, Water: 0.4, Earth: 0.4, Air: 0.05 },
     qualities: ["smooth", "earthy"],
     category: "vegetable",
@@ -227,6 +245,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   pecans: {
       description: "A buttery, rich tree nut (*Carya illinoinensis*) native to North America, boasting one of the highest fat contents of any nut. This fat gives them a melt-in-the-mouth texture and a naturally sweet, maple-like flavor that makes them a classic pairing for caramel and brown sugar.\n\n**Selection & Storage:** Look for uniform, plump halves without excessive broken pieces. Like walnuts, their high fat content makes them prone to spoiling quickly; store them in the refrigerator or freezer.",
     name: "pecans",
+    origin: ["North America"],
+    season: ["fall"],
     elementalProperties: { Fire: 0.2, Water: 0.1, Earth: 0.5, Air: 0.2 },
     qualities: ["rich", "buttery"],
     category: "nut_seed",
@@ -251,6 +271,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   cranberries: {
       description: "Cranberries is a fruit ingredient used for sweetness, acidity, aroma, and moisture balance. Ripeness and processing method meaningfully change flavor concentration and texture, so adjust sugar and acid around the ingredient's current state. Use chilled for freshness-driven dishes or cooked to concentrate body and flavor.",
     name: "cranberries",
+    origin: ["North America"],
+    season: ["fall"],
     elementalProperties: { Fire: 0.2, Water: 0.5, Earth: 0.15, Air: 0.15 },
     qualities: ["tart", "acidic"],
     category: "fruit",
@@ -275,6 +297,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   walnuts: {
       description: "A brain-shaped tree nut (*Juglans regia*) known for its high concentration of polyunsaturated fats (omega-3s) and a slightly bitter, astringent papery skin. Toasting them mellows this bitterness, bringing forward a rich, buttery, and deeply earthy flavor that pairs beautifully with dark chocolate or blue cheese.\n\n**Selection & Storage:** Buy shelled walnuts that look plump and light-colored; shriveled or very dark nuts may be old. They are highly susceptible to rancidity, so always store them in an airtight container in the freezer.",
     name: "walnuts",
+    origin: ["Western Asia"],
+    season: ["fall"],
     elementalProperties: { Fire: 0.25, Water: 0.1, Earth: 0.45, Air: 0.2 },
     qualities: ["rich", "earthy"],
     category: "nut_seed",
@@ -299,6 +323,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   hamburger_buns: {
       description: "Hamburger Buns is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "hamburger buns",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.15, Earth: 0.4, Air: 0.25 },
     qualities: ["soft", "starchy"],
     category: "grain",
@@ -323,6 +349,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   ketchup: {
       description: "A globally beloved table condiment characterized by a delicate balance of sweetness (sugar), acidity (vinegar), and umami (concentrated tomatoes). Its high viscosity and complex flavor profile make it a powerful base for barbecue sauces, glazes, and meatloaf.",
     name: "ketchup",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.35, Earth: 0.2, Air: 0.15 },
     qualities: ["sweet", "tangy"],
     category: "seasoning",
@@ -347,6 +375,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   mustard: {
       description: "A pungent condiment made from the crushed seeds of various mustard plants (*Brassica* and *Sinapis* species), blended with water, vinegar, or wine. The sharp heat comes from isothiocyanates, which develop when enzymes are activated by liquid. Mustard acts as both a flavor amplifier and a powerful culinary emulsifier, crucial for stabilizing vinaigrettes and binding rich sauces. Dijon offers sharp tang, whole-grain provides texture, and yellow mustard delivers mild, turmeric-tinted brightness.",
     name: "mustard",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.4, Water: 0.25, Earth: 0.2, Air: 0.15 },
     qualities: ["pungent", "sharp"],
     category: "seasoning",
@@ -371,6 +401,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   bacon: {
       description: "Salt-cured pork belly that is typically smoked, resulting in an incredibly savory, salty, and richly flavored ingredient. As it cooks, its high fat content renders out, crisping the meat while providing a highly flavorful cooking fat (lard) that can be used to fry eggs or sauté vegetables.",
     name: "bacon",
+    origin: ["Europe"],
+    season: ["all"],
     elementalProperties: { Fire: 0.45, Water: 0.15, Earth: 0.3, Air: 0.1 },
     qualities: ["smoky", "salty"],
     category: "protein",
@@ -395,6 +427,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   clams: {
       description: "A bivalve mollusk providing a briny, chewy, and distinctly oceanic flavor. Hard-shell clams (like littlenecks or cherrystones) are perfect for eating raw or tossing into pastas, while softer-shelled varieties (like steamers) are excellent for frying or broths.\n\n**Selection & Storage:** Buy clams that are tightly closed; if slightly open, they should snap shut when tapped. Store them in a breathable bag or bowl covered with a damp cloth in the refrigerator.",
     name: "clams",
+    origin: ["Worldwide"],
+    season: ["fall", "winter"],
     elementalProperties: { Fire: 0.1, Water: 0.55, Earth: 0.25, Air: 0.1 },
     qualities: ["briny", "tender"],
     category: "protein",
@@ -419,6 +453,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   puff_pastry: {
       description: "Puff Pastry is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "puff pastry",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.15, Earth: 0.3, Air: 0.35 },
     qualities: ["flaky", "buttery"],
     category: "grain",
@@ -443,6 +479,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   lobster_meat: {
       description: "A large marine crustacean whose meat is synonymous with luxury, offering an incredibly sweet, rich flavor and a firm, snappy texture. The tail provides dense, meaty portions, while the claws yield softer, more delicate meat that bathes perfectly in drawn butter.\n\n**Selection & Storage:** Live lobsters should be highly active and hold their tails tightly curled when picked up. Cook live lobsters the day you buy them; keep them in the refrigerator wrapped in damp newspaper, never in fresh water.",
     name: "lobster meat",
+    origin: ["North Atlantic", "Pacific"],
+    season: ["summer", "fall"],
     elementalProperties: { Fire: 0.15, Water: 0.5, Earth: 0.25, Air: 0.1 },
     qualities: ["sweet", "luxurious"],
     category: "protein",
@@ -467,6 +505,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   mayonnaise: {
       description: "A thick, creamy culinary emulsion created by slowly suspending droplets of oil in water (usually lemon juice or vinegar) utilizing the natural emulsifier lecithin found in egg yolks. It adds rich moisture to sandwiches, binds salads together, and promotes exceptional browning when spread on bread before grilling.",
     name: "mayonnaise",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.3, Earth: 0.3, Air: 0.25 },
     qualities: ["creamy", "rich"],
     category: "seasoning",
@@ -491,6 +531,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   split_top_buns: {
       description: "Split-top Buns is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "split-top buns",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.15, Earth: 0.4, Air: 0.25 },
     qualities: ["soft", "starchy"],
     category: "grain",
@@ -515,6 +557,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   sliced_turkey: {
       description: "A large poultry bird (*Meleagris gallopavo*) that yields exceptionally lean, mildly flavored meat. Due to the stark structural differences between its white breast meat (which cooks quickly and dries out) and dark leg meat (which requires longer cooking to break down collagen), it often requires careful heat management or brining.\n\n**Selection & Storage:** Fresh turkey meat should look plump, firm, and slightly pink with no off-odors. Keep fresh turkey refrigerated at 40°F (4°C) or below and use within two days.",
     name: "sliced turkey",
+    origin: ["Mesoamerica"],
+    season: ["fall", "winter"],
     elementalProperties: { Fire: 0.2, Water: 0.3, Earth: 0.35, Air: 0.15 },
     qualities: ["lean", "mild"],
     category: "protein",
@@ -539,6 +583,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   cranberry_sauce: {
       description: "A small, exceptionally tart, and astringent berry (*Vaccinium macrocarpon*) native to North American bogs. Because of their intense acidity and low sugar content, they are rarely eaten raw; instead, they are cooked with sugar to create brightly colored, pectin-rich sauces that cut through rich holiday roasts.\n\n**Selection & Storage:** Fresh cranberries should be firm, plump, and bright red; they should bounce if dropped. Store fresh berries in the refrigerator for up to a month, or freeze them indefinitely.",
     name: "cranberry sauce",
+    origin: ["North America"],
+    season: ["fall"],
     elementalProperties: { Fire: 0.2, Water: 0.45, Earth: 0.2, Air: 0.15 },
     qualities: ["sweet", "tart"],
     category: "seasoning",
@@ -563,6 +609,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   stuffing: {
       description: "Stuffing is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "stuffing",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.2, Earth: 0.4, Air: 0.2 },
     qualities: ["savory", "herbed"],
     category: "grain",
@@ -587,6 +635,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   bbq_sauce: {
       description: "A thick, highly complex condiment built on a foundation of sweetness (molasses or brown sugar), acidity (vinegar), umami (ketchup or tomato paste), and often liquid smoke. Its high sugar content makes it an exceptional glazing agent that caramelizes beautifully over indirect heat, though it will scorch quickly over open flames.",
     name: "BBQ sauce",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.35, Water: 0.3, Earth: 0.2, Air: 0.15 },
     qualities: ["smoky", "sweet"],
     category: "seasoning",
@@ -611,6 +661,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   brown_sugar: {
       description: "Granulated white sugar that has had molasses reintroduced to it (or left in during refining). The molasses provides a deeper, caramel-like flavor, slight acidity, and additional moisture (making baked goods softer and chewier), but it also causes the sugar to pack tightly together.",
     name: "brown sugar",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.15, Earth: 0.45, Air: 0.1 },
     qualities: ["sweet", "caramel"],
     category: "sweetener",
@@ -635,6 +687,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   lamb_chops: {
       description: "The meat of young domestic sheep (*Ovis aries*), renowned for its distinctive, slightly gamey, and grassy flavor profile, caused by branched-chain fatty acids in its fat. It pairs beautifully with strong, astringent aromatics like rosemary, mint, and garlic that cut through its rich intensity.\n\n**Selection & Storage:** Choose cuts with a light, rosy-red color and stark white, firm fat; dark red meat indicates an older animal (mutton). Keep tightly wrapped in the coldest section of the refrigerator and cook within 3-5 days.",
     name: "lamb chops",
+    origin: ["Western Asia"],
+    season: ["spring"],
     elementalProperties: { Fire: 0.4, Water: 0.2, Earth: 0.3, Air: 0.1 },
     qualities: ["rich", "tender"],
     category: "protein",
@@ -659,6 +713,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   cedar_plank: {
       description: "Cedar Plank is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "cedar plank",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.05, Earth: 0.5, Air: 0.15 },
     qualities: ["aromatic", "smoky"],
     category: "misc",
@@ -683,6 +739,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   whole_turkey: {
       description: "A large poultry bird (*Meleagris gallopavo*) that yields exceptionally lean, mildly flavored meat. Due to the stark structural differences between its white breast meat (which cooks quickly and dries out) and dark leg meat (which requires longer cooking to break down collagen), it often requires careful heat management or brining.\n\n**Selection & Storage:** Fresh turkey meat should look plump, firm, and slightly pink with no off-odors. Keep fresh turkey refrigerated at 40°F (4°C) or below and use within two days.",
     name: "whole turkey",
+    origin: ["Mesoamerica"],
+    season: ["fall", "winter"],
     elementalProperties: { Fire: 0.25, Water: 0.25, Earth: 0.35, Air: 0.15 },
     qualities: ["hearty", "lean"],
     category: "protein",
@@ -707,6 +765,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   white_sugar: {
       description: "Highly refined sucrose extracted from sugarcane or sugar beets. Its pure, neutral sweetness makes it a structural cornerstone in baking, where it aerates fats (creaming), stabilizes egg foams (meringues), and undergoes caramelization at high temperatures to build flavor and color.",
     name: "white sugar",
+    origin: ["South and Southeast Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.35, Water: 0.1, Earth: 0.45, Air: 0.1 },
     qualities: ["sweet", "pure"],
     category: "sweetener",
@@ -731,6 +791,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   chocolate_chips: {
       description: "A complex, semi-solid suspension of cocoa solids and cocoa butter extracted from the fermented, roasted seeds of the *Theobroma cacao* tree. Dark chocolate offers intense, bitter-roasted notes and snaps cleanly; milk chocolate is mellowed by dairy solids; and white chocolate relies entirely on cocoa butter without solids. Temperature control is critical: chocolate must be carefully tempered to align its fat crystals, ensuring a glossy finish and stable texture at room temperature.",
     name: "chocolate chips",
+    origin: ["Mesoamerica"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.15, Earth: 0.4, Air: 0.15 },
     qualities: ["sweet", "rich"],
     category: "sweetener",
@@ -755,6 +817,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   graham_crackers: {
       description: "Graham Crackers is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "graham crackers",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.1, Earth: 0.4, Air: 0.3 },
     qualities: ["sweet", "crunchy"],
     category: "grain",
@@ -779,6 +843,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   vanilla_extract: {
       description: "A potent liquid flavoring created by macerating vanilla beans in a solution of ethanol and water, which extracts the complex vanillin compounds. It serves as a universal flavor enhancer in baking, adding perceived sweetness and floral depth to cookies, cakes, and custards.",
     name: "vanilla extract",
+    origin: ["Mexico (Totonac region)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.35, Earth: 0.25, Air: 0.2 },
     qualities: ["aromatic", "sweet"],
     category: "seasoning",
@@ -803,6 +869,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   fresh_strawberries: {
       description: "Fresh Strawberries is a fruit ingredient used for sweetness, acidity, aroma, and moisture balance. Ripeness and processing method meaningfully change flavor concentration and texture, so adjust sugar and acid around the ingredient's current state. Use chilled for freshness-driven dishes or cooked to concentrate body and flavor.",
     name: "fresh strawberries",
+    origin: ["Europe", "Americas"],
+    season: ["spring", "summer"],
     elementalProperties: { Fire: 0.2, Water: 0.45, Earth: 0.15, Air: 0.2 },
     qualities: ["sweet", "juicy"],
     category: "fruit",
@@ -827,6 +895,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   marshmallows: {
       description: "A highly aerated, spongy confection originally made from the mucilaginous sap of the marsh-mallow plant (*Althaea officinalis*), but modernly constructed from a whipped matrix of sugar, corn syrup, and gelatin. It is a structural marvel, trapping massive amounts of air that expand and violently caramelize when exposed to the intense heat of an open flame.\n\n**Selection & Storage:** Keep tightly sealed in a dry pantry; exposure to ambient humidity will cause them to become sticky, while extreme dryness will turn them stale and hard.",
     name: "marshmallows",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.2, Earth: 0.2, Air: 0.4 },
     qualities: ["sweet", "fluffy"],
     category: "sweetener",
@@ -851,6 +921,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   chocolate_sauce: {
       description: "A complex, semi-solid suspension of cocoa solids and cocoa butter extracted from the fermented, roasted seeds of the *Theobroma cacao* tree. Dark chocolate offers intense, bitter-roasted notes and snaps cleanly; milk chocolate is mellowed by dairy solids; and white chocolate relies entirely on cocoa butter without solids. Temperature control is critical: chocolate must be carefully tempered to align its fat crystals, ensuring a glossy finish and stable texture at room temperature.",
     name: "chocolate sauce",
+    origin: ["Mesoamerica"],
+    season: ["all"],
     elementalProperties: { Fire: 0.25, Water: 0.3, Earth: 0.3, Air: 0.15 },
     qualities: ["sweet", "rich"],
     category: "seasoning",
@@ -875,6 +947,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   sea_salt: {
       description: "A broad category of salt obtained directly through the evaporation of seawater, rather than mined from subterranean rock deposits. While it is chemically mostly sodium chloride, it retains trace oceanic minerals (like magnesium and calcium) that provide a slightly more complex, 'briny' flavor profile than highly refined table salt.",
     name: "sea salt",
+    origin: ["Worldwide coasts"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.3, Earth: 0.5, Air: 0.1 },
     qualities: ["mineral", "briny"],
     category: "seasoning",
@@ -899,6 +973,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   pie_crust: {
       description: "Pie Crust is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "pie crust",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.15, Earth: 0.4, Air: 0.25 },
     qualities: ["flaky", "buttery"],
     category: "grain",
@@ -923,6 +999,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   molasses: {
       description: "The dark, viscous byproduct of the sugar refining process, containing concentrated sugars, minerals, and complex Maillard reaction products. Light molasses is sweeter and used in baking (like gingerbread), while blackstrap molasses is intensely bitter, salty, and best used sparingly in savory barbecue sauces or baked beans.",
     name: "molasses",
+    origin: ["Worldwide cane regions"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.3, Earth: 0.35, Air: 0.05 },
     qualities: ["sweet", "bitter"],
     category: "sweetener",
@@ -947,6 +1025,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   salt: {
       description: "A crystalline mineral composed primarily of sodium chloride (NaCl). It is the single most important ingredient in cooking, as it suppresses bitterness, enhances sweetness, and drastically amplifies volatile aromatic compounds, making food taste more like itself.",
     name: "salt",
+    origin: ["Worldwide mineral and sea sources"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.6, Air: 0.1 },
     qualities: ["mineral", "essential"],
     category: "seasoning",
@@ -971,6 +1051,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   char_siu_bao: {
       description: "Char Siu Bao is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "char siu bao",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.35, Air: 0.15 },
     qualities: ["savory", "sweet"],
     category: "preserved",
@@ -995,6 +1077,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   spring_rolls: {
       description: "Spring Rolls is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "spring rolls",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.25, Water: 0.25, Earth: 0.3, Air: 0.2 },
     qualities: ["crispy", "savory"],
     category: "preserved",
@@ -1019,6 +1103,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   whole_duck: {
       description: "A rich, fatty waterfowl (*Anas platyrhynchos*) known for its dark, deeply flavorful meat and thick layer of subcutaneous fat. Unlike chicken, its breast meat is typically served medium-rare to maintain tenderness, while the legs are slowly braised (often in their own fat as confit) to break down tough collagen.\n\n**Selection & Storage:** Look for plump birds or breasts with an intact, creamy white layer of skin and fat. Store in the coldest part of the refrigerator and cook within two days, or freeze.",
     name: "whole duck",
+    origin: ["East Asia"],
+    season: ["fall", "winter"],
     elementalProperties: { Fire: 0.35, Water: 0.25, Earth: 0.3, Air: 0.1 },
     qualities: ["rich", "fatty"],
     category: "protein",
@@ -1043,6 +1129,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   pastry_dough: {
       description: "Pastry Dough is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "pastry dough",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.2, Earth: 0.35, Air: 0.25 },
     qualities: ["buttery", "malleable"],
     category: "grain",
@@ -1067,6 +1155,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   dried_fruits: {
       description: "Dried Fruits is a fruit ingredient used for sweetness, acidity, aroma, and moisture balance. Ripeness and processing method meaningfully change flavor concentration and texture, so adjust sugar and acid around the ingredient's current state. Use chilled for freshness-driven dishes or cooked to concentrate body and flavor.",
     name: "dried fruits",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.25, Water: 0.1, Earth: 0.4, Air: 0.25 },
     qualities: ["sweet", "chewy"],
     category: "fruit",
@@ -1091,6 +1181,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   nuts: {
       description: "Hard-shelled seeds of various trees, valued for their dense concentration of fats, proteins, and rich, earthy flavors. While botanical definitions vary, culinary nuts encompass everything from walnuts and pecans to almonds and cashews. Their high oil content makes them prone to rancidity but also allows them to toast beautifully, enhancing their crunch and deepening their aromatic profile via the Maillard reaction. Store in the freezer to prolong freshness.",
     name: "nuts",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.1, Earth: 0.5, Air: 0.2 },
     qualities: ["crunchy", "rich"],
     category: "nut_seed",
@@ -1115,6 +1207,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   cr_me_fra_che: {
       description: "Crème Fraîche is a dairy ingredient that contributes richness, body, and protein structure to both savory and sweet preparations. Heat and acid can quickly shift texture from smooth to curdled, so gentle temperature control is important in sauces and custards. Keep refrigerated and handle with clean tools to maintain shelf life and flavor.",
     name: "crème fraîche",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.4, Earth: 0.3, Air: 0.2 },
     qualities: ["creamy", "tangy"],
     category: "dairy",
@@ -1139,6 +1233,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   fine_herbs: {
       description: "Fine Herbs is an aromatic herb used to brighten savory dishes with fresh, volatile flavor compounds. Add early for mellow infusion or late for sharper aromatic lift, depending on the recipe goal. Because aroma degrades quickly with heat and air, keep it cold and dry, and chop just before use when possible.",
     name: "fine herbs",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.3, Earth: 0.15, Air: 0.35 },
     qualities: ["delicate", "aromatic"],
     category: "culinary_herb",
@@ -1163,6 +1259,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   brioche: {
       description: "Brioche is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "brioche",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.25, Water: 0.2, Earth: 0.3, Air: 0.25 },
     qualities: ["buttery", "rich"],
     category: "grain",
@@ -1187,6 +1285,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   granulated_sugar: {
       description: "Refined sucrose crystallized from sugarcane (*Saccharum officinarum*) or sugar beets (*Beta vulgaris*) — the default sweetener of Western cooking and a critical functional ingredient beyond taste. In baking sugar tenderizes by competing for water, stabilizes foams, browns via Maillard and caramelization, and preserves by binding water activity. Granulated, superfine (caster), confectioners', turbinado, and demerara differ in crystal size, moisture, and residual molasses — each behaving differently in creaming, dissolving, or finishing.",
     name: "granulated sugar",
+    origin: ["South and Southeast Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.35, Water: 0.1, Earth: 0.45, Air: 0.1 },
     qualities: ["sweet", "pure"],
     category: "sweetener",
@@ -1211,6 +1311,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   white_ham: {
       description: "White Ham is a protein-forward ingredient valued for structure, satiety, and umami depth. Technique determines outcome: dry heat builds browning and intensity, while moist heat promotes tenderness and even hydration. Season in layers and cook to the right internal doneness target for both flavor and safety.",
     name: "white ham",
+    origin: ["Europe", "East Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.25, Water: 0.25, Earth: 0.35, Air: 0.15 },
     qualities: ["savory", "mild"],
     category: "protein",
@@ -1235,6 +1337,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   bechamel_sauce: {
       description: "Béchamel Sauce is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "béchamel sauce",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.4, Earth: 0.25, Air: 0.2 },
     qualities: ["creamy", "smooth"],
     category: "seasoning",
@@ -1259,6 +1363,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   anchovies: {
       description: "Small, oily forage fish (*Engraulis encrasicolus*) primarily preserved through heavy salt-curing and packing in oil. While aggressively fishy and salty on their own, they dissolve completely when heated, acting as a secret, umami-rich backbone for Caesar dressings, tomato sauces, and braises.",
     name: "anchovies",
+    origin: ["Mediterranean"],
+    season: ["spring", "summer"],
     elementalProperties: { Fire: 0.3, Water: 0.4, Earth: 0.2, Air: 0.1 },
     qualities: ["salty", "umami"],
     category: "protein",
@@ -1283,6 +1389,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   vinaigrette: {
       description: "Vinaigrette is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "vinaigrette",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.35, Earth: 0.15, Air: 0.3 },
     qualities: ["tangy", "light"],
     category: "seasoning",
@@ -1307,6 +1415,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   baguette: {
       description: "A classic French yeast bread characterized by its elongated shape, crisp, deeply browned crust, and chewy, open-crumb interior. Built from a lean dough of simply flour, water, yeast, and salt, its texture relies on a slow fermentation and baking in a steam-injected oven. Highly perishable due to its lack of fat, it is best consumed the day it is baked or repurposed into crostini, croutons, or bread pudding.",
     name: "baguette",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.25, Water: 0.15, Earth: 0.35, Air: 0.25 },
     qualities: ["crusty", "chewy"],
     category: "grain",
@@ -1331,6 +1441,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   lardons: {
       description: "Lardons is a protein-forward ingredient valued for structure, satiety, and umami depth. Technique determines outcome: dry heat builds browning and intensity, while moist heat promotes tenderness and even hydration. Season in layers and cook to the right internal doneness target for both flavor and safety.",
     name: "lardons",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.4, Water: 0.15, Earth: 0.35, Air: 0.1 },
     qualities: ["salty", "smoky"],
     category: "protein",
@@ -1355,6 +1467,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   bouquet_garni: {
       description: "Bouquet Garni is an aromatic herb used to brighten savory dishes with fresh, volatile flavor compounds. Add early for mellow infusion or late for sharper aromatic lift, depending on the recipe goal. Because aroma degrades quickly with heat and air, keep it cold and dry, and chop just before use when possible.",
     name: "bouquet garni",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.25, Earth: 0.2, Air: 0.35 },
     qualities: ["aromatic", "herbal"],
     category: "culinary_herb",
@@ -1379,6 +1493,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   cognac: {
       description: "Cognac is a liquid culinary ingredient used for hydration, extraction, and flavor transport. Temperature and dilution directly affect aroma release and mouthfeel, so tune handling to the dish rather than treating it as neutral water. Store as directed and keep containers sealed between uses to preserve freshness.",
     name: "cognac",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.5, Water: 0.25, Earth: 0.15, Air: 0.1 },
     qualities: ["warm", "complex"],
     category: "beverage",
@@ -1403,6 +1519,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   sole_fillets: {
       description: "Sole Fillets is a protein-forward ingredient valued for structure, satiety, and umami depth. Technique determines outcome: dry heat builds browning and intensity, while moist heat promotes tenderness and even hydration. Season in layers and cook to the right internal doneness target for both flavor and safety.",
     name: "sole fillets",
+    origin: ["Atlantic Ocean"],
+    season: ["spring", "summer"],
     elementalProperties: { Fire: 0.1, Water: 0.5, Earth: 0.25, Air: 0.15 },
     qualities: ["delicate", "mild"],
     category: "protein",
@@ -1427,6 +1545,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   bacon_or_pancetta: {
       description: "An Italian salumi made from pork belly meat that is salt-cured, heavily seasoned with black pepper, and often rolled into a tight cylinder (*arrotolata*), but importantly, it is not smoked. It provides a rich, porky saltiness to dishes without the overwhelming wood-smoke flavor of bacon.\n\n**Selection & Storage:** Buy whole pieces if using for cooking (to dice into lardons) or thinly sliced for wrapping. Store tightly sealed in the refrigerator for up to 3 weeks.",
     name: "bacon or pancetta",
+    origin: ["Europe"],
+    season: ["all"],
     elementalProperties: { Fire: 0.4, Water: 0.15, Earth: 0.35, Air: 0.1 },
     qualities: ["salty", "smoky"],
     category: "protein",
@@ -1451,6 +1571,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   sugar_for_caramelizing: {
       description: "Refined sucrose crystallized from sugarcane (*Saccharum officinarum*) or sugar beets (*Beta vulgaris*) — the default sweetener of Western cooking and a critical functional ingredient beyond taste. In baking sugar tenderizes by competing for water, stabilizes foams, browns via Maillard and caramelization, and preserves by binding water activity. Granulated, superfine (caster), confectioners', turbinado, and demerara differ in crystal size, moisture, and residual molasses — each behaving differently in creaming, dissolving, or finishing.",
     name: "sugar for caramelizing",
+    origin: ["South and Southeast Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.45, Water: 0.05, Earth: 0.4, Air: 0.1 },
     qualities: ["sweet", "transformative"],
     category: "sweetener",
@@ -1475,6 +1597,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   shortcrust_pastry: {
       description: "Shortcrust Pastry is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "shortcrust pastry",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.15, Earth: 0.4, Air: 0.25 },
     qualities: ["crumbly", "buttery"],
     category: "grain",
@@ -1499,6 +1623,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   choux_pastry: {
       description: "Choux Pastry is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "choux pastry",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.25, Water: 0.25, Earth: 0.2, Air: 0.3 },
     qualities: ["light", "eggy"],
     category: "grain",
@@ -1523,6 +1649,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   dark_chocolate: {
       description: "A rich confection made from cocoa mass (cocoa solids and cocoa butter) and sugar, with no milk added. Higher percentages (70% and above) indicate more cocoa mass and less sugar, resulting in an intensely bitter, complex, and astringent flavor profile that balances exceptionally sweet baked goods.",
     name: "dark chocolate",
+    origin: ["Mesoamerica"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.15, Earth: 0.4, Air: 0.15 },
     qualities: ["bitter", "rich"],
     category: "sweetener",
@@ -1547,6 +1675,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   phyllo_dough: {
       description: "Paper-thin sheets of unleavened flour-and-water dough, central to Middle Eastern and Balkan pastries like baklava and spanakopita. Lacking internal fat, phyllo relies on being layered and individually brushed with melted butter or oil before baking, resulting in a shatteringly crisp, flaky structure. It dries out and cracks rapidly when exposed to air, requiring cooks to keep unused sheets covered with a damp towel during assembly.",
     name: "phyllo dough",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.15, Earth: 0.3, Air: 0.4 },
     qualities: ["paper-thin", "crispy"],
     category: "grain",
@@ -1571,6 +1701,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   semolina: {
       description: "A coarse, pale-yellow flour milled from hard durum wheat (*Triticum durum*). Its extraordinarily high protein content and coarse grind make it the international standard for creating structured, resilient dried pasta, and it provides a gritty, satisfying crunch when dusted on pizza peels.",
     name: "semolina",
+    origin: ["Mediterranean"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.1, Earth: 0.5, Air: 0.2 },
     qualities: ["coarse", "hearty"],
     category: "grain",
@@ -1595,6 +1727,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   almonds: {
       description: "The edible seeds of the *Prunus dulcis* tree, highly valued for their subtle sweetness, firm crunch, and woody flavor. Blanched almonds (skins removed) are often ground into fine flours for delicate pastries like macarons, while skin-on, roasted almonds provide robust texture and bitterness to savory dishes.",
     name: "almonds",
+    origin: ["Western Asia"],
+    season: ["fall"],
     elementalProperties: { Fire: 0.2, Water: 0.1, Earth: 0.5, Air: 0.2 },
     qualities: ["crunchy", "nutty"],
     category: "nut_seed",
@@ -1619,6 +1753,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   urad_dal: {
       description: "Urad Dal is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "urad dal",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.2, Earth: 0.45, Air: 0.15 },
     qualities: ["earthy", "creamy"],
     category: "protein",
@@ -1643,6 +1779,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   toor_dal: {
       description: "Toor Dal is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "toor dal",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.2, Earth: 0.45, Air: 0.15 },
     qualities: ["earthy", "mild"],
     category: "protein",
@@ -1667,6 +1805,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   sambar_powder: {
       description: "Sambar Powder is a concentrated aromatic spice used in small amounts to add heat, fragrance, and depth to sauces, marinades, and dry rubs. Blooming it briefly in hot fat or toasting it gently before grinding helps release volatile oils and prevents flat flavor. Store airtight away from light and humidity, and refresh frequently to maintain potency.",
     name: "sambar powder",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.4, Water: 0.1, Earth: 0.3, Air: 0.2 },
     qualities: ["spicy", "complex"],
     category: "spice",
@@ -1691,6 +1831,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   vegetables: {
       description: "Any edible plant material — leaves, roots, stems, tubers, flowers, fruits used as savory ingredients — delivering fiber, vitamins, phytochemicals, and the flavor backbone of non-meat-forward cooking. Treat by structural group: hard roots (carrots, beets) need more heat and time; leafy greens cook in seconds; fungi need dry heat to develop depth; brassicas reward high heat for caramelization and charring. Freshness matters more than variety — a peak-season common vegetable beats an out-of-season rare one.",
     name: "vegetables",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.3, Air: 0.2 },
     qualities: ["fresh", "wholesome"],
     category: "vegetable",
@@ -1715,6 +1857,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   puri_shells: {
       description: "Puri Shells is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "puri shells",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.1, Earth: 0.35, Air: 0.25 },
     qualities: ["crispy", "hollow"],
     category: "grain",
@@ -1739,6 +1883,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   tamarind: {
       description: "The sticky, highly acidic pulp extracted from the seed pods of the *Tamarindus indica* tree. It provides a profoundly complex, fruity, and intensely tart flavor profile that acts as the primary souring agent in Pad Thai, Indian chutneys, and Worcestershire sauce.",
     name: "tamarind",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.25, Water: 0.35, Earth: 0.25, Air: 0.15 },
     qualities: ["sour", "tangy"],
     category: "fruit",
@@ -1763,6 +1909,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   black_salt: {
       description: "The mineral sodium chloride (NaCl), the single most important culinary seasoning — amplifier of sweetness, suppressor of bitterness, enabler of fermentation, and the substance without which most cooking falls flat. Form matters: table salt dissolves fast for baking; kosher has large flakes that coat meats evenly; fleur de sel and Maldon finish with crunch and bright brine. Salt early in cooking for penetration, at the end for texture; sprinkle deliberately rather than reflexively.",
     name: "black salt",
+    origin: ["Worldwide mineral and sea sources"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.2, Earth: 0.55, Air: 0.1 },
     qualities: ["sulfurous", "pungent"],
     category: "seasoning",
@@ -1787,6 +1935,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   sprouted_moong: {
       description: "Sprouted Moong is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "sprouted moong",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.35, Earth: 0.3, Air: 0.15 },
     qualities: ["crunchy", "fresh"],
     category: "protein",
@@ -1811,6 +1961,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   pistachios: {
       description: "The mildly sweet, pale green seed of a desert tree (*Pistacia vera*) encased in a hard, beige shell. They offer a rich, earthy, and distinctly piney flavor, making them equally prized as a standalone snack, folded into mortadella, or ground into sweet Middle Eastern pastries like baklava.\n\n**Selection & Storage:** Look for pistachios with partially open shells, indicating full maturity. Store shelled pistachios in an airtight container in the refrigerator or freezer to protect their delicate oils.",
     name: "pistachios",
+    origin: ["Western Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.25, Water: 0.1, Earth: 0.45, Air: 0.2 },
     qualities: ["nutty", "slightly sweet"],
     category: "nut_seed",
@@ -1835,6 +1987,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   almond_granita: {
       description: "A teardrop-shaped tree nut (*Prunus dulcis*) prized for its subtle sweetness, woody flavor, and firm crunch. Blanched almonds (skins removed) are often ground into fine flours for delicate pastries like macarons, while skin-on, roasted almonds provide robust texture and bitterness to savory dishes.\n\n**Selection & Storage:** Choose almonds that smell sweet and nutty, avoiding any that smell sharp or like paint (a sign of rancidity). Store them in an airtight container in the refrigerator or freezer to preserve their volatile oils.",
     name: "almond granita",
+    origin: ["Western Asia (Iran, Levant)"],
+    season: ["fall"],
     elementalProperties: { Fire: 0.1, Water: 0.5, Earth: 0.2, Air: 0.2 },
     qualities: ["icy", "sweet"],
     category: "misc",
@@ -1859,6 +2013,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   mascarpone: {
       description: "An Italian cream cheese coagulated through the addition of an acidic substance (like lemon juice or citric acid) rather than rennet. It boasts an exceptionally high butterfat content (up to 75%), yielding an unimaginably rich, velvety texture and a sweet, milky flavor crucial for tiramisu.",
     name: "mascarpone",
+    origin: ["Italy (Lombardy)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.35, Earth: 0.35, Air: 0.2 },
     qualities: ["creamy", "rich"],
     category: "dairy",
@@ -1883,6 +2039,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   natto: {
       description: "Natto is a protein-forward ingredient valued for structure, satiety, and umami depth. Technique determines outcome: dry heat builds browning and intensity, while moist heat promotes tenderness and even hydration. Season in layers and cook to the right internal doneness target for both flavor and safety.",
     name: "natto",
+    origin: ["Japan"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.3, Earth: 0.35, Air: 0.15 },
     qualities: ["fermented", "pungent"],
     category: "protein",
@@ -1907,6 +2065,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   umeboshi: {
       description: "Umeboshi is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "umeboshi",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.35, Earth: 0.3, Air: 0.15 },
     qualities: ["sour", "salty"],
     category: "seasoning",
@@ -1931,6 +2091,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   dashi: {
       description: "The foundational soup stock of Japanese cuisine, typically built from *kombu* (kelp) and *katsuobushi* (dried, fermented bonito flakes). This elemental pairing creates an intense synergy of glutamates and inosinates, yielding a profound, clear umami broth in minutes without the long simmering required for Western meat stocks. Dashi forms the backbone of miso soup, noodle broths, and simmering liquids, imparting a distinct, refined oceanic depth to dishes.",
     name: "dashi",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.55, Earth: 0.2, Air: 0.15 },
     qualities: ["umami", "delicate"],
     category: "seasoning",
@@ -1955,6 +2117,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   gyoza_wrappers: {
       description: "Gyoza Wrappers is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "gyoza wrappers",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.2, Earth: 0.4, Air: 0.25 },
     qualities: ["thin", "pliable"],
     category: "grain",
@@ -1979,6 +2143,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   soy_sauce: {
       description: "An essential East Asian liquid condiment produced by fermenting soybeans, roasted wheat, water, and salt with the mold *Aspergillus oryzae*. This long fermentation breaks down proteins into free amino acids (especially glutamate), creating a profoundly complex, salty, and umami-rich liquid.",
     name: "soy sauce",
+    origin: ["China"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.4, Earth: 0.25, Air: 0.15 },
     qualities: ["salty", "umami"],
     category: "seasoning",
@@ -2003,6 +2169,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   sake: {
       description: "A Japanese alcoholic beverage made by fermenting rice that has been polished to remove the bran. In cooking, it functions similarly to white wine, providing subtle acidity, tenderizing meats, and dissolving flavor compounds that are soluble only in alcohol.",
     name: "sake",
+    origin: ["Japan"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.4, Earth: 0.15, Air: 0.15 },
     qualities: ["clean", "delicate"],
     category: "beverage",
@@ -2027,6 +2195,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   aged_kimchi: {
       description: "A traditional Korean side dish (banchan) of salted and fermented vegetables, most commonly napa cabbage and Korean radishes. It is fermented by lactic acid bacteria in a paste of gochugaru, garlic, ginger, and salted seafood, resulting in a profoundly complex, sour, spicy, and umami-rich flavor.\n\n**Selection & Storage:** Kimchi is a living food; it will continue to ferment and sour over time. Keep it tightly sealed in the refrigerator; older, sour kimchi is superior for cooking stews (jjigae).",
     name: "aged kimchi",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.35, Water: 0.3, Earth: 0.2, Air: 0.15 },
     qualities: ["fermented", "pungent"],
     category: "seasoning",
@@ -2051,6 +2221,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   perilla_leaves: {
       description: "Perilla Leaves is an aromatic herb used to brighten savory dishes with fresh, volatile flavor compounds. Add early for mellow infusion or late for sharper aromatic lift, depending on the recipe goal. Because aroma degrades quickly with heat and air, keep it cold and dry, and chop just before use when possible.",
     name: "perilla leaves",
+    origin: ["East Asia"],
+    season: ["summer"],
     elementalProperties: { Fire: 0.2, Water: 0.3, Earth: 0.15, Air: 0.35 },
     qualities: ["aromatic", "minty"],
     category: "culinary_herb",
@@ -2075,6 +2247,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   ssamjang: {
       description: "Ssamjang is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "ssamjang",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.35, Water: 0.25, Earth: 0.25, Air: 0.15 },
     qualities: ["savory", "spicy"],
     category: "seasoning",
@@ -2099,6 +2273,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   kimchi: {
       description: "A traditional Korean side dish (banchan) of salted and fermented vegetables, most commonly napa cabbage and Korean radishes. It is fermented by lactic acid bacteria in a paste of gochugaru, garlic, ginger, and salted seafood, resulting in a profoundly complex, sour, spicy, and umami-rich flavor.",
     name: "kimchi",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.35, Water: 0.3, Earth: 0.2, Air: 0.15 },
     qualities: ["fermented", "spicy"],
     category: "seasoning",
@@ -2123,6 +2299,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   gochugaru: {
       description: "A coarsely ground Korean chili powder made from sun-dried peppers (*Capsicum annuum*). It possesses a unique flavor profile that is simultaneously spicy, sweet, and slightly smoky, providing the essential flavor base and vibrant red color for kimchi and gochujang.",
     name: "gochugaru",
+    origin: ["Korea"],
+    season: ["all"],
     elementalProperties: { Fire: 0.5, Water: 0.1, Earth: 0.25, Air: 0.15 },
     qualities: ["spicy", "smoky"],
     category: "spice",
@@ -2147,6 +2325,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   gochujang: {
       description: "A savory, sweet, and spicy fermented Korean condiment made from gochugaru (chili powder), glutinous rice, meju (fermented soybean) powder, and salt. Its long fermentation process creates an incredibly thick, sticky paste that acts as the foundational flavor base for tteokbokki and bibimbap.",
     name: "gochujang",
+    origin: ["Korea"],
+    season: ["all"],
     elementalProperties: { Fire: 0.4, Water: 0.25, Earth: 0.2, Air: 0.15 },
     qualities: ["spicy", "sweet"],
     category: "seasoning",
@@ -2171,6 +2351,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   saeujeot: {
       description: "Saeujeot is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "saeujeot",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.4, Earth: 0.25, Air: 0.15 },
     qualities: ["salty", "umami"],
     category: "seasoning",
@@ -2195,6 +2377,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   shaved_ice: {
       description: "Shaved Ice is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "shaved ice",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.0, Water: 0.8, Earth: 0.1, Air: 0.1 },
     qualities: ["cold", "refreshing"],
     category: "misc",
@@ -2219,6 +2403,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   sesame_seeds: {
       description: "Tiny, oil-rich seeds (*Sesamum indicum*) available in white, black, and brown varieties. Toasting them is essential to release their volatile aromatics, which provide an intensely nutty, savory, and almost meaty flavor profile that defines many Asian and Middle Eastern cuisines.\n\n**Selection & Storage:** Look for seeds that smell fresh and sweet. Because they are mostly oil, store them in a tightly sealed container in the refrigerator or freezer to prevent them from going rancid quickly.",
     name: "sesame seeds",
+    origin: ["Africa", "India"],
+    season: ["all"],
     elementalProperties: { Fire: 0.25, Water: 0.1, Earth: 0.45, Air: 0.2 },
     qualities: ["nutty", "crunchy"],
     category: "nut_seed",
@@ -2243,6 +2429,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   pine_needles: {
       description: "Pine Needles is an aromatic herb used to brighten savory dishes with fresh, volatile flavor compounds. Add early for mellow infusion or late for sharper aromatic lift, depending on the recipe goal. Because aroma degrades quickly with heat and air, keep it cold and dry, and chop just before use when possible.",
     name: "pine needles",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.2, Earth: 0.3, Air: 0.35 },
     qualities: ["aromatic", "resinous"],
     category: "culinary_herb",
@@ -2267,6 +2455,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   mixed_fruits: {
       description: "Mixed Fruits is a fruit ingredient used for sweetness, acidity, aroma, and moisture balance. Ripeness and processing method meaningfully change flavor concentration and texture, so adjust sugar and acid around the ingredient's current state. Use chilled for freshness-driven dishes or cooked to concentrate body and flavor.",
     name: "mixed fruits",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.45, Earth: 0.15, Air: 0.2 },
     qualities: ["sweet", "refreshing"],
     category: "fruit",
@@ -2291,6 +2481,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   dried_hominy: {
       description: "Dried Hominy is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "dried hominy",
+    origin: ["Mesoamerica"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.15, Earth: 0.5, Air: 0.2 },
     qualities: ["starchy", "hearty"],
     category: "grain",
@@ -2315,6 +2507,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   mixed_dried_chiles: {
       description: "Mixed Dried Chiles is a concentrated aromatic spice used in small amounts to add heat, fragrance, and depth to sauces, marinades, and dry rubs. Blooming it briefly in hot fat or toasting it gently before grinding helps release volatile oils and prevents flat flavor. Store airtight away from light and humidity, and refresh frequently to maintain potency.",
     name: "mixed dried chiles",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.5, Water: 0.05, Earth: 0.3, Air: 0.15 },
     qualities: ["spicy", "smoky"],
     category: "spice",
@@ -2339,6 +2533,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   chocolate: {
       description: "A complex, semi-solid suspension of cocoa solids and cocoa butter extracted from the fermented, roasted seeds of the *Theobroma cacao* tree. Dark chocolate offers intense, bitter-roasted notes and snaps cleanly; milk chocolate is mellowed by dairy solids; and white chocolate relies entirely on cocoa butter without solids. Temperature control is critical: chocolate must be carefully tempered to align its fat crystals, ensuring a glossy finish and stable texture at room temperature.",
     name: "chocolate",
+    origin: ["Mesoamerica"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.35, Air: 0.15 },
     qualities: ["sweet", "rich"],
     category: "sweetener",
@@ -2363,6 +2559,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   poblano_chiles: {
       description: "A mild to moderately hot, dark green chili pepper (*Capsicum annuum*). Its thick flesh and wide cavity make it the premier choice for stuffing (as in Chiles Rellenos), and roasting it transforms its mild, earthy flavor into something deeply savory, rich, and slightly sweet.\n\n**Selection & Storage:** Select dark green, firm peppers that feel heavy for their size. Store in the crisper drawer, though they are best roasted and peeled soon after purchase.",
     name: "poblano chiles",
+    origin: ["Mexico (Puebla)"],
+    season: ["summer", "fall"],
     elementalProperties: { Fire: 0.35, Water: 0.3, Earth: 0.2, Air: 0.15 },
     qualities: ["mild", "earthy"],
     category: "vegetable",
@@ -2387,6 +2585,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   masa_harina: {
       description: "A traditional Mexican flour made by drying and grinding corn that has undergone nixtamalization (soaking in an alkaline solution, usually calcium hydroxide). This process unlocks the corn's nutritional value, vastly improves its flavor, and allows the dough to bind together to form tortillas and tamales.",
     name: "masa harina",
+    origin: ["Mesoamerica"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.15, Earth: 0.5, Air: 0.2 },
     qualities: ["starchy", "earthy"],
     category: "grain",
@@ -2411,6 +2611,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   fresh_fruit: {
       description: "Fresh Fruit is a fruit ingredient used for sweetness, acidity, aroma, and moisture balance. Ripeness and processing method meaningfully change flavor concentration and texture, so adjust sugar and acid around the ingredient's current state. Use chilled for freshness-driven dishes or cooked to concentrate body and flavor.",
     name: "fresh fruit",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.45, Earth: 0.15, Air: 0.2 },
     qualities: ["sweet", "juicy"],
     category: "fruit",
@@ -2435,6 +2637,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   lamb_shoulder: {
       description: "The meat of young domestic sheep (*Ovis aries*), renowned for its distinctive, slightly gamey, and grassy flavor profile, caused by branched-chain fatty acids in its fat. It pairs beautifully with strong, astringent aromatics like rosemary, mint, and garlic that cut through its rich intensity.\n\n**Selection & Storage:** Choose cuts with a light, rosy-red color and stark white, firm fat; dark red meat indicates an older animal (mutton). Keep tightly wrapped in the coldest section of the refrigerator and cook within 3-5 days.",
     name: "lamb shoulder",
+    origin: ["Western Asia (domestication)"],
+    season: ["spring"],
     elementalProperties: { Fire: 0.35, Water: 0.25, Earth: 0.3, Air: 0.1 },
     qualities: ["rich", "succulent"],
     category: "protein",
@@ -2459,6 +2663,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   jameed: {
       description: "Jameed is a dairy ingredient that contributes richness, body, and protein structure to both savory and sweet preparations. Heat and acid can quickly shift texture from smooth to curdled, so gentle temperature control is important in sauces and custards. Keep refrigerated and handle with clean tools to maintain shelf life and flavor.",
     name: "jameed",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.2, Earth: 0.5, Air: 0.15 },
     qualities: ["tangy", "salty"],
     category: "dairy",
@@ -2483,6 +2689,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   pine_nuts: {
       description: "The small, teardrop-shaped edible seeds extracted from the cones of certain pine trees (*Pinus*). They possess a soft texture and a sweet, intensely buttery, and slightly resinous flavor that is greatly amplified by light toasting, serving as the essential base for classic Genovese pesto.\n\n**Selection & Storage:** Due to their exceptionally high oil content, they are highly prone to rancidity. Always store pine nuts in an airtight container in the refrigerator or freezer.",
     name: "pine nuts",
+    origin: ["Mediterranean"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.1, Earth: 0.5, Air: 0.2 },
     qualities: ["buttery", "delicate"],
     category: "nut_seed",
@@ -2507,6 +2715,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   kataifi_dough: {
       description: "Kataifi Dough is a grain-based ingredient that contributes starch, structure, and sustained body to dishes. Hydration ratio, particle size, and cooking time strongly affect final texture, from creamy and tender to chewy and crisp. Store dry in an airtight container and rotate stock to avoid stale or rancid flavors.",
     name: "kataifi dough",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.15, Earth: 0.3, Air: 0.4 },
     qualities: ["shredded", "crispy"],
     category: "grain",
@@ -2531,6 +2741,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   pickles: {
       description: "Vegetables or fruits preserved through anaerobic fermentation in brine or immersion in vinegar, resulting in a tart, tangy, and often crunchy condiment. Lactic acid bacteria produce the complex sourness in naturally fermented pickles, while vinegar-based pickles rely on acetic acid. They provide an essential acidic counterpoint to rich, fatty, or umami-heavy dishes, acting as a palate cleanser in sandwiches, burgers, and traditional charcuterie boards.",
     name: "pickles",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.45, Earth: 0.2, Air: 0.2 },
     qualities: ["sour", "crunchy"],
     category: "vegetable",
@@ -2555,6 +2767,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   green_papaya: {
       description: "A large, tropical berry (*Carica papaya*) featuring vibrant orange flesh and a central cavity filled with peppery, edible black seeds. It contains papain, a powerful proteolytic enzyme used globally as a meat tenderizer, and offers a sweet, slightly musky, and floral flavor.\n\n**Selection & Storage:** A ripe papaya will be mostly yellow/orange and yield to gentle pressure. Ripen at room temperature, then store in the refrigerator; green papaya is used unripe as a crisp vegetable in Southeast Asian salads.",
     name: "green papaya",
+    origin: ["Mesoamerica"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.4, Earth: 0.25, Air: 0.2 },
     qualities: ["crunchy", "mild"],
     category: "fruit",
@@ -2579,6 +2793,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   red_syrup: {
       description: "Red Syrup is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "red syrup",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.35, Earth: 0.2, Air: 0.15 },
     qualities: ["sweet", "vibrant"],
     category: "sweetener",
@@ -2603,6 +2819,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   green_syrup: {
       description: "Green Syrup is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "green syrup",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.4, Earth: 0.2, Air: 0.25 },
     qualities: ["sweet", "herbal"],
     category: "sweetener",
@@ -2627,6 +2845,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   palm_seeds: {
       description: "Palm Seeds is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "palm seeds",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     qualities: ["translucent", "chewy"],
     category: "nut_seed",
@@ -2651,6 +2871,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   grass_jelly: {
       description: "Grass Jelly is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "grass jelly",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.05, Water: 0.5, Earth: 0.25, Air: 0.2 },
     qualities: ["cooling", "herbal"],
     category: "misc",
@@ -2675,6 +2897,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   red_food_coloring: {
       description: "Red Food Coloring is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "red food coloring",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.5, Water: 0.3, Earth: 0.1, Air: 0.1 },
     qualities: ["vibrant", "decorative"],
     category: "misc",
@@ -2699,6 +2923,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   palm_sugar: {
       description: "Refined sucrose crystallized from sugarcane (*Saccharum officinarum*) or sugar beets (*Beta vulgaris*) — the default sweetener of Western cooking and a critical functional ingredient beyond taste. In baking sugar tenderizes by competing for water, stabilizes foams, browns via Maillard and caramelization, and preserves by binding water activity. Granulated, superfine (caster), confectioners', turbinado, and demerara differ in crystal size, moisture, and residual molasses — each behaving differently in creaming, dissolving, or finishing.",
     name: "palm sugar",
+    origin: ["Southeast Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["sweet", "caramel"],
     category: "sweetener",
@@ -2723,6 +2949,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   jackfruit: {
       description: "The largest tree-borne fruit in the world (*Artocarpus heterophyllus*). When ripe, the golden bulbs are intensely sweet and taste like a blend of mango, banana, and pineapple; when unripe (green), the flesh is neutral, stringy, and fibrous, acting as an incredibly popular vegan substitute for pulled pork or braised chicken.",
     name: "jackfruit",
+    origin: ["South India", "Southeast Asia"],
+    season: ["summer"],
     elementalProperties: { Fire: 0.2, Water: 0.35, Earth: 0.3, Air: 0.15 },
     qualities: ["sweet", "meaty"],
     category: "fruit",
@@ -2747,6 +2975,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   crushed_ice: {
       description: "Crushed Ice is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "crushed ice",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.0, Water: 0.8, Earth: 0.1, Air: 0.1 },
     qualities: ["cold", "refreshing"],
     category: "misc",
@@ -2771,6 +3001,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   pandan_extract: {
       description: "Pandan Extract is a seasoning ingredient used to adjust balance, aroma, and perceived intensity across savory and sweet cooking. Add in stages so you can control extraction during cooking and precision at the finish. Keep sealed and dry to preserve potency and prevent clumping or flavor drift.",
     name: "pandan extract",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.35, Earth: 0.2, Air: 0.35 },
     qualities: ["fragrant", "floral"],
     category: "seasoning",
@@ -2795,6 +3027,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   kabocha_pumpkin: {
       description: "A large, thick-skinned winter squash (*Cucurbita pepo*) prized for its sweet, earthy flesh and edible seeds. While large field pumpkins are bred for carving, smaller \"sugar\" or \"pie\" pumpkins have dense, less watery flesh ideal for roasting, pureeing, and baking.\n\n**Selection & Storage:** For cooking, select small pie pumpkins that feel dense and heavy with hard, unblemished rinds and an intact stem. Store whole in a cool, dark, dry place for several months.",
     name: "kabocha pumpkin",
+    origin: ["Japan", "Central America"],
+    season: ["fall", "winter"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.4, Air: 0.1 },
     qualities: ["sweet", "starchy"],
     category: "vegetable",
@@ -2819,6 +3053,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   pandan_leaves: {
       description: "Pandan Leaves is an aromatic herb used to brighten savory dishes with fresh, volatile flavor compounds. Add early for mellow infusion or late for sharper aromatic lift, depending on the recipe goal. Because aroma degrades quickly with heat and air, keep it cold and dry, and chop just before use when possible.",
     name: "pandan leaves",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.3, Earth: 0.2, Air: 0.4 },
     qualities: ["fragrant", "grassy"],
     category: "culinary_herb",
@@ -2843,6 +3079,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   tapioca_starch: {
       description: "A pure starch extracted from the storage roots of the cassava plant (*Manihot esculenta*). It provides a remarkably chewy, elastic texture when formed into pearls (boba), or acts as an excellent thickener for fruit pies, creating a perfectly clear gel that doesn't break down when frozen.\n\n**Selection & Storage:** Available as flour, flakes, or pearls. Store in an airtight container in a cool, dark pantry; it has an exceptionally long shelf life.",
     name: "tapioca starch",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.55, Air: 0.15 },
     qualities: ["starchy", "thickening"],
     category: "grain",
@@ -2867,6 +3105,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   herbs_mix: {
       description: "Herbs Mix is an aromatic herb used to brighten savory dishes with fresh, volatile flavor compounds. Add early for mellow infusion or late for sharper aromatic lift, depending on the recipe goal. Because aroma degrades quickly with heat and air, keep it cold and dry, and chop just before use when possible.",
     name: "herbs mix",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.25, Earth: 0.2, Air: 0.35 },
     qualities: ["aromatic", "savory"],
     category: "culinary_herb",
@@ -2891,6 +3131,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   annatto_seeds: {
       description: "The small, deeply red, triangular seeds of the achiote tree (*Bixa orellana*), native to the tropical Americas. While they offer a very mild, slightly peppery, and earthy flavor, their primary culinary function is to impart a brilliant yellow-orange dye to dishes like Mexican cochinita pibil and cheddar cheese.",
     name: "annatto seeds",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.1, Earth: 0.4, Air: 0.2 },
     qualities: ["earthy", "colorful"],
     category: "spice",
@@ -2915,6 +3157,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   vietnamese_herbs: {
       description: "Vietnamese Herbs is an aromatic herb used to brighten savory dishes with fresh, volatile flavor compounds. Add early for mellow infusion or late for sharper aromatic lift, depending on the recipe goal. Because aroma degrades quickly with heat and air, keep it cold and dry, and chop just before use when possible.",
     name: "Vietnamese herbs",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.2, Water: 0.3, Earth: 0.15, Air: 0.35 },
     qualities: ["fresh", "aromatic"],
     category: "culinary_herb",
@@ -2939,6 +3183,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   pickled_vegetables: {
       description: "Any edible plant material — leaves, roots, stems, tubers, flowers, fruits used as savory ingredients — delivering fiber, vitamins, phytochemicals, and the flavor backbone of non-meat-forward cooking. Treat by structural group: hard roots (carrots, beets) need more heat and time; leafy greens cook in seconds; fungi need dry heat to develop depth; brassicas reward high heat for caramelization and charring. Freshness matters more than variety — a peak-season common vegetable beats an out-of-season rare one.",
     name: "pickled vegetables",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.4, Earth: 0.25, Air: 0.2 },
     qualities: ["tangy", "crunchy"],
     category: "vegetable",
@@ -2963,6 +3209,8 @@ const rawMisc: Record<string, Partial<IngredientMapping>> = {
   pandan_jelly: {
       description: "Pandan Jelly is a culinary ingredient used to contribute flavor, texture, and functional balance within a dish. Its impact depends on when it is added and how it is prepared, so adjust timing and quantity to match the recipe's desired result. Store in stable, dry conditions and rotate inventory regularly for consistent quality.",
     name: "pandan jelly",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.05, Water: 0.45, Earth: 0.25, Air: 0.25 },
     qualities: ["fragrant", "refreshing"],
     category: "misc",

--- a/src/data/ingredients/misc/recipeCoverageIngredients.ts
+++ b/src/data/ingredients/misc/recipeCoverageIngredients.ts
@@ -5,6 +5,8 @@ import type { IngredientMapping } from "@/data/ingredients/types";
 export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping>> = {
   "thit_kho_tau": {
     name: "thit kho tau",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Thit Kho Tau is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -46,6 +48,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "lau_thai": {
     name: "lau thai",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Lau Thai is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -87,6 +91,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "thit_kho_t_u": {
     name: "thit kho t u",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Thit Kho T U is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -128,6 +134,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "lau_th_i": {
     name: "lau th i",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Lau Th I is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -169,6 +177,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "mirin": {
     name: "mirin",
+    origin: ["Japan"],
+    season: ["all"],
     provenance: "generated",
     description: "Sweet Japanese rice wine used to add gloss, mild sweetness, and aroma in sauces, braises, and tare.",
     category: "seasoning",
@@ -210,6 +220,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "active_dry_yeast": {
     name: "active dry yeast",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Granulated dehydrated yeast used for bread fermentation; typically bloomed in warm liquid before mixing.",
     category: "seasoning",
@@ -251,6 +263,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cornstarch": {
     name: "cornstarch",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Refined corn starch used to thicken sauces, stabilize batters, and improve crispness in frying.",
     category: "grain",
@@ -292,6 +306,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "oyster_sauce": {
     name: "oyster sauce",
+    origin: ["China (Guangdong)"],
+    season: ["all"],
     provenance: "generated",
     description: "Concentrated savory sauce made from oyster extract and seasonings, used for umami depth and glossy stir-fry finishes.",
     category: "seasoning",
@@ -333,6 +349,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "shaoxing_wine": {
     name: "shaoxing wine",
+    origin: ["China (Shaoxing)"],
+    season: ["all"],
     provenance: "generated",
     description: "Chinese rice wine used for aromatic depth, deglazing, and reducing perceived meat or seafood odors in cooking.",
     category: "seasoning",
@@ -374,6 +392,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "alchemical_binding_agent": {
     name: "alchemical binding agent",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Schema stand-in for recipe-specific binder or emulsifier. Replace with concrete ingredient names during recipe curation.",
     category: "seasoning",
@@ -415,6 +435,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "neutral_oil": {
     name: "neutral oil",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Refined low-aroma oil (e.g., canola, grapeseed, sunflower) used for high-heat frying or when no flavor contribution from fat is desired.",
     category: "oil",
@@ -456,6 +478,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "white_vinegar": {
     name: "white vinegar",
+    origin: ["Worldwide industrial production"],
+    season: ["all"],
     provenance: "generated",
     description: "Neutral distilled vinegar with sharp acetic acidity used for pickling, cleaning flavor profiles, and brightening sauces.",
     category: "vinegar",
@@ -497,6 +521,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "corn_tortillas": {
     name: "corn tortillas",
+    origin: ["Mesoamerica"],
+    season: ["summer"],
     provenance: "generated",
     description: "Nixtamalized corn flatbreads used in tacos, enchiladas, tostadas, and layered casseroles.",
     category: "grain",
@@ -538,6 +564,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "five_spice_powder": {
     name: "five spice powder",
+    origin: ["China"],
+    season: ["all"],
     provenance: "generated",
     description: "Chinese spice blend balancing sweet, warm, and numbing notes; commonly includes star anise, fennel, clove, cinnamon, and pepper.",
     category: "spice",
@@ -579,6 +607,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "firm_tofu": {
     name: "firm tofu",
+    origin: ["China"],
+    season: ["all"],
     provenance: "generated",
     description: "Pressable tofu with moderate water content that holds shape in stir-fries, braises, and pan-searing.",
     category: "protein",
@@ -620,6 +650,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cayenne_pepper": {
     name: "cayenne pepper",
+    origin: ["Central and South America"],
+    season: ["all"],
     provenance: "generated",
     description: "Hot red chili powder used for direct, fast-building capsaicin heat.",
     category: "spice",
@@ -661,6 +693,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "queso_fresco": {
     name: "queso fresco",
+    origin: ["Mexico", "Central America"],
+    season: ["all"],
     provenance: "generated",
     description: "Fresh crumbly Mexican cheese used as a salty, cooling finish for beans, tortillas, and chiles.",
     category: "dairy",
@@ -702,6 +736,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "bird_eye_chilies": {
     name: "bird eye chilies",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Small, very hot chiles common in Southeast Asian cooking, used fresh or pounded into pastes.",
     category: "spice",
@@ -744,6 +780,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "bird_s_eye_chilies": {
     name: "bird s eye chilies",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Alternate spelling variant for bird's eye chilies; treated as the same high-heat chili ingredient.",
     category: "spice",
@@ -786,6 +824,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "white_bread": {
     name: "white bread",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Refined wheat bread used for crumbs, soaks, sandwiches, and structure in fillings or meat mixtures.",
     category: "grain",
@@ -827,6 +867,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "capers": {
     name: "capers",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Capers is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -868,6 +910,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "sichuan_peppercorns": {
     name: "sichuan peppercorns",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Citrusy, numbing spice from prickly ash husks used for ma la profile and aromatic lift.",
     category: "spice",
@@ -909,6 +953,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "dried_red_chilies": {
     name: "dried red chilies",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Air-dried red chiles used whole, crushed, or rehydrated for layered heat and color.",
     category: "spice",
@@ -950,6 +996,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "garni": {
     name: "garni",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Shorthand for herb bouquet components (e.g., bouquet garni) used to infuse stocks and braises.",
     category: "culinary_herb",
@@ -991,6 +1039,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "oil": {
     name: "oil",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Generic recipe oil token used when a source recipe does not specify olive, canola, or another named fat. Treat as neutral cooking oil unless a regional context indicates otherwise.",
     category: "oil",
@@ -1032,6 +1082,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "frying_oil": {
     name: "frying oil",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Oil specified for deep or shallow frying where smoke point and oxidation stability are primary constraints.",
     category: "oil",
@@ -1073,6 +1125,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "bamboo_skewers": {
     name: "bamboo skewers",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Bamboo Skewers is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "vegetable",
@@ -1114,6 +1168,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "chili_flakes": {
     name: "chili flakes",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Crushed dried chili fragments used as finishing heat or infused in oil.",
     category: "spice",
@@ -1155,6 +1211,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "radishes": {
     name: "radishes",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Crisp pungent roots used raw for bite or pickled for acidity and crunch.",
     category: "vegetable",
@@ -1196,6 +1254,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "black_peppercorns": {
     name: "black peppercorns",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Black Peppercorns is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -1237,6 +1297,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "ice": {
     name: "ice",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Frozen water used for chilling, textural contrast, and dessert beverages rather than as a nutritional ingredient.",
     category: "seasoning",
@@ -1278,6 +1340,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "corn": {
     name: "corn",
+    origin: ["Mesoamerica"],
+    season: ["summer"],
     provenance: "generated",
     description: "Whole corn kernels or cut corn used as a starchy-sweet base ingredient across soups, stews, tortillas, and salads.",
     category: "grain",
@@ -1319,6 +1383,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "limes": {
     name: "limes",
+    origin: ["Southeast Asia", "India"],
+    season: ["summer", "fall"],
     provenance: "generated",
     description: "Limes is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "fruit",
@@ -1360,6 +1426,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "achiote_paste": {
     name: "achiote paste",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Achiote Paste is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -1401,6 +1469,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "ancho_chilies": {
     name: "ancho chilies",
+    origin: ["Mexico"],
+    season: ["all"],
     provenance: "generated",
     description: "Ancho Chilies is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -1442,6 +1512,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "allspice": {
     name: "allspice",
+    origin: ["Caribbean", "Central America"],
+    season: ["all"],
     provenance: "generated",
     description: "Warm spice from dried Pimenta berries with flavor notes of clove, cinnamon, and nutmeg.",
     category: "spice",
@@ -1483,6 +1555,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "red_curry_paste": {
     name: "red curry paste",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Red Curry Paste is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -1524,6 +1598,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "harissa_paste": {
     name: "harissa paste",
+    origin: ["North Africa (Tunisia)"],
+    season: ["all"],
     provenance: "generated",
     description: "Harissa Paste is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -1565,6 +1641,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "raisins": {
     name: "raisins",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Dried grapes used for concentrated sweetness and chew in savory rice dishes, breads, and desserts.",
     category: "fruit",
@@ -1606,6 +1684,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "worcestershire_sauce": {
     name: "worcestershire sauce",
+    origin: ["England (Worcester)"],
+    season: ["all"],
     provenance: "generated",
     description: "A highly complex, fermented liquid condiment created in England, featuring a base of vinegar flavored with molasses, sugar, salt, anchovies, tamarind, onion, and garlic. It provides an immediate hit of umami, tang, and sweetness, excelling as a marinade for beef or a seasoning for bloody marys.\n\n**Selection & Storage:** Highly stable due to its vinegar and salt content; store in a cool, dark pantry.",
     category: "misc",
@@ -1647,6 +1727,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "hot_sauce": {
     name: "hot sauce",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Hot Sauce is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -1688,6 +1770,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "heavy_whipping_cream": {
     name: "heavy whipping cream",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Heavy Whipping Cream is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "dairy",
@@ -1729,6 +1813,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "hoisin_sauce": {
     name: "hoisin sauce",
+    origin: ["China"],
+    season: ["all"],
     provenance: "generated",
     description: "A thick, fragrant sauce commonly used in Cantonese cuisine as a glaze for meat or a dipping sauce. It is sweet and salty, primarily made from fermented soybeans, garlic, five-spice powder, and sugar, offering a flavor profile similar to a Chinese BBQ sauce.\n\n**Selection & Storage:** Once opened, store tightly sealed in the refrigerator, where it will last for many months.",
     category: "misc",
@@ -1770,6 +1856,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "bamboo_shoots": {
     name: "bamboo shoots",
+    origin: ["East and Southeast Asia"],
+    season: ["spring"],
     provenance: "generated",
     description: "Bamboo Shoots is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "vegetable",
@@ -1811,6 +1899,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "sauerkraut": {
     name: "sauerkraut",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Finely shredded cabbage that has been fermented by various lactic acid bacteria, including *Leuconostoc*, *Lactobacillus*, and *Pediococcus*. This anaerobic fermentation converts the cabbage's natural sugars into lactic acid, providing a long shelf life and a distinctively sharp, sour tang.\n\n**Selection & Storage:** For the most health benefits, purchase unpasteurized sauerkraut found in the refrigerated section. Keep tightly sealed in the fridge, ensuring the cabbage remains submerged in its brine.",
     category: "misc",
@@ -1852,6 +1942,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cloves": {
     name: "cloves",
+    origin: ["Indonesia"],
+    season: ["all"],
     provenance: "generated",
     description: "Highly aromatic dried flower buds used in tiny quantities for warm, sweet, and medicinal spice notes.",
     category: "spice",
@@ -1893,6 +1985,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "asafoetida_hing": {
     name: "asafoetida hing",
+    origin: ["Western Asia (Iran, Afghanistan)"],
+    season: ["all"],
     provenance: "generated",
     description: "Asafoetida Hing is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -1934,6 +2028,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "kasuri_methi": {
     name: "kasuri methi",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Kasuri Methi is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -1975,6 +2071,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "pepper": {
     name: "pepper",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Generic pepper token, most often meaning black pepper in savory recipes. Use as a baseline pungent spice unless the recipe specifies a pepper type.",
     category: "spice",
@@ -2016,6 +2114,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "marsala_wine": {
     name: "marsala wine",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Marsala Wine is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -2057,6 +2157,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "golden_raisins": {
     name: "golden raisins",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Golden Raisins is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "fruit",
@@ -2098,6 +2200,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "nori_seaweed": {
     name: "nori seaweed",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Nori Seaweed is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -2139,6 +2243,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "fresh_ramen_noodles": {
     name: "fresh ramen noodles",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Fresh Ramen Noodles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -2180,6 +2286,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "dried_soba_noodles": {
     name: "dried soba noodles",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Dried Soba Noodles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -2221,6 +2329,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "wasabi": {
     name: "wasabi",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "The grated rhizome of a Japanese semi-aquatic plant (*Eutrema japonicum*). It produces volatile allyl isothiocyanate compounds when its cells are ruptured, delivering a fierce, vaporous heat that aggressively attacks the sinuses before dissipating completely within seconds.\n\n**Selection & Storage:** Real fresh wasabi is rare and must be grated immediately before serving, as its flavor vanishes in 15 minutes. Most commercial 'wasabi' is a stable mixture of horseradish, mustard, and green food coloring.",
     category: "misc",
@@ -2262,6 +2372,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "mixed_seafood": {
     name: "mixed seafood",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Mixed Seafood is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -2303,6 +2415,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "doenjang": {
     name: "doenjang",
+    origin: ["Korea"],
+    season: ["all"],
     provenance: "generated",
     description: "Doenjang is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -2344,6 +2458,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "aromatic_catalyst": {
     name: "aromatic catalyst",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Aromatic Catalyst is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -2385,6 +2501,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "ancho_chiles": {
     name: "ancho chiles",
+    origin: ["Mexico"],
+    season: ["all"],
     provenance: "generated",
     description: "Ancho Chiles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -2426,6 +2544,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "pasilla_chilies": {
     name: "pasilla chilies",
+    origin: ["Mexico"],
+    season: ["all"],
     provenance: "generated",
     description: "Pasilla Chilies is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -2467,6 +2587,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "poblano_peppers": {
     name: "poblano peppers",
+    origin: ["Mexico (Puebla)"],
+    season: ["summer", "fall"],
     provenance: "generated",
     description: "Poblano Peppers is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -2508,6 +2630,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "guajillo_chilies": {
     name: "guajillo chilies",
+    origin: ["Mexico"],
+    season: ["all"],
     provenance: "generated",
     description: "Guajillo Chilies is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -2549,6 +2673,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tahini": {
     name: "tahini",
+    origin: ["Levant"],
+    season: ["all"],
     provenance: "generated",
     description: "Ground sesame seed paste used for emulsions, sauces, dips, and nutty richness.",
     category: "seasoning",
@@ -2590,6 +2716,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "raw_tahini": {
     name: "raw tahini",
+    origin: ["Levant"],
+    season: ["all"],
     provenance: "generated",
     description: "Unroasted sesame paste with lighter bitterness and grassy sesame aroma compared with roasted tahini.",
     category: "seasoning",
@@ -2632,6 +2760,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "green_curry_paste": {
     name: "green curry paste",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Green Curry Paste is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -2673,6 +2803,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "niter_kibbeh": {
     name: "niter kibbeh",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Niter Kibbeh is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -2714,6 +2846,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "scotch_bonnet_pepper": {
     name: "scotch bonnet pepper",
+    origin: ["Caribbean"],
+    season: ["summer"],
     provenance: "generated",
     description: "Scotch Bonnet Pepper is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -2755,6 +2889,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "red_pepper_flakes": {
     name: "red pepper flakes",
+    origin: ["Mesoamerica"],
+    season: ["all"],
     provenance: "generated",
     description: "Red Pepper Flakes is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -2796,6 +2932,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "peri_peri_sauce": {
     name: "peri peri sauce",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Peri Peri Sauce is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -2837,6 +2975,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "unsliced_white_bread": {
     name: "unsliced white bread",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Unsliced White Bread is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -2878,6 +3018,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "habanero_pepper": {
     name: "habanero pepper",
+    origin: ["Yucatán Peninsula"],
+    season: ["summer", "fall"],
     provenance: "generated",
     description: "Habanero Pepper is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -2919,6 +3061,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cream_of_tartar": {
     name: "cream of tartar",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Cream Of Tartar is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "dairy",
@@ -2960,6 +3104,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "american_cheese": {
     name: "american cheese",
+    origin: ["Western Asia (Fertile Crescent)"],
+    season: ["all"],
     provenance: "generated",
     description: "American Cheese is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "dairy",
@@ -3001,6 +3147,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "creole_seasoning": {
     name: "creole seasoning",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Creole Seasoning is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -3042,6 +3190,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cornmeal": {
     name: "cornmeal",
+    origin: ["Mesoamerica"],
+    season: ["all"],
     provenance: "generated",
     description: "A coarse flour ground from dried maize (corn). Depending on the grind (fine, medium, or coarse), it provides structural integrity, a crunchy texture, and a sweet, earthy flavor to baked goods like cornbread, or serves as a crispy breading for fried fish.\n\n**Selection & Storage:** Stone-ground cornmeal retains the germ and spoils faster than degerminated cornmeal. Keep stone-ground varieties in the refrigerator or freezer in an airtight container.",
     category: "vegetable",
@@ -3083,6 +3233,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "wheat_starch": {
     name: "wheat starch",
+    origin: ["Fertile Crescent"],
+    season: ["all"],
     provenance: "generated",
     description: "Wheat Starch is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -3124,6 +3276,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "silken_tofu": {
     name: "silken tofu",
+    origin: ["China", "Japan"],
+    season: ["all"],
     provenance: "generated",
     description: "Silken Tofu is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -3165,6 +3319,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "fresh_wheat_noodles": {
     name: "fresh wheat noodles",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "High-moisture wheat noodles used in stir-fry and soup formats where chew and elasticity are important.",
     category: "grain",
@@ -3206,6 +3362,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "shellfish": {
     name: "shellfish",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Shellfish is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -3247,6 +3405,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "toulouse_sausage": {
     name: "toulouse sausage",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Toulouse Sausage is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -3288,6 +3448,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "kalamata_olives": {
     name: "kalamata olives",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Kalamata Olives is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -3329,6 +3491,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "pita_breads": {
     name: "pita breads",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Plural entry for pocket flatbreads used for wraps, dips, and baked chips.",
     category: "grain",
@@ -3371,6 +3535,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "biryani_masala": {
     name: "biryani masala",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Biryani Masala is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -3412,6 +3578,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cashew_paste": {
     name: "cashew paste",
+    origin: ["South America (Brazil)"],
+    season: ["all"],
     provenance: "generated",
     description: "Cashew Paste is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -3453,6 +3621,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "spaghetti": {
     name: "spaghetti",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "A long, thin, solid cylindrical pasta shape originating in Italy. Its high surface-area-to-volume ratio makes it exceptionally well-suited for clinging to loose, oil- or butter-based sauces (like Aglio e Olio) and smooth tomato sauces that can evenly coat the long strands.\n\n**Selection & Storage:** High-quality dried spaghetti will have a rough, matte texture (bronze-die extruded) rather than a smooth, shiny one, allowing sauces to adhere better. Store in a dry pantry.",
     category: "grain",
@@ -3494,6 +3664,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "guanciale": {
     name: "guanciale",
+    origin: ["Italy"],
+    season: ["all"],
     provenance: "generated",
     description: "An Italian cured meat prepared from pork jowl or cheeks. It is fundamentally similar to pancetta but boasts a significantly higher ratio of fat to meat, providing an incredibly rich, melt-in-the-mouth texture and a more robust, porky flavor essential for authentic Spaghetti alla Carbonara.\n\n**Selection & Storage:** Usually sold in blocks. Store tightly wrapped in the refrigerator, and dice it directly before rendering it in a cold pan.",
     category: "misc",
@@ -3535,6 +3707,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "strong_espresso": {
     name: "strong espresso",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Strong Espresso is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -3576,6 +3750,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "savoiardi_ladyfingers": {
     name: "savoiardi ladyfingers",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Savoiardi Ladyfingers is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -3617,6 +3793,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "unsweetened_cocoa_powder": {
     name: "unsweetened cocoa powder",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Unsweetened Cocoa Powder is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -3658,6 +3836,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "yakisoba_noodles": {
     name: "yakisoba noodles",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Yakisoba Noodles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -3699,6 +3879,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "yakisoba_sauce": {
     name: "yakisoba sauce",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Yakisoba Sauce is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -3740,6 +3922,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "ajitsuke_tamago": {
     name: "ajitsuke tamago",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Ajitsuke Tamago is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -3781,6 +3965,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tentsuyu": {
     name: "tentsuyu",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Tentsuyu is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -3822,6 +4008,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tenkasu_tempura_scraps": {
     name: "tenkasu tempura scraps",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Tenkasu Tempura Scraps is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -3863,6 +4051,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "okonomiyaki_sauce": {
     name: "okonomiyaki sauce",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Okonomiyaki Sauce is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -3904,6 +4094,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "katsuobushi_bonito_flakes": {
     name: "katsuobushi bonito flakes",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Katsuobushi Bonito Flakes is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -3945,6 +4137,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "shirataki_noodles": {
     name: "shirataki noodles",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Shirataki Noodles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -3986,6 +4180,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "kamaboko": {
     name: "kamaboko",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Kamaboko is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -4027,6 +4223,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "somyeon_thin_wheat_noodles": {
     name: "somyeon thin wheat noodles",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Somyeon Thin Wheat Noodles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -4068,6 +4266,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "medium_firm_tofu": {
     name: "medium firm tofu",
+    origin: ["China"],
+    season: ["all"],
     provenance: "generated",
     description: "Tofu texture between soft and firm, suitable for soups, braises, and gentle stir-fries.",
     category: "protein",
@@ -4109,6 +4309,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "gim_roasted_seaweed": {
     name: "gim roasted seaweed",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Gim Roasted Seaweed is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -4150,6 +4352,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "dangmyeon": {
     name: "dangmyeon",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Dangmyeon is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -4191,6 +4395,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "eomuk_fish_cakes": {
     name: "eomuk fish cakes",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Eomuk Fish Cakes is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -4232,6 +4438,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tomatillos": {
     name: "tomatillos",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Tomatillos is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -4273,6 +4481,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "crema_mexicana": {
     name: "crema mexicana",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Crema Mexicana is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -4314,6 +4524,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "lard": {
     name: "lard",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Rendered pork fat used for frying, pastry shortening, and savory depth in traditional regional cooking.",
     category: "oil",
@@ -4355,6 +4567,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "guajillo_chiles": {
     name: "guajillo chiles",
+    origin: ["Mexico"],
+    season: ["all"],
     provenance: "generated",
     description: "Guajillo Chiles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -4396,6 +4610,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "mulato_chilies": {
     name: "mulato chilies",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Mulato Chilies is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -4437,6 +4653,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "fresh_epazote": {
     name: "fresh epazote",
+    origin: ["Mexico", "Central America"],
+    season: ["summer"],
     provenance: "generated",
     description: "Fresh Epazote is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -4478,6 +4696,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "mexican_crema": {
     name: "mexican crema",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Mexican Crema is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -4519,6 +4739,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "pita_bread": {
     name: "pita bread",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Leavened Middle Eastern flatbread used for stuffing, dipping, and as a starch base.",
     category: "grain",
@@ -4561,6 +4783,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "shawarma_spice_blend": {
     name: "shawarma spice blend",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Shawarma Spice Blend is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -4602,6 +4826,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "pickle_brine": {
     name: "pickle brine",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Pickle Brine is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -4643,6 +4869,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tvorog_farmers_cheese": {
     name: "tvorog farmers cheese",
+    origin: ["Western Asia (Fertile Crescent)"],
+    season: ["all"],
     provenance: "generated",
     description: "Tvorog Farmers Cheese is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "dairy",
@@ -4684,6 +4912,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "nam_prik_pao": {
     name: "nam prik pao",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Nam Prik Pao is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -4725,6 +4955,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "bird_s_eye_chili": {
     name: "bird s eye chili",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Bird S Eye Chili is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -4766,6 +4998,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "massaman_curry_paste": {
     name: "massaman curry paste",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Massaman Curry Paste is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -4807,6 +5041,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "long_red_chilies": {
     name: "long red chilies",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Long Red Chilies is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -4848,6 +5084,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "dried_chili_flakes": {
     name: "dried chili flakes",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Shelf-stable crushed dried chiles used for controlled background heat.",
     category: "spice",
@@ -4890,6 +5128,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "toppings_matrix": {
     name: "toppings matrix",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Toppings Matrix is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -4931,6 +5171,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "hale_s_blue_boy_syrup": {
     name: "hale s blue boy syrup",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Hale S Blue Boy Syrup is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -4972,6 +5214,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "vietnamese_baguettes": {
     name: "vietnamese baguettes",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Vietnamese Baguettes is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -5013,6 +5257,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "leftover_dry_injera": {
     name: "leftover dry injera",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Leftover Dry Injera is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -5054,6 +5300,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "scotch_bonnet": {
     name: "scotch bonnet",
+    origin: ["Caribbean"],
+    season: ["summer"],
     provenance: "generated",
     description: "Scotch Bonnet is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -5095,6 +5343,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "scotch_bonnet_peppers_ata_rodo": {
     name: "scotch bonnet peppers ata rodo",
+    origin: ["Caribbean"],
+    season: ["summer"],
     provenance: "generated",
     description: "Scotch Bonnet Peppers Ata Rodo is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -5136,6 +5386,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "habanero": {
     name: "habanero",
+    origin: ["Yucatán Peninsula"],
+    season: ["summer", "fall"],
     provenance: "generated",
     description: "A small, lantern-shaped chili (*Capsicum chinense*) known for its intense heat (100,000 - 350,000 Scoville units) and highly distinctive, floral, and fruity flavor profile. They are essential to Caribbean and Yucatán cuisines, where their severe heat is balanced by sweet tropical fruits like mango.\n\n**Selection & Storage:** Choose firm, brilliantly colored peppers (usually orange or red) without soft spots. Store in a paper bag in the refrigerator, and always wear gloves when handling.",
     category: "misc",
@@ -5177,6 +5429,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "macaroni": {
     name: "macaroni",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "A short, tubular pasta shape, often curved (elbow macaroni). The hollow center is specifically designed to trap loose, creamy, or chunky sauces, making it the globally accepted standard for dense, dairy-heavy baked dishes like macaroni and cheese.\n\n**Selection & Storage:** Choose pasta with a consistent color and no broken pieces. Store in an airtight container or its original packaging in a cool, dry place.",
     category: "misc",
@@ -5218,6 +5472,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "vegetable_stock": {
     name: "vegetable stock",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Vegetable Stock is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -5259,6 +5515,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "vermicelli": {
     name: "vermicelli",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Thin noodles (wheat or rice depending on cuisine) used in soups, stir-fries, and cold dishes.",
     category: "grain",
@@ -5300,6 +5558,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "crushed_wheat_frik": {
     name: "crushed wheat frik",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Crushed Wheat Frik is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -5341,6 +5601,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "harissa": {
     name: "harissa",
+    origin: ["North Africa (Tunisia)"],
+    season: ["all"],
     provenance: "generated",
     description: "A vibrant, spicy, and aromatic chili paste originating from the Maghreb region of North Africa. It is traditionally composed of roasted red peppers, Baklouti chilies, garlic, caraway, coriander, and cumin, pounded into a paste with olive oil to create an intensely flavorful, earthy condiment.\n\n**Selection & Storage:** High-quality harissa comes in tubes or jars. Once opened, top the paste with a thin layer of olive oil to seal out air, and keep refrigerated.",
     category: "spice",
@@ -5382,6 +5644,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "brick_pastry_sheets": {
     name: "brick pastry sheets",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Brick Pastry Sheets is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -5423,6 +5687,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "ogbono_seeds": {
     name: "ogbono seeds",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Ogbono Seeds is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -5464,6 +5730,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "collard_greens": {
     name: "collard greens",
+    origin: ["Eastern Mediterranean", "Asia Minor"],
+    season: ["fall", "winter", "early spring"],
     provenance: "generated",
     description: "A robust, wide-leafed member of the cabbage family (*Brassica oleracea*). Because their leaves are incredibly tough and fibrous, they require long, slow braising (traditionally with smoked meats and acidic vinegar) to break down into a tender, deeply savory, and silky side dish.\n\n**Selection & Storage:** Choose bunches with dark green, broad leaves and firm stems. Store unwashed in the crisper drawer; they are quite hardy and will last up to a week.",
     category: "misc",
@@ -5505,6 +5773,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "ndol_leaves_bitterleaf": {
     name: "ndol leaves bitterleaf",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Ndol Leaves Bitterleaf is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "culinary_herb",
@@ -5546,6 +5816,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "couscous": {
     name: "couscous",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Tiny granules of rolled durum wheat semolina, common in North African cuisine. Because the granules are pre-steamed and dried during the manufacturing process, it cooks incredibly fast—often just requiring a brief steep in boiling water to hydrate and fluff into a light, airy side dish.\n\n**Selection & Storage:** Look for uniform granules; Moroccan couscous is tiny, while Israeli (pearl) couscous is larger and requires simmering. Store in an airtight container in a dark pantry.",
     category: "misc",
@@ -5587,6 +5859,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "durban_curry_masala": {
     name: "durban curry masala",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Durban Curry Masala is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -5628,6 +5902,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "mitmita": {
     name: "mitmita",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Mitmita is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -5669,6 +5945,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "kuli_kuli_powder": {
     name: "kuli kuli powder",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Kuli Kuli Powder is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -5710,6 +5988,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "bitterleaves": {
     name: "bitterleaves",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Bitterleaves is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "culinary_herb",
@@ -5751,6 +6031,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "vinegar_white": {
     name: "vinegar white",
+    origin: ["Western Asia"],
+    season: ["all"],
     provenance: "generated",
     description: "Vinegar White is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "vinegar",
@@ -5792,6 +6074,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "sourdough_bread": {
     name: "sourdough bread",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Sourdough Bread is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -5833,6 +6117,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "leeks": {
     name: "leeks",
+    origin: ["Mediterranean"],
+    season: ["fall", "winter", "spring"],
     provenance: "generated",
     description: "Leeks is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -5874,6 +6160,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "fresh_berries": {
     name: "fresh berries",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Fresh Berries is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -5915,6 +6203,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "sweet_pickle_relish": {
     name: "sweet pickle relish",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Sweet Pickle Relish is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -5956,6 +6246,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "watercress": {
     name: "watercress",
+    origin: ["Europe", "Asia"],
+    season: ["spring", "summer"],
     provenance: "generated",
     description: "A rapidly growing, aquatic leafy green (*Nasturtium officinale*) related to mustard and radish. It delivers a sharp, explosive, and peppery bite that acts as a brilliant, astringent palate cleanser when paired with rich steaks or creamy tea sandwiches.\n\n**Selection & Storage:** It is highly perishable. Look for perky, bright green leaves, and store the stems submerged in a glass of water in the refrigerator, loosely covered with a plastic bag.",
     category: "misc",
@@ -5997,6 +6289,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "top_split_hot_dog_buns": {
     name: "top split hot dog buns",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Top Split Hot Dog Buns is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -6038,6 +6332,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "thick_cut_sourdough": {
     name: "thick cut sourdough",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Thick Cut Sourdough is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -6079,6 +6375,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "dried_navy_beans": {
     name: "dried navy beans",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Dried Navy Beans is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -6120,6 +6418,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cube_steak": {
     name: "cube steak",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Cube Steak is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -6161,6 +6461,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "andouille_sausage": {
     name: "andouille sausage",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Andouille Sausage is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -6202,6 +6504,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "italian_sausage": {
     name: "italian sausage",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Italian Sausage is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -6243,6 +6547,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "hoagie_rolls": {
     name: "hoagie rolls",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Hoagie Rolls is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -6284,6 +6590,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "provolone_cheese": {
     name: "provolone cheese",
+    origin: ["Western Asia (Fertile Crescent)"],
+    season: ["all"],
     provenance: "generated",
     description: "Provolone Cheese is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "dairy",
@@ -6325,6 +6633,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "pie_dough": {
     name: "pie dough",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Pie Dough is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -6366,6 +6676,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cedar_grilling_plank": {
     name: "cedar grilling plank",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Cedar Grilling Plank is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -6407,6 +6719,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "youtiao_fried_dough": {
     name: "youtiao fried dough",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Youtiao Fried Dough is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -6448,6 +6762,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tianmianjiang_sweet_bean_sauce": {
     name: "tianmianjiang sweet bean sauce",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Tianmianjiang Sweet Bean Sauce is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -6489,6 +6805,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "baocui_crispy_fried_cracker": {
     name: "baocui crispy fried cracker",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Baocui Crispy Fried Cracker is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -6530,6 +6848,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "fresh_chinese_wheat_noodles": {
     name: "fresh chinese wheat noodles",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Fresh Chinese Wheat Noodles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -6571,6 +6891,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "sui_mi_ya_cai": {
     name: "sui mi ya cai",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Sui Mi Ya Cai is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -6612,6 +6934,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "chinese_sesame_paste": {
     name: "chinese sesame paste",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Chinese Sesame Paste is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -6653,6 +6977,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "pixian_doubanjiang": {
     name: "pixian doubanjiang",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Pixian Doubanjiang is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -6694,6 +7020,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "square_wonton_wrappers": {
     name: "square wonton wrappers",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Square Wonton Wrappers is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -6735,6 +7063,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "supreme_broth_gao_tang": {
     name: "supreme broth gao tang",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Supreme Broth Gao Tang is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -6776,6 +7106,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "chili_paste": {
     name: "chili paste",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Chili Paste is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -6817,6 +7149,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "doubanjiang": {
     name: "doubanjiang",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Doubanjiang is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -6858,6 +7192,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "black_tea_leaves": {
     name: "black tea leaves",
+    origin: ["China", "India"],
+    season: ["all"],
     provenance: "generated",
     description: "Black Tea Leaves is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "culinary_herb",
@@ -6899,6 +7235,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "maltose_syrup": {
     name: "maltose syrup",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Maltose Syrup is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -6940,6 +7278,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "sweet_bean_sauce": {
     name: "sweet bean sauce",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Sweet Bean Sauce is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -6981,6 +7321,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "doubanjiang_spicy_broad_bean_paste": {
     name: "doubanjiang spicy broad bean paste",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Doubanjiang Spicy Broad Bean Paste is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -7022,6 +7364,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "red_fermented_tofu": {
     name: "red fermented tofu",
+    origin: ["China"],
+    season: ["all"],
     provenance: "generated",
     description: "Red Fermented Tofu is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -7063,6 +7407,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "sesame_paste": {
     name: "sesame paste",
+    origin: ["Africa"],
+    season: ["all"],
     provenance: "generated",
     description: "Sesame Paste is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -7104,6 +7450,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "sichuan_peppercorn_powder": {
     name: "sichuan peppercorn powder",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Sichuan Peppercorn Powder is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -7145,6 +7493,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "flank_steak": {
     name: "flank steak",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Flank Steak is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -7186,6 +7536,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "wheat_starch_tang_mian_fen": {
     name: "wheat starch tang mian fen",
+    origin: ["Fertile Crescent"],
+    season: ["all"],
     provenance: "generated",
     description: "Wheat Starch Tang Mian Fen is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -7227,6 +7579,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "doubanjiang_spicy_bean_paste": {
     name: "doubanjiang spicy bean paste",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Doubanjiang Spicy Bean Paste is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -7268,6 +7622,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "sweet_bean_sauce_tianmianjiang": {
     name: "sweet bean sauce tianmianjiang",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Sweet Bean Sauce Tianmianjiang is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -7309,6 +7665,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "thick_fresh_wheat_noodles": {
     name: "thick fresh wheat noodles",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Thick Fresh Wheat Noodles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -7350,6 +7708,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "wonton_wrappers": {
     name: "wonton wrappers",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Wonton Wrappers is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -7391,6 +7751,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "croissant_au_beurre": {
     name: "croissant au beurre",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Croissant Au Beurre is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -7432,6 +7794,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cafe_au_lait": {
     name: "cafe au lait",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Cafe Au Lait is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -7473,6 +7837,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "jambon_de_paris_high_quality_cooked_ham": {
     name: "jambon de paris high quality cooked ham",
+    origin: ["Europe", "East Asia"],
+    season: ["all"],
     provenance: "generated",
     description: "Jambon De Paris High Quality Cooked Ham is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -7514,6 +7880,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "croutons": {
     name: "croutons",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Croutons is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -7555,6 +7923,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "jambon_blanc_cooked_ham": {
     name: "jambon blanc cooked ham",
+    origin: ["Europe", "East Asia"],
+    season: ["all"],
     provenance: "generated",
     description: "Jambon Blanc Cooked Ham is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -7596,6 +7966,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "gruyere": {
     name: "gruyere",
+    origin: ["Switzerland (Fribourg)"],
+    season: ["all"],
     provenance: "generated",
     description: "A firm, raw cow's milk cheese from Switzerland, renowned as one of the finest melting cheeses in the world due to its high water-to-oil ratio. It possesses a complex flavor profile that is sweet but slightly salty, with profound notes of earth, mushrooms, and toasted nuts.\n\n**Selection & Storage:** Look for a dense, slightly granular paste; older varieties will have small cracks and a darker color. Store wrapped in parchment or wax paper in the warmest part of the refrigerator.",
     category: "misc",
@@ -7637,6 +8009,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "escargots": {
     name: "escargots",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Escargots is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -7678,6 +8052,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "ni_u00e7oise_olives": {
     name: "ni u00e7oise olives",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Ni U00e7oise Olives is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -7719,6 +8095,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "dover_sole": {
     name: "dover sole",
+    origin: ["Atlantic Ocean"],
+    season: ["spring", "summer"],
     provenance: "generated",
     description: "Dover Sole is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -7760,6 +8138,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "sausages": {
     name: "sausages",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Sausages is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -7801,6 +8181,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "juniper_berries": {
     name: "juniper berries",
+    origin: ["Northern Europe", "North America"],
+    season: ["fall"],
     provenance: "generated",
     description: "Juniper Berries is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -7842,6 +8224,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "marrow_bone": {
     name: "marrow bone",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Marrow Bone is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -7883,6 +8267,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "leek": {
     name: "leek",
+    origin: ["Mediterranean", "Middle East"],
+    season: ["fall", "winter", "spring"],
     provenance: "generated",
     description: "A mild, sweet member of the onion family (*Allium ampeloprasum*) characterized by its tightly bundled cylindrical stem of broad, flat leaves. Unlike onions, leeks do not form a bulb and offer a subtle, grassy sweetness that thickens and enriches soups and braises.\n\n**Selection & Storage:** Select leeks with crisp, brightly colored green tops and a pristine white base. Because dirt easily gets trapped between the layers, slice and wash them thoroughly before cooking. Refrigerate unwashed leeks loosely wrapped in plastic for up to two weeks.",
     category: "misc",
@@ -7924,6 +8310,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "mixed_firm_and_flaky_fish": {
     name: "mixed firm and flaky fish",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Mixed Firm And Flaky Fish is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -7965,6 +8353,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "fish_stock": {
     name: "fish stock",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Fish Stock is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -8006,6 +8396,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "white_haricot_beans": {
     name: "white haricot beans",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "White Haricot Beans is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -8047,6 +8439,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "dried_white_tarbais_beans": {
     name: "dried white tarbais beans",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Dried White Tarbais Beans is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -8088,6 +8482,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "red_burgundy_wine": {
     name: "red burgundy wine",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Red Burgundy Wine is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -8129,6 +8525,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "small_bony_fish_for_stock": {
     name: "small bony fish for stock",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Small Bony Fish For Stock is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -8170,6 +8568,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "rouille": {
     name: "rouille",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Rouille is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -8211,6 +8611,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "piperade": {
     name: "piperade",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Piperade is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -8252,6 +8654,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "creme_patissiere": {
     name: "creme patissiere",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Creme Patissiere is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -8293,6 +8697,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "wooden_skewers": {
     name: "wooden skewers",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Wooden Skewers is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -8334,6 +8740,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "greek_pita_bread": {
     name: "greek pita bread",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Greek Pita Bread is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -8375,6 +8783,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "kefalotyri_cheese": {
     name: "kefalotyri cheese",
+    origin: ["Western Asia (Fertile Crescent)"],
+    season: ["all"],
     provenance: "generated",
     description: "Kefalotyri Cheese is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "dairy",
@@ -8416,6 +8826,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "vegetable_broth": {
     name: "vegetable broth",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Savory vegetable stock used as a liquid flavor base in soups, braises, and grain cooking.",
     category: "seasoning",
@@ -8457,6 +8869,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "kefalograviera_cheese": {
     name: "kefalograviera cheese",
+    origin: ["Western Asia (Fertile Crescent)"],
+    season: ["all"],
     provenance: "generated",
     description: "Kefalograviera Cheese is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "dairy",
@@ -8498,6 +8912,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "orzo_pasta": {
     name: "orzo pasta",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Orzo Pasta is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -8539,6 +8955,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "stale_bread": {
     name: "stale bread",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Stale Bread is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -8580,6 +8998,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "pastitsio_pasta_misko_no_2": {
     name: "pastitsio pasta misko no 2",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Pastitsio Pasta Misko No 2 is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -8621,6 +9041,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "dried_currants": {
     name: "dried currants",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Dried Currants is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -8662,6 +9084,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "allspice_berries": {
     name: "allspice berries",
+    origin: ["Caribbean", "Central America"],
+    season: ["all"],
     provenance: "generated",
     description: "Allspice Berries is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -8703,6 +9127,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "kritharaki_greek_orzo_pasta": {
     name: "kritharaki greek orzo pasta",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Kritharaki Greek Orzo Pasta is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -8744,6 +9170,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "kefalotyri": {
     name: "kefalotyri",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Kefalotyri is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -8785,6 +9213,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "dried_gigantes_beans": {
     name: "dried gigantes beans",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Dried Gigantes Beans is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -8826,6 +9256,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "stale_white_bread": {
     name: "stale white bread",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Stale White Bread is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -8867,6 +9299,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "phyllo_pastry": {
     name: "phyllo pastry",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Phyllo Pastry is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -8908,6 +9342,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "pastitsio_pasta": {
     name: "pastitsio pasta",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Pastitsio Pasta is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -8949,6 +9385,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "currants": {
     name: "currants",
+    origin: ["Europe"],
+    season: ["summer"],
     provenance: "generated",
     description: "Currants is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -8990,6 +9428,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "fenugreek_seeds": {
     name: "fenugreek seeds",
+    origin: ["Western Asia", "Mediterranean"],
+    season: ["all"],
     provenance: "generated",
     description: "Fenugreek Seeds is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -9031,6 +9471,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "kasuri_methi_dried_fenugreek_leaves": {
     name: "kasuri methi dried fenugreek leaves",
+    origin: ["Western Asia", "Mediterranean"],
+    season: ["winter", "spring"],
     provenance: "generated",
     description: "Kasuri Methi Dried Fenugreek Leaves is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "culinary_herb",
@@ -9072,6 +9514,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "sev": {
     name: "sev",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Sev is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -9113,6 +9557,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "mutton": {
     name: "mutton",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Mutton is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -9154,6 +9600,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "red_chilies": {
     name: "red chilies",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Generic ripe red chili pepper entry used for fresh heat and bright pepper aroma.",
     category: "spice",
@@ -9195,6 +9643,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "whole_green_gram_moong_dal": {
     name: "whole green gram moong dal",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Whole Green Gram Moong Dal is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -9236,6 +9686,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cooking_oil": {
     name: "cooking oil",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Cooking Oil is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "oil",
@@ -9277,6 +9729,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "green_chili_paste": {
     name: "green chili paste",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Green Chili Paste is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -9318,6 +9772,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "nihari_masala": {
     name: "nihari masala",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Nihari Masala is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -9359,6 +9815,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cashews": {
     name: "cashews",
+    origin: ["South America"],
+    season: ["all"],
     provenance: "generated",
     description: "Cashews is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -9400,6 +9858,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "chana_masala_powder": {
     name: "chana masala powder",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Chana Masala Powder is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -9441,6 +9901,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "carom_seeds_ajwain": {
     name: "carom seeds ajwain",
+    origin: ["South Asia", "Western Asia"],
+    season: ["all"],
     provenance: "generated",
     description: "Carom Seeds Ajwain is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -9482,6 +9944,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "amchur": {
     name: "amchur",
+    origin: ["South Asia"],
+    season: ["all"],
     provenance: "generated",
     description: "Amchur is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -9523,6 +9987,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "raisins_and_cashews": {
     name: "raisins and cashews",
+    origin: ["South America"],
+    season: ["all"],
     provenance: "generated",
     description: "Raisins And Cashews is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "fruit",
@@ -9564,6 +10030,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "crispy_puris": {
     name: "crispy puris",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Crispy Puris is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -9605,6 +10073,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "pav_bhaji_masala": {
     name: "pav bhaji masala",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Pav Bhaji Masala is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -9646,6 +10116,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "pav_rolls": {
     name: "pav rolls",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Pav Rolls is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -9687,6 +10159,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tiger_prawns": {
     name: "tiger prawns",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Tiger Prawns is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -9728,6 +10202,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "bydagi_chilies": {
     name: "bydagi chilies",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Bydagi Chilies is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -9769,6 +10245,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "ajwain_carom_seeds": {
     name: "ajwain carom seeds",
+    origin: ["South Asia", "Western Asia"],
+    season: ["all"],
     provenance: "generated",
     description: "Ajwain Carom Seeds is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -9810,6 +10288,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "khoya_mawa": {
     name: "khoya mawa",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Khoya Mawa is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -9851,6 +10331,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tikka_masala_spice_blend": {
     name: "tikka masala spice blend",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Tikka Masala Spice Blend is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -9892,6 +10374,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "dried_fenugreek_leaves_kasuri_methi": {
     name: "dried fenugreek leaves kasuri methi",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Dried Fenugreek Leaves Kasuri Methi is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "culinary_herb",
@@ -9933,6 +10417,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "khoya": {
     name: "khoya",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Khoya is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -9974,6 +10460,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "espresso": {
     name: "espresso",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Espresso is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -10015,6 +10503,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "high_quality_cocoa_powder": {
     name: "high quality cocoa powder",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "High Quality Cocoa Powder is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -10056,6 +10546,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cantuccini_biscotti": {
     name: "cantuccini biscotti",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Cantuccini Biscotti is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -10097,6 +10589,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "stale_crusty_bread_ideally_saltless_tuscan_bread": {
     name: "stale crusty bread ideally saltless tuscan bread",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Stale Crusty Bread Ideally Saltless Tuscan Bread is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -10138,6 +10632,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cannellini_beans": {
     name: "cannellini beans",
+    origin: ["Italy"],
+    season: ["all"],
     provenance: "generated",
     description: "Cannellini Beans is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -10179,6 +10675,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "stale_tuscan_bread": {
     name: "stale tuscan bread",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Stale Tuscan Bread is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -10220,6 +10718,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "dried_borlotti": {
     name: "dried borlotti",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Dried Borlotti is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -10261,6 +10761,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "ditalini": {
     name: "ditalini",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Ditalini is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -10302,6 +10804,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "fresh_yeast": {
     name: "fresh yeast",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Compressed baker's yeast used for active fermentation in breads and enriched doughs, with high activity and shorter shelf life than dry yeast.",
     category: "seasoning",
@@ -10343,6 +10847,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "olives": {
     name: "olives",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Brined or cured olive fruit used for saline bitterness and fat-like richness in Mediterranean and Middle Eastern dishes.",
     category: "fruit",
@@ -10384,6 +10890,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "pici_pasta": {
     name: "pici pasta",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Pici Pasta is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -10425,6 +10933,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "green_olives": {
     name: "green olives",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Green Olives is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -10466,6 +10976,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "vinegar": {
     name: "vinegar",
+    origin: ["Western Asia"],
+    season: ["all"],
     provenance: "generated",
     description: "Generic vinegar token used for acid balance, pickling, and deglazing when a specific vinegar type is not named.",
     category: "vinegar",
@@ -10507,6 +11019,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "oil_for_frying": {
     name: "oil for frying",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Oil For Frying is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "oil",
@@ -10548,6 +11062,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "puntarelle": {
     name: "puntarelle",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Puntarelle is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -10589,6 +11105,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "taleggio_cheese": {
     name: "taleggio cheese",
+    origin: ["Western Asia (Fertile Crescent)"],
+    season: ["all"],
     provenance: "generated",
     description: "Taleggio Cheese is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -10630,6 +11148,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "bolognese_rag": {
     name: "bolognese rag",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Bolognese Rag is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -10671,6 +11191,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "gremolata": {
     name: "gremolata",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Gremolata is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -10712,6 +11234,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "prosciutto_di_parma": {
     name: "prosciutto di parma",
+    origin: ["Italy (Parma, San Daniele)"],
+    season: ["all"],
     provenance: "generated",
     description: "Prosciutto Di Parma is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -10753,6 +11277,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cocoa_powder": {
     name: "cocoa powder",
+    origin: ["Mesoamerica"],
+    season: ["all"],
     provenance: "generated",
     description: "The dry, solid remains of roasted cacao beans after the fatty cocoa butter has been pressed out. Natural cocoa powder is acidic and sharp, while 'Dutch-processed' cocoa has been treated with an alkali to neutralize its acidity, resulting in a darker color and a smoother, milder chocolate flavor.\n\n**Selection & Storage:** Check your recipe to see if it requires Dutch-processed or natural cocoa powder, as they react differently with leavening agents. Store in an airtight container in a dark pantry.",
     category: "misc",
@@ -10794,6 +11320,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "sea_bass": {
     name: "sea bass",
+    origin: ["Mediterranean", "Atlantic"],
+    season: ["fall", "winter"],
     provenance: "generated",
     description: "Sea Bass is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -10835,6 +11363,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tonnarelli": {
     name: "tonnarelli",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Tonnarelli is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -10876,6 +11406,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "instant_yeast": {
     name: "instant yeast",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Instant Yeast is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -10917,6 +11449,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "savoiardi_ladyfinger_biscuits": {
     name: "savoiardi ladyfinger biscuits",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Savoiardi Ladyfinger Biscuits is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -10958,6 +11492,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "dextrose": {
     name: "dextrose",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Dextrose is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -10999,6 +11535,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "locust_bean_gum": {
     name: "locust bean gum",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Locust Bean Gum is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -11040,6 +11578,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "active_lieveto_madre_stiff_sourdough_starter": {
     name: "active lieveto madre stiff sourdough starter",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Active Lieveto Madre Stiff Sourdough Starter is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11081,6 +11621,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "miso_soup": {
     name: "miso soup",
+    origin: ["Japan"],
+    season: ["all"],
     provenance: "generated",
     description: "Miso Soup is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11122,6 +11664,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "kobachi_side_dish": {
     name: "kobachi side dish",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Kobachi Side Dish is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11163,6 +11707,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "ham": {
     name: "ham",
+    origin: ["Europe", "East Asia"],
+    season: ["all"],
     provenance: "generated",
     description: "Ham is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11204,6 +11750,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "edamame_beans": {
     name: "edamame beans",
+    origin: ["East Asia"],
+    season: ["summer", "fall"],
     provenance: "generated",
     description: "Edamame Beans is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -11245,6 +11793,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "katsuobushi": {
     name: "katsuobushi",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Katsuobushi is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11286,6 +11836,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tsuyu_noodle_sauce": {
     name: "tsuyu noodle sauce",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Tsuyu Noodle Sauce is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -11327,6 +11879,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "toasted_nori": {
     name: "toasted nori",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Toasted Nori is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11368,6 +11922,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "wasabi_paste": {
     name: "wasabi paste",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Wasabi Paste is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11409,6 +11965,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "shoyu_tare": {
     name: "shoyu tare",
+    origin: ["Japan"],
+    season: ["all"],
     provenance: "generated",
     description: "Shoyu Tare is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11450,6 +12008,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "white_miso_paste_shiro_miso": {
     name: "white miso paste shiro miso",
+    origin: ["Japan"],
+    season: ["all"],
     provenance: "generated",
     description: "White Miso Paste Shiro Miso is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11491,6 +12051,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "dried_wakame_seaweed": {
     name: "dried wakame seaweed",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Dried Wakame Seaweed is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11532,6 +12094,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "aonori_dried_green_seaweed_flakes": {
     name: "aonori dried green seaweed flakes",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Aonori Dried Green Seaweed Flakes is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11573,6 +12137,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cooked_octopus_tako": {
     name: "cooked octopus tako",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Cooked Octopus Tako is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11614,6 +12180,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "takoyaki_sauce": {
     name: "takoyaki sauce",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Takoyaki Sauce is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11655,6 +12223,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "mentsuyu_dipping_sauce": {
     name: "mentsuyu dipping sauce",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Mentsuyu Dipping Sauce is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11696,6 +12266,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "hot_green_tea_sencha": {
     name: "hot green tea sencha",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Hot Green Tea Sencha is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11737,6 +12309,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "nori_strips": {
     name: "nori strips",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Nori Strips is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11778,6 +12352,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "shungiku_chrysanthemum_greens": {
     name: "shungiku chrysanthemum greens",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Shungiku Chrysanthemum Greens is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11819,6 +12395,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "alkaline_wheat_noodles": {
     name: "alkaline wheat noodles",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Alkaline Wheat Noodles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -11860,6 +12438,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tare_sauce": {
     name: "tare sauce",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Tare Sauce is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11901,6 +12481,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tenkasu": {
     name: "tenkasu",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Tenkasu is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11942,6 +12524,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "katsuobushi_and_aonori": {
     name: "katsuobushi and aonori",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Katsuobushi And Aonori is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -11983,6 +12567,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "fresh": {
     name: "fresh",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "A modifier token indicating freshness (e.g., fresh herbs, fresh chilies) rather than a standalone ingredient. Resolve to the primary ingredient named in context.",
     category: "seasoning",
@@ -12024,6 +12610,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tonkatsu_sauce": {
     name: "tonkatsu sauce",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Tonkatsu Sauce is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -12065,6 +12653,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "mitsuba": {
     name: "mitsuba",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Mitsuba is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -12106,6 +12696,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "white_miso_paste": {
     name: "white miso paste",
+    origin: ["Japan"],
+    season: ["all"],
     provenance: "generated",
     description: "White Miso Paste is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -12147,6 +12739,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "nori": {
     name: "nori",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "An edible red algae (*Pyropia*) that is shredded, pulped, and pressed into thin, dark green sheets (much like the paper-making process). It offers a deeply savory, slightly sweet, and distinctively roasted oceanic flavor, functioning as the structural wrap for sushi rolls and onigiri.\n\n**Selection & Storage:** Nori absorbs ambient moisture instantly, turning tough and chewy. Store in a highly airtight container or zip-top bag with a desiccant packet.",
     category: "misc",
@@ -12188,6 +12782,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "naengmyeon_noodles": {
     name: "naengmyeon noodles",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Naengmyeon Noodles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -12229,6 +12825,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "dongchimi_brine": {
     name: "dongchimi brine",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Dongchimi Brine is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -12270,6 +12868,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "korean_pancake_mix": {
     name: "korean pancake mix",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Korean Pancake Mix is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -12311,6 +12911,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "red_chili_pepper": {
     name: "red chili pepper",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Red Chili Pepper is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -12352,6 +12954,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "garaetteok": {
     name: "garaetteok",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Garaetteok is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -12393,6 +12997,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "fish_cakes_eomuk": {
     name: "fish cakes eomuk",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Fish Cakes Eomuk is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -12434,6 +13040,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "jajangmyeon_noodles": {
     name: "jajangmyeon noodles",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Jajangmyeon Noodles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -12475,6 +13083,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "chunjang": {
     name: "chunjang",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Chunjang is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -12516,6 +13126,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cornstarch_slurry": {
     name: "cornstarch slurry",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Cornstarch Slurry is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -12557,6 +13169,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "core_element_of_haemul_pajeon": {
     name: "core element of haemul pajeon",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Core Element Of Haemul Pajeon is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -12598,6 +13212,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "alchemical_spice": {
     name: "alchemical spice",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Alchemical Spice is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -12639,6 +13255,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "pancake_mix": {
     name: "pancake mix",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Pancake Mix is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -12680,6 +13298,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "danmuji_yellow_pickled_radish": {
     name: "danmuji yellow pickled radish",
+    origin: ["China", "Southeast Asia"],
+    season: ["spring", "fall"],
     provenance: "generated",
     description: "Danmuji Yellow Pickled Radish is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "vegetable",
@@ -12721,6 +13341,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "round_mandu_wrappers": {
     name: "round mandu wrappers",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Round Mandu Wrappers is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -12762,6 +13384,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "chili_pepper": {
     name: "chili pepper",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Chili Pepper is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -12803,6 +13427,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "chestnuts": {
     name: "chestnuts",
+    origin: ["Europe"],
+    season: ["fall"],
     provenance: "generated",
     description: "Chestnuts is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -12844,6 +13470,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "jujubes_dried_dates": {
     name: "jujubes dried dates",
+    origin: ["Middle East"],
+    season: ["fall", "winter"],
     provenance: "generated",
     description: "Jujubes Dried Dates is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -12885,6 +13513,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "extra_firm_tofu": {
     name: "extra firm tofu",
+    origin: ["China"],
+    season: ["all"],
     provenance: "generated",
     description: "Low-moisture tofu ideal for high-heat searing, grilling, and crisp textures after pressing.",
     category: "protein",
@@ -12926,6 +13556,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "spam": {
     name: "spam",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Spam is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -12967,6 +13599,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "instant_ramen_noodles": {
     name: "instant ramen noodles",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Instant Ramen Noodles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -13008,6 +13642,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "hot_dogs": {
     name: "hot dogs",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Hot Dogs is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -13049,6 +13685,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "baked_beans": {
     name: "baked beans",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Baked Beans is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -13090,6 +13728,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "fresh_ginseng": {
     name: "fresh ginseng",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Fresh Ginseng is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -13131,6 +13771,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "dried_jujubes": {
     name: "dried jujubes",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Dried Jujubes is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -13172,6 +13814,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "dried_astragalus_root": {
     name: "dried astragalus root",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Dried Astragalus Root is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -13213,6 +13857,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "mochi": {
     name: "mochi",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Mochi is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -13254,6 +13900,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "primary_ingredient_for_hotteok": {
     name: "primary ingredient for hotteok",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Primary Ingredient For Hotteok is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -13295,6 +13943,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "primary_ingredient_for_songpyeon": {
     name: "primary ingredient for songpyeon",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Primary Ingredient For Songpyeon is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -13336,6 +13986,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "primary_ingredient_for_japchae": {
     name: "primary ingredient for japchae",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Primary Ingredient For Japchae is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -13377,6 +14029,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "jalapeno": {
     name: "jalapeno",
+    origin: ["Mexico (Veracruz)"],
+    season: ["summer"],
     provenance: "generated",
     description: "A medium-sized chili pepper (*Capsicum annuum*) offering a bright, grassy, and vegetal flavor accompanied by moderate heat (2,500 - 8,000 Scoville units). When green, they are sharp and crisp; as they ripen to red, they develop a sweeter, deeper flavor profile before being smoke-dried into chipotles.\n\n**Selection & Storage:** Look for firm, shiny peppers. Small white lines (corking) indicate a more mature, often hotter pepper. Store unwashed in a paper bag in the crisper drawer.",
     category: "misc",
@@ -13418,6 +14072,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "stale_corn_tortillas": {
     name: "stale corn tortillas",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Stale Corn Tortillas is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -13459,6 +14115,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "epazote": {
     name: "epazote",
+    origin: ["Mexico", "Central America"],
+    season: ["summer"],
     provenance: "generated",
     description: "Epazote is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -13500,6 +14158,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "bolillo_rolls": {
     name: "bolillo rolls",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Bolillo Rolls is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -13541,6 +14201,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "refried_beans": {
     name: "refried beans",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Refried Beans is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -13582,6 +14244,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "pico_de_gallo": {
     name: "pico de gallo",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Pico De Gallo is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -13623,6 +14287,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "chiltomate_sauce": {
     name: "chiltomate sauce",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Chiltomate Sauce is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -13664,6 +14330,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cooked_ham": {
     name: "cooked ham",
+    origin: ["Europe", "East Asia"],
+    season: ["all"],
     provenance: "generated",
     description: "Cooked Ham is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -13705,6 +14373,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "serrano_chilies": {
     name: "serrano chilies",
+    origin: ["Mexico"],
+    season: ["summer"],
     provenance: "generated",
     description: "Serrano Chilies is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -13746,6 +14416,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tlayudas": {
     name: "tlayudas",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Tlayudas is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -13787,6 +14459,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "oaxaca_cheese": {
     name: "oaxaca cheese",
+    origin: ["Western Asia (Fertile Crescent)"],
+    season: ["all"],
     provenance: "generated",
     description: "Oaxaca Cheese is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "dairy",
@@ -13828,6 +14502,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "chorizo": {
     name: "chorizo",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "A highly seasoned pork sausage available in two drastically different styles. Spanish chorizo is cured, hard, and deeply flavored with smoked paprika (pimentón), while Mexican chorizo is fresh, uncured, and aggressively seasoned with chili peppers and vinegar, requiring cooking before eating.\n\n**Selection & Storage:** Spanish (cured) chorizo can be stored at room temperature until sliced. Mexican (fresh) chorizo must be kept refrigerated and cooked thoroughly.",
     category: "misc",
@@ -13869,6 +14545,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "roma": {
     name: "roma",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Roma is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -13910,6 +14588,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "hass": {
     name: "hass",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Hass is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -13951,6 +14631,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "salsa_roja": {
     name: "salsa roja",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Salsa Roja is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -13992,6 +14674,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "nopales": {
     name: "nopales",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Nopales is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -14033,6 +14717,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cotija_cheese": {
     name: "cotija cheese",
+    origin: ["Western Asia (Fertile Crescent)"],
+    season: ["all"],
     provenance: "generated",
     description: "Cotija Cheese is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "dairy",
@@ -14074,6 +14760,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "chile_powder": {
     name: "chile powder",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Chile Powder is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -14115,6 +14803,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "juice": {
     name: "juice",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Generic juice token typically used for citrus acidity, fruit sweetness, or marinade moisture. Resolve to citrus, vegetable, or fruit source from recipe context.",
     category: "seasoning",
@@ -14156,6 +14846,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "fideo_pasta": {
     name: "fideo pasta",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Fideo Pasta is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -14197,6 +14889,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "mulato_chiles": {
     name: "mulato chiles",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Mulato Chiles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -14238,6 +14932,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "pasilla_chiles": {
     name: "pasilla chiles",
+    origin: ["Mexico"],
+    season: ["all"],
     provenance: "generated",
     description: "Pasilla Chiles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -14279,6 +14975,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "corn_tortilla": {
     name: "corn tortilla",
+    origin: ["Mesoamerica"],
+    season: ["summer"],
     provenance: "generated",
     description: "Single corn tortilla entry for recipe rows that use singular ingredient naming.",
     category: "grain",
@@ -14321,6 +15019,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "jalapenos": {
     name: "jalapenos",
+    origin: ["Mexico (Veracruz)"],
+    season: ["summer"],
     provenance: "generated",
     description: "Jalapenos is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -14362,6 +15062,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "serrano_chiles": {
     name: "serrano chiles",
+    origin: ["Mexico"],
+    season: ["summer"],
     provenance: "generated",
     description: "Serrano Chiles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -14403,6 +15105,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cascabel_chilies": {
     name: "cascabel chilies",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Cascabel Chilies is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -14444,6 +15148,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "salsa_verde": {
     name: "salsa verde",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Salsa Verde is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -14485,6 +15191,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "dried_corn_husks": {
     name: "dried corn husks",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Dried Corn Husks is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "vegetable",
@@ -14526,6 +15234,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "yucatecan_limes": {
     name: "yucatecan limes",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Yucatecan Limes is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "fruit",
@@ -14567,6 +15277,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "chilhuacle_negro_chilies": {
     name: "chilhuacle negro chilies",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Chilhuacle Negro Chilies is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -14608,6 +15320,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tajin": {
     name: "tajin",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Tajin is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -14649,6 +15363,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "chamoy_sauce": {
     name: "chamoy sauce",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Chamoy Sauce is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -14690,6 +15406,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cotija_cheese_crumbled": {
     name: "cotija cheese crumbled",
+    origin: ["Mexico (Michoacán)"],
+    season: ["all"],
     provenance: "generated",
     description: "Cotija Cheese Crumbled is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "dairy",
@@ -14731,6 +15449,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "ancho": {
     name: "ancho",
+    origin: ["Mexico"],
+    season: ["all"],
     provenance: "generated",
     description: "Dried poblano chile used for mild heat, earthy sweetness, and deep red-brown sauces.",
     category: "spice",
@@ -14772,6 +15492,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "aleppo_pepper_flakes": {
     name: "aleppo pepper flakes",
+    origin: ["Syria", "Turkey"],
+    season: ["all"],
     provenance: "generated",
     description: "Aleppo Pepper Flakes is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -14813,6 +15535,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "laurel_leaves": {
     name: "laurel leaves",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Laurel Leaves is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "culinary_herb",
@@ -14854,6 +15578,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "sumac": {
     name: "sumac",
+    origin: ["Western Asia", "Mediterranean"],
+    season: ["all"],
     provenance: "generated",
     description: "Sumac is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -14895,6 +15621,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "bulgur": {
     name: "bulgur",
+    origin: ["Western Asia"],
+    season: ["all"],
     provenance: "generated",
     description: "A whole grain made from cracked parboiled groats of several different wheat species, most often durum wheat. Because it has been parboiled, it cooks very quickly and offers a deeply nutty flavor and a satisfying, chewy texture, serving as the foundational ingredient in Middle Eastern tabbouleh.\n\n**Selection & Storage:** Available in different grinds (fine for salads, coarse for pilafs). Store in an airtight container in the pantry, or in the refrigerator to prolong its shelf life.",
     category: "misc",
@@ -14936,6 +15664,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "molokhia_leaves": {
     name: "molokhia leaves",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Molokhia Leaves is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "culinary_herb",
@@ -14977,6 +15707,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "b_u00e9chamel_sauce": {
     name: "b u00e9chamel sauce",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "B U00e9chamel Sauce is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -15018,6 +15750,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "shrak": {
     name: "shrak",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Shrak is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -15059,6 +15793,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "hawaij": {
     name: "hawaij",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Hawaij is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -15100,6 +15836,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "kataifi_pastry": {
     name: "kataifi pastry",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Kataifi Pastry is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -15141,6 +15879,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "nabulsi": {
     name: "nabulsi",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Nabulsi is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -15182,6 +15922,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "neutral_frying_oil": {
     name: "neutral frying oil",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Neutral Frying Oil is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "oil",
@@ -15223,6 +15965,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tahini_sauce": {
     name: "tahini sauce",
+    origin: ["Levant"],
+    season: ["all"],
     provenance: "generated",
     description: "Tahini Sauce is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -15264,6 +16008,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "kitchen_towel": {
     name: "kitchen towel",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Kitchen Towel is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -15305,6 +16051,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tvorog_farmer_s_cheese": {
     name: "tvorog farmer s cheese",
+    origin: ["Western Asia (Fertile Crescent)"],
+    season: ["all"],
     provenance: "generated",
     description: "Tvorog Farmer S Cheese is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "dairy",
@@ -15346,6 +16094,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "berry_preserves": {
     name: "berry preserves",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Berry Preserves is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "fruit",
@@ -15387,6 +16137,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "kefir": {
     name: "kefir",
+    origin: ["Caucasus"],
+    season: ["all"],
     provenance: "generated",
     description: "A highly probiotic, fermented milk drink with a consistency similar to thin yogurt. It is cultured using 'kefir grains' (a symbiotic matrix of bacteria and yeast), resulting in a tart, slightly effervescent beverage that makes a superb tenderizing marinade for poultry.\n\n**Selection & Storage:** Choose plain, unsweetened kefir for cooking applications. It has a relatively long shelf life due to its acidity; store it tightly sealed in the refrigerator.",
     category: "misc",
@@ -15428,6 +16180,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "small_fish": {
     name: "small fish",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Small whole fish used for broths, sauces, frying, and fermented preparations. Flavor intensity and salinity vary by species and preservation method.",
     category: "protein",
@@ -15469,6 +16223,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "prized_fish": {
     name: "prized fish",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Prized Fish is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -15510,6 +16266,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "vodka": {
     name: "vodka",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "A clear, highly distilled liquor composed primarily of water and ethanol, designed to be flavorless. In cooking, it is used purely for its chemical properties: it halts the development of gluten in pie crusts (yielding a flakier dough) and binds water to oil in tomato cream sauces (Penne alla Vodka).\n\n**Selection & Storage:** Store upright at room temperature; it is highly stable and will not degrade.",
     category: "misc",
@@ -15551,6 +16309,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "mixed_cured_meats": {
     name: "mixed cured meats",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Mixed Cured Meats is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -15592,6 +16352,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "black_olives": {
     name: "black olives",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Black Olives is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -15633,6 +16395,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cooked_meat": {
     name: "cooked meat",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Prepared meat component carried into soups, rice dishes, or wraps as a pre-cooked protein ingredient.",
     category: "protein",
@@ -15674,6 +16438,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "filling": {
     name: "filling",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Filling is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -15715,6 +16481,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "for_glaze": {
     name: "for glaze",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "For Glaze is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -15756,6 +16524,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cold_kvas": {
     name: "cold kvas",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Cold Kvas is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -15797,6 +16567,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "sriracha": {
     name: "sriracha",
+    origin: ["Thailand"],
+    season: ["all"],
     provenance: "generated",
     description: "A Thai-style hot sauce made from a paste of chili peppers, distilled vinegar, garlic, sugar, and salt. Unlike fermented hot sauces (like Tabasco), Sriracha relies on a balance of bright acidity, pronounced garlic, and moderate sweetness to deliver a highly versatile, viscous heat.\n\n**Selection & Storage:** Its high acid, salt, and sugar content make it highly stable. It can be stored at room temperature, though refrigeration will prevent its color from darkening over time.",
     category: "misc",
@@ -15838,6 +16610,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "finely_sliced": {
     name: "finely sliced",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Finely Sliced is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -15879,6 +16653,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "panang_curry_paste": {
     name: "panang curry paste",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Panang Curry Paste is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -15920,6 +16696,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "torn": {
     name: "torn",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Torn is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -15961,6 +16739,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "beaten": {
     name: "beaten",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Beaten is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -16002,6 +16782,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "nam_prik_pao_thai_chili_jam": {
     name: "nam prik pao thai chili jam",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Nam Prik Pao Thai Chili Jam is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -16043,6 +16825,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "preserved_radish_chai_poh": {
     name: "preserved radish chai poh",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Preserved Radish Chai Poh is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "vegetable",
@@ -16084,6 +16868,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "canned_bamboo_shoots": {
     name: "canned bamboo shoots",
+    origin: ["East and Southeast Asia"],
+    season: ["spring"],
     provenance: "generated",
     description: "Canned Bamboo Shoots is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "vegetable",
@@ -16125,6 +16911,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "gaeng_panang_neua": {
     name: "gaeng panang neua",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Gaeng Panang Neua is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -16166,6 +16954,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "khao_soi_gai": {
     name: "khao soi gai",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Khao Soi Gai is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -16207,6 +16997,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tub_tim_grob": {
     name: "tub tim grob",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Tub Tim Grob is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -16248,6 +17040,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "bua_loi": {
     name: "bua loi",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Bua Loi is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -16289,6 +17083,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "sangkaya_fak_thong": {
     name: "sangkaya fak thong",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Sangkaya Fak Thong is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -16330,6 +17126,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "kluay_tod": {
     name: "kluay tod",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Kluay Tod is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -16371,6 +17169,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "youtiao_quay": {
     name: "youtiao quay",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Youtiao Quay is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -16412,6 +17212,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "nuoc_cham": {
     name: "nuoc cham",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Nuoc Cham is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -16453,6 +17255,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "ch_l_a": {
     name: "ch l a",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Ch L A is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -16494,6 +17298,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "banh_mi_p_la": {
     name: "banh mi p la",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Banh Mi P La is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -16535,6 +17341,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "chao": {
     name: "chao",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Chao is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -16576,6 +17384,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "nuoc_mau": {
     name: "nuoc mau",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Nuoc Mau is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -16617,6 +17427,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "m_m_ru_c": {
     name: "m m ru c",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "M M Ru C is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -16658,6 +17470,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "annatto_oil": {
     name: "annatto oil",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Annatto Oil is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "oil",
@@ -16699,6 +17513,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "tapioca_noodles": {
     name: "tapioca noodles",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Tapioca Noodles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -16740,6 +17556,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "catfish_steaks": {
     name: "catfish steaks",
+    origin: ["Worldwide freshwater"],
+    season: ["spring", "summer"],
     provenance: "generated",
     description: "Catfish Steaks is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -16781,6 +17599,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "liver_p_t": {
     name: "liver p t",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Liver P T is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -16822,6 +17642,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "snakehead_fish": {
     name: "snakehead fish",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Snakehead Fish is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -16863,6 +17685,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "vietnamese_baguettes_banh_mi": {
     name: "vietnamese baguettes banh mi",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Vietnamese Baguettes Banh Mi is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -16904,6 +17728,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "nuoc_cham_dipping_sauce": {
     name: "nuoc cham dipping sauce",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Nuoc Cham Dipping Sauce is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -16945,6 +17771,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "sa_te_chili_paste": {
     name: "sa te chili paste",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Sa Te Chili Paste is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "spice",
@@ -16986,6 +17814,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cao_lau_noodles": {
     name: "cao lau noodles",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Cao Lau Noodles is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "grain",
@@ -17027,6 +17857,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "red_adzuki_beans": {
     name: "red adzuki beans",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Red Adzuki Beans is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "protein",
@@ -17068,6 +17900,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "ch_ba_mau": {
     name: "ch ba mau",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Ch Ba Mau is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -17109,6 +17943,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "ndole_leaves_bitterleaf": {
     name: "ndole leaves bitterleaf",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Ndole Leaves Bitterleaf is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "culinary_herb",
@@ -17150,6 +17986,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "bolognese_ragu": {
     name: "bolognese ragu",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Bolognese Ragu is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -17191,6 +18029,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "nuoc_cha_m": {
     name: "nuoc cha m",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Nuoc Cha M is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -17232,6 +18072,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cha_lua": {
     name: "cha lua",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Cha Lua is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -17273,6 +18115,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "banh_mi_op_la": {
     name: "banh mi op la",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Banh Mi Op La is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -17314,6 +18158,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "cha_o": {
     name: "cha o",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Cha O is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -17355,6 +18201,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "nuoc_ma_u": {
     name: "nuoc ma u",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Nuoc Ma U is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -17396,6 +18244,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "mam_ruo_c": {
     name: "mam ruo c",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Mam Ruo C is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -17437,6 +18287,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "liver_pate": {
     name: "liver pate",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Liver Pate is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",
@@ -17478,6 +18330,8 @@ export const recipeCoverageIngredients: Record<string, Partial<IngredientMapping
   },
   "che_ba_mau": {
     name: "che ba mau",
+    origin: ["Worldwide"],
+    season: ["all"],
     provenance: "generated",
     description: "Che Ba Mau is a recipe-linked ingredient captured from live cuisine data to ensure full ingredient-to-recipe coverage in the database. Use it as written in recipe context, then refine handling based on preparation method, concentration, and dish role. This entry includes standardized baseline metadata for compatibility with recommendation, search, and mapping APIs.",
     category: "misc",

--- a/src/data/ingredients/oils/oils.ts
+++ b/src/data/ingredients/oils/oils.ts
@@ -11,6 +11,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   olive_oil: {
       description: "A liquid fat extracted by pressing whole olives (*Olea europaea*). Extra-virgin olive oil (EVOO) is mechanically extracted without heat or chemicals, retaining high levels of antioxidants and an intensely grassy, peppery, and fruity flavor best reserved for finishing dishes or low-heat cooking.",
     name: "Olive Oil",
+    origin: ["Mediterranean"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.3, Earth: 0.3, Air: 0.2, Water: 0.2 },
@@ -112,6 +113,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   coconut_oil: {
       description: "An edible oil extracted from the meat of mature coconuts (*Cocos nucifera*), characterized by its high concentration of saturated fat, which makes it solid at room temperature. Virgin coconut oil retains a distinct tropical coconut aroma, while refined coconut oil is neutral and has a much higher smoke point for frying.",
     name: "Coconut Oil",
+    origin: ["Indo-Pacific"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.2, Water: 0.3, Earth: 0.3, Air: 0.2 },
@@ -196,6 +198,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   sesame_oil: {
       description: "An incredibly potent oil pressed from sesame seeds (*Sesamum indicum*). Toasted sesame oil (dark brown) provides a massive burst of savory, nutty pyrazines and should be used exclusively as a finishing oil, while plain sesame oil (pale yellow) is neutral and suitable for cooking.",
     name: "Sesame Oil",
+    origin: ["East Asia", "Africa"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.4, Water: 0.2, Earth: 0.2, Air: 0.2 },
@@ -303,6 +306,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   ghee: {
       description: "A class of clarified butter originating in ancient India, created by simmering butter until the water evaporates and the milk solids toast and sink to the bottom. Once strained, the resulting pure butterfat boasts an intensely nutty, caramel-like flavor and a massive smoke point (482°F / 250°C), making it ideal for high-heat frying.",
     name: "Ghee",
+    origin: ["South Asia"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.45, Water: 0.15, Earth: 0.25, Air: 0.15 },
@@ -391,6 +395,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   avocado_oil: {
       description: "An oil pressed from the fleshy pulp of avocados. It boasts the highest smoke point of any common culinary oil (up to 520°F / 271°C) and a very mild, buttery flavor, making it a premium choice for aggressive high-heat searing, grilling, and broiling.",
     name: "Avocado Oil",
+    origin: ["Mesoamerica"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.3, Water: 0.3, Earth: 0.2, Air: 0.2 },
@@ -479,6 +484,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   walnut_oil: {
       description: "A specialty finishing oil pressed from walnuts, boasting an intense, deeply roasted, and slightly astringent walnut flavor. Because heat destroys its delicate, volatile aromatics, it should never be used for cooking, but rather drizzled over roasted squash, blue cheese, or fresh pastas.",
     name: "Walnut Oil",
+    origin: ["France", "Western Asia"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.2, Water: 0.2, Earth: 0.4, Air: 0.2 },
@@ -563,6 +569,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   flaxseed_oil: {
       description: "An oil cold-pressed from flaxseeds, prized for its exceptionally high levels of omega-3 fatty acids. Because of its extremely low smoke point and delicate chemical structure, it must never be heated; it is used strictly as a finishing oil or nutritional supplement in smoothies.",
     name: "Flaxseed Oil",
+    origin: ["Northern Europe"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.1, Water: 0.3, Earth: 0.3, Air: 0.3 },
@@ -646,6 +653,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   peanut_oil: {
       description: "An oil pressed from peanuts, available in both refined (neutral) and unrefined (roasted) varieties. Refined peanut oil has an exceptionally high smoke point (450°F / 232°C) and does not absorb flavors, making it the premier choice for deep-frying foods and high-heat wok stir-frying.",
     name: "Peanut Oil",
+    origin: ["South America (Brazil)"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.4, Water: 0.2, Earth: 0.3, Air: 0.1 },
@@ -694,6 +702,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   mustard_oil: {
       description: "An intensely pungent, deeply yellow oil extracted from mustard seeds, forming the culinary backbone of traditional Bengali and Northern Indian cuisines. It contains extraordinarily high levels of allyl isothiocyanate, providing a sharp, vaporous, horseradish-like heat that must be brought to a smoking point before cooking to mellow its aggressive bite.",
     name: "Mustard Oil",
+    origin: ["South Asia"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.5, Water: 0.1, Earth: 0.2, Air: 0.2 },
@@ -741,6 +750,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   rice_bran_oil: {
       description: "A highly stable oil extracted from the hard outer brown layer (bran) of rice grains. It boasts an exceptionally high smoke point (450°F / 232°C) and a very mild, slightly nutty flavor, making it a highly prized, premium oil for deep-frying delicate foods like Japanese tempura without imparting greasy flavors.",
     name: "Rice Bran Oil",
+    origin: ["East and South Asia"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.3, Air: 0.2 },
@@ -788,6 +798,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   chili_oil: {
       description: "A vibrant red, infused condiment made by gently heating a neutral oil and pouring it over crushed chili flakes, aromatics (like garlic and star anise), and often Sichuan peppercorns. It provides immense depth, slow-building heat, and a glossy, fiery finish to dumplings, noodles, and broths.",
     name: "Chili Oil",
+    origin: ["Sichuan (China)"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.6, Water: 0.1, Earth: 0.2, Air: 0.1 },
@@ -835,6 +846,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   perilla_oil: {
       description: "A deeply toasted, powerfully aromatic oil pressed from the seeds of the *Perilla frutescens* plant, essential to Korean cuisine. It boasts an intensely rich, nutty, and distinctly earthy flavor profile (often compared to toasted sesame oil but deeper), used exclusively as a finishing oil over namul (vegetable side dishes).",
     name: "Perilla Oil",
+    origin: ["East Asia"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.2, Air: 0.3 },
@@ -882,6 +894,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   camellia_oil: {
       description: "Camellia Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "Camellia Oil",
+    origin: ["Cultivated worldwide"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.2, Water: 0.3, Earth: 0.3, Air: 0.2 },
@@ -929,6 +942,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   grapeseed_oil: {
       description: "A byproduct of the winemaking industry, pressed from the seeds of grapes. It has a moderately high smoke point and a remarkably clean, light, and unobtrusive flavor, making it highly favored by chefs for creating herb-infused oils and delicate vinaigrettes.",
     name: "Grapeseed Oil",
+    origin: ["Mediterranean"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.2, Water: 0.3, Earth: 0.2, Air: 0.3 },
@@ -978,6 +992,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   macadamia_oil: {
       description: "A highly prized, golden culinary oil cold-pressed from macadamia nuts. It features an extraordinarily high concentration of monounsaturated fats (making it highly stable at high temperatures) and an intensely buttery, slightly sweet, and luxurious nutty flavor that shines in both baking and searing.",
     name: "Macadamia Oil",
+    origin: ["Australia"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.2, Water: 0.2, Earth: 0.4, Air: 0.2 },
@@ -1025,6 +1040,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   palm_oil: {
       description: "A highly saturated, semi-solid fat extracted from the fleshy fruit of oil palms (*Elaeis guineensis*). Refined palm oil is completely neutral in flavor and boasts incredible oxidative stability, making it the globally dominant, workhorse fat used in commercial baking and processed snack foods.",
     name: "Palm Oil",
+    origin: ["West Africa"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.4, Water: 0.1, Earth: 0.4, Air: 0.1 },
@@ -1072,6 +1088,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   tea_seed_oil: {
       description: "Also known as camellia oil, this pale, golden oil is cold-pressed from the seeds of *Camellia oleifera* (closely related to the tea plant). It boasts an incredibly high smoke point (485°F / 252°C) and a very delicate, slightly herbaceous and sweet flavor, making it a premium oil for delicate Asian stir-fries.",
     name: "Tea Seed Oil",
+    origin: ["Southwest China"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.2, Air: 0.3 },
@@ -1119,6 +1136,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   shiso_oil: {
       description: "An oil cold-pressed from the seeds of the *Perilla frutescens* plant (shiso/perilla), predominantly used in East Asian cuisine. It offers a deeply complex, savory, and distinctly herbaceous flavor that pairs flawlessly with raw fish and delicate vegetables.",
     name: "Shiso Oil",
+    origin: ["East Asia"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.2, Water: 0.2, Earth: 0.2, Air: 0.4 },
@@ -1166,6 +1184,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   argan_oil: {
       description: "A highly prized, intensely nutty oil pressed from the kernels of the argan tree (*Argania spinosa*), endemic to Morocco. Culinary argan oil is made from lightly roasted kernels, resulting in a profound, toasted hazelnut flavor that is used exclusively as a finishing oil over couscous, dips, or desserts.",
     name: "Argan Oil",
+    origin: ["Morocco"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.2, Water: 0.2, Earth: 0.4, Air: 0.2 },
@@ -1213,6 +1232,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   hazelnut_oil: {
       description: "A specialty finishing oil pressed from hazelnuts, boasting an intense, deeply roasted, and slightly astringent hazelnut flavor. Because heat destroys its delicate, volatile aromatics, it should never be used for cooking, but rather drizzled over roasted squash, blue cheese, or fresh pastas.",
     name: "Hazelnut Oil",
+    origin: ["France", "Italy"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.2, Water: 0.2, Earth: 0.4, Air: 0.2 },
@@ -1260,6 +1280,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   pistachio_oil: {
       description: "A luxurious, deep green finishing oil pressed from pistachios (*Pistacia vera*). It delivers a profoundly rich, earthy, and distinctly roasted pistachio flavor that acts as a stunning drizzle over fresh burrata, delicate white fish, or simple citrus salads.",
     name: "Pistachio Oil",
+    origin: ["Western Asia (Iran)"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.2, Water: 0.2, Earth: 0.3, Air: 0.3 },
@@ -1307,6 +1328,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   hemp_seed_oil: {
       description: "An oil cold-pressed from hemp seeds (*Cannabis sativa*), known for its dark green color and earthy, distinctly grassy, and nutty flavor. It is rich in polyunsaturated fats and possesses a very low smoke point, making it suitable only as a finishing oil for salads or hummus.",
     name: "Hemp Seed Oil",
+    origin: ["Central Asia"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.1, Water: 0.3, Earth: 0.3, Air: 0.3 },
@@ -1354,6 +1376,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   black_seed_oil: {
       description: "A potent oil pressed from the seeds of *Nigella sativa*, featuring a dark amber color and a highly distinct, aggressive flavor profile described as a mix of cumin, black pepper, and oregano. Because of its intense bitterness and pungency, it is used very sparingly as a finishing oil or for medicinal purposes.",
     name: "Black Seed Oil",
+    origin: ["Cultivated worldwide"],
     category: "oil",
     subCategory: "specialty",
     elementalProperties: { Fire: 0.4, Water: 0.2, Earth: 0.2, Air: 0.2 },
@@ -1401,6 +1424,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   almond_oil: {
       description: "A culinary oil pressed from almonds, offering a clean, subtle, and sweet marzipan-like flavor. While refined almond oil has a high enough smoke point for sautéing, unrefined roasted almond oil is best used as a finishing touch for delicate fish, pastries, or salads.",
     name: "Almond Oil",
+    origin: ["Mediterranean"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.2, Water: 0.3, Earth: 0.3, Air: 0.2 },
@@ -1449,6 +1473,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   sunflower_oil: {
       description: "A light, neutral oil extracted from sunflower seeds. Refined sunflower oil behaves similarly to canola or vegetable oil in high-heat applications, while unrefined (cold-pressed) sunflower oil retains a distinct, nutty, and buttery flavor ideal for dressing salads.",
     name: "Sunflower Oil",
+    origin: ["North America", "Eastern Europe (cultivation)"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.2, Air: 0.3 },
@@ -1497,6 +1522,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   safflower_oil: {
       description: "An oil extracted from the seeds of the safflower plant, possessing a completely neutral flavor and an extremely high smoke point (up to 510°F / 265°C). It remains liquid at cold temperatures, making it an excellent choice for vinaigrettes that will be stored in the fridge.",
     name: "Safflower Oil",
+    origin: ["Western Asia", "Mediterranean"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.2, Air: 0.3 },
@@ -1547,6 +1573,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   white_truffle_oil: {
       description: "A finishing oil meant to mimic the incredibly rare, pungent aroma of the white Alba truffle (*Tuber magnatum*). It relies on synthesized aromatic compounds (primarily bis(methylthio)methane) to provide a piercing, garlicky, and deeply musky aroma intended to elevate neutral dishes like risotto or mashed potatoes.",
     name: "White Truffle Oil",
+    origin: ["Italy (Alba)"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.4, Air: 0.3 },
@@ -1594,6 +1621,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   red_palm_oil: {
       description: "An unrefined, highly saturated oil extracted from the fruit of the oil palm (*Elaeis guineensis*). Its striking, vibrant red-orange color comes from an incredibly high concentration of carotenes, and it imparts a strong, earthy, and slightly smoky flavor essential to authentic West African and Brazilian cuisines.",
     name: "Red Palm Oil",
+    origin: ["West Africa"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.4, Water: 0.1, Earth: 0.4, Air: 0.1 },
@@ -1641,6 +1669,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   roasted_pumpkin_seed_oil: {
       description: "A large, thick-skinned winter squash (*Cucurbita pepo*) prized for its sweet, earthy flesh and edible seeds. While large field pumpkins are bred for carving, smaller \"sugar\" or \"pie\" pumpkins have dense, less watery flesh ideal for roasting, pureeing, and baking.\n\n**Selection & Storage:** For cooking, select small pie pumpkins that feel dense and heavy with hard, unblemished rinds and an intact stem. Store whole in a cool, dark, dry place for several months.",
     name: "Roasted Pumpkin Seed Oil",
+    origin: ["Austria (Styria)"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.3, Air: 0.2 },
@@ -1692,6 +1721,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   mustard_seed_oil: {
       description: "A pungent condiment made from the crushed seeds of various mustard plants (*Brassica* and *Sinapis* species), blended with water, vinegar, or wine. The sharp heat comes from isothiocyanates, which develop when enzymes are activated by liquid. Mustard acts as both a flavor amplifier and a powerful culinary emulsifier, crucial for stabilizing vinaigrettes and binding rich sauces. Dijon offers sharp tang, whole-grain provides texture, and yellow mustard delivers mild, turmeric-tinted brightness.",
     name: "Mustard Seed Oil",
+    origin: ["Mediterranean", "South Asia"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.5, Water: 0.1, Earth: 0.2, Air: 0.2 },
@@ -1743,6 +1773,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   babassu_oil: {
       description: "A clear, light oil extracted from the seeds of the babassu palm (*Attalea speciosa*) native to the Amazon region. It is chemically very similar to coconut oil—solid at room temperature and melting quickly upon skin contact—but lacks the distinct tropical coconut aroma, making it a versatile, neutral fat for baking and frying.",
     name: "Babassu Oil",
+    origin: ["Cultivated worldwide"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.2, Water: 0.3, Earth: 0.3, Air: 0.2 },
@@ -1794,6 +1825,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   apricot_kernel_oil: {
       description: "A pale, delicate oil pressed from the kernels (seeds) of apricots. It possesses a very mild, slightly sweet, and nutty flavor profile (reminiscent of almonds) and a high smoke point, making it suitable for both high-heat sautéing and delicate salad dressings.",
     name: "Apricot Kernel Oil",
+    origin: ["Central Asia (Armenia)"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.2, Water: 0.3, Earth: 0.2, Air: 0.3 },
@@ -1841,6 +1873,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   canola_oil: {
       description: "A highly refined, neutral-tasting vegetable oil extracted from a specific, low-erucic acid variety of the rapeseed plant. Its high smoke point (400°F / 204°C) and lack of flavor make it a ubiquitous, all-purpose oil for deep-frying, baking, and emulsifying mild mayonnaises.",
     name: "Canola Oil",
+    origin: ["Canada"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.2, Air: 0.3 },
@@ -1910,6 +1943,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   mct_oil: {
       description: "A highly refined supplement oil composed exclusively of Medium-Chain Triglycerides, typically extracted from coconut or palm kernel oil. Because these specific fats are metabolized rapidly by the liver rather than stored, it is extremely popular in ketogenic diets and 'bulletproof' coffee, possessing a completely neutral, flavorless profile.",
     name: "MCT Oil",
+    origin: ["Cultivated worldwide"],
     category: "oil",
     subCategory: "specialty",
     elementalProperties: { Fire: 0.4, Water: 0.2, Earth: 0.2, Air: 0.2 },
@@ -1985,6 +2019,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   vegetable_oil: {
       description: "A generic term for any refined, plant-based oil, though in modern supermarkets it is almost exclusively 100% soybean oil. Like canola, it is completely flavorless and boasts a high smoke point, functioning purely as a structural cooking fat or heat-transfer medium.",
     name: "Vegetable Oil",
+    origin: ["Worldwide industrial blends"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.35, Water: 0.35, Earth: 0.2, Air: 0.1 },
@@ -2038,6 +2073,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   basil_infused_olive_oil: {
       description: "A tender, aromatic herb (*Ocimum basilicum*) of the mint family, defined by its bright green, delicate leaves. Its complex flavor profile includes notes of anise, clove, and sweet citrus; because its volatile oils evaporate quickly, it should be added at the very end of cooking or used raw.\n\n**Selection & Storage:** Choose vibrant, unblemished leaves; avoid any with black spots. Store fresh basil like a bouquet of flowers: stems in a glass of water at room temperature, loosely covered with a plastic bag.",
     name: "Basil-Infused Olive Oil",
+    origin: ["South Asia (India)", "Southeast Asia"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.2, Air: 0.3 },
@@ -2085,6 +2121,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   garlic_infused_olive_oil: {
       description: "A pungent bulb (*Allium sativum*) belonging to the onion genus, prized globally for its intense, savory flavor and aroma. When its cells are crushed or chopped, an enzyme reaction produces allicin, the compound responsible for its signature bite and potent antimicrobial properties. This sharpness mellows dramatically into deep, sweet nuttiness when roasted whole or slow-sautéed in fat. Look for firm, heavy bulbs with dry, unbroken papery skins and no green shoots — green means sprouting and bitterness.",
     name: "Garlic-Infused Olive Oil",
+    origin: ["Central Asia"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.4, Water: 0.2, Earth: 0.3, Air: 0.1 },
@@ -2136,6 +2173,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   lemon_infused_olive_oil: {
       description: "The oval yellow citrus fruit (*Citrus × limon*) delivering 5–6% citric acid plus fragrant d-limonene in the peel — essentially a complete seasoning of acid, aroma, and brightness in one package. Meyer lemons are sweeter with floral notes; Eureka and Lisbon are standard supermarket varieties. Use the whole fruit: zest for aroma (before juicing — the tool ruins the peel otherwise), juice for acid, rind for preserved lemons. Rolling the lemon before cutting breaks internal membranes and yields more juice.",
     name: "Lemon-Infused Olive Oil",
+    origin: ["South Asia", "Mediterranean (cultivated)"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.2, Air: 0.3 },
@@ -2187,6 +2225,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   black_truffle_oil: {
       description: "A finishing oil meant to mimic the incredibly rare, earthy, and musky aroma of black truffles (*Tuber melanosporum*). Most commercial truffle oils are synthesized using the chemical compound 2,4-dithiapentane rather than real truffles, providing an intense, sometimes overpowering burst of umami aroma.",
     name: "Black Truffle Oil",
+    origin: ["France (Périgord)"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.1, Water: 0.2, Earth: 0.5, Air: 0.2 },
@@ -2234,6 +2273,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   pumpkin_seed_oil: {
       description: "An intensely dark green-red oil pressed from roasted pumpkin seeds (*Cucurbita pepo*), heavily utilized in Austrian cuisine. It boasts an incredibly profound, nutty, and slightly sweet flavor profile that is utterly ruined by heat, meaning it must only be used raw as a drizzle over soups, salads, or vanilla ice cream.",
     name: "Pumpkin Seed Oil",
+    origin: ["Austria (Styria)"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.3, Air: 0.2 },
@@ -2281,6 +2321,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   chia_seed_oil: {
       description: "A highly nutritious oil cold-pressed from chia seeds (*Salvia hispanica*), boasting one of the highest botanical concentrations of omega-3 fatty acids. It has a very mild, slightly nutty flavor and a low smoke point, meaning it should never be heated but instead used as a finishing oil or in smoothies.",
     name: "Chia Seed Oil",
+    origin: ["Mesoamerica"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.1, Water: 0.3, Earth: 0.3, Air: 0.3 },
@@ -2331,6 +2372,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   moringa_oil: {
       description: "An incredibly stable, nutrient-dense oil cold-pressed from the seeds of the *Moringa oleifera* tree. It possesses a mild, pleasant, slightly nutty flavor resembling peanut oil and an extraordinarily high smoke point, making it suitable for both delicate salad dressings and high-heat frying.",
     name: "Moringa Oil",
+    origin: ["Cultivated worldwide"],
     category: "oil",
     subCategory: "specialty",
     elementalProperties: { Fire: 0.2, Water: 0.3, Earth: 0.3, Air: 0.2 },
@@ -2378,6 +2420,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   neem_oil: {
       description: "Neem Oil (Culinary Grade) is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "Neem Oil (Culinary Grade)",
+    origin: ["Cultivated worldwide"],
     category: "oil",
     subCategory: "specialty",
     elementalProperties: { Fire: 0.4, Water: 0.2, Earth: 0.3, Air: 0.1 },
@@ -2429,6 +2472,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   cottonseed_oil: {
       description: "A highly processed, neutral-tasting vegetable oil extracted from the seeds of the cotton plant. Like corn oil, it has an incredibly high smoke point and is chemically stable, making it a very common (though increasingly less popular) choice for commercial deep-frying and processed snack foods.",
     name: "Cottonseed Oil",
+    origin: ["Cultivated worldwide"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.3, Air: 0.2 },
@@ -2476,6 +2520,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   soybean_oil: {
       description: "A highly processed, neutral vegetable oil extracted from the seeds of the soybean (*Glycine max*). It is one of the most widely consumed cooking oils globally, offering a very high smoke point (450°F / 232°C) and a completely flavorless profile that acts purely as a structural cooking fat for frying and baking.",
     name: "Soybean Oil",
+    origin: ["East Asia"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.3, Water: 0.3, Earth: 0.2, Air: 0.2 },
@@ -2524,6 +2569,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   corn_oil: {
       description: "A highly refined oil extracted from the germ of corn kernels. Because it is highly processed, it is almost entirely flavorless and boasts a very high smoke point (450°F / 232°C), making it a stable, workhorse fat ideal for deep-frying and high-heat stovetop cooking.",
     name: "Corn Oil",
+    origin: ["North America"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.3, Air: 0.2 },
@@ -2572,6 +2618,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   rapeseed_oil: {
       description: "Rapeseed Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "Rapeseed Oil",
+    origin: ["Northern Europe"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.2, Air: 0.3 },
@@ -2623,6 +2670,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   sacha_inchi_oil: {
       description: "A highly specialized oil cold-pressed from the star-shaped seed pods of the *Plukenetia volubilis* plant native to the Amazon rainforest. It boasts one of the highest plant-based concentrations of omega-3 fatty acids and features a distinct, earthy, and strongly herbaceous/nutty flavor, used strictly as a finishing oil.",
     name: "Sacha Inchi Oil",
+    origin: ["Cultivated worldwide"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.2, Water: 0.3, Earth: 0.2, Air: 0.3 },

--- a/src/data/ingredients/proteins/dairy.ts
+++ b/src/data/ingredients/proteins/dairy.ts
@@ -4,6 +4,7 @@ import { fixIngredientMappings } from "@/utils/elementalUtils";
 const rawDairy = {
   greek_yogurt: {
     name: "Greek Yogurt",
+    origin: ["Greece"],
     description:
       "Strained yogurt with higher protein content and thick texture.",
     category: "dairy",
@@ -213,6 +214,7 @@ const rawDairy = {
 },
   cottage_cheese: {
     name: "Cottage Cheese",
+    origin: ["Northern Europe"],
     description:
       "Fresh cheese curd product with mild flavor and varying textures.",
     category: "dairy",
@@ -444,6 +446,7 @@ const rawDairy = {
 },
   ricotta: {
     name: "Ricotta",
+    origin: ["Italy"],
     description:
       "Soft, mild Italian whey cheese with small, fluffy curds and versatile applications.",
     category: "dairy",
@@ -655,6 +658,7 @@ const rawDairy = {
 },
   cream_cheese: {
     name: "Cream Cheese",
+    origin: ["United States"],
     description:
       "Soft, spreadable fresh cheese with mild flavor and smooth texture.",
     category: "dairy",
@@ -881,6 +885,7 @@ const rawDairy = {
 },
   milk: {
     name: "Milk",
+    origin: ["Worldwide pastoral cultures"],
     description:
       "Liquid secreted by mammary glands of cows (most commonly *Bos taurus*), providing protein (whey, casein), fat, calcium, and lactose. Pasteurized and homogenized for retail, or left raw for traditional cheeses. Whole milk is ~3.25% fat; 2%, 1%, and skim progressively reduce fat. The foundation of nearly every cheese, butter, yogurt, and cream. Grass-fed milks carry a deeper flavor and higher omega-3/CLA content than commodity milks.",
     category: "dairy",
@@ -935,6 +940,7 @@ const rawDairy = {
 },
   buttermilk: {
     name: "Buttermilk",
+    origin: ["Western Asia (originated)", "Worldwide"],
     description:
       "Tangy cultured dairy product made by fermenting low-fat milk with *Lactococcus* and related cultures (modern commercial buttermilk) or the liquid left after churning butter (traditional). Thick, creamy, pleasantly sour. Essential for tender biscuits, pancakes, fried chicken marinades, ranch dressing, and soda bread — its acidity activates baking soda for lift and tenderizes gluten.",
     category: "dairy",
@@ -986,6 +992,7 @@ const rawDairy = {
 },
   butter: {
     name: "Butter",
+    origin: ["Western Asia"],
     description:
       "Rich, yellow-gold dairy fat produced by churning cream until the fat globules separate from the buttermilk. Typically 80–85% fat, with water and milk solids making up the rest. The foundation of French cooking — melts, browns, emulsifies, enriches, glazes, and flakes pastry. European butters (82%+ fat) deliver richer flavor and flakier results; cultured butters add tang and complexity. Grass-fed butter (Kerrygold, Vermont Creamery) carries deeper yellow color and more complex dairy notes.",
     category: "dairy",
@@ -1045,6 +1052,7 @@ const rawDairy = {
 },
   goat_cheese: {
     name: "Goat Cheese",
+    origin: ["Western Asia", "Africa"],
     description:
       "Cheese made from goat's milk (*Capra aegagrus hircus*) with a distinctive tangy, earthy, slightly barnyard flavor and creamy, crumbly-to-spreadable texture. Fresh chèvre is young, bright, and spreadable; aged crottins develop bold pungency and mold rinds. Lower in lactose than cow's milk cheese. A Mediterranean and French staple — the star of warm goat-cheese salad, Greek feta (technically sheep/goat blend), and countless cheeseboards.",
     category: "dairy",
@@ -1098,6 +1106,7 @@ const rawDairy = {
 },
   cheddar_cheese: {
     name: "Cheddar Cheese",
+    origin: ["Western Asia (Fertile Crescent)"],
     description:
       "Hard cow's-milk cheese originally from the village of Cheddar, Somerset, England. Made via the distinctive 'cheddaring' process: curds are stacked, pressed, and turned repeatedly to expel whey. Flavor develops from mild and buttery (young, 2–3 months) through sharp and crystalline (aged 18+ months). Aged farmhouse cheddars (Cabot Clothbound, Montgomery's, Keen's) are among the world's great cheeses. Essential for grilled cheese, macaroni and cheese, Welsh rarebit, and classic cheeseboards.",
     category: "dairy",
@@ -1152,6 +1161,7 @@ const rawDairy = {
 },
   blue_cheese: {
     name: "Blue Cheese",
+    origin: ["Western Asia (Fertile Crescent)"],
     description:
       "Family of cheeses veined with blue or blue-green *Penicillium roqueforti* or *P. glaucum* mold, which develops during aging and contributes the distinctive sharp, salty, pungent flavor. The three classics: French Roquefort (sheep's milk, cave-aged in Aveyron), Italian Gorgonzola (cow's milk, from Piedmont/Lombardy), and English Stilton (cow's milk, PDO-protected). Creamy to crumbly texture. Essential on cheeseboards, in wedge salads, and melted into sauces for steak or pasta.",
     category: "dairy",
@@ -1206,6 +1216,7 @@ const rawDairy = {
 },
   heavy_cream: {
     name: "Heavy Cream",
+    origin: ["Worldwide"],
     description:
       "Cow's milk cream with at least 36% butterfat — rich enough to whip to stable peaks and beat into butter. Essential for whipped cream, pastry cream, ganache, Alfredo sauce, and any preparation requiring the creamy body that milk alone can't deliver. Higher-fat cream is more stable under heat (less prone to breaking) than lower-fat half-and-half. Pasture-raised versions carry deeper flavor and color.",
     category: "dairy",
@@ -1259,6 +1270,7 @@ const rawDairy = {
 },
   sour_cream: {
     name: "Sour Cream",
+    origin: ["Eastern Europe"],
     description:
       "Cultured cream (typically 18–20% fat) fermented with lactic-acid bacteria to a thick, tangy, spoonable consistency. A staple of American, Eastern European, and Mexican cooking. Dollops beautifully on baked potatoes, borscht, chili, and enchiladas; works as the base for sour-cream coffee cake; stabilizes mashed potatoes and adds tender moisture to quick breads. A close cousin of crème fraîche, which is richer (30%+ fat) and gentler-tangy.",
     category: "dairy",
@@ -1313,6 +1325,7 @@ const rawDairy = {
 },
   cold_butter: {
     name: "Cold Butter",
+    origin: ["Western Asia"],
     description:
       "Butter straight from the fridge at 34–40°F (1–4°C), firm and pliable enough to cut into flour without melting. Essential state for flaky pastry (pie dough, biscuits, scones) and laminated dough (croissants, puff) — tiny pieces of cold butter melt in the oven, releasing steam that creates distinct, separated layers. The rule is simple: cold butter = flaky; warm butter = dense.",
     category: "dairy",
@@ -1354,6 +1367,7 @@ const rawDairy = {
 },
   parmesan: {
     name: "Parmesan (Parmigiano-Reggiano)",
+    origin: ["Italy"],
     description:
       "Italian hard, granular cheese — PDO-protected when from Parma, Reggio Emilia, Modena, Bologna, or Mantua. Aged 12–36+ months from raw cow's milk, developing crunchy calcium-lactate crystals and an unmistakable deeply savory, nutty, fruity flavor. The 'King of Cheeses' — shaved over pasta, risotto, salads, and soups; the essential umami boost. Rinds add incredible depth to stocks and minestrone. American-made 'Parmesan' is not the same thing; look for the pin-dot rind mark of genuine Parmigiano-Reggiano.",
     category: "dairy",
@@ -1407,6 +1421,7 @@ const rawDairy = {
 },
   chocolate_ice_cream: {
     name: "Chocolate Ice Cream",
+    origin: ["Worldwide"],
     description:
       "Frozen dairy dessert built on a custard or Philadelphia-style base flavored with cocoa and/or melted chocolate. Premium versions use heavy cream, egg yolks, sugar, and high-percentage dark chocolate; lower-tier versions use more air (overrun) and stabilizers. French/custard styles are richer and denser; American/Philadelphia styles are cleaner and more chocolate-forward. A beloved flavor worldwide.",
     category: "dairy",
@@ -1455,6 +1470,7 @@ const rawDairy = {
 },
   evaporated_milk: {
     name: "Evaporated Milk",
+    origin: ["Worldwide pastoral cultures"],
     description:
       "Shelf-stable cow's milk with ~60% of its water removed through gentle simmering under vacuum, then canned and sterilized. Concentrates protein, fat, and calcium; develops a subtle caramelized, slightly cooked flavor. Not the same as sweetened condensed milk (which has added sugar). Classic ingredient in Latin American tres leches, pumpkin pie, creamy mac and cheese, and fudge. Reconstitute 1:1 with water for regular-strength milk in a pinch.",
     category: "dairy",
@@ -1503,6 +1519,7 @@ const rawDairy = {
 },
   butter_croissant: {
     name: "Butter Croissant",
+    origin: ["Western Asia"],
     description:
       "Classic French laminated viennoiserie: yeasted dough layered with cold butter through a series of folds (tourage) that creates 27+ distinct layers of dough and butter. Baked until shatteringly crisp outside, tender and honey-combed inside. A true butter croissant uses only butter — margarine versions lack the flavor and snap. Considered here as a dairy preparation because butter is structurally foundational. Best eaten within hours of baking.",
     category: "bakery",
@@ -1551,6 +1568,7 @@ const rawDairy = {
 },
   french_butter: {
     name: "French Butter",
+    origin: ["Western Asia"],
     description:
       "European-style butter (82%+ butterfat by French law) often cultured before churning for a tangy, complex flavor. The gold standard for pastry (flakier croissants, more tender pie crust) and sauces. Beurre de Charentes-Poitou, Échiré, and Isigny Sainte-Mère are the most celebrated. Noticeably more expensive than American butter (80% fat), and noticeably better for cooking where butter is the star.",
     category: "dairy",
@@ -1599,6 +1617,7 @@ const rawDairy = {
 },
   whole_milk: {
     name: "Whole Milk",
+    origin: ["Worldwide"],
     description:
       "Cow's milk with approximately 3.25% butterfat — the full, unmodified fat content. Richer mouthfeel and better at carrying fat-soluble flavors than reduced-fat milks. Essential in baking (tender crumb), coffee drinks (stable microfoam), béchamel, and custards. Grass-fed whole milk has deeper color and higher omega-3/CLA content. Raw (unpasteurized) whole milk, where legal, has the fullest flavor but carries food-safety considerations.",
     category: "dairy",
@@ -1647,6 +1666,7 @@ const rawDairy = {
 },
   unsalted_butter: {
     name: "Unsalted Butter",
+    origin: ["Western Asia"],
     description:
       "Butter churned without added salt — the baker's and pastry chef's standard, because it allows precise control over salt in the finished product. Typically 80% butterfat in the U.S., 82%+ in European versions. Also called 'sweet butter,' though it's not sweetened — the name refers to the absence of salt. Cleaner, purer dairy flavor than salted butter; spoils faster (salt is a preservative) so turn it over more often or freeze.",
     category: "dairy",
@@ -1695,6 +1715,7 @@ const rawDairy = {
 },
   clarified_butter: {
     name: "Clarified Butter / Ghee",
+    origin: ["Western Asia"],
     description:
       "Butter melted and gently cooked to separate the golden butterfat from the water and milk solids; the pure fat is strained and used. Ghee (Indian-style) takes this further by simmering until the milk solids brown, imparting a nutty, caramelized flavor. Without milk solids to burn, clarified butter tolerates much higher heat than regular butter (up to ~485°F/250°C). Essential for Indian cooking, Middle Eastern sweets, drawn butter for seafood, and any high-heat sauté requiring butter flavor.",
     category: "dairy",
@@ -1752,6 +1773,7 @@ const rawDairy = {
 },
   gruy_re_cheese: {
     name: "Gruyère Cheese",
+    origin: ["Western Asia (Fertile Crescent)"],
     description:
       "Hard Swiss cow's-milk cheese from the canton of Fribourg, aged 5–12 months. Dense, firm, nutty, slightly sweet with mushroom and caramel undertones in older wheels. The definitive melting cheese — essential for fondue, French onion soup gratinée, Croque Monsieur, and quiche Lorraine. Deep complexity makes it equally delicious straight from the cheeseboard. PDO-protected; true Gruyère AOP comes only from Switzerland, though similar 'Alpine-style' cheeses are made elsewhere.",
     category: "dairy",
@@ -1805,6 +1827,7 @@ const rawDairy = {
 },
   vanilla_ice_cream: {
     name: "Vanilla Ice Cream",
+    origin: ["Mexico (Totonac region)"],
     description:
       "Frozen dairy dessert flavored with vanilla — bean, paste, or extract. The quintessential flavor, against which all others are measured. Premium versions use real Madagascar or Tahitian vanilla beans (visible specks), egg-yolk custard base, and minimal air (low overrun); budget versions lean on artificial vanillin, stabilizers, and high overrun. Pair with nearly any dessert — pie à la mode, affogato, banana split. Equally satisfying eaten straight from the pint.",
     category: "dairy",
@@ -1858,6 +1881,7 @@ const rawDairy = {
 },
   yogurt: {
     name: "Yogurt",
+    origin: ["Western Asia", "Central Asia"],
     description:
       "Cultured milk product made by fermenting milk with *Lactobacillus bulgaricus* and *Streptococcus thermophilus* at ~110°F (43°C) for several hours. Thick, tangy, probiotic-rich. Regular (non-Greek) yogurt is lighter and pourable; Greek yogurt is strained for thicker texture and higher protein; Icelandic skyr is even thicker. A staple from Greek tzatziki to Indian raita, Bulgarian ayran, and American parfaits. Live-culture yogurts support gut health.",
     category: "dairy",
@@ -1912,6 +1936,7 @@ const rawDairy = {
 },
   mozzarella: {
     name: "Mozzarella",
+    origin: ["Italy (Campania)"],
     description:
       "Fresh Italian pasta-filata cheese — curds are heated and stretched to create a smooth, elastic, moist white cheese with a delicate milky flavor. Traditional *mozzarella di bufala* is made from water buffalo milk; *fior di latte* is made from cow's milk. Fresh mozzarella is stored in brine or whey; drier aged varieties (low-moisture mozzarella) are the standard for pizza. Essential for Caprese salad, margherita pizza, and pasta al forno.",
     category: "dairy",

--- a/src/data/ingredients/proteins/proteins.ts
+++ b/src/data/ingredients/proteins/proteins.ts
@@ -6,6 +6,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   eggs: {
       description: "The reproductive ovum of *Gallus gallus domesticus* — one of cooking's most versatile ingredients, delivering structure, aeration, emulsification, binding, and thickening in a single package. Yolks carry fat, lecithin (an emulsifier), and most of the flavor; whites are primarily water and coagulable proteins (ovalbumin, ovotransferrin) that unfold and bond when heated or whipped. Fresh eggs peel poorly when hard-boiled; slightly older eggs shed shells cleanly. Store pointed-end-down at 35–40°F.",
     name: "eggs",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "nutritious"],
     category: "protein",
@@ -38,6 +40,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   ground_beef: {
       description: "The culinary name for meat from cattle (*Bos taurus*), offering deep, savory, and rich umami flavors due to high concentrations of amino acids. High-collagen cuts (like chuck) require long, slow cooking to break down into tender gelatin, while tender, low-activity cuts (like loin) excel at fast, high heat.\n\n**Selection & Storage:** Look for bright, cherry-red meat with even, white marbling (intramuscular fat) and no gray or brown spots. Store tightly wrapped in the coldest part of the refrigerator for up to 3-5 days.",
     name: "ground beef",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "hearty", "savory"],
     category: "protein",
@@ -70,6 +74,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   grilled_chicken: {
       description: "A globally ubiquitous poultry (*Gallus gallus domesticus*) prized for its mild flavor and versatility. Its culinary behavior depends on the cut: lean, fast-cooking breast meat dries out easily, while fat- and collagen-rich thighs and drumsticks become unctuous and tender with slow braising or high-heat roasting.\n\n**Selection & Storage:** Fresh chicken should have pinkish, firm flesh, white fat, and no strong odor. Store in the coldest part of the refrigerator (usually the bottom shelf) in its original packaging for 1-2 days, or freeze for longer storage.",
     name: "grilled chicken",
+    origin: ["Southeast Asia (jungle fowl)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["lean", "versatile", "high-protein"],
     category: "protein",
@@ -102,6 +108,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   hard_boiled_eggs: {
       description: "The reproductive ovum of *Gallus gallus domesticus* — one of cooking's most versatile ingredients, delivering structure, aeration, emulsification, binding, and thickening in a single package. Yolks carry fat, lecithin (an emulsifier), and most of the flavor; whites are primarily water and coagulable proteins (ovalbumin, ovotransferrin) that unfold and bond when heated or whipped. Fresh eggs peel poorly when hard-boiled; slightly older eggs shed shells cleanly. Store pointed-end-down at 35–40°F.",
     name: "hard-boiled eggs",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "nutritious"],
     category: "protein",
@@ -133,6 +141,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   pork_ribs: {
       description: "The culinary name for the meat of the domestic pig (*Sus domesticus*), known for its sweet, mild flavor and exceptional fat-rendering qualities. Its versatility ranges from lean tenderloins that require careful, quick cooking to fatty shoulders that braise into meltingly tender pulled pork.\n\n**Selection & Storage:** Fresh pork should have a pinkish-red color, firm texture, and bright white fat without any sour odors. Store raw cuts tightly wrapped in the coldest part of the refrigerator for 3-5 days.",
     name: "pork ribs",
+    origin: ["East Asia (domestication)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "nutritious"],
     category: "protein",
@@ -163,6 +173,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   chicken_pieces: {
       description: "A globally ubiquitous poultry (*Gallus gallus domesticus*) prized for its mild flavor and versatility. Its culinary behavior depends on the cut: lean, fast-cooking breast meat dries out easily, while fat- and collagen-rich thighs and drumsticks become unctuous and tender with slow braising or high-heat roasting.\n\n**Selection & Storage:** Fresh chicken should have pinkish, firm flesh, white fat, and no strong odor. Store in the coldest part of the refrigerator (usually the bottom shelf) in its original packaging for 1-2 days, or freeze for longer storage.",
     name: "chicken pieces",
+    origin: ["Southeast Asia (jungle fowl)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "nutritious"],
     category: "protein",
@@ -193,6 +205,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   salmon_fillet: {
       description: "A silver-skinned, anadromous fish (*Salmo salar*) celebrated for its rich, buttery texture and high concentration of heart-healthy omega-3 fatty acids (EPA and DHA). Its distinct pink-to-orange flesh color comes from astaxanthin, a powerful antioxidant derived from its natural diet.\\n\\n**Selection & Storage:** Fresh fillets should look moist and brightly colored without dry edges, and smell faintly of the clean ocean, never \"fishy.\" When buying whole fish, look for clear, bright eyes and bright red gills. Keep refrigerated over ice and consume within a day or two of purchase.",
     name: "salmon fillet",
+    origin: ["North Atlantic", "North Pacific"],
+    season: ["summer", "fall"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["omega-rich", "flaky", "nutritious"],
     category: "protein",
@@ -225,6 +239,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   beef_chuck_roast: {
       description: "The culinary name for meat from cattle (*Bos taurus*), offering deep, savory, and rich umami flavors due to high concentrations of amino acids. High-collagen cuts (like chuck) require long, slow cooking to break down into tender gelatin, while tender, low-activity cuts (like loin) excel at fast, high heat.\n\n**Selection & Storage:** Look for bright, cherry-red meat with even, white marbling (intramuscular fat) and no gray or brown spots. Store tightly wrapped in the coldest part of the refrigerator for up to 3-5 days.",
     name: "beef chuck roast",
+    origin: ["Worldwide pastoral cultures"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "nutritious"],
     category: "protein",
@@ -255,6 +271,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   soybeans: {
       description: "Soybeans is a protein-forward ingredient valued for structure, satiety, and umami depth. Technique determines outcome: dry heat builds browning and intensity, while moist heat promotes tenderness and even hydration. Season in layers and cook to the right internal doneness target for both flavor and safety.",
     name: "soybeans",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "nutritious"],
     category: "protein",
@@ -285,6 +303,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   soft_tofu: {
       description: "A highly versatile, plant-based protein made by coagulating soy milk and pressing the resulting curds into blocks. Its neutral flavor acts as a blank canvas; silken tofu is ideal for blending into smoothies or delicate soups, while firm or extra-firm tofu holds its shape for frying, baking, or stir-frying.\n\n**Selection & Storage:** Choose firmness based on your recipe needs. Once opened, store unused tofu submerged in fresh water in an airtight container in the refrigerator, changing the water daily.",
     name: "soft tofu",
+    origin: ["China"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["mild", "plant-based", "versatile"],
     category: "protein",
@@ -323,6 +343,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   har_gow__shrimp_dumplings_: {
       description: "A widely consumed crustacean known for its sweet, briny flavor and firm, snappy texture. They cook incredibly fast—turning pink and opaque in minutes as heat denatures their proteins—and become tough and rubbery if exposed to high heat for too long.\n\n**Selection & Storage:** Look for firm bodies attached tightly to their shells with a clean, mild saltwater scent; avoid any with black spots (melanosis) on their shells or a smell of ammonia. Store over ice in the refrigerator and consume within a day.",
     name: "har gow (shrimp dumplings)",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "nutritious"],
     category: "protein",
@@ -353,6 +375,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   siu_mai__pork_dumplings_: {
       description: "The culinary name for the meat of the domestic pig (*Sus domesticus*), known for its sweet, mild flavor and exceptional fat-rendering qualities. Its versatility ranges from lean tenderloins that require careful, quick cooking to fatty shoulders that braise into meltingly tender pulled pork.\n\n**Selection & Storage:** Fresh pork should have a pinkish-red color, firm texture, and bright white fat without any sour odors. Store raw cuts tightly wrapped in the coldest part of the refrigerator for 3-5 days.",
     name: "siu mai (pork dumplings)",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "nutritious"],
     category: "protein",
@@ -383,6 +407,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   fresh_eggs: {
       description: "The reproductive ovum of *Gallus gallus domesticus* — one of cooking's most versatile ingredients, delivering structure, aeration, emulsification, binding, and thickening in a single package. Yolks carry fat, lecithin (an emulsifier), and most of the flavor; whites are primarily water and coagulable proteins (ovalbumin, ovotransferrin) that unfold and bond when heated or whipped. Fresh eggs peel poorly when hard-boiled; slightly older eggs shed shells cleanly. Store pointed-end-down at 35–40°F.",
     name: "fresh eggs",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "nutritious"],
     category: "protein",
@@ -413,6 +439,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   vanilla_bean: {
       description: "A profoundly complex spice derived from the cured pods of orchids in the genus *Vanilla*. It contains hundreds of distinct flavor compounds (primarily vanillin) that provide a rich, sweet, and woody floral aroma, acting as a foundational flavor enhancer in nearly all sweet baking.\n\n**Selection & Storage:** Look for plump, dark, and pliable pods that smell highly aromatic; dry, brittle beans have lost their essential oils. Store beans tightly wrapped or submerged in alcohol (to make extract) in a cool, dark place.",
     name: "vanilla bean",
+    origin: ["Mexico"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["aromatic", "sweet", "flavorful"],
     category: "spice",
@@ -443,6 +471,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   oil_packed_tuna: {
       description: "A large, fast-swimming predatory fish (*Thunnini tribe*) with dense, meaty, and dark red flesh resulting from high levels of myoglobin. Its steak-like texture and rich, robust flavor make it a premium ingredient served raw as sushi, quickly seared, or high-quality oil-packed in cans.\n\n**Selection & Storage:** Fresh tuna steaks should be deep red, firm, and glossy with a clean ocean scent, lacking any strong \"fishy\" odor or brown spots. Keep heavily iced or in the coldest part of the fridge and consume the same day.",
     name: "oil-packed tuna",
+    origin: ["Worldwide warm seas"],
+    season: ["summer", "fall"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "nutritious"],
     category: "protein",
@@ -473,6 +503,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   beef_stock: {
       description: "The culinary name for meat from cattle (*Bos taurus*), offering deep, savory, and rich umami flavors due to high concentrations of amino acids. High-collagen cuts (like chuck) require long, slow cooking to break down into tender gelatin, while tender, low-activity cuts (like loin) excel at fast, high heat.\n\n**Selection & Storage:** Look for bright, cherry-red meat with even, white marbling (intramuscular fat) and no gray or brown spots. Store tightly wrapped in the coldest part of the refrigerator for up to 3-5 days.",
     name: "beef stock",
+    origin: ["Worldwide pastoral cultures"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["flavorful", "base", "nourishing"],
     category: "protein",
@@ -503,6 +535,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   chicken: {
       description: "A globally ubiquitous poultry (*Gallus gallus domesticus*) prized for its mild flavor and versatility. Its culinary behavior depends on the cut: lean, fast-cooking breast meat dries out easily, while fat- and collagen-rich thighs and drumsticks become unctuous and tender with slow braising or high-heat roasting.",
     name: "chicken",
+    origin: ["Southeast Asia (jungle fowl)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "nutritious"],
     category: "protein",
@@ -533,6 +567,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   beef_chuck: {
       description: "The culinary name for meat from cattle (*Bos taurus*), offering deep, savory, and rich umami flavors due to high concentrations of amino acids. High-collagen cuts (like chuck) require long, slow cooking to break down into tender gelatin, while tender, low-activity cuts (like loin) excel at fast, high heat.\n\n**Selection & Storage:** Look for bright, cherry-red meat with even, white marbling (intramuscular fat) and no gray or brown spots. Store tightly wrapped in the coldest part of the refrigerator for up to 3-5 days.",
     name: "beef chuck",
+    origin: ["Worldwide pastoral cultures"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "nutritious"],
     category: "protein",
@@ -563,6 +599,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   egg_yolks: {
       description: "The reproductive ovum of *Gallus gallus domesticus* — one of cooking's most versatile ingredients, delivering structure, aeration, emulsification, binding, and thickening. The yolk carries fat, lecithin (an emulsifier), and most of the flavor; the white is water plus coagulable proteins that unfold and bond when heated or whipped. Temperature control matters: yolks coagulate ~149°F, whites ~145°F, so gentle heat and timing dictate whether you get a silky custard or a rubbery scramble.",
     name: "egg yolks",
+    origin: ["Southeast Asia (chicken)", "Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["rich", "emulsifying", "nutritious"],
     category: "protein",
@@ -593,6 +631,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   pork: {
       description: "The culinary name for the meat of the domestic pig (*Sus domesticus*), known for its sweet, mild flavor and exceptional fat-rendering qualities. Its versatility ranges from lean tenderloins that require careful, quick cooking to fatty shoulders that braise into meltingly tender pulled pork.",
     name: "pork",
+    origin: ["East Asia (domestication)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["rich", "flavorful", "versatile"],
     category: "protein",
@@ -623,6 +663,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   white_beans: {
       description: "White Beans is a protein-forward ingredient valued for structure, satiety, and umami depth. Technique determines outcome: dry heat builds browning and intensity, while moist heat promotes tenderness and even hydration. Season in layers and cook to the right internal doneness target for both flavor and safety.",
     name: "white beans",
+    origin: ["Mesoamerica"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "fiber-rich"],
     category: "protein",
@@ -654,6 +696,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   yellow_lentils: {
       description: "Hulled and split lentils (*Lens culinaris*), often referred to as Moong Dal when derived from mung beans or Chana Dal when derived from chickpeas. Without their seed coats, they disintegrate completely when boiled, creating a remarkably thick, creamy, and mildly sweet puree essential for Indian dals.",
     name: "yellow lentils",
+    origin: ["Western Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "quick-cooking"],
     category: "protein",
@@ -685,6 +729,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   black_lentils: {
       description: "A tiny, lens-shaped legume (*Lens culinaris*) that cooks much faster than other beans because it does not require soaking. Brown and green lentils hold their shape well for salads, while red and yellow varieties break down into a thick, comforting porridge (like dal) when simmered.\n\n**Selection & Storage:** Look for uniformly colored, debris-free lentils. Store dried lentils in an airtight container in a cool, dark place, where they will retain their best quality for up to a year.",
     name: "black lentils",
+    origin: ["South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "earthy"],
     category: "protein",
@@ -716,6 +762,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   kidney_beans: {
       description: "Kidney Beans is a protein-forward ingredient valued for structure, satiety, and umami depth. Technique determines outcome: dry heat builds browning and intensity, while moist heat promotes tenderness and even hydration. Season in layers and cook to the right internal doneness target for both flavor and safety.",
     name: "kidney beans",
+    origin: ["Mesoamerica"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "robust"],
     category: "protein",
@@ -747,6 +795,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   egg: {
       description: "The reproductive ovum of *Gallus gallus domesticus* — one of cooking's most versatile ingredients, delivering structure, aeration, emulsification, binding, and thickening. The yolk carries fat, lecithin (an emulsifier), and most of the flavor; the white is water plus coagulable proteins that unfold and bond when heated or whipped. Temperature control matters: yolks coagulate ~149°F, whites ~145°F, so gentle heat and timing dictate whether you get a silky custard or a rubbery scramble.",
     name: "egg",
+    origin: ["Southeast Asia (chicken)", "Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "nutritious"],
     category: "protein",
@@ -777,6 +827,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   parmigiano_reggiano: {
       description: "Parmigiano-Reggiano is a dairy ingredient that contributes richness, body, and protein structure to both savory and sweet preparations. Heat and acid can quickly shift texture from smooth to curdled, so gentle temperature control is important in sauces and custards. Keep refrigerated and handle with clean tools to maintain shelf life and flavor.",
     name: "Parmigiano-Reggiano",
+    origin: ["Italy (Emilia-Romagna)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["rich", "savory", "nutritious"],
     category: "dairy",
@@ -807,6 +859,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   chicken_thigh: {
       description: "A globally ubiquitous poultry (*Gallus gallus domesticus*) prized for its mild flavor and versatility. Its culinary behavior depends on the cut: lean, fast-cooking breast meat dries out easily, while fat- and collagen-rich thighs and drumsticks become unctuous and tender with slow braising or high-heat roasting.\n\n**Selection & Storage:** Fresh chicken should have pinkish, firm flesh, white fat, and no strong odor. Store in the coldest part of the refrigerator (usually the bottom shelf) in its original packaging for 1-2 days, or freeze for longer storage.",
     name: "chicken thigh",
+    origin: ["Southeast Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["flavorful", "juicy", "protein-rich"],
     category: "protein",
@@ -837,6 +891,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   pork_belly: {
       description: "The culinary name for the meat of the domestic pig (*Sus domesticus*), known for its sweet, mild flavor and exceptional fat-rendering qualities. Its versatility ranges from lean tenderloins that require careful, quick cooking to fatty shoulders that braise into meltingly tender pulled pork.\n\n**Selection & Storage:** Fresh pork should have a pinkish-red color, firm texture, and bright white fat without any sour odors. Store raw cuts tightly wrapped in the coldest part of the refrigerator for 3-5 days.",
     name: "pork belly",
+    origin: ["East Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["rich", "fatty", "flavorful"],
     category: "protein",
@@ -867,6 +923,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   beef_sirloin: {
       description: "The culinary name for meat from cattle (*Bos taurus*), offering deep, savory, and rich umami flavors due to high concentrations of amino acids. High-collagen cuts (like chuck) require long, slow cooking to break down into tender gelatin, while tender, low-activity cuts (like loin) excel at fast, high heat.\n\n**Selection & Storage:** Look for bright, cherry-red meat with even, white marbling (intramuscular fat) and no gray or brown spots. Store tightly wrapped in the coldest part of the refrigerator for up to 3-5 days.",
     name: "beef sirloin",
+    origin: ["Worldwide pastoral cultures"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["lean", "protein-rich", "savory"],
     category: "protein",
@@ -897,6 +955,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   pork_spine: {
       description: "The culinary name for the meat of the domestic pig (*Sus domesticus*), known for its sweet, mild flavor and exceptional fat-rendering qualities. Its versatility ranges from lean tenderloins that require careful, quick cooking to fatty shoulders that braise into meltingly tender pulled pork.\n\n**Selection & Storage:** Fresh pork should have a pinkish-red color, firm texture, and bright white fat without any sour odors. Store raw cuts tightly wrapped in the coldest part of the refrigerator for 3-5 days.",
     name: "pork spine",
+    origin: ["East Asia (domestication)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["base", "flavorful", "sustaining"],
     category: "protein",
@@ -927,6 +987,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   bean_sprouts: {
       description: "The crisp, tender shoots of germinated beans—most commonly mung beans (*Vigna radiata*) or soybeans. They are a staple in East and Southeast Asian cuisines, prized for contributing a refreshing, watery crunch to stir-fries, noodle dishes, and fresh spring rolls. Because their delicate cell walls break down quickly under heat, they are typically added at the very end of cooking or served raw as a textural garnish.",
     name: "bean sprouts",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["crunchy", "fresh", "light"],
     category: "vegetable",
@@ -957,6 +1019,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   fava_beans: {
       description: "Fava Beans is a protein-forward ingredient valued for structure, satiety, and umami depth. Technique determines outcome: dry heat builds browning and intensity, while moist heat promotes tenderness and even hydration. Season in layers and cook to the right internal doneness target for both flavor and safety.",
     name: "fava beans",
+    origin: ["Mediterranean"],
+    season: ["spring"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "nutritious"],
     category: "protein",
@@ -988,6 +1052,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   brown_lentils: {
       description: "Small, lens-shaped legumes (*Lens culinaris*) that are left whole with their seed coat intact. They offer an incredibly mild, earthy flavor and hold their shape moderately well during cooking, making them a highly versatile, quick-cooking base for warm salads, vegetarian shepherd's pies, and hearty soups.",
     name: "brown lentils",
+    origin: ["Western Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "earthy"],
     category: "protein",
@@ -1019,6 +1085,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   buckwheat_groats: {
       description: "A nutrient-dense pseudocereal (*Fagopyrum esculentum*) that is completely unrelated to wheat and naturally gluten-free. It provides an aggressively earthy, nutty, and slightly bitter flavor, and is the essential ingredient in Japanese soba noodles and French Breton galettes (crepes).\n\n**Selection & Storage:** Available as whole groats (which can be toasted into 'kasha') or ground flour. Store in an airtight container in a cool, dark pantry or the refrigerator.",
     name: "buckwheat groats",
+    origin: ["Central Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "nutritious"],
     category: "grain",
@@ -1049,6 +1117,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   white_fish: {
       description: "White Fish is a protein-forward ingredient valued for structure, satiety, and umami depth. Technique determines outcome: dry heat builds browning and intensity, while moist heat promotes tenderness and even hydration. Season in layers and cook to the right internal doneness target for both flavor and safety.",
     name: "white fish",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["lean", "protein-rich", "versatile"],
     category: "protein",
@@ -1080,6 +1150,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   long_beans: {
       description: "Long Beans is a vegetable ingredient that contributes structure, micronutrients, and a broad range of textures depending on cut and heat level. High heat emphasizes caramelization and sweetness, while gentle cooking preserves water content and delicate notes. Prep consistently so pieces cook evenly and integrate cleanly into the dish.",
     name: "long beans",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["crunchy", "fresh", "light"],
     category: "vegetable",
@@ -1110,6 +1182,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   red_beans: {
       description: "Red Beans is a protein-forward ingredient valued for structure, satiety, and umami depth. Technique determines outcome: dry heat builds browning and intensity, while moist heat promotes tenderness and even hydration. Season in layers and cook to the right internal doneness target for both flavor and safety.",
     name: "red beans",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "sustaining", "nutritious"],
     category: "protein",
@@ -1141,6 +1215,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   beef_bones: {
       description: "The culinary name for meat from cattle (*Bos taurus*), offering deep, savory, and rich umami flavors due to high concentrations of amino acids. High-collagen cuts (like chuck) require long, slow cooking to break down into tender gelatin, while tender, low-activity cuts (like loin) excel at fast, high heat.\n\n**Selection & Storage:** Look for bright, cherry-red meat with even, white marbling (intramuscular fat) and no gray or brown spots. Store tightly wrapped in the coldest part of the refrigerator for up to 3-5 days.",
     name: "beef bones",
+    origin: ["Worldwide pastoral cultures"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["rich", "base", "nourishing"],
     category: "protein",
@@ -1171,6 +1247,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   ground_pork: {
       description: "The culinary name for the meat of the domestic pig (*Sus domesticus*), known for its sweet, mild flavor and exceptional fat-rendering qualities. Its versatility ranges from lean tenderloins that require careful, quick cooking to fatty shoulders that braise into meltingly tender pulled pork.\n\n**Selection & Storage:** Fresh pork should have a pinkish-red color, firm texture, and bright white fat without any sour odors. Store raw cuts tightly wrapped in the coldest part of the refrigerator for 3-5 days.",
     name: "ground pork",
+    origin: ["East Asia (domestication)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["rich", "savory", "versatile"],
     category: "protein",
@@ -1201,6 +1279,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   fish_sauce: {
       description: "An amber-colored liquid condiment derived from fish (usually anchovies) that have been coated in salt and fermented for up to two years. It provides an intense, pungent burst of pure umami (glutamate) and salt that mellows and adds incredible savory depth when cooked into Southeast Asian curries and stir-fries.",
     name: "fish sauce",
+    origin: ["Southeast Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["umami", "pungent", "savory"],
     category: "seasoning",
@@ -1231,6 +1311,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   beef_shank: {
       description: "The culinary name for meat from cattle (*Bos taurus*), offering deep, savory, and rich umami flavors due to high concentrations of amino acids. High-collagen cuts (like chuck) require long, slow cooking to break down into tender gelatin, while tender, low-activity cuts (like loin) excel at fast, high heat.\n\n**Selection & Storage:** Look for bright, cherry-red meat with even, white marbling (intramuscular fat) and no gray or brown spots. Store tightly wrapped in the coldest part of the refrigerator for up to 3-5 days.",
     name: "beef shank",
+    origin: ["Worldwide pastoral cultures"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["tough", "flavorful", "sustaining"],
     category: "protein",
@@ -1261,6 +1343,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   pork_knuckles: {
       description: "The culinary name for the meat of the domestic pig (*Sus domesticus*), known for its sweet, mild flavor and exceptional fat-rendering qualities. Its versatility ranges from lean tenderloins that require careful, quick cooking to fatty shoulders that braise into meltingly tender pulled pork.\n\n**Selection & Storage:** Fresh pork should have a pinkish-red color, firm texture, and bright white fat without any sour odors. Store raw cuts tightly wrapped in the coldest part of the refrigerator for 3-5 days.",
     name: "pork knuckles",
+    origin: ["East Asia (domestication)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["collagen-rich", "flavorful", "tough"],
     category: "protein",
@@ -1291,6 +1375,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   pork_chops: {
       description: "The culinary name for the meat of the domestic pig (*Sus domesticus*), known for its sweet, mild flavor and exceptional fat-rendering qualities. Its versatility ranges from lean tenderloins that require careful, quick cooking to fatty shoulders that braise into meltingly tender pulled pork.\n\n**Selection & Storage:** Fresh pork should have a pinkish-red color, firm texture, and bright white fat without any sour odors. Store raw cuts tightly wrapped in the coldest part of the refrigerator for 3-5 days.",
     name: "pork chops",
+    origin: ["East Asia (domestication)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["versatile", "protein-rich", "savory"],
     category: "protein",
@@ -1321,6 +1407,8 @@ const rawProteins: Record<string, Partial<IngredientMapping>> = {
   mung_beans: {
       description: "Mung Beans is a protein-forward ingredient valued for structure, satiety, and umami depth. Technique determines outcome: dry heat builds browning and intensity, while moist heat promotes tenderness and even hydration. Season in layers and cook to the right internal doneness target for both flavor and safety.",
     name: "mung beans",
+    origin: ["Worldwide"],
+    season: ["all"],
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.4, Air: 0.1 },
     qualities: ["protein-rich", "cooling", "nutritious"],
     category: "protein",

--- a/src/data/ingredients/seasonings/aromatics.ts
+++ b/src/data/ingredients/seasonings/aromatics.ts
@@ -5,6 +5,7 @@ const rawAromatics = {
   onion: {
       description: "A foundational aromatic (*Allium cepa*) that builds savory depth in nearly every global cuisine. Its concentric layers contain sulfur compounds that, when exposed to heat, undergo the Maillard reaction to create deep, sweet, and complex flavors ranging from sharp when raw to caramel-like when slow-cooked.",
     name: "Onion",
+    season: ["all"],
     elementalProperties: { Fire: 0.4, Earth: 0.3, Water: 0.2, Air: 0.1 },
     alchemicalProperties: { Spirit: 0.55, Essence: 0.50, Matter: 0.55, Substance: 0.45 },
     astrologicalProfile: {
@@ -67,6 +68,7 @@ const rawAromatics = {
   garlic: {
       description: "A pungent bulb (*Allium sativum*) belonging to the onion genus, prized globally for its intense, savory flavor and aroma. When its cells are crushed or chopped, an enzyme reaction produces allicin, the compound responsible for its signature bite and potent antimicrobial properties. This sharpness mellows into a deep, sweet nuttiness when roasted or sautéed.\\n\\n",
     name: "Garlic",
+    season: ["summer", "fall"],
     elementalProperties: { Fire: 0.6, Earth: 0.3, Air: 0.1, Water: 0 },
     alchemicalProperties: { Spirit: 0.82, Essence: 0.55, Matter: 0.45, Substance: 0.38 },
     astrologicalProfile: {
@@ -129,6 +131,7 @@ const rawAromatics = {
   ginger: {
       description: "A knobby, fibrous rhizome (*Zingiber officinale*) prized for its warm, spicy, and slightly citrusy bite. The active compound gingerol provides its signature sharp heat, which mellows and deepens into a warming aromatic when cooked.",
     name: "Ginger",
+    season: ["all"],
     elementalProperties: { Fire: 0.7, Earth: 0.2, Air: 0.1, Water: 0 },
     alchemicalProperties: { Spirit: 0.85, Essence: 0.58, Matter: 0.40, Substance: 0.35 },
     astrologicalProfile: {
@@ -210,6 +213,7 @@ const rawAromatics = {
   lemongrass: {
       description: "A tall, fibrous tropical grass (*Cymbopogon citratus*) with a tough outer stalk and a tender, highly aromatic inner core. It provides a complex, bright, and floral citrus flavor without the sharp acidity of lemon juice, making it indispensable in Southeast Asian curries and soups.",
     name: "Lemongrass",
+    season: ["summer"],
     elementalProperties: { Air: 0.5, Water: 0.3, Fire: 0.2, Earth: 0 },
     alchemicalProperties: { Spirit: 0.78, Essence: 0.65, Matter: 0.15, Substance: 0.18 },
     astrologicalProfile: {
@@ -276,6 +280,7 @@ const rawAromatics = {
   shallot: {
       description: "A small, teardrop-shaped allium (*Allium cepa var. aggregatum*) that grows in clusters similar to garlic. It offers a more delicate, sweeter, and less pungent flavor profile than standard onions, making it the classic choice for refined sauces, vinaigrettes, and raw applications.",
     name: "Shallot",
+    season: ["summer", "fall"],
     elementalProperties: { Earth: 0.4, Fire: 0.3, Water: 0.2, Air: 0.1 },
     alchemicalProperties: { Spirit: 0.48, Essence: 0.52, Matter: 0.48, Substance: 0.40 },
     astrologicalProfile: {
@@ -332,6 +337,7 @@ const rawAromatics = {
   scallion: {
       description: "Also known as green onions (*Allium fistulosum*), these alliums are harvested before a bulb forms. They offer a dual flavor profile: the white bases provide a sharp, pungent onion bite, while the hollow green tops deliver a fresh, herbaceous flavor ideal for garnishing.",
     name: "Scallion",
+    season: ["spring", "summer", "fall"],
     elementalProperties: { Air: 0.4, Water: 0.3, Earth: 0.2, Fire: 0.1 },
     alchemicalProperties: { Spirit: 0.38, Essence: 0.62, Matter: 0.22, Substance: 0.25 },
     astrologicalProfile: {
@@ -388,6 +394,7 @@ const rawAromatics = {
   saffron: {
       description: "The world's most expensive spice, consisting of the dried crimson stigmas of the *Crocus sativus* flower. It imparts a brilliant golden-yellow hue and a highly complex, honey-like, floral, and slightly metallic or earthy flavor, making it the defining characteristic of classic dishes like paella and risotto alla milanese.",
     name: "Saffron",
+    season: ["fall"],
     elementalProperties: { Fire: 0.7, Earth: 0.2, Air: 0.1, Water: 0 },
     alchemicalProperties: { Spirit: 0.90, Essence: 0.70, Matter: 0.08, Substance: 0.10 },
     astrologicalProfile: {

--- a/src/data/ingredients/seasonings/oils.ts
+++ b/src/data/ingredients/seasonings/oils.ts
@@ -8,6 +8,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   olive_oil: {
       description: "A liquid fat extracted by pressing whole olives (*Olea europaea*). Extra-virgin olive oil (EVOO) is mechanically extracted without heat or chemicals, retaining high levels of antioxidants and an intensely grassy, peppery, and fruity flavor best reserved for finishing dishes or low-heat cooking.",
     name: "Olive Oil",
+    origin: ["Mediterranean"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.3, Earth: 0.3, Air: 0.2, Water: 0.2 },
@@ -71,6 +72,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "coconut oil": {
       description: "Coconut Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "coconut oil",
+    origin: ["Indo-Pacific"],
     category: "oil",
     elementalProperties: {
       Fire: 0.2,
@@ -119,6 +121,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   sesame_oil: {
       description: "An incredibly potent oil pressed from sesame seeds (*Sesamum indicum*). Toasted sesame oil (dark brown) provides a massive burst of savory, nutty pyrazines and should be used exclusively as a finishing oil, while plain sesame oil (pale yellow) is neutral and suitable for cooking.",
     name: "Sesame Oil",
+    origin: ["East Asia", "Africa"],
     category: "oil",
     subCategory: "finishing",
     elementalProperties: { Fire: 0.4, Water: 0.2, Earth: 0.2, Air: 0.2 },
@@ -182,6 +185,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   ghee: {
       description: "A class of clarified butter originating in ancient India, created by simmering butter until the water evaporates and the milk solids toast and sink to the bottom. Once strained, the resulting pure butterfat boasts an intensely nutty, caramel-like flavor and a massive smoke point (482°F / 250°C), making it ideal for high-heat frying.",
     name: "Ghee",
+    origin: ["South Asia"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.45, Water: 0.15, Earth: 0.25, Air: 0.15 },
@@ -227,6 +231,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   avocado_oil: {
       description: "An oil pressed from the fleshy pulp of avocados. It boasts the highest smoke point of any common culinary oil (up to 520°F / 271°C) and a very mild, buttery flavor, making it a premium choice for aggressive high-heat searing, grilling, and broiling.",
     name: "Avocado Oil",
+    origin: ["Mesoamerica"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.3, Water: 0.3, Earth: 0.2, Air: 0.2 },
@@ -273,6 +278,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "peanut oil": {
       description: "Peanut Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "peanut oil",
+    origin: ["South America (Brazil)"],
     category: "oil",
     elementalProperties: {
       Fire: 0.4,
@@ -321,6 +327,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "mustard oil": {
       description: "Mustard Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "mustard oil",
+    origin: ["South Asia"],
     category: "oil",
     elementalProperties: {
       Fire: 0.5,
@@ -356,6 +363,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "walnut oil": {
       description: "Walnut Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "walnut oil",
+    origin: ["France", "Western Asia"],
     category: "oil",
     elementalProperties: {
       Fire: 0.2,
@@ -404,6 +412,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "rice bran oil": {
       description: "Rice Bran Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "rice bran oil",
+    origin: ["East and South Asia"],
     category: "oil",
     elementalProperties: {
       Fire: 0.3,
@@ -439,6 +448,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "chili oil": {
       description: "Chili Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "chili oil",
+    origin: ["Sichuan (China)"],
     category: "oil",
     elementalProperties: {
       Fire: 0.6,
@@ -474,6 +484,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "perilla oil": {
       description: "Perilla Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "perilla oil",
+    origin: ["East Asia"],
     category: "oil",
     elementalProperties: {
       Fire: 0.3,
@@ -509,6 +520,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "camellia oil": {
       description: "Camellia Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "camellia oil",
+    origin: ["Worldwide"],
     category: "oil",
     elementalProperties: {
       Fire: 0.2,
@@ -544,6 +556,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "grapeseed oil": {
       description: "Grapeseed Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "grapeseed oil",
+    origin: ["Mediterranean"],
     category: "oil",
     elementalProperties: {
       Fire: 0.2,
@@ -593,6 +606,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "macadamia oil": {
       description: "Macadamia Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "macadamia oil",
+    origin: ["Australia"],
     category: "oil",
     elementalProperties: {
       Fire: 0.2,
@@ -628,6 +642,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "palm oil": {
       description: "Palm Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "palm oil",
+    origin: ["West Africa"],
     category: "oil",
     elementalProperties: {
       Fire: 0.4,
@@ -663,6 +678,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "tea seed oil": {
       description: "Tea Seed Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "tea seed oil",
+    origin: ["Southwest China"],
     category: "oil",
     elementalProperties: {
       Fire: 0.3,
@@ -698,6 +714,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "shiso oil": {
       description: "Shiso Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "shiso oil",
+    origin: ["East Asia"],
     category: "oil",
     elementalProperties: {
       Fire: 0.2,
@@ -733,6 +750,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "argan oil": {
       description: "Argan Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "argan oil",
+    origin: ["Morocco"],
     category: "oil",
     elementalProperties: {
       Fire: 0.2,
@@ -768,6 +786,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "hazelnut oil": {
       description: "Hazelnut Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "hazelnut oil",
+    origin: ["France", "Italy"],
     category: "oil",
     elementalProperties: {
       Fire: 0.2,
@@ -803,6 +822,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "pistachio oil": {
       description: "Pistachio Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "pistachio oil",
+    origin: ["Western Asia (Iran)"],
     category: "oil",
     elementalProperties: {
       Fire: 0.2,
@@ -838,6 +858,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "hemp seed oil": {
       description: "Hemp Seed Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "hemp seed oil",
+    origin: ["Central Asia"],
     category: "oil",
     elementalProperties: {
       Fire: 0.1,
@@ -873,6 +894,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "black seed oil": {
       description: "Black Seed Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "black seed oil",
+    origin: ["Worldwide"],
     category: "oil",
     elementalProperties: {
       Fire: 0.4,
@@ -908,6 +930,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "almond oil": {
       description: "Almond Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "almond oil",
+    origin: ["Mediterranean"],
     category: "oil",
     elementalProperties: {
       Fire: 0.2,
@@ -956,6 +979,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "sunflower oil": {
       description: "Sunflower Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "sunflower oil",
+    origin: ["North America", "Eastern Europe (cultivation)"],
     category: "oil",
     elementalProperties: {
       Fire: 0.3,
@@ -1004,6 +1028,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "safflower oil": {
       description: "Safflower Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "safflower oil",
+    origin: ["Western Asia", "Mediterranean"],
     category: "oil",
     elementalProperties: {
       Fire: 0.3,
@@ -1042,6 +1067,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "white truffle oil": {
       description: "White Truffle Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "white truffle oil",
+    origin: ["Italy (Alba)"],
     category: "oil",
     elementalProperties: {
       Fire: 0.1,
@@ -1077,6 +1103,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "flaxseed oil": {
       description: "Flaxseed Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "flaxseed oil",
+    origin: ["Northern Europe"],
     category: "oil",
     elementalProperties: {
       Fire: 0.1,
@@ -1125,6 +1152,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "red palm oil": {
       description: "Red Palm Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "red palm oil",
+    origin: ["West Africa"],
     category: "oil",
     elementalProperties: {
       Fire: 0.4,
@@ -1160,6 +1188,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "roasted pumpkin seed oil": {
       description: "Roasted Pumpkin Seed Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "roasted pumpkin seed oil",
+    origin: ["Austria (Styria)"],
     category: "oil",
     elementalProperties: {
       Fire: 0.3,
@@ -1199,6 +1228,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "mustard seed oil": {
       description: "Mustard Seed Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "mustard seed oil",
+    origin: ["Mediterranean", "South Asia"],
     category: "oil",
     elementalProperties: {
       Fire: 0.5,
@@ -1238,6 +1268,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "babassu oil": {
       description: "Babassu Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "babassu oil",
+    origin: ["Worldwide"],
     category: "oil",
     elementalProperties: {
       Fire: 0.2,
@@ -1277,6 +1308,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "apricot kernel oil": {
       description: "Apricot Kernel Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "apricot kernel oil",
+    origin: ["Central Asia (Armenia)"],
     category: "oil",
     elementalProperties: {
       Fire: 0.2,
@@ -1312,6 +1344,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   "grape seed oil": {
       description: "Grape Seed Oil is a culinary fat used for heat transfer, texture, and flavor delivery. Its best use depends on smoke point and flavor intensity: neutral oils for high-heat cooking, expressive oils for finishing and emulsions. Limit exposure to heat, oxygen, and light to slow oxidation and preserve flavor integrity.",
     name: "grape seed oil",
+    origin: ["Western Asia", "Mediterranean"],
     category: "oil",
     elementalProperties: {
       Fire: 0.3,
@@ -1365,6 +1398,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   canola_oil: {
       description: "A highly refined, neutral-tasting vegetable oil extracted from a specific, low-erucic acid variety of the rapeseed plant. Its high smoke point (400°F / 204°C) and lack of flavor make it a ubiquitous, all-purpose oil for deep-frying, baking, and emulsifying mild mayonnaises.",
     name: "Canola Oil",
+    origin: ["Canada"],
     category: "oil",
     subCategory: "cooking",
     elementalProperties: { Fire: 0.3, Water: 0.2, Earth: 0.2, Air: 0.3 },
@@ -1427,6 +1461,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
   mct_oil: {
       description: "A highly refined supplement oil composed exclusively of Medium-Chain Triglycerides, typically extracted from coconut or palm kernel oil. Because these specific fats are metabolized rapidly by the liver rather than stored, it is extremely popular in ketogenic diets and 'bulletproof' coffee, possessing a completely neutral, flavorless profile.",
     name: "MCT Oil",
+    origin: ["Worldwide"],
     category: "oil",
     subCategory: "specialty",
     elementalProperties: { Fire: 0.4, Water: 0.2, Earth: 0.2, Air: 0.2 },

--- a/src/data/ingredients/seasonings/peppers.ts
+++ b/src/data/ingredients/seasonings/peppers.ts
@@ -5,6 +5,7 @@ const rawPeppers = {
   black_pepper: {
       description: "The world's most ubiquitous spice (*Piper nigrum*), made from the dried, unripe berries of a flowering vine. It provides a sharp, biting heat due to the alkaloid piperine, and complex, woody aromas that quickly degrade, which is why it should always be freshly ground just before use.",
     name: "Black Pepper",
+    season: ["all"],
     elementalProperties: { Fire: 0.7, Air: 0.2, Earth: 0.1, Water: 0 },
     alchemicalProperties: { Spirit: 0.85, Essence: 0.35, Matter: 0.15, Substance: 0.20 },
     astrologicalProfile: {
@@ -121,6 +122,7 @@ const rawPeppers = {
   white_pepper: {
       description: "The seed of the *Piper nigrum* vine, with its dark outer skin removed before drying. It offers a sharper, earthier, and slightly more fermented or musky flavor than black pepper, and is prized in French and Chinese cuisines where dark black specks are visually undesirable in pale sauces.",
     name: "White Pepper",
+    season: ["all"],
     elementalProperties: { Fire: 0.5, Earth: 0.3, Air: 0.2, Water: 0 },
     alchemicalProperties: { Spirit: 0.75, Essence: 0.30, Matter: 0.18, Substance: 0.22 },
     astrologicalProfile: {
@@ -203,6 +205,7 @@ const rawPeppers = {
   pink_peppercorn: {
       description: "The dried berries of the *Schinus molle* (Peruvian peppertree) or *Schinus terebinthifolia* (Brazilian peppertree), entirely unrelated to true black pepper. They offer a very mild, slightly sweet, and profoundly floral heat with notes of rose and citrus, providing brilliant color and delicate crunch to light cream sauces or fish.",
     name: "Pink Peppercorn",
+    season: ["all"],
     elementalProperties: { Air: 0.4, Fire: 0.3, Water: 0.2, Earth: 0.1 },
     alchemicalProperties: { Spirit: 0.70, Essence: 0.45, Matter: 0.10, Substance: 0.15 },
     astrologicalProfile: {
@@ -276,6 +279,7 @@ const rawPeppers = {
   szechuan_peppercorn: {
       description: "The dried berry husks of the prickly ash tree (*Zanthoxylum*), completely unrelated to black pepper or chili peppers. They contain hydroxy-alpha sanshool, a compound that creates a unique vibrating, numbing, and tingling sensation (málà) on the tongue, accompanied by a bright citrus aroma.",
     name: "Szechuan Peppercorn",
+    season: ["all"],
     elementalProperties: { Fire: 0.56, Water: 0, Earth: 0.11, Air: 0.33 },
     alchemicalProperties: { Spirit: 0.88, Essence: 0.40, Matter: 0.12, Substance: 0.18 },
     astrologicalProfile: {
@@ -337,6 +341,7 @@ const rawPeppers = {
   long_pepper: {
       description: "An exotic flowering vine (*Piper longum*) closely related to black pepper, producing tiny fruit clusters that look like slender catkins. It possesses a complex, sweet, and incredibly pungent heat that is earthier and more aromatic than black pepper, boasting notes of nutmeg, cinnamon, and cardamom.",
     name: "Long Pepper",
+    season: ["all"],
     elementalProperties: { Fire: 0.6, Earth: 0.3, Air: 0.1, Water: 0 },
     alchemicalProperties: { Spirit: 0.78, Essence: 0.35, Matter: 0.18, Substance: 0.20 },
     astrologicalProfile: {

--- a/src/data/ingredients/seasonings/salts.ts
+++ b/src/data/ingredients/seasonings/salts.ts
@@ -607,6 +607,7 @@ const rawSalts = {
   sea_salt: {
       description: "A broad category of salt obtained directly through the evaporation of seawater, rather than mined from subterranean rock deposits. While it is chemically mostly sodium chloride, it retains trace oceanic minerals (like magnesium and calcium) that provide a slightly more complex, 'briny' flavor profile than highly refined table salt.",
     name: "Sea Salt",
+    season: ["all"],
     elementalProperties: { Water: 0.6, Earth: 0.2, Air: 0.1, Fire: 0.1 },
     alchemicalProperties: { Spirit: 0.05, Essence: 0.18, Matter: 0.92, Substance: 0.95 },
     astrologicalProfile: {
@@ -695,6 +696,7 @@ const rawSalts = {
   himalayan_salt: {
       description: "A rock salt mined from the Punjab region of Pakistan, characterized by its distinct pink color, which is derived from trace minerals like iron, magnesium, and calcium. While nutrally similar to table salt, its large, coarse crystals make it an excellent visual and textural finishing salt.",
     name: "Himalayan Salt",
+    season: ["all"],
     elementalProperties: { Earth: 0.6, Fire: 0.2, Water: 0.1, Air: 0.1 },
     alchemicalProperties: { Spirit: 0.10, Essence: 0.10, Matter: 0.95, Substance: 0.95 },
     astrologicalProfile: {
@@ -990,6 +992,7 @@ const rawSalts = {
   kosher_salt: {
       description: "A coarse-grained, additive-free salt that features large, irregular, flat crystals. Originally designed for the Jewish dietary practice of dry-brining (koshering) meat, its large surface area draws out moisture effectively and makes it exceptionally easy for chefs to pinch and accurately judge quantities by feel, compared to dense table salt.",
     name: "Kosher Salt",
+    season: ["all"],
     elementalProperties: { Earth: 0.6, Water: 0.2, Air: 0.1, Fire: 0.1 },
     alchemicalProperties: { Spirit: 0.03, Essence: 0.08, Matter: 0.92, Substance: 0.95 },
     qualities: ["clean", "consistent", "pure"],
@@ -1070,6 +1073,7 @@ const rawSalts = {
   table_salt: {
       description: "A highly refined, fine-grained salt consisting of nearly 100% pure sodium chloride, typically mined from underground salt deposits. Because its grains are uniformly small and dense, it dissolves instantly in water, though it is incredibly easy to over-salt dishes if measuring by volume instead of weight.",
     name: "Table Salt",
+    season: ["all"],
     elementalProperties: { Earth: 0.7, Water: 0.1, Air: 0.1, Fire: 0.1 },
     alchemicalProperties: { Spirit: 0.02, Essence: 0.05, Matter: 0.95, Substance: 0.98 },
     qualities: ["basic", "refined", "uniform"],

--- a/src/data/ingredients/spices/spiceBlends.ts
+++ b/src/data/ingredients/spices/spiceBlends.ts
@@ -441,6 +441,7 @@ const rawSpiceBlends: Record<string, Partial<IngredientMapping>> = {
   za_atar: {
       description: "A vibrant, aromatic Middle Eastern spice blend featuring a base of dried wild thyme or oregano mixed with toasted sesame seeds, salt, and the defining tart, citrusy zing of sumac. It provides a profoundly earthy, nutty, and bright flavor profile perfect for dusting over hummus, flatbreads, or roasted chicken.",
     name: "Za Atar",
+    season: ["all"],
     elementalProperties: { Earth: 0.4, Air: 0.3, Fire: 0.2, Water: 0.1 },
     qualities: ["earthy", "tangy", "aromatic"],
     origin: ["Levant"],
@@ -511,6 +512,7 @@ const rawSpiceBlends: Record<string, Partial<IngredientMapping>> = {
   curry_powder: {
       description: "A Western commercial spice blend designed to approximate the complex flavors of Indian cuisine. It typically features a brightly colored base of turmeric, rounded out with sweet and earthy spices like coriander, cumin, fenugreek, and varying amounts of chili pepper for heat.",
     name: "Curry Powder",
+    season: ["all"],
     elementalProperties: { Fire: 0.4, Air: 0.3, Earth: 0.2, Water: 0.1 },
     qualities: ["warming", "complex", "pungent"],
     origin: ["British-Indian"],
@@ -578,6 +580,7 @@ const rawSpiceBlends: Record<string, Partial<IngredientMapping>> = {
   berbere: {
       description: "A fiery, complex, and highly aromatic spice blend that forms the foundational flavor profile of Ethiopian and Eritrean cuisines. It is a deeply red, textured mix typically containing chili peppers, garlic, ginger, basil, korarima, rue, ajwain or radhuni, nigella, and fenugreek, offering immense savory depth and sustained heat.",
     name: "Berbere",
+    season: ["all"],
     elementalProperties: { Fire: 0.6, Air: 0.2, Earth: 0.1, Water: 0.1 },
     qualities: ["hot", "complex", "earthy"],
     origin: ["Ethiopia"],
@@ -640,6 +643,7 @@ const rawSpiceBlends: Record<string, Partial<IngredientMapping>> = {
   dukkah: {
       description: "A traditional Egyptian condiment consisting of a coarse mixture of roasted nuts (usually hazelnuts), sesame seeds, coriander, cumin, and salt. It provides an immediate, incredibly satisfying, crunchy, and savory-spicy burst of flavor, traditionally eaten by dipping bread in olive oil and then into the mixture.",
     name: "Dukkah",
+    season: ["all"],
     elementalProperties: { Earth: 0.4, Air: 0.3, Fire: 0.2, Water: 0.1 },
     qualities: ["nutty", "aromatic", "crunchy"],
     origin: ["Egypt"],
@@ -702,6 +706,7 @@ const rawSpiceBlends: Record<string, Partial<IngredientMapping>> = {
   shichimi_togarashi: {
       description: "A traditional Japanese seven-spice blend designed to add bright, complex heat and texture to noodles and soups. While recipes vary, it almost universally includes coarsely ground red chili pepper, sansho (Japanese pepper), roasted orange peel, black and white sesame seeds, hemp seed, ginger, and nori (seaweed).",
     name: "Shichimi Togarashi",
+    season: ["all"],
     elementalProperties: { Fire: 0.61, Water: 0.13, Earth: 0.13, Air: 0.13 },
     qualities: ["spicy", "citrusy", "nutty"],
     origin: ["Japan"],
@@ -765,6 +770,7 @@ const rawSpiceBlends: Record<string, Partial<IngredientMapping>> = {
   baharat: {
       description: "Baharat is a concentrated aromatic spice used in small amounts to add heat, fragrance, and depth to sauces, marinades, and dry rubs. Blooming it briefly in hot fat or toasting it gently before grinding helps release volatile oils and prevents flat flavor. Store airtight away from light and humidity, and refresh frequently to maintain potency.",
     name: "Baharat",
+    season: ["all"],
     elementalProperties: { Fire: 0.4, Air: 0.3, Earth: 0.2, Water: 0.1 },
     qualities: ["warming", "aromatic", "complex"],
     origin: ["Middle East"],
@@ -827,6 +833,7 @@ const rawSpiceBlends: Record<string, Partial<IngredientMapping>> = {
   jerk_seasoning: {
       description: "A highly assertive, intensely spicy, and aromatic dry rub or wet marinade originating in Jamaica. It is fundamentally defined by the fiery heat of Scotch bonnet peppers paired with the warm, sweet, and woodsy depth of allspice (pimento), thyme, and scallions, creating a deeply complex crust on grilled meats.",
     name: "Jerk Seasoning",
+    season: ["all"],
     elementalProperties: { Fire: 0.5, Earth: 0.2, Air: 0.2, Water: 0.1 },
     qualities: ["hot", "pungent", "aromatic"],
     origin: ["Jamaica"],

--- a/src/data/ingredients/spices/spices.ts
+++ b/src/data/ingredients/spices/spices.ts
@@ -6,6 +6,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   ginger: {
       description: "A knobby, fibrous rhizome (*Zingiber officinale*) prized for its warm, spicy, and slightly citrusy bite. The active compound gingerol provides its signature sharp heat, which mellows and deepens into a warming aromatic when cooked.",
     name: "ginger",
+    origin: ["Maritime Southeast Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.45, Water: 0.05, Earth: 0.15, Air: 0.35 },
     qualities: ["aromatic", "flavorful", "preservative", "warming"],
     category: "spice",
@@ -37,6 +39,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   cinnamon: {
       description: "A warm, sweet spice derived from the inner bark of trees (*Cinnamomum*). Cassia cinnamon is strong, spicy, and common in baking, while true \"Ceylon\" cinnamon is softer, more floral, and delicate; both provide a deep, aromatic warmth that enhances both sweet pastries and savory curries.",
     name: "cinnamon",
+    origin: ["Sri Lanka", "Southeast Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.45, Water: 0.05, Earth: 0.15, Air: 0.35 },
     qualities: ["aromatic", "flavorful", "preservative", "warming"],
     category: "spice",
@@ -68,6 +72,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   nutmeg: {
       description: "The hard, inner seed of the fruit from a tropical evergreen (*Myristica fragrans*). It possesses an intensely warm, sweet, and slightly woody flavor that is classically paired with dairy (like in béchamel or eggnog) or baked goods to add depth and warmth.",
     name: "nutmeg",
+    origin: ["Indonesia (Banda Islands)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.45, Water: 0.05, Earth: 0.15, Air: 0.35 },
     qualities: ["aromatic", "flavorful", "preservative", "warming"],
     category: "spice",
@@ -99,6 +105,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   paprika: {
       description: "A vibrantly red spice made from dried and ground sweet peppers (*Capsicum annuum*). Sweet paprika provides a mild, fruity earthiness and brilliant color, while smoked paprika (Pimentón de la Vera) adds a profound, deep wood-smoke flavor that instantly imparts a 'cooked over fire' quality to any dish.",
     name: "paprika",
+    origin: ["Central America", "Hungary (cultivated)"],
+    season: ["all"],
     elementalProperties: { Fire: 0.45, Water: 0.05, Earth: 0.15, Air: 0.35 },
     qualities: ["aromatic", "flavorful", "preservative", "warming"],
     category: "spice",
@@ -130,6 +138,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   red_bean_paste: {
       description: "Red Bean Paste is a concentrated aromatic spice used in small amounts to add heat, fragrance, and depth to sauces, marinades, and dry rubs. Blooming it briefly in hot fat or toasting it gently before grinding helps release volatile oils and prevents flat flavor. Store airtight away from light and humidity, and refresh frequently to maintain potency.",
     name: "red bean paste",
+    origin: ["Tropical and subtropical regions"],
+    season: ["all"],
     elementalProperties: { Fire: 0.25, Water: 0.2, Earth: 0.4, Air: 0.15 },
     qualities: ["sweet", "earthy", "dense"],
     category: "spice",
@@ -161,6 +171,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   curry_leaves: {
       description: "Curry Leaves is a concentrated aromatic spice used in small amounts to add heat, fragrance, and depth to sauces, marinades, and dry rubs. Blooming it briefly in hot fat or toasting it gently before grinding helps release volatile oils and prevents flat flavor. Store airtight away from light and humidity, and refresh frequently to maintain potency.",
     name: "curry leaves",
+    origin: ["South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.35, Water: 0.1, Earth: 0.2, Air: 0.35 },
     qualities: ["aromatic", "flavorful", "preservative", "warming"],
     category: "spice",
@@ -192,6 +204,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   mustard_seeds: {
       description: "Tiny, round seeds of various mustard plants (*Brassica* and *Sinapis*) available in yellow, brown, and black varieties. The seeds themselves have no heat until crushed and mixed with a cold liquid, which triggers an enzyme reaction creating the sharp, pungent compound allyl isothiocyanate.\n\n**Selection & Storage:** Yellow seeds are the mildest, while black and brown are much sharper and more pungent. Store whole seeds in an airtight container in a dark pantry, as they keep indefinitely.",
     name: "mustard seeds",
+    origin: ["Mediterranean", "South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.45, Water: 0.05, Earth: 0.15, Air: 0.35 },
     qualities: ["pungent", "hot", "flavorful"],
     category: "spice",
@@ -228,6 +242,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   turmeric: {
       description: "A bright yellow-orange rhizome (*Curcuma longa*) of the ginger family, containing the powerful anti-inflammatory compound curcumin. It offers a distinctly earthy, slightly bitter, and mustard-like flavor, and is primarily used to impart a brilliant golden color to curries, rice, and mustards.",
     name: "turmeric",
+    origin: ["South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.4, Water: 0.05, Earth: 0.25, Air: 0.3 },
     qualities: ["aromatic", "flavorful", "healing", "warming"],
     category: "spice",
@@ -259,6 +275,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   green_chilies: {
       description: "Green Chilies is a concentrated aromatic spice used in small amounts to add heat, fragrance, and depth to sauces, marinades, and dry rubs. Blooming it briefly in hot fat or toasting it gently before grinding helps release volatile oils and prevents flat flavor. Store airtight away from light and humidity, and refresh frequently to maintain potency.",
     name: "green chilies",
+    origin: ["Tropical and subtropical regions"],
+    season: ["all"],
     elementalProperties: { Fire: 0.55, Water: 0.1, Earth: 0.1, Air: 0.25 },
     qualities: ["spicy", "pungent", "vibrant"],
     category: "spice",
@@ -290,6 +308,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   chole_masala: {
       description: "Chole Masala is a concentrated aromatic spice used in small amounts to add heat, fragrance, and depth to sauces, marinades, and dry rubs. Blooming it briefly in hot fat or toasting it gently before grinding helps release volatile oils and prevents flat flavor. Store airtight away from light and humidity, and refresh frequently to maintain potency.",
     name: "chole masala",
+    origin: ["Tropical and subtropical regions"],
+    season: ["all"],
     elementalProperties: { Fire: 0.45, Water: 0.05, Earth: 0.15, Air: 0.35 },
     qualities: ["aromatic", "flavorful", "warming"],
     category: "spice",
@@ -321,6 +341,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   chaat_masala: {
       description: "Chaat Masala is a concentrated aromatic spice used in small amounts to add heat, fragrance, and depth to sauces, marinades, and dry rubs. Blooming it briefly in hot fat or toasting it gently before grinding helps release volatile oils and prevents flat flavor. Store airtight away from light and humidity, and refresh frequently to maintain potency.",
     name: "chaat masala",
+    origin: ["Tropical and subtropical regions"],
+    season: ["all"],
     elementalProperties: { Fire: 0.4, Water: 0.05, Earth: 0.2, Air: 0.35 },
     qualities: ["tangy", "aromatic", "flavorful"],
     category: "spice",
@@ -352,6 +374,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   cumin_seeds: {
       description: "A potent, earthy spice derived from the seeds of a parsley relative (*Cuminum cyminum*). When toasted, it releases powerful, warm, and slightly musky pyrazines that form the backbone of savory flavor profiles in Mexican, Indian, and Middle Eastern cuisines.",
     name: "cumin seeds",
+    origin: ["Western Asia", "Mediterranean"],
+    season: ["all"],
     elementalProperties: { Fire: 0.4, Water: 0.05, Earth: 0.3, Air: 0.25 },
     qualities: ["earthy", "warm", "pungent"],
     category: "spice",
@@ -383,6 +407,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   garam_masala: {
       description: "A deeply warming, complex spice blend originating from the Indian subcontinent, translating roughly to 'hot spices' (referring to metabolic heat, not chili spice). It typically contains heavily aromatic, sweet spices like cardamom, cinnamon, clove, cumin, and nutmeg, and is usually added near the end of cooking to preserve its aromatics.",
     name: "garam masala",
+    origin: ["South Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.45, Water: 0.05, Earth: 0.15, Air: 0.35 },
     qualities: ["aromatic", "warming", "complex"],
     category: "spice",
@@ -414,6 +440,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   cardamom: {
       description: "A highly aromatic, resinous spice (*Elettaria cardamomum*) enclosed in small green or black pods. Green cardamom offers a complex, cooling, eucalyptus-and-citrus sweetness essential for Scandinavian baking and Indian sweets, while black cardamom is heavily smoked and deeply savory.",
     name: "cardamom",
+    origin: ["South India", "Sri Lanka"],
+    season: ["all"],
     elementalProperties: { Fire: 0.35, Water: 0.05, Earth: 0.2, Air: 0.4 },
     qualities: ["aromatic", "flavorful", "warming"],
     category: "spice",
@@ -445,6 +473,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   saffron: {
       description: "The world's most expensive spice, consisting of the dried crimson stigmas of the *Crocus sativus* flower. It imparts a brilliant golden-yellow hue and a highly complex, honey-like, floral, and slightly metallic or earthy flavor, making it the defining characteristic of classic dishes like paella and risotto alla milanese.",
     name: "saffron",
+    origin: ["Western Asia (Iran, Greece)"],
+    season: ["fall"],
     elementalProperties: { Fire: 0.4, Water: 0.1, Earth: 0.2, Air: 0.3 },
     qualities: ["aromatic", "luxurious", "coloring"],
     category: "spice",
@@ -476,6 +506,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   curry_roux: {
       description: "Curry Roux is a concentrated aromatic spice used in small amounts to add heat, fragrance, and depth to sauces, marinades, and dry rubs. Blooming it briefly in hot fat or toasting it gently before grinding helps release volatile oils and prevents flat flavor. Store airtight away from light and humidity, and refresh frequently to maintain potency.",
     name: "curry roux",
+    origin: ["Tropical and subtropical regions"],
+    season: ["all"],
     elementalProperties: { Fire: 0.35, Water: 0.15, Earth: 0.3, Air: 0.2 },
     qualities: ["aromatic", "flavorful", "thickening"],
     category: "spice",
@@ -507,6 +539,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   chili_powder: {
       description: "A generic term that can refer either to pure ground dried chilies (like cayenne or ancho) or to a Tex-Mex spice blend containing ground chilies, cumin, oregano, and garlic powder. It provides earthy warmth, savory depth, and varying levels of capsaicin-driven heat depending on the chilies used.",
     name: "chili powder",
+    origin: ["Mesoamerica"],
+    season: ["all"],
     elementalProperties: { Fire: 0.55, Water: 0.05, Earth: 0.15, Air: 0.25 },
     qualities: ["spicy", "flavorful", "warming"],
     category: "spice",
@@ -538,6 +572,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   cumin: {
       description: "A potent, earthy spice derived from the seeds of a parsley relative (*Cuminum cyminum*). When toasted, it releases powerful, warm, and slightly musky pyrazines that form the backbone of savory flavor profiles in Mexican, Indian, and Middle Eastern cuisines.",
     name: "cumin",
+    origin: ["Western Asia", "Mediterranean"],
+    season: ["all"],
     elementalProperties: { Fire: 0.4, Water: 0.05, Earth: 0.3, Air: 0.25 },
     qualities: ["earthy", "warm", "pungent"],
     category: "spice",
@@ -569,6 +605,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   coriander: {
       description: "The dried seeds of the cilantro plant (*Coriandrum sativum*), yielding a completely different flavor profile than its leaves. The seeds provide a warm, floral, and slightly citrusy sweetness that is a crucial balancing component in heavy, spicy curry blends and pickling brines.",
     name: "coriander",
+    origin: ["Mediterranean"],
+    season: ["spring", "fall"],
     elementalProperties: { Fire: 0.3, Water: 0.1, Earth: 0.3, Air: 0.3 },
     qualities: ["citrusy", "aromatic", "flavorful"],
     category: "spice",
@@ -600,6 +638,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   thai_chilies: {
       description: "Thai Chilies is a concentrated aromatic spice used in small amounts to add heat, fragrance, and depth to sauces, marinades, and dry rubs. Blooming it briefly in hot fat or toasting it gently before grinding helps release volatile oils and prevents flat flavor. Store airtight away from light and humidity, and refresh frequently to maintain potency.",
     name: "Thai chilies",
+    origin: ["Tropical and subtropical regions"],
+    season: ["all"],
     elementalProperties: { Fire: 0.6, Water: 0.05, Earth: 0.1, Air: 0.25 },
     qualities: ["very spicy", "pungent", "vibrant"],
     category: "spice",
@@ -631,6 +671,8 @@ const rawSpices: Record<string, Partial<IngredientMapping>> = {
   shrimp_paste: {
       description: "A widely consumed crustacean known for its sweet, briny flavor and firm, snappy texture. They cook incredibly fast—turning pink and opaque in minutes as heat denatures their proteins—and become tough and rubbery if exposed to high heat for too long.\n\n**Selection & Storage:** Look for firm bodies attached tightly to their shells with a clean, mild saltwater scent; avoid any with black spots (melanosis) on their shells or a smell of ammonia. Store over ice in the refrigerator and consume within a day.",
     name: "shrimp paste",
+    origin: ["Worldwide warm waters"],
+    season: ["summer", "fall"],
     elementalProperties: { Fire: 0.2, Water: 0.35, Earth: 0.3, Air: 0.15 },
     qualities: ["umami", "pungent", "savory"],
     category: "spice",

--- a/src/data/ingredients/spices/warmSpices.ts
+++ b/src/data/ingredients/spices/warmSpices.ts
@@ -5,6 +5,7 @@ const rawWarmSpices = {
   cinnamon: {
       description: "A warm, sweet spice derived from the inner bark of trees (*Cinnamomum*). Cassia cinnamon is strong, spicy, and common in baking, while true \"Ceylon\" cinnamon is softer, more floral, and delicate; both provide a deep, aromatic warmth that enhances both sweet pastries and savory curries.",
     name: "Cinnamon",
+    season: ["all"],
     elementalProperties: { Fire: 0.7, Water: 0.0, Earth: 0.2, Air: 0.1 }, // ← Pattern GG-5: Added missing Water property
     astrologicalProfile: {
       planetaryRuler: "Sun",
@@ -38,7 +39,6 @@ const rawWarmSpices = {
       "cardamom",
       "ginger",
     ],
-    season: "winter",
     nutritionalProfile: {
       serving_size: "1 tsp ground",
       calories: 6,

--- a/src/data/ingredients/spices/wholespices.ts
+++ b/src/data/ingredients/spices/wholespices.ts
@@ -5,6 +5,7 @@ const rawWholeSpices = {
   star_anise: {
       description: "The star-shaped pericarp of a small evergreen tree (*Illicium verum*) native to Vietnam and southwest China. It is highly concentrated with anethole, providing an intensely sweet, pungent, licorice-like flavor that is crucial to Chinese five-spice powder and Vietnamese pho broth.",
     name: "Star Anise",
+    season: ["all"],
     elementalProperties: { Fire: 0.49, Water: 0.13, Earth: 0.13, Air: 0.25 },
     astrologicalProfile: {
       rulingPlanets: ["Saturn", "Mars"],
@@ -77,6 +78,7 @@ const rawWholeSpices = {
   cardamom_pods: {
       description: "A highly aromatic, resinous spice (*Elettaria cardamomum*) enclosed in small green or black pods. Green cardamom offers a complex, cooling, eucalyptus-and-citrus sweetness essential for Scandinavian baking and Indian sweets, while black cardamom is heavily smoked and deeply savory.",
     name: "Cardamom Pods",
+    season: ["all"],
     elementalProperties: { Air: 0.4, Fire: 0.3, Earth: 0.2, Water: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Mercury", "Venus"],
@@ -161,6 +163,7 @@ const rawWholeSpices = {
   mustard_seeds: {
       description: "Tiny, round seeds of various mustard plants (*Brassica* and *Sinapis*) available in yellow, brown, and black varieties. The seeds themselves have no heat until crushed and mixed with a cold liquid, which triggers an enzyme reaction creating the sharp, pungent compound allyl isothiocyanate.\n\n**Selection & Storage:** Yellow seeds are the mildest, while black and brown are much sharper and more pungent. Store whole seeds in an airtight container in a dark pantry, as they keep indefinitely.",
     name: "Mustard Seeds",
+    season: ["all"],
     elementalProperties: { Fire: 0.4, Air: 0.3, Earth: 0.2, Water: 0.1 },
     qualities: ["pungent", "hot", "nutty"],
     origin: ["India", "Canada", "Nepal"],
@@ -246,6 +249,7 @@ const rawWholeSpices = {
   fennel_seeds: {
       description: "The dried seeds of the fennel plant (*Foeniculum vulgare*), providing a highly aromatic, sweet, and warm licorice flavor. They are a crucial component of Chinese Five Spice, Indian Panch Phoron, and traditional sweet Italian sausages.",
     name: "Fennel Seeds",
+    season: ["all"],
     elementalProperties: { Air: 0.4, Fire: 0.3, Earth: 0.2, Water: 0.1 },
     qualities: ["sweet", "anise-like", "warming"],
     origin: ["India", "Mediterranean", "China"],
@@ -327,6 +331,7 @@ const rawWholeSpices = {
   coriander_seeds: {
       description: "The dried seeds of the cilantro plant (*Coriandrum sativum*), yielding a completely different flavor profile than its leaves. The seeds provide a warm, floral, and slightly citrusy sweetness that is a crucial balancing component in heavy, spicy curry blends and pickling brines.",
     name: "Coriander Seeds",
+    season: ["spring", "fall"],
     elementalProperties: { Air: 0.4, Earth: 0.3, Fire: 0.2, Water: 0.1 },
     qualities: ["citrusy", "nutty", "floral"],
     origin: ["India", "Morocco", "Eastern Europe"],
@@ -397,6 +402,7 @@ const rawWholeSpices = {
   cumin_seeds: {
       description: "A potent, earthy spice derived from the seeds of a parsley relative (*Cuminum cyminum*). When toasted, it releases powerful, warm, and slightly musky pyrazines that form the backbone of savory flavor profiles in Mexican, Indian, and Middle Eastern cuisines.",
     name: "Cumin Seeds",
+    season: ["all"],
     elementalProperties: { Earth: 0.4, Fire: 0.3, Air: 0.2, Water: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Mercury", "Saturn"],
@@ -478,6 +484,7 @@ const rawWholeSpices = {
   caraway_seeds: {
       description: "The dried, crescent-shaped fruit of a biennial plant (*Carum carvi*) in the parsley family. They provide a highly pungent, slightly sweet, and distinctively anise/licorice flavor profile that cuts through rich, fatty dishes, acting as the essential defining flavor of rye bread and sauerkraut.",
     name: "Caraway Seeds",
+    season: ["all"],
     elementalProperties: { Air: 0.4, Earth: 0.3, Fire: 0.2, Water: 0.1 },
     qualities: ["warming", "sharp", "slightly sweet"],
     origin: ["Netherlands", "Eastern Europe", "Finland"],

--- a/src/data/ingredients/vegetables/alliums.ts
+++ b/src/data/ingredients/vegetables/alliums.ts
@@ -310,6 +310,8 @@ const rawAlliums: Record<string, Partial<IngredientMapping>> = {
   onions: {
     description: "Foundational aromatics (*Allium cepa*) that build savory depth across global cuisines. Their concentric layers contain sulfur compounds which, under heat, undergo Maillard reactions to create complex flavors from sharp when raw to deeply caramel when slow-cooked. Yellow onions are the all-purpose workhorse for mirepoix and stocks; sweet varieties for raw eating; red for salads and quick pickles; pearl for whole-braising. Always use a sharp knife to minimize the enzymatic release that causes tears.",
     name: "onions",
+    origin: ["Central Asia", "Persia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.52,
@@ -350,6 +352,8 @@ const rawAlliums: Record<string, Partial<IngredientMapping>> = {
   yellow_onions: {
     description: "Foundational aromatics (*Allium cepa*) that build savory depth across global cuisines. Their concentric layers contain sulfur compounds which, under heat, undergo Maillard reactions to create complex flavors from sharp when raw to deeply caramel when slow-cooked. Yellow onions are the all-purpose workhorse for mirepoix and stocks; sweet varieties for raw eating; red for salads and quick pickles; pearl for whole-braising. Always use a sharp knife to minimize the enzymatic release that causes tears.",
     name: "yellow onions",
+    origin: ["Central Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.55,
@@ -375,6 +379,8 @@ const rawAlliums: Record<string, Partial<IngredientMapping>> = {
   pearl_onions: {
     description: "Foundational aromatics (*Allium cepa*) that build savory depth across global cuisines. Their concentric layers contain sulfur compounds which, under heat, undergo Maillard reactions to create complex flavors from sharp when raw to deeply caramel when slow-cooked. Yellow onions are the all-purpose workhorse for mirepoix and stocks; sweet varieties for raw eating; red for salads and quick pickles; pearl for whole-braising. Always use a sharp knife to minimize the enzymatic release that causes tears.",
     name: "pearl onions",
+    origin: ["Cultivated worldwide"],
+    season: ["varies by variety"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.40,
@@ -400,6 +406,8 @@ const rawAlliums: Record<string, Partial<IngredientMapping>> = {
   shallots: {
     description: "A small, teardrop-shaped allium (*Allium cepa var. aggregatum*) that grows in clusters similar to garlic. It offers a more delicate, sweeter, and less pungent flavor profile than standard onions, making it the classic choice for refined sauces, vinaigrettes, and raw applications.\n\n**Selection & Storage:** Look for firm, heavy bulbs with intact, coppery-pink papery skins. Keep them in a cool, dry, and dark environment with good air circulation to maximize their shelf life.",
     name: "shallots",
+    origin: ["Central Asia"],
+    season: ["summer", "fall"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.45,
@@ -425,6 +433,8 @@ const rawAlliums: Record<string, Partial<IngredientMapping>> = {
   green_onions: {
     description: "Foundational aromatics (*Allium cepa*) that build savory depth across global cuisines. Their concentric layers contain sulfur compounds which, under heat, undergo Maillard reactions to create complex flavors from sharp when raw to deeply caramel when slow-cooked. Yellow onions are the all-purpose workhorse for mirepoix and stocks; sweet varieties for raw eating; red for salads and quick pickles; pearl for whole-braising. Always use a sharp knife to minimize the enzymatic release that causes tears.",
     name: "green onions",
+    origin: ["China"],
+    season: ["spring", "summer"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.35,
@@ -450,6 +460,8 @@ const rawAlliums: Record<string, Partial<IngredientMapping>> = {
   yellow_onion: {
     description: "A foundational aromatic (*Allium cepa*) that builds savory depth in nearly every global cuisine. Its concentric layers contain sulfur compounds which, when exposed to heat, undergo Maillard reaction to create sweet, complex flavors ranging from sharp when raw to deeply caramel when slow-cooked. Yellow is the all-purpose workhorse; sweet (Vidalia, Walla Walla) for quick raw use; red for salads and pickling; pearl and cipollini for whole-roasting. Slice with a sharp blade to minimize enzymatic tear-gas release.",
     name: "yellow onion",
+    origin: ["Central Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.55,
@@ -475,6 +487,8 @@ const rawAlliums: Record<string, Partial<IngredientMapping>> = {
   red_onion: {
     description: "A foundational aromatic (*Allium cepa*) that builds savory depth in nearly every global cuisine. Its concentric layers contain sulfur compounds which, when exposed to heat, undergo Maillard reaction to create sweet, complex flavors ranging from sharp when raw to deeply caramel when slow-cooked. Yellow is the all-purpose workhorse; sweet (Vidalia, Walla Walla) for quick raw use; red for salads and pickling; pearl and cipollini for whole-roasting. Slice with a sharp blade to minimize enzymatic tear-gas release.",
     name: "red onion",
+    origin: ["Central Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.50,

--- a/src/data/ingredients/vegetables/cruciferous.ts
+++ b/src/data/ingredients/vegetables/cruciferous.ts
@@ -5,6 +5,7 @@ const rawCruciferous: Record<string, Partial<IngredientMapping>> = {
   cauliflower: {
       description: "A versatile, mildly sweet cruciferous vegetable (*Brassica oleracea var. botrytis*) composed of undeveloped flower buds. Its neutral flavor and dense structure make it a culinary chameleon, easily absorbing strong spices, roasting to a nutty caramelization, or pureeing into a creamy, starch-free mash.",
     name: "Cauliflower",
+    origin: ["Cultivated worldwide"],
 
     // Base elemental properties (unscaled)
     elementalProperties: { Air: 0.4, Earth: 0.3, Water: 0.2, Fire: 0.1 },
@@ -238,6 +239,8 @@ const rawCruciferous: Record<string, Partial<IngredientMapping>> = {
   cabbage: {
       description: "A tightly packed, leafy biennial (*Brassica oleracea*) that is a cornerstone of global preservation through fermentation (like sauerkraut and kimchi). Rich in sulfur compounds, it transforms from crisp and peppery when raw to profoundly sweet and tender when slowly braised or roasted.",
     name: "cabbage",
+    origin: ["Cultivated worldwide"],
+    season: ["varies by variety"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     qualities: ["crunchy", "mild", "versatile"],
     category: "vegetable",
@@ -271,6 +274,8 @@ const rawCruciferous: Record<string, Partial<IngredientMapping>> = {
   napa_cabbage: {
       description: "A tightly packed, leafy biennial (*Brassica oleracea*) that is a cornerstone of global preservation through fermentation (like sauerkraut and kimchi). Rich in sulfur compounds, it transforms from crisp and peppery when raw to profoundly sweet and tender when slowly braised or roasted.\n\n**Selection & Storage:** Select heads that feel heavy for their size with tight, unblemished outer leaves. Whole cabbage is remarkably resilient and can be stored loose in the crisper drawer for several weeks.",
     name: "napa cabbage",
+    origin: ["China (Beijing region)"],
+    season: ["fall", "winter"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     qualities: ["nutritious", "versatile", "fresh"],
     category: "vegetable",

--- a/src/data/ingredients/vegetables/fungi.ts
+++ b/src/data/ingredients/vegetables/fungi.ts
@@ -5,6 +5,8 @@ const rawFungi: Record<string, Partial<IngredientMapping>> = {
   mushrooms: {
       description: "The fleshy, spore-bearing fruiting body of a fungus (e.g., *Agaricus bisporus*). They are composed largely of chitin and water, and contain immense amounts of glutamate, lending a profoundly deep, savory, and meaty umami flavor to dishes, especially when roasted or sautéed until deeply browned.\n\n**Selection & Storage:** Select firm, dry mushrooms without slimy spots or excessive bruising. Store them in a paper bag in the main compartment of the refrigerator, as plastic traps moisture and accelerates rot.",
     name: "mushrooms",
+    origin: ["Cultivated worldwide"],
+    season: ["varies by variety"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.35,
@@ -29,6 +31,8 @@ const rawFungi: Record<string, Partial<IngredientMapping>> = {
   cremini_mushrooms: {
       description: "The adolescent stage of the *Agaricus bisporus* mushroom (between a white button and a mature portobello). They are light brown, firmer than white buttons, and offer a deeper, more pronounced earthy flavor, making them an excellent, versatile upgrade for sautés and stews.\n\n**Selection & Storage:** Choose firm mushrooms with tightly closed caps (where the veil completely covers the gills). Store unwashed in a paper bag in the refrigerator.",
     name: "cremini mushrooms",
+    origin: ["Europe", "North America"],
+    season: ["fall", "winter"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.30,

--- a/src/data/ingredients/vegetables/leafyGreens.ts
+++ b/src/data/ingredients/vegetables/leafyGreens.ts
@@ -267,6 +267,7 @@ const rawLeafyGreens: Record<string, Partial<IngredientMapping>> = {
   "swiss chard": {
       description: "Swiss Chard is a vegetable ingredient that contributes structure, micronutrients, and a broad range of textures depending on cut and heat level. High heat emphasizes caramelization and sweetness, while gentle cooking preserves water content and delicate notes. Prep consistently so pieces cook evenly and integrate cleanly into the dish.",
     name: "Swiss chard",
+    origin: ["Mediterranean", "Sicily"],
     elementalProperties: { Water: 0.39, Earth: 0.33, Air: 0.21, Fire: 0.07 },
     astrologicalProfile: {
       rulingPlanets: ["Venus", "Saturn"],
@@ -310,6 +311,8 @@ const rawLeafyGreens: Record<string, Partial<IngredientMapping>> = {
   lettuce: {
       description: "A leafy herbaceous plant (*Lactuca sativa*), primarily cultivated for its crisp, hydrating leaves. Iceberg and romaine varieties provide high water content and structural crunch that resists wilting under heavy dressings, while butterhead and loose-leaf types offer delicate, tender textures. Although typically consumed raw in salads or as a cooling counterpoint in sandwiches, hearty varieties like romaine can be lightly grilled or braised to develop surprising smoky depth.",
     name: "lettuce",
+    origin: ["Cultivated worldwide"],
+    season: ["varies by variety"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     qualities: ["nutritious", "versatile", "fresh"],
     category: "vegetable",
@@ -328,6 +331,8 @@ const rawLeafyGreens: Record<string, Partial<IngredientMapping>> = {
   romaine_lettuce: {
       description: "A leafy herbaceous plant (*Lactuca sativa*), primarily cultivated for its crisp, hydrating leaves. Iceberg and romaine varieties provide high water content and structural crunch that resists wilting under heavy dressings, while butterhead and loose-leaf types offer delicate, tender textures. Although typically consumed raw in salads or as a cooling counterpoint in sandwiches, hearty varieties like romaine can be lightly grilled or braised to develop surprising smoky depth.",
     name: "romaine lettuce",
+    origin: ["Mediterranean"],
+    season: ["spring", "fall"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     qualities: ["nutritious", "versatile", "fresh"],
     category: "vegetable",
@@ -346,6 +351,8 @@ const rawLeafyGreens: Record<string, Partial<IngredientMapping>> = {
   lettuce_leaves: {
       description: "A leafy herbaceous plant (*Lactuca sativa*), primarily cultivated for its crisp, hydrating leaves. Iceberg and romaine varieties provide high water content and structural crunch that resists wilting under heavy dressings, while butterhead and loose-leaf types offer delicate, tender textures. Although typically consumed raw in salads or as a cooling counterpoint in sandwiches, hearty varieties like romaine can be lightly grilled or braised to develop surprising smoky depth.",
     name: "lettuce leaves",
+    origin: ["Cultivated worldwide"],
+    season: ["varies by variety"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     qualities: ["nutritious", "versatile", "fresh"],
     category: "vegetable",

--- a/src/data/ingredients/vegetables/legumes.ts
+++ b/src/data/ingredients/vegetables/legumes.ts
@@ -5,6 +5,8 @@ const rawLegumes: Record<string, Partial<IngredientMapping>> = {
   chickpeas: {
       description: "Also known as garbanzo beans (*Cicer arietinum*), these versatile legumes maintain a firm, meaty texture even after long cooking. Their mild, nutty flavor and high starch-to-protein ratio make them ideal for blending into creamy hummus, roasting until crispy, or bulking up stews.",
     name: "chickpeas",
+    origin: ["Western Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.12,
@@ -51,6 +53,8 @@ const rawLegumes: Record<string, Partial<IngredientMapping>> = {
   dried_chickpeas: {
       description: "Also known as garbanzo beans (*Cicer arietinum*), these versatile legumes maintain a firm, meaty texture even after long cooking. Their mild, nutty flavor and high starch-to-protein ratio make them ideal for blending into creamy hummus, roasting until crispy, or bulking up stews.\n\n**Selection & Storage:** Dried chickpeas should be uniform in color and unbroken. Store dried beans in an airtight container in a dark pantry; canned chickpeas should be stored at room temperature until opened.",
     name: "dried chickpeas",
+    origin: ["Western Asia"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.10,
@@ -75,6 +79,8 @@ const rawLegumes: Record<string, Partial<IngredientMapping>> = {
   peanuts: {
       description: "Botanically a legume but culinary treated as a nut (*Arachis hypogaea*), peanuts grow underground. They boast a high fat and protein content that, when roasted, develops complex pyrazines—yielding a deeply savory, universally appealing flavor ideal for both sweet baked goods and savory Asian sauces.\n\n**Selection & Storage:** If buying in the shell, look for clean, unblemished pods that feel heavy. Because of their high oil content, shelled peanuts should be stored in an airtight container in the refrigerator to prevent rancidity.",
     name: "peanuts",
+    origin: ["Cultivated worldwide"],
+    season: ["varies by variety"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.14,
@@ -99,6 +105,8 @@ const rawLegumes: Record<string, Partial<IngredientMapping>> = {
   crushed_peanuts: {
       description: "Botanically a legume but culinary treated as a nut (*Arachis hypogaea*), peanuts grow underground. They boast a high fat and protein content that, when roasted, develops complex pyrazines—yielding a deeply savory, universally appealing flavor ideal for both sweet baked goods and savory Asian sauces.\n\n**Selection & Storage:** If buying in the shell, look for clean, unblemished pods that feel heavy. Because of their high oil content, shelled peanuts should be stored in an airtight container in the refrigerator to prevent rancidity.",
     name: "crushed peanuts",
+    origin: ["Cultivated worldwide"],
+    season: ["varies by variety"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.14,

--- a/src/data/ingredients/vegetables/nightshades.ts
+++ b/src/data/ingredients/vegetables/nightshades.ts
@@ -307,6 +307,7 @@ const rawNightshades: Record<string, Partial<IngredientMapping>> = {
   eggplant: {
       description: "A spongy, absorbent nightshade fruit (*Solanum melongena*) with a slightly bitter, complex flavor and a texture that ranges from meaty to silkily creamy when cooked. Its cellular structure acts like a sponge, readily soaking up cooking oils and rich sauces in dishes like curries and parmigianas.",
     name: "eggplant",
+    origin: ["South Asia (India)"],
     category: "vegetable",
     subcategory: "nightshade",
     elementalProperties: { Water: 0.4, Air: 0.3, Earth: 0.2, Fire: 0.1 },
@@ -349,6 +350,8 @@ const rawNightshades: Record<string, Partial<IngredientMapping>> = {
   tomato_paste: {
       description: "The fruit of *Solanum lycopersicum*, botanically a berry, culinarily a vegetable — packed with glutamic acid that makes it the umami champion among garden produce. Flavor peaks when fully ripe and at room temperature; refrigeration below 55°F permanently damages aromatic compounds. Paste and plum varieties reduce into sauces; beefsteak and heirloom eat best raw; cherry and grape tomatoes caramelize whole. Sun-dried tomatoes concentrate sweetness and umami dramatically; rehydrate in warm water or oil.",
     name: "tomato paste",
+    origin: ["Western South America", "Mesoamerica"],
+    season: ["summer"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.40,
@@ -389,6 +392,8 @@ const rawNightshades: Record<string, Partial<IngredientMapping>> = {
   cherry_tomatoes: {
       description: "The fruit of *Solanum lycopersicum*, botanically a berry, culinarily a vegetable — packed with glutamic acid that makes them the umami champion among garden produce. Flavor peaks when fully ripe and at room temperature; refrigeration below 55°F permanently damages aromatic compounds. Paste and plum varieties reduce well into sauces; beefsteak and heirloom eat best raw; cherry and grape tomatoes caramelize beautifully whole. Salt sliced tomatoes 20 min before serving to draw out water and concentrate flavor.",
     name: "cherry tomatoes",
+    origin: ["South America"],
+    season: ["summer"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.32,
@@ -414,6 +419,8 @@ const rawNightshades: Record<string, Partial<IngredientMapping>> = {
   tomato_sauce: {
       description: "The fruit of *Solanum lycopersicum*, botanically a berry, culinarily a vegetable — packed with glutamic acid that makes it the umami champion among garden produce. Flavor peaks when fully ripe and at room temperature; refrigeration below 55°F permanently damages aromatic compounds. Paste and plum varieties reduce into sauces; beefsteak and heirloom eat best raw; cherry and grape tomatoes caramelize whole. Sun-dried tomatoes concentrate sweetness and umami dramatically; rehydrate in warm water or oil.",
     name: "tomato sauce",
+    origin: ["Western South America", "Mesoamerica"],
+    season: ["summer"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.28,
@@ -439,6 +446,8 @@ const rawNightshades: Record<string, Partial<IngredientMapping>> = {
   eggplants: {
       description: "A spongy, absorbent nightshade fruit (*Solanum melongena*) with a slightly bitter, complex flavor and a texture that ranges from meaty to silkily creamy when cooked. Its cellular structure acts like a sponge, readily soaking up cooking oils and rich sauces in dishes like curries and parmigianas.\n\n**Selection & Storage:** Select eggplants with smooth, shiny, deeply colored skin that feel heavy for their size; the stem should be bright green. They are sensitive to both heat and extreme cold; store in a cool, dark place or in the crisper drawer for only a few days.",
     name: "eggplants",
+    origin: ["South Asia (India)"],
+    season: ["summer", "fall"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.10,
@@ -464,6 +473,8 @@ const rawNightshades: Record<string, Partial<IngredientMapping>> = {
   large_eggplant: {
       description: "A spongy, absorbent nightshade fruit (*Solanum melongena*) with a slightly bitter, complex flavor and a texture that ranges from meaty to silkily creamy when cooked. Its cellular structure acts like a sponge, readily soaking up cooking oils and rich sauces in dishes like curries and parmigianas.\n\n**Selection & Storage:** Select eggplants with smooth, shiny, deeply colored skin that feel heavy for their size; the stem should be bright green. They are sensitive to both heat and extreme cold; store in a cool, dark place or in the crisper drawer for only a few days.",
     name: "large eggplant",
+    origin: ["South Asia (India)"],
+    season: ["summer", "fall"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.10,
@@ -489,6 +500,8 @@ const rawNightshades: Record<string, Partial<IngredientMapping>> = {
   tomatoes: {
       description: "The fruit of *Solanum lycopersicum*, botanically a berry, culinarily a vegetable — packed with glutamic acid that makes them the umami champion among garden produce. Flavor peaks when fully ripe and at room temperature; refrigeration below 55°F permanently damages aromatic compounds. Paste and plum varieties reduce well into sauces; beefsteak and heirloom eat best raw; cherry and grape tomatoes caramelize beautifully whole. Salt sliced tomatoes 20 min before serving to draw out water and concentrate flavor.",
     name: "tomatoes",
+    origin: ["South America"],
+    season: ["summer"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.30,
@@ -514,6 +527,8 @@ const rawNightshades: Record<string, Partial<IngredientMapping>> = {
   bell_peppers: {
       description: "A sweet, non-spicy fruit of the capsicum family (*Capsicum annuum*) that is botanically a berry but treated as a culinary vegetable. Green peppers are harvested early and taste grassy and slightly bitter, while red, yellow, and orange varieties are fully ripe, offering a fruity sweetness and high Vitamin C content.\n\n**Selection & Storage:** Choose peppers that are firm, heavy for their size, and boast smooth, taut, brightly colored skin without soft spots. Store them unwashed in the crisper drawer, where they will last for a week to ten days.",
     name: "bell peppers",
+    origin: ["Central and South America"],
+    season: ["summer", "fall"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.22,
@@ -554,6 +569,8 @@ const rawNightshades: Record<string, Partial<IngredientMapping>> = {
   green_peppers: {
       description: "Green Peppers is a vegetable ingredient that contributes structure, micronutrients, and a broad range of textures depending on cut and heat level. High heat emphasizes caramelization and sweetness, while gentle cooking preserves water content and delicate notes. Prep consistently so pieces cook evenly and integrate cleanly into the dish.",
     name: "green peppers",
+    origin: ["South India"],
+    season: ["all"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.22,

--- a/src/data/ingredients/vegetables/otherVegetables.ts
+++ b/src/data/ingredients/vegetables/otherVegetables.ts
@@ -160,6 +160,7 @@ const rawOtherVegetables: Record<string, Partial<IngredientMapping>> = {
   artichoke: {
       description: "The large, unopened flower bud of a thistle plant (*Cynara cardunculus*). Harvesting the tender, meaty 'heart' requires navigating tough, fibrous outer leaves and a fuzzy 'choke.' They contain cynarin, a unique compound that inhibits sweet receptors on the tongue, making water and subsequently eaten foods taste artificially sweet.",
     name: "artichoke",
+    origin: ["Mediterranean (North Africa)"],
     elementalProperties: {
       Fire: 0.1,
       Water: 0.7,
@@ -192,6 +193,7 @@ const rawOtherVegetables: Record<string, Partial<IngredientMapping>> = {
   cucumber: {
       description: "A cylindrical, water-dense fruit (*Cucumis sativus*) eaten as a culinary vegetable. Composed of over 95% water, cucumbers provide essential crispness, hydration, and a cooling, melon-like aroma to salads, cold soups, and pickles. English and Persian varieties are bred to have thin, edible skins and fewer seeds, whereas standard slicing cucumbers have thicker, waxy skins that often benefit from peeling. Salting them before use draws out excess water and concentrates their flavor.",
     name: "cucumber",
+    origin: ["South Asia (India)"],
     elementalProperties: {
       Fire: 0.1,
       Water: 0.8,
@@ -227,6 +229,7 @@ const rawOtherVegetables: Record<string, Partial<IngredientMapping>> = {
   okra: {
       description: "A warm-season vegetable (*Abelmoschus esculentus*) known for its edible green seed pods. It is famous (or infamous) for its mucilaginous interior, which naturally thickens complex stews like gumbo; high-heat applications like deep-frying or roasting effectively eliminate this slick texture while retaining a mild, grassy flavor.",
     name: "okra",
+    origin: ["Africa (Ethiopia region)"],
     elementalProperties: {
       Fire: 0.2,
       Water: 0.3,
@@ -259,6 +262,7 @@ const rawOtherVegetables: Record<string, Partial<IngredientMapping>> = {
   zucchini: {
       description: "A fast-growing summer squash (*Cucurbita pepo*) with a thin, edible dark green skin and high water content. Its mild, slightly sweet flavor makes it highly versatile, suitable for raw ribbons in salads, quick sautéing, or baking into moist breads.",
     name: "zucchini",
+    origin: ["Mesoamerica", "Italy (modern variety)"],
     elementalProperties: {
       Fire: 0.1,
       Water: 0.7,
@@ -291,6 +295,7 @@ const rawOtherVegetables: Record<string, Partial<IngredientMapping>> = {
   fennel: {
       description: "A bulbous, layered vegetable (*Foeniculum vulgare*) of the carrot family with feathery fronds. It offers a crisp texture and a sweet, distinctively anise or licorice-like flavor that mellows and caramelizes beautifully when braised or roasted, pairing exceptionally well with seafood.",
     name: "fennel",
+    origin: ["Mediterranean"],
     elementalProperties: {
       Fire: 0.1,
       Water: 0.3,
@@ -323,6 +328,8 @@ const rawOtherVegetables: Record<string, Partial<IngredientMapping>> = {
   celery: {
       description: "A crunchy, fibrous marshland plant (*Apium graveolens*) known for its high water content and distinctively vegetal, slightly salty flavor. As a core component of the classic French mirepoix and Cajun holy trinity, it provides essential aromatic depth to stocks, soups, and braises.",
     name: "celery",
+    origin: ["Mediterranean"],
+    season: ["summer", "fall"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.15,
@@ -347,6 +354,8 @@ const rawOtherVegetables: Record<string, Partial<IngredientMapping>> = {
   peas: {
       description: "Small, spherical, sweet seeds (*Pisum sativum*) grown inside a pod. Garden peas (or English peas) are shelled for their starchy, incredibly sweet interior, which degrades rapidly into bland starches after picking, making frozen peas generally superior to out-of-season fresh ones.\n\n**Selection & Storage:** For fresh peas, choose firm, bright green, and plump pods. Keep unwashed pods in a perforated plastic bag in the refrigerator and shell them immediately before use.",
     name: "peas",
+    origin: ["Mediterranean"],
+    season: ["spring"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.14,
@@ -371,6 +380,8 @@ const rawOtherVegetables: Record<string, Partial<IngredientMapping>> = {
   fresh_peas: {
       description: "Small, spherical, sweet seeds (*Pisum sativum*) grown inside a pod. Garden peas (or English peas) are shelled for their starchy, incredibly sweet interior, which degrades rapidly into bland starches after picking, making frozen peas generally superior to out-of-season fresh ones.\n\n**Selection & Storage:** For fresh peas, choose firm, bright green, and plump pods. Keep unwashed pods in a perforated plastic bag in the refrigerator and shell them immediately before use.",
     name: "fresh peas",
+    origin: ["Mediterranean"],
+    season: ["spring"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.14,
@@ -395,6 +406,8 @@ const rawOtherVegetables: Record<string, Partial<IngredientMapping>> = {
   sweet_corn: {
       description: "A large grain plant (*Zea mays*) primarily consumed as a sweet vegetable when picked young (sweet corn). Its kernels are packed with natural sugars that immediately begin converting to complex starches upon harvesting, which is why fresh, seasonal corn has an unparalleled, milky sweetness.\n\n**Selection & Storage:** Look for husks that are bright green and tightly wrapped, with pale, slightly sticky silk. Eat as soon as possible after purchasing, storing unhusked in the refrigerator in the meantime.",
     name: "sweet corn",
+    origin: ["Mesoamerica"],
+    season: ["summer"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.14,
@@ -419,6 +432,8 @@ const rawOtherVegetables: Record<string, Partial<IngredientMapping>> = {
   corn_on_the_cob: {
       description: "A large grain plant (*Zea mays*) primarily consumed as a sweet vegetable when picked young (sweet corn). Its kernels are packed with natural sugars that immediately begin converting to complex starches upon harvesting, which is why fresh, seasonal corn has an unparalleled, milky sweetness.\n\n**Selection & Storage:** Look for husks that are bright green and tightly wrapped, with pale, slightly sticky silk. Eat as soon as possible after purchasing, storing unhusked in the refrigerator in the meantime.",
     name: "corn on the cob",
+    origin: ["Mesoamerica"],
+    season: ["summer"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.14,
@@ -443,6 +458,8 @@ const rawOtherVegetables: Record<string, Partial<IngredientMapping>> = {
   green_beans: {
       description: "Also known as string beans or snap beans (*Phaseolus vulgaris*), these are unripe, tender pods enclosing small, immature seeds. They have a fresh, grassy sweetness and a firm snap that is best preserved through quick cooking methods like blanching or stir-frying.\n\n**Selection & Storage:** Look for vibrant green beans that snap cleanly when bent. Store them unwashed in a plastic bag or container in the crisper drawer for up to a week.",
     name: "green beans",
+    origin: ["Central and South America"],
+    season: ["summer"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.15,

--- a/src/data/ingredients/vegetables/rootVegetables.ts
+++ b/src/data/ingredients/vegetables/rootVegetables.ts
@@ -5,6 +5,7 @@ const rawRootVegetables = {
   "sweet potato": {
       description: "Sweet Potato is a vegetable ingredient that contributes structure, micronutrients, and a broad range of textures depending on cut and heat level. High heat emphasizes caramelization and sweetness, while gentle cooking preserves water content and delicate notes. Prep consistently so pieces cook evenly and integrate cleanly into the dish.",
     name: "Sweet potato",
+    origin: ["Central and South America"],
 
     // Base elemental properties (unscaled)
     elementalProperties: { Earth: 0.5, Fire: 0.3, Water: 0.1, Air: 0.1 },
@@ -65,6 +66,7 @@ const rawRootVegetables = {
   parsnip: {
       description: "A pale, cream-colored root vegetable (*Pastinaca sativa*) closely related to the carrot. It is profoundly starchy and packs an intense, woody sweetness with distinct notes of nutmeg and spiced cider, making it ideal for roasting until deeply caramelized.",
     name: "Parsnip",
+    origin: ["Eurasia"],
     elementalProperties: { Earth: 0.5, Air: 0.2, Fire: 0.2, Water: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Mercury", "Saturn"],
@@ -106,6 +108,7 @@ const rawRootVegetables = {
   beet: {
       description: "An earthy, vividly colored root vegetable (*Beta vulgaris*) rich in natural sugars and betalains, the antioxidant pigments responsible for its deep red-purple hue. Its earthy flavor is due to geosmin, an organic compound that pairs exceptionally well with bright acids and rich dairy.",
     name: "Beet",
+    origin: ["Mediterranean", "North Africa"],
     elementalProperties: { Earth: 0.6, Fire: 0.2, Water: 0.1, Air: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Saturn", "Mars"],
@@ -148,6 +151,7 @@ const rawRootVegetables = {
   turnip: {
       description: "A round, white root vegetable with a purple top (*Brassica rapa*) belonging to the mustard family. It has a crisp texture and a mild, slightly peppery, cabbage-like flavor that sweetens when cooked, making it an excellent, low-starch alternative to potatoes in purees and stews.",
     name: "Turnip",
+    origin: ["Central Asia", "Mediterranean"],
     elementalProperties: { Earth: 0.4, Water: 0.3, Air: 0.2, Fire: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Saturn", "Moon"],

--- a/src/data/ingredients/vegetables/roots.ts
+++ b/src/data/ingredients/vegetables/roots.ts
@@ -5,6 +5,7 @@ const rawRootVegetables: Record<string, Partial<IngredientMapping>> = {
   heirloom_carrot: {
       description: "A sweet, crunchy root vegetable (*Daucus carota*) renowned for its high beta-carotene content, which the body converts into Vitamin A. Its natural sugars concentrate during roasting or caramelizing, making it a versatile foundational ingredient for mirepoix and sweet baking alike. Look for firm, brightly colored carrots with smooth skin; if green tops are attached, they should be fresh and vibrant. Remove tops before storing — they draw moisture from the root — and keep in plastic in the crisper drawer up to three weeks.",
     name: "Heirloom Carrot",
+    origin: ["Persia (Afghanistan region)"],
     elementalProperties: { Earth: 0.5, Fire: 0.3, Water: 0.1, Air: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Venus", "Saturn"],
@@ -42,6 +43,7 @@ const rawRootVegetables: Record<string, Partial<IngredientMapping>> = {
   black_radish: {
       description: "A large, winter root vegetable (*Raphanus sativus var. niger*) with a tough, coal-black exterior and a stark white interior. It possesses a remarkably sharp, aggressively spicy, and pungent bite when raw, which mellows dramatically into a sweet, earthy flavor when roasted or braised.",
     name: "Black Radish",
+    origin: ["China", "Southeast Asia"],
     elementalProperties: { Earth: 0.6, Fire: 0.25, Air: 0.1, Water: 0.05 },
     astrologicalProfile: {
       rulingPlanets: ["Saturn", "Mars"],
@@ -223,6 +225,7 @@ const rawRootVegetables: Record<string, Partial<IngredientMapping>> = {
   ginger: {
       description: "A knobby, fibrous rhizome (*Zingiber officinale*) prized for its warm, spicy, and slightly citrusy bite. The active compound gingerol provides its signature sharp heat, which mellows and deepens into a warming aromatic when cooked.",
     name: "Ginger",
+    origin: ["Maritime Southeast Asia"],
     elementalProperties: { Fire: 0.6, Earth: 0.2, Air: 0.1, Water: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Mars", "Sun"],
@@ -260,6 +263,7 @@ const rawRootVegetables: Record<string, Partial<IngredientMapping>> = {
   jerusalem_artichoke: {
       description: "Also known as a sunchoke, this lumpy tuber (*Helianthus tuberosus*) is actually the root of a species of sunflower. It provides a sweet, intensely nutty flavor and a texture that ranges from water-chestnut crunchy when raw, to remarkably creamy and silken when roasted or pureed.",
     name: "Jerusalem Artichoke",
+    origin: ["Mediterranean (North Africa)"],
     elementalProperties: { Earth: 0.55, Water: 0.25, Air: 0.1, Fire: 0.1 },
     astrologicalProfile: {
       rulingPlanets: ["Venus", "Moon"],
@@ -297,6 +301,8 @@ const rawRootVegetables: Record<string, Partial<IngredientMapping>> = {
   carrots: {
       description: "A sweet, crunchy root vegetable (*Daucus carota*) renowned for its high beta-carotene content, which the body converts into Vitamin A. Its natural sugars concentrate during roasting or caramelizing, making it a versatile foundational ingredient for mirepoix and sweet baking alike. Look for firm, brightly colored carrots with smooth skin; if green tops are attached, they should be fresh and vibrant. Remove tops before storing — they draw moisture from the root — and keep in plastic in the crisper drawer up to three weeks.",
     name: "carrots",
+    origin: ["Persia"],
+    season: ["fall", "winter", "spring"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     qualities: ["nutritious", "versatile", "fresh"],
     category: "vegetable",
@@ -315,6 +321,8 @@ const rawRootVegetables: Record<string, Partial<IngredientMapping>> = {
   parsnips: {
       description: "A pale, cream-colored root vegetable (*Pastinaca sativa*) closely related to the carrot. It is profoundly starchy and packs an intense, woody sweetness with distinct notes of nutmeg and spiced cider, making it ideal for roasting until deeply caramelized.\n\n**Selection & Storage:** Choose small to medium parsnips; very large ones often have a tough, woody core that must be removed. Store unwashed in a plastic bag in the refrigerator.",
     name: "parsnips",
+    origin: ["Eurasia"],
+    season: ["fall", "winter"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     qualities: ["nutritious", "versatile", "fresh"],
     category: "vegetable",

--- a/src/data/ingredients/vegetables/squash.ts
+++ b/src/data/ingredients/vegetables/squash.ts
@@ -5,6 +5,7 @@ const rawSquash = {
   "butternut squash": {
       description: "Butternut Squash is a vegetable ingredient that contributes structure, micronutrients, and a broad range of textures depending on cut and heat level. High heat emphasizes caramelization and sweetness, while gentle cooking preserves water content and delicate notes. Prep consistently so pieces cook evenly and integrate cleanly into the dish.",
     name: "Butternut squash",
+    origin: ["North America", "Mesoamerica"],
     elementalProperties: {
       Earth: 0.4,
       Water: 0.3,
@@ -75,6 +76,7 @@ const rawSquash = {
   zucchini: {
       description: "A fast-growing summer squash (*Cucurbita pepo*) with a thin, edible dark green skin and high water content. Its mild, slightly sweet flavor makes it highly versatile, suitable for raw ribbons in salads, quick sautéing, or baking into moist breads.",
     name: "zucchini",
+    origin: ["Mesoamerica", "Italy (modern variety)"],
     elementalProperties: {
       Fire: 0.4204917086683852,
       Water: 0.5121388172829056,
@@ -132,6 +134,7 @@ const rawSquash = {
   pumpkin: {
       description: "A large, thick-skinned winter squash (*Cucurbita pepo*) prized for its sweet, earthy flesh and edible seeds. While large field pumpkins are bred for carving, smaller \"sugar\" or \"pie\" pumpkins have dense, less watery flesh ideal for roasting, pureeing, and baking.",
     name: "Pumpkin",
+    origin: ["North America"],
     elementalProperties: {
       Earth: 0.5,
       Water: 0.2,
@@ -202,6 +205,7 @@ const rawSquash = {
   "acorn squash": {
       description: "Acorn Squash is a vegetable ingredient that contributes structure, micronutrients, and a broad range of textures depending on cut and heat level. High heat emphasizes caramelization and sweetness, while gentle cooking preserves water content and delicate notes. Prep consistently so pieces cook evenly and integrate cleanly into the dish.",
     name: "Acorn squash",
+    origin: ["North America"],
     elementalProperties: {
       Earth: 0.4,
       Water: 0.3,

--- a/src/data/ingredients/vegetables/starchy.ts
+++ b/src/data/ingredients/vegetables/starchy.ts
@@ -5,6 +5,8 @@ const rawStarchy: Record<string, Partial<IngredientMapping>> = {
   potatoes: {
       description: "A starchy, energy-dense tuber (*Solanum tuberosum*) that serves as a global culinary staple. The culinary application depends on the starch content: high-starch varieties (like Russets) are fluffy and ideal for mashing or frying, while waxy varieties (like red potatoes) hold their shape for boiling and salads.\n\n**Selection & Storage:** Select potatoes that are firm and unyielding, avoiding any with green tinges (indicating solanine buildup) or sprouting eyes. Store in a cool, dark, and dry place; refrigerating potatoes converts their starches to sugars, altering their texture and taste.",
     name: "potatoes",
+    origin: ["Andes"],
+    season: ["fall", "winter"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.05,
@@ -29,6 +31,8 @@ const rawStarchy: Record<string, Partial<IngredientMapping>> = {
   potato: {
       description: "A starchy, energy-dense tuber (*Solanum tuberosum*) that serves as a global culinary staple. The culinary application depends on the starch content: high-starch varieties (like Russets) are fluffy and ideal for mashing or frying, while waxy varieties (like red potatoes) hold their shape for boiling and salads.",
     name: "potato",
+    origin: ["Andes (Peru, Bolivia)"],
+    season: ["fall", "winter"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.05,
@@ -53,6 +57,8 @@ const rawStarchy: Record<string, Partial<IngredientMapping>> = {
   russet_potatoes: {
       description: "Russet Potatoes is a vegetable ingredient that contributes structure, micronutrients, and a broad range of textures depending on cut and heat level. High heat emphasizes caramelization and sweetness, while gentle cooking preserves water content and delicate notes. Prep consistently so pieces cook evenly and integrate cleanly into the dish.",
     name: "russet potatoes",
+    origin: ["Andes"],
+    season: ["fall", "winter"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.05,
@@ -77,6 +83,8 @@ const rawStarchy: Record<string, Partial<IngredientMapping>> = {
   sweet_potato: {
       description: "A naturally sweet, nutrient-dense root vegetable (*Ipomoea batatas*) packed with complex carbohydrates and vibrant orange beta-carotene. Its flesh becomes remarkably creamy and intensely sweet when baked or roasted, as its enzymes break down starches into maltose.",
     name: "sweet potato",
+    origin: ["Central and South America"],
+    season: ["fall", "winter"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.10,
@@ -101,6 +109,8 @@ const rawStarchy: Record<string, Partial<IngredientMapping>> = {
   potato_starch: {
       description: "A fine white powder extracted from crushed potatoes. It is prized in European baking to keep sponges tender and moist, and in Asian cooking to create a shatteringly crisp, glass-like coating on deep-fried foods (like Japanese Karaage) that stays crunchy longer than wheat flour.",
     name: "potato starch",
+    origin: ["Andes (Peru, Bolivia)"],
+    season: ["fall", "winter"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.02,
@@ -125,6 +135,8 @@ const rawStarchy: Record<string, Partial<IngredientMapping>> = {
   sweet_potato_noodles: {
       description: "A broad category of unleavened dough stretched, rolled, or cut into long, thin strips, prevalent in Asian cuisines. Unlike Italian pasta, which is almost exclusively wheat-based, Asian noodles are often made from rice, mung beans, sweet potatoes, or buckwheat, dramatically altering their cooking times and chewy textures.\n\n**Selection & Storage:** Dried rice or glass noodles require only a quick soak in hot water, while fresh wheat noodles require boiling. Store dried noodles in the pantry, and keep fresh noodles tightly wrapped in the refrigerator.",
     name: "sweet potato noodles",
+    origin: ["Central and South America"],
+    season: ["fall", "winter"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.08,
@@ -149,6 +161,8 @@ const rawStarchy: Record<string, Partial<IngredientMapping>> = {
   tapioca_pearls: {
       description: "A pure starch extracted from the storage roots of the cassava plant (*Manihot esculenta*). It provides a remarkably chewy, elastic texture when formed into pearls (boba), or acts as an excellent thickener for fruit pies, creating a perfectly clear gel that doesn't break down when frozen.\n\n**Selection & Storage:** Available as flour, flakes, or pearls. Store in an airtight container in a cool, dark pantry; it has an exceptionally long shelf life.",
     name: "tapioca pearls",
+    origin: ["Cultivated worldwide"],
+    season: ["varies by variety"],
     elementalProperties: { Fire: 0.15, Water: 0.35, Earth: 0.35, Air: 0.15 },
     alchemicalProperties: {
       Spirit: 0.03,

--- a/src/data/ingredients/vinegars/vinegars.ts
+++ b/src/data/ingredients/vinegars/vinegars.ts
@@ -5,6 +5,7 @@ const rawVinegars = {
   rice_vinegar: {
       description: "A mild, slightly sweet vinegar made by fermenting rice wine (sake). Its exceptionally low acidity (around 4%) and subtle, floral sweetness make it an unobtrusive, delicate acid essential for seasoning sushi rice and balancing sharp Asian dipping sauces.",
     name: "Rice Vinegar",
+    season: ["all"],
     category: "vinegars",
     subCategory: "grain",
 
@@ -57,6 +58,7 @@ const rawVinegars = {
   balsamic_vinegar: {
       description: "A deeply complex, dark vinegar originating from Modena, Italy, made from the reduced must (juice) of Trebbiano grapes. Traditional balsamic is aged for decades in wooden barrels, transforming into a thick, sweet, and syrupy elixir, while commercial varieties mimic this with added caramel coloring and thickeners.",
     name: "Balsamic Vinegar",
+    season: ["all"],
     category: "vinegars",
     subCategory: "grape",
     elementalProperties: {
@@ -96,6 +98,7 @@ const rawVinegars = {
   apple_cider_vinegar: {
       description: "A fruity, moderately acidic vinegar made by fermenting apple cider, first into alcohol and then into acetic acid via an *Acetobacter* culture (the \"mother\"). Its subtle apple flavor and mild acidity make it excellent for tenderizing pork marinades, quick pickling, and deglazing pans.",
     name: "Apple Cider Vinegar",
+    season: ["all"],
     category: "vinegars",
     subCategory: "fruit",
     elementalProperties: {
@@ -135,6 +138,7 @@ const rawVinegars = {
   red_wine_vinegar: {
       description: "A sharp, robust vinegar created by fermenting red wine with an *Acetobacter* culture. It retains the complex fruit notes and tannins of the original wine, making it the classic, assertive acidic backbone for traditional French vinaigrettes and hearty beef marinades.",
     name: "Red Wine Vinegar",
+    season: ["all"],
     category: "vinegars",
     subCategory: "wine",
     elementalProperties: {
@@ -174,6 +178,7 @@ const rawVinegars = {
   sherry_vinegar: {
       description: "A Spanish vinegar made from fermented sherry wine, aged in a complex solera system of oak barrels. It strikes a perfect balance between the sharp bite of wine vinegar and the sweet, nutty, and oxidized complexity of balsamic, making it a profound flavor enhancer for gazpacho and pan sauces.",
     name: "Sherry Vinegar",
+    season: ["all"],
     category: "vinegars",
     subCategory: "wine",
     elementalProperties: {
@@ -213,6 +218,7 @@ const rawVinegars = {
   white_wine_vinegar: {
       description: "A bright, moderately sharp vinegar made by fermenting white wine. It is significantly less assertive and tannic than red wine vinegar, offering a delicate, slightly floral acidity that perfectly balances lighter dishes like chicken salads, delicate fish, or hollandaise sauce.",
     name: "White Wine Vinegar",
+    season: ["all"],
     category: "vinegars",
     subCategory: "wine",
     elementalProperties: {
@@ -252,6 +258,7 @@ const rawVinegars = {
   champagne_vinegar: {
       description: "A pale, elegant vinegar made by fermenting wine derived from the same grape varieties used to produce Champagne (Chardonnay, Pinot Noir, and Pinot Meunier). It is significantly softer, more delicate, and more floral than standard white wine vinegar, making it the ideal acid for subtle vinaigrettes and delicate fish dishes.",
     name: "Champagne Vinegar",
+    season: ["all"],
     category: "vinegars",
     subCategory: "wine",
     elementalProperties: {
@@ -291,6 +298,7 @@ const rawVinegars = {
   malt_vinegar: {
       description: "A pungent, darkly colored vinegar made by malting barley (converting its starches to sugars), fermenting it into ale, and then into vinegar. It possesses a deeply toasty, nutty, and slightly bitter flavor profile, serving as the traditional, astringent accompaniment to British fish and chips.",
     name: "Malt Vinegar",
+    season: ["all"],
     category: "vinegars",
     subCategory: "grain",
     elementalProperties: {
@@ -330,6 +338,7 @@ const rawVinegars = {
   coconut_vinegar: {
       description: "A cloudy, distinctively sharp vinegar made by fermenting the sap of the coconut palm flower (not the coconut water itself). It offers a sharp, yeasty, and slightly sweet flavor profile that is significantly less harsh than white vinegar, serving as a staple acid in Filipino adobo and dipping sauces.",
     name: "Coconut Vinegar",
+    season: ["all"],
     category: "vinegars",
     subCategory: "fruit",
     elementalProperties: {
@@ -369,6 +378,7 @@ const rawVinegars = {
   black_vinegar: {
       description: "Also known as Chinkiang vinegar, a deeply complex, inky-black condiment made from fermented glutinous rice, wheat, or sorghum. It is aged extensively, resulting in a profound, earthy, and slightly smoky flavor profile—resembling a savory, less-sweet balsamic—essential for soup dumplings and braises.",
     name: "Black Vinegar",
+    season: ["all"],
     category: "vinegars",
     subCategory: "grain",
     elementalProperties: {
@@ -408,6 +418,7 @@ const rawVinegars = {
   date_vinegar: {
       description: "A rich, complex, and dark vinegar traditionally made in the Middle East by fermenting dates. It offers a mellow acidity and a profound, fruity sweetness (resembling a less syrupy balsamic), making it an excellent marinade for lamb or a glaze for roasted root vegetables.",
     name: "Date Vinegar",
+    season: ["fall", "winter"],
     category: "vinegars",
     subCategory: "fruit",
     elementalProperties: {
@@ -454,6 +465,7 @@ const rawArtisanalVinegars = {
   aged_balsamic: {
       description: "Aged Balsamic Vinegar is an acidic ingredient used to balance richness, sharpen flavor, and improve perceived freshness in finished dishes. In small doses it can also support emulsification and brighten sauces, pickles, and braises. Add gradually and taste as you go, since acidity intensity varies significantly by style and concentration.",
     name: "Aged Balsamic Vinegar",
+    season: ["all"],
     category: "vinegars",
     subCategory: "artisanal",
     elementalProperties: {
@@ -489,6 +501,7 @@ const rawArtisanalVinegars = {
   fig_vinegar: {
       description: "A rich, fruity vinegar made by fermenting crushed figs. It provides a sweet, jammy, and deeply complex acidity that perfectly balances bitter winter greens (like radicchio) or acts as a reduction glaze for roasted pork.",
     name: "Fig Vinegar",
+    season: ["summer", "fall"],
     category: "vinegars",
     subCategory: "artisanal",
     elementalProperties: {
@@ -524,6 +537,7 @@ const rawArtisanalVinegars = {
   champagne_rose_vinegar: {
       description: "Champagne Rose Vinegar is an acidic ingredient used to balance richness, sharpen flavor, and improve perceived freshness in finished dishes. In small doses it can also support emulsification and brighten sauces, pickles, and braises. Add gradually and taste as you go, since acidity intensity varies significantly by style and concentration.",
     name: "Champagne Rose Vinegar",
+    season: ["all"],
     category: "vinegars",
     subCategory: "artisanal",
     elementalProperties: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: "class",
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
## Summary

- **Dark theme system**: Added `ThemeContext` with light/dark/system preference + diurnal auto-switching (6–18h = light, otherwise dark) to reflect alchemical day/night quantity differences. `ThemeToggle` component placed in header. Tailwind `darkMode: \"class\"` enabled.
- **Ingredient card dark restyling**: `IngredientCard` and `EnhancedIngredientRecommender` updated with dark-first styling and `dark:` Tailwind variants throughout. Ingredient scoring algorithm extended with astrological, lunar, and diurnal dimensions using existing `astrologicalProfile`, `kineticsImpact`, and `qualities` data.
- **Ingredient data enrichment**: All 60 ingredient data files populated with `origin` and `season` fields — ~1,221 additions across 12 categories using a curated KB of ~250 staple ingredients with category-level fallbacks.
- **Cuisine card redesign**: `CuisineCard` fully recolored to dark slate/purple palette matching the `#08080e` site theme. Added a per-cuisine 6-flavor bar chart (Spicy · Umami · Salty · Sweet · Sour · Bitter) sourced live from `cuisineFlavorProfiles.ts` for all 14 cuisines. Compact cards show top-3 flavor pills.
- **Cuisine recommender header**: Section heading, live indicator, toggle button, and refresh button all updated to dark theme.

## Test plan

- [ ] Toggle between Light / Dark / Auto modes via header icon — verify theme flips and persists on reload
- [ ] Check Auto mode: between 6–18h local time resolves to light; outside that window resolves to dark
- [ ] Confirm all ingredient cards are readable in both themes (dark bg with light text, light bg with dark text)
- [ ] Confirm cuisine cards show dark slate backgrounds, purple borders, and planetary gradient headers
- [ ] Confirm each cuisine card's flavor profile bars render with correct values (e.g. Japanese umami ≈ 90, Korean spicy ≈ 80)
- [ ] Compact cuisine cards (Show more section) show colored flavor pills
- [ ] TypeScript: zero errors (`yarn tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)