### PR TITLE
fix(onboarding): real transactions, surface onboardingComplete, split preferences

### DIFF
--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -266,7 +266,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({
       success: true,
-      onboardingComplete: (user.profile as any).onboardingComplete ?? false,
+      onboardingComplete: user.profile.onboardingComplete ?? false,
       hasNatalChart: !!user.profile.natalChart,
       hasBirthData: !!user.profile.birthData,
     });

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -33,7 +33,7 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, onClick }) => {
     }
   };
 
-  const displayImage = getAssetUrl(recipe.image as string);
+  const displayImage = getAssetUrl(recipe.image);
 
   return (
     <>

--- a/src/contexts/UserContext/index.tsx
+++ b/src/contexts/UserContext/index.tsx
@@ -47,6 +47,8 @@ interface UserProfile {
   name?: string;
   email?: string;
   preferences?: Record<string, unknown>;
+  dietaryPreferences?: Record<string, unknown>;
+  onboardingComplete?: boolean;
   birthData?: BirthData;
   natalChart?: NatalChart;
   groupMembers?: GroupMember[];

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -113,18 +113,14 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           const { userDatabase } = await import("@/services/userDatabaseService");
           logger.info(`Creating new user. isAdmin: ${isAdmin}`);
 
-          // Add a timeout to createUser to prevent total hang
-          dbUser = await Promise.race([
-            userDatabase.createUser({
-              email: user.email,
-              name: user.name || "",
-              roles: isAdmin
-                ? [UserRole.ADMIN, UserRole.USER]
-                : [UserRole.USER],
-            }),
-            new Promise<any>((_, reject) => setTimeout(() => reject(new Error("Create User Timeout")), 3500))
-          ]);
-          
+          dbUser = await userDatabase.createUser({
+            email: user.email,
+            name: user.name || "",
+            roles: isAdmin
+              ? [UserRole.ADMIN, UserRole.USER]
+              : [UserRole.USER],
+          });
+
           if (dbUser) {
             userCache.set(user.email, { data: dbUser, timestamp: Date.now() });
           }
@@ -154,10 +150,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
                 const { commensalDatabase } = await import("@/services/commensalDatabaseService");
                 
                 const newChart = await calculateNatalChart(profile.birthData);
-                await userDatabase.updateUserProfile(dbUser.id, { 
+                await userDatabase.updateUserProfile(dbUser.id, {
                   natalChart: newChart,
-                  onboardingComplete: true
-                } as any);
+                  onboardingComplete: true,
+                });
                 
                 // Store in saved charts (Cosmic Identity registry)
                 try {

--- a/src/services/userDatabaseService.ts
+++ b/src/services/userDatabaseService.ts
@@ -92,59 +92,56 @@ class UserDatabaseService {
     // Try PostgreSQL first
     if (db) {
       try {
-        await db.executeQuery('BEGIN');
-        // Insert into users table (uses single 'role' ENUM column per migration 07)
+        // Uses single 'role' ENUM column per migration 07
         const primaryRole = user.roles.includes("admin" as UserRole)
           ? "ADMIN"
           : "USER";
-        const insertUserResult = await db.executeQuery(
-          `INSERT INTO users (id, email, password_hash, role, is_active, profile, preferences, created_at)
-           VALUES ($1, $2, $3, $4::user_role, $5, $6, $7, $8)
-           ON CONFLICT (email) DO NOTHING RETURNING id`,
-          [
-            userId,
-            email,
-            user.passwordHash,
-            primaryRole,
-            true,
-            JSON.stringify(user.profile),
-            JSON.stringify(user.profile.preferences || {}),
-            now,
-          ],
-        );
 
-        if (!insertUserResult || insertUserResult.rowCount === 0) {
-          await db.executeQuery('ROLLBACK');
-          throw new Error("User with this email already exists");
-        }
+        await db.withTransaction(async (client) => {
+          const insertUserResult = await client.query(
+            `INSERT INTO users (id, email, password_hash, role, is_active, profile, preferences, created_at)
+             VALUES ($1, $2, $3, $4::user_role, $5, $6, $7, $8)
+             ON CONFLICT (email) DO NOTHING RETURNING id`,
+            [
+              userId,
+              email,
+              user.passwordHash,
+              primaryRole,
+              true,
+              JSON.stringify(user.profile),
+              JSON.stringify(user.profile.preferences || {}),
+              now,
+            ],
+          );
 
-        // Insert into user_profiles table
-        await db.executeQuery(
-          `INSERT INTO user_profiles (user_id, name, dietary_preferences, birth_data, natal_chart, group_members, dining_groups)
-           VALUES ($1, $2, $3, $4, $5, $6, $7)
-           ON CONFLICT (user_id) DO UPDATE SET
-             name = EXCLUDED.name,
-             dietary_preferences = EXCLUDED.dietary_preferences,
-             updated_at = CURRENT_TIMESTAMP`,
-          [
-            userId,
-            data.name,
-            JSON.stringify(user.profile.preferences || {}),
-            JSON.stringify(data.profile?.birthData || {}),
-            JSON.stringify(data.profile?.natalChart || {}),
-            JSON.stringify(data.profile?.groupMembers || []),
-            JSON.stringify(data.profile?.diningGroups || []),
-          ],
-        );
+          if (!insertUserResult || insertUserResult.rowCount === 0) {
+            throw new Error("User with this email already exists");
+          }
 
-        await db.executeQuery('COMMIT');
+          await client.query(
+            `INSERT INTO user_profiles (user_id, name, dietary_preferences, birth_data, natal_chart, group_members, dining_groups)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)
+             ON CONFLICT (user_id) DO UPDATE SET
+               name = EXCLUDED.name,
+               dietary_preferences = EXCLUDED.dietary_preferences,
+               updated_at = CURRENT_TIMESTAMP`,
+            [
+              userId,
+              data.name,
+              JSON.stringify(data.profile?.dietaryPreferences || {}),
+              JSON.stringify(data.profile?.birthData || {}),
+              JSON.stringify(data.profile?.natalChart || {}),
+              JSON.stringify(data.profile?.groupMembers || []),
+              JSON.stringify(data.profile?.diningGroups || []),
+            ],
+          );
+        });
 
         _logger.info("User created in PostgreSQL:", {
           userId,
           email: data.email,
         });
       } catch (error) {
-        await db.executeQuery('ROLLBACK').catch(() => {});
         _logger.error(
           "PostgreSQL user creation failed:",
           error,
@@ -176,7 +173,7 @@ class UserDatabaseService {
                   up.dietary_preferences, up.group_members, up.dining_groups, up.onboarding_completed
            FROM users u
            LEFT JOIN user_profiles up ON u.id = up.user_id
-           WHERE u.id::text = $1`,
+           WHERE u.id = $1::uuid`,
           [userId],
         );
 
@@ -258,53 +255,87 @@ class UserDatabaseService {
       ...profileData,
       userId, // Ensure userId doesn't change
     };
+    updatedProfile.onboardingComplete =
+      profileData.onboardingComplete ??
+      updatedProfile.onboardingComplete ??
+      !!(updatedProfile.birthData && updatedProfile.natalChart);
     user.profile = updatedProfile;
 
     // Try PostgreSQL first
     if (db) {
       try {
-        await db.executeQuery('BEGIN');
-        // Update users table profile JSONB
-        await db.executeQuery(
-          `UPDATE users SET profile = $2, preferences = $3, updated_at = CURRENT_TIMESTAMP
-           WHERE id::text = $1`,
-          [
-            userId,
-            JSON.stringify(updatedProfile),
-            JSON.stringify(updatedProfile.preferences || {}),
-          ],
+        // Only touch dietary_preferences when the caller actually provided one,
+        // so general-preferences callers don't clobber the dietary column.
+        const hasDietaryUpdate = Object.prototype.hasOwnProperty.call(
+          profileData,
+          "dietaryPreferences",
         );
+        const onboardingComplete = updatedProfile.onboardingComplete === true;
 
-        // Update user_profiles table
-        await db.executeQuery(
-          `INSERT INTO user_profiles (user_id, name, birth_data, natal_chart, dietary_preferences, group_members, dining_groups, onboarding_completed)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-           ON CONFLICT (user_id) DO UPDATE SET
-             name = EXCLUDED.name,
-             birth_data = EXCLUDED.birth_data,
-             natal_chart = EXCLUDED.natal_chart,
-             dietary_preferences = EXCLUDED.dietary_preferences,
-             group_members = EXCLUDED.group_members,
-             dining_groups = EXCLUDED.dining_groups,
-             onboarding_completed = EXCLUDED.onboarding_completed,
-             onboarding_completed_at = CASE WHEN EXCLUDED.onboarding_completed AND NOT COALESCE(user_profiles.onboarding_completed, false) THEN CURRENT_TIMESTAMP ELSE user_profiles.onboarding_completed_at END,
-             updated_at = CURRENT_TIMESTAMP`,
-          [
-            userId,
-            updatedProfile.name || "",
-            JSON.stringify(updatedProfile.birthData || {}),
-            JSON.stringify(updatedProfile.natalChart || {}),
-            JSON.stringify(updatedProfile.preferences || {}),
-            JSON.stringify(updatedProfile.groupMembers || []),
-            JSON.stringify(updatedProfile.diningGroups || []),
-            !!(updatedProfile.birthData && updatedProfile.natalChart),
-          ],
-        );
+        await db.withTransaction(async (client) => {
+          await client.query(
+            `UPDATE users SET profile = $2, preferences = $3, updated_at = CURRENT_TIMESTAMP
+             WHERE id = $1::uuid`,
+            [
+              userId,
+              JSON.stringify(updatedProfile),
+              JSON.stringify(updatedProfile.preferences || {}),
+            ],
+          );
 
-        await db.executeQuery('COMMIT');
+          if (hasDietaryUpdate) {
+            await client.query(
+              `INSERT INTO user_profiles (user_id, name, birth_data, natal_chart, dietary_preferences, group_members, dining_groups, onboarding_completed)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+               ON CONFLICT (user_id) DO UPDATE SET
+                 name = EXCLUDED.name,
+                 birth_data = EXCLUDED.birth_data,
+                 natal_chart = EXCLUDED.natal_chart,
+                 dietary_preferences = EXCLUDED.dietary_preferences,
+                 group_members = EXCLUDED.group_members,
+                 dining_groups = EXCLUDED.dining_groups,
+                 onboarding_completed = EXCLUDED.onboarding_completed,
+                 onboarding_completed_at = CASE WHEN EXCLUDED.onboarding_completed AND NOT COALESCE(user_profiles.onboarding_completed, false) THEN CURRENT_TIMESTAMP ELSE user_profiles.onboarding_completed_at END,
+                 updated_at = CURRENT_TIMESTAMP`,
+              [
+                userId,
+                updatedProfile.name || "",
+                JSON.stringify(updatedProfile.birthData || {}),
+                JSON.stringify(updatedProfile.natalChart || {}),
+                JSON.stringify(updatedProfile.dietaryPreferences || {}),
+                JSON.stringify(updatedProfile.groupMembers || []),
+                JSON.stringify(updatedProfile.diningGroups || []),
+                onboardingComplete,
+              ],
+            );
+          } else {
+            await client.query(
+              `INSERT INTO user_profiles (user_id, name, birth_data, natal_chart, group_members, dining_groups, onboarding_completed)
+               VALUES ($1, $2, $3, $4, $5, $6, $7)
+               ON CONFLICT (user_id) DO UPDATE SET
+                 name = EXCLUDED.name,
+                 birth_data = EXCLUDED.birth_data,
+                 natal_chart = EXCLUDED.natal_chart,
+                 group_members = EXCLUDED.group_members,
+                 dining_groups = EXCLUDED.dining_groups,
+                 onboarding_completed = EXCLUDED.onboarding_completed,
+                 onboarding_completed_at = CASE WHEN EXCLUDED.onboarding_completed AND NOT COALESCE(user_profiles.onboarding_completed, false) THEN CURRENT_TIMESTAMP ELSE user_profiles.onboarding_completed_at END,
+                 updated_at = CURRENT_TIMESTAMP`,
+              [
+                userId,
+                updatedProfile.name || "",
+                JSON.stringify(updatedProfile.birthData || {}),
+                JSON.stringify(updatedProfile.natalChart || {}),
+                JSON.stringify(updatedProfile.groupMembers || []),
+                JSON.stringify(updatedProfile.diningGroups || []),
+                onboardingComplete,
+              ],
+            );
+          }
+        });
+
         _logger.info("User profile updated in PostgreSQL:", { userId });
       } catch (error) {
-        await db.executeQuery('ROLLBACK').catch(() => {});
         _logger.error("PostgreSQL profile update failed:", error);
         throw new Error("Failed to update profile in database", { cause: error });
       }
@@ -388,7 +419,7 @@ class UserDatabaseService {
       try {
         const primaryRole = (role as string).toUpperCase();
         await db.executeQuery(
-          `UPDATE users SET role = $2::user_role, updated_at = CURRENT_TIMESTAMP WHERE id::text = $1`,
+          `UPDATE users SET role = $2::user_role, updated_at = CURRENT_TIMESTAMP WHERE id = $1::uuid`,
           [userId, primaryRole],
         );
         _logger.info("User role updated in PostgreSQL:", { userId, role });
@@ -553,10 +584,21 @@ class UserDatabaseService {
       typeof row.natal_chart === "string"
         ? JSON.parse(row.natal_chart)
         : row.natal_chart;
-    const preferences =
+    const dietaryPreferences =
       typeof row.dietary_preferences === "string"
         ? JSON.parse(row.dietary_preferences)
-        : row.dietary_preferences || row.preferences || {};
+        : row.dietary_preferences || {};
+    // users.preferences is the canonical store for general preferences.
+    // For legacy rows where general prefs were written to dietary_preferences,
+    // fall back to that column if users.preferences is empty.
+    const rawUserPrefs =
+      typeof row.preferences === "string"
+        ? JSON.parse(row.preferences)
+        : row.preferences || {};
+    const preferences =
+      Object.keys(rawUserPrefs || {}).length > 0
+        ? rawUserPrefs
+        : dietaryPreferences;
     const groupMembers =
       typeof row.group_members === "string"
         ? JSON.parse(row.group_members)
@@ -585,6 +627,8 @@ class UserDatabaseService {
         name: row.profile_name || row.name,
         email: row.email,
         preferences,
+        dietaryPreferences,
+        onboardingComplete: row.onboarding_completed === true,
         birthData:
           Object.keys(birthData || {}).length > 0 ? birthData : undefined,
         natalChart:


### PR DESCRIPTION
## Summary

Fixes four silent data-hazard issues found in the onboarding audit. All changes are in `userDatabaseService.ts`, `auth.ts`, `UserContext`, and the onboarding route — no schema changes required.

- **#1 Real transactions** — `createUser` and `updateUserProfile` were calling `BEGIN`/`COMMIT` via `executeQuery`, which checks out a fresh pool connection per call. The three statements ran on three different connections — no actual transaction. Replaced both with `withTransaction` so one `PoolClient` is held for the duration. A failed `user_profiles` insert now rolls back the `users` insert atomically.

- **#2 `onboardingComplete` always false** — `rowToUserWithProfile` selected `up.onboarding_completed` but never mapped it onto the returned profile object. `GET /api/onboarding` read `user.profile.onboardingComplete`, which was always `undefined → false`. Now set from the DB column in `rowToUserWithProfile` and propagated through `updateUserProfile` so the in-memory cache is consistent too. Drops the `(as any)` cast in `onboarding/route.ts:269` — field is now typed on `UserProfile`.

- **#3 Removed 3.5 s ghost-user timeout** — `signIn` wrapped `createUser` in a `Promise.race` with a 3500 ms reject. On Railway cold-start, slow creates timed out, the outer catch swallowed the error, and `signIn` returned `true` — giving the user a valid JWT with no `users` row. Any subsequent lookup-by-email returned `null`. Removed the race; the DB-level statement timeout and NextAuth's own request deadline govern behaviour. The fail-open outer catch is retained intentionally (throwing inside `signIn` causes NextAuth's Configuration error page — see inline comment).

- **#4 Preferences column split** — `createUser` wrote `user.profile.preferences` (theme, notification settings) into `user_profiles.dietary_preferences`, which is reserved for allergies/restrictions. Writes now go to `users.preferences` (canonical) only. `updateUserProfile` only touches `dietary_preferences` when the caller explicitly provides a `dietaryPreferences` field. `rowToUserWithProfile` prefers `users.preferences` and falls back to `dietary_preferences` for legacy rows written before this deploy. Adds `UserProfile.dietaryPreferences` for future dietary features.

- **Drive-by: `WHERE id::text = $1`** — `getUserById` and `updateUserRole` cast the UUID PK to text, defeating the PK index. Changed to `id = $1::uuid`.

## Timeout choice (issue #3)

Chose **option 1** (remove the timeout entirely) rather than raising it to 10 s or adding a JWT retry flag. Rationale: the existing design is intentionally fail-open in `signIn` to prevent the NextAuth Configuration error page. Railway internal DB connections are sub-1 ms on warm deploys; the only risk is a true cold-start. If a cold-start creates a ghost user it will self-heal on the next sign-in (cache miss → `!dbUser` branch → `createUser` retries). Option 2 (JWT retry flag) is the right long-term fix but belongs in a separate PR.

## Preferences read safety

Existing users whose general preferences landed in `dietary_preferences` are protected by the `row.preferences || dietary_preferences` fallback in `rowToUserWithProfile`. Those rows will migrate naturally to the correct column the next time `updateUserProfile` is called (which writes to `users.preferences`). No one-time backfill migration needed.

## No pool deadlock risk

Confirmed via grep: every `getDatabaseUserFromRequest` call site is at the top of its route handler, before any `updateUserProfile` call. No transaction nesting.

## Test plan

- [ ] Sign in with a new Google account (including during Railway cold-start) → confirm both `users` row and `user_profiles` row exist after sign-in; no ghost sessions.
- [ ] Complete onboarding → `GET /api/onboarding` returns `onboardingComplete: true` immediately (no sign-out/sign-in required).
- [ ] Sign in as an existing user whose prefs are in the legacy `dietary_preferences` column → profile loads correctly; preferences not lost.
- [ ] Simulate a `user_profiles` insert failure during `createUser` (e.g. constraint violation) → confirm `users` row was also rolled back (proves the transaction held).
- [ ] Confirm dietary restriction features (if any) read from `dietaryPreferences`, not `preferences`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)