### PR TITLE
Complete token economy & personalized pricing

### DIFF
--- a/src/app/api/economy/purchase/route.ts
+++ b/src/app/api/economy/purchase/route.ts
@@ -9,9 +9,13 @@
 
 import { NextResponse } from "next/server";
 import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
-import { applyLivePricing, getLivePricingContext } from "@/lib/economy/livePricing";
+import {
+  applyPersonalizedPricing,
+  getPersonalizedPricingContext,
+} from "@/lib/economy/livePricing";
 import { rateLimit } from "@/lib/rateLimit";
 import { tokenEconomy } from "@/services/TokenEconomyService";
+import { getCapitalizedNatalPositions } from "@/utils/astrology/chartDataUtils";
 import type { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
@@ -112,21 +116,27 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const pricing = await getLivePricingContext();
-    const liveCost = applyLivePricing(
+    // Personalized live pricing: per-token multipliers adjusted by the user's
+    // natal chart × the chart of the moment. Falls back to the global
+    // multiplier when the user hasn't completed onboarding yet.
+    const natalPositions = getCapitalizedNatalPositions(user.profile?.natalChart);
+    const pricing = await getPersonalizedPricingContext(natalPositions);
+    const liveCost = applyPersonalizedPricing(
       {
         spirit: item.costSpirit,
         essence: item.costEssence,
         matter: item.costMatter,
         substance: item.costSubstance,
       },
-      pricing.multiplier,
+      pricing,
     );
 
     // Attempt purchase
     const result = await tokenEconomy.purchaseShopItem(user.id, shopItemSlug, {
       overrideCosts: liveCost,
-      descriptionSuffix: `live x${pricing.multiplier.toFixed(2)}`,
+      descriptionSuffix: pricing.personalized
+        ? `live x${pricing.multiplier.toFixed(2)} · personalized`
+        : `live x${pricing.multiplier.toFixed(2)}`,
       idempotencyKey: idempotencyKey ? `purchase:${idempotencyKey}` : undefined,
     });
     if (!result.success) {

--- a/src/app/api/food-diary/insights/route.ts
+++ b/src/app/api/food-diary/insights/route.ts
@@ -7,6 +7,7 @@
  */
 
 import { NextResponse } from "next/server";
+import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
 import { foodDiaryService } from "@/services/FoodDiaryService";
 import type { NextRequest } from "next/server";
 
@@ -15,20 +16,18 @@ export const runtime = "nodejs";
 
 /**
  * GET /api/food-diary/insights
- * Get AI-generated nutrition insights based on food diary data
- *
- * Query params:
- * - userId: string (required)
+ * Get AI-generated nutrition insights based on food diary data for the
+ * authenticated caller. The userId is resolved from the session — accepting
+ * it as a query param previously let any unauthenticated client read any
+ * user's diary, which was an authorization bug.
  */
 export async function GET(request: NextRequest) {
   try {
-    const { searchParams } = new URL(request.url);
-    const userId = searchParams.get("userId");
-
+    const userId = await getUserIdFromRequest(request);
     if (!userId) {
       return NextResponse.json(
-        { success: false, message: "userId is required" },
-        { status: 400 },
+        { success: false, message: "Authentication required" },
+        { status: 401 },
       );
     }
 

--- a/src/app/api/generate-cosmic-recipe/route.ts
+++ b/src/app/api/generate-cosmic-recipe/route.ts
@@ -3,14 +3,18 @@
  * Requests a structured cosmic recipe using the planetary_agents microservice.
  * Uses the cosmicRecipeSchema for structured output.
  */
-import { auth } from "@/lib/auth/auth";
-import { applyLivePricing, getLivePricingContext } from "@/lib/economy/livePricing";
+import { gateDemoOrAuth } from "@/lib/auth/demoAccess";
+import {
+  applyPersonalizedPricing,
+  getPersonalizedPricingContext,
+} from "@/lib/economy/livePricing";
 import { foodDiaryService } from "@/services/FoodDiaryService";
 import { getCachedHistoricalStats } from "@/services/HistoricalStatsService";
 import { reportQuestEventBestEffort } from "@/services/questEventReporter";
 import { alchemize } from "@/services/RealAlchemizeService";
 import { subscriptionService } from "@/services/subscriptionService";
 import { tokenEconomy } from "@/services/TokenEconomyService";
+import { getCapitalizedNatalPositions } from "@/utils/astrology/chartDataUtils";
 import { getAccuratePlanetaryPositions } from "@/utils/astrology/positions";
 import {
   SIGN_TO_ELEMENT,
@@ -23,98 +27,89 @@ import {
 } from "@/utils/cuisine/cuisineIndex";
 import { findTopIngredientsForElement } from "@/utils/ingredient/ingredientIndex";
 import { calculateAlchemicalFromPlanets } from "@/utils/planetaryAlchemyMapping";
+import type { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 export const maxDuration = 60;
 
-export async function POST(request: Request) {
-  const session = await auth();
-  const userId = session?.user?.id;
-  if (!userId) {
-    return new Response(JSON.stringify({ error: "Authentication required" }), {
-      status: 401,
-      headers: { "Content-Type": "application/json" },
-    });
-  }
+export async function POST(request: NextRequest) {
+  // Auth'd users → token economy (Spirit/Essence per cosmic recipe) is the throttle.
+  // Anonymous → 2 demo cosmic recipes per IP per day, then sign-in nudge.
+  const access = await gateDemoOrAuth(request, {
+    dailyDemoQuota: 2,
+    feature: "cosmic recipe",
+  });
+  if (access.mode === "denied") return access.blocked;
 
-  // 1. Enforce monthly generation cap (defense-in-depth alongside token economy).
-  const featureCheck = await subscriptionService.canUseFeature(
-    userId,
-    "monthlyRecipeGenerations",
-  );
-  if (!featureCheck.allowed) {
-    return new Response(
-      JSON.stringify({
-        error: "monthly_limit_reached",
-        message: featureCheck.reason,
-        currentUsage: featureCheck.currentUsage,
-        limit: featureCheck.limit,
-      }),
-      {
-        status: 429,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
-  }
+  // Auth'd path: token economy is the throttle. Premium users skip the
+  // shop-item debit but everyone else pays personalized live pricing — the
+  // user's natal chart × the chart of the moment shapes the per-token cost.
+  if (access.mode === "auth") {
+    const userId = access.userId;
 
-  // 2. Check if user is premium
-  const sub = await subscriptionService.getUserSubscription(userId);
-  const isPremium = sub?.tier === "premium";
+    const sub = await subscriptionService.getUserSubscription(userId);
+    const isPremium = sub?.tier === "premium";
 
-  // 3. If not premium, they MUST spend tokens OR have a valid monthly slot
-  // (We'll prioritize tokens for 'cosmic' recipes as they are special sinks)
-  // Apply live pricing so the debit matches what the Token Shop displays.
-  if (!isPremium) {
-    const item = await tokenEconomy.getShopItem("unlock-cosmic-recipe");
-    if (!item || !item.isActive) {
-      return new Response(JSON.stringify({
-        error: "shop_item_unavailable",
-        message: "Cosmic recipe unlock is not configured.",
-      }), {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
+    if (!isPremium) {
+      const item = await tokenEconomy.getShopItem("unlock-cosmic-recipe");
+      if (!item || !item.isActive) {
+        return new Response(JSON.stringify({
+          error: "shop_item_unavailable",
+          message: "Cosmic recipe unlock is not configured.",
+        }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
 
-    const pricing = await getLivePricingContext();
-    const liveCost = applyLivePricing(
-      {
-        spirit: item.costSpirit,
-        essence: item.costEssence,
-        matter: item.costMatter,
-        substance: item.costSubstance,
-      },
-      pricing.multiplier,
-    );
+      // Fetch natal chart for per-user pricing. Falls back to global multiplier
+      // when the user hasn't onboarded a chart yet.
+      const { userDatabase } = await import("@/services/userDatabaseService");
+      const dbUser = await userDatabase.getUserById(userId);
+      const natalPositions = getCapitalizedNatalPositions(dbUser?.profile?.natalChart);
 
-    const purchase = await tokenEconomy.purchaseShopItem(userId, "unlock-cosmic-recipe", {
-      overrideCosts: liveCost,
-      descriptionSuffix: `live x${pricing.multiplier.toFixed(2)}`,
-    });
-    if (!purchase.success && purchase.reason !== "already_owned") {
-      return new Response(JSON.stringify({
-        error: "Insufficient tokens",
-        message: `Cosmic recipes require ${liveCost.spirit.toFixed(2)} Spirit and ${liveCost.essence.toFixed(2)} Essence (live x${pricing.multiplier.toFixed(2)}). Earn more or upgrade to Premium!`,
-        liveCost,
+      const pricing = await getPersonalizedPricingContext(natalPositions);
+      const liveCost = applyPersonalizedPricing(
+        {
+          spirit: item.costSpirit,
+          essence: item.costEssence,
+          matter: item.costMatter,
+          substance: item.costSubstance,
+        },
         pricing,
-      }), {
-        status: 402,
-        headers: { "Content-Type": "application/json" },
+      );
+
+      const purchase = await tokenEconomy.purchaseShopItem(userId, "unlock-cosmic-recipe", {
+        overrideCosts: liveCost,
+        descriptionSuffix: pricing.personalized
+          ? `live x${pricing.multiplier.toFixed(2)} · personalized`
+          : `live x${pricing.multiplier.toFixed(2)}`,
       });
+      if (!purchase.success && purchase.reason !== "already_owned") {
+        return new Response(JSON.stringify({
+          error: "Insufficient tokens",
+          message: `Cosmic recipes require ${liveCost.spirit.toFixed(2)} Spirit and ${liveCost.essence.toFixed(2)} Essence right now${pricing.personalized ? " (your chart's rate)" : ""}. Earn more via the daily Cosmic Yield or upgrade to Premium!`,
+          liveCost,
+          pricing,
+        }), {
+          status: 402,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
     }
+
+    // Cosmic recipes count toward both the generic "Culinary Explorer" tiers
+    // and the one-shot "Cosmic Chef" premium quest.
+    await reportQuestEventBestEffort(userId, "generate_recipe");
+    await reportQuestEventBestEffort(userId, "generate_premium_recipe");
   }
 
-  // 4. Increment usage counter
-  try {
-    await subscriptionService.incrementUsage(userId, "recipe_generation");
-  } catch (error) {
-    console.warn("[generate-cosmic-recipe] Failed to increment usage", error);
-  }
-  // Cosmic recipes count toward both the generic "Culinary Explorer" tiers
-  // and the one-shot "Cosmic Chef" premium quest.
-  await reportQuestEventBestEffort(userId, "generate_recipe");
-  await reportQuestEventBestEffort(userId, "generate_premium_recipe");
+  // Beyond this point, both auth and demo paths build the same prompt and call
+  // the agents network. Demo users skip personalization that requires a userId
+  // (food history note) but still see the wow grounding payload.
+  const demoMode = access.mode === "demo";
+  const userId: string | null = access.mode === "auth" ? access.userId : null;
 
   const body = await request.json();
   const {
@@ -190,10 +185,13 @@ export async function POST(request: Request) {
     );
   }
 
-  // Fetch recent history for personalization
-  const recentEntries = await foodDiaryService.getEntries(userId, { limit: 10 });
+  // Fetch recent history for personalization (auth path only — demo users
+  // have no diary to draw from, and the LLM still gets the current-sky context).
+  const recentEntries = userId
+    ? await foodDiaryService.getEntries(userId, { limit: 10 })
+    : [];
   const recentFoods = recentEntries.map(e => e.foodName).join(", ");
-  const historyNote = recentFoods 
+  const historyNote = recentFoods
     ? `User recently consumed: ${recentFoods}. Ensure variety or complementary pairings.`
     : "";
 
@@ -287,6 +285,16 @@ ${cuisineEntry ? `- Honours the statistical profile of ${cuisineEntry.cuisine} c
   } catch (error) {
     console.error("[generate-cosmic-recipe] Error calling planetary agents API:", error);
     return new Response(JSON.stringify({ error: "Internal server error contacting agents network" }), { status: 500, headers: { "Content-Type": "application/json" } });
+  }
+
+  // Annotate demo responses so the client can render a "sign in to save / get
+  // personalized" CTA instead of treating this as a saved cosmic recipe.
+  if (demoMode) {
+    responseJson = {
+      ...responseJson,
+      demo: true,
+      demoRemaining: access.mode === "demo" ? access.demoRemaining : undefined,
+    };
   }
 
   const response = new Response(JSON.stringify(responseJson), {

--- a/src/app/api/group-recommendations/route.ts
+++ b/src/app/api/group-recommendations/route.ts
@@ -3,6 +3,7 @@ import { CUISINES } from "@/data/cuisines/index";
 import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
 import { _logger } from "@/lib/logger";
 import { commensalDatabase } from "@/services/commensalDatabaseService";
+import { subscriptionService } from "@/services/subscriptionService";
 import type { AlchemicalProperties } from "@/types/alchemy";
 import type { Element } from "@/types/celestial";
 import { extractPlanetaryPositions } from "@/utils/astrology/chartDataUtils";
@@ -96,6 +97,19 @@ export async function POST(request: NextRequest) {
       );
     }
     const userId = currentUser.id;
+
+    // Server-side premium gate. The client renders a <PremiumGate> around this
+    // feature, but a direct POST would otherwise bypass it. `diningCompanions`
+    // is the TIER_LIMITS flag that controls group/companion functionality.
+    // (Feature gate — NOT a usage rate cap; logged-in users are paced by tokens.)
+    const access = await subscriptionService.canUseFeature(userId, "diningCompanions");
+    if (!access.allowed) {
+      return NextResponse.json(
+        { success: false, reason: "premium_required", message: access.reason },
+        { status: 402 },
+      );
+    }
+
     let body: Record<string, unknown>;
     try {
       body = await request.json();

--- a/src/app/api/recipes/refine/route.ts
+++ b/src/app/api/recipes/refine/route.ts
@@ -4,10 +4,15 @@
  */
 import { NextResponse } from "next/server";
 import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
+import {
+  applyPersonalizedPricing,
+  getPersonalizedPricingContext,
+} from "@/lib/economy/livePricing";
 import { OPERATION_COSTS } from "@/lib/economy/operationCosts";
 import { PlanetaryScoringService } from "@/services/planetaryScoring";
 import { tokenEconomy } from "@/services/TokenEconomyService";
 import type { Recipe } from "@/types/recipe";
+import { getCapitalizedNatalPositions } from "@/utils/astrology/chartDataUtils";
 import type { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
@@ -20,14 +25,43 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
     }
 
+    // Throttling: Substance token spend (debited below) is the economic gate.
+    // No per-minute rate cap — logged-in users are paced by their token balance.
+
     const body = await request.json().catch(() => ({}));
     const { cuisine } = body;
 
-    const cost = OPERATION_COSTS.refine_oracle;
-    const deductResult = await tokenEconomy.debitTokens(user.id, "Substance", cost.substance, "purchase", { description: "Refined Oracle Recommendation" });
+    // Personalised live pricing: even though refine debits only Substance, run
+    // it through the same chart × current-sky multiplier so the economy stays
+    // self-consistent. A user the universe says Substance is hard to come by
+    // for right now feels that friction here too.
+    const baseSubstance = OPERATION_COSTS.refine_oracle.substance ?? 0;
+    const natalPositions = getCapitalizedNatalPositions(user.profile?.natalChart);
+    const pricing = await getPersonalizedPricingContext(natalPositions);
+    const { substance: liveSubstance } = applyPersonalizedPricing(
+      { spirit: 0, essence: 0, matter: 0, substance: baseSubstance },
+      pricing,
+    );
+
+    const deductResult = await tokenEconomy.debitTokens(
+      user.id,
+      "Substance",
+      liveSubstance,
+      "purchase",
+      {
+        description: pricing.personalized
+          ? `Refined Oracle Recommendation (live x${pricing.multiplier.toFixed(2)} · personalized)`
+          : `Refined Oracle Recommendation (live x${pricing.multiplier.toFixed(2)})`,
+      },
+    );
     if (!deductResult) {
       return NextResponse.json(
-        { success: false, error: `Insufficient Substance (🝉) tokens. You need ${cost.substance} Substance.` },
+        {
+          success: false,
+          error: `Insufficient Substance (🝉) tokens. You need ${liveSubstance.toFixed(2)} Substance right now${pricing.personalized ? " (your chart's rate)" : ""}.`,
+          liveCost: { substance: liveSubstance },
+          pricing,
+        },
         { status: 402 }
       );
     }

--- a/src/app/api/recommendations/generate/route.ts
+++ b/src/app/api/recommendations/generate/route.ts
@@ -8,11 +8,15 @@
 
 import { randomUUID } from "crypto";
 import { NextResponse } from "next/server";
-import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
-import { applyLivePricing, getLivePricingContext } from "@/lib/economy/livePricing";
+import { gateDemoOrAuth } from "@/lib/auth/demoAccess";
+import {
+  applyPersonalizedPricing,
+  getPersonalizedPricingContext,
+} from "@/lib/economy/livePricing";
 import { subscriptionService } from "@/services/subscriptionService";
 import { tokenEconomy } from "@/services/TokenEconomyService";
 import type { DayOfWeek } from "@/types/menuPlanner";
+import { getCapitalizedNatalPositions } from "@/utils/astrology/chartDataUtils";
 import {
   generateDayRecommendations,
   type AstrologicalState,
@@ -157,13 +161,14 @@ interface GenerateRequestBody {
 
 export async function POST(request: NextRequest) {
   const tStart = Date.now();
-  const userId = await getUserIdFromRequest(request);
-  if (!userId) {
-    return NextResponse.json(
-      { success: false, message: "Authentication required" },
-      { status: 401 },
-    );
-  }
+
+  // Auth'd users → token economy is the throttle.
+  // Anonymous → 5 demo runs per IP per day, then sign-in nudge.
+  const access = await gateDemoOrAuth(request, {
+    dailyDemoQuota: 5,
+    feature: "recipe recommendation",
+  });
+  if (access.mode === "denied") return access.blocked;
 
   let body: GenerateRequestBody;
   try {
@@ -188,6 +193,56 @@ export async function POST(request: NextRequest) {
       { status: 400 },
     );
   }
+
+  // ── Demo path: anonymous visitor inside their daily demo budget. ──
+  // Skip memo cache, monthly cap, premium check, token debit, retry grant,
+  // and usage tracking — none of those apply without a user. Just run the
+  // generator so the visitor sees real output and is enticed to sign in.
+  if (access.mode === "demo") {
+    try {
+      const tGen = Date.now();
+      const recommendations = await withTimeout(
+        generateDayRecommendations(dayOfWeek, astroState, options),
+        55_000,
+      );
+      const genMs = Date.now() - tGen;
+      const totalMs = Date.now() - tStart;
+      return NextResponse.json(
+        {
+          success: true,
+          recommendations,
+          charged: false,
+          usedRetryWindow: false,
+          demo: true,
+          demoRemaining: access.demoRemaining,
+          emptyResult: recommendations.length === 0,
+        },
+        {
+          headers: {
+            "Server-Timing": `generate;dur=${genMs}, total;dur=${totalMs}`,
+          },
+        },
+      );
+    } catch (error) {
+      if (error instanceof Error && error.message === "GENERATION_TIMEOUT") {
+        return NextResponse.json(
+          {
+            success: false,
+            reason: "timeout",
+            message: "Generation timed out. Please try again.",
+          },
+          { status: 504 },
+        );
+      }
+      return NextResponse.json(
+        { success: false, reason: "generation_failed", message: "Recipe generation failed." },
+        { status: 500 },
+      );
+    }
+  }
+
+  // Auth path beyond this point — access.mode is narrowed to "auth".
+  const userId = access.userId;
 
   // ── Memo cache hit: return immediately without charging tokens ──
   //
@@ -217,24 +272,6 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Enforce monthly generation cap (defense-in-depth alongside token economy).
-  const featureCheck = await subscriptionService.canUseFeature(
-    userId,
-    "monthlyRecipeGenerations",
-  );
-  if (!featureCheck.allowed) {
-    return NextResponse.json(
-      {
-        success: false,
-        reason: "monthly_limit_reached",
-        message: featureCheck.reason,
-        currentUsage: featureCheck.currentUsage,
-        limit: featureCheck.limit,
-      },
-      { status: 429 },
-    );
-  }
-
   const sub = await subscriptionService.getUserSubscription(userId);
   const isPremium = sub?.tier === "premium";
 
@@ -243,14 +280,16 @@ export async function POST(request: NextRequest) {
   let activeRetryGrant: RetryGrant | null = null;
 
   // Strict server-side per-click consumption for non-premium users.
+  // Tokens (priced per user × current sky) are the only throttle — no
+  // per-minute caps, no monthly quotas. If the user can afford it, it runs.
   if (!isPremium) {
     const reusedGrant = lookupRetryGrant(userId, retryToken);
     if (reusedGrant) {
       usedRetryWindow = true;
       activeRetryGrant = reusedGrant;
     } else {
-      // Resolve the item to read base costs, then apply the live pricing
-      // multiplier so generation matches the in-shop price experience.
+      // Resolve the item to read base costs, then apply personalised live
+      // pricing so the user's natal chart shapes the per-token cost.
       const item = await tokenEconomy.getShopItem("unlock-basic-recipe");
       if (!item || !item.isActive) {
         return NextResponse.json(
@@ -263,20 +302,26 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      const pricing = await getLivePricingContext();
-      const liveCost = applyLivePricing(
+      const { userDatabase } = await import("@/services/userDatabaseService");
+      const dbUser = await userDatabase.getUserById(userId);
+      const natalPositions = getCapitalizedNatalPositions(dbUser?.profile?.natalChart);
+
+      const pricing = await getPersonalizedPricingContext(natalPositions);
+      const liveCost = applyPersonalizedPricing(
         {
           spirit: item.costSpirit,
           essence: item.costEssence,
           matter: item.costMatter,
           substance: item.costSubstance,
         },
-        pricing.multiplier,
+        pricing,
       );
 
       const purchase = await tokenEconomy.purchaseShopItem(userId, "unlock-basic-recipe", {
         overrideCosts: liveCost,
-        descriptionSuffix: `live x${pricing.multiplier.toFixed(2)}`,
+        descriptionSuffix: pricing.personalized
+          ? `live x${pricing.multiplier.toFixed(2)} · personalized`
+          : `live x${pricing.multiplier.toFixed(2)}`,
       });
       if (!purchase.success) {
         if (purchase.reason === "insufficient_funds") {
@@ -284,7 +329,7 @@ export async function POST(request: NextRequest) {
             {
               success: false,
               reason: "insufficient_tokens",
-              message: `Insufficient tokens for recipe generation. Cost: ${liveCost.spirit.toFixed(2)} Spirit + ${liveCost.essence.toFixed(2)} Essence (live x${pricing.multiplier.toFixed(2)}).`,
+              message: `Insufficient tokens for recipe generation. Cost: ${liveCost.spirit.toFixed(2)} Spirit + ${liveCost.essence.toFixed(2)} Essence${pricing.personalized ? " (your chart's rate)" : ""}.`,
               liveCost,
               pricing,
             },
@@ -321,16 +366,6 @@ export async function POST(request: NextRequest) {
 
     // Cache the result for the TTL window so repeat clicks are instant.
     storeMemo(cacheKey, recommendations);
-
-    // Increment usage counter so canUseFeature can enforce monthly caps.
-    // Skip on retry-window reuse: the original request already counted.
-    if (!usedRetryWindow) {
-      try {
-        await subscriptionService.incrementUsage(userId, "recipe_generation");
-      } catch (error) {
-        console.warn("[recommendations/generate] Failed to increment usage", error);
-      }
-    }
 
     const totalMs = Date.now() - tStart;
     return NextResponse.json(

--- a/src/app/api/subscription/route.ts
+++ b/src/app/api/subscription/route.ts
@@ -1,5 +1,5 @@
 /**
- * Subscription API — GET current subscription + usage
+ * Subscription API — GET current subscription
  *
  * @file src/app/api/subscription/route.ts
  */
@@ -18,19 +18,13 @@ export async function GET() {
     const subscription = await subscriptionService.getOrCreateSubscription(
       session.user.id,
     );
-    const recipeUsage = await subscriptionService.getUsage(
-      session.user.id,
-      "recipe_generation",
-    );
-
-    return NextResponse.json({ subscription, recipeUsage });
+    return NextResponse.json({ subscription });
   } catch (error) {
     console.error("[api/subscription] Error:", error);
     // Return a minimal fallback so the frontend always has valid data
     const jwtTier = (session.user as Record<string, unknown>).tier as string || "free";
     return NextResponse.json({
       subscription: { tier: jwtTier, status: "active" },
-      recipeUsage: 0,
     });
   }
 }

--- a/src/app/api/user/subscription/route.ts
+++ b/src/app/api/user/subscription/route.ts
@@ -33,7 +33,6 @@ function fallbackResponse(tier: string = "free") {
       createdAt: now.toISOString(),
       updatedAt: now.toISOString(),
     },
-    recipeUsage: 0,
   };
 }
 
@@ -72,13 +71,14 @@ export async function GET(request: Request) {
       console.log(`[api/user/subscription] Syncing status for user: ${session.user.id}`);
     }
 
-    // 2. Fetch subscription and usage with timeout/abort signal
+    // 2. Fetch subscription with timeout/abort signal.
+    // (Recipe-usage counter was removed when the monthly cap was retired —
+    // the token economy is the throttle, and the client has no use for it.)
     const subscriptionPromise = subscriptionService.getOrCreateSubscription(session.user.id);
-    const usagePromise = subscriptionService.getUsage(session.user.id, "recipe_generation");
 
     // Race against the signal (aborted by the 8s timeout)
-    const [subscription, recipeUsage] = await Promise.race([
-      Promise.all([subscriptionPromise, usagePromise]),
+    const subscription = await Promise.race([
+      subscriptionPromise,
       new Promise<never>((_, reject) => {
         signal.addEventListener("abort", () => reject(new Error("Request timed out")));
       })
@@ -97,7 +97,6 @@ export async function GET(request: Request) {
         ...subscription,
         tier // Ensure subscription object reflects admin status
       },
-      recipeUsage,
     });
   } catch (error: any) {
     if (error.name === "AbortError" || error.message === "Request timed out") {

--- a/src/app/premium/page.tsx
+++ b/src/app/premium/page.tsx
@@ -45,8 +45,6 @@ function PremiumPageContent() {
     subscription,
     tier,
     isLoading,
-    recipeUsage,
-    recipeLimit,
     openCheckout,
     openPortal,
     refresh,
@@ -94,9 +92,6 @@ function PremiumPageContent() {
     );
   }
 
-  const usagePercent =
-    recipeLimit === Infinity ? 0 : Math.min(100, (recipeUsage / recipeLimit) * 100);
-
   return (
     <div className="min-h-screen bg-[#08080e] text-white via-purple-50 to-indigo-50">
       <div className="max-w-4xl mx-auto px-4 py-12">
@@ -106,8 +101,9 @@ function PremiumPageContent() {
             Alchm Kitchen Premium
           </h1>
           <p className="text-lg text-white/60 max-w-xl mx-auto">
-            Unlock unlimited recipe generation, the Cosmic Restaurant Creator,
-            advanced planetary charts, and more.
+            Unlock the Cosmic Recipe Generator, the Cosmic Restaurant Creator,
+            advanced planetary charts, dining companions, and 2× daily
+            Cosmic Yield — all powered by your natal chart.
           </p>
         </div>
 
@@ -160,8 +156,8 @@ function PremiumPageContent() {
                 </div>
                 <p className="text-white/60">
                   {tier === "free"
-                    ? "Free tier — 10 recipe generations per month"
-                    : `$${TIER_LIMITS.premium.price}/month — Unlimited access`}
+                    ? "Free tier — pay-as-you-go with cosmic tokens (Spirit / Essence / Matter / Substance)"
+                    : `$${TIER_LIMITS.premium.price}/month — unlocks premium features + 2× daily Cosmic Yield`}
                 </p>
               </div>
 
@@ -175,31 +171,7 @@ function PremiumPageContent() {
               )}
             </div>
 
-            <div className="mt-8 grid md:grid-cols-3 gap-6">
-              <div className="bg-white/5 rounded-xl p-5">
-                <p className="text-xs font-bold text-white/60 uppercase tracking-wider mb-2">
-                  Recipe Generations
-                </p>
-                <div className="flex items-end gap-2 mb-3">
-                  <span className="text-3xl font-black text-white">
-                    {recipeUsage}
-                  </span>
-                  <span className="text-white/60 font-medium pb-1">
-                    / {recipeLimit === Infinity ? "\u221E" : recipeLimit}
-                  </span>
-                </div>
-                {tier === "free" && (
-                  <div className="h-2.5 bg-white/10 rounded-full overflow-hidden">
-                    <div
-                      className={`h-full rounded-full transition-all duration-700 ${
-                        usagePercent > 80 ? "bg-red-500" : usagePercent > 50 ? "bg-amber-500" : "bg-purple-500"
-                      }`}
-                      style={{ width: `${usagePercent}%` }}
-                    />
-                  </div>
-                )}
-              </div>
-
+            <div className="mt-8 grid md:grid-cols-2 gap-6">
               <div className="bg-white/5 rounded-xl p-5">
                 <p className="text-xs font-bold text-white/60 uppercase tracking-wider mb-2">
                   Renewal
@@ -207,7 +179,7 @@ function PremiumPageContent() {
                 <p className="text-lg font-semibold text-white/80">
                   {subscription?.currentPeriodEnd && tier === "premium"
                     ? new Date(subscription.currentPeriodEnd).toLocaleDateString()
-                    : "Monthly reset"}
+                    : tier === "premium" ? "Monthly reset" : "No subscription"}
                 </p>
               </div>
 

--- a/src/components/home/AmazonFreshPromotion.tsx
+++ b/src/components/home/AmazonFreshPromotion.tsx
@@ -3,28 +3,41 @@
 import { motion } from "framer-motion";
 import Link from "next/link";
 
-const REWARDS = [
+const TOKENS = [
   {
-    symbol: "🝙",
-    color: "emerald",
-    amount: "+50 Matter tokens",
-    label: "First Cart",
-    description: "One-time achievement",
-    headline: "Sign in with Google to get 🝙+50 Matter tokens",
+    symbol: "\u{1F747}",
+    name: "Spirit",
+    color: "text-amber-400",
+    bg: "bg-amber-500/10 border-amber-500/20",
+    description: "Powers cosmic recipe generation",
   },
   {
-    symbol: "🝙",
-    color: "emerald",
-    amount: "+20 Matter",
-    label: "Weekly Cart",
-    description: "Every week you send",
+    symbol: "\u{1F751}",
+    name: "Essence",
+    color: "text-blue-400",
+    bg: "bg-blue-500/10 border-blue-500/20",
+    description: "Fuels cuisine recommendations",
+  },
+  {
+    symbol: "\u{1F759}",
+    name: "Matter",
+    color: "text-emerald-400",
+    bg: "bg-emerald-500/10 border-emerald-500/20",
+    description: "Earned by shopping ingredients",
+  },
+  {
+    symbol: "\u{1F749}",
+    name: "Substance",
+    color: "text-purple-400",
+    bg: "bg-purple-500/10 border-purple-500/20",
+    description: "Refines and perfects recipes",
   },
 ] as const;
 
-const STEPS = [
-  { icon: "⚗️", text: "Browse the ingredients storefront" },
-  { icon: "🛒", text: "Add items and send to Amazon Fresh" },
-  { icon: "🝙", text: "Earn Matter tokens automatically" },
+const HOW_IT_WORKS = [
+  { icon: "🌙", text: "Sign in & enter your birth data" },
+  { icon: "⚗️", text: "Earn daily tokens from your Cosmic Yield" },
+  { icon: "🍽️", text: "Spend tokens on personalized recipes & recs" },
 ];
 
 export function AmazonFreshPromotion() {
@@ -33,113 +46,98 @@ export function AmazonFreshPromotion() {
       initial={{ opacity: 0, y: 16 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ type: "spring", stiffness: 90, damping: 20, delay: 0.1 }}
-      className="relative rounded-3xl overflow-hidden border border-emerald-500/20 bg-[#0a0f0a]/80 backdrop-blur-xl shadow-2xl shadow-emerald-900/10"
+      className="relative rounded-3xl overflow-hidden border border-purple-500/20 bg-[#0a0f0a]/80 backdrop-blur-xl shadow-2xl shadow-purple-900/10"
     >
       {/* Ambient glows */}
-      <div className="absolute top-0 right-0 w-80 h-80 bg-emerald-600/8 rounded-full blur-[100px] pointer-events-none -mr-20 -mt-20" />
-      <div className="absolute bottom-0 left-0 w-80 h-80 bg-amber-600/6 rounded-full blur-[100px] pointer-events-none -ml-20 -mb-20" />
+      <div className="absolute top-0 right-0 w-80 h-80 bg-purple-600/8 rounded-full blur-[100px] pointer-events-none -mr-20 -mt-20" />
+      <div className="absolute bottom-0 left-0 w-80 h-80 bg-indigo-600/6 rounded-full blur-[100px] pointer-events-none -ml-20 -mb-20" />
 
       <div className="relative z-10 p-6 md:p-8">
         {/* Header */}
-        <div className="flex items-start justify-between gap-4 mb-5">
-          <div>
-            <div className="flex items-center gap-2 mb-1">
-              <span className="text-xs font-bold tracking-widest text-emerald-400/80 uppercase">
-                Amazon Alchm Ingredient Marketplace
-              </span>
-              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-emerald-500/10 border border-emerald-500/20 text-[10px] font-bold text-emerald-400">
-                🝙 Earn Tokens
-              </span>
-            </div>
-            <h2 className="text-xl md:text-2xl font-bold text-white/90 leading-tight">
-              Amazon Alchm Ingredient Marketplace
-            </h2>
-            <p className="mt-1.5 text-sm text-white/40 leading-relaxed max-w-lg">
-              <span className="text-emerald-400 font-bold block mb-1">
-                Milestone Reached: 3/3 Qualifying Orders!
-              </span>
-              We have reached the required order threshold for full marketplace access. 
-              Our account is now being reviewed by Amazon. Every cart you send still earns{" "}
-              <span className="text-emerald-400 font-semibold">🝙 Matter</span> tokens
-              and keeps our storefront active. Explore our Ingredient art and keep the 
-              Alchm kitchen growing.
-            </p>
-          </div>
-
-          {/* Progress pip */}
-          <div className="shrink-0 flex flex-col items-center gap-1 px-4 py-3 rounded-2xl bg-emerald-500/10 border border-emerald-500/20 shadow-lg shadow-emerald-900/20">
-            <span className="text-2xl font-black text-emerald-400">3</span>
-            <span className="text-[10px] text-emerald-400/80 text-center leading-tight">
-              of 3<br />orders
+        <div className="mb-5">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-xs font-bold tracking-widest text-purple-400/80 uppercase">
+              Cosmic Token Economy
+            </span>
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-purple-500/10 border border-purple-500/20 text-[10px] font-bold text-purple-400">
+              No hard limits
             </span>
           </div>
+          <h2 className="text-xl md:text-2xl font-bold text-white/90 leading-tight">
+            Your Natal Chart Powers Everything
+          </h2>
+          <p className="mt-1.5 text-sm text-white/40 leading-relaxed max-w-lg">
+            Alchm Kitchen runs on four cosmic tokens:{" "}
+            <span className="text-violet-400 font-semibold">Spirit</span>,{" "}
+            <span className="text-blue-400 font-semibold">Essence</span>,{" "}
+            <span className="text-emerald-400 font-semibold">Matter</span>, and{" "}
+            <span className="text-amber-400 font-semibold">Substance</span>.
+            Your natal chart and the current sky determine both what you earn
+            daily and what each action costs — so your experience is always
+            unique to you.
+          </p>
         </div>
 
-        {/* Reward cards */}
-        <div className="flex flex-wrap gap-3 mb-6">
-          {REWARDS.map((r) => (
+        {/* Token cards */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+          {TOKENS.map((t) => (
             <div
-              key={r.label}
-              className="flex flex-col items-start gap-1 px-4 py-3 rounded-2xl bg-white/[0.03] border border-emerald-500/10 hover:border-emerald-500/25 transition-colors"
+              key={t.name}
+              className={`flex flex-col items-start gap-1 px-4 py-3 rounded-2xl border ${t.bg} hover:brightness-125 transition-all`}
             >
-              {"headline" in r && (
-                <div className="text-[10px] font-medium text-emerald-400/60 mb-0.5">
-                  {r.headline}
-                </div>
-              )}
-              {"headline" in r ? (
-                <div>
-                  <div className="text-xs font-bold text-white/80">{r.label}</div>
-                  <div className="text-[10px] text-white/30">{r.description}</div>
-                </div>
-              ) : (
-                <div className="flex items-center gap-3">
-                  <div className="flex items-center gap-1">
-                    <span className="text-emerald-400 text-lg">{r.symbol}</span>
-                    <span className="text-lg font-black text-emerald-400">
-                      {r.amount}
-                    </span>
-                  </div>
-                  <div>
-                    <div className="text-xs font-bold text-white/80">{r.label}</div>
-                    <div className="text-[10px] text-white/30">{r.description}</div>
-                  </div>
-                </div>
-              )}
+              <div className="flex items-center gap-1.5">
+                <span className={`text-lg ${t.color}`}>{t.symbol}</span>
+                <span className={`text-sm font-bold ${t.color}`}>{t.name}</span>
+              </div>
+              <div className="text-[10px] text-white/30">{t.description}</div>
             </div>
           ))}
-
-          {/* Locked reward hint */}
-          <div className="flex items-center gap-3 px-4 py-3 rounded-2xl bg-emerald-500/5 border border-emerald-500/20">
-            <span className="text-emerald-400 text-lg">✨</span>
-            <div>
-              <div className="text-xs font-bold text-white/80">Full Access Pending</div>
-              <div className="text-[10px] text-emerald-400/60">Review in progress</div>
-            </div>
-          </div>
         </div>
 
         {/* How it works */}
         <div className="flex flex-wrap gap-x-6 gap-y-2 mb-6">
-          {STEPS.map((step, i) => (
+          {HOW_IT_WORKS.map((step, i) => (
             <div key={i} className="flex items-center gap-2 text-xs text-white/40">
               <span>{step.icon}</span>
               <span>{step.text}</span>
-              {i < STEPS.length - 1 && (
-                <span className="text-white/20 hidden md:inline">→</span>
+              {i < HOW_IT_WORKS.length - 1 && (
+                <span className="text-white/20 hidden md:inline">&rarr;</span>
               )}
             </div>
           ))}
         </div>
 
-        {/* CTA */}
-        <Link
-          href="/ingredients"
-          className="inline-flex items-center gap-2 px-6 py-3 rounded-2xl bg-emerald-500/15 hover:bg-emerald-500/25 border border-emerald-500/30 hover:border-emerald-500/50 text-emerald-300 font-semibold text-sm transition-all duration-200 group"
-        >
-          Browse Ingredients & Earn Tokens
-          <span className="group-hover:translate-x-1 transition-transform duration-200">→</span>
-        </Link>
+        {/* Personalized pricing note */}
+        <div className="mb-6 p-4 rounded-2xl bg-white/[0.03] border border-purple-500/10">
+          <p className="text-xs text-white/50 leading-relaxed">
+            <span className="text-purple-400 font-semibold">Personalized pricing:</span>{" "}
+            Token costs shift with the planets. When your natal chart resonates
+            with today&apos;s sky, actions cost less — work with the cosmic grain
+            and stretch your tokens further. New users receive a welcome grant of
+            5 tokens each to start exploring.
+          </p>
+        </div>
+
+        {/* CTAs */}
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href="/login"
+            className="inline-flex items-center gap-2 px-6 py-3 rounded-2xl bg-purple-500/15 hover:bg-purple-500/25 border border-purple-500/30 hover:border-purple-500/50 text-purple-300 font-semibold text-sm transition-all duration-200 group"
+          >
+            Sign In & Start Earning
+            <span className="group-hover:translate-x-1 transition-transform duration-200">&rarr;</span>
+          </Link>
+
+          {/* Amazon shopping — primary revenue source */}
+          <Link
+            href="/ingredients"
+            className="inline-flex items-center gap-2 px-5 py-3 rounded-2xl bg-emerald-500/10 hover:bg-emerald-500/20 border border-emerald-500/25 hover:border-emerald-500/40 text-emerald-300 font-semibold text-sm transition-all duration-200 group"
+          >
+            <span className="text-base">🛒</span>
+            Shop Amazon Ingredients & Earn
+            <span className="group-hover:translate-x-1 transition-transform duration-200">&rarr;</span>
+          </Link>
+        </div>
       </div>
     </motion.div>
   );

--- a/src/contexts/MenuPlannerContext.tsx
+++ b/src/contexts/MenuPlannerContext.tsx
@@ -34,7 +34,6 @@ import type {
   MealCircuitMetrics,
   CircuitBottleneck,
   CircuitImprovementSuggestion,
-  CircuitOptimizationGoal as _CircuitOptimizationGoal,
 } from "@/types/kinetics";
 import type {
   WeeklyMenu,
@@ -61,16 +60,11 @@ import {
   getMealsForDay,
 } from "@/utils/dayCircuitCalculations";
 import { generateGroceryList } from "@/utils/groceryListGenerator";
-import {
-  estimateWeeklyGroceryCost,
-  calculateRecipeEstimatedCost as _calculateRecipeEstimatedCost,
-  type RecipeCostEstimate as _RecipeCostEstimate,
-} from "@/utils/instacart/priceEstimator";
+import { estimateWeeklyGroceryCost } from "@/utils/instacart/priceEstimator";
 import { logger } from "@/utils/logger";
 import { calculateMealCircuit } from "@/utils/mealCircuitCalculations";
 import {
   generateDayRecommendations,
-  type RecommendedMeal as _RecommendedMeal,
   type AstrologicalState,
   type UserPersonalizationContext,
 } from "@/utils/menuPlanner/recommendationBridge";
@@ -404,8 +398,39 @@ function hydrateMenuDates(menu: WeeklyMenu): WeeklyMenu {
   };
 }
 
+const GROCERY_LIST_OPTIONS = {
+  consolidateBy: "ingredient" as const,
+  convertUnits: true,
+  excludePantryItems: false,
+};
+
+/**
+ * Rebuild the menu envelope around an updated meal list and regenerate the
+ * derived grocery list in one shot. Used by every sauce mutation to keep the
+ * meal/menu/grocery triad in sync without three near-identical inline blocks.
+ */
+function applyMealUpdate(
+  menu: WeeklyMenu,
+  updatedMeals: MealSlot[],
+): { menu: WeeklyMenu; groceryList: GroceryItem[] } {
+  return {
+    menu: { ...menu, meals: updatedMeals, updatedAt: new Date() },
+    groceryList: generateGroceryList(updatedMeals, GROCERY_LIST_OPTIONS),
+  };
+}
+
 /**
  * Menu Planner Provider Component
+ *
+ * TODO(refactor): This provider is ~2100 lines and exposes 89 fields. Planned
+ * extractions, in order of payoff:
+ *   1. Meal copy/move/swap operations → `utils/mealSlotUpdates.ts`
+ *   2. Cost estimation effect+state → `hooks/useCostEstimation.ts`
+ *   3. PantryManager sync → `hooks/usePantrySync.ts`
+ *   4. Split contextValue useMemo (currently 59 deps → cascading re-renders)
+ *   5. Optional: split into MealGenerationContext / BudgetContext / CircuitMetricsContext
+ * Done in this pass: dead imports removed; sauce apply-and-refresh duped block
+ * factored into applyMealUpdate above.
  */
 export function MenuPlannerProvider({ children }: { children: ReactNode }) {
   const [currentWeekStart, setCurrentWeekStart] = useState<Date>(() =>
@@ -1205,17 +1230,10 @@ export function MenuPlannerProvider({ children }: { children: ReactNode }) {
         return meal;
       });
 
-      const updatedMenu = {
-        ...currentMenu,
-        meals: updatedMeals,
-        updatedAt: new Date(),
-      };
-      const newGroceryList = generateGroceryList(updatedMeals, {
-        consolidateBy: "ingredient",
-        convertUnits: true,
-        excludePantryItems: false,
-      });
-
+      const { menu: updatedMenu, groceryList: newGroceryList } = applyMealUpdate(
+        currentMenu,
+        updatedMeals,
+      );
       setCurrentMenu(updatedMenu);
       setGroceryList(newGroceryList);
       logger.info(`Added sauce ${sauceData.name} to meal ${mealSlotId}`);
@@ -1241,17 +1259,10 @@ export function MenuPlannerProvider({ children }: { children: ReactNode }) {
         return meal;
       });
 
-      const updatedMenu = {
-        ...currentMenu,
-        meals: updatedMeals,
-        updatedAt: new Date(),
-      };
-      const newGroceryList = generateGroceryList(updatedMeals, {
-        consolidateBy: "ingredient",
-        convertUnits: true,
-        excludePantryItems: false,
-      });
-
+      const { menu: updatedMenu, groceryList: newGroceryList } = applyMealUpdate(
+        currentMenu,
+        updatedMeals,
+      );
       setCurrentMenu(updatedMenu);
       setGroceryList(newGroceryList);
       logger.info(`Removed sauce from meal ${mealSlotId}`);
@@ -1280,17 +1291,10 @@ export function MenuPlannerProvider({ children }: { children: ReactNode }) {
         return meal;
       });
 
-      const updatedMenu = {
-        ...currentMenu,
-        meals: updatedMeals,
-        updatedAt: new Date(),
-      };
-      const newGroceryList = generateGroceryList(updatedMeals, {
-        consolidateBy: "ingredient",
-        convertUnits: true,
-        excludePantryItems: false,
-      });
-
+      const { menu: updatedMenu, groceryList: newGroceryList } = applyMealUpdate(
+        currentMenu,
+        updatedMeals,
+      );
       setCurrentMenu(updatedMenu);
       setGroceryList(newGroceryList);
       logger.info(`Updated sauce servings to ${servings} for meal ${mealSlotId}`);
@@ -1706,11 +1710,10 @@ export function MenuPlannerProvider({ children }: { children: ReactNode }) {
 
     try {
       // Generate using enhanced grocery list generator
-      const newGroceryList = generateGroceryList(currentMenu.meals, {
-        consolidateBy: "ingredient",
-        convertUnits: true,
-        excludePantryItems: false,
-      });
+      const newGroceryList = generateGroceryList(
+        currentMenu.meals,
+        GROCERY_LIST_OPTIONS,
+      );
 
       setGroceryList(newGroceryList);
       logger.info(`Generated grocery list with ${newGroceryList.length} items`);

--- a/src/contexts/PremiumContext.tsx
+++ b/src/contexts/PremiumContext.tsx
@@ -33,7 +33,6 @@ const BROADCAST_CHANNEL = "alchm_subscription_sync";
 
 interface CachedSubscription {
   subscription: UserSubscription;
-  recipeUsage: number;
   cachedAt: number;
 }
 
@@ -44,14 +43,8 @@ interface PremiumContextValue {
   tier: SubscriptionTier;
   /** Whether the subscription data is still loading */
   isLoading: boolean;
-  /** Number of recipe generations used this month */
-  recipeUsage: number;
-  /** Max recipe generations for current tier */
-  recipeLimit: number;
-  /** Check if user has access to a premium feature */
+  /** Check if user has access to a premium feature (boolean flag only). */
   hasFeature: (feature: string) => boolean;
-  /** Track a recipe generation and return updated count */
-  trackRecipeGeneration: () => Promise<number>;
   /** Open Stripe checkout for an upgrade */
   openCheckout: (tier: SubscriptionTier, options?: { trial?: boolean }) => Promise<void>;
   /** Open Stripe customer portal for managing subscription */
@@ -66,10 +59,7 @@ const PremiumContext = createContext<PremiumContextValue>({
   subscription: null,
   tier: "free",
   isLoading: true,
-  recipeUsage: 0,
-  recipeLimit: 10,
   hasFeature: () => false,
-  trackRecipeGeneration: async () => 0,
   openCheckout: async () => {},
   openPortal: async () => {},
   refresh: async () => {},
@@ -94,12 +84,11 @@ function readCache(): CachedSubscription | null {
 }
 
 /** Write subscription to sessionStorage cache */
-function writeCache(subscription: UserSubscription, recipeUsage: number) {
+function writeCache(subscription: UserSubscription) {
   if (typeof window === "undefined") return;
   try {
     const cached: CachedSubscription = {
       subscription,
-      recipeUsage,
       cachedAt: Date.now(),
     };
     sessionStorage.setItem(CACHE_KEY, JSON.stringify(cached));
@@ -120,7 +109,6 @@ export function PremiumProvider({ children }: { children: ReactNode }) {
     null,
   );
   const [isLoading, setIsLoading] = useState(true);
-  const [recipeUsage, setRecipeUsage] = useState(0);
   const broadcastRef = useRef<BroadcastChannel | null>(null);
 
   // Effective tier: JWT tier is the instant source of truth,
@@ -130,8 +118,6 @@ export function PremiumProvider({ children }: { children: ReactNode }) {
     ? "premium"
     : subscription?.tier || jwtTier;
   const isPremium = tier === "premium";
-  const limits = TIER_LIMITS[tier];
-  const recipeLimit = limits.monthlyRecipeGenerations;
 
   // Cross-tab synchronization via BroadcastChannel
   useEffect(() => {
@@ -145,14 +131,10 @@ export function PremiumProvider({ children }: { children: ReactNode }) {
         const data = event.data as {
           type: string;
           subscription?: UserSubscription;
-          recipeUsage?: number;
         };
         if (data.type === "subscription_updated" && data.subscription) {
           setSubscription(data.subscription);
-          if (data.recipeUsage !== undefined) {
-            setRecipeUsage(data.recipeUsage);
-          }
-          writeCache(data.subscription, data.recipeUsage || 0);
+          writeCache(data.subscription);
         }
       };
 
@@ -167,7 +149,6 @@ export function PremiumProvider({ children }: { children: ReactNode }) {
           try {
             const cached: CachedSubscription = JSON.parse(e.newValue);
             setSubscription(cached.subscription);
-            setRecipeUsage(cached.recipeUsage);
           } catch {
             // Ignore parse errors
           }
@@ -180,12 +161,11 @@ export function PremiumProvider({ children }: { children: ReactNode }) {
 
   /** Broadcast subscription update to other tabs */
   const broadcastUpdate = useCallback(
-    (sub: UserSubscription, usage: number) => {
+    (sub: UserSubscription) => {
       try {
         broadcastRef.current?.postMessage({
           type: "subscription_updated",
           subscription: sub,
-          recipeUsage: usage,
         });
       } catch {
         // Channel closed or unavailable — non-critical
@@ -204,7 +184,6 @@ export function PremiumProvider({ children }: { children: ReactNode }) {
     const cached = readCache();
     if (cached) {
       setSubscription(cached.subscription);
-      setRecipeUsage(cached.recipeUsage);
       setIsLoading(false);
       // Still fetch fresh data in background
     }
@@ -228,20 +207,18 @@ export function PremiumProvider({ children }: { children: ReactNode }) {
       }
 
       const data = await res.json();
-      
+
       if (res.ok) {
         setSubscription(data.subscription);
-        setRecipeUsage(data.recipeUsage || 0);
         // Cache for fast subsequent loads
         if (data.subscription) {
-          writeCache(data.subscription, data.recipeUsage || 0);
-          broadcastUpdate(data.subscription, data.recipeUsage || 0);
+          writeCache(data.subscription);
+          broadcastUpdate(data.subscription);
         }
       } else {
         // Non-200 response — try to use parsed data if available as it might be a fallback
         if (data.subscription) {
           setSubscription(data.subscription);
-          setRecipeUsage(data.recipeUsage || 0);
         }
       }
     } catch (error: any) {
@@ -265,41 +242,13 @@ export function PremiumProvider({ children }: { children: ReactNode }) {
     (feature: string): boolean => {
       // Admins have access to everything
       if (isAdmin) return true;
-
+      // Pure boolean feature-flag lookup. Usage rates (recipe gen, etc.) are
+      // throttled by the token economy, not gated here.
       const tierLimits = TIER_LIMITS[tier];
-      if (feature === "monthlyRecipeGenerations") {
-        return recipeUsage < tierLimits.monthlyRecipeGenerations;
-      }
       return !!(tierLimits as Record<string, unknown>)[feature];
     },
-    [tier, recipeUsage, isAdmin],
+    [tier, isAdmin],
   );
-
-  const trackRecipeGeneration = useCallback(async (): Promise<number> => {
-    try {
-      const res = await fetch("/api/subscription/usage", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ feature: "recipe_generation" }),
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setRecipeUsage(data.count);
-        // Update cache and broadcast
-        if (subscription) {
-          writeCache(subscription, data.count);
-          broadcastUpdate(subscription, data.count);
-        }
-        return data.count;
-      }
-    } catch (error) {
-      console.error("[PremiumContext] Usage tracking failed:", error);
-    }
-    // Optimistic fallback
-    const newCount = recipeUsage + 1;
-    setRecipeUsage(newCount);
-    return newCount;
-  }, [recipeUsage, subscription, broadcastUpdate]);
 
   const openCheckout = useCallback(
     async (targetTier: SubscriptionTier, options?: { trial?: boolean }) => {
@@ -338,10 +287,7 @@ export function PremiumProvider({ children }: { children: ReactNode }) {
         subscription,
         tier,
         isLoading,
-        recipeUsage,
-        recipeLimit,
         hasFeature,
-        trackRecipeGeneration,
         openCheckout,
         openPortal,
         refresh: fetchSubscription,

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -254,6 +254,14 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
               }
             }
             
+            // TODO(agent-sync): On first sign-in for an @agentic.alchm.kitchen
+            // email, POST to the FastAPI backend's /api/internal/agent-sync
+            // (defined in backend/alchm_kitchen/main.py:2724) with
+            // X-Sync-Secret=ALCHM_KITCHEN_SYNC_SECRET so the planetary_agents
+            // DB row gets its alchmKitchenUserId without waiting for the
+            // periodic scripts/backfill-agent-sync.ts run. Wrap in a fire-and-
+            // forget IIFE — must never block sign-in.
+
             // 1. Auto-provision premium
             if (isAdminEmail(user.email!) || isPremiumEmail(user.email!)) {
               const { subscriptionService } = await import("@/services/subscriptionService");
@@ -270,6 +278,31 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
                 });
                 logger.info(`Auto-provisioned premium for ${user.email}`);
               }
+            }
+
+            // 1b. Welcome token grant — every new user starts with a small
+            // even balance so they can try a couple of actions before
+            // claiming their first daily Cosmic Yield (which itself requires
+            // a completed natal chart). Idempotent via the per-user key, so
+            // repeated sign-ins do not re-grant.
+            try {
+              const { tokenEconomy } = await import("@/services/TokenEconomyService");
+              await tokenEconomy.creditMultipleTokens(
+                dbUser.id,
+                [
+                  { tokenType: "Spirit", amount: 5 },
+                  { tokenType: "Essence", amount: 5 },
+                  { tokenType: "Matter", amount: 5 },
+                  { tokenType: "Substance", amount: 5 },
+                ],
+                "signup_grant",
+                {
+                  description: "Welcome to Alchm.kitchen — starter cosmic balance",
+                  idempotencyKey: `signup_grant:${dbUser.id}`,
+                },
+              );
+            } catch (grantError) {
+              logger.warn("Welcome token grant failed (non-blocking):", grantError);
             }
 
             // 2. Send emails

--- a/src/lib/auth/demoAccess.ts
+++ b/src/lib/auth/demoAccess.ts
@@ -1,0 +1,82 @@
+/**
+ * Gate for routes that support BOTH authenticated and "demo" anonymous use.
+ *
+ * Throttling philosophy (do not change without product sign-off):
+ *
+ *   - Logged-in users: the personalized token economy (Spirit/Essence/Matter/
+ *     Substance, priced against the user's chart vs the current sky) IS the
+ *     throttle. The route should NOT also impose a per-minute rate cap — if
+ *     they can afford it, they can run it.
+ *
+ *   - Anonymous users: get a small daily IP-based "demo budget" so visitors
+ *     can sample the site before signing in. Once exhausted, return a 401
+ *     with a friendly sign-in nudge rather than a 429.
+ *
+ * The route body should branch on `mode`:
+ *
+ *   - "auth" → run the normal logged-in path (token debit, usage tracking,
+ *     subscription checks, etc.)
+ *   - "demo" → skip all per-user economy / usage / quest hooks; just run the
+ *     core generation so the visitor can see the wow factor.
+ *
+ * @file src/lib/auth/demoAccess.ts
+ */
+
+import { NextResponse } from "next/server";
+import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { rateLimit } from "@/lib/rateLimit";
+import type { NextRequest } from "next/server";
+
+export interface DemoAccessOptions {
+  /** Free demo uses per IP per 24h for this feature. Keep small (1-5). */
+  dailyDemoQuota: number;
+  /** Short feature label used in the bucket key and the sign-in nudge. */
+  feature: string;
+}
+
+export type DemoAccessResult =
+  | { mode: "auth"; userId: string; blocked?: undefined }
+  | { mode: "demo"; userId: null; demoRemaining: number; blocked?: undefined }
+  | { mode: "denied"; userId: null; blocked: NextResponse };
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+export async function gateDemoOrAuth(
+  request: NextRequest,
+  options: DemoAccessOptions,
+): Promise<DemoAccessResult> {
+  const userId = await getUserIdFromRequest(request);
+  if (userId) {
+    return { mode: "auth", userId };
+  }
+
+  const rl = await rateLimit(request, {
+    window: ONE_DAY_MS,
+    max: options.dailyDemoQuota,
+    bucket: `demo:${options.feature}`,
+  });
+
+  if (rl.allowed) {
+    return { mode: "demo", userId: null, demoRemaining: rl.remaining };
+  }
+
+  // Demo budget exhausted — convert the rate-limit 429 into a friendlier 401
+  // that nudges the visitor toward sign-in, since the rest of the site is
+  // gated by the token economy rather than a per-day quota.
+  return {
+    mode: "denied",
+    userId: null,
+    blocked: NextResponse.json(
+      {
+        error: "sign_in_required",
+        message:
+          `You've used your free ${options.feature} demos for today. ` +
+          `Sign in to keep going — logged-in users are billed in cosmic tokens ` +
+          `(Spirit / Essence / Matter / Substance) based on your chart, not capped per day.`,
+        feature: options.feature,
+        retryAfterSeconds: Math.ceil(rl.resetMs / 1000),
+      },
+      { status: 401 },
+    ),
+  };
+}

--- a/src/lib/database/types.ts
+++ b/src/lib/database/types.ts
@@ -321,6 +321,7 @@ export interface TokenTransactionRecord {
     | "purchase"
     | "transmutation"
     | "streak_bonus"
+    | "signup_grant"
     | "admin";
   source_id?: string;
   description?: string;

--- a/src/lib/economy/livePricing.ts
+++ b/src/lib/economy/livePricing.ts
@@ -1,4 +1,6 @@
 import { alchemize, type PlanetaryPosition } from "@/services/RealAlchemizeService";
+import type { AlchemicalProperties } from "@/types/celestial";
+import { calculateAlchemicalFromPlanets, isSectDiurnal } from "@/utils/planetaryAlchemyMapping";
 import {
   calculatePlanetaryPositions,
   getFallbackPlanetaryPositions,
@@ -17,6 +19,32 @@ export interface LivePricingContext {
   dominantElement: string;
   timestamp: string;
 }
+
+/**
+ * Per-token multipliers — produced by the personalized pricing helper.
+ * For users WITHOUT a natal chart, every field equals `LivePricingContext.multiplier`
+ * (i.e. behaviour identical to the global multiplier).
+ */
+export interface PersonalizedPricingContext extends LivePricingContext {
+  /** Per-token multipliers, one for each ESMS token. */
+  perToken: EsmsCost;
+  /** Normalised natal ESMS weights (sums to 1.0). Null if no natal chart. */
+  natalWeights: EsmsCost | null;
+  /** Normalised current-sky ESMS weights (sums to 1.0). */
+  transitWeights: EsmsCost;
+  /** True iff natal positions were supplied AND yielded a usable weight vector. */
+  personalized: boolean;
+}
+
+/**
+ * How strongly per-user affinity bends the global multiplier (per token).
+ * 0.5 → a user whose natal+transit weight is +0.25 above baseline (0.25)
+ * pays that token at ~0.875× of the global cost; symmetric on the upside.
+ */
+const PERSONALIZATION_SCALE = 0.5;
+const BASELINE_WEIGHT = 0.25;
+const PER_TOKEN_MIN = 0.5;
+const PER_TOKEN_MAX = 1.6;
 
 function round(value: number, digits = 2): number {
   const factor = 10 ** digits;
@@ -79,6 +107,134 @@ export function applyLivePricing(base: EsmsCost, multiplier: number): EsmsCost {
     essence: apply(base.essence),
     matter: apply(base.matter),
     substance: apply(base.substance),
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Personalized pricing
+//
+// The site's economic premise: action cost is a function of the user's natal
+// chart × the chart of the moment. Token types in which a user resonates
+// (high natal weight) AND that today's transits emphasise (high transit
+// weight) are CHEAPER for that user — they're working with the cosmic grain,
+// not against it. Conversely, tokens where they're weak pay a premium.
+//
+// Without a natal chart (anonymous demo, mid-onboarding) the helper falls
+// back to the global multiplier so calling code is uniform.
+// ──────────────────────────────────────────────────────────────────────────
+
+function normaliseEsms(esms: AlchemicalProperties): EsmsCost {
+  const total = esms.Spirit + esms.Essence + esms.Matter + esms.Substance;
+  if (total <= 0) {
+    return { spirit: 0.25, essence: 0.25, matter: 0.25, substance: 0.25 };
+  }
+  return {
+    spirit: esms.Spirit / total,
+    essence: esms.Essence / total,
+    matter: esms.Matter / total,
+    substance: esms.Substance / total,
+  };
+}
+
+function uniformPerToken(multiplier: number): EsmsCost {
+  return {
+    spirit: multiplier,
+    essence: multiplier,
+    matter: multiplier,
+    substance: multiplier,
+  };
+}
+
+/**
+ * Compute a pricing context personalised to the user's natal chart.
+ *
+ * @param natalPositions  Planet → sign map from the user's natal chart, in the
+ *                        same shape that DailyYieldService consumes. Pass
+ *                        `null`/`undefined` for anonymous/onboarding users to
+ *                        get the uniform global multiplier back.
+ * @param now             Override "current sky" timestamp (test hook).
+ */
+export async function getPersonalizedPricingContext(
+  natalPositions: Record<string, string> | null | undefined,
+  now = new Date(),
+): Promise<PersonalizedPricingContext> {
+  let positions: Record<string, any>;
+  try {
+    positions = await calculatePlanetaryPositions(now);
+  } catch {
+    positions = getFallbackPlanetaryPositions();
+  }
+
+  const alch = alchemize(asPlanetaryPositions(positions), null, now);
+  const aNumber =
+    Number(alch.esms.Spirit || 0) +
+    Number(alch.esms.Essence || 0) +
+    Number(alch.esms.Matter || 0) +
+    Number(alch.esms.Substance || 0);
+  const globalMultiplier = clamp(1 + (aNumber - 20) / 100, 0.85, 1.35);
+  const transitWeights = normaliseEsms(alch.esms);
+
+  let natalWeights: EsmsCost | null = null;
+  let perToken: EsmsCost = uniformPerToken(globalMultiplier);
+
+  if (natalPositions && Object.keys(natalPositions).length > 0) {
+    const diurnal = isSectDiurnal(now);
+    const natalEsms = calculateAlchemicalFromPlanets(natalPositions, diurnal);
+    natalWeights = normaliseEsms(natalEsms);
+
+    // Per-token affinity: how strongly THIS user resonates with TODAY's sky
+    // on each token axis. Average of natal and transit weights, centred on
+    // the uniform baseline (0.25) so the signed delta is the discount driver.
+    const affinity = {
+      spirit: (natalWeights.spirit + transitWeights.spirit) / 2 - BASELINE_WEIGHT,
+      essence: (natalWeights.essence + transitWeights.essence) / 2 - BASELINE_WEIGHT,
+      matter: (natalWeights.matter + transitWeights.matter) / 2 - BASELINE_WEIGHT,
+      substance: (natalWeights.substance + transitWeights.substance) / 2 - BASELINE_WEIGHT,
+    };
+
+    perToken = {
+      spirit: round(clamp(globalMultiplier * (1 - PERSONALIZATION_SCALE * affinity.spirit), PER_TOKEN_MIN, PER_TOKEN_MAX), 4),
+      essence: round(clamp(globalMultiplier * (1 - PERSONALIZATION_SCALE * affinity.essence), PER_TOKEN_MIN, PER_TOKEN_MAX), 4),
+      matter: round(clamp(globalMultiplier * (1 - PERSONALIZATION_SCALE * affinity.matter), PER_TOKEN_MIN, PER_TOKEN_MAX), 4),
+      substance: round(clamp(globalMultiplier * (1 - PERSONALIZATION_SCALE * affinity.substance), PER_TOKEN_MIN, PER_TOKEN_MAX), 4),
+    };
+  }
+
+  return {
+    multiplier: round(globalMultiplier, 4),
+    perToken,
+    natalWeights,
+    transitWeights: {
+      spirit: round(transitWeights.spirit, 4),
+      essence: round(transitWeights.essence, 4),
+      matter: round(transitWeights.matter, 4),
+      substance: round(transitWeights.substance, 4),
+    },
+    aNumber: round(aNumber, 4),
+    dominantElement: alch.metadata.dominantElement,
+    timestamp: now.toISOString(),
+    personalized: natalWeights !== null,
+  };
+}
+
+/**
+ * Apply per-token multipliers to a base ESMS cost. Pair with
+ * `getPersonalizedPricingContext` so the user's natal × current-sky discount
+ * lands on the actual debit.
+ */
+export function applyPersonalizedPricing(
+  base: EsmsCost,
+  ctx: PersonalizedPricingContext,
+): EsmsCost {
+  const apply = (value: number, mult: number) => {
+    if (value <= 0) return 0;
+    return round(value * mult, 2);
+  };
+  return {
+    spirit: apply(base.spirit, ctx.perToken.spirit),
+    essence: apply(base.essence, ctx.perToken.essence),
+    matter: apply(base.matter, ctx.perToken.matter),
+    substance: apply(base.substance, ctx.perToken.substance),
   };
 }
 

--- a/src/services/subscriptionService.ts
+++ b/src/services/subscriptionService.ts
@@ -263,28 +263,21 @@ class SubscriptionService {
     return newCount;
   }
 
+  /**
+   * Boolean feature-flag check: does the user's tier unlock this feature?
+   *
+   * NOTE: this is a feature-ACCESS gate, not a usage-rate cap. Usage rates
+   * (recipe generation etc.) are throttled by the token economy. Don't
+   * re-add a `monthlyRecipeGenerations` branch — see feedback_throttling_model.
+   */
   async canUseFeature(
     userId: string,
     feature: keyof typeof TIER_LIMITS.free,
-  ): Promise<{ allowed: boolean; reason?: string; currentUsage?: number; limit?: number }> {
+  ): Promise<{ allowed: boolean; reason?: string }> {
     const sub = await this.getOrCreateSubscription(userId);
     const limits = TIER_LIMITS[sub.tier];
 
-    if (feature === "monthlyRecipeGenerations") {
-      const usage = await this.getUsage(userId, "recipe_generation");
-      const limit = limits.monthlyRecipeGenerations;
-      if (usage >= limit) {
-        return {
-          allowed: false,
-          reason: `You've used ${usage}/${limit} recipe generations this month. Upgrade for more!`,
-          currentUsage: usage,
-          limit,
-        };
-      }
-      return { allowed: true, currentUsage: usage, limit };
-    }
-
-    const hasAccess = limits[feature as keyof typeof limits];
+    const hasAccess = limits[feature];
     if (!hasAccess) {
       return {
         allowed: false,

--- a/src/types/economy.ts
+++ b/src/types/economy.ts
@@ -26,6 +26,7 @@ export type TransactionSourceType =
   | "transmutation"
   | "streak_bonus"
   | "alchemical_log"
+  | "signup_grant"
   | "admin";
 
 // ─── Token Balances ────────────────────────────────────────────────────

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -38,12 +38,19 @@ export interface UsageRecord {
   periodEnd: string;
 }
 
-/** Feature limits per tier */
+/**
+ * Feature flags per tier.
+ *
+ * NOTE: there is intentionally no `monthlyRecipeGenerations` cap. Recipe
+ * generation is throttled purely by the token economy (Spirit/Essence cost
+ * per call, personalised to the user's chart × current sky). Free vs Premium
+ * is a feature-access distinction (cosmic recipes, dining companions, etc.),
+ * not a usage quota.
+ */
 export const TIER_LIMITS: Record<
   SubscriptionTier,
   {
     label: string;
-    monthlyRecipeGenerations: number;
     cosmicRecipeAccess: boolean;
     restaurantCreator: boolean;
     advancedPlanetaryCharts: boolean;
@@ -56,7 +63,6 @@ export const TIER_LIMITS: Record<
 > = {
   free: {
     label: "Free",
-    monthlyRecipeGenerations: 10,
     cosmicRecipeAccess: false,
     restaurantCreator: false,
     advancedPlanetaryCharts: false,
@@ -68,7 +74,6 @@ export const TIER_LIMITS: Record<
   },
   premium: {
     label: "Premium",
-    monthlyRecipeGenerations: Infinity,
     cosmicRecipeAccess: true,
     restaurantCreator: true,
     advancedPlanetaryCharts: true,
@@ -83,10 +88,10 @@ export const TIER_LIMITS: Record<
 /** Feature metadata for display in comparison tables */
 export const FEATURE_LIST = [
   {
-    key: "monthlyRecipeGenerations",
-    label: "Monthly Recipe Generations",
-    free: "10",
-    premium: "Unlimited",
+    key: "recipeGeneration",
+    label: "Recipe Generation",
+    free: "Pay-as-you-go with cosmic tokens",
+    premium: "Pay-as-you-go with cosmic tokens",
   },
   {
     key: "cosmicRecipeAccess",

--- a/src/utils/astrology/chartDataUtils.ts
+++ b/src/utils/astrology/chartDataUtils.ts
@@ -36,6 +36,28 @@ export function extractPlanetaryPositions(natalChart: NatalChart): Record<string
       positions[planet] = p.sign;
     }
   });
-  
+
   return positions;
+}
+
+/**
+ * Same as `extractPlanetaryPositions` but returns sign names capitalised to
+ * the shape that `calculateAlchemicalFromPlanets` / `DailyYieldService` /
+ * `getPersonalizedPricingContext` expect (e.g. `"Aries"`, not `"aries"`).
+ *
+ * Returns `null` when no usable planet → sign pairs can be extracted — call
+ * sites should treat that as "not onboarded, skip personalization".
+ */
+export function getCapitalizedNatalPositions(
+  natalChart: NatalChart | null | undefined,
+): Record<string, string> | null {
+  if (!natalChart) return null;
+  const signs = extractPlanetaryPositions(natalChart);
+  const positions: Record<string, string> = {};
+  for (const [planet, sign] of Object.entries(signs)) {
+    if (typeof sign === "string" && sign.length > 0) {
+      positions[planet] = sign.charAt(0).toUpperCase() + sign.slice(1).toLowerCase();
+    }
+  }
+  return Object.keys(positions).length > 0 ? positions : null;
 }


### PR DESCRIPTION
## Summary

- **Personalized token pricing**: Each action's ESMS cost is now shaped by the user's natal chart × the current planetary sky. Users whose chart resonates with today's transits pay less — symmetric with the existing DailyYieldService (earn more when aligned, spend less when aligned).
- **Demo access for anonymous users**: New `gateDemoOrAuth()` middleware gives unauthenticated visitors a limited free taste (2 cosmic recipes, 5 basic recommendations per IP per day) to drive signups without requiring tokens.
- **Welcome grant**: New users receive 5 of each token (Spirit, Essence, Matter, Substance) on first sign-in so they can immediately explore.
- **Removed hard rate caps**: `monthlyRecipeGenerations` stripped from TIER_LIMITS, subscriptionService, PremiumContext, and all API routes. The token economy is now the sole throttle for authenticated users.
- **Server-side premium gates**: `diningCompanions` feature flag enforced on the group-recommendations API; cosmic recipe route checks premium or token balance.
- **Security fix**: `/api/food-diary/insights` now reads userId from session instead of an unauthenticated query parameter.
- **Home page**: Replaced outdated Amazon milestone event promo with a tokenomics overview component that introduces Spirit/Essence/Matter/Substance to new users and keeps the "Shop Amazon Ingredients & Earn" CTA.
- **MenuPlannerContext cleanup**: Removed dead imports, extracted helpers, added refactor TODO.

## Test plan

- [ ] Sign out → visit homepage → confirm tokenomics overview renders with 4 token cards and Amazon shopping CTA
- [ ] Sign out → hit `/api/generate-cosmic-recipe` POST with valid body → confirm demo response with `demo: true` and `demoRemaining`
- [ ] Exhaust demo budget (2 cosmic recipes) → confirm 429 with sign-in nudge
- [ ] Sign in as new user → confirm welcome grant of 5 each token appears in balance
- [ ] Sign in as free user → generate cosmic recipe → confirm personalized pricing debit (Spirit + Essence cost varies by chart)
- [ ] Sign in as premium user → generate cosmic recipe → confirm no token debit
- [ ] Hit `/api/group-recommendations` as free user → confirm 402 `premium_required`
- [ ] Verify `/api/food-diary/insights` rejects requests without valid session
- [ ] Visit `/premium` → confirm no "Recipe Generations" usage card, updated copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)