### PR TITLE
fix(onboarding): harden new-user sign-in against transient DB connection failures

### DIFF
--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -10,6 +10,7 @@
 
 import { NextResponse } from "next/server";
 import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
+import { auth } from "@/lib/auth/auth";
 import { _logger } from "@/lib/logger";
 import { OnboardingRequestSchema } from "@/lib/validation/apiSchemas";
 import { getPlanetaryPositionsForDateTime } from "@/services/astrologizeApi";
@@ -97,6 +98,26 @@ export async function POST(request: NextRequest) {
     const user = await getDatabaseUserFromRequest(request);
 
     if (!user) {
+      // Distinguish "not logged in" (401) from "logged in but DB unavailable" (503).
+      // getDatabaseUserFromRequest already attempted JIT creation; if it still returned
+      // null, check whether a valid NextAuth session exists so the client knows whether
+      // to prompt re-login or to retry after a moment.
+      let hasValidSession = false;
+      try {
+        const session = await auth();
+        hasValidSession = !!(session?.user?.email);
+      } catch {
+        // auth() failed — treat as unauthenticated
+      }
+
+      if (hasValidSession) {
+        _logger.warn("[POST /api/onboarding] Session valid but DB lookup failed — returning 503 for client retry");
+        return NextResponse.json(
+          { success: false, message: "Service temporarily unavailable. Please try again in a moment." },
+          { status: 503 },
+        );
+      }
+
       _logger.warn("[POST /api/onboarding] User not found or not authenticated");
       return NextResponse.json(
         { success: false, message: "User not found. Please sign in first." },

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -98,14 +98,21 @@ export default function OnboardingPage() {
         throw new Error(`Invalid birth data: ${Object.values(parsedPayload.error.flatten().fieldErrors).flat().join(", ")}`);
       }
 
-      const response = await fetch("/api/onboarding", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(parsedPayload.data),
-      });
+      // POST with automatic retry on 503 (DB temporarily unavailable after OAuth).
+      // New users occasionally hit this when the connection pool is saturated during sign-in.
+      let response: Response | null = null;
+      for (let attempt = 1; attempt <= 3; attempt++) {
+        response = await fetch("/api/onboarding", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(parsedPayload.data),
+        });
+        if (response.status !== 503) break;
+        if (attempt < 3) await new Promise(r => setTimeout(r, attempt * 1500));
+      }
 
-      if (!response.ok) throw new Error(`Server error (${response.status})`);
-      const data = await response.json();
+      if (!response!.ok) throw new Error(`Server error (${response!.status})`);
+      const data = await response!.json();
 
       if (!data.success) {
         throw new Error(data.message || "Onboarding failed");

--- a/src/lib/database/config.ts
+++ b/src/lib/database/config.ts
@@ -22,10 +22,11 @@ export const databaseConfig = {
   password: process.env.DB_PASSWORD || "pass",
   ssl: process.env.DB_SSL === "true",
 
-  // Connection pool settings
-  maxConnections: parseInt(process.env.DB_MAX_CONNECTIONS || "50", 10),
-  idleTimeout: parseInt(process.env.DB_IDLE_TIMEOUT || "30000", 10),
-  connectionTimeout: parseInt(process.env.DB_CONNECTION_TIMEOUT || "10000", 10),
+  // Connection pool settings — kept small for serverless (each Vercel invocation
+  // owns its own pool; 50 concurrent connections per instance would exhaust Railway).
+  maxConnections: parseInt(process.env.DB_MAX_CONNECTIONS || "5", 10),
+  idleTimeout: parseInt(process.env.DB_IDLE_TIMEOUT || "10000", 10),
+  connectionTimeout: parseInt(process.env.DB_CONNECTION_TIMEOUT || "5000", 10),
 
   // Application settings
   environment: process.env.NODE_ENV || "development",


### PR DESCRIPTION
## Root Cause

The DB pool was configured for a persistent server (`max=50`, `connectionTimeout=10s`), but Vercel runs serverless — each function invocation owns its own pool. Under moderate load, concurrent Vercel invocations exhaust Railway's connection limit. New-user creation fails silently in the OAuth callback, leaving the user with a **valid NextAuth session but no DB record**, so every subsequent API call returns 401.

Evidence from Vercel runtime logs (2026-05-16 20:10:44):
- `[ERROR] PostgreSQL user creation failed` during `/api/auth/callback/google`  
- Preceded by `Vercel Runtime Timeout Error` on `/profile` and `/restaurant-creator` (pool exhaustion cascade)
- All layout API calls (notifications, subscription, profile) → 401 immediately after OAuth redirect

## Changes

**`src/lib/database/config.ts`**
- `maxConnections`: 50 → 5 (serverless: many instances × 5 << Railway limit)
- `connectionTimeout`: 10 000ms → 5 000ms (fail fast, don't hang Vercel's 10s window)
- `idleTimeout`: 30 000ms → 10 000ms (release idle connections sooner)

**`src/app/api/onboarding/route.ts`**
- When `getDatabaseUserFromRequest` returns null, check if a valid NextAuth session exists
- If yes → **503** ("service temporarily unavailable, retry") not **401** ("go re-authenticate")

**`src/app/onboarding/page.tsx`**
- Auto-retry `POST /api/onboarding` up to 3× on 503, with 1.5 s / 3 s backoff
- No UX change for the happy path

## Test Plan
- [ ] Re-run alchmtest@gmail.com onboarding in the "test account" Chrome profile
- [ ] Confirm redirect → `/onboarding` → form submit → redirect → `/profile`
- [ ] Check Vercel runtime logs: no more `PostgreSQL user creation failed` under normal load
- [ ] Verify existing auth (gregcastro23) still works normally

🤖 Generated with [Claude Code](https://claude.ai/claude-code)