### PR TITLE
fix: add missing Link import to recipes page

### DIFF
--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import React, { useState, useEffect, Suspense, useCallback } from "react";
 import { FaWind } from "react-icons/fa";


### PR DESCRIPTION
## Summary

- PRs #359 and #360 both failed to deploy to Vercel production with a TypeScript build error.
- Root cause: commit `6cc88883` (from PR #360) replaced a bare `<a>` with `<Link>` in `src/app/recipes/page.tsx` but forgot to add `import Link from "next/link"`, causing `TS2304: Cannot find name 'Link'` during the `next build` type-check phase.
- Fix: adds the missing import on line 3 of the file.

## Test plan

- [ ] Vercel build should pass — the only TypeScript error (`src/app/recipes/page.tsx:170`) is now resolved.
- [ ] Recipes page still renders a `<Link href="/">← Back to Home</Link>` when no cuisine is selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)