### PR TITLE
refactor(menu-planner): extract useMenuStats + useMenuPersistence, ra…

### DIFF
--- a/src/app/api/alchm-quantities/aspects/route.ts
+++ b/src/app/api/alchm-quantities/aspects/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { rateLimit } from "@/lib/rateLimit";
 import { calculateComprehensiveAspects } from "@/utils/aspectCalculator";
 import { createLogger } from "@/utils/logger";
 import { AVERAGE_DAILY_MOTION } from "@/utils/planetaryTransitions";
@@ -45,7 +46,12 @@ export interface AspectEntry {
   influence: "harmonious" | "challenging" | "neutral";
 }
 
-export async function GET() {
+const RATE_LIMIT = { window: 60_000, max: 30, bucket: "alchm-quantities-aspects" };
+
+export async function GET(request: Request) {
+  const rl = rateLimit(request, RATE_LIMIT);
+  if (!rl.allowed) return rl.response!;
+
   try {
     logger.info("Aspects API called");
 

--- a/src/app/api/alchm-quantities/echoes/route.ts
+++ b/src/app/api/alchm-quantities/echoes/route.ts
@@ -10,6 +10,7 @@
  * within recorded history.
  */
 import { NextResponse } from "next/server";
+import { rateLimit } from "@/lib/rateLimit";
 import {
   ECHO_PLANETS,
   findOuterPlanetEcho,
@@ -28,7 +29,12 @@ function isEchoPlanet(value: string | null): value is EchoPlanet {
   return value !== null && (ECHO_PLANETS as readonly string[]).includes(value);
 }
 
+const RATE_LIMIT = { window: 60_000, max: 30, bucket: "alchm-quantities-echoes" };
+
 export async function GET(request: Request) {
+  const rl = rateLimit(request, RATE_LIMIT);
+  if (!rl.allowed) return rl.response!;
+
   try {
     const url = new URL(request.url);
     const planetParam = url.searchParams.get("planet");

--- a/src/app/api/alchm-quantities/planetary/route.ts
+++ b/src/app/api/alchm-quantities/planetary/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { rateLimit } from "@/lib/rateLimit";
 import type { PlanetPosition } from "@/utils/astrologyUtils";
 import { createLogger } from "@/utils/logger";
 import {
@@ -43,7 +44,12 @@ interface PlanetaryData {
   };
 }
 
-export async function GET() {
+const RATE_LIMIT = { window: 60_000, max: 30, bucket: "alchm-quantities-planetary" };
+
+export async function GET(request: Request) {
+  const rl = rateLimit(request, RATE_LIMIT);
+  if (!rl.allowed) return rl.response!;
+
   try {
     logger.info("Planetary Contributions API called - starting processing");
 

--- a/src/app/api/alchm-quantities/statistics/route.ts
+++ b/src/app/api/alchm-quantities/statistics/route.ts
@@ -10,6 +10,7 @@
  * astronomy-engine calls, no backend round-trips.
  */
 import { NextResponse } from "next/server";
+import { rateLimit } from "@/lib/rateLimit";
 import {
   getAllPeriodStatistics,
   getSampleFileMeta,
@@ -37,7 +38,12 @@ function isPeriod(value: string | null): value is StatPeriod {
   return value !== null && (VALID_PERIODS as string[]).includes(value);
 }
 
+const RATE_LIMIT = { window: 60_000, max: 60, bucket: "alchm-quantities-statistics" };
+
 export async function GET(request: Request) {
+  const rl = rateLimit(request, RATE_LIMIT);
+  if (!rl.allowed) return rl.response!;
+
   try {
     const url = new URL(request.url);
     const periodParam = url.searchParams.get("period");

--- a/src/app/api/alchm-quantities/trends/route.ts
+++ b/src/app/api/alchm-quantities/trends/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { rateLimit } from "@/lib/rateLimit";
 import { alchemize } from "@/services/RealAlchemizeService";
 import { createLogger } from "@/utils/logger";
 import { isSectDiurnal } from "@/utils/planetaryAlchemyMapping";
@@ -29,7 +30,12 @@ interface TrendPoint {
   isDiurnal: boolean;
 }
 
-export async function GET() {
+const RATE_LIMIT = { window: 60_000, max: 30, bucket: "alchm-quantities-trends" };
+
+export async function GET(request: Request) {
+  const rl = rateLimit(request, RATE_LIMIT);
+  if (!rl.allowed) return rl.response!;
+
   try {
     logger.info("Alchm Quantities Trends API called");
 

--- a/src/app/api/amazon/feedback/route.ts
+++ b/src/app/api/amazon/feedback/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { executeQuery } from "@/lib/database/connection";
 import { auth } from "@/lib/auth/auth";
+import { executeQuery } from "@/lib/database/connection";
 
 export async function POST(request: Request) {
   try {

--- a/src/app/api/amazon/search/route.ts
+++ b/src/app/api/amazon/search/route.ts
@@ -1,11 +1,11 @@
 import { openai } from "@ai-sdk/openai";
 import { generateText } from "ai";
 import { NextResponse } from "next/server";
-import { rateLimit } from "@/lib/rateLimit";
 import {
   hasAmazonCreatorsCredentials,
   searchAmazonCreatorsCatalog,
 } from "@/lib/amazonCreators";
+import { rateLimit } from "@/lib/rateLimit";
 
 export async function GET(request: Request) {
   const rl = rateLimit(request, { window: 60_000, max: 30, bucket: "amazon-search" });

--- a/src/app/api/quests/claim/route.ts
+++ b/src/app/api/quests/claim/route.ts
@@ -1,12 +1,18 @@
 import { NextResponse } from "next/server";
 import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { rateLimit } from "@/lib/rateLimit";
 import { questService } from "@/services/QuestService";
 import type { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+const RATE_LIMIT = { window: 60_000, max: 30, bucket: "quests-claim" };
+
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, RATE_LIMIT);
+  if (!rl.allowed) return rl.response!;
+
   const userId = await getUserIdFromRequest(request);
   if (!userId) {
     return NextResponse.json(

--- a/src/app/api/quests/masters-pantry/route.ts
+++ b/src/app/api/quests/masters-pantry/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
 import { executeQuery } from "@/lib/database/connection";
+import { rateLimit } from "@/lib/rateLimit";
 import { questService } from "@/services/QuestService";
 import { tokenEconomy } from "@/services/TokenEconomyService";
 import type { NextRequest } from "next/server";
@@ -8,8 +9,12 @@ import type { NextRequest } from "next/server";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-// GET a random unverified ingredient
+const RATE_LIMIT = { window: 60_000, max: 60, bucket: "quests-masters-pantry" };
+
 export async function GET(request: NextRequest) {
+  const rl = rateLimit(request, RATE_LIMIT);
+  if (!rl.allowed) return rl.response!;
+
   try {
     const user = await getDatabaseUserFromRequest(request);
     if (!user) return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
@@ -43,8 +48,10 @@ export async function GET(request: NextRequest) {
   }
 }
 
-// POST to verify an ingredient and earn tokens
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, RATE_LIMIT);
+  if (!rl.allowed) return rl.response!;
+
   try {
     const user = await getDatabaseUserFromRequest(request);
     if (!user) return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/quests/streak/route.ts
+++ b/src/app/api/quests/streak/route.ts
@@ -5,6 +5,7 @@
 
 import { NextResponse } from "next/server";
 import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { rateLimit } from "@/lib/rateLimit";
 import { streakService } from "@/services/StreakService";
 import { getStreakMultiplier } from "@/types/economy";
 import type { NextRequest } from "next/server";
@@ -12,7 +13,12 @@ import type { NextRequest } from "next/server";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+const RATE_LIMIT = { window: 60_000, max: 60, bucket: "quests-streak" };
+
 export async function GET(request: NextRequest) {
+  const rl = rateLimit(request, RATE_LIMIT);
+  if (!rl.allowed) return rl.response!;
+
   try {
     const userId = await getUserIdFromRequest(request);
     if (!userId) {

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -11,8 +11,8 @@ import type { UserProfile } from "@/contexts/UserContext";
 import {
   getDatabaseUserFromRequest,
 } from "@/lib/auth/validateRequest";
-import { UserProfileUpdateSchema } from "@/lib/validation/apiSchemas";
 import { _logger } from "@/lib/logger";
+import { UserProfileUpdateSchema } from "@/lib/validation/apiSchemas";
 import { getPlanetaryPositionsForDateTime } from "@/services/astrologizeApi";
 import { userDatabase } from "@/services/userDatabaseService";
 import type { NextRequest } from "next/server";

--- a/src/app/cuisines/page.tsx
+++ b/src/app/cuisines/page.tsx
@@ -2,8 +2,8 @@
 
 import { motion } from "framer-motion";
 import dynamic from "next/dynamic";
-import type { Variants } from "framer-motion";
 import { PremiumGate } from "@/components/PremiumGate";
+import type { Variants } from "framer-motion";
 
 function SectionLoader() {
   return (

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -165,7 +165,7 @@ function RecipesPageContent() {
             <p className="text-6xl mb-6">🍽️</p>
             <h2 className="text-2xl font-bold text-white mb-3">No Recipes Found</h2>
             <p className="text-gray-400 mb-8 max-w-md mx-auto">
-              We couldn't find any recipes matching your selection. Try a different cuisine or check back later.
+              We couldn&apos;t find any recipes matching your selection. Try a different cuisine or check back later.
             </p>
             <Link
               href="/"

--- a/src/components/CookingMethods.tsx
+++ b/src/components/CookingMethods.tsx
@@ -402,7 +402,7 @@ export default function CookingMethods() {
 
   useEffect(() => {
     let isMounted = true;
-    getCulturalCookingMethods().then(methods => {
+    void getCulturalCookingMethods().then(methods => {
       if (isMounted) {
         setCulturalMethods(methods);
       }
@@ -484,7 +484,7 @@ export default function CookingMethods() {
       console.error("Error initializing culture map:", error);
       return map;
     }
-  }, []);
+  }, [culturalMethods]);
 
   // Get global astrological adjustment info
   const _globalAstrologicalAdjustment = useMemo(() => {

--- a/src/components/CuisineRecommender.tsx
+++ b/src/components/CuisineRecommender.tsx
@@ -737,7 +737,7 @@ export default function CuisineRecommender() {
             <div 
               key={cuisine.id}
               className={`rounded border p-2 cursor-pointer transition-all duration-200 hover:shadow-md ${selectedCuisine === cuisine.id ? 'border-blue-400 bg-blue-50' : 'border-gray-200'}`}
-              onClick={() => handleCuisineSelect(cuisine.id)}
+              onClick={() => { void handleCuisineSelect(cuisine.id); }}
             >
               <div className="flex justify-between items-center mb-1">
                 <h3 className="font-medium text-sm">{cuisineData.name}</h3>

--- a/src/components/grocery-cart/GroceryCartDrawer.tsx
+++ b/src/components/grocery-cart/GroceryCartDrawer.tsx
@@ -190,32 +190,32 @@ export function GroceryCartDrawer() {
                       </div>
                       <form 
                         className="flex items-center gap-1 pl-2"
-                        onSubmit={async (e) => {
+                        onSubmit={(e) => {
                           e.preventDefault();
                           const form = e.currentTarget;
                           const formData = new FormData(form);
                           const asin = formData.get('asin') as string;
                           if (!asin) return;
-                          
-                          // Optimistic local update — always apply regardless of auth status
                           updateAsin(item.id, asin);
                           form.reset();
-                          try {
-                            const res = await fetch('/api/amazon/feedback', {
-                              method: 'POST',
-                              headers: { 'Content-Type': 'application/json' },
-                              body: JSON.stringify({ ingredientName: item.name, asin })
-                            });
-                            if (res.ok) {
-                              showToast('ASIN mapped and saved to database!', 'success');
-                            } else if (res.status === 401) {
-                              showToast('Mapped locally (sign in to save permanently)', 'success');
-                            } else {
-                              showToast('Mapped locally (database save failed)', 'success');
+                          void (async () => {
+                            try {
+                              const res = await fetch('/api/amazon/feedback', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ ingredientName: item.name, asin })
+                              });
+                              if (res.ok) {
+                                showToast('ASIN mapped and saved to database!', 'success');
+                              } else if (res.status === 401) {
+                                showToast('Mapped locally (sign in to save permanently)', 'success');
+                              } else {
+                                showToast('Mapped locally (database save failed)', 'success');
+                              }
+                            } catch {
+                              showToast('Mapped locally (offline — database save skipped)', 'success');
                             }
-                          } catch {
-                            showToast('Mapped locally (offline — database save skipped)', 'success');
-                          }
+                          })();
                         }}
                       >
                         <input 

--- a/src/components/profile/TierUpgradePrompt.tsx
+++ b/src/components/profile/TierUpgradePrompt.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import React from 'react';
-import { PREMIUM_FEATURES_DISPLAY } from '@/lib/tiers';
 import { usePremium } from '@/contexts/PremiumContext';
+import { PREMIUM_FEATURES_DISPLAY } from '@/lib/tiers';
 
 export const TierUpgradePrompt: React.FC = () => {
   const { openCheckout } = usePremium();

--- a/src/components/recommendations/EnhancedSauceRecommender.tsx
+++ b/src/components/recommendations/EnhancedSauceRecommender.tsx
@@ -11,7 +11,6 @@ import { allSauces } from "@/data/sauces";
 import { useAstrologicalState } from "@/hooks/useAstrologicalState";
 import { useCurrentSeason } from "@/hooks/useCurrentSeason";
 import {
-  buildCuisineSaucePool,
   getCuisineFingerprint,
   listCuisines,
   recommendForCuisineContext,
@@ -19,7 +18,6 @@ import {
   type CuisineSauceResult,
   type FlavorAxis,
   type SauceRole,
-  type UnifiedSauce,
 } from "@/utils/cuisine/cuisineSauceProfiler";
 import { scaleSauceIngredients, parseYieldToServings } from "@/utils/sauceScaling";
 
@@ -31,7 +29,7 @@ const PROTEINS = ["beef", "pork", "chicken", "fish", "seafood", "tofu", "vegetar
 const VEGETABLES = ["leafy", "root", "nightshades", "squash", "mushroom", "seaweed"];
 const COOKING_METHODS = ["grilling", "baking", "frying", "deep-frying", "braising", "steaming", "simmering", "raw", "sautéing", "roasting"];
 
-const DIETARY = [
+const _DIETARY = [
   { key: "vegetarian", label: "Vegetarian" },
   { key: "vegan", label: "Vegan" },
   { key: "glutenFree", label: "Gluten-Free" },
@@ -39,7 +37,7 @@ const DIETARY = [
   { key: "lowSodium", label: "Low-Sodium" },
 ];
 
-const FLAVOR_AXES: Array<{ key: FlavorAxis; label: string; color: string }> = [
+const _FLAVOR_AXES: Array<{ key: FlavorAxis; label: string; color: string }> = [
   { key: "umami", label: "Umami", color: "bg-rose-500/15 text-rose-700 border-rose-300/40" },
   { key: "spicy", label: "Spicy", color: "bg-orange-500/15 text-orange-700 border-orange-300/40" },
   { key: "sweet", label: "Sweet", color: "bg-amber-500/15 text-amber-700 border-amber-300/40" },
@@ -48,14 +46,14 @@ const FLAVOR_AXES: Array<{ key: FlavorAxis; label: string; color: string }> = [
   { key: "salty", label: "Salty", color: "bg-sky-500/15 text-sky-700 border-sky-300/40" },
 ];
 
-const ROLES: Array<{ key: SauceRole; label: string; description: string }> = [
+const _ROLES: Array<{ key: SauceRole; label: string; description: string }> = [
   { key: "complement", label: "Complement", description: "Mirror the cuisine's energy" },
   { key: "contrast", label: "Contrast", description: "Cut through and contrast" },
   { key: "enhance", label: "Enhance", description: "Amplify the dominant note" },
   { key: "balance", label: "Balance", description: "Round out the missing notes" },
 ];
 
-const SEASON_OPTIONS = [
+const _SEASON_OPTIONS = [
   { key: "all", label: "Year-round" },
   { key: "spring", label: "Spring" },
   { key: "summer", label: "Summer" },
@@ -253,10 +251,10 @@ export default function EnhancedSauceRecommender() {
   const [protein, setProtein] = useState<string | undefined>(undefined);
   const [vegetable, setVegetable] = useState<string | undefined>(undefined);
   const [cookingMethod, setCookingMethod] = useState<string | undefined>(undefined);
-  const [dietary, setDietary] = useState<string[]>([]);
-  const [flavorTargets, setFlavorTargets] = useState<FlavorAxis[]>([]);
-  const [role, setRole] = useState<SauceRole>("complement");
-  const [season, setSeason] = useState<CuisineSauceContext["season"]>(detectedSeason.toLowerCase() as any);
+  const [dietary, _setDietary] = useState<string[]>([]);
+  const [flavorTargets, _setFlavorTargets] = useState<FlavorAxis[]>([]);
+  const [role, _setRole] = useState<SauceRole>("complement");
+  const [season, _setSeason] = useState<CuisineSauceContext["season"]>(detectedSeason.toLowerCase() as any);
   const [cosmicSync, setCosmicSync] = useState(false);
   const [strictCuisine, setStrictCuisine] = useState(false);
   const [recommendations, setRecommendations] = useState<CuisineSauceResult[]>([]);
@@ -293,7 +291,7 @@ export default function EnhancedSauceRecommender() {
     }, 300);
   }, [ctx, strictCuisine, cuisinesMapData]);
 
-  const toggleInArray = useCallback(<T extends string>(value: T, arr: T[], setter: (v: T[]) => void) => {
+  const _toggleInArray = useCallback(<T extends string>(value: T, arr: T[], setter: (v: T[]) => void) => {
     setter(arr.includes(value) ? arr.filter((x) => x !== value) : [...arr, value]);
   }, []);
 
@@ -312,15 +310,15 @@ export default function EnhancedSauceRecommender() {
           </h3>
           <div className="space-y-4">
             <div>
-              <label className="text-[10px] uppercase font-bold text-slate-400 mb-1.5 block">Region/Tradition</label>
-              <select value={cuisineKey} onChange={(e) => { setCuisineKey(e.target.value); setRegion(undefined); }} className="w-full bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm">
+              <label htmlFor="sauce-cuisine-key" className="text-[10px] uppercase font-bold text-slate-400 mb-1.5 block">Region/Tradition</label>
+              <select id="sauce-cuisine-key" value={cuisineKey} onChange={(e) => { setCuisineKey(e.target.value); setRegion(undefined); }} className="w-full bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm">
                 {availableCuisines.map(c => <option key={c.key} value={c.key}>{c.name}</option>)}
               </select>
             </div>
             {fingerprint && fingerprint.regions.length > 0 && (
               <div>
-                <label className="text-[10px] uppercase font-bold text-slate-400 mb-1.5 block">Regional Variant</label>
-                <select value={region || ""} onChange={(e) => setRegion(e.target.value || undefined)} className="w-full bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm">
+                <label htmlFor="sauce-region" className="text-[10px] uppercase font-bold text-slate-400 mb-1.5 block">Regional Variant</label>
+                <select id="sauce-region" value={region || ""} onChange={(e) => setRegion(e.target.value || undefined)} className="w-full bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm">
                   <option value="">Full {fingerprint.name} Cuisine</option>
                   {fingerprint.regions.map(r => <option key={r.key} value={r.key}>{r.name}</option>)}
                 </select>
@@ -338,23 +336,23 @@ export default function EnhancedSauceRecommender() {
           <div className="grid grid-cols-1 gap-4">
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className="text-[10px] uppercase font-bold text-slate-400 mb-1 block">Protein</label>
-                <select value={protein || ""} onChange={(e) => setProtein(e.target.value || undefined)} className="w-full bg-white border border-slate-200 rounded-lg px-2 py-1.5 text-xs">
+                <label htmlFor="sauce-protein" className="text-[10px] uppercase font-bold text-slate-400 mb-1 block">Protein</label>
+                <select id="sauce-protein" value={protein || ""} onChange={(e) => setProtein(e.target.value || undefined)} className="w-full bg-white border border-slate-200 rounded-lg px-2 py-1.5 text-xs">
                   <option value="">Select...</option>
                   {PROTEINS.map(p => <option key={p} value={p}>{p}</option>)}
                 </select>
               </div>
               <div>
-                <label className="text-[10px] uppercase font-bold text-slate-400 mb-1 block">Vegetable</label>
-                <select value={vegetable || ""} onChange={(e) => setVegetable(e.target.value || undefined)} className="w-full bg-white border border-slate-200 rounded-lg px-2 py-1.5 text-xs">
+                <label htmlFor="sauce-vegetable" className="text-[10px] uppercase font-bold text-slate-400 mb-1 block">Vegetable</label>
+                <select id="sauce-vegetable" value={vegetable || ""} onChange={(e) => setVegetable(e.target.value || undefined)} className="w-full bg-white border border-slate-200 rounded-lg px-2 py-1.5 text-xs">
                   <option value="">Select...</option>
                   {VEGETABLES.map(v => <option key={v} value={v}>{v}</option>)}
                 </select>
               </div>
             </div>
             <div>
-              <label className="text-[10px] uppercase font-bold text-slate-400 mb-1 block">Cooking Method</label>
-              <select value={cookingMethod || ""} onChange={(e) => setCookingMethod(e.target.value || undefined)} className="w-full bg-white border border-slate-200 rounded-lg px-2 py-1.5 text-xs">
+              <label htmlFor="sauce-cooking-method" className="text-[10px] uppercase font-bold text-slate-400 mb-1 block">Cooking Method</label>
+              <select id="sauce-cooking-method" value={cookingMethod || ""} onChange={(e) => setCookingMethod(e.target.value || undefined)} className="w-full bg-white border border-slate-200 rounded-lg px-2 py-1.5 text-xs">
                 <option value="">Select...</option>
                 {COOKING_METHODS.map(m => <option key={m} value={m}>{m}</option>)}
               </select>

--- a/src/contexts/GroceryCartContext.tsx
+++ b/src/contexts/GroceryCartContext.tsx
@@ -250,7 +250,7 @@ export function GroceryCartProvider({ children }: { children: ReactNode }) {
         }
       };
       // Simple timeout to prevent overwhelming
-      setTimeout(searchItem, 500);
+      setTimeout(() => { void searchItem(); }, 500);
     });
   }, [unmappedItems, updateAsin]);
 

--- a/src/contexts/MenuPlannerContext.tsx
+++ b/src/contexts/MenuPlannerContext.tsx
@@ -22,6 +22,8 @@ import React, {
 import { useUser } from "@/contexts/UserContext";
 import type { MonicaOptimizedRecipe } from "@/data/unified/recipeBuilding";
 import { useAstrologicalState } from "@/hooks/useAstrologicalState";
+import { useMenuPersistence } from "@/hooks/useMenuPersistence";
+import { useMenuStats } from "@/hooks/useMenuStats";
 import { reportQuestEvent } from "@/lib/questReporter";
 import ChartComparisonService, {
   type ChartComparison,
@@ -238,6 +240,11 @@ interface MenuPlannerContextType {
   weeklyStats: WeeklyMenuStats | null;
   refreshStats: () => void;
 
+  // Template persistence state
+  isTemplateSaving: boolean;
+  isTemplateLoading: boolean;
+  persistenceError: Error | null;
+
   // Circuit operations (NEW - Phase 3A)
   calculateMealCircuit: (
     mealSlotId: string,
@@ -408,7 +415,7 @@ export function MenuPlannerProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<Error | null>(null);
   const [groceryList, setGroceryList] = useState<GroceryItem[]>([]);
-  const [weeklyStats, setWeeklyStats] = useState<WeeklyMenuStats | null>(null);
+
   const { currentUser } = useUser();
 
   // Guest alchemist participants
@@ -1614,7 +1621,7 @@ export function MenuPlannerProvider({ children }: { children: ReactNode }) {
 
             // Only add if slot is empty
             if (!existingSlot) {
-              const score =
+              const _score =
                 recommendation.personalizedScore || recommendation.score;
               await addMealToSlot(
                 dayOfWeek,
@@ -1712,145 +1719,30 @@ export function MenuPlannerProvider({ children }: { children: ReactNode }) {
     }
   }, [currentMenu]);
 
-  /**
-   * Save as template
-   * TODO: Implement backend persistence in Phase 4
-   */
-  const saveAsTemplate = useCallback(
-    async (name: string, _description?: string) => {
-      if (!currentMenu) return;
+  const {
+    saveAsTemplate,
+    loadTemplate,
+    isSaving: isTemplateSaving,
+    isLoading: isTemplateLoading,
+    persistenceError,
+  } = useMenuPersistence({
+    currentMenu,
+    groceryList,
+    inventory,
+    weeklyBudget,
+    currentWeekStart,
+    createInitialMenu,
+    setCurrentMenu,
+    setGroceryList,
+    setInventoryRaw,
+    setWeeklyBudgetRaw,
+    persistMenu,
+  });
 
-      try {
-        const response = await fetch("/api/menu-planner/templates", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          credentials: "include",
-          body: JSON.stringify({
-            name,
-            weekStartDate: currentMenu.weekStartDate,
-            meals: currentMenu.meals,
-            nutritionalTotals: currentMenu.nutritionalTotals,
-            groceryList,
-            inventory,
-            weeklyBudget,
-          }),
-        });
-
-        if (!response.ok) {
-          throw new Error(`Template save failed with status ${response.status}`);
-        }
-
-        logger.info(`Saved menu as template: ${name}`);
-      } catch (err) {
-        logger.error("Failed to save template:", err);
-        throw err;
-      }
-    },
-    [currentMenu, groceryList, inventory, weeklyBudget],
-  );
-
-  /**
-   * Load template
-   * TODO: Implement backend loading in Phase 4
-   */
-  const loadTemplate = useCallback(
-    async (templateId: string) => {
-      try {
-        const response = await fetch(
-          `/api/menu-planner/templates?id=${encodeURIComponent(templateId)}`,
-          { credentials: "include" },
-        );
-        if (!response.ok) {
-          throw new Error(`Template load failed with status ${response.status}`);
-        }
-        const data = await response.json();
-        const template = data?.template;
-
-        if (!template) {
-          throw new Error("Template not found");
-        }
-
-        // Create new menu from template
-        const newMenu = createInitialMenu(currentWeekStart);
-        newMenu.meals = template.meals.map((m: any, index: number) => ({
-          ...m,
-          id: `${m.dayOfWeek}-${m.mealType}-${Date.now()}-${index}`,
-          planetarySnapshot: newMenu.meals.find(
-            (nm) => nm.dayOfWeek === m.dayOfWeek && nm.mealType === m.mealType,
-          )!.planetarySnapshot,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        }));
-
-        setCurrentMenu(newMenu);
-        setGroceryList(template.groceryList || []);
-        setInventoryRaw(
-          Array.isArray(template.inventory) ? template.inventory : [],
-        );
-        setWeeklyBudgetRaw(
-          typeof template.weeklyBudget === "number"
-            ? template.weeklyBudget
-            : null,
-        );
-        void persistMenu({
-          menu: newMenu,
-          groceryList: template.groceryList || [],
-          inventory: Array.isArray(template.inventory)
-            ? template.inventory
-            : [],
-          weeklyBudget:
-            typeof template.weeklyBudget === "number"
-              ? template.weeklyBudget
-              : null,
-        });
-        logger.info(`Loaded template: ${template.name}`);
-      } catch (err) {
-        logger.error("Failed to load template:", err);
-        throw err;
-      }
-    },
-    [currentWeekStart, persistMenu],
-  );
-
-  /**
-   * Refresh weekly statistics
-   * TODO: Implement full stats calculation in Phase 3
-   */
+  const weeklyStats = useMenuStats(currentMenu);
   const refreshStats = useCallback(() => {
-    if (!currentMenu) return;
-
-    try {
-      const totalMeals = currentMenu.meals.filter((m) => m.recipe).length;
-      const uniqueRecipes = new Set(
-        currentMenu.meals.filter((m) => m.recipe).map((m) => m.recipe!.id),
-      ).size;
-
-      const stats: WeeklyMenuStats = {
-        totalMeals,
-        totalRecipes: uniqueRecipes,
-        averageGregsEnergy: 0, // TODO: Calculate
-        averageMonica: 0, // TODO: Calculate
-        elementalDistribution: { Fire: 0, Water: 0, Earth: 0, Air: 0 },
-        cuisineDistribution: {},
-        dietaryCompliance: {
-          vegetarian: false,
-          vegan: false,
-          glutenFree: false,
-          dairyFree: false,
-        },
-        missingMeals: currentMenu.meals
-          .filter((m) => !m.recipe)
-          .map((m) => ({
-            dayOfWeek: m.dayOfWeek,
-            mealType: m.mealType,
-          })),
-      };
-
-      setWeeklyStats(stats);
-    } catch (err) {
-      logger.error("Failed to refresh stats:", err);
-    }
-  }, [currentMenu]);
+    // Stats are now computed eagerly via useMenuStats — this is a no-op for backward compat
+  }, []);
 
   /**
    * Save menu (persistence)
@@ -2190,6 +2082,9 @@ export function MenuPlannerProvider({ children }: { children: ReactNode }) {
       loadTemplate,
       weeklyStats,
       refreshStats,
+      isTemplateSaving,
+      isTemplateLoading,
+      persistenceError,
       calculateMealCircuit: calculateMealCircuitMetrics,
       calculateDayCircuit: calculateDayCircuitMetrics,
       calculateWeeklyCircuit: calculateWeeklyCircuitMetrics,
@@ -2246,6 +2141,9 @@ export function MenuPlannerProvider({ children }: { children: ReactNode }) {
       loadTemplate,
       weeklyStats,
       refreshStats,
+      isTemplateSaving,
+      isTemplateLoading,
+      persistenceError,
       calculateMealCircuitMetrics,
       calculateDayCircuitMetrics,
       calculateWeeklyCircuitMetrics,

--- a/src/hooks/useMenuPersistence.ts
+++ b/src/hooks/useMenuPersistence.ts
@@ -1,0 +1,163 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { WeeklyMenu, GroceryItem } from "@/types/menuPlanner";
+import { logger } from "@/utils/logger";
+
+interface UseMenuPersistenceArgs {
+  currentMenu: WeeklyMenu | null;
+  groceryList: GroceryItem[];
+  inventory: string[];
+  weeklyBudget: number | null;
+  currentWeekStart: Date;
+  createInitialMenu: (weekStart: Date) => WeeklyMenu;
+  setCurrentMenu: (menu: WeeklyMenu) => void;
+  setGroceryList: (list: GroceryItem[]) => void;
+  setInventoryRaw: (inv: string[]) => void;
+  setWeeklyBudgetRaw: (budget: number | null) => void;
+  persistMenu: (overrides?: {
+    menu?: WeeklyMenu;
+    groceryList?: GroceryItem[];
+    inventory?: string[];
+    weeklyBudget?: number | null;
+  }) => Promise<void>;
+}
+
+interface UseMenuPersistenceReturn {
+  saveAsTemplate: (name: string, description?: string) => Promise<void>;
+  loadTemplate: (templateId: string) => Promise<void>;
+  isSaving: boolean;
+  isLoading: boolean;
+  persistenceError: Error | null;
+}
+
+export function useMenuPersistence({
+  currentMenu,
+  groceryList,
+  inventory,
+  weeklyBudget,
+  currentWeekStart,
+  createInitialMenu,
+  setCurrentMenu,
+  setGroceryList,
+  setInventoryRaw,
+  setWeeklyBudgetRaw,
+  persistMenu,
+}: UseMenuPersistenceArgs): UseMenuPersistenceReturn {
+  const [isSaving, setIsSaving] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [persistenceError, setPersistenceError] = useState<Error | null>(null);
+
+  const saveAsTemplate = useCallback(
+    async (name: string, _description?: string) => {
+      if (!currentMenu) return;
+
+      setIsSaving(true);
+      setPersistenceError(null);
+      try {
+        const response = await fetch("/api/menu-planner/templates", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({
+            name,
+            weekStartDate: currentMenu.weekStartDate,
+            meals: currentMenu.meals,
+            nutritionalTotals: currentMenu.nutritionalTotals,
+            groceryList,
+            inventory,
+            weeklyBudget,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Template save failed with status ${response.status}`);
+        }
+
+        logger.info(`Saved menu as template: ${name}`);
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        setPersistenceError(error);
+        logger.error("Failed to save template:", err);
+        throw error;
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [currentMenu, groceryList, inventory, weeklyBudget],
+  );
+
+  const loadTemplate = useCallback(
+    async (templateId: string) => {
+      setIsLoading(true);
+      setPersistenceError(null);
+      try {
+        const response = await fetch(
+          `/api/menu-planner/templates?id=${encodeURIComponent(templateId)}`,
+          { credentials: "include" },
+        );
+        if (!response.ok) {
+          throw new Error(`Template load failed with status ${response.status}`);
+        }
+        const data = await response.json();
+        const template = data?.template;
+
+        if (!template) {
+          throw new Error("Template not found");
+        }
+
+        const newMenu = createInitialMenu(currentWeekStart);
+        newMenu.meals = template.meals.map((m: any, index: number) => ({
+          ...m,
+          id: `${m.dayOfWeek}-${m.mealType}-${Date.now()}-${index}`,
+          planetarySnapshot: newMenu.meals.find(
+            (nm) => nm.dayOfWeek === m.dayOfWeek && nm.mealType === m.mealType,
+          )!.planetarySnapshot,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }));
+
+        setCurrentMenu(newMenu);
+        setGroceryList(template.groceryList || []);
+        setInventoryRaw(
+          Array.isArray(template.inventory) ? template.inventory : [],
+        );
+        setWeeklyBudgetRaw(
+          typeof template.weeklyBudget === "number"
+            ? template.weeklyBudget
+            : null,
+        );
+        void persistMenu({
+          menu: newMenu,
+          groceryList: template.groceryList || [],
+          inventory: Array.isArray(template.inventory)
+            ? template.inventory
+            : [],
+          weeklyBudget:
+            typeof template.weeklyBudget === "number"
+              ? template.weeklyBudget
+              : null,
+        });
+        logger.info(`Loaded template: ${template.name}`);
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        setPersistenceError(error);
+        logger.error("Failed to load template:", err);
+        throw error;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [
+      currentWeekStart,
+      createInitialMenu,
+      setCurrentMenu,
+      setGroceryList,
+      setInventoryRaw,
+      setWeeklyBudgetRaw,
+      persistMenu,
+    ],
+  );
+
+  return { saveAsTemplate, loadTemplate, isSaving, isLoading, persistenceError };
+}

--- a/src/hooks/useMenuStats.ts
+++ b/src/hooks/useMenuStats.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { useMemo } from "react";
+import type { WeeklyMenu, WeeklyMenuStats } from "@/types/menuPlanner";
+
+export function useMenuStats(
+  currentMenu: WeeklyMenu | null,
+): WeeklyMenuStats | null {
+  return useMemo(() => {
+    if (!currentMenu) return null;
+
+    const filledMeals = currentMenu.meals.filter((m) => m.recipe);
+    const totalMeals = filledMeals.length;
+    const totalRecipes = new Set(filledMeals.map((m) => m.recipe!.id)).size;
+
+    // Elemental distribution: sum then normalize
+    const rawElemental = { Fire: 0, Water: 0, Earth: 0, Air: 0 };
+    for (const meal of filledMeals) {
+      const ep = meal.recipe!.elementalProperties;
+      rawElemental.Fire += ep.Fire ?? 0;
+      rawElemental.Water += ep.Water ?? 0;
+      rawElemental.Earth += ep.Earth ?? 0;
+      rawElemental.Air += ep.Air ?? 0;
+    }
+    const elementalSum =
+      rawElemental.Fire + rawElemental.Water + rawElemental.Earth + rawElemental.Air;
+    const elementalDistribution =
+      elementalSum > 0
+        ? {
+            Fire: rawElemental.Fire / elementalSum,
+            Water: rawElemental.Water / elementalSum,
+            Earth: rawElemental.Earth / elementalSum,
+            Air: rawElemental.Air / elementalSum,
+          }
+        : { Fire: 0, Water: 0, Earth: 0, Air: 0 };
+
+    // averageGregsEnergy: mean of monicaScore across filled meals
+    const monicaScores = filledMeals
+      .map((m) => m.recipe!.monicaScore)
+      .filter((s): s is number => s != null);
+    const averageGregsEnergy =
+      monicaScores.length > 0
+        ? monicaScores.reduce((a, b) => a + b, 0) / monicaScores.length
+        : 0;
+
+    // averageMonica: mean of (spirit + essence + matter + substance) / 4
+    const monicaValues: number[] = [];
+    for (const meal of filledMeals) {
+      const r = meal.recipe!;
+      if (
+        r.spirit != null &&
+        r.essence != null &&
+        r.matter != null &&
+        r.substance != null
+      ) {
+        monicaValues.push((r.spirit + r.essence + r.matter + r.substance) / 4);
+      }
+    }
+    const averageMonica =
+      monicaValues.length > 0
+        ? monicaValues.reduce((a, b) => a + b, 0) / monicaValues.length
+        : 0;
+
+    // Cuisine distribution: count by cuisine, sort descending
+    const cuisineCounts: Record<string, number> = {};
+    for (const meal of filledMeals) {
+      const c = meal.recipe!.cuisine;
+      if (c) {
+        cuisineCounts[c] = (cuisineCounts[c] ?? 0) + 1;
+      }
+    }
+    const cuisineDistribution = Object.fromEntries(
+      Object.entries(cuisineCounts).sort(([, a], [, b]) => b - a),
+    );
+
+    // Dietary compliance: true only if ALL filled meals satisfy the constraint
+    const dietaryCompliance = {
+      vegetarian:
+        totalMeals > 0 && filledMeals.every((m) => m.recipe!.isVegetarian === true),
+      vegan:
+        totalMeals > 0 && filledMeals.every((m) => m.recipe!.isVegan === true),
+      glutenFree:
+        totalMeals > 0 && filledMeals.every((m) => m.recipe!.isGlutenFree === true),
+      dairyFree:
+        totalMeals > 0 && filledMeals.every((m) => m.recipe!.isDairyFree === true),
+    };
+
+    // Missing meals: slots with no recipe
+    const missingMeals = currentMenu.meals
+      .filter((m) => !m.recipe)
+      .map((m) => ({ dayOfWeek: m.dayOfWeek, mealType: m.mealType }));
+
+    return {
+      totalMeals,
+      totalRecipes,
+      averageGregsEnergy,
+      averageMonica,
+      elementalDistribution,
+      cuisineDistribution,
+      dietaryCompliance,
+      missingMeals,
+    };
+  }, [currentMenu]);
+}

--- a/src/lib/auth/validateRequest.ts
+++ b/src/lib/auth/validateRequest.ts
@@ -9,9 +9,9 @@
 import { jwtVerify, errors as JOSEerrors } from "jose";
 import { NextResponse } from "next/server";
 import { UserRole } from "@/lib/auth/roles";
+import { applyRequestAuthOrigin } from "@/lib/auth/runtimeOrigin";
 import type { UserWithProfile } from "@/services/userDatabaseService";
 import type { NextRequest } from "next/server";
-import { applyRequestAuthOrigin } from "@/lib/auth/runtimeOrigin";
 
 type AuthResolver = typeof import("@/lib/auth/auth").auth;
 type UserDatabaseResolver =

--- a/src/utils/cuisine/sauceLineage.ts
+++ b/src/utils/cuisine/sauceLineage.ts
@@ -8,7 +8,7 @@
 
 import { cuisinesMap } from "@/data/cuisines";
 import { allSauces } from "@/data/sauces";
-import type { Cuisine } from "@/types/cuisine";
+
 
 // ============================================================================
 // Types


### PR DESCRIPTION
…te-limit sub-routes, zero lint warnings

MenuPlannerContext refactor (2,281-line monolith):
- Extract useMenuStats hook: pure useMemo computing all WeeklyMenuStats fields (elementalDistribution normalized, averageGregsEnergy from monicaScore, averageMonica from SMES grid, cuisineDistribution sorted, dietaryCompliance all-or-nothing, missingMeals). Removes Phase 3 TODO stubs.
- Extract useMenuPersistence hook: saveAsTemplate + loadTemplate with isSaving/isLoading/persistenceError state. Removes Phase 4 TODO stubs.
- Wire both hooks into context; add isTemplateSaving, isTemplateLoading, persistenceError as new context keys (no existing keys renamed/removed).

Rate-limit 8 remaining unguarded sub-routes (30–60 req/min each):
  alchm-quantities/{aspects,echoes,planetary,statistics,trends}
  quests/{claim,masters-pantry,streak}

ESLint: reduce warnings from 30 → 0 across 14 files:
  - import/order: fix import sequencing in 6 files
  - no-unused-vars: remove/prefix unused imports, consts, state setters
  - no-misused-promises / no-floating-promises: void-wrap async handlers
  - react-hooks/exhaustive-deps: add missing culturalMethods dep
  - react/no-unescaped-entities: escape apostrophe in recipes page
  - jsx-a11y/label-has-associated-control: add htmlFor/id to 5 labels