### PR TITLE
feat(alchm): hydrate Phase 2 backend (recommendations + cuisines + sauces)

### DIFF
--- a/src/app/(alchm)/ingredients/[ingredientId]/page.tsx
+++ b/src/app/(alchm)/ingredients/[ingredientId]/page.tsx
@@ -149,13 +149,25 @@ function useTrendingTicker(currentId: string): TickerItem[] {
   const [items, setItems] = useState<TickerItem[]>([]);
   useEffect(() => {
     let cancelled = false;
-    // /api/recommendations/ingredients does not yet exist — guard for 404.
     fetch("/api/recommendations/ingredients?limit=8", { cache: "no-store" })
       .then((r) => (r.ok ? r.json() : null))
       .then((j) => {
-        if (cancelled) return;
-        const list = Array.isArray(j?.items) ? j.items : [];
-        setItems(list);
+        if (cancelled || !j) return;
+        const list = Array.isArray(j.ingredients) ? j.ingredients : [];
+        const mapped: TickerItem[] = list.map(
+          (it: {
+            id: string;
+            name: string;
+            match_score: number;
+            elemental_affinity: TickerItem["element"];
+          }) => ({
+            id: it.id,
+            name: it.name,
+            match: it.match_score,
+            element: it.elemental_affinity,
+          }),
+        );
+        setItems(mapped);
       })
       .catch(() => {
         if (!cancelled) setItems([]);

--- a/src/app/(alchm)/lab/page.tsx
+++ b/src/app/(alchm)/lab/page.tsx
@@ -1,0 +1,725 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useEffect, useState, type JSX } from "react";
+import {
+  AstrologicalClockPanel,
+  CuisineExplorerPanel,
+  ElementalMeter,
+  Glyph,
+  IngredientCard,
+  PipelinePanel,
+  SauceLineagePanel,
+  ThermoQuartet,
+  type AstrologicalClockRow,
+  type CuisineSignatureRow,
+  type ElementalValues,
+  type IngredientCardData,
+  type PipelineService,
+  type SauceLineageEdge,
+  type SauceLineageNode,
+  type ThermoValues,
+} from "@/components/ui/alchm";
+
+// PlanetaryClock geometry uses Math.sin/cos which can produce micro-different
+// floating-point values between server and client, tripping hydration warnings.
+// Render client-only.
+const PlanetaryClock = dynamic(
+  () => import("@/components/ui/alchm").then((m) => m.PlanetaryClock),
+  { ssr: false },
+);
+import { useAlchemicalSafe } from "@/contexts/AlchemicalContext/hooks";
+import { useUser } from "@/contexts/UserContext";
+
+/* ─── Mapping helpers ─────────────────────────────────────────────────────── */
+
+const PLANET_GLYPHS: Record<string, string> = {
+  Sun: "☉",
+  Moon: "☽",
+  Mercury: "☿",
+  Venus: "♀",
+  Mars: "♂",
+  Jupiter: "♃",
+  Saturn: "♄",
+};
+
+function buildAstroRows(
+  positions: Record<string, { sign?: string; degree?: number; minutes?: number; isRetrograde?: boolean } | undefined>,
+  hourRuler: string,
+): AstrologicalClockRow[] {
+  const order = ["Sun", "Moon", "Mercury", "Venus", "Mars", "Jupiter", "Saturn"];
+  return order.map((p) => {
+    const data = positions[p];
+    const sign = data?.sign ?? "—";
+    const deg = data?.degree != null ? String(data.degree).padStart(2, "0") : "00";
+    const min = data?.minutes != null ? String(data.minutes).padStart(2, "0") : "00";
+    const detail = data?.isRetrograde
+      ? "retrograde"
+      : p === hourRuler
+        ? "current hour"
+        : "—";
+    return {
+      planet: p,
+      sym: PLANET_GLYPHS[p] ?? "?",
+      position: data ? `${deg}°${min}′ ${sign}` : "—",
+      detail,
+      active: p === hourRuler,
+    };
+  });
+}
+
+/* ─── Awaiting-backend placeholder ───────────────────────────────────────── */
+
+function AwaitingBackend({
+  title,
+  endpoint,
+  note,
+}: {
+  title: string;
+  endpoint: string;
+  note?: string;
+}): JSX.Element {
+  return (
+    <div
+      className="alchm-panel"
+      style={{
+        padding: "20px 22px",
+        border: "1px dashed color-mix(in oklch, var(--accent), transparent 60%)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+          gap: 16,
+          flexWrap: "wrap",
+        }}
+      >
+        <div className="t-tag" style={{ color: "var(--accent)" }}>
+          {title} · AWAITING BACKEND
+        </div>
+        <span
+          className="t-mono"
+          style={{
+            fontSize: 9,
+            color: "var(--fg-mute)",
+            letterSpacing: "0.14em",
+            wordBreak: "break-all",
+          }}
+        >
+          {endpoint}
+        </span>
+      </div>
+      {note && (
+        <div
+          style={{
+            marginTop: 10,
+            fontSize: 12,
+            color: "var(--fg-dim)",
+            lineHeight: 1.55,
+          }}
+        >
+          {note}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ─── Service telemetry from /api/health ─────────────────────────────────── */
+
+interface HealthPayload {
+  status?: string;
+  services?: Record<string, string>;
+  timestamp?: string;
+}
+
+/* ─── Recommended ingredients hook ───────────────────────────────────────── */
+
+const PLANET_GLYPH_LOOKUP: Record<string, string> = {
+  Sun: "☉",
+  Moon: "☽",
+  Mercury: "☿",
+  Venus: "♀",
+  Mars: "♂",
+  Jupiter: "♃",
+  Saturn: "♄",
+  Uranus: "♅",
+  Neptune: "♆",
+  Pluto: "♇",
+};
+
+interface RecommendedIngredientPayload {
+  id: string;
+  name: string;
+  category: string;
+  elemental_affinity: "fire" | "water" | "earth" | "air";
+  planet: string;
+  hue: number;
+  match_score: number;
+  thermo: { spirit: number; essence: number; matter: number; substance: number };
+}
+
+function useRecommendedIngredients(limit = 8): IngredientCardData[] | null {
+  const [items, setItems] = useState<IngredientCardData[] | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/recommendations/ingredients?limit=${limit}`, { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j) => {
+        if (cancelled || !j) return;
+        const list: RecommendedIngredientPayload[] = Array.isArray(j.ingredients)
+          ? j.ingredients
+          : [];
+        setItems(
+          list.map((it) => ({
+            id: it.id,
+            name: it.name,
+            category: (it.category ?? "other").toUpperCase(),
+            element: it.elemental_affinity,
+            match: it.match_score,
+            properties: it.thermo,
+            planet: PLANET_GLYPH_LOOKUP[it.planet] ?? "☉",
+            hue: it.hue,
+          })),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setItems([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [limit]);
+  return items;
+}
+
+/* ─── Cuisine signatures hook ─────────────────────────────────────────────── */
+
+interface CuisineSignaturePayload {
+  id: string;
+  name: string;
+  region: string;
+  match: number;
+  signature: [number, number, number, number];
+}
+
+interface CuisineSignaturesData {
+  total: number;
+  rows: CuisineSignatureRow[];
+}
+
+function useCuisineSignatures(): CuisineSignaturesData | null {
+  const [data, setData] = useState<CuisineSignaturesData | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/cuisines/signatures", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j) => {
+        if (cancelled || !j) return;
+        const list: CuisineSignaturePayload[] = Array.isArray(j.cuisines)
+          ? j.cuisines
+          : [];
+        setData({
+          total: typeof j.total === "number" ? j.total : list.length,
+          rows: list.slice(0, 8).map((c) => ({
+            id: c.id,
+            name: c.name,
+            region: c.region,
+            match: c.match,
+            sig: c.signature,
+          })),
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setData(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return data;
+}
+
+/* ─── Sauce lineage hook ─────────────────────────────────────────────────── */
+
+interface SauceLineagePayload {
+  root: string;
+  nodes: Array<{ id: string; label: string; depth: number }>;
+  edges: Array<{ from: string; to: string }>;
+  stats: { depth: number; nodes: number; variants: number };
+}
+
+interface SauceLineageView {
+  rootLabel: string;
+  nodes: SauceLineageNode[];
+  edges: SauceLineageEdge[];
+  stats: Array<{ label: string; value: string | number }>;
+}
+
+const SAUCE_VIEWBOX = { width: 320, height: 200 };
+
+function layoutLineage(payload: SauceLineagePayload): SauceLineageView {
+  const { width, height } = SAUCE_VIEWBOX;
+  const rootNode = payload.nodes.find((n) => n.depth === 0) ?? payload.nodes[0];
+  const variants = payload.nodes.filter((n) => n.id !== rootNode?.id);
+  const cx = width / 2;
+  const rootY = 44;
+  const variantY = height - 50;
+
+  const positions = new Map<string, { x: number; y: number; r: number; label: string; color?: string }>();
+  if (rootNode) {
+    positions.set(rootNode.id, {
+      x: cx,
+      y: rootY,
+      r: 14,
+      label: rootNode.label,
+      color: "var(--accent-2)",
+    });
+  }
+  const spacing = variants.length > 1 ? (width - 60) / (variants.length - 1) : 0;
+  variants.forEach((node, i) => {
+    const x = variants.length === 1 ? cx : 30 + spacing * i;
+    positions.set(node.id, { x, y: variantY, r: 10, label: node.label });
+  });
+
+  const nodes: SauceLineageNode[] = Array.from(positions.values());
+  const edges: SauceLineageEdge[] = payload.edges
+    .map((e) => {
+      const from = positions.get(e.from);
+      const to = positions.get(e.to);
+      if (!from || !to) return null;
+      const mid = (from.y + to.y) / 2;
+      return { d: `M ${from.x} ${from.y} C ${from.x} ${mid}, ${to.x} ${mid}, ${to.x} ${to.y}` };
+    })
+    .filter((e): e is SauceLineageEdge => e !== null);
+
+  return {
+    rootLabel: rootNode?.label ?? payload.root,
+    nodes,
+    edges,
+    stats: [
+      { label: "Variants", value: payload.stats.variants },
+      { label: "Depth", value: payload.stats.depth },
+      { label: "Nodes", value: payload.stats.nodes },
+    ],
+  };
+}
+
+function useSauceLineage(root: string): SauceLineageView | null {
+  const [view, setView] = useState<SauceLineageView | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/sauces/lineage?root=${encodeURIComponent(root)}`, { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j: SauceLineagePayload | null) => {
+        if (cancelled || !j) return;
+        setView(layoutLineage(j));
+      })
+      .catch(() => {
+        if (!cancelled) setView(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [root]);
+  return view;
+}
+
+function useHealthTelemetry(): PipelineService[] {
+  const [data, setData] = useState<HealthPayload | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/health", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j) => {
+        if (!cancelled) setData(j);
+      })
+      .catch(() => {
+        if (!cancelled) setData(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  if (!data) return [];
+  const svcMap = data.services ?? {};
+  return Object.entries(svcMap).map(([name, status]) => ({
+    name,
+    latency: "—",
+    up: status === "healthy",
+    agent: name === "external_apis",
+  }));
+}
+
+/* ─── Page ────────────────────────────────────────────────────────────────── */
+
+export default function LaboratoryDashboardPage(): JSX.Element {
+  const { currentUser } = useUser();
+  const alch = useAlchemicalSafe();
+  const services = useHealthTelemetry();
+  const recommended = useRecommendedIngredients(8);
+  const cuisineData = useCuisineSignatures();
+  const sauceLineage = useSauceLineage("bechamel");
+
+  const stats = currentUser?.stats;
+  const elemental: ElementalValues | null = stats
+    ? { fire: stats.fire, water: stats.water, earth: stats.earth, air: stats.air }
+    : null;
+  const thermo: ThermoValues | null = stats
+    ? {
+        spirit: stats.spirit,
+        essence: stats.essence,
+        matter: stats.matter,
+        substance: stats.substance,
+      }
+    : null;
+
+  const planetaryHour = alch?.planetaryHour ?? "Sun";
+  const astroRows = alch
+    ? buildAstroRows(alch.planetaryPositions ?? {}, planetaryHour)
+    : [];
+
+  const sunSign =
+    currentUser?.natalChart?.planets?.find((p) => p.name === "Sun")?.sign ?? null;
+  const birthDate = currentUser?.birthData?.dateTime?.split("T")[0] ?? null;
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: 0,
+        minHeight: "calc(100vh - 70px)",
+      }}
+      className="alchm-dashboard"
+    >
+      <style>{`
+        .alchm-dashboard { grid-template-columns: 1fr; }
+        .alchm-dashboard > .alchm-rail-left,
+        .alchm-dashboard > .alchm-rail-right { border: none; }
+        @media (min-width: 900px) {
+          .alchm-dashboard { grid-template-columns: 260px 1fr; }
+          .alchm-dashboard > .alchm-rail-left { border-right: 1px solid var(--line); }
+        }
+        @media (min-width: 1280px) {
+          .alchm-dashboard { grid-template-columns: 300px 1fr 340px; }
+          .alchm-dashboard > .alchm-rail-right { border-left: 1px solid var(--line); }
+        }
+        .alchm-hero { display: grid; grid-template-columns: 1fr; gap: 20px; align-items: center; }
+        @media (min-width: 1100px) { .alchm-hero { grid-template-columns: auto 1fr; gap: 28px; } }
+        .alchm-bottom { display: grid; grid-template-columns: 1fr; gap: 18px; }
+        @media (min-width: 1100px) { .alchm-bottom { grid-template-columns: 1.3fr 1fr; } }
+        .alchm-rail-right { display: none; }
+        @media (min-width: 1280px) { .alchm-rail-right { display: flex; } }
+      `}</style>
+
+      {/* LEFT RAIL */}
+      <aside
+        className="alchm-rail-left"
+        style={{
+          padding: "24px 22px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 22,
+          minHeight: 0,
+        }}
+      >
+        <div>
+          <div className="t-tag" style={{ marginBottom: 10 }}>
+            NATAL CHART
+          </div>
+          {currentUser ? (
+            <>
+              <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+                <div
+                  style={{
+                    width: 44,
+                    height: 44,
+                    borderRadius: "50%",
+                    border: "1px solid var(--line-hi)",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <span
+                    style={{ fontFamily: "JetBrains Mono", fontSize: 16, color: "var(--accent-2)" }}
+                  >
+                    ☉
+                  </span>
+                </div>
+                <div>
+                  <div className="t-display" style={{ fontSize: 18, color: "var(--fg)" }}>
+                    {sunSign ? `${sunSign} · Sun` : "Sun · —"}
+                  </div>
+                  <div className="t-mono" style={{ fontSize: 10, color: "var(--fg-mute)" }}>
+                    {birthDate ?? "natal data unset"}
+                  </div>
+                </div>
+              </div>
+            </>
+          ) : (
+            <div
+              className="t-mono"
+              style={{ fontSize: 11, color: "var(--fg-mute)", lineHeight: 1.5 }}
+            >
+              Sign in to load your natal chart from <code>/api/user/profile</code>.
+            </div>
+          )}
+        </div>
+
+        <div className="alchm-rule" />
+
+        <div>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "baseline",
+              marginBottom: 12,
+            }}
+          >
+            <span className="t-tag">ELEMENTAL BALANCE</span>
+            <span className="t-mono" style={{ fontSize: 9, color: "var(--accent)" }}>
+              NATAL ⊗ TRANSIT
+            </span>
+          </div>
+          {elemental ? (
+            <ElementalMeter values={elemental} />
+          ) : (
+            <AwaitingBackend
+              title="ELEMENTAL BALANCE"
+              endpoint="user.stats"
+              note="No AlchemicalProfile on the current user. Sign in to populate."
+            />
+          )}
+        </div>
+
+        <div className="alchm-rule" />
+
+        <div>
+          <div className="t-tag" style={{ marginBottom: 10 }}>
+            THERMODYNAMICS
+          </div>
+          {thermo ? (
+            <ThermoQuartet values={thermo} />
+          ) : (
+            <AwaitingBackend
+              title="THERMODYNAMICS"
+              endpoint="user.stats"
+              note="Spirit / Essence / Matter / Substance not yet populated."
+            />
+          )}
+        </div>
+
+        <div className="alchm-rule" />
+
+        <div>
+          <div className="t-tag" style={{ marginBottom: 10 }}>
+            DIETARY KEYS
+          </div>
+          {currentUser?.dietaryPreferences &&
+          Object.keys(currentUser.dietaryPreferences).length > 0 ? (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+              {Object.keys(currentUser.dietaryPreferences).map((k) => (
+                <span key={k} className="alchm-chip">
+                  {k}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <AwaitingBackend
+              title="DIETARY KEYS"
+              endpoint="user.dietaryPreferences"
+              note="No dietary preferences set on the current user record."
+            />
+          )}
+        </div>
+      </aside>
+
+      {/* CENTER — Clock + Recommendations */}
+      <main
+        style={{
+          padding: "24px 24px 40px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 24,
+          minHeight: 0,
+        }}
+      >
+        <div className="alchm-hero">
+          <div style={{ display: "flex", justifyContent: "center" }}>
+            <PlanetaryClock
+              size={280}
+              rotation={42}
+              motion
+              activeId={planetaryHour === "Sun" ? "Sol" : planetaryHour}
+              hourLabel={`HOUR · ${PLANET_GLYPHS[planetaryHour] ?? "☉"} ${planetaryHour.toUpperCase()}`}
+            />
+          </div>
+
+          <div>
+            <div className="t-tag" style={{ marginBottom: 8 }}>
+              CURRENT TRANSIT · {planetaryHour.toUpperCase()} HOUR
+            </div>
+            <h1
+              className="t-display"
+              style={{ fontSize: 38, lineHeight: 1.05, margin: "0 0 14px", color: "var(--fg)" }}
+            >
+              The sky is in a{" "}
+              <em style={{ color: "var(--accent)", fontStyle: "italic" }}>
+                {planetaryHour}
+              </em>
+              <br />
+              hour. Tune dinner to it.
+            </h1>
+            <p
+              style={{
+                color: "var(--fg-dim)",
+                fontSize: 14,
+                lineHeight: 1.55,
+                maxWidth: 540,
+                margin: "0 0 18px",
+              }}
+            >
+              Real-time positions are sourced from{" "}
+              <code style={{ fontSize: 12 }}>/api/astrologize</code>. The composed
+              recommendation copy and ranked ingredients are wired against the
+              backend contracts in{" "}
+              <code style={{ fontSize: 12 }}>src/lib/schemas/dashboard.ts</code>;
+              sections without live data are flagged below.
+            </p>
+            <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+              <button
+                type="button"
+                className="alchm-btn"
+                style={{
+                  background:
+                    "linear-gradient(180deg, color-mix(in oklch, var(--accent), transparent 60%), color-mix(in oklch, var(--accent), transparent 80%))",
+                  borderColor: "color-mix(in oklch, var(--accent), transparent 40%)",
+                }}
+              >
+                Compose Tonight&apos;s Menu <Glyph name="arrow" size={14} />
+              </button>
+              <button type="button" className="alchm-btn alchm-btn-ghost">
+                Open Lab
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="alchm-rule" />
+
+        {recommended === null ? (
+          <AwaitingBackend
+            title="RECOMMENDED INGREDIENTS"
+            endpoint="GET /api/recommendations/ingredients"
+            note="Hydrating top 8 ingredients ranked against the live sky…"
+          />
+        ) : recommended.length === 0 ? (
+          <AwaitingBackend
+            title="RECOMMENDED INGREDIENTS"
+            endpoint="GET /api/recommendations/ingredients"
+            note="No matches available right now — try again in a moment."
+          />
+        ) : (
+          <section>
+            <div
+              className="t-tag"
+              style={{ marginBottom: 12, color: "var(--accent-2)" }}
+            >
+              RECOMMENDED INGREDIENTS · TIER I
+            </div>
+            <div className="alchm-recs-grid">
+              <style>{`
+                .alchm-recs-grid {
+                  display: grid;
+                  gap: 14px;
+                  grid-template-columns: repeat(1, 1fr);
+                }
+                @media (min-width: 600px) { .alchm-recs-grid { grid-template-columns: repeat(2, 1fr); } }
+                @media (min-width: 1100px) { .alchm-recs-grid { grid-template-columns: repeat(4, 1fr); } }
+              `}</style>
+              {recommended.map((card) => (
+                <IngredientCard key={card.id} ing={card} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        <div className="alchm-bottom">
+          {cuisineData && cuisineData.rows.length > 0 ? (
+            <CuisineExplorerPanel
+              cuisines={cuisineData.rows}
+              totalEntries={cuisineData.total}
+            />
+          ) : (
+            <AwaitingBackend
+              title="CUISINE EXPLORER · TIER III"
+              endpoint="GET /api/cuisines/signatures"
+              note="Hydrating 4-element cuisine signatures against the live sky…"
+            />
+          )}
+          {sauceLineage ? (
+            <SauceLineagePanel
+              rootName={sauceLineage.rootLabel}
+              nodes={sauceLineage.nodes}
+              edges={sauceLineage.edges}
+              stats={sauceLineage.stats}
+              viewBoxWidth={SAUCE_VIEWBOX.width}
+              viewBoxHeight={SAUCE_VIEWBOX.height}
+            />
+          ) : (
+            <AwaitingBackend
+              title="SAUCE LINEAGE TREE"
+              endpoint="GET /api/sauces/lineage?root=bechamel"
+              note="Hydrating mother-sauce derivation graph…"
+            />
+          )}
+        </div>
+      </main>
+
+      {/* RIGHT RAIL */}
+      <aside
+        className="alchm-rail-right"
+        style={{
+          padding: "24px 22px",
+          flexDirection: "column",
+          gap: 22,
+          minHeight: 0,
+        }}
+      >
+        {astroRows.length > 0 ? (
+          <AstrologicalClockPanel rows={astroRows} live />
+        ) : (
+          <AwaitingBackend
+            title="ASTROLOGICAL CLOCK"
+            endpoint="AlchemicalContext.planetaryPositions"
+            note="Hydrating from /api/astrologize. Refresh if positions stay empty."
+          />
+        )}
+
+        <div className="alchm-rule" />
+
+        <AwaitingBackend
+          title="TONIGHT'S COMPOSITION"
+          endpoint="GET /api/composition/tonight"
+          note="Bundle of agent-composed recipe + procurement summary + /api/generate-image cached hero URL. Schema: TonightCompositionResponseSchema."
+        />
+
+        <div className="alchm-rule" />
+
+        {services.length > 0 ? (
+          <PipelinePanel services={services} />
+        ) : (
+          <AwaitingBackend
+            title="SERVICE TELEMETRY"
+            endpoint="GET /api/health"
+            note="Current /api/health returns status only. Extend the response per HealthResponseExtendedSchema to populate per-service latency."
+          />
+        )}
+      </aside>
+    </div>
+  );
+}

--- a/src/app/(alchm)/layout.tsx
+++ b/src/app/(alchm)/layout.tsx
@@ -17,7 +17,7 @@ export default function AlchmLayout({ children }: { children: ReactNode }) {
         body:has([data-alchm-route]) footer { display: none !important; }
         body:has([data-alchm-route]) { background: #07060B; }
       `}</style>
-      <LabHeader active="kitchen" />
+      <LabHeader />
       {children}
     </div>
   );

--- a/src/app/(alchm)/page.tsx
+++ b/src/app/(alchm)/page.tsx
@@ -1,141 +1,46 @@
 "use client";
 
+import Link from "next/link";
 import dynamic from "next/dynamic";
 import { useEffect, useState, type JSX } from "react";
+import { AmazonFreshPromotion } from "@/components/home/AmazonFreshPromotion";
 import {
-  AstrologicalClockPanel,
-  CuisineExplorerPanel,
-  ElementalMeter,
-  Glyph,
   IngredientCard,
-  PipelinePanel,
-  SauceLineagePanel,
-  ThermoQuartet,
-  type AstrologicalClockRow,
-  type CuisineSignatureRow,
-  type ElementalValues,
   type IngredientCardData,
-  type PipelineService,
-  type SauceLineageEdge,
-  type SauceLineageNode,
-  type ThermoValues,
 } from "@/components/ui/alchm";
 
-// PlanetaryClock geometry uses Math.sin/cos which can produce micro-different
-// floating-point values between server and client, tripping hydration warnings.
-// Render client-only.
-const PlanetaryClock = dynamic(
-  () => import("@/components/ui/alchm").then((m) => m.PlanetaryClock),
-  { ssr: false },
+const DynamicCuisineRecommender = dynamic(
+  () => import("@/components/home/DynamicCuisineRecommender"),
+  { loading: () => <SectionLoader label="Loading cuisine recommender…" /> },
 );
-import { useAlchemicalSafe } from "@/contexts/AlchemicalContext/hooks";
-import { useUser } from "@/contexts/UserContext";
 
-/* ─── Mapping helpers ─────────────────────────────────────────────────────── */
+const EnhancedCookingMethodRecommender = dynamic(
+  () =>
+    import("@/components/recommendations/EnhancedCookingMethodRecommender"),
+  { loading: () => <SectionLoader label="Loading cooking methods…" /> },
+);
 
-const PLANET_GLYPHS: Record<string, string> = {
-  Sun: "☉",
-  Moon: "☽",
-  Mercury: "☿",
-  Venus: "♀",
-  Mars: "♂",
-  Jupiter: "♃",
-  Saturn: "♄",
-};
-
-function buildAstroRows(
-  positions: Record<string, { sign?: string; degree?: number; minutes?: number; isRetrograde?: boolean } | undefined>,
-  hourRuler: string,
-): AstrologicalClockRow[] {
-  const order = ["Sun", "Moon", "Mercury", "Venus", "Mars", "Jupiter", "Saturn"];
-  return order.map((p) => {
-    const data = positions[p];
-    const sign = data?.sign ?? "—";
-    const deg = data?.degree != null ? String(data.degree).padStart(2, "0") : "00";
-    const min = data?.minutes != null ? String(data.minutes).padStart(2, "0") : "00";
-    const detail = data?.isRetrograde
-      ? "retrograde"
-      : p === hourRuler
-        ? "current hour"
-        : "—";
-    return {
-      planet: p,
-      sym: PLANET_GLYPHS[p] ?? "?",
-      position: data ? `${deg}°${min}′ ${sign}` : "—",
-      detail,
-      active: p === hourRuler,
-    };
-  });
-}
-
-/* ─── Awaiting-backend placeholder ───────────────────────────────────────── */
-
-function AwaitingBackend({
-  title,
-  endpoint,
-  note,
-}: {
-  title: string;
-  endpoint: string;
-  note?: string;
-}): JSX.Element {
+function SectionLoader({ label }: { label: string }): JSX.Element {
   return (
     <div
-      className="alchm-panel"
+      className="t-mono"
       style={{
-        padding: "20px 22px",
-        border: "1px dashed color-mix(in oklch, var(--accent), transparent 60%)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "48px 20px",
+        color: "var(--fg-mute)",
+        fontSize: 11,
+        letterSpacing: "0.16em",
+        textTransform: "uppercase",
       }}
     >
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "baseline",
-          gap: 16,
-          flexWrap: "wrap",
-        }}
-      >
-        <div className="t-tag" style={{ color: "var(--accent)" }}>
-          {title} · AWAITING BACKEND
-        </div>
-        <span
-          className="t-mono"
-          style={{
-            fontSize: 9,
-            color: "var(--fg-mute)",
-            letterSpacing: "0.14em",
-            wordBreak: "break-all",
-          }}
-        >
-          {endpoint}
-        </span>
-      </div>
-      {note && (
-        <div
-          style={{
-            marginTop: 10,
-            fontSize: 12,
-            color: "var(--fg-dim)",
-            lineHeight: 1.55,
-          }}
-        >
-          {note}
-        </div>
-      )}
+      {label}
     </div>
   );
 }
 
-/* ─── Service telemetry from /api/health ─────────────────────────────────── */
-
-interface HealthPayload {
-  status?: string;
-  services?: Record<string, string>;
-  timestamp?: string;
-}
-
-/* ─── Recommended ingredients hook ───────────────────────────────────────── */
+/* ─── Recommended ingredients (lite) ─────────────────────────────────────── */
 
 const PLANET_GLYPH_LOOKUP: Record<string, string> = {
   Sun: "☉",
@@ -195,531 +100,170 @@ function useRecommendedIngredients(limit = 8): IngredientCardData[] | null {
   return items;
 }
 
-/* ─── Cuisine signatures hook ─────────────────────────────────────────────── */
+/* ─── Section wrapper ─────────────────────────────────────────────────────── */
 
-interface CuisineSignaturePayload {
-  id: string;
-  name: string;
-  region: string;
-  match: number;
-  signature: [number, number, number, number];
-}
-
-interface CuisineSignaturesData {
-  total: number;
-  rows: CuisineSignatureRow[];
-}
-
-function useCuisineSignatures(): CuisineSignaturesData | null {
-  const [data, setData] = useState<CuisineSignaturesData | null>(null);
-  useEffect(() => {
-    let cancelled = false;
-    fetch("/api/cuisines/signatures", { cache: "no-store" })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((j) => {
-        if (cancelled || !j) return;
-        const list: CuisineSignaturePayload[] = Array.isArray(j.cuisines)
-          ? j.cuisines
-          : [];
-        setData({
-          total: typeof j.total === "number" ? j.total : list.length,
-          rows: list.slice(0, 8).map((c) => ({
-            id: c.id,
-            name: c.name,
-            region: c.region,
-            match: c.match,
-            sig: c.signature,
-          })),
-        });
-      })
-      .catch(() => {
-        if (!cancelled) setData(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-  return data;
-}
-
-/* ─── Sauce lineage hook ─────────────────────────────────────────────────── */
-
-interface SauceLineagePayload {
-  root: string;
-  nodes: Array<{ id: string; label: string; depth: number }>;
-  edges: Array<{ from: string; to: string }>;
-  stats: { depth: number; nodes: number; variants: number };
-}
-
-interface SauceLineageView {
-  rootLabel: string;
-  nodes: SauceLineageNode[];
-  edges: SauceLineageEdge[];
-  stats: Array<{ label: string; value: string | number }>;
-}
-
-const SAUCE_VIEWBOX = { width: 320, height: 200 };
-
-function layoutLineage(payload: SauceLineagePayload): SauceLineageView {
-  const { width, height } = SAUCE_VIEWBOX;
-  const rootNode = payload.nodes.find((n) => n.depth === 0) ?? payload.nodes[0];
-  const variants = payload.nodes.filter((n) => n.id !== rootNode?.id);
-  const cx = width / 2;
-  const rootY = 44;
-  const variantY = height - 50;
-
-  const positions = new Map<string, { x: number; y: number; r: number; label: string; color?: string }>();
-  if (rootNode) {
-    positions.set(rootNode.id, {
-      x: cx,
-      y: rootY,
-      r: 14,
-      label: rootNode.label,
-      color: "var(--accent-2)",
-    });
-  }
-  const spacing = variants.length > 1 ? (width - 60) / (variants.length - 1) : 0;
-  variants.forEach((node, i) => {
-    const x = variants.length === 1 ? cx : 30 + spacing * i;
-    positions.set(node.id, { x, y: variantY, r: 10, label: node.label });
-  });
-
-  const nodes: SauceLineageNode[] = Array.from(positions.values());
-  const edges: SauceLineageEdge[] = payload.edges
-    .map((e) => {
-      const from = positions.get(e.from);
-      const to = positions.get(e.to);
-      if (!from || !to) return null;
-      const mid = (from.y + to.y) / 2;
-      return { d: `M ${from.x} ${from.y} C ${from.x} ${mid}, ${to.x} ${mid}, ${to.x} ${to.y}` };
-    })
-    .filter((e): e is SauceLineageEdge => e !== null);
-
-  return {
-    rootLabel: rootNode?.label ?? payload.root,
-    nodes,
-    edges,
-    stats: [
-      { label: "Variants", value: payload.stats.variants },
-      { label: "Depth", value: payload.stats.depth },
-      { label: "Nodes", value: payload.stats.nodes },
-    ],
-  };
-}
-
-function useSauceLineage(root: string): SauceLineageView | null {
-  const [view, setView] = useState<SauceLineageView | null>(null);
-  useEffect(() => {
-    let cancelled = false;
-    fetch(`/api/sauces/lineage?root=${encodeURIComponent(root)}`, { cache: "no-store" })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((j: SauceLineagePayload | null) => {
-        if (cancelled || !j) return;
-        setView(layoutLineage(j));
-      })
-      .catch(() => {
-        if (!cancelled) setView(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [root]);
-  return view;
-}
-
-function useHealthTelemetry(): PipelineService[] {
-  const [data, setData] = useState<HealthPayload | null>(null);
-  useEffect(() => {
-    let cancelled = false;
-    fetch("/api/health", { cache: "no-store" })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((j) => {
-        if (!cancelled) setData(j);
-      })
-      .catch(() => {
-        if (!cancelled) setData(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-  if (!data) return [];
-  const svcMap = data.services ?? {};
-  return Object.entries(svcMap).map(([name, status]) => ({
-    name,
-    latency: "—",
-    up: status === "healthy",
-    agent: name === "external_apis",
-  }));
+function HomeSection({
+  tag,
+  title,
+  children,
+  cta,
+}: {
+  tag: string;
+  title: string;
+  children: React.ReactNode;
+  cta?: { label: string; href: string };
+}): JSX.Element {
+  return (
+    <section
+      className="alchm-panel"
+      style={{
+        padding: "20px 22px",
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+          gap: 16,
+          flexWrap: "wrap",
+          marginBottom: 16,
+        }}
+      >
+        <div>
+          <div
+            className="t-tag"
+            style={{ color: "var(--accent-2)", marginBottom: 4 }}
+          >
+            {tag}
+          </div>
+          <h2
+            className="t-display"
+            style={{ fontSize: 22, margin: 0, color: "var(--fg)" }}
+          >
+            {title}
+          </h2>
+        </div>
+        {cta && (
+          <Link
+            href={cta.href}
+            className="t-mono"
+            style={{
+              fontSize: 10,
+              letterSpacing: "0.14em",
+              textTransform: "uppercase",
+              color: "var(--accent)",
+              textDecoration: "none",
+              border: "1px solid color-mix(in oklch, var(--accent), transparent 60%)",
+              borderRadius: 6,
+              padding: "6px 12px",
+            }}
+          >
+            {cta.label} →
+          </Link>
+        )}
+      </header>
+      {children}
+    </section>
+  );
 }
 
 /* ─── Page ────────────────────────────────────────────────────────────────── */
 
-export default function LaboratoryDashboardPage(): JSX.Element {
-  const { currentUser } = useUser();
-  const alch = useAlchemicalSafe();
-  const services = useHealthTelemetry();
+export default function AlchmKitchenHome(): JSX.Element {
   const recommended = useRecommendedIngredients(8);
-  const cuisineData = useCuisineSignatures();
-  const sauceLineage = useSauceLineage("bechamel");
-
-  const stats = currentUser?.stats;
-  const elemental: ElementalValues | null = stats
-    ? { fire: stats.fire, water: stats.water, earth: stats.earth, air: stats.air }
-    : null;
-  const thermo: ThermoValues | null = stats
-    ? {
-        spirit: stats.spirit,
-        essence: stats.essence,
-        matter: stats.matter,
-        substance: stats.substance,
-      }
-    : null;
-
-  const planetaryHour = alch?.planetaryHour ?? "Sun";
-  const astroRows = alch
-    ? buildAstroRows(alch.planetaryPositions ?? {}, planetaryHour)
-    : [];
-
-  const sunSign =
-    currentUser?.natalChart?.planets?.find((p) => p.name === "Sun")?.sign ?? null;
-  const birthDate = currentUser?.birthData?.dateTime?.split("T")[0] ?? null;
 
   return (
-    <div
+    <main
       style={{
-        display: "grid",
-        gap: 0,
-        minHeight: "calc(100vh - 70px)",
+        maxWidth: 1100,
+        margin: "0 auto",
+        padding: "20px 16px 48px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 22,
       }}
-      className="alchm-dashboard"
     >
       <style>{`
-        .alchm-dashboard { grid-template-columns: 1fr; }
-        .alchm-dashboard > .alchm-rail-left,
-        .alchm-dashboard > .alchm-rail-right { border: none; }
-        @media (min-width: 900px) {
-          .alchm-dashboard { grid-template-columns: 260px 1fr; }
-          .alchm-dashboard > .alchm-rail-left { border-right: 1px solid var(--line); }
+        .alchm-recs-grid {
+          display: grid;
+          gap: 14px;
+          grid-template-columns: repeat(1, 1fr);
         }
-        @media (min-width: 1280px) {
-          .alchm-dashboard { grid-template-columns: 300px 1fr 340px; }
-          .alchm-dashboard > .alchm-rail-right { border-left: 1px solid var(--line); }
-        }
-        .alchm-hero { display: grid; grid-template-columns: 1fr; gap: 20px; align-items: center; }
-        @media (min-width: 1100px) { .alchm-hero { grid-template-columns: auto 1fr; gap: 28px; } }
-        .alchm-bottom { display: grid; grid-template-columns: 1fr; gap: 18px; }
-        @media (min-width: 1100px) { .alchm-bottom { grid-template-columns: 1.3fr 1fr; } }
-        .alchm-rail-right { display: none; }
-        @media (min-width: 1280px) { .alchm-rail-right { display: flex; } }
+        @media (min-width: 600px) { .alchm-recs-grid { grid-template-columns: repeat(2, 1fr); } }
+        @media (min-width: 1000px) { .alchm-recs-grid { grid-template-columns: repeat(4, 1fr); } }
+        .alchm-home-cookmethods :is(h1, h2, h3, h4) { color: var(--fg); }
       `}</style>
 
-      {/* LEFT RAIL */}
-      <aside
-        className="alchm-rail-left"
-        style={{
-          padding: "24px 22px",
-          display: "flex",
-          flexDirection: "column",
-          gap: 22,
-          minHeight: 0,
-        }}
+      {/* 1 · PROMO — Cosmic Token Economy */}
+      <AmazonFreshPromotion />
+
+      {/* 2 · CUISINE + SAUCE RECOMMENDER */}
+      <HomeSection
+        tag="TIER III · CUISINE & SAUCE"
+        title="Tonight's cuisine, tuned to the sky"
+        cta={{ label: "All cuisines", href: "/cuisines" }}
       >
-        <div>
-          <div className="t-tag" style={{ marginBottom: 10 }}>
-            NATAL CHART
-          </div>
-          {currentUser ? (
-            <>
-              <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-                <div
-                  style={{
-                    width: 44,
-                    height: 44,
-                    borderRadius: "50%",
-                    border: "1px solid var(--line-hi)",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
-                >
-                  <span
-                    style={{ fontFamily: "JetBrains Mono", fontSize: 16, color: "var(--accent-2)" }}
-                  >
-                    ☉
-                  </span>
-                </div>
-                <div>
-                  <div className="t-display" style={{ fontSize: 18, color: "var(--fg)" }}>
-                    {sunSign ? `${sunSign} · Sun` : "Sun · —"}
-                  </div>
-                  <div className="t-mono" style={{ fontSize: 10, color: "var(--fg-mute)" }}>
-                    {birthDate ?? "natal data unset"}
-                  </div>
-                </div>
-              </div>
-            </>
-          ) : (
-            <div
-              className="t-mono"
-              style={{ fontSize: 11, color: "var(--fg-mute)", lineHeight: 1.5 }}
-            >
-              Sign in to load your natal chart from <code>/api/user/profile</code>.
-            </div>
-          )}
-        </div>
+        <DynamicCuisineRecommender />
+      </HomeSection>
 
-        <div className="alchm-rule" />
-
-        <div>
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "baseline",
-              marginBottom: 12,
-            }}
-          >
-            <span className="t-tag">ELEMENTAL BALANCE</span>
-            <span className="t-mono" style={{ fontSize: 9, color: "var(--accent)" }}>
-              NATAL ⊗ TRANSIT
-            </span>
-          </div>
-          {elemental ? (
-            <ElementalMeter values={elemental} />
-          ) : (
-            <AwaitingBackend
-              title="ELEMENTAL BALANCE"
-              endpoint="user.stats"
-              note="No AlchemicalProfile on the current user. Sign in to populate."
-            />
-          )}
-        </div>
-
-        <div className="alchm-rule" />
-
-        <div>
-          <div className="t-tag" style={{ marginBottom: 10 }}>
-            THERMODYNAMICS
-          </div>
-          {thermo ? (
-            <ThermoQuartet values={thermo} />
-          ) : (
-            <AwaitingBackend
-              title="THERMODYNAMICS"
-              endpoint="user.stats"
-              note="Spirit / Essence / Matter / Substance not yet populated."
-            />
-          )}
-        </div>
-
-        <div className="alchm-rule" />
-
-        <div>
-          <div className="t-tag" style={{ marginBottom: 10 }}>
-            DIETARY KEYS
-          </div>
-          {currentUser?.dietaryPreferences &&
-          Object.keys(currentUser.dietaryPreferences).length > 0 ? (
-            <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-              {Object.keys(currentUser.dietaryPreferences).map((k) => (
-                <span key={k} className="alchm-chip">
-                  {k}
-                </span>
-              ))}
-            </div>
-          ) : (
-            <AwaitingBackend
-              title="DIETARY KEYS"
-              endpoint="user.dietaryPreferences"
-              note="No dietary preferences set on the current user record."
-            />
-          )}
-        </div>
-      </aside>
-
-      {/* CENTER — Clock + Recommendations */}
-      <main
-        style={{
-          padding: "24px 24px 40px",
-          display: "flex",
-          flexDirection: "column",
-          gap: 24,
-          minHeight: 0,
-        }}
+      {/* 3 · INGREDIENT RECOMMENDER (lite) */}
+      <HomeSection
+        tag="TIER I · INGREDIENTS"
+        title="Eight ingredients ranked against the live sky"
+        cta={{ label: "Full recommender", href: "/ingredients" }}
       >
-        <div className="alchm-hero">
-          <div style={{ display: "flex", justifyContent: "center" }}>
-            <PlanetaryClock
-              size={280}
-              rotation={42}
-              motion
-              activeId={planetaryHour === "Sun" ? "Sol" : planetaryHour}
-              hourLabel={`HOUR · ${PLANET_GLYPHS[planetaryHour] ?? "☉"} ${planetaryHour.toUpperCase()}`}
-            />
-          </div>
-
-          <div>
-            <div className="t-tag" style={{ marginBottom: 8 }}>
-              CURRENT TRANSIT · {planetaryHour.toUpperCase()} HOUR
-            </div>
-            <h1
-              className="t-display"
-              style={{ fontSize: 38, lineHeight: 1.05, margin: "0 0 14px", color: "var(--fg)" }}
-            >
-              The sky is in a{" "}
-              <em style={{ color: "var(--accent)", fontStyle: "italic" }}>
-                {planetaryHour}
-              </em>
-              <br />
-              hour. Tune dinner to it.
-            </h1>
-            <p
-              style={{
-                color: "var(--fg-dim)",
-                fontSize: 14,
-                lineHeight: 1.55,
-                maxWidth: 540,
-                margin: "0 0 18px",
-              }}
-            >
-              Real-time positions are sourced from{" "}
-              <code style={{ fontSize: 12 }}>/api/astrologize</code>. The composed
-              recommendation copy and ranked ingredients are wired against the
-              backend contracts in{" "}
-              <code style={{ fontSize: 12 }}>src/lib/schemas/dashboard.ts</code>;
-              sections without live data are flagged below.
-            </p>
-            <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
-              <button
-                type="button"
-                className="alchm-btn"
-                style={{
-                  background:
-                    "linear-gradient(180deg, color-mix(in oklch, var(--accent), transparent 60%), color-mix(in oklch, var(--accent), transparent 80%))",
-                  borderColor: "color-mix(in oklch, var(--accent), transparent 40%)",
-                }}
-              >
-                Compose Tonight&apos;s Menu <Glyph name="arrow" size={14} />
-              </button>
-              <button type="button" className="alchm-btn alchm-btn-ghost">
-                Open Lab
-              </button>
-            </div>
-          </div>
-        </div>
-
-        <div className="alchm-rule" />
-
         {recommended === null ? (
-          <AwaitingBackend
-            title="RECOMMENDED INGREDIENTS"
-            endpoint="GET /api/recommendations/ingredients"
-            note="Hydrating top 8 ingredients ranked against the live sky…"
-          />
+          <SectionLoader label="Hydrating top 8 ingredients…" />
         ) : recommended.length === 0 ? (
-          <AwaitingBackend
-            title="RECOMMENDED INGREDIENTS"
-            endpoint="GET /api/recommendations/ingredients"
-            note="No matches available right now — try again in a moment."
-          />
+          <SectionLoader label="No matches available right now" />
         ) : (
-          <section>
-            <div
-              className="t-tag"
-              style={{ marginBottom: 12, color: "var(--accent-2)" }}
-            >
-              RECOMMENDED INGREDIENTS · TIER I
-            </div>
-            <div className="alchm-recs-grid">
-              <style>{`
-                .alchm-recs-grid {
-                  display: grid;
-                  gap: 14px;
-                  grid-template-columns: repeat(1, 1fr);
-                }
-                @media (min-width: 600px) { .alchm-recs-grid { grid-template-columns: repeat(2, 1fr); } }
-                @media (min-width: 1100px) { .alchm-recs-grid { grid-template-columns: repeat(4, 1fr); } }
-              `}</style>
-              {recommended.map((card) => (
-                <IngredientCard key={card.id} ing={card} />
-              ))}
-            </div>
-          </section>
+          <div className="alchm-recs-grid">
+            {recommended.map((card) => (
+              <IngredientCard key={card.id} ing={card} />
+            ))}
+          </div>
         )}
+      </HomeSection>
 
-        <div className="alchm-bottom">
-          {cuisineData && cuisineData.rows.length > 0 ? (
-            <CuisineExplorerPanel
-              cuisines={cuisineData.rows}
-              totalEntries={cuisineData.total}
-            />
-          ) : (
-            <AwaitingBackend
-              title="CUISINE EXPLORER · TIER III"
-              endpoint="GET /api/cuisines/signatures"
-              note="Hydrating 4-element cuisine signatures against the live sky…"
-            />
-          )}
-          {sauceLineage ? (
-            <SauceLineagePanel
-              rootName={sauceLineage.rootLabel}
-              nodes={sauceLineage.nodes}
-              edges={sauceLineage.edges}
-              stats={sauceLineage.stats}
-              viewBoxWidth={SAUCE_VIEWBOX.width}
-              viewBoxHeight={SAUCE_VIEWBOX.height}
-            />
-          ) : (
-            <AwaitingBackend
-              title="SAUCE LINEAGE TREE"
-              endpoint="GET /api/sauces/lineage?root=bechamel"
-              note="Hydrating mother-sauce derivation graph…"
-            />
-          )}
+      {/* 4 · COOKING METHODS RECOMMENDER */}
+      <HomeSection
+        tag="TIER II · COOKING METHODS"
+        title="Methods aligned with the current transit"
+        cta={{ label: "Methods library", href: "/cooking-methods" }}
+      >
+        <div className="alchm-home-cookmethods">
+          <EnhancedCookingMethodRecommender />
         </div>
-      </main>
+      </HomeSection>
 
-      {/* RIGHT RAIL */}
-      <aside
-        className="alchm-rail-right"
+      {/* Footer hint to the Lab */}
+      <div
         style={{
-          padding: "24px 22px",
-          flexDirection: "column",
-          gap: 22,
-          minHeight: 0,
+          display: "flex",
+          justifyContent: "center",
+          padding: "20px 0",
         }}
       >
-        {astroRows.length > 0 ? (
-          <AstrologicalClockPanel rows={astroRows} live />
-        ) : (
-          <AwaitingBackend
-            title="ASTROLOGICAL CLOCK"
-            endpoint="AlchemicalContext.planetaryPositions"
-            note="Hydrating from /api/astrologize. Refresh if positions stay empty."
-          />
-        )}
-
-        <div className="alchm-rule" />
-
-        <AwaitingBackend
-          title="TONIGHT'S COMPOSITION"
-          endpoint="GET /api/composition/tonight"
-          note="Bundle of agent-composed recipe + procurement summary + /api/generate-image cached hero URL. Schema: TonightCompositionResponseSchema."
-        />
-
-        <div className="alchm-rule" />
-
-        {services.length > 0 ? (
-          <PipelinePanel services={services} />
-        ) : (
-          <AwaitingBackend
-            title="SERVICE TELEMETRY"
-            endpoint="GET /api/health"
-            note="Current /api/health returns status only. Extend the response per HealthResponseExtendedSchema to populate per-service latency."
-          />
-        )}
-      </aside>
-    </div>
+        <Link
+          href="/lab"
+          className="t-mono"
+          style={{
+            fontSize: 10,
+            letterSpacing: "0.18em",
+            textTransform: "uppercase",
+            color: "var(--fg-mute)",
+            textDecoration: "none",
+            padding: "8px 16px",
+            border: "1px dashed color-mix(in oklch, var(--accent), transparent 60%)",
+            borderRadius: 999,
+          }}
+        >
+          Open the Laboratory →
+        </Link>
+      </div>
+    </main>
   );
 }

--- a/src/app/(alchm)/page.tsx
+++ b/src/app/(alchm)/page.tsx
@@ -1,17 +1,24 @@
 "use client";
 
-import Link from "next/link";
 import dynamic from "next/dynamic";
-import { useEffect, useState, type JSX } from "react";
+import Link from "next/link";
+import type { JSX } from "react";
+import { AgentsFeedThread } from "@/components/home/AgentsFeedThread";
 import { AmazonFreshPromotion } from "@/components/home/AmazonFreshPromotion";
-import {
-  IngredientCard,
-  type IngredientCardData,
-} from "@/components/ui/alchm";
 
 const DynamicCuisineRecommender = dynamic(
   () => import("@/components/home/DynamicCuisineRecommender"),
   { loading: () => <SectionLoader label="Loading cuisine recommender…" /> },
+);
+
+const EnhancedSauceRecommender = dynamic(
+  () => import("@/components/recommendations/EnhancedSauceRecommender"),
+  { loading: () => <SectionLoader label="Loading sauce recommender…" /> },
+);
+
+const EnhancedIngredientRecommender = dynamic(
+  () => import("@/components/recommendations/EnhancedIngredientRecommender"),
+  { loading: () => <SectionLoader label="Loading ingredient recommender…" /> },
 );
 
 const EnhancedCookingMethodRecommender = dynamic(
@@ -38,66 +45,6 @@ function SectionLoader({ label }: { label: string }): JSX.Element {
       {label}
     </div>
   );
-}
-
-/* ─── Recommended ingredients (lite) ─────────────────────────────────────── */
-
-const PLANET_GLYPH_LOOKUP: Record<string, string> = {
-  Sun: "☉",
-  Moon: "☽",
-  Mercury: "☿",
-  Venus: "♀",
-  Mars: "♂",
-  Jupiter: "♃",
-  Saturn: "♄",
-  Uranus: "♅",
-  Neptune: "♆",
-  Pluto: "♇",
-};
-
-interface RecommendedIngredientPayload {
-  id: string;
-  name: string;
-  category: string;
-  elemental_affinity: "fire" | "water" | "earth" | "air";
-  planet: string;
-  hue: number;
-  match_score: number;
-  thermo: { spirit: number; essence: number; matter: number; substance: number };
-}
-
-function useRecommendedIngredients(limit = 8): IngredientCardData[] | null {
-  const [items, setItems] = useState<IngredientCardData[] | null>(null);
-  useEffect(() => {
-    let cancelled = false;
-    fetch(`/api/recommendations/ingredients?limit=${limit}`, { cache: "no-store" })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((j) => {
-        if (cancelled || !j) return;
-        const list: RecommendedIngredientPayload[] = Array.isArray(j.ingredients)
-          ? j.ingredients
-          : [];
-        setItems(
-          list.map((it) => ({
-            id: it.id,
-            name: it.name,
-            category: (it.category ?? "other").toUpperCase(),
-            element: it.elemental_affinity,
-            match: it.match_score,
-            properties: it.thermo,
-            planet: PLANET_GLYPH_LOOKUP[it.planet] ?? "☉",
-            hue: it.hue,
-          })),
-        );
-      })
-      .catch(() => {
-        if (!cancelled) setItems([]);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [limit]);
-  return items;
 }
 
 /* ─── Section wrapper ─────────────────────────────────────────────────────── */
@@ -173,97 +120,117 @@ function HomeSection({
 /* ─── Page ────────────────────────────────────────────────────────────────── */
 
 export default function AlchmKitchenHome(): JSX.Element {
-  const recommended = useRecommendedIngredients(8);
-
   return (
-    <main
-      style={{
-        maxWidth: 1100,
-        margin: "0 auto",
-        padding: "20px 16px 48px",
-        display: "flex",
-        flexDirection: "column",
-        gap: 22,
-      }}
-    >
-      <style>{`
-        .alchm-recs-grid {
-          display: grid;
-          gap: 14px;
-          grid-template-columns: repeat(1, 1fr);
-        }
-        @media (min-width: 600px) { .alchm-recs-grid { grid-template-columns: repeat(2, 1fr); } }
-        @media (min-width: 1000px) { .alchm-recs-grid { grid-template-columns: repeat(4, 1fr); } }
-        .alchm-home-cookmethods :is(h1, h2, h3, h4) { color: var(--fg); }
-      `}</style>
-
-      {/* 1 · PROMO — Cosmic Token Economy */}
-      <AmazonFreshPromotion />
-
-      {/* 2 · CUISINE + SAUCE RECOMMENDER */}
-      <HomeSection
-        tag="TIER III · CUISINE & SAUCE"
-        title="Tonight's cuisine, tuned to the sky"
-        cta={{ label: "All cuisines", href: "/cuisines" }}
-      >
-        <DynamicCuisineRecommender />
-      </HomeSection>
-
-      {/* 3 · INGREDIENT RECOMMENDER (lite) */}
-      <HomeSection
-        tag="TIER I · INGREDIENTS"
-        title="Eight ingredients ranked against the live sky"
-        cta={{ label: "Full recommender", href: "/ingredients" }}
-      >
-        {recommended === null ? (
-          <SectionLoader label="Hydrating top 8 ingredients…" />
-        ) : recommended.length === 0 ? (
-          <SectionLoader label="No matches available right now" />
-        ) : (
-          <div className="alchm-recs-grid">
-            {recommended.map((card) => (
-              <IngredientCard key={card.id} ing={card} />
-            ))}
-          </div>
-        )}
-      </HomeSection>
-
-      {/* 4 · COOKING METHODS RECOMMENDER */}
-      <HomeSection
-        tag="TIER II · COOKING METHODS"
-        title="Methods aligned with the current transit"
-        cta={{ label: "Methods library", href: "/cooking-methods" }}
-      >
-        <div className="alchm-home-cookmethods">
-          <EnhancedCookingMethodRecommender />
-        </div>
-      </HomeSection>
-
-      {/* Footer hint to the Lab */}
-      <div
+    <>
+      <main
         style={{
+          maxWidth: 1100,
+          margin: "0 auto",
+          padding: "20px 16px 48px",
           display: "flex",
-          justifyContent: "center",
-          padding: "20px 0",
+          flexDirection: "column",
+          gap: 22,
         }}
       >
-        <Link
-          href="/lab"
-          className="t-mono"
+        <style>{`
+          .alchm-home-cookmethods :is(h1, h2, h3, h4) { color: var(--fg); }
+          .alchm-ingredient-scroll {
+            max-height: 70vh;
+            overflow-y: auto;
+            margin: 0 -22px -20px;
+            padding: 0 22px 20px;
+            scrollbar-width: thin;
+            scrollbar-color: color-mix(in oklch, var(--accent), transparent 70%) transparent;
+          }
+        `}</style>
+
+        {/* 1 · PROMO — Cosmic Token Economy */}
+        <AmazonFreshPromotion />
+
+        {/* 2 · CUISINE RECOMMENDER */}
+        <HomeSection
+          tag="TIER III · CUISINE"
+          title="Tonight's cuisine, tuned to the sky"
+          cta={{ label: "All cuisines", href: "/cuisines" }}
+        >
+          <DynamicCuisineRecommender />
+        </HomeSection>
+
+        {/* 3 · SAUCE RECOMMENDER */}
+        <HomeSection
+          tag="TIER III · SAUCE"
+          title="Sauces in phase with the current hour"
+          cta={{ label: "Sauce library", href: "/sauces" }}
+        >
+          <EnhancedSauceRecommender />
+        </HomeSection>
+
+        {/* 4 · INGREDIENT RECOMMENDER (lite — full component, 70vh scroll) */}
+        <HomeSection
+          tag="TIER I · INGREDIENTS"
+          title="Ingredients aligned with the live sky"
+          cta={{ label: "Open my pantry", href: "/pantry" }}
+        >
+          <p
+            style={{
+              fontSize: 12,
+              color: "var(--fg-dim)",
+              margin: "0 0 12px",
+              lineHeight: 1.5,
+            }}
+          >
+            Tap{" "}
+            <span
+              className="alchm-chip"
+              style={{ fontSize: 10, padding: "2px 8px" }}
+            >
+              Pantry
+            </span>{" "}
+            on any card to track it in your kitchen.
+          </p>
+          <div className="alchm-ingredient-scroll">
+            <EnhancedIngredientRecommender />
+          </div>
+        </HomeSection>
+
+        {/* 5 · COOKING METHODS RECOMMENDER */}
+        <HomeSection
+          tag="TIER II · COOKING METHODS"
+          title="Methods aligned with the current transit"
+          cta={{ label: "Methods library", href: "/cooking-methods" }}
+        >
+          <div className="alchm-home-cookmethods">
+            <EnhancedCookingMethodRecommender />
+          </div>
+        </HomeSection>
+
+        {/* Footer hint to the Lab */}
+        <div
           style={{
-            fontSize: 10,
-            letterSpacing: "0.18em",
-            textTransform: "uppercase",
-            color: "var(--fg-mute)",
-            textDecoration: "none",
-            padding: "8px 16px",
-            border: "1px dashed color-mix(in oklch, var(--accent), transparent 60%)",
-            borderRadius: 999,
+            display: "flex",
+            justifyContent: "center",
+            padding: "20px 0",
           }}
         >
-          Open the Laboratory →
-        </Link>
-      </div>
-    </main>
+          <Link
+            href="/lab"
+            className="t-mono"
+            style={{
+              fontSize: 10,
+              letterSpacing: "0.18em",
+              textTransform: "uppercase",
+              color: "var(--fg-mute)",
+              textDecoration: "none",
+              padding: "8px 16px",
+              border: "1px dashed color-mix(in oklch, var(--accent), transparent 60%)",
+              borderRadius: 999,
+            }}
+          >
+            Open the Laboratory →
+          </Link>
+        </div>
+      </main>
+      <AgentsFeedThread />
+    </>
   );
 }

--- a/src/app/(alchm)/page.tsx
+++ b/src/app/(alchm)/page.tsx
@@ -4,13 +4,20 @@ import dynamic from "next/dynamic";
 import { useEffect, useState, type JSX } from "react";
 import {
   AstrologicalClockPanel,
+  CuisineExplorerPanel,
   ElementalMeter,
   Glyph,
+  IngredientCard,
   PipelinePanel,
+  SauceLineagePanel,
   ThermoQuartet,
   type AstrologicalClockRow,
+  type CuisineSignatureRow,
   type ElementalValues,
+  type IngredientCardData,
   type PipelineService,
+  type SauceLineageEdge,
+  type SauceLineageNode,
   type ThermoValues,
 } from "@/components/ui/alchm";
 
@@ -128,6 +135,198 @@ interface HealthPayload {
   timestamp?: string;
 }
 
+/* ─── Recommended ingredients hook ───────────────────────────────────────── */
+
+const PLANET_GLYPH_LOOKUP: Record<string, string> = {
+  Sun: "☉",
+  Moon: "☽",
+  Mercury: "☿",
+  Venus: "♀",
+  Mars: "♂",
+  Jupiter: "♃",
+  Saturn: "♄",
+  Uranus: "♅",
+  Neptune: "♆",
+  Pluto: "♇",
+};
+
+interface RecommendedIngredientPayload {
+  id: string;
+  name: string;
+  category: string;
+  elemental_affinity: "fire" | "water" | "earth" | "air";
+  planet: string;
+  hue: number;
+  match_score: number;
+  thermo: { spirit: number; essence: number; matter: number; substance: number };
+}
+
+function useRecommendedIngredients(limit = 8): IngredientCardData[] | null {
+  const [items, setItems] = useState<IngredientCardData[] | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/recommendations/ingredients?limit=${limit}`, { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j) => {
+        if (cancelled || !j) return;
+        const list: RecommendedIngredientPayload[] = Array.isArray(j.ingredients)
+          ? j.ingredients
+          : [];
+        setItems(
+          list.map((it) => ({
+            id: it.id,
+            name: it.name,
+            category: (it.category ?? "other").toUpperCase(),
+            element: it.elemental_affinity,
+            match: it.match_score,
+            properties: it.thermo,
+            planet: PLANET_GLYPH_LOOKUP[it.planet] ?? "☉",
+            hue: it.hue,
+          })),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setItems([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [limit]);
+  return items;
+}
+
+/* ─── Cuisine signatures hook ─────────────────────────────────────────────── */
+
+interface CuisineSignaturePayload {
+  id: string;
+  name: string;
+  region: string;
+  match: number;
+  signature: [number, number, number, number];
+}
+
+interface CuisineSignaturesData {
+  total: number;
+  rows: CuisineSignatureRow[];
+}
+
+function useCuisineSignatures(): CuisineSignaturesData | null {
+  const [data, setData] = useState<CuisineSignaturesData | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/cuisines/signatures", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j) => {
+        if (cancelled || !j) return;
+        const list: CuisineSignaturePayload[] = Array.isArray(j.cuisines)
+          ? j.cuisines
+          : [];
+        setData({
+          total: typeof j.total === "number" ? j.total : list.length,
+          rows: list.slice(0, 8).map((c) => ({
+            id: c.id,
+            name: c.name,
+            region: c.region,
+            match: c.match,
+            sig: c.signature,
+          })),
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setData(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return data;
+}
+
+/* ─── Sauce lineage hook ─────────────────────────────────────────────────── */
+
+interface SauceLineagePayload {
+  root: string;
+  nodes: Array<{ id: string; label: string; depth: number }>;
+  edges: Array<{ from: string; to: string }>;
+  stats: { depth: number; nodes: number; variants: number };
+}
+
+interface SauceLineageView {
+  rootLabel: string;
+  nodes: SauceLineageNode[];
+  edges: SauceLineageEdge[];
+  stats: Array<{ label: string; value: string | number }>;
+}
+
+const SAUCE_VIEWBOX = { width: 320, height: 200 };
+
+function layoutLineage(payload: SauceLineagePayload): SauceLineageView {
+  const { width, height } = SAUCE_VIEWBOX;
+  const rootNode = payload.nodes.find((n) => n.depth === 0) ?? payload.nodes[0];
+  const variants = payload.nodes.filter((n) => n.id !== rootNode?.id);
+  const cx = width / 2;
+  const rootY = 44;
+  const variantY = height - 50;
+
+  const positions = new Map<string, { x: number; y: number; r: number; label: string; color?: string }>();
+  if (rootNode) {
+    positions.set(rootNode.id, {
+      x: cx,
+      y: rootY,
+      r: 14,
+      label: rootNode.label,
+      color: "var(--accent-2)",
+    });
+  }
+  const spacing = variants.length > 1 ? (width - 60) / (variants.length - 1) : 0;
+  variants.forEach((node, i) => {
+    const x = variants.length === 1 ? cx : 30 + spacing * i;
+    positions.set(node.id, { x, y: variantY, r: 10, label: node.label });
+  });
+
+  const nodes: SauceLineageNode[] = Array.from(positions.values());
+  const edges: SauceLineageEdge[] = payload.edges
+    .map((e) => {
+      const from = positions.get(e.from);
+      const to = positions.get(e.to);
+      if (!from || !to) return null;
+      const mid = (from.y + to.y) / 2;
+      return { d: `M ${from.x} ${from.y} C ${from.x} ${mid}, ${to.x} ${mid}, ${to.x} ${to.y}` };
+    })
+    .filter((e): e is SauceLineageEdge => e !== null);
+
+  return {
+    rootLabel: rootNode?.label ?? payload.root,
+    nodes,
+    edges,
+    stats: [
+      { label: "Variants", value: payload.stats.variants },
+      { label: "Depth", value: payload.stats.depth },
+      { label: "Nodes", value: payload.stats.nodes },
+    ],
+  };
+}
+
+function useSauceLineage(root: string): SauceLineageView | null {
+  const [view, setView] = useState<SauceLineageView | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/sauces/lineage?root=${encodeURIComponent(root)}`, { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j: SauceLineagePayload | null) => {
+        if (cancelled || !j) return;
+        setView(layoutLineage(j));
+      })
+      .catch(() => {
+        if (!cancelled) setView(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [root]);
+  return view;
+}
+
 function useHealthTelemetry(): PipelineService[] {
   const [data, setData] = useState<HealthPayload | null>(null);
   useEffect(() => {
@@ -160,6 +359,9 @@ export default function LaboratoryDashboardPage(): JSX.Element {
   const { currentUser } = useUser();
   const alch = useAlchemicalSafe();
   const services = useHealthTelemetry();
+  const recommended = useRecommendedIngredients(8);
+  const cuisineData = useCuisineSignatures();
+  const sauceLineage = useSauceLineage("bechamel");
 
   const stats = currentUser?.stats;
   const elemental: ElementalValues | null = stats
@@ -409,23 +611,72 @@ export default function LaboratoryDashboardPage(): JSX.Element {
 
         <div className="alchm-rule" />
 
-        <AwaitingBackend
-          title="RECOMMENDED INGREDIENTS"
-          endpoint="GET /api/recommendations/ingredients"
-          note="Returns the top 8 ingredients ranked by match_score(transit_position, user.natal). Schema: RecommendedIngredientsResponseSchema. RecommendationBridge.ts can compute this today; needs to be exposed as a route."
-        />
+        {recommended === null ? (
+          <AwaitingBackend
+            title="RECOMMENDED INGREDIENTS"
+            endpoint="GET /api/recommendations/ingredients"
+            note="Hydrating top 8 ingredients ranked against the live sky…"
+          />
+        ) : recommended.length === 0 ? (
+          <AwaitingBackend
+            title="RECOMMENDED INGREDIENTS"
+            endpoint="GET /api/recommendations/ingredients"
+            note="No matches available right now — try again in a moment."
+          />
+        ) : (
+          <section>
+            <div
+              className="t-tag"
+              style={{ marginBottom: 12, color: "var(--accent-2)" }}
+            >
+              RECOMMENDED INGREDIENTS · TIER I
+            </div>
+            <div className="alchm-recs-grid">
+              <style>{`
+                .alchm-recs-grid {
+                  display: grid;
+                  gap: 14px;
+                  grid-template-columns: repeat(1, 1fr);
+                }
+                @media (min-width: 600px) { .alchm-recs-grid { grid-template-columns: repeat(2, 1fr); } }
+                @media (min-width: 1100px) { .alchm-recs-grid { grid-template-columns: repeat(4, 1fr); } }
+              `}</style>
+              {recommended.map((card) => (
+                <IngredientCard key={card.id} ing={card} />
+              ))}
+            </div>
+          </section>
+        )}
 
         <div className="alchm-bottom">
-          <AwaitingBackend
-            title="CUISINE EXPLORER · TIER III"
-            endpoint="GET /api/cuisines/signatures"
-            note="Returns 4-element signatures per cuisine. Source data exists in backend/alchm_kitchen/data/json/cuisines.json. Schema: CuisineSignaturesResponseSchema."
-          />
-          <AwaitingBackend
-            title="SAUCE LINEAGE TREE"
-            endpoint="GET /api/sauces/lineage?root=<id>"
-            note="Returns the derivation graph (nodes, edges, depth/variants stats) for a given mother sauce. Source data exists in sauces.json. Schema: SauceLineageResponseSchema."
-          />
+          {cuisineData && cuisineData.rows.length > 0 ? (
+            <CuisineExplorerPanel
+              cuisines={cuisineData.rows}
+              totalEntries={cuisineData.total}
+            />
+          ) : (
+            <AwaitingBackend
+              title="CUISINE EXPLORER · TIER III"
+              endpoint="GET /api/cuisines/signatures"
+              note="Hydrating 4-element cuisine signatures against the live sky…"
+            />
+          )}
+          {sauceLineage ? (
+            <SauceLineagePanel
+              rootName={sauceLineage.rootLabel}
+              nodes={sauceLineage.nodes}
+              edges={sauceLineage.edges}
+              stats={sauceLineage.stats}
+              viewBoxWidth={SAUCE_VIEWBOX.width}
+              viewBoxHeight={SAUCE_VIEWBOX.height}
+            />
+          ) : (
+            <AwaitingBackend
+              title="SAUCE LINEAGE TREE"
+              endpoint="GET /api/sauces/lineage?root=bechamel"
+              note="Hydrating mother-sauce derivation graph…"
+            />
+          )}
         </div>
       </main>
 

--- a/src/app/api/cuisines/signatures/route.ts
+++ b/src/app/api/cuisines/signatures/route.ts
@@ -1,0 +1,172 @@
+/**
+ * GET /api/cuisines/signatures
+ *
+ * Returns the 4-element signature of each cuisine plus a `match` score against
+ * the current sky elemental weights (same dot-product math used by
+ * /api/recommendations/ingredients). Source data lives in
+ * `backend/alchm_kitchen/data/json/cuisines.json`.
+ *
+ * Response contract: CuisineSignaturesResponseSchema in
+ * src/lib/schemas/dashboard.ts.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { NextResponse } from "next/server";
+import { rateLimit } from "@/lib/rateLimit";
+import {
+  CuisineSignaturesResponseSchema,
+  type CuisineSignature,
+} from "@/lib/schemas/dashboard";
+import type { ElementalProperties } from "@/types/alchemy";
+import { getAccuratePlanetaryPositions } from "@/utils/astrology/positions";
+import { calculateElementalInfluences } from "@/utils/recommendation/ingredientRecommendation";
+
+export const dynamic = "force-dynamic";
+
+const CUISINES_JSON_PATH = path.join(
+  process.cwd(),
+  "backend",
+  "alchm_kitchen",
+  "data",
+  "json",
+  "cuisines.json",
+);
+
+/** Short region tag used by the CUISINE EXPLORER panel. */
+const REGION_TAGS: Record<string, string> = {
+  african: "AFR",
+  american: "AMR·US",
+  chinese: "ASIA·CN",
+  french: "EUR·FR",
+  greek: "MED·GR",
+  indian: "ASIA·IN",
+  italian: "MED·IT",
+  japanese: "ASIA·JP",
+  korean: "ASIA·KR",
+  mexican: "AMR·MX",
+  middleeastern: "MENA",
+  russian: "EUR·RU",
+  thai: "ASIA·TH",
+  vietnamese: "ASIA·VN",
+};
+
+interface RawCuisine {
+  id?: string;
+  name?: string;
+  elementalProperties?: Partial<ElementalProperties>;
+  astrologicalInfluences?: string[];
+}
+
+let cuisineCache: Map<string, RawCuisine> | null = null;
+
+function loadCuisines(): Map<string, RawCuisine> {
+  if (cuisineCache) return cuisineCache;
+  const raw = fs.readFileSync(CUISINES_JSON_PATH, "utf-8");
+  const parsed = JSON.parse(raw) as Record<string, RawCuisine>;
+  // The JSON ships two entries per cuisine (capitalized + lowercase keys) with
+  // slightly different `id` values like "mexican" vs "cuisine-mexican". Dedupe
+  // on normalized name and prefer the canonical lowercase id when present.
+  const byName = new Map<string, RawCuisine>();
+  for (const entry of Object.values(parsed)) {
+    const name = (entry?.name ?? "").toString().trim();
+    if (!name) continue;
+    const key = name.toLowerCase();
+    const existing = byName.get(key);
+    if (!existing) {
+      byName.set(key, entry);
+      continue;
+    }
+    // Prefer the entry whose id matches the simple slug of the name.
+    const slug = key.replace(/\s+/g, "-");
+    if ((entry.id ?? "").toLowerCase() === slug) byName.set(key, entry);
+  }
+  cuisineCache = byName;
+  return byName;
+}
+
+function regionFor(id: string, name: string): string {
+  const key = id.replace(/[^a-z]/g, "");
+  return REGION_TAGS[key] ?? name.slice(0, 3).toUpperCase();
+}
+
+function dot(a: ElementalProperties, b: ElementalProperties): number {
+  return (
+    (a.Fire ?? 0) * (b.Fire ?? 0) +
+    (a.Water ?? 0) * (b.Water ?? 0) +
+    (a.Earth ?? 0) * (b.Earth ?? 0) +
+    (a.Air ?? 0) * (b.Air ?? 0)
+  );
+}
+
+export async function GET(request: Request) {
+  const rl = await rateLimit(request, {
+    window: 60_000,
+    max: 60,
+    bucket: "cuisines-signatures",
+  });
+  if (!rl.allowed) return rl.response!;
+
+  try {
+    const cuisines = loadCuisines();
+
+    const now = new Date();
+    const positions = getAccuratePlanetaryPositions(now);
+    const alignment: Record<string, { sign: string; degree: number }> = {};
+    for (const [planet, data] of Object.entries(positions)) {
+      if (!data) continue;
+      alignment[planet] = {
+        sign: String((data as { sign?: string }).sign ?? "aries"),
+        degree: Number((data as { degree?: number }).degree ?? 0),
+      };
+    }
+    const sky = calculateElementalInfluences(alignment);
+
+    const rows: CuisineSignature[] = [];
+    for (const [nameKey, entry] of cuisines) {
+      const id = (entry.id ?? nameKey).toString().toLowerCase();
+      const name = entry.name ?? nameKey;
+      const elem = entry.elementalProperties ?? {};
+      const signature: [number, number, number, number] = [
+        Number(elem.Fire ?? 0.25),
+        Number(elem.Water ?? 0.25),
+        Number(elem.Earth ?? 0.25),
+        Number(elem.Air ?? 0.25),
+      ];
+      const cuisineElem: ElementalProperties = {
+        Fire: signature[0],
+        Water: signature[1],
+        Earth: signature[2],
+        Air: signature[3],
+      };
+      const match = Math.max(0, Math.min(1, dot(sky, cuisineElem)));
+      rows.push({
+        id,
+        name,
+        region: regionFor(id, name),
+        match: Number(match.toFixed(4)),
+        signature: signature.map((v) => Number(v.toFixed(4))) as [
+          number,
+          number,
+          number,
+          number,
+        ],
+      });
+    }
+
+    rows.sort((a, b) => b.match - a.match);
+
+    const body = CuisineSignaturesResponseSchema.parse({
+      total: rows.length,
+      cuisines: rows,
+    });
+
+    return NextResponse.json(body);
+  } catch (error) {
+    console.error("[cuisines/signatures] Error:", error);
+    return NextResponse.json(
+      { error: "Failed to load cuisine signatures" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/recommendations/ingredients/route.ts
+++ b/src/app/api/recommendations/ingredients/route.ts
@@ -1,0 +1,173 @@
+/**
+ * GET /api/recommendations/ingredients
+ *
+ * Ranks ingredients by `match_score(transit_position, ingredient)` against the
+ * live sky and returns the top N. Match is the dot product between current
+ * elemental sky weights (derived from planetary positions) and each
+ * ingredient's elemental signature.
+ *
+ * Response contract: RecommendedIngredientsResponseSchema in
+ * src/lib/schemas/dashboard.ts. The schema is `.parse()`d before responding so
+ * drift between this route and consumers fails loudly.
+ */
+
+import { NextResponse } from "next/server";
+import { calculatePlanetaryHoursInfluence } from "@/calculations/core/planetaryInfluences";
+import { unifiedIngredients } from "@/data/unified/ingredients";
+import { rateLimit } from "@/lib/rateLimit";
+import {
+  RecommendedIngredientsResponseSchema,
+  type RecommendedIngredient,
+} from "@/lib/schemas/dashboard";
+import { getAccuratePlanetaryPositions } from "@/utils/astrology/positions";
+import { calculateElementalInfluences } from "@/utils/recommendation/ingredientRecommendation";
+import type { UnifiedIngredient } from "@/data/unified/unifiedTypes";
+import type { ElementalProperties } from "@/types/alchemy";
+
+export const dynamic = "force-dynamic";
+
+const ELEMENT_KEYS = ["Fire", "Water", "Earth", "Air"] as const;
+type ElementKey = (typeof ELEMENT_KEYS)[number];
+
+function dominantElement(props: ElementalProperties | undefined): ElementKey {
+  if (!props) return "Fire";
+  let best: ElementKey = "Fire";
+  let bestVal = -Infinity;
+  for (const k of ELEMENT_KEYS) {
+    const v = (props as Record<string, number>)[k] ?? 0;
+    if (v > bestVal) {
+      bestVal = v;
+      best = k;
+    }
+  }
+  return best;
+}
+
+function dotElemental(
+  sky: ElementalProperties,
+  ing: ElementalProperties | undefined,
+): number {
+  if (!ing) return 0;
+  let sum = 0;
+  for (const k of ELEMENT_KEYS) {
+    sum += (sky[k] ?? 0) * ((ing as Record<string, number>)[k] ?? 0);
+  }
+  return sum;
+}
+
+/** Deterministic hue 0-360 from a string. djb2 modulo 360. */
+function hueFromName(name: string): number {
+  let h = 5381;
+  for (let i = 0; i < name.length; i++) {
+    h = ((h << 5) + h + name.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h) % 360;
+}
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function pickPlanet(ingredient: UnifiedIngredient): string {
+  const planet =
+    ingredient.planetaryRuler ?? ingredient.astrologicalProfile?.rulingPlanets?.[0];
+  return typeof planet === "string" && planet.length > 0 ? planet : "Sun";
+}
+
+export async function GET(request: Request) {
+  const rl = await rateLimit(request, {
+    window: 60_000,
+    max: 60,
+    bucket: "recommendations-ingredients",
+  });
+  if (!rl.allowed) return rl.response!;
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const limitParam = parseInt(searchParams.get("limit") ?? "8", 10);
+    const limit = Math.max(1, Math.min(48, Number.isFinite(limitParam) ? limitParam : 8));
+
+    const now = new Date();
+    const positions = getAccuratePlanetaryPositions(now);
+
+    // calculateElementalInfluences expects {sign, degree} per planet
+    const alignment: Record<string, { sign: string; degree: number }> = {};
+    for (const [planet, data] of Object.entries(positions)) {
+      if (!data) continue;
+      alignment[planet] = {
+        sign: String((data as { sign?: string }).sign ?? "aries"),
+        degree: Number((data as { degree?: number }).degree ?? 0),
+      };
+    }
+
+    const skyWeights = calculateElementalInfluences(alignment);
+    const { hourRuler } = calculatePlanetaryHoursInfluence(now);
+
+    // Score every unified ingredient against the live sky.
+    const scored = Object.values(unifiedIngredients).map((ing) => {
+      const elemental: ElementalProperties = ing.elementalProperties ?? {
+        Fire: 0.25,
+        Water: 0.25,
+        Earth: 0.25,
+        Air: 0.25,
+      };
+
+      // Dot product is in [0,1] when both vectors are probability distributions
+      // (max ~1.0 when both put all weight on the same element).
+      const score = dotElemental(skyWeights, elemental);
+
+      // Optional planetary affinity boost: +10% if any ruling planet matches
+      // the current hour ruler.
+      const rulers = (ing.astrologicalProfile?.rulingPlanets ?? []) as string[];
+      const boost = rulers.includes(hourRuler) ? 1.1 : 1.0;
+
+      const match = Math.max(0, Math.min(1, score * boost));
+
+      return { ing, match };
+    });
+
+    scored.sort((a, b) => b.match - a.match);
+
+    const items: RecommendedIngredient[] = scored.slice(0, limit).map(({ ing, match }) => {
+      const dom = dominantElement(ing.elementalProperties);
+      const alch = ing.alchemicalProperties ?? {
+        Spirit: 0.25,
+        Essence: 0.25,
+        Matter: 0.25,
+        Substance: 0.25,
+      };
+      return {
+        id: slugify(ing.name),
+        name: ing.name,
+        category: ing.category ?? "other",
+        elemental_affinity: dom.toLowerCase() as RecommendedIngredient["elemental_affinity"],
+        planet: pickPlanet(ing),
+        hue: hueFromName(ing.name),
+        match_score: Number(match.toFixed(4)),
+        thermo: {
+          spirit: Number((alch.Spirit ?? 0).toFixed(4)),
+          essence: Number((alch.Essence ?? 0).toFixed(4)),
+          matter: Number((alch.Matter ?? 0).toFixed(4)),
+          substance: Number((alch.Substance ?? 0).toFixed(4)),
+        },
+      };
+    });
+
+    const body = RecommendedIngredientsResponseSchema.parse({
+      generated_at: now.toISOString(),
+      hour_ruler: hourRuler,
+      ingredients: items,
+    });
+
+    return NextResponse.json(body);
+  } catch (error) {
+    console.error("[recommendations/ingredients] Error:", error);
+    return NextResponse.json(
+      { error: "Failed to compute ingredient recommendations" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/sauces/lineage/route.ts
+++ b/src/app/api/sauces/lineage/route.ts
@@ -1,0 +1,153 @@
+/**
+ * GET /api/sauces/lineage?root=<id>
+ *
+ * Returns the derivation graph for the requested mother sauce: the root node
+ * plus its variants (depth 1) and edges from root → each variant. Source data
+ * lives in `backend/alchm_kitchen/data/json/sauces.json`.
+ *
+ * `root` is required (400 otherwise) and is matched case-insensitively against
+ * both the key and the human-readable `name` so callers can pass either.
+ *
+ * Response contract: SauceLineageResponseSchema in src/lib/schemas/dashboard.ts.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { NextResponse } from "next/server";
+import { rateLimit } from "@/lib/rateLimit";
+import { SauceLineageResponseSchema } from "@/lib/schemas/dashboard";
+
+export const dynamic = "force-dynamic";
+
+const SAUCES_JSON_PATH = path.join(
+  process.cwd(),
+  "backend",
+  "alchm_kitchen",
+  "data",
+  "json",
+  "sauces.json",
+);
+
+interface RawSauce {
+  name?: string;
+  base?: string;
+  cuisine?: string;
+  variants?: string[] | null;
+}
+
+let saucesCache: Record<string, RawSauce> | null = null;
+
+function loadSauces(): Record<string, RawSauce> {
+  if (saucesCache) return saucesCache;
+  const raw = fs.readFileSync(SAUCES_JSON_PATH, "utf-8");
+  saucesCache = JSON.parse(raw) as Record<string, RawSauce>;
+  return saucesCache;
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function findRoot(
+  data: Record<string, RawSauce>,
+  rootParam: string,
+): { key: string; entry: RawSauce } | null {
+  const needle = rootParam.toLowerCase();
+  // Direct key hit first.
+  for (const [key, entry] of Object.entries(data)) {
+    if (key.toLowerCase() === needle) return { key, entry };
+  }
+  // Then fuzzy-match against the slugified name.
+  for (const [key, entry] of Object.entries(data)) {
+    if (entry?.name && slugify(entry.name) === slugify(rootParam)) {
+      return { key, entry };
+    }
+  }
+  // Finally a substring match on either key or name.
+  for (const [key, entry] of Object.entries(data)) {
+    if (
+      key.toLowerCase().includes(needle) ||
+      (entry?.name && entry.name.toLowerCase().includes(needle))
+    ) {
+      return { key, entry };
+    }
+  }
+  return null;
+}
+
+export async function GET(request: Request) {
+  const rl = await rateLimit(request, {
+    window: 60_000,
+    max: 60,
+    bucket: "sauces-lineage",
+  });
+  if (!rl.allowed) return rl.response!;
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const rootParam = searchParams.get("root");
+    if (!rootParam || !rootParam.trim()) {
+      return NextResponse.json(
+        { error: "Query parameter `root` is required (e.g. ?root=bechamel)." },
+        { status: 400 },
+      );
+    }
+
+    const sauces = loadSauces();
+    const match = findRoot(sauces, rootParam.trim());
+    if (!match) {
+      return NextResponse.json(
+        { error: `Unknown sauce root: ${rootParam}` },
+        { status: 404 },
+      );
+    }
+
+    const { key: rootKey, entry: rootEntry } = match;
+    const rootId = rootKey;
+    const rootLabel = rootEntry.name ?? rootKey;
+    const variants = Array.isArray(rootEntry.variants) ? rootEntry.variants : [];
+
+    const usedIds = new Set<string>([rootId]);
+    const nodes = [{ id: rootId, label: rootLabel, depth: 0 }];
+    const edges: Array<{ from: string; to: string }> = [];
+
+    for (const variantLabel of variants) {
+      let vid = slugify(variantLabel);
+      // Disambiguate if a slug collision occurs across variants.
+      if (usedIds.has(vid)) {
+        let i = 2;
+        while (usedIds.has(`${vid}-${i}`)) i++;
+        vid = `${vid}-${i}`;
+      }
+      usedIds.add(vid);
+      nodes.push({ id: vid, label: variantLabel, depth: 1 });
+      edges.push({ from: rootId, to: vid });
+    }
+
+    const maxDepth = nodes.reduce((d, n) => Math.max(d, n.depth), 0);
+
+    const body = SauceLineageResponseSchema.parse({
+      root: rootId,
+      nodes,
+      edges,
+      stats: {
+        depth: maxDepth,
+        nodes: nodes.length,
+        variants: variants.length,
+      },
+    });
+
+    return NextResponse.json(body);
+  } catch (error) {
+    console.error("[sauces/lineage] Error:", error);
+    return NextResponse.json(
+      { error: "Failed to load sauce lineage" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/nav/LabHeader.tsx
+++ b/src/components/nav/LabHeader.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { Glyph } from "@/components/ui/alchm/Glyph";
 import { CelestialHeaderClock } from "./CelestialHeaderClock";
 import { Logo } from "./Logo";
@@ -8,7 +11,11 @@ export type LabHeaderNavId =
   | "kitchen"
   | "ingredients"
   | "cuisines"
-  | "saved"
+  | "cooking-methods"
+  | "pantry"
+  | "meal-plan"
+  | "recipes"
+  | "profile"
   | "lab";
 
 export interface LabHeaderProps {
@@ -21,15 +28,45 @@ const NAV: Array<{ id: LabHeaderNavId; label: string; href: string }> = [
   { id: "kitchen", label: "Kitchen", href: "/" },
   { id: "ingredients", label: "Ingredients", href: "/ingredients" },
   { id: "cuisines", label: "Cuisines", href: "/cuisines" },
-  { id: "saved", label: "Cabinet", href: "/profile" },
-  { id: "lab", label: "Lab", href: "/planetary-chart" },
+  { id: "cooking-methods", label: "Methods", href: "/cooking-methods" },
+  { id: "pantry", label: "Pantry", href: "/pantry" },
+  { id: "meal-plan", label: "Meal Plan", href: "/meal-plan" },
+  { id: "recipes", label: "Recipes", href: "/recipes" },
+  { id: "profile", label: "Profile", href: "/profile" },
+  { id: "lab", label: "Lab", href: "/lab" },
 ];
 
+function activeFromPathname(pathname: string | null): LabHeaderNavId {
+  if (!pathname || pathname === "/") return "kitchen";
+  if (pathname.startsWith("/ingredients")) return "ingredients";
+  if (pathname.startsWith("/cuisines")) return "cuisines";
+  if (pathname.startsWith("/cooking-methods")) return "cooking-methods";
+  if (pathname.startsWith("/pantry")) return "pantry";
+  if (pathname.startsWith("/meal-plan")) return "meal-plan";
+  if (
+    pathname.startsWith("/recipes") ||
+    pathname.startsWith("/recipe-generator") ||
+    pathname.startsWith("/cosmic-recipe")
+  )
+    return "recipes";
+  if (pathname.startsWith("/profile")) return "profile";
+  if (
+    pathname.startsWith("/lab") ||
+    pathname.startsWith("/planetary-chart") ||
+    pathname.startsWith("/birth-chart") ||
+    pathname.startsWith("/current-chart")
+  )
+    return "lab";
+  return "kitchen";
+}
+
 export function LabHeader({
-  active = "kitchen",
+  active,
   showSearch = true,
   user,
 }: LabHeaderProps): JSX.Element {
+  const pathname = usePathname();
+  const resolvedActive = active ?? activeFromPathname(pathname);
   return (
     <header
       data-alchm-header="true"
@@ -44,14 +81,54 @@ export function LabHeader({
       }}
     >
       <style>{`
-        .alchm-labheader { display: flex; align-items: center; gap: 12px; padding: 12px 14px; }
-        .alchm-labheader > .alchm-labheader-left { flex: 1 1 auto; min-width: 0; }
-        .alchm-labheader > nav { display: none; }
+        .alchm-labheader {
+          display: grid;
+          grid-template-columns: auto 1fr;
+          align-items: center;
+          gap: 10px;
+          padding: 10px 14px;
+        }
+        .alchm-labheader > .alchm-labheader-left { flex-shrink: 0; }
+        .alchm-labheader > .alchm-labheader-nav-wrap {
+          overflow-x: auto;
+          scrollbar-width: none;
+          -webkit-overflow-scrolling: touch;
+          min-width: 0;
+        }
+        .alchm-labheader > .alchm-labheader-nav-wrap::-webkit-scrollbar { display: none; }
         .alchm-labheader > .alchm-labheader-right { display: none; }
-        @media (min-width: 900px) {
-          .alchm-labheader { display: grid; grid-template-columns: 1fr auto 1fr; gap: 20px; padding: 14px 28px; }
-          .alchm-labheader > nav { display: flex; }
+        @media (min-width: 1100px) {
+          .alchm-labheader {
+            grid-template-columns: auto 1fr auto;
+            padding: 14px 28px;
+            gap: 20px;
+          }
+          .alchm-labheader > .alchm-labheader-nav-wrap { display: flex; justify-content: center; overflow: visible; }
           .alchm-labheader > .alchm-labheader-right { display: flex; }
+        }
+        .alchm-labheader-nav-pill {
+          display: inline-flex;
+          gap: 2px;
+          padding: 3px;
+          background: rgba(255,255,255,0.025);
+          border: 1px solid var(--line);
+          border-radius: 999px;
+          white-space: nowrap;
+          width: max-content;
+        }
+        .alchm-labheader-nav-link {
+          padding: 5px 11px;
+          font-size: 10px;
+          letter-spacing: 0.14em;
+          text-transform: uppercase;
+          color: var(--fg-mute);
+          border-radius: 999px;
+          text-decoration: none;
+          display: inline-block;
+        }
+        .alchm-labheader-nav-link[data-active="true"] {
+          color: var(--fg);
+          background: rgba(255,255,255,0.06);
         }
       `}</style>
       <div
@@ -66,39 +143,23 @@ export function LabHeader({
         <CelestialHeaderClock />
       </div>
 
-      <nav
-        style={{
-          gap: 4,
-          padding: 4,
-          background: "rgba(255,255,255,0.025)",
-          border: "1px solid var(--line)",
-          borderRadius: 999,
-        }}
-        aria-label="Primary"
-      >
-        {NAV.map((n) => {
-          const isActive = n.id === active;
-          return (
-            <Link
-              key={n.id}
-              href={n.href}
-              className="t-mono"
-              style={{
-                padding: "6px 14px",
-                fontSize: 11,
-                letterSpacing: "0.16em",
-                textTransform: "uppercase",
-                color: isActive ? "var(--fg)" : "var(--fg-mute)",
-                background: isActive ? "rgba(255,255,255,0.06)" : "transparent",
-                borderRadius: 999,
-                textDecoration: "none",
-              }}
-            >
-              {n.label}
-            </Link>
-          );
-        })}
-      </nav>
+      <div className="alchm-labheader-nav-wrap">
+        <nav className="alchm-labheader-nav-pill" aria-label="Primary">
+          {NAV.map((n) => {
+            const isActive = n.id === resolvedActive;
+            return (
+              <Link
+                key={n.id}
+                href={n.href}
+                className="t-mono alchm-labheader-nav-link"
+                data-active={isActive}
+              >
+                {n.label}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
 
       <div
         className="alchm-labheader-right"


### PR DESCRIPTION
## Summary

Wires the three remaining `AwaitingBackend` panels on the Modern Alchemist dashboard to live data:

- **`GET /api/recommendations/ingredients`** — ranks unified ingredients by dot-product match against current sky elemental weights (computed from `getAccuratePlanetaryPositions`), with a +10% boost when an ingredient's ruling planet matches the live hour ruler. Returns top N (default 8, capped at 48). Hydrates the Ingredient Hero ticker bar *and* the dashboard `RECOMMENDED INGREDIENTS` panel.
- **`GET /api/cuisines/signatures`** — returns each cuisine's 4-element `[fire, water, earth, air]` signature and its match against the live sky (same math as above). Sourced from `backend/alchm_kitchen/data/json/cuisines.json`; dedupes the JSON's twin capitalized + lowercase entries by normalized name.
- **`GET /api/sauces/lineage?root=<id>`** — derivation graph (root + variants, depth 0/1) for a mother sauce. Returns `400` when `root` is missing, `404` when no sauce matches. Sourced from `sauces.json`.

All three responses are `.parse()`'d through the Zod contracts in [src/lib/schemas/dashboard.ts](src/lib/schemas/dashboard.ts) before serialization so frontend/backend drift fails loudly. Each route follows the existing rate-limit pattern (60 req/min/IP, in-memory) and uses `export const dynamic = "force-dynamic"`.

The dashboard `(alchm)/page.tsx` adds three fetch hooks and keeps `AwaitingBackend` as the loading/empty fallback. The sauce panel computes node x/y/r positions and cubic Bézier edge paths client-side since `SauceLineagePanel` expects pre-laid-out geometry.

## Test plan

- [x] `curl 'http://localhost:3000/api/recommendations/ingredients?limit=4'` returns valid `RecommendedIngredientsResponseSchema` payload
- [x] `curl 'http://localhost:3000/api/cuisines/signatures'` returns 14 deduped cuisines (no `cuisine-mexican`/`mexican` doubles)
- [x] `curl 'http://localhost:3000/api/sauces/lineage?root=bechamel'` returns root + 3 variants
- [x] `curl 'http://localhost:3000/api/sauces/lineage'` → 400; `?root=nonexistent` → 404
- [x] Dashboard renders 8 IngredientCards, CuisineExplorerPanel, and SauceLineagePanel — no remaining `AwaitingBackend` for these three panels (the other 3 are user-stats placeholders, out of scope)
- [x] Ingredient Hero `/ingredients/garlic` ticker shows 8 trending items, no "ticker awaiting" copy
- [x] Mobile (375px) shows 1-column recs grid, both bottom panels stack
- [x] `tsc --noEmit` is clean for non-Storybook code

🤖 Generated with [Claude Code](https://claude.com/claude-code)