### PR TITLE
feat: cross-site token economy for Planetary Agents integration

### DIFF
--- a/database/init/17-token-economy-schema.sql
+++ b/database/init/17-token-economy-schema.sql
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS token_balances (
     matter DECIMAL(12, 4) NOT NULL DEFAULT 0,
     substance DECIMAL(12, 4) NOT NULL DEFAULT 0,
     last_daily_claim_at TIMESTAMPTZ,
+    last_daily_claim_agents_at TIMESTAMPTZ,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (user_id)
 );

--- a/src/app/api/economy/balance/route.ts
+++ b/src/app/api/economy/balance/route.ts
@@ -23,12 +23,16 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    const { searchParams } = new URL(request.url);
+    const siteParam = searchParams.get("site");
+    const site: "main" | "agents" = siteParam === "agents" ? "agents" : "main";
+
     const [balances, streak] = await Promise.all([
       tokenEconomy.getBalances(userId),
       streakService.getStreak(userId),
     ]);
 
-    const canClaimDaily = !(await tokenEconomy.hasClaimedToday(userId));
+    const canClaimDaily = !(await tokenEconomy.hasClaimedToday(userId, site));
 
     const response: EconomyBalanceResponse = {
       success: true,

--- a/src/app/api/economy/claim-daily/route.ts
+++ b/src/app/api/economy/claim-daily/route.ts
@@ -59,12 +59,17 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Determine origin site — agents site passes ?site=agents
+    const { searchParams } = new URL(request.url);
+    const siteParam = searchParams.get("site");
+    const site: "main" | "agents" = siteParam === "agents" ? "agents" : "main";
+
     // Check if user is premium for yield multiplier
     const sub = await subscriptionService.getUserSubscription(user.id);
-    const isPremium = sub?.tier === "premium";
+    const isPremium = sub?.tier === "premium" && sub?.status === "active";
 
-    // Claim the daily yield
-    const yieldResult = await dailyYieldService.claimDailyYield(user.id, natalPositions, isPremium);
+    // Claim the daily yield (site-specific idempotency)
+    const yieldResult = await dailyYieldService.claimDailyYield(user.id, natalPositions, isPremium, site);
 
     if (!yieldResult) {
       return NextResponse.json(

--- a/src/app/api/recipes/refine/route.ts
+++ b/src/app/api/recipes/refine/route.ts
@@ -4,6 +4,7 @@
  */
 import { NextResponse } from "next/server";
 import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
+import { OPERATION_COSTS } from "@/lib/economy/operationCosts";
 import { PlanetaryScoringService } from "@/services/planetaryScoring";
 import { tokenEconomy } from "@/services/TokenEconomyService";
 import type { Recipe } from "@/types/recipe";
@@ -22,11 +23,11 @@ export async function POST(request: NextRequest) {
     const body = await request.json().catch(() => ({}));
     const { cuisine } = body;
 
-    // Deduct 5 Substance tokens
-    const deductResult = await tokenEconomy.debitTokens(user.id, "Substance", 5, "purchase", { description: "Refined Oracle Recommendation" });
+    const cost = OPERATION_COSTS.refine_oracle;
+    const deductResult = await tokenEconomy.debitTokens(user.id, "Substance", cost.substance!, "purchase", { description: "Refined Oracle Recommendation" });
     if (!deductResult) {
       return NextResponse.json(
-        { success: false, error: "Insufficient Substance (🝉) tokens. You need 5 Substance." },
+        { success: false, error: `Insufficient Substance (🝉) tokens. You need ${cost.substance} Substance.` },
         { status: 402 }
       );
     }

--- a/src/lib/economy/operationCosts.ts
+++ b/src/lib/economy/operationCosts.ts
@@ -1,0 +1,7 @@
+import type { TokenType } from "@/types/economy";
+
+export type TokenCost = Partial<Record<Lowercase<TokenType>, number>>;
+
+export const OPERATION_COSTS = {
+  refine_oracle: { substance: 5 },
+} as const satisfies Record<string, TokenCost>;

--- a/src/services/DailyYieldService.ts
+++ b/src/services/DailyYieldService.ts
@@ -251,17 +251,20 @@ class DailyYieldService {
    *
    * @param userId - User's database ID
    * @param natalPositions - Planet → sign map from user's natal chart
+   * @param isPremium - Whether the user has a premium subscription (2× yield)
+   * @param site - Origin site ('main' | 'agents'). Each site has an independent daily claim.
    * @returns DailyYieldResult with amounts and new balances, or null if already claimed
    */
   async claimDailyYield(
     userId: string,
     natalPositions: Record<string, string>,
     isPremium: boolean = false,
+    site: "main" | "agents" = "main",
   ): Promise<DailyYieldResult | null> {
-    // 1. Idempotency check
-    const alreadyClaimed = await tokenEconomy.hasClaimedToday(userId);
+    // 1. Idempotency check (site-specific)
+    const alreadyClaimed = await tokenEconomy.hasClaimedToday(userId, site);
     if (alreadyClaimed) {
-      _logger.info("[DailyYield] User already claimed today:", { userId });
+      _logger.info("[DailyYield] User already claimed today:", { userId, site });
       return null;
     }
 
@@ -300,13 +303,14 @@ class DailyYieldService {
     ];
     const credits = allCredits.filter(c => c.amount > 0);
 
+    const sourceType = site === "agents" ? "agents_yield" : "daily_yield";
     const newBalances = await tokenEconomy.creditMultipleTokens(
       userId,
       credits,
-      "daily_yield",
+      sourceType,
       {
-        description: `Cosmic Yield for ${todayStr}`,
-        idempotencyKey: `daily:${userId}:${todayStr}`,
+        description: `Cosmic Yield for ${todayStr} (${site})`,
+        idempotencyKey: `daily:${site}:${userId}:${todayStr}`,
       },
     );
 
@@ -315,8 +319,8 @@ class DailyYieldService {
       return null;
     }
 
-    // 8. Update daily claim timestamp and streak
-    await tokenEconomy.updateDailyClaimTimestamp(userId);
+    // 8. Update site-specific daily claim timestamp and streak
+    await tokenEconomy.updateDailyClaimTimestamp(userId, site);
     await streakService.recordActivity(userId);
 
     const updatedStreak = await streakService.getStreak(userId);

--- a/src/services/TokenEconomyService.ts
+++ b/src/services/TokenEconomyService.ts
@@ -54,6 +54,7 @@ function rowToBalances(row: any): TokenBalances {
     matter: parseFloat(row.matter) || 0,
     substance: parseFloat(row.substance) || 0,
     lastDailyClaimAt: row.last_daily_claim_at?.toISOString?.() || row.last_daily_claim_at || null,
+    lastDailyClaimAgentsAt: row.last_daily_claim_agents_at?.toISOString?.() || row.last_daily_claim_agents_at || null,
     updatedAt: row.updated_at?.toISOString?.() || row.updated_at || new Date().toISOString(),
   };
 }
@@ -350,15 +351,17 @@ class TokenEconomyService {
   // ═══════════════════════════════════════════════════════════════════
 
   /**
-   * Update the last_daily_claim_at timestamp.
+   * Update the site-specific daily claim timestamp.
+   * 'main' updates last_daily_claim_at; 'agents' updates last_daily_claim_agents_at.
    */
-  async updateDailyClaimTimestamp(userId: string): Promise<void> {
+  async updateDailyClaimTimestamp(userId: string, site: "main" | "agents" = "main"): Promise<void> {
+    const column = site === "agents" ? "last_daily_claim_agents_at" : "last_daily_claim_at";
     const db = await getDbModule();
 
     if (db) {
       try {
         await db.executeQuery(
-          `UPDATE token_balances SET last_daily_claim_at = now(), updated_at = now() WHERE user_id = $1`,
+          `UPDATE token_balances SET ${column} = now(), updated_at = now() WHERE user_id = $1`,
           [userId],
         );
       } catch (error) {
@@ -369,18 +372,25 @@ class TokenEconomyService {
     // In-memory
     const bal = memoryBalances.get(userId);
     if (bal) {
-      bal.lastDailyClaimAt = new Date().toISOString();
+      const ts = new Date().toISOString();
+      if (site === "agents") {
+        bal.lastDailyClaimAgentsAt = ts;
+      } else {
+        bal.lastDailyClaimAt = ts;
+      }
     }
   }
 
   /**
-   * Check if a user has already claimed their daily yield today.
+   * Check if a user has already claimed their daily yield today for the given site.
+   * Main and agents yields are tracked independently.
    */
-  async hasClaimedToday(userId: string): Promise<boolean> {
+  async hasClaimedToday(userId: string, site: "main" | "agents" = "main"): Promise<boolean> {
     const balances = await this.getBalances(userId);
-    if (!balances.lastDailyClaimAt) return false;
+    const claimTimestamp = site === "agents" ? balances.lastDailyClaimAgentsAt : balances.lastDailyClaimAt;
+    if (!claimTimestamp) return false;
 
-    const lastClaim = new Date(balances.lastDailyClaimAt);
+    const lastClaim = new Date(claimTimestamp);
     const now = new Date();
 
     // Compare UTC dates

--- a/src/types/economy.ts
+++ b/src/types/economy.ts
@@ -18,6 +18,8 @@ export const TOKEN_TYPES: TokenType[] = ["Spirit", "Essence", "Matter", "Substan
 /** Source of a token transaction */
 export type TransactionSourceType =
   | "daily_yield"
+  | "agents_yield"
+  | "agents_operation"
   | "quest_reward"
   | "purchase"
   | "premium_purchase"
@@ -35,6 +37,7 @@ export interface TokenBalances {
   matter: number;
   substance: number;
   lastDailyClaimAt: string | null;
+  lastDailyClaimAgentsAt: string | null;
   updatedAt: string;
 }
 
@@ -45,6 +48,7 @@ export const EMPTY_BALANCES: TokenBalances = {
   matter: 0,
   substance: 0,
   lastDailyClaimAt: null,
+  lastDailyClaimAgentsAt: null,
   updatedAt: new Date().toISOString(),
 };
 


### PR DESCRIPTION
Add independent daily yield claiming per site (main vs agents) so users can collect from both alchm.kitchen and Planetary Agents without blocking each other. Each site tracks its own claim timestamp and uses namespaced idempotency keys to prevent cross-contamination.

- Add last_daily_claim_agents_at column to token_balances schema
- Add agents_yield and agents_operation transaction source types
- Refactor hasClaimedToday/updateDailyClaimTimestamp to accept site param
- Thread site through DailyYieldService.claimDailyYield
- Accept ?site=agents query param on claim-daily and balance routes
- Tighten premium check to require both tier=premium AND status=active
- Extract hardcoded refine cost into shared operationCosts config