### PR TITLE
feat(ingredients): pantry toggle on cards + transit element caching

### DIFF
--- a/src/app/ingredients/page.tsx
+++ b/src/app/ingredients/page.tsx
@@ -11,10 +11,11 @@
 
 import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
-import React, { useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { resolveAsin } from "@/data/amazon/ingredientAsins";
 import { allIngredients } from "@/data/ingredients";
 import { useAlchemical } from "@/hooks/useAlchemical";
+import { usePantry } from "@/hooks/usePantry";
 import { getAmazonLink, getAmazonButtonText } from "@/lib/amazonUrl";
 import type { Ingredient } from "@/types";
 import { normalizeForDisplay } from "@/utils/elemental/normalization";
@@ -281,6 +282,27 @@ export default function IngredientsPage() {
   const [verifiedOnly, setVerifiedOnly] = useState(false);
   const [activeName, setActiveName] = useState<string | null>(null);
 
+  const { hasItem, addItem, removeItem, items } = usePantry();
+
+  const pantryToggle = useCallback(
+    (ing: Ingredient) => {
+      const existing = items.find(
+        (i) => i.name.toLowerCase() === ing.name.toLowerCase(),
+      );
+      if (existing) {
+        removeItem(existing.id);
+      } else {
+        addItem({
+          name: ing.name,
+          quantity: 1,
+          unit: "unit",
+          category: ing.category || "other",
+        });
+      }
+    },
+    [items, addItem, removeItem],
+  );
+
   // Compute the user's "alchemical resonance" — a weight per element derived
   // from the live planetary positions. Used to personalize ranking.
   const resonance = useMemo<Record<ElementKey, number>>(() => {
@@ -499,6 +521,8 @@ export default function IngredientsPage() {
                       prev === d.ingredient.name ? null : d.ingredient.name,
                     )
                   }
+                  inPantry={hasItem(d.ingredient.name)}
+                  onPantryToggle={() => pantryToggle(d.ingredient)}
                 />
               ))}
             </AnimatePresence>
@@ -645,10 +669,14 @@ function IngredientCard({
   data,
   expanded,
   onToggle,
+  inPantry,
+  onPantryToggle,
 }: {
   data: DerivedIngredient;
   expanded: boolean;
   onToggle: () => void;
+  inPantry: boolean;
+  onPantryToggle: () => void;
 }) {
   const { ingredient, dominant, asin, seasons } = data;
   const meta = ELEMENT_META[dominant];
@@ -732,6 +760,20 @@ function IngredientCard({
           </p>
         )}
       </button>
+
+      <div className="px-4 pb-3 flex justify-end border-t border-white/[0.04]">
+        <button
+          onClick={onPantryToggle}
+          className={`text-[10px] font-bold px-2.5 py-1 rounded-full border transition-all ${
+            inPantry
+              ? "bg-emerald-500/20 text-emerald-300 border-emerald-400/40 hover:bg-red-500/10 hover:text-red-300 hover:border-red-400/30"
+              : "bg-white/5 text-white/40 border-white/10 hover:bg-emerald-500/15 hover:text-emerald-300 hover:border-emerald-400/30"
+          }`}
+          title={inPantry ? "Remove from pantry" : "Add to pantry"}
+        >
+          {inPantry ? "✓ In Pantry" : "+ Pantry"}
+        </button>
+      </div>
 
       <AnimatePresence initial={false}>
         {expanded && (

--- a/src/hooks/useAlchemical.ts
+++ b/src/hooks/useAlchemical.ts
@@ -8,6 +8,34 @@ export interface AlchemicalState {
   error: string | null;
 }
 
+const CACHE_KEY = "alchm:planetary:cache";
+const CACHE_TTL = 3_600_000; // 1 hour
+
+interface PlanetaryCache {
+  positions: { [key: string]: PlanetPosition };
+  ts: number;
+}
+
+function readCache(): PlanetaryCache | null {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PlanetaryCache;
+    if (Date.now() - parsed.ts > CACHE_TTL) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(positions: { [key: string]: PlanetPosition }): void {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ positions, ts: Date.now() }));
+  } catch {
+    // localStorage unavailable (private browsing, quota exceeded) — safe to skip
+  }
+}
+
 export function useAlchemical() {
   const [state, setState] = useState<AlchemicalState>({
     planetaryPositions: {},
@@ -17,6 +45,20 @@ export function useAlchemical() {
   });
 
   const fetchPlanetaryPositions = useCallback(async () => {
+    const hour = new Date().getHours();
+    const isDaytime = hour >= 6 && hour < 18;
+
+    const cached = readCache();
+    if (cached) {
+      setState({
+        planetaryPositions: cached.positions,
+        isDaytime,
+        isLoading: false,
+        error: null,
+      });
+      return;
+    }
+
     try {
       setState((prev) => ({ ...prev, isLoading: true, error: null }));
 
@@ -28,11 +70,7 @@ export function useAlchemical() {
       }
 
       const data = await response.json();
-
-      // Determine if it's daytime (simplified - you might want to use more sophisticated logic)
-      const now = new Date();
-      const hour = now.getHours();
-      const isDaytime = hour >= 6 && hour < 18;
+      writeCache(data.positions || {});
 
       setState({
         planetaryPositions: data.positions || {},


### PR DESCRIPTION
## Summary

- **Pantry toggle on `/ingredients` cards** — every `IngredientCard` now shows a `+ Pantry` / `✓ In Pantry` pill button (bottom-right of collapsed card). Clicking adds the ingredient at quantity 1 via the existing `usePantry` hook (localStorage, synced cross-tab). Hovering an already-in-pantry button signals removal with a red tint. No new dependencies; the `usePantry` hook is called once in the page component and results passed down as `inPantry`/`onPantryToggle` props to avoid instantiating the hook per-card.

- **1-hour localStorage cache for planetary positions** (`alchm:planetary:cache`) — `useAlchemical` now checks the cache before hitting `/api/planetary-positions`. On a cache hit the hook resolves synchronously (no loading flash). On a miss it fetches, writes the cache, and continues as before. `refresh()` still bypasses the cache. This eliminates the skeleton re-flash on every `/ingredients` page visit.

- **Note on priority #1** — `/api/amazon/feedback` already exists (merged in PR #387) and directly updates `ingredients.amazon_asin`. No new table needed; the existing route covers the feedback form.

## Test plan

- [ ] Visit `/ingredients`, confirm each card shows `+ Pantry` pill
- [ ] Click `+ Pantry` on a card → button turns `✓ In Pantry` (emerald)
- [ ] Navigate to `/pantry` → ingredient appears in the list
- [ ] Return to `/ingredients` → button is still `✓ In Pantry` (localStorage persisted)
- [ ] Click `✓ In Pantry` → removes it; button reverts to `+ Pantry`
- [ ] Open `/ingredients` in a second tab → pantry state matches (cross-tab sync)
- [ ] Hard-refresh `/ingredients` → no skeleton flash for planetary data (cache hit logged in DevTools → Network tab shows no `/api/planetary-positions` request within 1 hour)
- [ ] Clear localStorage, reload → skeleton appears briefly as normal on first visit

🤖 Generated with [Claude Code](https://claude.com/claude-code)