### PR TITLE
fix(types): resolve all ESLint warnings and improve type safety

### DIFF
--- a/src/app/api/debug/natal-chart/route.ts
+++ b/src/app/api/debug/natal-chart/route.ts
@@ -53,9 +53,10 @@ export async function GET(request: NextRequest) {
     // Compare positions
     const comparison: Record<string, any> = {};
     const planets = ['Sun', 'Moon', 'Mercury', 'Venus', 'Mars', 'Jupiter', 'Saturn', 'Uranus', 'Neptune', 'Pluto'];
+    const natalPlanetaryPositions = natalChart.planetaryPositions as Record<string, string> | undefined;
 
     for (const planet of planets) {
-      const natalSign = natalChart.planetaryPositions?.[planet];
+      const natalSign = natalPlanetaryPositions?.[planet];
       const currentSign = currentPositions[planet]?.sign;
       const areIdentical = natalSign?.toLowerCase() === currentSign?.toLowerCase();
 
@@ -80,14 +81,14 @@ export async function GET(request: NextRequest) {
     // Convert natal chart format to validation format
     for (const planet of [...planets, 'Ascendant']) {
       const planetInfo = natalChart.planets?.find(p => p.name === planet);
-      const sign = natalChart.planetaryPositions?.[planet];
+      const sign = natalPlanetaryPositions?.[planet];
 
       if (sign && planetInfo) {
         const degree = Math.floor(planetInfo.position % 30);
         const minute = Math.floor(((planetInfo.position % 30) - degree) * 60);
 
         natalPositionsForValidation[planet] = {
-          sign,
+          sign: sign as PlanetPosition["sign"],
           degree,
           minute,
           exactLongitude: planetInfo.position,

--- a/src/app/api/personalized-recommendations/route.ts
+++ b/src/app/api/personalized-recommendations/route.ts
@@ -110,7 +110,18 @@ export async function POST(request: NextRequest) {
     ];
 
     // Chart comparison (only if natal chart available and requested)
-    let chartComparison = null;
+    let chartComparison: {
+      overallHarmony: number;
+      elementalHarmony: number;
+      alchemicalAlignment: number;
+      planetaryResonance: number;
+      insights: {
+        favorableElements: string[];
+        challengingElements: string[];
+        harmonicPlanets: string[];
+        recommendations: string[];
+      };
+    } | null = null;
     if (includeChartAnalysis && Object.keys(natalPositions).length > 0) {
       const natalDiurnal = natalChart?.birthData?.dateTime ? isSectDiurnal(new Date(natalChart.birthData.dateTime)) : true;
       const currentDiurnal = isSectDiurnal(new Date());
@@ -153,7 +164,6 @@ export async function POST(request: NextRequest) {
 
       const overallHarmony = (alchemicalAlignment * 0.4 + elementalHarmony * 0.35 + planetaryResonance * 0.25);
 
-      // @ts-expect-error - Auto-fixed by script
       chartComparison = {
         overallHarmony,
         elementalHarmony,

--- a/src/app/api/user/taste-graph/correct/route.ts
+++ b/src/app/api/user/taste-graph/correct/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { updateTasteCorrections } from "@/services/userInteractionsService";
 import { auth } from "@/lib/auth/auth";
+import { updateTasteCorrections } from "@/services/userInteractionsService";
 
 export async function POST(request: Request) {
   try {

--- a/src/app/api/users/[userId]/route.ts
+++ b/src/app/api/users/[userId]/route.ts
@@ -7,11 +7,11 @@
  */
 
 import { NextResponse, type NextRequest } from "next/server";
-import { executeQuery } from "@/lib/database";
 import {
   agentSlugFromEmail,
   fetchAgentProfile,
 } from "@/lib/agents/fetchAgentProfile";
+import { executeQuery } from "@/lib/database";
 import { computeTasteGraph } from "@/services/userInteractionsService";
 
 export const dynamic = "force-dynamic";
@@ -127,8 +127,8 @@ export async function GET(
     const natalChart = parseJsonField<Record<string, unknown>>(row.natal_chart, {});
     const natalPositions = parseJsonField<unknown[]>(row.natal_positions, []);
     const birthData = parseJsonField<Record<string, unknown>>(row.birth_data, {});
-    const dietary_preferences = parseJsonField<Record<string, unknown>>(row.dietary_preferences, {});
-    const profile_layout = parseJsonField<unknown[]>(row.profile_layout, ["natalChart", "alchemicalConstitution", "tasteGraph", "dietaryPrefs", "insightsTicker", "tokenEconomy", "recentActivity"]);
+    const dietaryPreferences = parseJsonField<Record<string, unknown>>(row.dietary_preferences, {});
+    const profileLayout = parseJsonField<unknown[]>(row.profile_layout, ["natalChart", "alchemicalConstitution", "tasteGraph", "dietaryPrefs", "insightsTicker", "tokenEconomy", "recentActivity"]);
 
     // For agent users, pull the rich CraftedAgent profile from
     // planetary_agents-main. Cached 24h upstream-side; falls back to null
@@ -151,8 +151,8 @@ export async function GET(
         natalChart,
         natalPositions,
         birthData,
-        dietary_preferences,
-        profile_layout,
+        dietary_preferences: dietaryPreferences,
+        profile_layout: profileLayout,
         tasteGraph,
         createdAt: row.created_at,
         balances: {

--- a/src/app/profile/[userId]/page.tsx
+++ b/src/app/profile/[userId]/page.tsx
@@ -3,13 +3,13 @@
 import { motion } from "framer-motion";
 import Link from "next/link";
 import { useParams } from "next/navigation";
+import { useSession } from "next-auth/react";
 import React, { useEffect, useState } from "react";
 import Header from "@/components/Header";
+import { CustomizeDrawer } from "@/components/profile/CustomizeDrawer";
+import { PROFILE_BLOCKS, type ProfileTab } from "@/components/profile/ProfileBlockRegistry";
 import type { CraftedAgentProfile } from "@/lib/agents/craftedAgentTypes";
 import AgentProfile from "./AgentProfile";
-import { useSession } from "next-auth/react";
-import { PROFILE_BLOCKS, ProfileTab } from "@/components/profile/ProfileBlockRegistry";
-import { CustomizeDrawer } from "@/components/profile/CustomizeDrawer";
 
 interface NatalPosition {
   planet?: string;

--- a/src/app/restaurant-creator/page.tsx
+++ b/src/app/restaurant-creator/page.tsx
@@ -95,11 +95,12 @@ export default function RestaurantCreatorPage() {
       Mars: "Martian", Jupiter: "Jovian", Saturn: "Saturnine",
     }[planetaryDay] || "Cosmic";
 
-    const nameSuffix = {
+    const zodiacSuffixMap: Record<string, string> = {
       aries: "Flame", taurus: "Garden", gemini: "Mirror", cancer: "Tide",
       leo: "Crown", virgo: "Harvest", libra: "Balance", scorpio: "Depth",
       sagittarius: "Arrow", capricorn: "Summit", aquarius: "Stream", pisces: "Dream",
-    }[zodiac?.toLowerCase()] || "Table";
+    };
+    const nameSuffix = zodiacSuffixMap[zodiac?.toLowerCase()] ?? "Table";
 
     const randomFusion =
       CUISINE_FUSIONS[Math.floor(Math.random() * CUISINE_FUSIONS.length)];

--- a/src/calculations/combinationEffects.ts
+++ b/src/calculations/combinationEffects.ts
@@ -1,4 +1,5 @@
 import { ELEMENT_COMBINATIONS } from "@/constants/elementalCore";
+import type { IngredientMapping } from "@/data/ingredients/types";
 import type {
   CombinationEffect,
   EffectType,
@@ -8,6 +9,8 @@ import type {
 import type { Element } from "@/types/celestial";
 import { ingredientMappings } from "@/utils/elementalMappings/ingredients";
 import { logger } from "@/utils/logger";
+
+const ingredientLookup = ingredientMappings as Record<string, IngredientMapping | undefined>;
 
 type CookingMethod =
   | "simmered"
@@ -150,8 +153,8 @@ const calculateElementalInteractions = (
   const effects: CombinationEffect[] = [];
   const ingredientPairs = getPairs(ingredients);
   ingredientPairs.forEach(([ing1, ing2]) => {
-    const elem1 = ingredientMappings[ing1]?.elementalProperties;
-    const elem2 = ingredientMappings[ing2]?.elementalProperties;
+    const elem1 = ingredientLookup[ing1]?.elementalProperties;
+    const elem2 = ingredientLookup[ing2]?.elementalProperties;
 
     if (!elem1 || !elem2) return;
     if (isHarmoniousCombination(elem1, elem2)) {
@@ -253,7 +256,7 @@ const calculateCombinedElements = (
   };
 
   ingredients.forEach((ing) => {
-    const elements = ingredientMappings[ing]?.elementalProperties;
+    const elements = ingredientLookup[ing]?.elementalProperties;
     if (elements) {
       Object.entries(elements).forEach(([element, value]) => {
         // Pattern KK-1: Safe arithmetic with type validation

--- a/src/components/profile/CustomizeDrawer.tsx
+++ b/src/components/profile/CustomizeDrawer.tsx
@@ -158,7 +158,7 @@ export function CustomizeDrawer({
             Cancel
           </button>
           <button
-            onClick={handleSave}
+            onClick={() => void handleSave()}
             disabled={saving}
             className="flex-1 py-2 text-xs bg-purple-500 hover:bg-purple-400 text-white font-bold rounded-lg transition-colors disabled:opacity-50"
           >

--- a/src/components/profile/ProfileBlockRegistry.tsx
+++ b/src/components/profile/ProfileBlockRegistry.tsx
@@ -100,7 +100,7 @@ const DietaryPrefsBlock = ({ data, isOwner }: { data: any, isOwner: boolean }) =
           </div>
           <div className="flex gap-2 justify-end">
             <button onClick={() => setIsEditing(false)} className="text-xs text-white/50 hover:text-white">Cancel</button>
-            <button onClick={handleSave} disabled={saving} className="text-xs bg-purple-500 text-white px-3 py-1 rounded hover:bg-purple-400">
+            <button onClick={() => void handleSave()} disabled={saving} className="text-xs bg-purple-500 text-white px-3 py-1 rounded hover:bg-purple-400">
               {saving ? 'Saving...' : 'Save'}
             </button>
           </div>
@@ -152,7 +152,7 @@ const DataPrivacyBlock = ({ data, isOwner }: { data: any, isOwner: boolean }) =>
           </div>
           <button 
             onClick={() => {
-              const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(data));
+              const dataStr = `data:text/json;charset=utf-8,${encodeURIComponent(JSON.stringify(data))}`;
               const downloadAnchorNode = document.createElement('a');
               downloadAnchorNode.setAttribute("href",     dataStr);
               downloadAnchorNode.setAttribute("download", "alchm_profile.json");

--- a/src/services/RealAlchemizeService.ts
+++ b/src/services/RealAlchemizeService.ts
@@ -47,7 +47,7 @@ export interface PlanetaryPosition {
   sign: any;
   degree: number;
   minute: number;
-  isRetrograde: boolean;
+  isRetrograde?: boolean;
   exactLongitude?: number;
 }
 export interface ThermodynamicProperties {


### PR DESCRIPTION
## Summary

- **ESLint warnings cleared (6 → 0):** fixed `import/order` violations in 3 routes, renamed snake_case locals to camelCase, added `type`-only import for `ProfileTab`, wrapped two async `onClick` handlers with `void` to satisfy `no-misused-promises`, and replaced a string concatenation with a template literal
- **Type safety hardened (5 fixes):** made `PlanetaryPosition.isRetrograde` optional to match its actual source type; replaced stale `@ts-expect-error` with an explicit union type for `chartComparison`; added typed cast for `natalChart.planetaryPositions` lookups; extracted `zodiacSuffixMap` as `Record<string, string>` to fix implicit-any indexing; added `ingredientLookup` typed cast for string-keyed `ingredientMappings` accesses
- `tsc --noEmit` and `eslint` both pass clean after all changes

## Files changed

| File | Change |
|------|--------|
| `src/app/api/user/taste-graph/correct/route.ts` | import order |
| `src/app/api/users/[userId]/route.ts` | import order + camelCase locals |
| `src/app/profile/[userId]/page.tsx` | import order + `type ProfileTab` |
| `src/components/profile/CustomizeDrawer.tsx` | `no-misused-promises` |
| `src/components/profile/ProfileBlockRegistry.tsx` | `no-misused-promises` + template literal |
| `src/services/RealAlchemizeService.ts` | `isRetrograde` made optional |
| `src/app/api/personalized-recommendations/route.ts` | remove stale `@ts-expect-error`, type `chartComparison` |
| `src/app/api/debug/natal-chart/route.ts` | typed `natalPlanetaryPositions` cast |
| `src/app/restaurant-creator/page.tsx` | typed `zodiacSuffixMap` |
| `src/calculations/combinationEffects.ts` | typed `ingredientLookup` |

## Test plan

- [ ] `bun run build` passes
- [ ] `bunx tsc --noEmit` — no errors
- [ ] `bunx next lint` — ✔ No ESLint warnings or errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)