### PR TITLE
feat(security): server-side recipe-gen limits + in-memory rate limiting

### DIFF
--- a/src/app/api/alchemize/route.ts
+++ b/src/app/api/alchemize/route.ts
@@ -13,6 +13,7 @@
  * - enhanced: true to use full enhanced calculation, false for legacy (defaults to true)
  */
 import { NextResponse } from "next/server";
+import { rateLimit } from "@/lib/rateLimit";
 import { AlchemizeQuerySchema } from "@/lib/validation/railway";
 import { calculateComprehensiveAspects, type PlanetaryPositionData } from "@/utils/aspectCalculator";
 import type { AspectWithStrength } from "@/utils/aspectESMSEffects";
@@ -35,7 +36,11 @@ const SIGN_TO_MODALITY: Record<string, string> = {
   gemini: "Mutable", virgo: "Mutable", sagittarius: "Mutable", pisces: "Mutable",
 };
 
+const ALCHEMIZE_LIMIT = { window: 60_000, max: 60, bucket: "alchemize" };
+
 export async function GET(request: Request) {
+  const rl = rateLimit(request, ALCHEMIZE_LIMIT);
+  if (!rl.allowed) return rl.response!;
   try {
     const { searchParams } = new URL(request.url);
 

--- a/src/app/api/cuisines/recommend/route.ts
+++ b/src/app/api/cuisines/recommend/route.ts
@@ -14,8 +14,11 @@
  */
 import { NextResponse } from "next/server";
 import { allRecipes } from "@/data/recipes/index";
+import { rateLimit } from "@/lib/rateLimit";
 import { CuisinesQuerySchema, parseCuisinesResponse } from "@/lib/validation/railway";
 import { getAccuratePlanetaryPositions } from "@/utils/astrology/positions";
+
+const CUISINES_LIMIT = { window: 60_000, max: 60, bucket: "cuisines-recommend" };
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -177,9 +180,13 @@ async function handleRequest(request: Request) {
 }
 
 export async function GET(request: Request) {
+  const rl = rateLimit(request, CUISINES_LIMIT);
+  if (!rl.allowed) return rl.response!;
   return handleRequest(request);
 }
 
 export async function POST(request: Request) {
+  const rl = rateLimit(request, CUISINES_LIMIT);
+  if (!rl.allowed) return rl.response!;
   return handleRequest(request);
 }

--- a/src/app/api/current-moment/route.ts
+++ b/src/app/api/current-moment/route.ts
@@ -3,10 +3,13 @@
  * Returns current astrological moment — planetary positions + elemental snapshot.
  */
 import { NextResponse } from "next/server";
+import { rateLimit } from "@/lib/rateLimit";
 import { getAccuratePlanetaryPositions } from "@/utils/astrology/positions";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+const CURRENT_MOMENT_LIMIT = { window: 60_000, max: 60, bucket: "current-moment" };
 
 const SIGN_TO_ELEMENT: Record<string, string> = {
   aries: "Fire", leo: "Fire", sagittarius: "Fire",
@@ -15,7 +18,11 @@ const SIGN_TO_ELEMENT: Record<string, string> = {
   cancer: "Water", scorpio: "Water", pisces: "Water",
 };
 
-export async function GET() {
+export async function GET(request?: Request) {
+  if (request) {
+    const rl = rateLimit(request, CURRENT_MOMENT_LIMIT);
+    if (!rl.allowed) return rl.response!;
+  }
   try {
     const now = new Date();
     const raw = getAccuratePlanetaryPositions(now);
@@ -60,4 +67,4 @@ export async function GET() {
   }
 }
 
-export async function POST() { return GET(); }
+export async function POST(request: Request) { return GET(request); }

--- a/src/app/api/generate-cosmic-recipe/route.ts
+++ b/src/app/api/generate-cosmic-recipe/route.ts
@@ -41,11 +41,31 @@ export async function POST(request: Request) {
     });
   }
 
-  // 1. Check if user is premium
+  // 1. Enforce monthly generation cap (defense-in-depth alongside token economy).
+  const featureCheck = await subscriptionService.canUseFeature(
+    userId,
+    "monthlyRecipeGenerations",
+  );
+  if (!featureCheck.allowed) {
+    return new Response(
+      JSON.stringify({
+        error: "monthly_limit_reached",
+        message: featureCheck.reason,
+        currentUsage: featureCheck.currentUsage,
+        limit: featureCheck.limit,
+      }),
+      {
+        status: 429,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  // 2. Check if user is premium
   const sub = await subscriptionService.getUserSubscription(userId);
   const isPremium = sub?.tier === "premium";
 
-  // 2. If not premium, they MUST spend tokens OR have a valid monthly slot
+  // 3. If not premium, they MUST spend tokens OR have a valid monthly slot
   // (We'll prioritize tokens for 'cosmic' recipes as they are special sinks)
   // Apply live pricing so the debit matches what the Token Shop displays.
   if (!isPremium) {
@@ -88,7 +108,7 @@ export async function POST(request: Request) {
     }
   }
 
-  // 3. Increment usage counter
+  // 4. Increment usage counter
   try {
     await subscriptionService.incrementUsage(userId, "recipe_generation");
   } catch (error) {

--- a/src/app/api/planetary-positions/route.ts
+++ b/src/app/api/planetary-positions/route.ts
@@ -6,8 +6,11 @@
  * Used by useAlchemical, astrologyDataProvider, astrologyValidation.
  */
 import { NextResponse } from "next/server";
+import { rateLimit } from "@/lib/rateLimit";
 import { getAccuratePlanetaryPositions, getSignFromLongitude } from "@/utils/astrology/positions";
 import type { NextRequest } from "next/server";
+
+const PLANETARY_LIMIT = { window: 60_000, max: 60, bucket: "planetary-positions" };
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -167,6 +170,8 @@ function toResponse(
 }
 
 export async function GET(request: NextRequest) {
+  const rl = rateLimit(request, PLANETARY_LIMIT);
+  if (!rl.allowed) return rl.response!;
   try {
     const params = parsePlanetaryRequest(request);
     const backendPositions = await fetchFromBackend(params);
@@ -194,6 +199,8 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, PLANETARY_LIMIT);
+  if (!rl.allowed) return rl.response!;
   try {
     const body = (await request.json()) as PlanetaryRequestBody;
     const backendPositions = await fetchFromBackend(body || {});

--- a/src/app/api/recommendations/generate/route.ts
+++ b/src/app/api/recommendations/generate/route.ts
@@ -217,6 +217,24 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Enforce monthly generation cap (defense-in-depth alongside token economy).
+  const featureCheck = await subscriptionService.canUseFeature(
+    userId,
+    "monthlyRecipeGenerations",
+  );
+  if (!featureCheck.allowed) {
+    return NextResponse.json(
+      {
+        success: false,
+        reason: "monthly_limit_reached",
+        message: featureCheck.reason,
+        currentUsage: featureCheck.currentUsage,
+        limit: featureCheck.limit,
+      },
+      { status: 429 },
+    );
+  }
+
   const sub = await subscriptionService.getUserSubscription(userId);
   const isPremium = sub?.tier === "premium";
 
@@ -303,6 +321,16 @@ export async function POST(request: NextRequest) {
 
     // Cache the result for the TTL window so repeat clicks are instant.
     storeMemo(cacheKey, recommendations);
+
+    // Increment usage counter so canUseFeature can enforce monthly caps.
+    // Skip on retry-window reuse: the original request already counted.
+    if (!usedRetryWindow) {
+      try {
+        await subscriptionService.incrementUsage(userId, "recipe_generation");
+      } catch (error) {
+        console.warn("[recommendations/generate] Failed to increment usage", error);
+      }
+    }
 
     const totalMs = Date.now() - tStart;
     return NextResponse.json(

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,0 +1,103 @@
+/**
+ * Lightweight sliding-window rate limiter for Next.js API routes.
+ *
+ * In-memory by design: Railway runs a single Node process per service, so a
+ * shared Map is sufficient. If we ever scale horizontally, swap the store
+ * for Upstash Redis (`@upstash/ratelimit`) — the call sites do not change.
+ *
+ * Usage:
+ *   const rl = await rateLimit(request, { window: 60_000, max: 30 });
+ *   if (!rl.allowed) return rl.response;
+ */
+import { NextResponse } from "next/server";
+
+interface Bucket {
+  timestamps: number[];
+}
+
+const store = new Map<string, Bucket>();
+const MAX_KEYS = 10_000;
+
+function clientKey(request: Request): string {
+  const xff = request.headers.get("x-forwarded-for");
+  if (xff) return xff.split(",")[0]!.trim();
+  const real = request.headers.get("x-real-ip");
+  if (real) return real.trim();
+  return "unknown";
+}
+
+export interface RateLimitOptions {
+  /** Sliding window length in ms. */
+  window: number;
+  /** Max requests allowed within the window. */
+  max: number;
+  /** Optional bucket name to namespace counters per route. */
+  bucket?: string;
+  /** Optional override for the client identifier (e.g. user id). */
+  identifier?: string;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  resetMs: number;
+  response?: NextResponse;
+}
+
+export function rateLimit(
+  request: Request,
+  options: RateLimitOptions,
+): RateLimitResult {
+  const { window, max, bucket = "global", identifier } = options;
+  const id = identifier ?? clientKey(request);
+  const key = `${bucket}:${id}`;
+  const now = Date.now();
+  const cutoff = now - window;
+
+  let entry = store.get(key);
+  if (!entry) {
+    if (store.size >= MAX_KEYS) {
+      // Drop oldest insertion-order key to bound memory under attack.
+      const oldest = store.keys().next().value;
+      if (oldest !== undefined) store.delete(oldest);
+    }
+    entry = { timestamps: [] };
+    store.set(key, entry);
+  }
+
+  entry.timestamps = entry.timestamps.filter((t) => t > cutoff);
+
+  if (entry.timestamps.length >= max) {
+    const oldestInWindow = entry.timestamps[0]!;
+    const resetMs = Math.max(0, window - (now - oldestInWindow));
+    const retryAfter = Math.ceil(resetMs / 1000);
+    return {
+      allowed: false,
+      remaining: 0,
+      resetMs,
+      response: NextResponse.json(
+        {
+          error: "rate_limit_exceeded",
+          message: "Too many requests. Please try again shortly.",
+          retryAfter,
+        },
+        {
+          status: 429,
+          headers: {
+            "Retry-After": String(retryAfter),
+            "X-RateLimit-Limit": String(max),
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": String(Math.ceil((now + resetMs) / 1000)),
+          },
+        },
+      ),
+    };
+  }
+
+  entry.timestamps.push(now);
+  return {
+    allowed: true,
+    remaining: max - entry.timestamps.length,
+    resetMs: window,
+  };
+}


### PR DESCRIPTION
Add canUseFeature('monthlyRecipeGenerations') guard (HTTP 429) before any AI/generation work in /api/generate-cosmic-recipe and /api/recommendations/generate. The latter now also increments usage on success (skipped for retry-window reuse). Previously the monthly cap was UI-only, allowing direct-POST bypass.

Add src/lib/rateLimit.ts — sliding-window in-memory limiter for Next.js API routes. Wire it at 60 req/min/IP to /api/alchemize, /api/planetary-positions, /api/cuisines/recommend, and /api/current-moment. The old express-based src/middleware/rate-limiting.ts was fully mocked and is left untouched (dead code).