### PR TITLE
feat(cuisines): cook-it / order-it flow with grocery cart, Instacart, Yelp + Foursquare

### DIFF
--- a/src/app/api/restaurants/search/route.ts
+++ b/src/app/api/restaurants/search/route.ts
@@ -12,27 +12,29 @@
  */
 
 import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
 import { yelpService } from "@/services/yelpService";
-import type {
-  RestaurantSearchResponse,
-  CosmicContext,
-} from "@/types/yelp";
+import type { ElementalProperties } from "@/types/alchemy";
 import type {
   AstrologicalState,
   Element,
   AlchemicalProperties,
   Planet,
 } from "@/types/celestial";
-import type { ElementalProperties } from "@/types/alchemy";
+import type {
+  AlchmScoredRestaurant,
+  RestaurantSearchResponse,
+  CosmicContext,
+  YelpBusiness,
+} from "@/types/yelp";
 import { getAccuratePlanetaryPositions } from "@/utils/astrology/positions";
-import { getTimeFactors } from "@/utils/time";
+import { getLunarPhaseFromDate } from "@/utils/lunarPhaseUtils";
 import {
   aggregateEnhancedZodiacElementals,
   calculateAlchemicalFromPlanets,
   isSectDiurnal,
 } from "@/utils/planetaryAlchemyMapping";
-import { getLunarPhaseFromDate } from "@/utils/lunarPhaseUtils";
+import { getTimeFactors } from "@/utils/time";
+import type { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
 // Note: Removed `runtime = 'edge'` - Cloudflare Workers are already edge functions
@@ -254,6 +256,116 @@ function buildAstrologicalState(now: Date = new Date()): {
   return { state, cosmicContext, alchemicalProperties, diurnal };
 }
 
+// ─── Foursquare fallback (used by POST when Yelp is unavailable) ───────────
+
+interface FoursquareNearbyRaw {
+  fsq_id?: string;
+  name?: string;
+  location?: {
+    formatted_address?: string;
+    locality?: string;
+    region?: string;
+    address?: string;
+  };
+  categories?: Array<{ name?: string }>;
+  rating?: number;
+  distance?: number;
+  geocodes?: { main?: { latitude?: number; longitude?: number } };
+  link?: string;
+}
+
+/**
+ * Fetches restaurants near (lat,lng) for the given cuisine via Foursquare
+ * Places v3 and shapes them into AlchmScoredRestaurant entries with neutral
+ * scoring (Foursquare doesn't provide the cosmic alignment data we use).
+ *
+ * Returns null when Foursquare is unconfigured or returns no usable results.
+ */
+async function fetchFoursquareFallback(
+  cuisineType: string,
+  latitude: number,
+  longitude: number,
+  radiusMeters: number,
+  limit: number,
+): Promise<AlchmScoredRestaurant[] | null> {
+  const apiKey = process.env.FOURSQUARE_API_KEY;
+  if (!apiKey) return null;
+
+  try {
+    const params = new URLSearchParams();
+    params.set("query", cuisineType);
+    params.set("ll", `${latitude},${longitude}`);
+    params.set("radius", String(Math.min(Math.max(radiusMeters, 100), 100000)));
+    params.set("categories", RESTAURANT_CATEGORY_ID);
+    params.set(
+      "fields",
+      "fsq_id,name,location,categories,rating,distance,geocodes,link",
+    );
+    params.set("limit", String(Math.min(Math.max(limit, 1), 50)));
+
+    const response = await fetch(`${FOURSQUARE_BASE}?${params.toString()}`, {
+      headers: { Authorization: apiKey, Accept: "application/json" },
+    });
+    if (!response.ok) return null;
+
+    const data = (await response.json()) as { results?: FoursquareNearbyRaw[] };
+    const results = data.results ?? [];
+    if (results.length === 0) return null;
+
+    return results
+      .filter((p): p is FoursquareNearbyRaw & { fsq_id: string; name: string } =>
+        Boolean(p.fsq_id && p.name),
+      )
+      .map((place): AlchmScoredRestaurant => {
+        const business: YelpBusiness = {
+          id: place.fsq_id,
+          name: place.name,
+          // Foursquare's deep-link to place detail; falls back to a search URL
+          url:
+            place.link
+              ? `https://foursquare.com${place.link}`
+              : `https://foursquare.com/v/${place.fsq_id}`,
+          phone: "",
+          rating: typeof place.rating === "number" ? place.rating / 2 : 0,
+          review_count: 0,
+          distance: typeof place.distance === "number" ? place.distance : undefined,
+          categories: (place.categories ?? [])
+            .filter((c): c is { name: string } => typeof c.name === "string")
+            .map((c) => ({ alias: c.name.toLowerCase(), title: c.name })),
+          location: {
+            address1: place.location?.address ?? "",
+            city: place.location?.locality ?? "",
+            state: place.location?.region ?? "",
+            zip_code: "",
+            display_address: place.location?.formatted_address
+              ? [place.location.formatted_address]
+              : [],
+          },
+          coordinates: {
+            latitude: place.geocodes?.main?.latitude ?? latitude,
+            longitude: place.geocodes?.main?.longitude ?? longitude,
+          },
+          is_closed: false,
+        };
+
+        return {
+          business,
+          alchmScore: 0,
+          elementalMatch: 0,
+          planetaryAlignment: 0,
+          monicaCompatibility: 0,
+          dominantElement: "Earth",
+          matchReasons: [
+            `${cuisineType} match from Foursquare — cosmic scoring unavailable`,
+          ],
+          cuisineElement: { Fire: 0.25, Water: 0.25, Earth: 0.25, Air: 0.25 },
+        };
+      });
+  } catch {
+    return null;
+  }
+}
+
 export async function POST(request: NextRequest) {
   let body: ScoredSearchBody;
   try {
@@ -295,58 +407,71 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Graceful degradation when Yelp isn't configured
-  if (!yelpService.isConfigured()) {
-    return NextResponse.json(
-      {
-        restaurants: [],
-        cosmicContext: emptyCosmicContext(),
-        error: "Yelp integration not configured",
-      } satisfies RestaurantSearchResponse,
-      { status: 200 },
-    );
-  }
-
   const built = buildAstrologicalState();
-  if (!built) {
-    return NextResponse.json(
-      {
-        restaurants: [],
-        cosmicContext: emptyCosmicContext(),
-        error:
-          "Planetary positions unavailable — cannot compute alchemical scoring",
-      } satisfies RestaurantSearchResponse,
-      { status: 503 },
-    );
-  }
-  const { state, cosmicContext, alchemicalProperties, diurnal } = built;
+  const cosmicContext = built?.cosmicContext ?? emptyCosmicContext();
 
-  const { data, error } = await yelpService.getScoredRestaurants({
+  // Try Yelp first when configured + planetary state is available.
+  if (yelpService.isConfigured() && built) {
+    const { data } = await yelpService.getScoredRestaurants({
+      cuisineType,
+      latitude,
+      longitude,
+      astrologicalState: built.state,
+      alchemicalProperties: built.alchemicalProperties,
+      diurnal: built.diurnal,
+      radius,
+      limit,
+    });
+
+    if (data && data.length > 0) {
+      return NextResponse.json(
+        {
+          restaurants: data.slice(0, 5),
+          cosmicContext,
+          source: "yelp",
+        } satisfies RestaurantSearchResponse,
+        { status: 200 },
+      );
+    }
+  }
+
+  // Foursquare fallback — covers: Yelp unconfigured, Yelp errored, Yelp empty,
+  // or planetary state unavailable. No cosmic scoring on these results.
+  const radiusMeters = typeof radius === "number" ? radius : 8000;
+  const foursquare = await fetchFoursquareFallback(
     cuisineType,
     latitude,
     longitude,
-    astrologicalState: state,
-    alchemicalProperties,
-    diurnal,
-    radius,
+    radiusMeters,
     limit,
-  });
+  );
 
-  if (!data) {
+  if (foursquare && foursquare.length > 0) {
+    const reason = !yelpService.isConfigured()
+      ? "Yelp not configured — showing Foursquare results without cosmic scoring."
+      : !built
+        ? "Planetary positions unavailable — showing Foursquare results without cosmic scoring."
+        : "Yelp returned no matches — showing Foursquare results without cosmic scoring.";
+
     return NextResponse.json(
       {
-        restaurants: [],
+        restaurants: foursquare.slice(0, 5),
         cosmicContext,
-        error: error ?? "Yelp search failed",
+        source: "foursquare",
+        sourceNotice: reason,
       } satisfies RestaurantSearchResponse,
       { status: 200 },
     );
   }
 
+  // Neither provider returned anything we can show.
   return NextResponse.json(
     {
-      restaurants: data.slice(0, 5),
+      restaurants: [],
       cosmicContext,
+      error: !yelpService.isConfigured() && !process.env.FOURSQUARE_API_KEY
+        ? "Restaurant discovery is not configured."
+        : "No restaurants found.",
     } satisfies RestaurantSearchResponse,
     { status: 200 },
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import React from "react";
 import SignInModal from "@/components/auth/SignInModal";
 import TokenShopModal from "@/components/economy/TokenShopModal";
+import { GroceryCartButton } from "@/components/grocery-cart/GroceryCartButton";
+import { GroceryCartDrawer } from "@/components/grocery-cart/GroceryCartDrawer";
 import MobileNavToggle from "@/components/nav/MobileNavToggle";
 import NavAuthLink from "@/components/nav/NavAuthLink";
 import NotificationBell from "@/components/nav/NotificationBell";
@@ -77,6 +79,7 @@ export default function RootLayout({
                 <div className="flex flex-col items-center xl:items-end flex-grow w-full xl:w-2/3">
                   <div className="flex items-center gap-3 w-full justify-end mb-4 xl:mb-6">
                     <ThemeToggle compact />
+                    <GroceryCartButton />
                     <NotificationBell />
                     {/* Hamburger toggle for mobile */}
                     <MobileNavToggle>
@@ -246,6 +249,7 @@ export default function RootLayout({
           </footer>
           <SignInModal />
           <TokenShopModal />
+          <GroceryCartDrawer />
         </ClientProviders>
         <Analytics />
       </body>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { ToastProvider } from "@/components/ToastProvider";
 import { AlchemicalProvider } from "@/contexts/AlchemicalContext/provider";
 import { AlchemicalDataProvider } from "@/contexts/AlchemicalDataContext";
+import { GroceryCartProvider } from "@/contexts/GroceryCartContext";
 import { PremiumProvider } from "@/contexts/PremiumContext";
 import { RecipeBuilderProvider } from "@/contexts/RecipeBuilderContext";
 import { ThemeProvider } from "@/contexts/ThemeContext";
@@ -21,7 +22,9 @@ export default function Providers({ children }: { children: React.ReactNode }) {
               <PremiumProvider>
                 <AlchemicalDataProvider>
                   <AlchemicalProvider>
-                    <RecipeBuilderProvider>{children}</RecipeBuilderProvider>
+                    <RecipeBuilderProvider>
+                      <GroceryCartProvider>{children}</GroceryCartProvider>
+                    </RecipeBuilderProvider>
                   </AlchemicalProvider>
                 </AlchemicalDataProvider>
               </PremiumProvider>

--- a/src/app/recipes/[recipeId]/RecipeClient.tsx
+++ b/src/app/recipes/[recipeId]/RecipeClient.tsx
@@ -14,6 +14,8 @@ import { RiffOnThisLink } from "@/components/recipes/RiffOnThisLink";
 import { SocialSection } from "@/components/recipes/SocialSection";
 import { TechniqueModal } from "@/components/recipes/TechniqueModal";
 import { TimeShortcutsPanel } from "@/components/recipes/TimeShortcutsPanel";
+import { useToast } from "@/components/ToastProvider";
+import { useGroceryCart } from "@/contexts/GroceryCartContext";
 import type { Recipe } from "@/types/recipe";
 import { adaptRecipe, type DietaryMode } from "@/utils/dietaryAdaptation";
 import { analyzeTimeShortcuts, type TimeBudget } from "@/utils/timeShortcuts";
@@ -697,6 +699,41 @@ export default function RecipeClient({ recipe, recommendedSauces, recommendedRec
   const baseServings = useMemo(() => getBaseServings(recipe), [recipe]);
   const scale = servings / baseServings;
 
+  const { addRecipe: addRecipeToGroceryCart, open: openGroceryCart } = useGroceryCart();
+  const { showToast } = useToast();
+  const [addedToCart, setAddedToCart] = useState(false);
+
+  const handleAddToGroceryCart = useCallback(() => {
+    if (!recipe || !recipe.ingredients || recipe.ingredients.length === 0) {
+      showToast("This recipe has no ingredients to add.", "warning");
+      return;
+    }
+    const normalized = recipe.ingredients
+      .filter((ing) => ing && ing.name)
+      .map((ing) => ({
+        name: ing.name,
+        amount: typeof ing.amount === "number" ? ing.amount : 1,
+        unit: ing.unit || "each",
+        category: ing.category,
+        notes: ing.notes,
+      }));
+    addRecipeToGroceryCart(
+      {
+        id: String(recipe.id || recipe.name),
+        name: recipe.name,
+        baseServings,
+        ingredients: normalized,
+      },
+      servings,
+    );
+    setAddedToCart(true);
+    setTimeout(() => setAddedToCart(false), 2000);
+    showToast(
+      `Added ${normalized.length} ingredient${normalized.length === 1 ? "" : "s"} for ${servings} serving${servings === 1 ? "" : "s"}`,
+      "success",
+      { action: { label: "View cart", onClick: openGroceryCart } },
+    );
+  }, [recipe, baseServings, servings, addRecipeToGroceryCart, openGroceryCart, showToast]);
 
   const handleCopyRecipe = useCallback(async () => {
     if (!recipe) return;
@@ -838,6 +875,28 @@ export default function RecipeClient({ recipe, recommendedSauces, recommendedRec
             </div>
 
             <AddToMealPlanButton recipe={recipe} servings={servings} />
+
+            <button
+              type="button"
+              onClick={handleAddToGroceryCart}
+              className={`flex items-center gap-2 px-5 py-2.5 rounded-xl font-medium transition-all duration-200 ${
+                addedToCart
+                  ? "bg-emerald-500/20 border border-emerald-500/50 text-emerald-300"
+                  : "bg-gradient-to-r from-orange-500 to-amber-500 border border-orange-400/50 text-white hover:from-orange-400 hover:to-amber-400"
+              }`}
+            >
+              {addedToCart ? (
+                <>
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
+                  Added to cart
+                </>
+              ) : (
+                <>
+                  <span aria-hidden>🛒</span>
+                  Add to grocery cart
+                </>
+              )}
+            </button>
 
             <RiffOnThisLink recipe={recipe} />
 

--- a/src/app/restaurants/RestaurantsPageClient.tsx
+++ b/src/app/restaurants/RestaurantsPageClient.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useState } from "react";
+import { RestaurantDiscovery } from "@/components/RestaurantDiscovery/RestaurantDiscovery";
+
+const POPULAR_CUISINES = [
+  "Italian",
+  "Mexican",
+  "Japanese",
+  "Chinese",
+  "Indian",
+  "Thai",
+  "French",
+  "Mediterranean",
+  "Middle-Eastern",
+  "Korean",
+  "Vietnamese",
+  "American",
+  "African",
+  "Greek",
+];
+
+export default function RestaurantsPageClient() {
+  const params = useSearchParams();
+  const initial = params.get("cuisine") ?? "";
+  const [cuisine, setCuisine] = useState(initial);
+  const [draft, setDraft] = useState(initial);
+
+  return (
+    <main className="min-h-screen bg-[#08080e] text-white">
+      <div className="max-w-4xl mx-auto px-4 pt-8 pb-16">
+        <Link
+          href="/#cuisines"
+          className="inline-flex items-center gap-1 text-sm text-white/60 hover:text-orange-300 transition-colors mb-6"
+        >
+          ← Back to cuisines
+        </Link>
+
+        <header className="mb-8">
+          <h1 className="text-3xl md:text-5xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-rose-300 via-orange-300 to-amber-300 leading-tight pb-1">
+            Explore Local Restaurants
+          </h1>
+          <p className="mt-3 text-base text-white/60 max-w-2xl">
+            Don&apos;t feel like cooking? We&apos;ll find restaurants near you,
+            ranked by their alignment to the current cosmic moment.
+          </p>
+        </header>
+
+        {/* Cuisine selector */}
+        <section className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-5">
+          <h2 className="text-sm uppercase tracking-wider text-white/60 font-semibold mb-3">
+            What do you feel like?
+          </h2>
+          <form
+            className="flex flex-col sm:flex-row gap-2 mb-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+              setCuisine(draft.trim());
+            }}
+          >
+            <input
+              type="text"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              placeholder="e.g. Italian, Thai, Japanese…"
+              className="flex-1 px-4 py-2.5 rounded-lg bg-black/30 border border-white/10 text-white placeholder-white/30 focus:outline-none focus:border-orange-400"
+            />
+            <button
+              type="submit"
+              className="px-5 py-2.5 rounded-lg bg-gradient-to-r from-rose-500 to-orange-500 text-white font-bold text-sm hover:from-rose-400 hover:to-orange-400 transition-all"
+            >
+              Search
+            </button>
+          </form>
+          <div className="flex flex-wrap gap-2">
+            {POPULAR_CUISINES.map((c) => (
+              <button
+                key={c}
+                type="button"
+                onClick={() => {
+                  setDraft(c);
+                  setCuisine(c);
+                }}
+                className={`px-3 py-1.5 rounded-full border text-xs font-semibold transition-all ${
+                  cuisine.toLowerCase() === c.toLowerCase()
+                    ? "bg-orange-500 border-orange-400 text-white"
+                    : "bg-white/5 border-white/10 text-white/70 hover:text-white hover:border-orange-400/40"
+                }`}
+              >
+                {c}
+              </button>
+            ))}
+          </div>
+        </section>
+
+        {cuisine ? (
+          <RestaurantDiscovery cuisineType={cuisine} className="!bg-white/5 !border-white/10" />
+        ) : (
+          <div className="rounded-2xl border border-dashed border-white/15 bg-white/5 p-10 text-center">
+            <div className="text-5xl mb-3" aria-hidden>
+              🍽️
+            </div>
+            <p className="text-white/70 text-sm">
+              Pick a cuisine above to discover restaurants near you.
+            </p>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/restaurants/page.tsx
+++ b/src/app/restaurants/page.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from "react";
+import RestaurantsPageClient from "./RestaurantsPageClient";
+
+export const metadata = {
+  title: "Explore Local Restaurants — Alchm Kitchen",
+  description:
+    "Discover restaurants near you, ranked by cosmic alignment with the current planetary moment.",
+};
+
+export default function RestaurantsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-[#08080e] text-white flex items-center justify-center">
+          <p className="text-sm text-gray-400">Loading restaurants…</p>
+        </div>
+      }
+    >
+      <RestaurantsPageClient />
+    </Suspense>
+  );
+}

--- a/src/components/CuisineRecommender.tsx
+++ b/src/components/CuisineRecommender.tsx
@@ -2,11 +2,15 @@
 'use client';
 
 import { Flame, Droplets, Mountain, Wind } from 'lucide-react';
-import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import type { AlchemicalItem } from '@/calculations/alchemicalTransformation';
+import { useToast } from '@/components/ToastProvider';
 import { useAlchemical } from '@/contexts/AlchemicalContext/hooks';
-// @ts-expect-error - Auto-fixed by script
 import { useAlchemicalData } from '@/contexts/AlchemicalDataContext';
+import { useGroceryCart } from '@/contexts/GroceryCartContext';
+// @ts-expect-error - Auto-fixed by script
 import { getRecipesForCuisineMatch } from '@/data/cuisineFlavorProfiles';
 import type { ZodiacSign, LunarPhase, ElementalProperties } from '@/types/alchemy';
 import { _transformCuisines as transformCuisines, _sortByAlchemicalCompatibility as sortByAlchemicalCompatibility } from '@/utils/alchemicalTransformationUtils';
@@ -84,6 +88,63 @@ export default function CuisineRecommender() {
   const [topRecommendedSauces, setTopRecommendedSauces] = useState<any[]>([]);
   const [expandedSauceCards, setExpandedSauceCards] = useState<Record<string, boolean>>({});
   const [showCuisineDetails, setShowCuisineDetails] = useState<boolean>(false);
+  const recipesSectionRef = useRef<HTMLDivElement | null>(null);
+  const router = useRouter();
+  const { addRecipe: addRecipeToGroceryCart, open: openGroceryCart } = useGroceryCart();
+  const { showToast } = useToast();
+
+  const handleViewRecipes = useCallback((cuisineId: string) => {
+    setSelectedCuisine(cuisineId);
+    setShowCuisineDetails(true);
+    requestAnimationFrame(() => {
+      recipesSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  }, []);
+
+  const handleOrderCuisine = useCallback((cuisineName: string) => {
+    router.push(`/restaurants?cuisine=${encodeURIComponent(cuisineName)}`);
+  }, [router]);
+
+  const buildRecipeHref = useCallback((recipe: any): string | null => {
+    const slug = recipe?.id || recipe?.name;
+    if (!slug) return null;
+    return `/recipes/${encodeURIComponent(String(slug))}`;
+  }, []);
+
+  const handleAddRecipeToCart = useCallback((recipe: any) => {
+    if (!recipe) return;
+    const ingredients = Array.isArray(recipe.ingredients) ? recipe.ingredients : [];
+    const normalized = ingredients
+      .map((ing: any) => {
+        if (!ing) return null;
+        if (typeof ing === 'string') {
+          return { name: ing, amount: 1, unit: 'each' };
+        }
+        return {
+          name: ing.name,
+          amount: typeof ing.amount === 'number' ? ing.amount : 1,
+          unit: ing.unit || 'each',
+          category: ing.category,
+          notes: ing.notes,
+        };
+      })
+      .filter((x: any) => x && x.name);
+
+    if (normalized.length === 0) {
+      showToast('This recipe has no ingredients to add.', 'warning');
+      return;
+    }
+
+    const baseServings = Number(recipe.servingSize ?? recipe.numberOfServings ?? recipe.servings) || 1;
+    const recipeId = String(recipe.id || recipe.name);
+    addRecipeToGroceryCart(
+      { id: recipeId, name: recipe.name, baseServings, ingredients: normalized },
+      baseServings,
+    );
+    showToast(`Added ${normalized.length} ingredient${normalized.length === 1 ? '' : 's'} from ${recipe.name}`, 'success', {
+      action: { label: 'View cart', onClick: openGroceryCart },
+    });
+  }, [addRecipeToGroceryCart, openGroceryCart, showToast]);
   
   // Get elemental profile from current astrological state instead of using placeholder values
   const [currentMomentElementalProfile, setCurrentMomentElementalProfile] = useState<ElementalProperties>(
@@ -640,10 +701,28 @@ export default function CuisineRecommender() {
           </div>
           
           <p className="text-sm text-gray-600 mb-3">{selectedCuisineData.description}</p>
-          
+
+          {/* Cuisine action buttons: cook it (recipes) or order it (restaurants) */}
+          <div className="grid grid-cols-2 gap-2 mb-4">
+            <button
+              type="button"
+              onClick={() => handleViewRecipes(selectedCuisineData.id)}
+              className="flex items-center justify-center gap-1.5 px-3 py-2.5 rounded-lg bg-gradient-to-r from-amber-500 to-orange-500 text-white text-sm font-bold shadow-sm hover:from-amber-400 hover:to-orange-400 transition-all"
+            >
+              <span aria-hidden>🥘</span> Recipes
+            </button>
+            <button
+              type="button"
+              onClick={() => handleOrderCuisine(selectedCuisineData.name)}
+              className="flex items-center justify-center gap-1.5 px-3 py-2.5 rounded-lg bg-gradient-to-r from-rose-500 to-purple-500 text-white text-sm font-bold shadow-sm hover:from-rose-400 hover:to-purple-400 transition-all"
+            >
+              <span aria-hidden>📍</span> Order Local
+            </button>
+          </div>
+
           {/* Recipe Recommendations - Shown Immediately */}
           {cuisineRecipes.length > 0 ? (
-            <div className="mt-2">
+            <div ref={recipesSectionRef} className="mt-2">
               <h4 className="text-xs uppercase font-medium text-gray-500 mb-2">Recipes</h4>
               <div className="grid grid-cols-2 gap-2">
                 {cuisineRecipes.slice(0, showAllRecipes ? undefined : 5).map((recipe, index) => (
@@ -784,6 +863,28 @@ export default function CuisineRecommender() {
                             <p>{Array.isArray(recipe.astrologicalInfluences) ? recipe.astrologicalInfluences.join(', ') : recipe.astrologicalInfluences}</p>
                           </div>
                         )}
+
+                        {/* Recipe sub-card actions: open full page, add to grocery cart */}
+                        <div className="mt-3 pt-2 border-t border-gray-100 flex flex-wrap gap-2" onClick={(e) => e.stopPropagation()}>
+                          {buildRecipeHref(recipe) && (
+                            <Link
+                              href={buildRecipeHref(recipe) as string}
+                              className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-md bg-blue-600 text-white text-[11px] font-semibold hover:bg-blue-500 transition-colors"
+                            >
+                              View full recipe →
+                            </Link>
+                          )}
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleAddRecipeToCart(recipe);
+                            }}
+                            className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-md bg-orange-600 text-white text-[11px] font-semibold hover:bg-orange-500 transition-colors"
+                          >
+                            🛒 Add to grocery cart
+                          </button>
+                        </div>
                       </div>
                     )}
                   </div>

--- a/src/components/RestaurantDiscovery/RestaurantDiscovery.tsx
+++ b/src/components/RestaurantDiscovery/RestaurantDiscovery.tsx
@@ -10,6 +10,9 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useToast } from "@/components/ToastProvider";
+import { useUser } from "@/contexts/UserContext";
+import type { SavedRestaurant } from "@/types/restaurant";
 import type { AlchmScoredRestaurant, RestaurantSearchResponse } from "@/types/yelp";
 
 interface RestaurantDiscoveryProps {
@@ -60,6 +63,11 @@ function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
 }
 
+interface SavedRestaurantsPrefs {
+  savedRestaurants?: SavedRestaurant[];
+  [k: string]: unknown;
+}
+
 export function RestaurantDiscovery({
   cuisineType,
   userLatitude,
@@ -74,6 +82,112 @@ export function RestaurantDiscovery({
   );
   const [locationError, setLocationError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const [savedIds, setSavedIds] = useState<Set<string>>(new Set());
+  const { currentUser, updateProfile } = useUser();
+  const { showToast } = useToast();
+
+  // Hydrate saved restaurant IDs from user prefs (logged-in) or localStorage (anon).
+  useEffect(() => {
+    const ids = new Set<string>();
+    const prefs = currentUser?.preferences as SavedRestaurantsPrefs | undefined;
+    prefs?.savedRestaurants?.forEach((r) => {
+      if (r.externalId) ids.add(r.externalId);
+    });
+    if (typeof window !== "undefined") {
+      try {
+        const raw = window.localStorage.getItem("userFoodPreferences");
+        if (raw) {
+          const parsed = JSON.parse(raw) as SavedRestaurantsPrefs;
+          parsed.savedRestaurants?.forEach((r) => {
+            if (r.externalId) ids.add(r.externalId);
+          });
+        }
+      } catch {
+        // ignore malformed localStorage
+      }
+    }
+    setSavedIds(ids);
+  }, [currentUser]);
+
+  const saveRestaurant = useCallback(
+    async (entry: AlchmScoredRestaurant, source: "yelp" | "foursquare") => {
+      const { business } = entry;
+      if (savedIds.has(business.id)) return;
+
+      const restaurant: SavedRestaurant = {
+        id: `${source}_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
+        name: business.name,
+        cuisine: business.categories[0]?.title || cuisineType || "Restaurant",
+        location:
+          [business.location.city, business.location.state]
+            .filter(Boolean)
+            .join(", ") || undefined,
+        address:
+          business.location.display_address.join(", ") ||
+          business.location.address1 ||
+          undefined,
+        menuItems: [],
+        rating: business.rating,
+        source,
+        externalId: business.id,
+        addedAt: new Date().toISOString(),
+      };
+
+      // Optimistic UI
+      setSavedIds((prev) => {
+        const next = new Set(prev);
+        next.add(business.id);
+        return next;
+      });
+
+      // Persist to user profile when logged in.
+      if (currentUser?.userId) {
+        const currentPrefs =
+          (currentUser.preferences as SavedRestaurantsPrefs | undefined) ?? {};
+        const newSaved = [...(currentPrefs.savedRestaurants ?? []), restaurant];
+        try {
+          await updateProfile({
+            preferences: { ...currentPrefs, savedRestaurants: newSaved },
+          });
+        } catch (err) {
+          // Roll back optimistic state on failure
+          setSavedIds((prev) => {
+            const next = new Set(prev);
+            next.delete(business.id);
+            return next;
+          });
+          showToast(
+            err instanceof Error ? err.message : "Failed to save restaurant",
+            "error",
+          );
+          return;
+        }
+      }
+
+      // Always also write to localStorage so anon users + ProfilePage fallback see it.
+      if (typeof window !== "undefined") {
+        try {
+          const raw = window.localStorage.getItem("userFoodPreferences");
+          const parsed: SavedRestaurantsPrefs = raw
+            ? (JSON.parse(raw) as SavedRestaurantsPrefs)
+            : {};
+          parsed.savedRestaurants = [
+            ...(parsed.savedRestaurants ?? []),
+            restaurant,
+          ];
+          window.localStorage.setItem(
+            "userFoodPreferences",
+            JSON.stringify(parsed),
+          );
+        } catch {
+          // ignore quota / parse errors
+        }
+      }
+
+      showToast(`Saved ${business.name} to your restaurants`, "success");
+    },
+    [cuisineType, currentUser, savedIds, showToast, updateProfile],
+  );
 
   // Sync coords when parent provides them
   useEffect(() => {
@@ -148,7 +262,10 @@ export function RestaurantDiscovery({
 
         const data = (await res.json()) as RestaurantSearchResponse;
 
-        if (data.error === "Yelp integration not configured") {
+        if (
+          data.error === "Yelp integration not configured" ||
+          data.error === "Restaurant discovery is not configured."
+        ) {
           setStatus({ kind: "not-configured" });
           return;
         }
@@ -249,9 +366,10 @@ export function RestaurantDiscovery({
       )}
 
       {status.kind === "not-configured" && (
-        <div className="rounded-lg bg-white/60 border border-amber-200 p-3 text-xs text-amber-900">
-          Restaurant discovery isn't configured yet. Add{" "}
-          <code className="font-mono bg-amber-100 px-1 rounded">YELP_API_KEY</code> to enable.
+        <div className="rounded-lg bg-white/60 border border-amber-200 p-3 text-xs text-amber-900 leading-snug">
+          Restaurant discovery isn&apos;t configured yet. Add{" "}
+          <code className="font-mono bg-amber-100 px-1 rounded">YELP_API_KEY</code> for cosmic-scored results, or{" "}
+          <code className="font-mono bg-amber-100 px-1 rounded">FOURSQUARE_API_KEY</code> for unscored fallback.
         </div>
       )}
 
@@ -268,83 +386,115 @@ export function RestaurantDiscovery({
       )}
 
       {status.kind === "ready" && (
-        <ul className="space-y-2">
-          {status.data.restaurants.map((entry) => {
-            const { business } = entry;
-            const decoration = ELEMENT_DECORATION[entry.dominantElement];
-            const distance = metersToMiles(business.distance);
-            const scorePct = Math.round(entry.alchmScore * 100);
-            const reasons = entry.matchReasons.slice(0, 2);
+        <>
+          {status.data.source === "foursquare" && status.data.sourceNotice && (
+            <div className="mb-3 rounded-lg border border-amber-300 bg-amber-100/60 p-2.5 text-[11px] text-amber-900 leading-snug">
+              ✦ {status.data.sourceNotice}
+            </div>
+          )}
+          <ul className="space-y-2">
+            {status.data.restaurants.map((entry) => {
+              const { business } = entry;
+              const source = status.data.source ?? "yelp";
+              const isScored = source === "yelp";
+              const decoration = ELEMENT_DECORATION[entry.dominantElement];
+              const distance = metersToMiles(business.distance);
+              const scorePct = Math.round(entry.alchmScore * 100);
+              const reasons = entry.matchReasons.slice(0, 2);
+              const isSaved = savedIds.has(business.id);
 
-            return (
-              <li
-                key={business.id}
-                className="flex items-start gap-3 p-3 rounded-lg bg-white border border-amber-100 shadow-sm hover:border-amber-300 transition-colors"
-              >
-                {/* Score badge */}
-                <div className="flex-shrink-0 flex flex-col items-center">
-                  <div className="px-2 py-1 rounded-md bg-gradient-to-br from-amber-400 to-amber-600 text-white text-xs font-extrabold shadow-sm">
-                    {scorePct}% <span aria-hidden>✦</span>
-                  </div>
-                  <span
-                    className={`mt-1 inline-flex items-center gap-1 px-1.5 py-0.5 rounded border text-[10px] font-semibold ${decoration.chipClass}`}
-                    title={`${decoration.label} dominant`}
-                  >
-                    <span aria-hidden>{decoration.emoji}</span>
-                    {decoration.label}
-                  </span>
-                </div>
-
-                {/* Details */}
-                <div className="flex-1 min-w-0">
-                  <h4 className="text-sm font-bold text-gray-800 truncate">
-                    {business.name}
-                  </h4>
-                  <div className="flex flex-wrap items-center gap-x-2 text-[11px] text-gray-500 mt-0.5">
-                    {typeof business.rating === "number" && (
-                      <span className="text-amber-600 font-semibold">
-                        ★ {business.rating.toFixed(1)}
-                      </span>
-                    )}
-                    {business.review_count > 0 && (
-                      <span className="text-gray-400">
-                        ({business.review_count})
-                      </span>
-                    )}
-                    {business.price && (
-                      <span className="text-emerald-600 font-medium">
-                        {business.price}
-                      </span>
-                    )}
-                    {distance && <span>· {distance}</span>}
-                  </div>
-                  {reasons.length > 0 && (
-                    <ul className="mt-1 space-y-0.5">
-                      {reasons.map((reason, i) => (
-                        <li
-                          key={i}
-                          className="text-[11px] text-amber-800 italic leading-snug"
-                        >
-                          — {reason}
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </div>
-
-                {/* CTA */}
-                <a
-                  href={business.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex-shrink-0 self-center px-3 py-2 bg-amber-600 text-white text-xs font-bold rounded-lg hover:bg-amber-700 transition-colors whitespace-nowrap"
+              return (
+                <li
+                  key={business.id}
+                  className="flex items-start gap-3 p-3 rounded-lg bg-white border border-amber-100 shadow-sm hover:border-amber-300 transition-colors"
                 >
-                  Order it →
-                </a>
-              </li>
-            );
-          })}
-        </ul>
+                  {/* Score / source badge */}
+                  <div className="flex-shrink-0 flex flex-col items-center">
+                    {isScored ? (
+                      <>
+                        <div className="px-2 py-1 rounded-md bg-gradient-to-br from-amber-400 to-amber-600 text-white text-xs font-extrabold shadow-sm">
+                          {scorePct}% <span aria-hidden>✦</span>
+                        </div>
+                        <span
+                          className={`mt-1 inline-flex items-center gap-1 px-1.5 py-0.5 rounded border text-[10px] font-semibold ${decoration.chipClass}`}
+                          title={`${decoration.label} dominant`}
+                        >
+                          <span aria-hidden>{decoration.emoji}</span>
+                          {decoration.label}
+                        </span>
+                      </>
+                    ) : (
+                      <div className="px-2 py-1 rounded-md bg-blue-100 text-blue-700 text-[10px] font-bold border border-blue-200">
+                        Foursquare
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Details */}
+                  <div className="flex-1 min-w-0">
+                    <h4 className="text-sm font-bold text-gray-800 truncate">
+                      {business.name}
+                    </h4>
+                    <div className="flex flex-wrap items-center gap-x-2 text-[11px] text-gray-500 mt-0.5">
+                      {typeof business.rating === "number" && business.rating > 0 && (
+                        <span className="text-amber-600 font-semibold">
+                          ★ {business.rating.toFixed(1)}
+                        </span>
+                      )}
+                      {business.review_count > 0 && (
+                        <span className="text-gray-400">
+                          ({business.review_count})
+                        </span>
+                      )}
+                      {business.price && (
+                        <span className="text-emerald-600 font-medium">
+                          {business.price}
+                        </span>
+                      )}
+                      {distance && <span>· {distance}</span>}
+                    </div>
+                    {isScored && reasons.length > 0 && (
+                      <ul className="mt-1 space-y-0.5">
+                        {reasons.map((reason, i) => (
+                          <li
+                            key={i}
+                            className="text-[11px] text-amber-800 italic leading-snug"
+                          >
+                            — {reason}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+
+                  {/* CTAs */}
+                  <div className="flex-shrink-0 self-center flex flex-col gap-1.5">
+                    <a
+                      href={business.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="px-3 py-1.5 bg-amber-600 text-white text-xs font-bold rounded-lg hover:bg-amber-700 transition-colors whitespace-nowrap text-center"
+                    >
+                      Order it →
+                    </a>
+                    <button
+                      type="button"
+                      onClick={() => void saveRestaurant(entry, source)}
+                      disabled={isSaved}
+                      className={`px-3 py-1.5 rounded-lg text-xs font-semibold transition-all whitespace-nowrap ${
+                        isSaved
+                          ? "bg-emerald-50 text-emerald-700 border border-emerald-200 cursor-default"
+                          : "bg-white text-purple-700 border border-purple-200 hover:bg-purple-50"
+                      }`}
+                    >
+                      {isSaved ? "✓ Saved" : "+ Save"}
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </>
       )}
 
       {/* Cosmic context line */}
@@ -354,8 +504,13 @@ export function RestaurantDiscovery({
         </p>
       )}
 
-      {/* Yelp ToS attribution */}
-      {(status.kind === "ready" || status.kind === "empty") && (
+      {/* Provider attribution */}
+      {status.kind === "ready" && (
+        <p className="mt-2 text-[10px] text-gray-400 text-center">
+          Powered by {status.data.source === "foursquare" ? "Foursquare" : "Yelp"}
+        </p>
+      )}
+      {status.kind === "empty" && (
         <p className="mt-2 text-[10px] text-gray-400 text-center">
           Powered by Yelp
         </p>

--- a/src/components/grocery-cart/GroceryCartButton.tsx
+++ b/src/components/grocery-cart/GroceryCartButton.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useGroceryCart } from "@/contexts/GroceryCartContext";
+
+export function GroceryCartButton() {
+  const { itemCount, toggle } = useGroceryCart();
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className="relative px-3 py-2 rounded-lg bg-orange-900/40 hover:bg-orange-800/60 text-orange-200 hover:text-white font-semibold text-sm border border-orange-500/30 transition-all duration-200 hover:scale-105"
+      aria-label={`Grocery cart (${itemCount} item${itemCount === 1 ? "" : "s"})`}
+    >
+      <span aria-hidden>🛒</span>
+      <span className="ml-1.5 hidden sm:inline">Cart</span>
+      {itemCount > 0 && (
+        <span
+          className="absolute -top-1.5 -right-1.5 min-w-[20px] h-5 px-1.5 rounded-full bg-gradient-to-br from-orange-500 to-rose-500 text-white text-[10px] font-extrabold flex items-center justify-center shadow-lg shadow-orange-500/40"
+          aria-hidden
+        >
+          {itemCount > 99 ? "99+" : itemCount}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export default GroceryCartButton;

--- a/src/components/grocery-cart/GroceryCartDrawer.tsx
+++ b/src/components/grocery-cart/GroceryCartDrawer.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState } from "react";
+import { useToast } from "@/components/ToastProvider";
+import { useGroceryCart } from "@/contexts/GroceryCartContext";
+
+export function GroceryCartDrawer() {
+  const {
+    items,
+    isOpen,
+    close,
+    removeItem,
+    updateQuantity,
+    clear,
+    checkoutToInstacart,
+  } = useGroceryCart();
+  const { showToast } = useToast();
+  const [checkingOut, setCheckingOut] = useState(false);
+
+  const handleCheckout = async () => {
+    setCheckingOut(true);
+    try {
+      const url = await checkoutToInstacart();
+      showToast("Opening Instacart with your cart...", "success");
+      window.open(url, "_blank", "noopener,noreferrer");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to send to Instacart.";
+      showToast(msg, "error");
+    } finally {
+      setCheckingOut(false);
+    }
+  };
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className={`fixed inset-0 z-[60] bg-black/60 backdrop-blur-sm transition-opacity duration-200 ${
+          isOpen ? "opacity-100" : "opacity-0 pointer-events-none"
+        }`}
+        onClick={close}
+        aria-hidden={!isOpen}
+      />
+
+      {/* Drawer */}
+      <aside
+        className={`fixed top-0 right-0 z-[61] h-full w-full max-w-md bg-[#0d0b16] border-l border-purple-500/30 shadow-2xl shadow-purple-900/40 flex flex-col transition-transform duration-300 ${
+          isOpen ? "translate-x-0" : "translate-x-full"
+        }`}
+        role="dialog"
+        aria-label="Grocery cart"
+        aria-hidden={!isOpen}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-purple-500/30 bg-gradient-to-r from-purple-900/30 to-transparent">
+          <div>
+            <h2 className="text-lg font-bold text-transparent bg-clip-text bg-gradient-to-r from-purple-300 to-orange-300">
+              Grocery Cart
+            </h2>
+            <p className="text-xs text-gray-400">
+              {items.length === 0
+                ? "Empty"
+                : `${items.length} ingredient${items.length === 1 ? "" : "s"}`}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={close}
+            className="text-gray-400 hover:text-white text-2xl leading-none p-1"
+            aria-label="Close grocery cart"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Items */}
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          {items.length === 0 ? (
+            <div className="h-full flex flex-col items-center justify-center text-center text-gray-400 px-4">
+              <div className="text-5xl mb-3" aria-hidden>🛒</div>
+              <p className="text-sm">Your cart is empty.</p>
+              <p className="text-xs mt-2 text-gray-500">
+                Open a recipe and tap <span className="text-purple-300">Add to grocery cart</span> to get started.
+              </p>
+            </div>
+          ) : (
+            <ul className="space-y-2">
+              {items.map((item) => (
+                <li
+                  key={item.id}
+                  className="rounded-lg border border-purple-500/20 bg-white/5 p-3"
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-semibold text-white capitalize truncate">
+                        {item.name}
+                      </div>
+                      <div className="mt-1 flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => updateQuantity(item.id, item.quantity - 1)}
+                          className="w-6 h-6 flex items-center justify-center rounded bg-white/10 hover:bg-white/20 text-white text-sm font-bold"
+                          aria-label={`Decrease ${item.name}`}
+                        >
+                          −
+                        </button>
+                        <input
+                          type="number"
+                          min={0}
+                          step="0.25"
+                          value={item.quantity}
+                          onChange={(e) => {
+                            const v = parseFloat(e.target.value);
+                            if (!Number.isNaN(v)) updateQuantity(item.id, v);
+                          }}
+                          className="w-16 text-center bg-white/5 border border-white/10 rounded text-white text-sm py-0.5 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => updateQuantity(item.id, item.quantity + 1)}
+                          className="w-6 h-6 flex items-center justify-center rounded bg-white/10 hover:bg-white/20 text-white text-sm font-bold"
+                          aria-label={`Increase ${item.name}`}
+                        >
+                          +
+                        </button>
+                        <span className="text-xs text-gray-400">{item.unit}</span>
+                      </div>
+                      {item.recipeIds.length > 0 && (
+                        <p className="mt-1.5 text-[11px] text-gray-500 italic truncate">
+                          From {item.recipeIds.length} recipe{item.recipeIds.length === 1 ? "" : "s"}
+                        </p>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => removeItem(item.id)}
+                      className="text-gray-500 hover:text-rose-400 text-lg leading-none p-1"
+                      aria-label={`Remove ${item.name}`}
+                    >
+                      ×
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Footer actions */}
+        {items.length > 0 && (
+          <div className="border-t border-purple-500/30 p-4 space-y-2 bg-black/40">
+            <button
+              type="button"
+              onClick={() => void handleCheckout()}
+              disabled={checkingOut}
+              className="w-full px-4 py-3 rounded-xl bg-gradient-to-r from-orange-500 to-amber-500 text-white font-bold text-sm hover:from-orange-400 hover:to-amber-400 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            >
+              {checkingOut ? (
+                <>
+                  <span className="inline-block w-4 h-4 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                  Sending to Instacart...
+                </>
+              ) : (
+                <>
+                  <span aria-hidden>🛍️</span> Checkout with Instacart
+                </>
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={clear}
+              className="w-full px-4 py-2 rounded-lg border border-white/10 text-gray-400 text-xs hover:text-white hover:border-white/20 transition-colors"
+            >
+              Clear cart
+            </button>
+          </div>
+        )}
+      </aside>
+    </>
+  );
+}
+
+export default GroceryCartDrawer;

--- a/src/contexts/GroceryCartContext.tsx
+++ b/src/contexts/GroceryCartContext.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+/**
+ * GroceryCartContext — lightweight, app-wide cart that aggregates ingredients
+ * from one or more recipes and hands off to Instacart for checkout.
+ *
+ * Lives independently of MenuPlannerContext (which is scoped to weekly menu
+ * planning). Persisted to localStorage so the cart survives reloads.
+ *
+ * Pipeline:
+ *   addRecipe(recipe, servings) → ingredients scaled and aggregated by
+ *   (name, normalizedUnit) → checkoutToInstacart() → /api/instacart/shopping-list
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { instacartService } from "@/services/InstacartService";
+import type { GroceryItem } from "@/types/menuPlanner";
+
+const STORAGE_KEY = "alchm:grocery-cart:v1";
+
+export interface GroceryCartIngredientInput {
+  name: string;
+  amount?: number;
+  unit?: string;
+  category?: string;
+  notes?: string;
+}
+
+export interface GroceryCartRecipeInput {
+  id: string;
+  name: string;
+  baseServings: number;
+  ingredients: GroceryCartIngredientInput[];
+}
+
+export interface GroceryCartItem {
+  /** Stable id derived from ingredient name + normalized unit */
+  id: string;
+  name: string;
+  quantity: number;
+  unit: string;
+  category?: string;
+  /** Recipe ids that contributed to this line */
+  recipeIds: string[];
+  /** Free-form notes from any contributing recipe */
+  notes?: string;
+  addedAt: number;
+}
+
+interface GroceryCartContextValue {
+  items: GroceryCartItem[];
+  itemCount: number;
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  /**
+   * Add a recipe's ingredients to the cart, scaled to `targetServings`.
+   * Returns the number of cart lines added or merged.
+   */
+  addRecipe: (recipe: GroceryCartRecipeInput, targetServings: number) => number;
+  removeItem: (id: string) => void;
+  updateQuantity: (id: string, qty: number) => void;
+  clear: () => void;
+  /**
+   * Hands off the current cart to Instacart and returns the shoppable URL.
+   * Throws if cart is empty or the IDP call fails.
+   */
+  checkoutToInstacart: () => Promise<string>;
+}
+
+const GroceryCartContext = createContext<GroceryCartContextValue | null>(null);
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function normalizeUnit(unit?: string): string {
+  if (!unit) return "each";
+  return unit.toLowerCase().trim();
+}
+
+function buildItemId(name: string, unit?: string): string {
+  return `${slugify(name)}__${slugify(normalizeUnit(unit))}`;
+}
+
+function safeRound(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+function readFromStorage(): GroceryCartItem[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (item): item is GroceryCartItem =>
+        typeof item === "object" &&
+        item !== null &&
+        typeof (item as GroceryCartItem).id === "string" &&
+        typeof (item as GroceryCartItem).name === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeToStorage(items: GroceryCartItem[]) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch {
+    // Ignore quota errors
+  }
+}
+
+export function GroceryCartProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<GroceryCartItem[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const hydratedRef = useRef(false);
+
+  // Hydrate from localStorage on mount
+  useEffect(() => {
+    setItems(readFromStorage());
+    hydratedRef.current = true;
+  }, []);
+
+  // Persist on change (skip first paint before hydration)
+  useEffect(() => {
+    if (!hydratedRef.current) return;
+    writeToStorage(items);
+  }, [items]);
+
+  const addRecipe = useCallback(
+    (recipe: GroceryCartRecipeInput, targetServings: number): number => {
+      const baseServings = Math.max(1, recipe.baseServings || 1);
+      const scale = Math.max(0, targetServings) / baseServings;
+      if (scale === 0 || recipe.ingredients.length === 0) return 0;
+
+      let touched = 0;
+      setItems((prev) => {
+        const map = new Map<string, GroceryCartItem>();
+        prev.forEach((item) => map.set(item.id, item));
+
+        for (const ing of recipe.ingredients) {
+          if (!ing.name) continue;
+          const unit = normalizeUnit(ing.unit);
+          const id = buildItemId(ing.name, unit);
+          const scaledAmount = safeRound((ing.amount ?? 1) * scale);
+
+          const existing = map.get(id);
+          if (existing) {
+            map.set(id, {
+              ...existing,
+              quantity: safeRound(existing.quantity + scaledAmount),
+              recipeIds: existing.recipeIds.includes(recipe.id)
+                ? existing.recipeIds
+                : [...existing.recipeIds, recipe.id],
+              notes: existing.notes ?? ing.notes,
+            });
+          } else {
+            map.set(id, {
+              id,
+              name: ing.name,
+              quantity: scaledAmount,
+              unit,
+              category: ing.category,
+              recipeIds: [recipe.id],
+              notes: ing.notes,
+              addedAt: Date.now(),
+            });
+          }
+          touched += 1;
+        }
+
+        return Array.from(map.values()).sort((a, b) => b.addedAt - a.addedAt);
+      });
+      return touched;
+    },
+    [],
+  );
+
+  const removeItem = useCallback((id: string) => {
+    setItems((prev) => prev.filter((item) => item.id !== id));
+  }, []);
+
+  const updateQuantity = useCallback((id: string, qty: number) => {
+    setItems((prev) => {
+      if (qty <= 0) return prev.filter((item) => item.id !== id);
+      return prev.map((item) =>
+        item.id === id ? { ...item, quantity: safeRound(qty) } : item,
+      );
+    });
+  }, []);
+
+  const clear = useCallback(() => {
+    setItems([]);
+  }, []);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => setIsOpen((v) => !v), []);
+
+  const checkoutToInstacart = useCallback(async (): Promise<string> => {
+    if (items.length === 0) {
+      throw new Error("Your grocery cart is empty.");
+    }
+    // Map our cart items into the GroceryItem shape InstacartService expects.
+    const groceryItems: GroceryItem[] = items.map((item) => ({
+      id: item.id,
+      ingredient: item.name,
+      quantity: item.quantity,
+      unit: item.unit,
+      category: item.category ?? "other",
+      inPantry: false,
+      purchased: false,
+      usedInRecipes: item.recipeIds,
+      notes: item.notes,
+    }));
+
+    const url = await instacartService.createShoppingList(
+      groceryItems,
+      "Alchm Kitchen Grocery Cart",
+    );
+    return url;
+  }, [items]);
+
+  const value = useMemo<GroceryCartContextValue>(
+    () => ({
+      items,
+      itemCount: items.length,
+      isOpen,
+      open,
+      close,
+      toggle,
+      addRecipe,
+      removeItem,
+      updateQuantity,
+      clear,
+      checkoutToInstacart,
+    }),
+    [
+      items,
+      isOpen,
+      open,
+      close,
+      toggle,
+      addRecipe,
+      removeItem,
+      updateQuantity,
+      clear,
+      checkoutToInstacart,
+    ],
+  );
+
+  return (
+    <GroceryCartContext.Provider value={value}>
+      {children}
+    </GroceryCartContext.Provider>
+  );
+}
+
+export function useGroceryCart(): GroceryCartContextValue {
+  const ctx = useContext(GroceryCartContext);
+  if (!ctx) {
+    throw new Error("useGroceryCart must be used inside <GroceryCartProvider>");
+  }
+  return ctx;
+}

--- a/src/types/restaurant.ts
+++ b/src/types/restaurant.ts
@@ -36,7 +36,7 @@ export interface SavedRestaurant {
   menuItems: MenuItem[];
   rating?: number;
   addedAt: string;
-  source?: 'manual' | 'foursquare';
+  source?: 'manual' | 'foursquare' | 'yelp';
   externalId?: string;
   address?: string;
 }

--- a/src/types/yelp.ts
+++ b/src/types/yelp.ts
@@ -70,8 +70,18 @@ export interface CosmicContext {
   dominantElement: string;
 }
 
+/** Provider that produced the restaurant results in a discovery response. */
+export type RestaurantDiscoverySource = "yelp" | "foursquare";
+
 export interface RestaurantSearchResponse {
   restaurants: AlchmScoredRestaurant[];
   cosmicContext: CosmicContext;
+  /** Provider that produced these results. Foursquare results are unscored. */
+  source?: RestaurantDiscoverySource;
+  /**
+   * Note shown to the user when scoring/precision is degraded
+   * (e.g. Yelp unavailable, falling back to Foursquare without alchm scoring).
+   */
+  sourceNotice?: string;
   error?: string;
 }


### PR DESCRIPTION
## Summary

Closes the loop on the cuisine recommender so each cuisine offers two parallel actions: cook it (recipes → scaled grocery cart → Instacart checkout) or order it (Yelp/Foursquare discovery → save to profile).

- **Recipes** button on every cuisine profile surfaces matching recipes inline; each sub-card has *View full recipe →* (links to `/recipes/[id]`) and *🛒 Add to grocery cart* (scales ingredients to base servings).
- **Order Local** button routes to a new `/restaurants` page with geolocation-aware discovery, Yelp cosmic scoring with Foursquare fallback, and per-result *+ Save* to the user profile.
- New app-wide **grocery cart** (header pill + slide-out drawer) aggregates ingredients across recipes by name + normalized unit, persists to localStorage, and checks out via the existing `/api/instacart/shopping-list` route.
- Recipe detail page also gains an **Add to grocery cart** button that respects the live servings selector.

## What's new

### Files added
- `src/contexts/GroceryCartContext.tsx` — lightweight context with localStorage persistence, ingredient aggregation, and `checkoutToInstacart()` calling the existing `instacartService.createShoppingList`. Distinct from `MenuPlannerContext` (which is scoped to weekly menu planning).
- `src/components/grocery-cart/GroceryCartButton.tsx` — header pill with item-count badge.
- `src/components/grocery-cart/GroceryCartDrawer.tsx` — slide-out panel: quantity adjuster, remove, clear, "Checkout with Instacart".
- `src/app/restaurants/page.tsx` + `RestaurantsPageClient.tsx` — `/restaurants?cuisine=Italian` page with cuisine search/quick-pick chips wrapping `RestaurantDiscovery`.

### Files modified
- `src/components/CuisineRecommender.tsx` — adds the two action buttons under each selected cuisine's profile description; expanded recipe sub-cards get *View full recipe →* and *🛒 Add to grocery cart*.
- `src/app/recipes/[recipeId]/RecipeClient.tsx` — adds *Add to grocery cart* button next to the existing meal-plan / copy buttons; scales at add-time using current servings.
- `src/app/providers.tsx` + `src/app/layout.tsx` — wraps the tree in `<GroceryCartProvider>`, mounts `<GroceryCartButton />` in nav and `<GroceryCartDrawer />` at root.
- `src/app/api/restaurants/search/route.ts` — POST now tries Yelp first, falls back to Foursquare Places v3 (lat/lng query) when Yelp is unconfigured / empty / errors. Returns `source` + `sourceNotice` for the UI.
- `src/components/RestaurantDiscovery/RestaurantDiscovery.tsx` — source-notice banner, Foursquare chip in place of cosmic score badge when scoring is unavailable, *+ Save* button per result that persists to `currentUser.preferences.savedRestaurants` (UserContext) with `localStorage.userFoodPreferences` mirror for anon users. Hydrates saved-state from both stores on mount.
- `src/types/yelp.ts` — adds `RestaurantDiscoverySource`, `source`, `sourceNotice` to `RestaurantSearchResponse`.
- `src/types/restaurant.ts` — `SavedRestaurant.source` accepts `'yelp'` alongside `'manual' | 'foursquare'`.

## Provider behavior matrix (POST `/api/restaurants/search`)

| Yelp configured | Yelp returns results | Foursquare configured | Result |
|---|---|---|---|
| ✅ | ✅ | — | Yelp scored, `source: "yelp"` |
| ✅ | ❌ | ✅ | Foursquare unscored + `sourceNotice` |
| ❌ | — | ✅ | Foursquare unscored + `sourceNotice` |
| ❌ | — | ❌ | `error: "Restaurant discovery is not configured."` |

Foursquare results are shaped into the existing `AlchmScoredRestaurant` type with neutral score values, so the UI doesn't need a separate render path. Saved restaurants from this flow surface in the existing `/profile` Recommendations panel via the same `savedRestaurants` array.

## Notes for reviewers

- `CuisineRecommender.tsx` is `// @ts-nocheck` — the new handlers were written with that in mind and don't introduce type contracts elsewhere.
- The grocery cart is intentionally separate from `MenuPlannerContext` because it's app-wide (open from any page) and aggregates across loose recipes rather than weekly meal slots.
- Saved-restaurants persistence path matches `RecommendationsPanel.handleSaveRestaurant` exactly (UserContext + localStorage mirror), so the existing profile UI and this new discovery UI stay in sync.
- Ingredient aggregation collapses by `(slugified name, slugified unit)`. We don't do unit reconciliation across rows ("2 cloves" + "1 tbsp minced" stay separate) — that's a known limitation, can be a follow-up.
- Squarespace was a misread of "Foursquare" — no Squarespace work was needed.

## Test plan
- [ ] `/` → expand a cuisine card → confirm Recipes + Order Local buttons render under the description
- [ ] Click *Add to grocery cart* on an expanded recipe sub-card → cart icon badge increments, drawer shows the line item
- [ ] Open a recipe page, change servings, click Add to grocery cart → quantities reflect the chosen servings
- [ ] Cart drawer → +/- quantity controls, remove, clear all
- [ ] Cart drawer → *Checkout with Instacart* opens an IDP shoppable URL in a new tab
- [ ] Click Order Local → `/restaurants?cuisine=<name>` loads, browser prompts for location
- [ ] With `YELP_API_KEY` set: results show cosmic score + element badge + match reasons
- [ ] With only `FOURSQUARE_API_KEY` set: results show Foursquare chip + degraded-mode banner
- [ ] *+ Save* on a result → toast confirms, button flips to ✓ Saved, restaurant appears in `/profile` Recommendations
- [ ] Reload `/restaurants` → previously saved restaurants show ✓ Saved without re-fetching
- [ ] `yarn tsc --noEmit` → 0 errors (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)