### PR TITLE
feat(recommendations): real planetary alchemy in recommendation + astrological services

### DIFF
--- a/src/services/AstrologicalService.ts
+++ b/src/services/AstrologicalService.ts
@@ -27,7 +27,13 @@ import type {
   LunarPhase,
 } from "@/types/celestial";
 import { AstrologicalState as _CentralizedAstrologicalState } from "@/types/celestial";
+import {
+  aggregateEnhancedZodiacElementals,
+  calculateAlchemicalFromPlanets,
+  isSectDiurnal,
+} from "@/utils/planetaryAlchemyMapping";
 import { createLogger } from "../utils/logger";
+import astrologizeApiCache from "./AstrologizeApiCache";
 
 // Create a component-specific logger
 const logger = createLogger("AstrologicalService");
@@ -243,25 +249,45 @@ export class AstrologicalService {
     planetaryPositions: PlanetaryPositions,
   ): Promise<PlanetaryInfluenceResponse> {
     try {
-      // Mock planetary influence calculation
-      const influences = {
-        planetaryPositions,
-        elementalBoost: {
-          Fire: 0.25,
-          Water: 0.25,
-          Earth: 0.25,
-          Air: 0.25,
-        },
-        alchemicalModifier: {
-          Spirit: 0.25,
-          Essence: 0.25,
-          Matter: 0.25,
-          Substance: 0.25,
-        },
-        compatibilityScore: 0.75,
+      // Build sign map from positions (skip the dominantPlanet string field)
+      const signMap: Record<string, string> = {};
+      for (const [planet, pos] of Object.entries(planetaryPositions)) {
+        if (planet === "dominantPlanet" || typeof pos === "string") continue;
+        const sign = (pos as { sign?: string })?.sign;
+        if (sign) signMap[planet] = sign;
+      }
+
+      const diurnal = isSectDiurnal();
+      const elementalBoost = aggregateEnhancedZodiacElementals(signMap, diurnal);
+      const rawAlchemical = calculateAlchemicalFromPlanets(signMap, diurnal);
+
+      // Normalize ESMS to 0..1 range for the modifier
+      const esmsTotal =
+        rawAlchemical.Spirit +
+        rawAlchemical.Essence +
+        rawAlchemical.Matter +
+        rawAlchemical.Substance || 1;
+      const alchemicalModifier = {
+        Spirit: rawAlchemical.Spirit / esmsTotal,
+        Essence: rawAlchemical.Essence / esmsTotal,
+        Matter: rawAlchemical.Matter / esmsTotal,
+        Substance: rawAlchemical.Substance / esmsTotal,
       };
 
-      return _createSuccessResponse(influences);
+      const dominant = Math.max(
+        elementalBoost.Fire,
+        elementalBoost.Water,
+        elementalBoost.Earth,
+        elementalBoost.Air,
+      );
+      const compatibilityScore = 0.5 + dominant * 0.5;
+
+      return _createSuccessResponse({
+        planetaryPositions,
+        elementalBoost,
+        alchemicalModifier,
+        compatibilityScore,
+      });
     } catch (error) {
       return _createErrorResponse(
         `Planetary influence calculation failed: ${error instanceof Error ? error.message : "Unknown error"}`,
@@ -302,8 +328,38 @@ export type MoonPhase =
 // Canonical async function to get the latest astrological state - Updated with standardized response
 export async function getLatestAstrologicalState(): Promise<AstrologicalCalculationResponse> {
   try {
-    // TODO: Integrate with actual astrologize/alchemize API result cache or state management
-    // For now, return a minimal valid state as a placeholder
+    // On the client, check if the cache already has a real computed entry and
+    // derive real elementals from it rather than returning hardcoded defaults.
+    const cached =
+      typeof window !== "undefined" ? astrologizeApiCache.getLatestEntry() : null;
+
+    if (cached) {
+      const signMap: Record<string, string> = {};
+      for (const [planet, pos] of Object.entries(cached.planetaryPositions)) {
+        const sign = (pos as { sign?: string })?.sign;
+        if (sign) signMap[planet] = sign;
+      }
+
+      const diurnal = isSectDiurnal(cached.date);
+      const elementalInfluence = aggregateEnhancedZodiacElementals(signMap, diurnal);
+
+      const sunSign = signMap["Sun"]?.toLowerCase() as StandardZodiacSignType | undefined;
+      const accuracy =
+        cached.quality === "high" ? 0.95
+        : cached.quality === "medium" ? 0.75
+        : 0.5;
+
+      return _createSuccessResponse({
+        planetaryPositions: cached.planetaryPositions,
+        zodiacSign: sunSign ?? "aries",
+        lunarPhase: "new moon",
+        elementalInfluence,
+        accuracy,
+        calculationTimestamp: new Date(cached.timestamp).toISOString(),
+      });
+    }
+
+    // Fallback: balanced defaults when no cached chart exists
     const astrologicalData = {
       planetaryPositions: DefaultPlanetaryPositions,
       zodiacSign: "aries" as StandardZodiacSignType,

--- a/src/services/AstrologizeApiCache.ts
+++ b/src/services/AstrologizeApiCache.ts
@@ -439,6 +439,22 @@ class AstrologizeApiCache {
   }
 
   /**
+   * Return the most recently stored cache entry regardless of coordinates.
+   * Used by getLatestAstrologicalState to avoid returning hardcoded defaults
+   * when the user has already computed a real chart.
+   */
+  public getLatestEntry(): CachedAstrologicalData | null {
+    if (this.cache.size === 0) return null;
+    let latest: CachedAstrologicalData | null = null;
+    for (const entry of this.cache.values()) {
+      if (!latest || entry.timestamp > latest.timestamp) {
+        latest = entry;
+      }
+    }
+    return latest;
+  }
+
+  /**
    * Public methods for cache management
    */
   public getCacheStats() {

--- a/src/services/RecommendationService.ts
+++ b/src/services/RecommendationService.ts
@@ -3,6 +3,10 @@ import type { ElementalProperties } from "@/types/alchemy";
 import type { Ingredient } from "@/types/ingredient";
 import type { Recipe } from "@/types/recipe";
 import { logger } from "@/utils/logger";
+import {
+  aggregateEnhancedZodiacElementals,
+  isSectDiurnal,
+} from "@/utils/planetaryAlchemyMapping";
 import { RecipeService } from "./RecipeService";
 import type {
     CookingMethodRecommendationCriteria,
@@ -526,8 +530,6 @@ export class RecommendationService implements RecommendationServiceInterface {
         `Getting ${type} recommendations for planetary alignment:`,
         planetaryPositions,
       );
-      // For now, convert planetary positions to elemental properties
-      // TODO: Implement direct planetary compatibility calculation
       const elementalProperties =
         this.planetaryPositionsToElemental(planetaryPositions);
       return await this.getRecommendationsForElements(
@@ -576,47 +578,16 @@ export class RecommendationService implements RecommendationServiceInterface {
     };
   }
   /**
-   * Convert planetary positions to elemental properties (simplified)
+   * Convert planetary positions to elemental properties using mass-weighted,
+   * sect-aware zodiac mapping.
    */
   private planetaryPositionsToElemental(
     positions: Record<string, { sign: string; degree: number }>,
   ): ElementalProperties {
-    // Simplified conversion - in reality this would use the planetary alchemy mapping
-    const elements: ElementalProperties = {
-      Fire: 0,
-      Water: 0,
-      Earth: 0,
-      Air: 0,
-    };
-    // Count planets in each element's signs
-    const elementSigns = {
-      Fire: ["aries", "leo", "sagittarius"],
-      Water: ["cancer", "scorpio", "pisces"],
-      Earth: ["taurus", "virgo", "capricorn"],
-      Air: ["gemini", "libra", "aquarius"],
-    };
-    let totalPlanets = 0;
-    Object.values(positions).forEach((position) => {
-      const sign = position.sign.toLowerCase();
-      totalPlanets++;
-      for (const [element, signs] of Object.entries(elementSigns)) {
-        if (signs.includes(sign)) {
-          elements[element as keyof ElementalProperties] += 1;
-        }
-      }
-    });
-    // Normalize to sum to 1
-    if (totalPlanets > 0) {
-      Object.keys(elements).forEach((key) => {
-        elements[key as keyof ElementalProperties] /= totalPlanets;
-      });
-    } else {
-      // Default balanced distribution
-      Object.keys(elements).forEach((key) => {
-        elements[key as keyof ElementalProperties] = 0.25;
-      });
-    }
-    return elements;
+    const signMap = Object.fromEntries(
+      Object.entries(positions).map(([planet, pos]) => [planet, pos.sign]),
+    );
+    return aggregateEnhancedZodiacElementals(signMap, isSectDiurnal());
   }
 }
 // Export singleton instance


### PR DESCRIPTION
## Summary

- **P1 #6 — RecommendationService**: replaced the simple zodiac sign-count `planetaryPositionsToElemental` with `aggregateEnhancedZodiacElementals` from `planetaryAlchemyMapping`. Both call sites (recipe filter and `getRecommendationsForPlanetaryAlignment`) now use mass-weighted, sect-aware (day/night chart) elemental computation instead of a naïve planet count.
- **P1 #7 — AstrologicalService**: `calculatePlanetaryInfluences` now computes real `elementalBoost` via `aggregateEnhancedZodiacElementals` and a normalized ESMS `alchemicalModifier` via `calculateAlchemicalFromPlanets`; `compatibilityScore` is derived from the dominant element strength rather than a hardcoded 0.75.
- **P1 #7 cont. — getLatestAstrologicalState**: on the client, reads the most recently stored `AstrologizeApiCache` entry (via new `getLatestEntry()`) and derives real elementals from it, falling back to balanced defaults when the cache is empty or on the server.
- **AstrologizeApiCache**: added `getLatestEntry()` — returns the highest-timestamp entry regardless of coordinates.

## Test plan

- [ ] Typecheck: `bun run typecheck` passes
- [ ] Lint: `bun run lint` passes
- [ ] Manually verify: open any recipe recommendation page and observe planetary-position filter uses real elemental weighting
- [ ] Manually verify: call `calculatePlanetaryInfluences` via devtools/API with known chart positions and confirm non-uniform elemental values

🤖 Generated with [Claude Code](https://claude.com/claude-code)