### PR TITLE
feat(cuisines): browse grid, slug pages, group-by-cuisine view, Stripe reserve

### DIFF
--- a/src/app/api/restaurants/discover/route.ts
+++ b/src/app/api/restaurants/discover/route.ts
@@ -29,6 +29,9 @@ const GOOGLE_FIELD_MASK = [
   "places.formattedAddress",
   "places.rating",
   "places.photos",
+  "places.primaryType",
+  "places.primaryTypeDisplayName",
+  "places.types",
 ].join(",");
 
 interface DiscoverBody {
@@ -45,6 +48,9 @@ interface GooglePlaceRaw {
   formattedAddress?: string;
   rating?: number;
   photos?: Array<{ name?: string }>;
+  primaryType?: string;
+  primaryTypeDisplayName?: { text?: string };
+  types?: string[];
 }
 
 interface NormalizedGoogleRestaurant {
@@ -54,6 +60,59 @@ interface NormalizedGoogleRestaurant {
   rating: number;
   imageUrl?: string;
   business: YelpBusiness;
+  cuisineLabel?: string;
+  primaryType?: string;
+}
+
+const PLACE_TYPE_TO_CUISINE: Record<string, string> = {
+  italian_restaurant: "Italian",
+  pizza_restaurant: "Italian",
+  chinese_restaurant: "Chinese",
+  japanese_restaurant: "Japanese",
+  sushi_restaurant: "Japanese",
+  ramen_restaurant: "Japanese",
+  korean_restaurant: "Korean",
+  thai_restaurant: "Thai",
+  vietnamese_restaurant: "Vietnamese",
+  indian_restaurant: "Indian",
+  mexican_restaurant: "Mexican",
+  american_restaurant: "American",
+  hamburger_restaurant: "American",
+  steak_house: "American",
+  french_restaurant: "French",
+  greek_restaurant: "Greek",
+  mediterranean_restaurant: "Middle Eastern",
+  middle_eastern_restaurant: "Middle Eastern",
+  lebanese_restaurant: "Middle Eastern",
+  turkish_restaurant: "Middle Eastern",
+  african_restaurant: "African",
+  ethiopian_restaurant: "African",
+  russian_restaurant: "Russian",
+  seafood_restaurant: "Seafood",
+  vegetarian_restaurant: "Vegetarian",
+  vegan_restaurant: "Vegan",
+  brunch_restaurant: "Brunch",
+  breakfast_restaurant: "Breakfast",
+  bakery: "Bakery",
+  cafe: "Café",
+  coffee_shop: "Café",
+  bar: "Bar",
+  fast_food_restaurant: "Fast Food",
+};
+
+function deriveCuisineLabel(raw: GooglePlaceRaw): string | undefined {
+  if (raw.primaryType && PLACE_TYPE_TO_CUISINE[raw.primaryType]) {
+    return PLACE_TYPE_TO_CUISINE[raw.primaryType];
+  }
+  if (raw.primaryTypeDisplayName?.text) {
+    return raw.primaryTypeDisplayName.text;
+  }
+  if (Array.isArray(raw.types)) {
+    for (const t of raw.types) {
+      if (PLACE_TYPE_TO_CUISINE[t]) return PLACE_TYPE_TO_CUISINE[t];
+    }
+  }
+  return undefined;
 }
 
 interface PartnerRestaurantRow {
@@ -119,6 +178,8 @@ function normalizeGooglePlace(raw: GooglePlaceRaw): NormalizedGoogleRestaurant |
     rating: business.rating,
     imageUrl: undefined,
     business,
+    cuisineLabel: deriveCuisineLabel(raw),
+    primaryType: raw.primaryType,
   };
 }
 
@@ -152,6 +213,8 @@ function toEntry(
       ? ["Partner restaurant with in-app menu ordering"]
       : ["Nearby restaurant from Google Places"],
     cuisineElement: { Fire: 0.25, Water: 0.25, Earth: 0.25, Air: 0.25 },
+    cuisineLabel: restaurant.cuisineLabel,
+    primaryType: restaurant.primaryType,
   };
 }
 

--- a/src/app/cuisines/[slug]/page.tsx
+++ b/src/app/cuisines/[slug]/page.tsx
@@ -1,0 +1,121 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import dynamic from "next/dynamic";
+import { CUISINES_METADATA } from "@/data/cuisines/index";
+import { cuisineToSlug, slugToCuisineKey } from "@/utils/cuisineSlug";
+
+const CuisineRestaurantFinder = dynamic(
+  () => import("@/components/RestaurantDiscovery/CuisineRestaurantFinder"),
+  {
+    loading: () => (
+      <div className="flex items-center justify-center py-12">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-500/50" />
+      </div>
+    ),
+  },
+);
+
+type ElementName = "Fire" | "Water" | "Earth" | "Air";
+
+const ELEMENT_GLYPH: Record<ElementName, { emoji: string; chip: string; glow: string }> = {
+  Fire:  { emoji: "🔥", chip: "bg-rose-500/15 text-rose-200 border-rose-400/30",       glow: "bg-rose-600/15" },
+  Water: { emoji: "💧", chip: "bg-blue-500/15 text-blue-200 border-blue-400/30",       glow: "bg-blue-600/15" },
+  Earth: { emoji: "🌿", chip: "bg-emerald-500/15 text-emerald-200 border-emerald-400/30", glow: "bg-emerald-600/15" },
+  Air:   { emoji: "💨", chip: "bg-sky-500/15 text-sky-200 border-sky-400/30",          glow: "bg-sky-600/15" },
+};
+
+export function generateStaticParams() {
+  return Object.entries(CUISINES_METADATA).map(([key, meta]) => ({
+    slug: cuisineToSlug(meta.name ?? key),
+  }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const key = slugToCuisineKey(slug);
+  if (!key) return { title: "Cuisine — Alchm Kitchen" };
+  const meta = CUISINES_METADATA[key];
+  const name = meta?.name ?? key;
+  return {
+    title: `${name} cuisine — Alchm Kitchen`,
+    description: meta?.description ?? `${name} culinary tradition.`,
+  };
+}
+
+export default async function CuisineDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const key = slugToCuisineKey(slug);
+  if (!key) notFound();
+
+  const meta = CUISINES_METADATA[key];
+  const name = meta?.name ?? key;
+  const description = meta?.description ?? "";
+
+  const props = meta?.elementalProperties ?? {};
+  const ordered = (Object.entries(props) as Array<[ElementName, number]>).sort(
+    (a, b) => b[1] - a[1],
+  );
+  const dominant: ElementName = ordered[0]?.[0] ?? "Earth";
+  const dominantDecoration = ELEMENT_GLYPH[dominant];
+
+  return (
+    <main className="min-h-screen bg-[#08080e] text-white p-4 md:p-8">
+      <div className="max-w-4xl mx-auto pb-16">
+        <Link
+          href="/cuisines"
+          className="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-[0.18em] text-purple-300/70 hover:text-purple-200 mb-6"
+        >
+          <span aria-hidden>←</span> All cuisines
+        </Link>
+
+        <header className="relative overflow-hidden rounded-3xl border border-white/10 bg-[#0c0c14]/80 backdrop-blur-xl p-8 md:p-10 mb-8">
+          <div
+            className={`absolute top-0 right-0 w-96 h-96 rounded-full blur-[120px] pointer-events-none -mr-20 -mt-20 ${dominantDecoration.glow}`}
+            aria-hidden
+          />
+          <div className="relative z-10">
+            <div className="text-6xl mb-4" aria-hidden>
+              {dominantDecoration.emoji}
+            </div>
+            <h1 className="text-4xl md:text-6xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-purple-300 via-pink-300 to-rose-300 leading-tight pb-2">
+              {name}
+            </h1>
+            {description && (
+              <p className="mt-4 text-lg text-white/60 max-w-2xl leading-relaxed">
+                {description}
+              </p>
+            )}
+
+            <ul className="mt-6 flex flex-wrap gap-2">
+              {ordered.map(([element, value]) => {
+                const dec = ELEMENT_GLYPH[element];
+                return (
+                  <li
+                    key={element}
+                    className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full border text-[11px] font-black uppercase tracking-widest ${dec.chip}`}
+                  >
+                    <span aria-hidden>{dec.emoji}</span>
+                    {element}
+                    <span className="opacity-60">{(value * 100).toFixed(0)}%</span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </header>
+
+        <section>
+          <CuisineRestaurantFinder initialCuisineType={name} />
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/cuisines/[slug]/page.tsx
+++ b/src/app/cuisines/[slug]/page.tsx
@@ -1,6 +1,6 @@
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import dynamic from "next/dynamic";
 import { CUISINES_METADATA } from "@/data/cuisines/index";
 import { cuisineToSlug, slugToCuisineKey } from "@/utils/cuisineSlug";
 

--- a/src/app/cuisines/page.tsx
+++ b/src/app/cuisines/page.tsx
@@ -28,6 +28,16 @@ const CuisineRestaurantFinder = dynamic(
   { loading: () => <SectionLoader /> },
 );
 
+const CuisineBrowseGrid = dynamic(
+  () => import("@/components/RestaurantDiscovery/CuisineBrowseGrid"),
+  { loading: () => <SectionLoader /> },
+);
+
+const LocalCuisineGroups = dynamic(
+  () => import("@/components/RestaurantDiscovery/LocalCuisineGroups"),
+  { loading: () => <SectionLoader /> },
+);
+
 const staggerContainer: Variants = {
   hidden: { opacity: 0 },
   show: {
@@ -64,14 +74,18 @@ export default function CuisinesPage() {
           </p>
         </motion.header>
 
-        <motion.section 
+        <motion.section variants={fadeInItem}>
+          <CuisineBrowseGrid />
+        </motion.section>
+
+        <motion.section
           variants={fadeInItem}
         >
           <div className="glass-card-premium rounded-3xl p-6 md:p-8 border border-white/10 shadow-2xl shadow-purple-900/20 relative overflow-hidden bg-[#0c0c14]/80 backdrop-blur-xl">
             {/* Ambient Background Glow */}
             <div className="absolute top-0 right-0 w-96 h-96 bg-purple-600/10 rounded-full blur-[100px] pointer-events-none -mr-20 -mt-20" />
             <div className="absolute bottom-0 left-0 w-96 h-96 bg-rose-600/10 rounded-full blur-[100px] pointer-events-none -ml-20 -mb-20" />
-            
+
             <div className="relative z-10">
               {/* Cuisine recommender is shown to everyone (also on the home page
                   as a marketing preview). The premium-only piece is the sauce
@@ -81,13 +95,12 @@ export default function CuisinesPage() {
           </div>
         </motion.section>
 
-        <motion.section
-          variants={fadeInItem}
-          className="mt-8"
-        >
-          <div className="glass-card-premium rounded-3xl p-1 border border-white/5 relative overflow-hidden bg-[#0c0c14]/50 backdrop-blur-sm">
-             <CuisineRestaurantFinder />
-          </div>
+        <motion.section variants={fadeInItem}>
+          <LocalCuisineGroups />
+        </motion.section>
+
+        <motion.section variants={fadeInItem}>
+          <CuisineRestaurantFinder />
         </motion.section>
 
         <motion.section

--- a/src/components/RestaurantDiscovery/CuisineBrowseGrid.tsx
+++ b/src/components/RestaurantDiscovery/CuisineBrowseGrid.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+/**
+ * CuisineBrowseGrid — clickable card grid for the 14 primary cuisines.
+ *
+ * Each card surfaces the cuisine's dominant element and links to the
+ * cuisine deep page at /cuisines/[slug].
+ */
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { CUISINES_METADATA } from "@/data/cuisines/index";
+import { cuisineToSlug } from "@/utils/cuisineSlug";
+import type { Variants } from "framer-motion";
+
+type ElementName = "Fire" | "Water" | "Earth" | "Air";
+
+interface ElementMeta {
+  emoji: string;
+  label: ElementName;
+  ring: string;
+  glow: string;
+  chip: string;
+}
+
+const ELEMENT_META: Record<ElementName, ElementMeta> = {
+  Fire: {
+    emoji: "🔥",
+    label: "Fire",
+    ring: "border-rose-400/30 hover:border-rose-300/60",
+    glow: "from-rose-500/20 to-orange-500/10",
+    chip: "bg-rose-500/15 text-rose-200 border-rose-400/30",
+  },
+  Water: {
+    emoji: "💧",
+    label: "Water",
+    ring: "border-blue-400/30 hover:border-blue-300/60",
+    glow: "from-blue-500/20 to-cyan-500/10",
+    chip: "bg-blue-500/15 text-blue-200 border-blue-400/30",
+  },
+  Earth: {
+    emoji: "🌿",
+    label: "Earth",
+    ring: "border-emerald-400/30 hover:border-emerald-300/60",
+    glow: "from-emerald-500/20 to-lime-500/10",
+    chip: "bg-emerald-500/15 text-emerald-200 border-emerald-400/30",
+  },
+  Air: {
+    emoji: "💨",
+    label: "Air",
+    ring: "border-sky-400/30 hover:border-sky-300/60",
+    glow: "from-sky-500/20 to-indigo-500/10",
+    chip: "bg-sky-500/15 text-sky-200 border-sky-400/30",
+  },
+};
+
+function dominantElement(props: Partial<Record<ElementName, number>> | undefined): ElementName {
+  if (!props) return "Earth";
+  let max: ElementName = "Earth";
+  let maxValue = -Infinity;
+  (Object.keys(ELEMENT_META) as ElementName[]).forEach((el) => {
+    const v = props[el] ?? 0;
+    if (v > maxValue) {
+      maxValue = v;
+      max = el;
+    }
+  });
+  return max;
+}
+
+const containerVariants: Variants = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: { staggerChildren: 0.04 },
+  },
+};
+
+const cardVariants: Variants = {
+  hidden: { y: 12, opacity: 0 },
+  show: { y: 0, opacity: 1, transition: { type: "spring", stiffness: 140, damping: 18 } },
+};
+
+export function CuisineBrowseGrid() {
+  const entries = Object.entries(CUISINES_METADATA);
+
+  return (
+    <section aria-label="Browse cuisines" className="space-y-4">
+      <div className="flex items-baseline justify-between gap-4">
+        <div>
+          <h2 className="text-2xl md:text-3xl font-extrabold text-white">
+            Browse Cuisines
+          </h2>
+          <p className="mt-1 text-xs text-white/50">
+            Explore the elemental signature of each tradition.
+          </p>
+        </div>
+        <span className="hidden sm:inline-flex text-[10px] font-bold uppercase tracking-[0.18em] text-purple-300/60">
+          {entries.length} cuisines
+        </span>
+      </div>
+
+      <motion.ul
+        className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3"
+        variants={containerVariants}
+        initial="hidden"
+        animate="show"
+      >
+        {entries.map(([key, meta]) => {
+          const displayName = meta.name ?? key;
+          const slug = cuisineToSlug(displayName);
+          const element = dominantElement(meta.elementalProperties);
+          const decoration = ELEMENT_META[element];
+
+          return (
+            <motion.li key={key} variants={cardVariants}>
+              <Link
+                href={`/cuisines/${slug}`}
+                className={`group relative block overflow-hidden rounded-2xl border bg-black/40 p-4 backdrop-blur-sm transition-all hover:bg-black/60 ${decoration.ring}`}
+              >
+                <div
+                  className={`pointer-events-none absolute inset-0 bg-gradient-to-br opacity-60 transition-opacity group-hover:opacity-100 ${decoration.glow}`}
+                  aria-hidden
+                />
+                <div className="relative z-10">
+                  <div className="text-2xl mb-2" aria-hidden>
+                    {decoration.emoji}
+                  </div>
+                  <div className="text-sm font-extrabold text-white leading-tight">
+                    {displayName}
+                  </div>
+                  <span
+                    className={`mt-2 inline-flex items-center gap-1 px-2 py-0.5 rounded-full border text-[9px] font-black uppercase tracking-widest ${decoration.chip}`}
+                  >
+                    {decoration.label}
+                  </span>
+                </div>
+              </Link>
+            </motion.li>
+          );
+        })}
+      </motion.ul>
+    </section>
+  );
+}
+
+export default CuisineBrowseGrid;

--- a/src/components/RestaurantDiscovery/CuisineBrowseGrid.tsx
+++ b/src/components/RestaurantDiscovery/CuisineBrowseGrid.tsx
@@ -7,8 +7,8 @@
  * cuisine deep page at /cuisines/[slug].
  */
 
-import Link from "next/link";
 import { motion } from "framer-motion";
+import Link from "next/link";
 import { CUISINES_METADATA } from "@/data/cuisines/index";
 import { cuisineToSlug } from "@/utils/cuisineSlug";
 import type { Variants } from "framer-motion";

--- a/src/components/RestaurantDiscovery/CuisineRestaurantFinder.tsx
+++ b/src/components/RestaurantDiscovery/CuisineRestaurantFinder.tsx
@@ -9,6 +9,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AddToDiaryModal } from "@/components/food-diary/AddToDiaryModal";
+import { ReservationModal } from "@/components/RestaurantDiscovery/ReservationModal";
 import { useToast } from "@/components/ToastProvider";
 import { useUser } from "@/contexts/UserContext";
 import type { SavedRestaurant } from "@/types/restaurant";
@@ -38,10 +39,10 @@ const ELEMENT_DECORATION: Record<
   AlchmScoredRestaurant["dominantElement"],
   { emoji: string; label: string; chipClass: string }
 > = {
-  Fire:  { emoji: "🔥", label: "Fire",  chipClass: "bg-rose-100 text-rose-700 border-rose-200" },
-  Water: { emoji: "💧", label: "Water", chipClass: "bg-blue-100 text-blue-700 border-blue-200" },
-  Earth: { emoji: "🌿", label: "Earth", chipClass: "bg-emerald-100 text-emerald-700 border-emerald-200" },
-  Air:   { emoji: "💨", label: "Air",   chipClass: "bg-sky-100 text-sky-700 border-sky-200" },
+  Fire:  { emoji: "🔥", label: "Fire",  chipClass: "bg-rose-500/15 text-rose-200 border-rose-400/30" },
+  Water: { emoji: "💧", label: "Water", chipClass: "bg-blue-500/15 text-blue-200 border-blue-400/30" },
+  Earth: { emoji: "🌿", label: "Earth", chipClass: "bg-emerald-500/15 text-emerald-200 border-emerald-400/30" },
+  Air:   { emoji: "💨", label: "Air",   chipClass: "bg-sky-500/15 text-sky-200 border-sky-400/30" },
 };
 
 const ZODIAC_GLYPH: Record<string, string> = {
@@ -101,6 +102,7 @@ export function CuisineRestaurantFinder({
   );
   const [locationError, setLocationError] = useState<string | null>(null);
   const [loggingItem, setLoggingItem] = useState<AlchmScoredRestaurant | null>(null);
+  const [reservingItem, setReservingItem] = useState<AlchmScoredRestaurant | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const [savedIds, setSavedIds] = useState<Set<string>>(new Set());
   const { currentUser, updateProfile } = useUser();
@@ -304,7 +306,7 @@ export function CuisineRestaurantFinder({
 
   return (
     <section
-      className={`mt-4 rounded-xl border border-amber-200 bg-gradient-to-br from-amber-50 to-rose-50 p-4 ${
+      className={`mt-4 rounded-3xl border border-white/10 bg-gradient-to-br from-[#0c0c14]/90 to-[#16101e]/90 backdrop-blur-xl p-6 shadow-2xl shadow-purple-900/20 ${
         className ?? ""
       }`}
       aria-label="Restaurant discovery"
@@ -312,26 +314,26 @@ export function CuisineRestaurantFinder({
       {/* Header */}
       <div className="flex flex-col md:flex-row items-center justify-between gap-4 mb-6">
         <div>
-          <h3 className="text-sm font-extrabold text-amber-900 flex items-center gap-2">
-            <span aria-hidden>✦</span>
+          <h3 className="text-sm font-extrabold text-purple-100 flex items-center gap-2 uppercase tracking-[0.18em]">
+            <span aria-hidden className="text-purple-300">✦</span>
             Order it — Restaurants Aligned to the Moment
           </h3>
-          <p className="text-[11px] text-amber-700/80 mt-0.5">
+          <p className="text-[11px] text-white/50 mt-1 font-medium">
             {cuisineType ? `${cuisineType} cuisine, scored by current cosmic state` : "Search for a cuisine to discover restaurants near you."}
           </p>
         </div>
-        
+
         <form onSubmit={handleSearch} className="flex w-full md:w-auto gap-2">
           <input
             type="text"
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
             placeholder="Search cuisine..."
-            className="flex-1 md:w-48 px-3 py-1.5 text-xs rounded-lg border border-amber-200 focus:outline-none focus:ring-2 focus:ring-amber-500/30 bg-white/80 text-amber-950"
+            className="flex-1 md:w-48 px-3 py-2 text-xs rounded-lg border border-white/10 bg-black/40 text-white placeholder:text-white/30 focus:outline-none focus:ring-2 focus:ring-purple-400/40 focus:border-purple-400/50"
           />
           <button
             type="submit"
-            className="px-3 py-1.5 bg-amber-600 text-white text-xs font-bold rounded-lg hover:bg-amber-700 transition-colors"
+            className="px-4 py-2 bg-gradient-to-r from-purple-500 to-pink-500 text-white text-xs font-black uppercase tracking-wider rounded-lg shadow-lg shadow-purple-900/30 hover:brightness-110 transition-all"
           >
             Find
           </button>
@@ -340,20 +342,20 @@ export function CuisineRestaurantFinder({
 
       {/* Body */}
       {status.kind === "needs-location" && (
-        <div className="rounded-lg bg-white/60 border border-amber-200 p-6 text-center">
-          <div className="text-2xl mb-3">📍</div>
-          <p className="text-xs text-amber-900 mb-4">
+        <div className="rounded-2xl bg-black/30 border border-white/10 p-8 text-center">
+          <div className="text-3xl mb-3">📍</div>
+          <p className="text-xs text-white/70 mb-4">
             Enable location to discover {cuisineType || "matching"} restaurants near you.
           </p>
           <button
             type="button"
             onClick={requestLocation}
-            className="px-4 py-2 bg-amber-600 text-white text-xs font-bold rounded-xl hover:bg-amber-700 transition-colors shadow-sm"
+            className="px-5 py-2.5 bg-gradient-to-r from-purple-500 to-pink-500 text-white text-xs font-black uppercase tracking-wider rounded-xl shadow-lg shadow-purple-900/30 hover:brightness-110 transition-all"
           >
             Use my location
           </button>
           {locationError && (
-            <p className="text-[11px] text-rose-600 mt-3">{locationError}</p>
+            <p className="text-[11px] text-rose-300 mt-3">{locationError}</p>
           )}
         </div>
       )}
@@ -363,12 +365,12 @@ export function CuisineRestaurantFinder({
           {[0, 1, 2].map((i) => (
             <div
               key={i}
-              className="animate-pulse flex gap-3 p-4 rounded-xl bg-white/60 border border-amber-100"
+              className="animate-pulse flex gap-3 p-4 rounded-xl bg-black/30 border border-white/5"
             >
-              <div className="h-12 w-12 rounded-lg bg-amber-100 shrink-0" />
+              <div className="h-12 w-12 rounded-lg bg-white/10 shrink-0" />
               <div className="flex-1 space-y-3">
-                <div className="h-3 bg-amber-100 rounded w-2/3" />
-                <div className="h-2 bg-amber-100/70 rounded w-1/2" />
+                <div className="h-3 bg-white/10 rounded w-2/3" />
+                <div className="h-2 bg-white/10 rounded w-1/2" />
               </div>
             </div>
           ))}
@@ -376,32 +378,32 @@ export function CuisineRestaurantFinder({
       )}
 
       {status.kind === "not-configured" && (
-        <div className="rounded-lg bg-white/60 border border-amber-200 p-3 text-xs text-amber-900 leading-snug">
+        <div className="rounded-lg bg-black/30 border border-white/10 p-3 text-xs text-white/70 leading-snug">
           Restaurant discovery isn&apos;t configured yet. Add{" "}
-          <code className="font-mono bg-amber-100 px-1 rounded">GOOGLE_PLACES_API_KEY</code> for Google Nearby Search.
+          <code className="font-mono bg-white/10 text-purple-200 px-1 rounded">GOOGLE_PLACES_API_KEY</code> for Google Nearby Search.
         </div>
       )}
 
       {status.kind === "error" && (
-        <div className="rounded-lg bg-rose-50 border border-rose-200 p-3 text-xs text-rose-700">
+        <div className="rounded-lg bg-rose-500/10 border border-rose-400/30 p-3 text-xs text-rose-200">
           ⚠️ {status.message}
         </div>
       )}
 
       {status.kind === "empty" && (
-        <div className="rounded-lg bg-white/60 border border-amber-200 p-8 text-center">
-          <div className="text-2xl mb-2">🍽️</div>
-          <p className="text-xs text-amber-900 font-medium">
+        <div className="rounded-2xl bg-black/30 border border-white/10 p-8 text-center">
+          <div className="text-3xl mb-2">🍽️</div>
+          <p className="text-xs text-white/70 font-medium">
             No {cuisineType} restaurants found in your area right now.
           </p>
-          <p className="text-[10px] text-amber-700/60 mt-1">Try searching for a broader cuisine or adjusting your location.</p>
+          <p className="text-[10px] text-white/40 mt-1">Try searching for a broader cuisine or adjusting your location.</p>
         </div>
       )}
 
       {status.kind === "ready" && (
         <>
           {status.data.sourceNotice && (
-            <div className="mb-4 rounded-lg border border-amber-300 bg-amber-100/60 p-3 text-[11px] text-amber-900 leading-snug">
+            <div className="mb-4 rounded-lg border border-purple-400/30 bg-purple-500/10 p-3 text-[11px] text-purple-100 leading-snug">
               ✦ {status.data.sourceNotice}
             </div>
           )}
@@ -421,17 +423,17 @@ export function CuisineRestaurantFinder({
               return (
                 <li
                   key={business.id}
-                  className={`flex flex-col sm:flex-row items-start gap-4 p-4 rounded-xl bg-white border shadow-sm transition-all hover:shadow-md ${
+                  className={`flex flex-col sm:flex-row items-start gap-4 p-4 rounded-2xl bg-black/40 border backdrop-blur-sm transition-all hover:bg-black/50 ${
                     isPartner
-                      ? "border-emerald-300 ring-1 ring-emerald-200/50"
-                      : "border-amber-100"
+                      ? "border-emerald-400/40 ring-1 ring-emerald-400/20"
+                      : "border-white/10"
                   }`}
                 >
                   {/* Score / source badge */}
                   <div className="flex sm:flex-col items-center gap-2 sm:gap-1.5 shrink-0">
                     {isScored ? (
                       <>
-                        <div className="px-3 py-1.5 rounded-lg bg-gradient-to-br from-amber-400 to-amber-600 text-white text-xs font-black shadow-sm">
+                        <div className="px-3 py-1.5 rounded-lg bg-gradient-to-br from-purple-500 to-pink-500 text-white text-xs font-black shadow-lg shadow-purple-900/40">
                           {scorePct}% <span aria-hidden>✦</span>
                         </div>
                         {decoration && (
@@ -445,7 +447,7 @@ export function CuisineRestaurantFinder({
                         )}
                       </>
                     ) : (
-                      <div className="px-2 py-1 rounded-md bg-blue-100 text-blue-700 text-[10px] font-bold border border-blue-200">
+                      <div className="px-2 py-1 rounded-md bg-purple-500/15 text-purple-200 text-[10px] font-bold border border-purple-400/30">
                         {providerLabel}
                       </div>
                     )}
@@ -454,19 +456,19 @@ export function CuisineRestaurantFinder({
                   {/* Details */}
                   <div className="flex-1 min-w-0">
                     <div className="flex items-start justify-between gap-2">
-                      <h4 className="text-sm font-black text-amber-950 truncate">
+                      <h4 className="text-sm font-black text-white truncate">
                         {business.name}
                       </h4>
                       {isPartner && (
-                        <span className="shrink-0 rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[9px] font-black uppercase tracking-widest text-emerald-700">
+                        <span className="shrink-0 rounded-full border border-emerald-400/30 bg-emerald-500/15 px-2 py-0.5 text-[9px] font-black uppercase tracking-widest text-emerald-200">
                           Partner
                         </span>
                       )}
                     </div>
-                    
-                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-amber-800/60 mt-1 font-medium">
+
+                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-white/50 mt-1 font-medium">
                       {typeof business.rating === "number" && business.rating > 0 && (
-                        <span className="text-amber-600 font-bold">
+                        <span className="text-amber-300 font-bold">
                           ★ {business.rating.toFixed(1)}
                         </span>
                       )}
@@ -476,19 +478,19 @@ export function CuisineRestaurantFinder({
                         </span>
                       )}
                       {business.price && (
-                        <span className="text-emerald-700 font-black">
+                        <span className="text-emerald-300 font-black">
                           {business.price}
                         </span>
                       )}
                       {distance && <span>· {distance}</span>}
                     </div>
-                    
+
                     {isScored && reasons.length > 0 && (
-                      <ul className="mt-2 space-y-1 border-l-2 border-amber-100 pl-3">
+                      <ul className="mt-2 space-y-1 border-l-2 border-purple-400/30 pl-3">
                         {reasons.map((reason, i) => (
                           <li
                             key={i}
-                            className="text-[10px] text-amber-800/70 font-medium leading-relaxed italic"
+                            className="text-[10px] text-white/60 font-medium leading-relaxed italic"
                           >
                             {reason}
                           </li>
@@ -502,38 +504,46 @@ export function CuisineRestaurantFinder({
                     {isPartner && entry.partnerRestaurantId ? (
                       <a
                         href={`/restaurants/${encodeURIComponent(entry.partnerRestaurantId)}/menu`}
-                        className="flex-1 sm:w-32 px-3 py-2 text-white text-[10px] font-black uppercase tracking-widest rounded-lg transition-colors text-center bg-emerald-600 hover:bg-emerald-700 shadow-sm"
+                        className="flex-1 sm:w-32 px-3 py-2 text-white text-[10px] font-black uppercase tracking-widest rounded-lg transition-all text-center bg-gradient-to-r from-emerald-500 to-emerald-600 hover:brightness-110 shadow-lg shadow-emerald-900/30"
                       >
                         Order Now
                       </a>
                     ) : (
+                      <button
+                        type="button"
+                        onClick={() => setReservingItem(entry)}
+                        className="flex-1 sm:w-32 px-3 py-2 text-white text-[10px] font-black uppercase tracking-widest rounded-lg transition-all text-center bg-gradient-to-r from-purple-500 to-pink-500 hover:brightness-110 shadow-lg shadow-purple-900/30"
+                      >
+                        Reserve
+                      </button>
+                    )}
+
+                    <div className="flex gap-2 flex-1 sm:w-32">
                       <a
                         href={business.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="flex-1 sm:w-32 px-3 py-2 text-white text-[10px] font-black uppercase tracking-widest rounded-lg transition-colors text-center bg-amber-600 hover:bg-amber-700 shadow-sm"
+                        className="flex-1 px-2 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest text-center bg-white/5 text-white/80 border border-white/10 hover:bg-white/10 transition-colors"
                       >
-                        View Menu
+                        Menu
                       </a>
-                    )}
-                    
-                    <div className="flex gap-2 flex-1 sm:w-32">
                       <button
                         type="button"
                         onClick={() => void saveRestaurant(entry, source)}
                         disabled={isSaved}
-                        className={`flex-1 px-2 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest transition-all ${
+                        className={`px-2 py-2 rounded-lg text-[10px] font-black uppercase tracking-widest transition-all ${
                           isSaved
-                            ? "bg-emerald-50 text-emerald-700 border border-emerald-200 cursor-default"
-                            : "bg-white text-purple-700 border border-purple-200 hover:bg-purple-50 shadow-sm"
+                            ? "bg-emerald-500/15 text-emerald-200 border border-emerald-400/30 cursor-default"
+                            : "bg-white/5 text-purple-200 border border-purple-400/30 hover:bg-purple-500/15"
                         }`}
+                        title={isSaved ? "Saved" : "Save restaurant"}
                       >
-                        {isSaved ? "Saved" : "Save"}
+                        {isSaved ? "✓" : "♡"}
                       </button>
                       <button
                         type="button"
                         onClick={() => setLoggingItem(entry)}
-                        className="px-3 py-2 bg-amber-100 text-amber-800 border border-amber-200 rounded-lg text-[10px] font-black uppercase tracking-widest hover:bg-amber-200 transition-colors shadow-sm"
+                        className="px-3 py-2 bg-white/5 text-white/80 border border-white/10 rounded-lg text-[10px] font-black uppercase tracking-widest hover:bg-white/10 transition-colors"
                         title="Log to Food Diary"
                       >
                         +
@@ -555,16 +565,25 @@ export function CuisineRestaurantFinder({
         />
       )}
 
+      {reservingItem && (
+        <ReservationModal
+          entry={reservingItem}
+          source={status.kind === "ready" ? (status.data.source ?? "google") : "google"}
+          cuisineType={cuisineType}
+          onClose={() => setReservingItem(null)}
+        />
+      )}
+
       {/* Cosmic context line */}
       {cosmicLine && (
-        <p className="mt-6 text-[10px] text-amber-700/60 font-bold uppercase tracking-[0.2em] text-center">
+        <p className="mt-6 text-[10px] text-purple-300/60 font-bold uppercase tracking-[0.2em] text-center">
           Aligned to {cosmicLine}
         </p>
       )}
 
       {/* Provider attribution */}
       {status.kind === "ready" && (
-        <p className="mt-4 text-[9px] text-gray-400 text-center uppercase tracking-widest font-bold">
+        <p className="mt-4 text-[9px] text-white/30 text-center uppercase tracking-widest font-bold">
           Data source: {sourceLabel(status.data.source)}
         </p>
       )}

--- a/src/components/RestaurantDiscovery/LocalCuisineGroups.tsx
+++ b/src/components/RestaurantDiscovery/LocalCuisineGroups.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+/**
+ * LocalCuisineGroups — fetch nearby restaurants without a cuisine filter,
+ * then group them by detected cuisine label (from Google Places primaryType).
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  AlchmScoredRestaurant,
+  RestaurantSearchResponse,
+} from "@/types/yelp";
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "needs-location" }
+  | { kind: "loading" }
+  | { kind: "ready"; data: RestaurantSearchResponse }
+  | { kind: "empty" }
+  | { kind: "not-configured" }
+  | { kind: "error"; message: string };
+
+function metersToMiles(meters?: number): string | null {
+  if (typeof meters !== "number" || !Number.isFinite(meters)) return null;
+  const miles = meters / 1609.344;
+  return miles < 0.1 ? "<0.1 mi" : `${miles.toFixed(1)} mi`;
+}
+
+function groupByCuisine(
+  list: AlchmScoredRestaurant[],
+): Array<{ cuisine: string; items: AlchmScoredRestaurant[] }> {
+  const map = new Map<string, AlchmScoredRestaurant[]>();
+  for (const entry of list) {
+    const label = entry.cuisineLabel ?? "Other";
+    if (!map.has(label)) map.set(label, []);
+    map.get(label)!.push(entry);
+  }
+  return Array.from(map.entries())
+    .map(([cuisine, items]) => ({ cuisine, items }))
+    .sort((a, b) => {
+      if (b.items.length !== a.items.length) return b.items.length - a.items.length;
+      return a.cuisine.localeCompare(b.cuisine);
+    });
+}
+
+export function LocalCuisineGroups() {
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+  const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(null);
+  const [locationError, setLocationError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const abortRef = useRef<AbortController | null>(null);
+
+  const requestLocation = useCallback(() => {
+    if (typeof navigator === "undefined" || !navigator.geolocation) {
+      setLocationError("Location services are unavailable in this browser.");
+      return;
+    }
+    setLocationError(null);
+    navigator.geolocation.getCurrentPosition(
+      (pos) =>
+        setCoords({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
+      (err) => {
+        setLocationError(
+          err.code === err.PERMISSION_DENIED
+            ? "Location permission denied. Enable it to see local cuisines."
+            : "Couldn't read your location. Please try again.",
+        );
+      },
+      { enableHighAccuracy: false, timeout: 10000, maximumAge: 5 * 60 * 1000 },
+    );
+  }, []);
+
+  useEffect(() => {
+    if (!coords) {
+      setStatus({ kind: "needs-location" });
+      return;
+    }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setStatus({ kind: "loading" });
+
+    void (async () => {
+      try {
+        const params = new URLSearchParams({
+          lat: String(coords.lat),
+          lng: String(coords.lng),
+          limit: "20",
+        });
+        const res = await fetch(
+          `/api/restaurants/discover?${params.toString()}`,
+          { signal: controller.signal },
+        );
+
+        if (!res.ok) {
+          setStatus({ kind: "error", message: `Server error (${res.status})` });
+          return;
+        }
+        const data = (await res.json()) as RestaurantSearchResponse;
+        if (
+          data.error === "Google Places integration is not configured." ||
+          data.error === "Restaurant discovery is not configured."
+        ) {
+          setStatus({ kind: "not-configured" });
+          return;
+        }
+        if (data.error) {
+          setStatus({ kind: "error", message: data.error });
+          return;
+        }
+        if (!data.restaurants || data.restaurants.length === 0) {
+          setStatus({ kind: "empty" });
+          return;
+        }
+        setStatus({ kind: "ready", data });
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setStatus({
+          kind: "error",
+          message: err instanceof Error ? err.message : "Failed to load.",
+        });
+      }
+    })();
+
+    return () => controller.abort();
+  }, [coords]);
+
+  const groups = useMemo(
+    () =>
+      status.kind === "ready" ? groupByCuisine(status.data.restaurants) : [],
+    [status],
+  );
+
+  const toggle = (cuisine: string) =>
+    setExpanded((prev) => ({ ...prev, [cuisine]: !prev[cuisine] }));
+
+  return (
+    <section
+      aria-label="Local restaurants grouped by cuisine"
+      className="rounded-3xl border border-white/10 bg-gradient-to-br from-[#0c0c14]/90 to-[#16101e]/90 backdrop-blur-xl p-6 shadow-2xl shadow-purple-900/20"
+    >
+      <header className="mb-6">
+        <h3 className="text-sm font-extrabold text-purple-100 uppercase tracking-[0.18em] flex items-center gap-2">
+          <span aria-hidden className="text-purple-300">⌖</span>
+          What&apos;s Cooking Near You
+        </h3>
+        <p className="text-[11px] text-white/50 mt-1 font-medium">
+          Local restaurants grouped by cuisine — based on your current location.
+        </p>
+      </header>
+
+      {status.kind === "needs-location" && (
+        <div className="rounded-2xl bg-black/30 border border-white/10 p-8 text-center">
+          <div className="text-3xl mb-3">📍</div>
+          <p className="text-xs text-white/70 mb-4">
+            Enable location to see what cuisines are available near you.
+          </p>
+          <button
+            type="button"
+            onClick={requestLocation}
+            className="px-5 py-2.5 bg-gradient-to-r from-purple-500 to-pink-500 text-white text-xs font-black uppercase tracking-wider rounded-xl shadow-lg shadow-purple-900/30 hover:brightness-110 transition-all"
+          >
+            Use my location
+          </button>
+          {locationError && (
+            <p className="text-[11px] text-rose-300 mt-3">{locationError}</p>
+          )}
+        </div>
+      )}
+
+      {status.kind === "loading" && (
+        <div className="space-y-3" aria-busy="true">
+          {[0, 1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="animate-pulse h-14 rounded-xl bg-white/5 border border-white/5"
+            />
+          ))}
+        </div>
+      )}
+
+      {status.kind === "not-configured" && (
+        <div className="rounded-lg bg-black/30 border border-white/10 p-3 text-xs text-white/70">
+          Local discovery isn&apos;t configured. Add{" "}
+          <code className="font-mono bg-white/10 text-purple-200 px-1 rounded">
+            GOOGLE_PLACES_API_KEY
+          </code>
+          .
+        </div>
+      )}
+
+      {status.kind === "error" && (
+        <div className="rounded-lg bg-rose-500/10 border border-rose-400/30 p-3 text-xs text-rose-200">
+          ⚠️ {status.message}
+        </div>
+      )}
+
+      {status.kind === "empty" && (
+        <div className="rounded-2xl bg-black/30 border border-white/10 p-8 text-center">
+          <div className="text-3xl mb-2">🍽️</div>
+          <p className="text-xs text-white/70">
+            No restaurants found in your immediate area.
+          </p>
+        </div>
+      )}
+
+      {status.kind === "ready" && (
+        <ul className="space-y-2">
+          {groups.map(({ cuisine, items }) => {
+            const isOpen = expanded[cuisine] ?? false;
+            return (
+              <li
+                key={cuisine}
+                className="rounded-2xl border border-white/10 bg-black/30 overflow-hidden"
+              >
+                <button
+                  type="button"
+                  onClick={() => toggle(cuisine)}
+                  className="w-full flex items-center justify-between gap-3 px-4 py-3 hover:bg-white/5 transition-colors"
+                  aria-expanded={isOpen}
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-sm font-extrabold text-white">
+                      {cuisine}
+                    </span>
+                    <span className="px-2 py-0.5 rounded-full bg-purple-500/15 border border-purple-400/30 text-[10px] font-black uppercase tracking-widest text-purple-200">
+                      {items.length}
+                    </span>
+                  </div>
+                  <span
+                    aria-hidden
+                    className={`text-purple-300/70 transition-transform ${isOpen ? "rotate-90" : ""}`}
+                  >
+                    ▶
+                  </span>
+                </button>
+                {isOpen && (
+                  <ul className="border-t border-white/5 divide-y divide-white/5">
+                    {items.map((entry) => {
+                      const distance = metersToMiles(entry.business.distance);
+                      return (
+                        <li
+                          key={entry.business.id}
+                          className="flex items-center justify-between gap-3 px-4 py-2.5 hover:bg-white/[0.02] transition-colors"
+                        >
+                          <div className="min-w-0 flex-1">
+                            <div className="text-xs font-bold text-white truncate">
+                              {entry.business.name}
+                            </div>
+                            <div className="text-[10px] text-white/40 mt-0.5 flex gap-2">
+                              {typeof entry.business.rating === "number" &&
+                                entry.business.rating > 0 && (
+                                  <span className="text-amber-300">
+                                    ★ {entry.business.rating.toFixed(1)}
+                                  </span>
+                                )}
+                              {distance && <span>· {distance}</span>}
+                            </div>
+                          </div>
+                          <a
+                            href={entry.business.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="shrink-0 px-3 py-1.5 rounded-md bg-white/5 border border-white/10 text-[10px] font-black uppercase tracking-widest text-white/80 hover:bg-white/10 transition-colors"
+                          >
+                            View
+                          </a>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export default LocalCuisineGroups;

--- a/src/components/RestaurantDiscovery/ReservationModal.tsx
+++ b/src/components/RestaurantDiscovery/ReservationModal.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+/**
+ * ReservationModal — small Stripe checkout flow for any restaurant.
+ *
+ * Posts to /api/stripe/restaurant-order with a user-entered tab amount.
+ * Handles both stripe_checkout (redirect) and external (open in new tab)
+ * response modes.
+ */
+
+import { useState } from "react";
+import { useToast } from "@/components/ToastProvider";
+import type { AlchmScoredRestaurant, RestaurantDiscoverySource } from "@/types/yelp";
+
+interface ReservationModalProps {
+  entry: AlchmScoredRestaurant;
+  source: RestaurantDiscoverySource;
+  cuisineType: string;
+  onClose: () => void;
+}
+
+type SubmitState =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "error"; message: string };
+
+const PRESET_AMOUNTS = [25, 50, 100];
+
+export function ReservationModal({
+  entry,
+  source,
+  cuisineType,
+  onClose,
+}: ReservationModalProps) {
+  const { business } = entry;
+  const [amount, setAmount] = useState<string>("50");
+  const [state, setState] = useState<SubmitState>({ kind: "idle" });
+  const { showToast } = useToast();
+
+  const handleSubmit = async () => {
+    const parsed = Number(amount);
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      setState({ kind: "error", message: "Enter an amount of at least $1." });
+      return;
+    }
+    if (parsed > 5000) {
+      setState({ kind: "error", message: "Maximum reservation is $5,000." });
+      return;
+    }
+
+    setState({ kind: "submitting" });
+    try {
+      const res = await fetch("/api/stripe/restaurant-order", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          cuisineType: cuisineType || "Restaurant",
+          provider: source,
+          restaurant: {
+            id: business.id,
+            name: business.name,
+            url: business.url,
+            stripeConnectedAccountId: entry.stripeConnectAccountId,
+          },
+          order: {
+            amountCents: Math.round(parsed * 100),
+            currency: "usd",
+            description: `Alchm Kitchen pre-paid tab at ${business.name}`,
+            orderType: "pickup",
+          },
+        }),
+      });
+
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        setState({
+          kind: "error",
+          message: data?.error ?? `Checkout failed (${res.status})`,
+        });
+        return;
+      }
+
+      const data = (await res.json()) as
+        | { mode: "stripe_checkout"; url: string; orderId: string }
+        | { mode: "external"; url: string; reason: string; orderId: string };
+
+      if (data.mode === "stripe_checkout") {
+        window.location.href = data.url;
+        return;
+      }
+
+      // External fallback: Stripe not configured or no partner; surface the restaurant link.
+      showToast(
+        "Stripe checkout isn't available for this restaurant — opening their site.",
+        "info",
+      );
+      window.open(data.url, "_blank", "noopener,noreferrer");
+      onClose();
+    } catch (err) {
+      setState({
+        kind: "error",
+        message: err instanceof Error ? err.message : "Checkout failed.",
+      });
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-md rounded-3xl border border-purple-500/30 bg-gradient-to-br from-[#0c0c14] to-[#1a0f24] p-6 shadow-2xl shadow-purple-900/40"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-4 top-4 text-white/40 hover:text-white/80"
+          aria-label="Close"
+        >
+          ✕
+        </button>
+
+        <div className="mb-1 text-xs font-bold uppercase tracking-[0.2em] text-purple-300/80">
+          Alchm Pre-Pay
+        </div>
+        <h3 className="text-xl font-extrabold text-white">{business.name}</h3>
+        <p className="mt-2 text-sm text-white/60 leading-relaxed">
+          Pre-pay your tab through Alchm Kitchen. We&apos;ll send you a receipt and
+          a code to show the restaurant.
+        </p>
+
+        <div className="mt-6">
+          <label className="text-[10px] font-black uppercase tracking-[0.18em] text-purple-200/70">
+            Amount
+          </label>
+          <div className="mt-2 flex items-center gap-2 rounded-xl border border-white/10 bg-black/40 px-4 py-3 focus-within:border-purple-400/60">
+            <span className="text-2xl font-extrabold text-white/40">$</span>
+            <input
+              type="number"
+              inputMode="decimal"
+              min={1}
+              max={5000}
+              step={1}
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              className="flex-1 bg-transparent text-2xl font-extrabold text-white outline-none placeholder:text-white/20"
+              placeholder="50"
+            />
+          </div>
+
+          <div className="mt-3 flex gap-2">
+            {PRESET_AMOUNTS.map((preset) => (
+              <button
+                key={preset}
+                type="button"
+                onClick={() => setAmount(String(preset))}
+                className={`flex-1 rounded-lg border px-3 py-2 text-xs font-bold transition-colors ${
+                  Number(amount) === preset
+                    ? "border-purple-400/60 bg-purple-500/20 text-purple-100"
+                    : "border-white/10 bg-white/5 text-white/60 hover:bg-white/10"
+                }`}
+              >
+                ${preset}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {state.kind === "error" && (
+          <p className="mt-4 rounded-lg border border-rose-400/30 bg-rose-500/10 p-3 text-xs text-rose-200">
+            {state.message}
+          </p>
+        )}
+
+        <button
+          type="button"
+          onClick={() => void handleSubmit()}
+          disabled={state.kind === "submitting"}
+          className="mt-6 w-full rounded-xl bg-gradient-to-r from-purple-500 to-pink-500 px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-white shadow-lg shadow-purple-900/40 transition-all hover:brightness-110 disabled:opacity-50"
+        >
+          {state.kind === "submitting" ? "Opening Stripe…" : "Continue to Checkout"}
+        </button>
+
+        <p className="mt-3 text-center text-[10px] font-medium text-white/30">
+          Payments processed securely by Stripe.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default ReservationModal;

--- a/src/components/RestaurantDiscovery/ReservationModal.tsx
+++ b/src/components/RestaurantDiscovery/ReservationModal.tsx
@@ -134,12 +134,16 @@ export function ReservationModal({
         </p>
 
         <div className="mt-6">
-          <label className="text-[10px] font-black uppercase tracking-[0.18em] text-purple-200/70">
+          <label
+            htmlFor="reservation-amount"
+            className="text-[10px] font-black uppercase tracking-[0.18em] text-purple-200/70"
+          >
             Amount
           </label>
           <div className="mt-2 flex items-center gap-2 rounded-xl border border-white/10 bg-black/40 px-4 py-3 focus-within:border-purple-400/60">
             <span className="text-2xl font-extrabold text-white/40">$</span>
             <input
+              id="reservation-amount"
               type="number"
               inputMode="decimal"
               min={1}

--- a/src/types/yelp.ts
+++ b/src/types/yelp.ts
@@ -74,6 +74,10 @@ export interface AlchmScoredRestaurant {
   partnerOnboardingStatus?: string;
   stripeConnectAccountId?: string;
   deliverectLocationId?: string;
+  /** Human-readable cuisine label derived from the provider's place classification. */
+  cuisineLabel?: string;
+  /** Raw provider type identifier (e.g. Google Places primaryType). */
+  primaryType?: string;
 }
 
 export interface CosmicContext {

--- a/src/utils/cuisineSlug.ts
+++ b/src/utils/cuisineSlug.ts
@@ -1,0 +1,35 @@
+/**
+ * Slug helpers for cuisine routing.
+ *
+ * Maps between CUISINES_METADATA keys ("MiddleEastern"), display names
+ * ("Middle Eastern"), and URL slugs ("middle-eastern").
+ */
+
+import { CUISINES_METADATA } from "@/data/cuisines/index";
+
+export function cuisineToSlug(displayName: string): string {
+  return displayName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function slugToCuisineKey(slug: string): string | null {
+  const normalized = slug.toLowerCase();
+  for (const key of Object.keys(CUISINES_METADATA)) {
+    const meta = CUISINES_METADATA[key];
+    const display = meta?.name ?? key;
+    if (cuisineToSlug(display) === normalized) return key;
+  }
+  return null;
+}
+
+export function getCuisineByDisplayName(displayName: string) {
+  const target = displayName.trim().toLowerCase();
+  for (const key of Object.keys(CUISINES_METADATA)) {
+    const meta = CUISINES_METADATA[key];
+    if ((meta?.name ?? "").toLowerCase() === target) return { key, meta };
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Builds out the `/cuisines` page on top of the existing Google Places / Yelp / Foursquare restaurant stack, and adds a missing per-cuisine deep-page route.

- **Browse grid** of all 14 cuisines (cards with dominant-element chip) → links to `/cuisines/[slug]`
- **`/cuisines/[slug]` page** — hero + elemental breakdown + pre-loaded restaurant finder
- **Group-by-cuisine local view** — fetches nearby restaurants with no filter, buckets by detected Google Places `primaryType`
- **Reserve via Stripe** — Reserve button on non-partner restaurant cards opens a modal, posts to the existing `/api/stripe/restaurant-order`, redirects to Stripe Checkout (or external URL fallback)
- **CuisineRestaurantFinder reskin** — amber/cream → dark cosmic theme to match the rest of the page

## Why

The cuisines page existed but only surfaced the cosmic recommender and a free-text search finder whose styling clashed with the page. There was no way to browse the 14 cuisine traditions, no deep page per cuisine, no \"what cuisines are around me right now\" view, and Stripe checkout only fired on Connect-onboarded partner restaurants. This wires the pieces together.

## Files

**New**
- `src/app/cuisines/[slug]/page.tsx` — Next 15 async-params dynamic route + `generateStaticParams`
- `src/components/RestaurantDiscovery/CuisineBrowseGrid.tsx`
- `src/components/RestaurantDiscovery/LocalCuisineGroups.tsx`
- `src/components/RestaurantDiscovery/ReservationModal.tsx`
- `src/utils/cuisineSlug.ts` — slug ↔ metadata-key helpers

**Changed**
- `src/app/api/restaurants/discover/route.ts` — adds `primaryType`/`types` to the Google Places field mask and derives a `cuisineLabel` for grouping; carries it through `toEntry`
- `src/app/cuisines/page.tsx` — composes the new sections
- `src/components/RestaurantDiscovery/CuisineRestaurantFinder.tsx` — dark theme + Reserve button → `ReservationModal`
- `src/types/yelp.ts` — `AlchmScoredRestaurant.cuisineLabel`/`primaryType`

## Environment requirements

- `GOOGLE_PLACES_API_KEY` — required for discover/groups to return results (UI handles missing key gracefully).
- `STRIPE_SECRET_KEY` — required for Stripe Checkout flow; without it `restaurant-order` falls back to the restaurant's external URL.

## Test plan

- [ ] Visit `/cuisines` → see browse grid (14 cards), recommender, \"What's Cooking Near You\" location prompt, restaurant finder, premium sauce gate
- [ ] Click any cuisine card → routes to `/cuisines/<slug>` with hero, element breakdown, and finder pre-filled with that cuisine name
- [ ] On the finder, enter a cuisine + grant location → Reserve button appears on non-partner cards; clicking opens modal, submitting redirects to Stripe (or opens external URL if Stripe isn't configured)
- [ ] On \"What's Cooking Near You\", grant location → restaurants render in cuisine-labeled collapsible groups
- [ ] Verify dark cosmic theme is consistent across all sections (no leftover amber/cream styling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)