### PR TITLE
Audit hardening + advanced auth metrics + token-grant script

### DIFF
--- a/database/init/34-auth-events.sql
+++ b/database/init/34-auth-events.sql
@@ -1,0 +1,64 @@
+-- Auth events: a structured audit log for everything that happens during
+-- sign-in, sign-out, and session management.
+--
+-- This is the source of truth for "how many login attempts did we have", and
+-- it captures both successful and failed flows including: DB lookup failures,
+-- JIT user-creation failures, account-link upsert errors, role promotions,
+-- explicit sign-outs, session revocations, and OAuth provider errors that
+-- surface on the /auth/error page.
+--
+-- Design notes
+--  * `user_id` is nullable because failed sign-ins (provider error, JIT
+--    failure) often happen before we can resolve a DB user.
+--  * `email` is captured separately for the same reason and lets us
+--    correlate failures by identity even when no row was ever created.
+--  * `event_type` is a short enum-ish string; we use TEXT + a CHECK so we
+--    can extend it without an enum migration (auth-system evolution is
+--    typically the *reason* we need this table).
+--  * `status` is `success` | `failure` | `info` — `info` covers state
+--    transitions like role promotion or session-cookie refresh.
+--  * `metadata` JSONB carries event-specific structured data
+--    (e.g., `{ "provider": "google", "isNewUser": true }`).
+--  * Indexes target the access patterns we actually ship:
+--      - per-user history (UI, debugging single account)
+--      - per-event-type rollups (counting attempts, failure rates)
+--      - recent activity (admin dashboard)
+
+CREATE TABLE IF NOT EXISTS auth_events (
+  id             BIGSERIAL PRIMARY KEY,
+  user_id        TEXT,
+  email          TEXT,
+  event_type     TEXT NOT NULL,
+  status         TEXT NOT NULL CHECK (status IN ('success', 'failure', 'info')),
+  provider       TEXT,
+  ip_hash        TEXT,
+  user_agent     TEXT,
+  error_code     TEXT,
+  error_message  TEXT,
+  metadata       JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_events_user_created
+  ON auth_events (user_id, created_at DESC)
+  WHERE user_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_auth_events_email_created
+  ON auth_events (email, created_at DESC)
+  WHERE email IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_auth_events_type_status_created
+  ON auth_events (event_type, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_auth_events_created
+  ON auth_events (created_at DESC);
+
+-- Optional: partial index to make "find recent failures" instant.
+CREATE INDEX IF NOT EXISTS idx_auth_events_failures
+  ON auth_events (created_at DESC, event_type)
+  WHERE status = 'failure';
+
+COMMENT ON TABLE auth_events IS
+  'Structured audit log for sign-in / sign-out / session events. Source of truth for login-attempt analytics. Safe to truncate older rows (this is not the primary data store).';
+COMMENT ON COLUMN auth_events.event_type IS
+  'Short snake_case identifier. Examples: signin_started, signin_user_lookup_failed, signin_user_created, signin_account_link_failed, signin_complete, signin_provider_error, signout, session_revoked.';

--- a/scripts/grant-test-tokens.ts
+++ b/scripts/grant-test-tokens.ts
@@ -1,0 +1,231 @@
+/**
+ * scripts/grant-test-tokens.ts
+ *
+ * One-shot, idempotent admin grant of 5 Spirit + 5 Essence + 5 Matter +
+ * 5 Substance to every **active, onboarded** user. Used to verify the
+ * end-to-end onboarding → balance flow against production data.
+ *
+ * Safe to re-run: the idempotency key (`ADMIN_TEST_GRANT_KEY`) ensures the
+ * underlying `token_transactions.idempotency_key` unique index blocks any
+ * duplicate credit, so repeat invocations are a no-op for users who already
+ * received the grant.
+ *
+ * Run from Railway so it sees postgres.railway.internal:
+ *
+ *   railway run bun scripts/grant-test-tokens.ts --dry-run     # preview only
+ *   railway run bun scripts/grant-test-tokens.ts               # execute
+ *
+ * Optional flags:
+ *   --dry-run        Print the plan + audience count, write nothing.
+ *   --limit N        Cap the audience to the first N users (smoke-test).
+ *   --emails a,b,c   Limit to specific email addresses (comma-separated).
+ *
+ * Exit codes:
+ *   0  success (or dry run)
+ *   1  fatal error (missing DATABASE_URL, query failure)
+ *   2  partial failure (some users could not be credited)
+ */
+
+import { Pool } from "pg";
+import { tokenEconomy } from "../src/services/TokenEconomyService";
+import { TOKEN_TYPES } from "../src/types/economy";
+
+const GRANT_AMOUNT = 5;
+const ADMIN_TEST_GRANT_KEY = "admin-test-grant-2026-05-20";
+const GRANT_DESCRIPTION =
+  "Admin test grant — onboarding/persistence verification (5 of each ESMS token)";
+
+interface Args {
+  dryRun: boolean;
+  limit: number | null;
+  emails: string[] | null;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { dryRun: false, limit: null, emails: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") args.dryRun = true;
+    else if (a === "--limit") {
+      const v = Number(argv[++i]);
+      if (!Number.isFinite(v) || v <= 0) {
+        console.error("--limit must be a positive integer");
+        process.exit(1);
+      }
+      args.limit = v;
+    } else if (a === "--emails") {
+      const v = argv[++i] ?? "";
+      args.emails = v
+        .split(",")
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean);
+      if (args.emails.length === 0) {
+        console.error("--emails requires at least one comma-separated address");
+        process.exit(1);
+      }
+    } else if (a === "--help" || a === "-h") {
+      console.log(
+        "Usage: bun scripts/grant-test-tokens.ts [--dry-run] [--limit N] [--emails a,b,c]",
+      );
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+interface AudienceRow {
+  id: string;
+  email: string;
+}
+
+async function selectAudience(
+  pool: Pool,
+  emails: string[] | null,
+  limit: number | null,
+): Promise<AudienceRow[]> {
+  const params: unknown[] = [];
+  let where = `u.is_active = true AND up.onboarding_completed = true`;
+  if (emails && emails.length > 0) {
+    params.push(emails);
+    where += ` AND lower(u.email) = ANY($${params.length}::text[])`;
+  }
+  let sql = `SELECT u.id::text AS id, u.email AS email
+             FROM users u
+             JOIN user_profiles up ON up.user_id = u.id
+             WHERE ${where}
+             ORDER BY u.created_at ASC`;
+  if (limit) {
+    params.push(limit);
+    sql += ` LIMIT $${params.length}`;
+  }
+  const result = await pool.query<AudienceRow>(sql, params);
+  return result.rows;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error("DATABASE_URL is not set. Run via `railway run` or export it first.");
+    process.exit(1);
+  }
+
+  const dbHost = (() => {
+    try {
+      return new URL(databaseUrl).hostname;
+    } catch {
+      return "unknown";
+    }
+  })();
+
+  console.log("─".repeat(60));
+  console.log("Admin test grant — 5 of each ESMS token per user");
+  console.log("─".repeat(60));
+  console.log(`Mode:            ${args.dryRun ? "DRY RUN (no writes)" : "EXECUTE"}`);
+  console.log(`Database host:   ${dbHost}`);
+  console.log(`Idempotency key: ${ADMIN_TEST_GRANT_KEY}`);
+  console.log(`Amount per user: ${GRANT_AMOUNT} × [${TOKEN_TYPES.join(", ")}]`);
+  console.log(
+    `Audience:        active && onboarded${
+      args.emails ? ` && email IN [${args.emails.join(", ")}]` : ""
+    }${args.limit ? ` LIMIT ${args.limit}` : ""}`,
+  );
+  console.log("─".repeat(60));
+
+  const pool = new Pool({
+    connectionString: databaseUrl,
+    ssl: databaseUrl.includes("sslmode=require")
+      ? { rejectUnauthorized: false }
+      : undefined,
+  });
+
+  let audience: AudienceRow[];
+  try {
+    audience = await selectAudience(pool, args.emails, args.limit);
+  } catch (err) {
+    console.error("Failed to query audience:", err);
+    await pool.end();
+    process.exit(1);
+  }
+
+  console.log(`Audience size:   ${audience.length} user(s)`);
+  if (audience.length === 0) {
+    console.log("Nothing to do.");
+    await pool.end();
+    return;
+  }
+
+  // Preview the first few so the operator can sanity-check before committing.
+  const preview = audience.slice(0, 5);
+  console.log("First few:");
+  preview.forEach((u) => console.log(`  • ${u.id}  ${u.email}`));
+  if (audience.length > preview.length) {
+    console.log(`  … and ${audience.length - preview.length} more`);
+  }
+  console.log("─".repeat(60));
+
+  if (args.dryRun) {
+    console.log("Dry run complete. Re-run without --dry-run to credit tokens.");
+    await pool.end();
+    return;
+  }
+
+  // We rely on TokenEconomyService.creditMultipleTokens for atomicity per user
+  // and on the unique index over token_transactions.idempotency_key for the
+  // global "exactly once" guarantee across re-runs.
+  const credits = TOKEN_TYPES.map((tokenType) => ({
+    tokenType,
+    amount: GRANT_AMOUNT,
+  }));
+
+  let credited = 0;
+  let alreadyClaimed = 0;
+  let failed = 0;
+  const start = Date.now();
+
+  for (const user of audience) {
+    const idempotencyKey = `${ADMIN_TEST_GRANT_KEY}:${user.id}`;
+    try {
+      const result = await tokenEconomy.creditMultipleTokens(
+        user.id,
+        credits,
+        "admin",
+        {
+          description: GRANT_DESCRIPTION,
+          idempotencyKey,
+        },
+      );
+
+      if (result === null) {
+        alreadyClaimed++;
+      } else {
+        credited++;
+      }
+    } catch (err) {
+      failed++;
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`  ✗ ${user.email}: ${message}`);
+    }
+  }
+
+  const elapsedMs = Date.now() - start;
+
+  console.log("─".repeat(60));
+  console.log(`Credited:        ${credited}`);
+  console.log(`Already claimed: ${alreadyClaimed}  (idempotency skip)`);
+  console.log(`Failed:          ${failed}`);
+  console.log(`Elapsed:         ${(elapsedMs / 1000).toFixed(2)}s`);
+  console.log("─".repeat(60));
+
+  await pool.end();
+
+  if (failed > 0) {
+    process.exit(2);
+  }
+}
+
+main().catch((err) => {
+  console.error("FATAL:", err);
+  process.exit(1);
+});

--- a/src/app/(alchm)/layout.tsx
+++ b/src/app/(alchm)/layout.tsx
@@ -8,7 +8,14 @@ import type { ReactNode } from "react";
  * its own LabHeader. We keep the `.alchm-root .lab` wrapper to activate
  * the design-system tokens (--bg-elev, --el-fire, etc.) and the
  * obsidian backdrop for everything inside this group.
+ *
+ * The dynamic rendering directive is scoped to this group because every
+ * route here depends on per-request providers (Chakra, User, Alchemical).
+ * Marketing/static routes (terms, privacy, login, etc.) outside this group
+ * can still be cached at the segment level by Next.js / the CDN.
  */
+export const dynamic = "force-dynamic";
+
 export default function AlchmLayout({ children }: { children: ReactNode }) {
   return (
     <div data-alchm-route="true" className="alchm-root lab">

--- a/src/app/(alchm)/page.tsx
+++ b/src/app/(alchm)/page.tsx
@@ -184,7 +184,13 @@ function HomeSection({
 export default function AlchmKitchenHome(): JSX.Element {
   return (
     <>
-      <main
+      {/*
+        The root layout (src/app/layout.tsx) already provides the <main>
+        landmark, so this wrapper is a <div>. We expose a single visually-hidden
+        <h1> so screen readers and crawlers get a clear page title even though
+        the visual design uses display-style section headers.
+      */}
+      <div
         style={{
           maxWidth: 1100,
           margin: "0 auto",
@@ -204,7 +210,21 @@ export default function AlchmKitchenHome(): JSX.Element {
             scrollbar-width: thin;
             scrollbar-color: color-mix(in oklch, var(--accent), transparent 70%) transparent;
           }
+          .alchm-sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+          }
         `}</style>
+        <h1 className="alchm-sr-only">
+          Alchm Kitchen — personalized food recommendations powered by your natal chart and the live sky
+        </h1>
 
         {/* Natal chart soft-prompt banner (shown after skip) */}
         <NatalPromptBanner />
@@ -294,7 +314,7 @@ export default function AlchmKitchenHome(): JSX.Element {
             Open the Laboratory →
           </Link>
         </div>
-      </main>
+      </div>
       <AgentsFeedThread />
     </>
   );

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import React, { useEffect, useState } from "react";
+import AdvancedMetricsPanel from "@/components/admin/AdvancedMetricsPanel";
 
 interface DashboardStats {
   totalUsers: number;
@@ -167,6 +168,11 @@ export default function AdminDashboardPage() {
             </div>
           </div>
         </div>
+      </div>
+
+      {/* Advanced metrics (auth events, abuse, observability, digest) */}
+      <div className="mb-8">
+        <AdvancedMetricsPanel />
       </div>
 
       {/* Recent Users */}

--- a/src/app/api/admin/abuse/route.ts
+++ b/src/app/api/admin/abuse/route.ts
@@ -1,0 +1,126 @@
+/**
+ * Admin Abuse Detection
+ * GET /api/admin/abuse?window=1h
+ *
+ * Reads from `auth_events` to surface IPs and email addresses that look
+ * like brute-force attempts: many failures in a short window, distributed
+ * across multiple targets.
+ *
+ * Cheap and non-blocking — purely a read endpoint. Auto-block is not
+ * implemented here; once an admin reviews the results, blocking moves
+ * to an explicit decision (e.g. add an IP to an allowlist/blocklist).
+ *
+ * @requires Authentication - Admin role required
+ */
+
+import { NextResponse } from "next/server";
+import { executeQuery } from "@/lib/database";
+import { validateAdminRequest } from "@/lib/auth/validateRequest";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+interface IpRow {
+  ip_hash: string;
+  failures: number;
+  successes: number;
+  emails_targeted: number;
+  first_seen: Date;
+  last_seen: Date;
+}
+
+interface EmailRow {
+  email: string | null;
+  failures: number;
+  ips: number;
+  last_seen: Date;
+}
+
+const WINDOWS: Record<string, string> = {
+  "15m": "15 minutes",
+  "1h": "1 hour",
+  "6h": "6 hours",
+  "24h": "24 hours",
+  "7d": "7 days",
+};
+
+export async function GET(request: NextRequest) {
+  try {
+    const authResult = await validateAdminRequest(request);
+    if ("error" in authResult) return authResult.error;
+
+    const { searchParams } = new URL(request.url);
+    const windowKey = searchParams.get("window") ?? "1h";
+    const interval = WINDOWS[windowKey] ?? WINDOWS["1h"];
+    const minFailures = Math.max(
+      1,
+      parseInt(searchParams.get("minFailures") ?? "5", 10) || 5,
+    );
+
+    // IPs with concentrated failures — usually scripted brute-force.
+    const ipResult = await executeQuery<IpRow>(
+      `SELECT
+         ip_hash,
+         COUNT(*) FILTER (WHERE status = 'failure')::int AS failures,
+         COUNT(*) FILTER (WHERE status = 'success')::int AS successes,
+         COUNT(DISTINCT email) FILTER (WHERE status = 'failure')::int AS emails_targeted,
+         MIN(created_at) AS first_seen,
+         MAX(created_at) AS last_seen
+       FROM auth_events
+       WHERE ip_hash IS NOT NULL
+         AND created_at >= NOW() - INTERVAL '${interval}'
+       GROUP BY ip_hash
+       HAVING COUNT(*) FILTER (WHERE status = 'failure') >= $1
+       ORDER BY failures DESC, emails_targeted DESC
+       LIMIT 100`,
+      [minFailures],
+    );
+
+    // Emails repeatedly failing — could be a user typo, but multiple distinct
+    // IPs targeting the same email is a credential-stuffing signal.
+    const emailResult = await executeQuery<EmailRow>(
+      `SELECT
+         email,
+         COUNT(*)::int AS failures,
+         COUNT(DISTINCT ip_hash)::int AS ips,
+         MAX(created_at) AS last_seen
+       FROM auth_events
+       WHERE email IS NOT NULL
+         AND status = 'failure'
+         AND created_at >= NOW() - INTERVAL '${interval}'
+       GROUP BY email
+       HAVING COUNT(*) >= $1
+       ORDER BY failures DESC
+       LIMIT 100`,
+      [minFailures],
+    );
+
+    return NextResponse.json({
+      success: true,
+      generatedAt: new Date().toISOString(),
+      window: windowKey,
+      minFailures,
+      suspiciousIps: ipResult.rows.map((r) => ({
+        ipHash: r.ip_hash,
+        failures: r.failures,
+        successes: r.successes,
+        emailsTargeted: r.emails_targeted,
+        firstSeen: r.first_seen,
+        lastSeen: r.last_seen,
+      })),
+      targetedEmails: emailResult.rows.map((r) => ({
+        email: r.email,
+        failures: r.failures,
+        distinctIps: r.ips,
+        lastSeen: r.last_seen,
+      })),
+    });
+  } catch (error) {
+    console.error("[admin/abuse] Failed:", error);
+    return NextResponse.json(
+      { success: false, message: "Failed to compute abuse metrics" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/digest/route.ts
+++ b/src/app/api/admin/digest/route.ts
@@ -1,0 +1,209 @@
+/**
+ * Admin Auth Digest
+ * POST /api/admin/digest
+ *
+ * Composes a daily/weekly summary from `users`, `auth_events`, and
+ * `device_sessions` and emails it to AUTH_ADMIN_EMAIL. Designed to be
+ * called from a scheduled job (Railway cron) but also runnable on
+ * demand by an admin in the browser for testing.
+ *
+ * Auth modes:
+ *   1. Bearer token = INTERNAL_API_SECRET → trusted cron caller.
+ *   2. Admin session → ad-hoc preview/test.
+ *
+ * Query/body params:
+ *   period = "daily" | "weekly"   (default "daily")
+ *   dryRun = "true" → returns the payload without emailing
+ *
+ * @requires Authentication - admin session OR internal bearer
+ */
+
+import { timingSafeEqual } from "node:crypto";
+import { NextResponse } from "next/server";
+import { executeQuery } from "@/lib/database";
+import { validateAdminRequest } from "@/lib/auth/validateRequest";
+import { getEventCounts } from "@/services/authEventsService";
+import emailService from "@/services/emailService";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function isInternalCaller(authHeader: string | null): boolean {
+  const secret = process.env.INTERNAL_API_SECRET;
+  if (!secret || !authHeader) return false;
+  const expected = Buffer.from(`Bearer ${secret}`);
+  const received = Buffer.from(authHeader);
+  if (received.length !== expected.length) return false;
+  return timingSafeEqual(received, expected);
+}
+
+interface CountsRow {
+  total: number;
+  new_24h: number;
+  new_7d: number;
+  active_24h: number;
+  active_7d: number;
+  active_sessions: number;
+  premium: number;
+}
+
+async function buildPayload(period: "daily" | "weekly") {
+  const windowMs = period === "weekly" ? 7 * 24 * 60 * 60 * 1000 : 24 * 60 * 60 * 1000;
+  const interval = period === "weekly" ? "7 days" : "24 hours";
+
+  const rollup = await executeQuery<CountsRow>(
+    `SELECT
+       COUNT(*)::int AS total,
+       COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '24 hours')::int AS new_24h,
+       COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '7 days')::int AS new_7d,
+       COUNT(*) FILTER (WHERE last_login_at >= NOW() - INTERVAL '24 hours')::int AS active_24h,
+       COUNT(*) FILTER (WHERE last_login_at >= NOW() - INTERVAL '${interval}')::int AS active_7d,
+       (SELECT COUNT(*)::int FROM device_sessions WHERE revoked_at IS NULL) AS active_sessions,
+       (SELECT COUNT(*)::int FROM user_subscriptions WHERE tier = 'premium' AND status = 'active') AS premium
+     FROM users`,
+  );
+
+  const events = await getEventCounts(windowMs);
+
+  return {
+    period,
+    generatedAt: new Date().toISOString(),
+    users: rollup.rows[0] ?? {
+      total: 0,
+      new_24h: 0,
+      new_7d: 0,
+      active_24h: 0,
+      active_7d: 0,
+      active_sessions: 0,
+      premium: 0,
+    },
+    authEvents: events,
+  };
+}
+
+function renderHtml(payload: Awaited<ReturnType<typeof buildPayload>>): string {
+  const u = payload.users;
+  const e = payload.authEvents;
+  const failingTypes = e.byType
+    .filter((b) => b.status === "failure")
+    .slice(0, 8)
+    .map((b) => `<tr><td>${b.type}</td><td style="text-align:right">${b.count}</td></tr>`)
+    .join("");
+
+  return `
+  <div style="font-family:Manrope,system-ui,sans-serif;max-width:560px;margin:auto;padding:24px;color:#1f1d2b">
+    <h1 style="font-size:18px;margin:0 0 6px">Alchm Kitchen — ${payload.period === "weekly" ? "Weekly" : "Daily"} digest</h1>
+    <p style="color:#666;font-size:12px;margin:0 0 24px">${payload.generatedAt}</p>
+
+    <h2 style="font-size:14px;margin:16px 0 8px">Users</h2>
+    <table style="width:100%;border-collapse:collapse;font-size:13px">
+      <tr><td>Total accounts</td><td style="text-align:right">${u.total}</td></tr>
+      <tr><td>New (24h / 7d)</td><td style="text-align:right">${u.new_24h} / ${u.new_7d}</td></tr>
+      <tr><td>Signed in (24h / 7d)</td><td style="text-align:right">${u.active_24h} / ${u.active_7d}</td></tr>
+      <tr><td>Active sessions</td><td style="text-align:right">${u.active_sessions}</td></tr>
+      <tr><td>Premium</td><td style="text-align:right">${u.premium}</td></tr>
+    </table>
+
+    <h2 style="font-size:14px;margin:24px 0 8px">Auth events (last ${payload.period === "weekly" ? "7 days" : "24 hours"})</h2>
+    <p style="font-size:13px;margin:0 0 8px">
+      <strong>${e.successes}</strong> success ·
+      <strong style="color:#b00020">${e.failures}</strong> failure ·
+      ${e.total} total
+    </p>
+    ${failingTypes ? `<table style="width:100%;border-collapse:collapse;font-size:13px"><thead><tr><th align="left">Failure type</th><th align="right">Count</th></tr></thead><tbody>${failingTypes}</tbody></table>` : `<p style="font-size:13px;color:#666">No failures in window — quiet skies.</p>`}
+
+    <p style="font-size:11px;color:#888;margin-top:32px">
+      Sent by alchm.kitchen · See full metrics at /admin
+    </p>
+  </div>`;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const isInternal = isInternalCaller(request.headers.get("Authorization"));
+    if (!isInternal) {
+      const authResult = await validateAdminRequest(request);
+      if ("error" in authResult) return authResult.error;
+    }
+
+    const { searchParams } = new URL(request.url);
+    const period = searchParams.get("period") === "weekly" ? "weekly" : "daily";
+    const dryRun = searchParams.get("dryRun") === "true";
+
+    const payload = await buildPayload(period);
+
+    const recipient =
+      process.env.AUTH_ADMIN_EMAIL ||
+      process.env.ADMIN_NOTIFICATION_EMAIL ||
+      "";
+
+    if (dryRun) {
+      return NextResponse.json({ success: true, dryRun: true, payload, recipient: recipient || null });
+    }
+
+    if (!recipient) {
+      return NextResponse.json(
+        { success: false, message: "No recipient configured (AUTH_ADMIN_EMAIL)" },
+        { status: 503 },
+      );
+    }
+
+    try {
+      emailService.ensureInitialized();
+    } catch {
+      /* configured below */
+    }
+    if (!emailService.isConfigured()) {
+      return NextResponse.json(
+        { success: false, message: "Email service is not configured" },
+        { status: 503 },
+      );
+    }
+
+    const subject = `Alchm Kitchen — ${period === "weekly" ? "Weekly" : "Daily"} digest`;
+    const html = renderHtml(payload);
+    const text = JSON.stringify(payload, null, 2);
+    const sent = await emailService.sendEmail({ to: recipient, subject, html, text });
+
+    return NextResponse.json({
+      success: sent !== false,
+      delivered: sent !== false,
+      recipient,
+      payload,
+    });
+  } catch (error) {
+    console.error("[admin/digest] Failed:", error);
+    return NextResponse.json(
+      { success: false, message: "Failed to build/send digest" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function GET(request: NextRequest) {
+  // GET is dry-run only. POST is the side-effecting variant. This lets
+  // an admin click in a browser to preview without accidentally emailing.
+  try {
+    const isInternal = isInternalCaller(request.headers.get("Authorization"));
+    if (!isInternal) {
+      const authResult = await validateAdminRequest(request);
+      if ("error" in authResult) return authResult.error;
+    }
+
+    const { searchParams } = new URL(request.url);
+    const period = searchParams.get("period") === "weekly" ? "weekly" : "daily";
+    const payload = await buildPayload(period);
+    const recipient =
+      process.env.AUTH_ADMIN_EMAIL ||
+      process.env.ADMIN_NOTIFICATION_EMAIL ||
+      null;
+    return NextResponse.json({ success: true, dryRun: true, payload, recipient });
+  } catch (error) {
+    console.error("[admin/digest] GET failed:", error);
+    return NextResponse.json(
+      { success: false, message: "Failed to build digest preview" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/observability/route.ts
+++ b/src/app/api/admin/observability/route.ts
@@ -1,0 +1,63 @@
+/**
+ * Admin Observability
+ * GET /api/admin/observability
+ *
+ * Reads the in-memory request and slow-query rings populated by
+ * src/lib/observability/*. These rings are per-process and reset on
+ * deploy — they're for live debugging and admin dashboards, not for
+ * long-term retention. The auth_events table fills the durable role.
+ *
+ * @requires Authentication - Admin role required
+ */
+
+import { NextResponse } from "next/server";
+import { validateAdminRequest } from "@/lib/auth/validateRequest";
+import {
+  getRecentRequests,
+  summarizeRecent,
+} from "@/lib/observability/requestLog";
+import {
+  getRecentSlowQueries,
+  summarizeSlowQueries,
+} from "@/lib/observability/slowQueryLog";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  try {
+    const authResult = await validateAdminRequest(request);
+    if ("error" in authResult) return authResult.error;
+
+    const { searchParams } = new URL(request.url);
+    const requestLimit = Math.min(
+      Math.max(parseInt(searchParams.get("requestLimit") ?? "100", 10) || 100, 1),
+      500,
+    );
+    const slowLimit = Math.min(
+      Math.max(parseInt(searchParams.get("slowLimit") ?? "50", 10) || 50, 1),
+      200,
+    );
+
+    return NextResponse.json({
+      success: true,
+      generatedAt: new Date().toISOString(),
+      requests: {
+        summary: summarizeRecent(),
+        recent: getRecentRequests({ limit: requestLimit }),
+        recentFailures: getRecentRequests({ limit: 50, statusGte: 500 }),
+      },
+      slowQueries: {
+        summary: summarizeSlowQueries(),
+        recent: getRecentSlowQueries(slowLimit),
+      },
+    });
+  } catch (error) {
+    console.error("[admin/observability] Failed:", error);
+    return NextResponse.json(
+      { success: false, message: "Failed to load observability data" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,23 +1,52 @@
 /**
  * Admin Users API Route
- * GET  /api/admin/users         - List all users with tier info
+ * GET  /api/admin/users         - List users (paginated) with tier + activity metrics
  * PATCH /api/admin/users/[id]   - Update user role or tier (handled in [id]/route.ts)
  *
  * @requires Authentication - Admin role required
  */
 
 import { NextResponse } from "next/server";
+import { executeQuery } from "@/lib/database";
 import { validateAdminRequest } from "@/lib/auth/validateRequest";
-import { subscriptionService } from "@/services/subscriptionService";
 import { userDatabase } from "@/services/userDatabaseService";
 import type { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+const DEFAULT_PAGE_SIZE = 50;
+const MAX_PAGE_SIZE = 200;
+
+interface AdminUserRow {
+  id: string;
+  email: string;
+  name: string | null;
+  role: string;
+  is_active: boolean;
+  is_agent: boolean | null;
+  created_at: Date;
+  last_login_at: Date | null;
+  login_count: number | null;
+  onboarding_completed: boolean | null;
+  dominant_element: string | null;
+  subscription_tier: string | null;
+  subscription_status: string | null;
+  active_sessions: number | null;
+}
+
 /**
  * GET /api/admin/users
- * Returns all users with profile and subscription tier information.
+ *
+ * Returns a paginated user list with subscription tier, login count,
+ * and active session count joined in a single query (no N+1).
+ *
+ * Query parameters:
+ *   search    — substring match on email or name
+ *   status    — "active" | "inactive"
+ *   tier      — "free" | "premium"
+ *   page      — 1-indexed (default 1)
+ *   pageSize  — 1..200 (default 50)
  */
 export async function GET(request: NextRequest) {
   try {
@@ -27,81 +56,150 @@ export async function GET(request: NextRequest) {
     }
 
     const { searchParams } = new URL(request.url);
-    const search = searchParams.get("search")?.toLowerCase();
-    const status = searchParams.get("status"); // "active" | "inactive" | null
-    const tierFilter = searchParams.get("tier"); // "free" | "premium" | null
+    const search = searchParams.get("search")?.toLowerCase()?.trim() || null;
+    const status = searchParams.get("status");
+    const tierFilter = searchParams.get("tier");
+    const page = Math.max(parseInt(searchParams.get("page") ?? "1", 10) || 1, 1);
+    const pageSize = Math.min(
+      Math.max(parseInt(searchParams.get("pageSize") ?? `${DEFAULT_PAGE_SIZE}`, 10) || DEFAULT_PAGE_SIZE, 1),
+      MAX_PAGE_SIZE,
+    );
 
-    let users = await userDatabase.getAllUsers();
+    // Build WHERE clauses dynamically so we only filter when params are present.
+    const where: string[] = [];
+    const params: unknown[] = [];
 
     if (search) {
-      users = users.filter(
-        (u) =>
-          u.email.toLowerCase().includes(search) ||
-          u.profile.name?.toLowerCase().includes(search),
-      );
+      params.push(`%${search}%`);
+      const i = params.length;
+      where.push(`(lower(u.email) LIKE $${i} OR lower(COALESCE(up.name, u.name, '')) LIKE $${i})`);
+    }
+    if (status === "active") where.push(`u.is_active = true`);
+    else if (status === "inactive") where.push(`u.is_active = false`);
+
+    if (tierFilter === "premium") {
+      // Admins are effectively premium even without a row in user_subscriptions.
+      where.push(`(s.tier = 'premium' OR u.role = 'ADMIN')`);
+    } else if (tierFilter === "free") {
+      where.push(`(COALESCE(s.tier, 'free') = 'free' AND u.role <> 'ADMIN')`);
     }
 
-    if (status === "active") {
-      users = users.filter((u) => u.isActive);
-    } else if (status === "inactive") {
-      users = users.filter((u) => !u.isActive);
-    }
+    const whereSql = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
 
-    // Sort newest first
-    users.sort(
-      (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    // Pull users + profile + subscription + active session count in ONE query.
+    // Previously this was N+1 (one DB call per user for subscriptions).
+    const sessionsLateral = `LEFT JOIN LATERAL (
+      SELECT COUNT(*)::int AS active_sessions
+      FROM device_sessions
+      WHERE user_id = u.id::text AND revoked_at IS NULL
+    ) ds ON true`;
+
+    const countResult = await executeQuery<{ total: number }>(
+      `SELECT COUNT(DISTINCT u.id)::int AS total
+       FROM users u
+       LEFT JOIN user_profiles up ON up.user_id = u.id
+       LEFT JOIN user_subscriptions s ON s.user_id = u.id
+       ${whereSql}`,
+      params,
+    );
+    const total = countResult.rows[0]?.total ?? 0;
+
+    params.push(pageSize);
+    const limitIdx = params.length;
+    params.push((page - 1) * pageSize);
+    const offsetIdx = params.length;
+
+    const result = await executeQuery<AdminUserRow>(
+      `SELECT
+         u.id::text AS id,
+         u.email,
+         COALESCE(up.name, u.name) AS name,
+         u.role::text AS role,
+         u.is_active,
+         u.is_agent,
+         u.created_at,
+         u.last_login_at,
+         u.login_count,
+         up.onboarding_completed,
+         up.natal_chart->>'dominantElement' AS dominant_element,
+         s.tier::text AS subscription_tier,
+         s.status::text AS subscription_status,
+         ds.active_sessions
+       FROM users u
+       LEFT JOIN user_profiles up ON up.user_id = u.id
+       LEFT JOIN user_subscriptions s ON s.user_id = u.id
+       ${sessionsLateral}
+       ${whereSql}
+       ORDER BY u.created_at DESC
+       LIMIT $${limitIdx} OFFSET $${offsetIdx}`,
+      params,
     );
 
-    // Fetch subscription tiers in parallel — errors are non-fatal
-    const subscriptions = await Promise.allSettled(
-      users.map((u) => subscriptionService.getUserSubscription(u.id)),
-    );
-
-    const mappedUsers = users.map((u, i) => {
-      const subResult = subscriptions[i];
-      const sub =
-        subResult.status === "fulfilled" ? subResult.value : null;
-
-      // Admins always get premium regardless of DB subscription state
-      const isAdmin = u.roles.some(
-        (r) => String(r).toLowerCase() === "admin",
-      );
-      const tier = isAdmin ? "premium" : (sub?.tier ?? "free");
-
+    const users = result.rows.map((row) => {
+      const isAdmin = (row.role || "").toUpperCase() === "ADMIN";
+      const effectiveTier = isAdmin ? "premium" : (row.subscription_tier ?? "free");
       return {
-        id: u.id,
-        email: u.email,
-        name: u.profile.name ?? null,
-        roles: u.roles,
-        tier,
-        subscriptionStatus: sub?.status ?? null,
-        isActive: u.isActive,
-        createdAt: u.createdAt,
-        lastLoginAt: u.lastLoginAt ?? null,
-        dominantElement: u.profile.natalChart?.dominantElement ?? null,
-        hasCompletedOnboarding: !!(
-          u.profile.birthData && u.profile.natalChart
-        ),
+        id: row.id,
+        email: row.email,
+        name: row.name ?? null,
+        roles: isAdmin ? ["admin", "user"] : ["user"],
+        tier: effectiveTier,
+        subscriptionStatus: row.subscription_status ?? null,
+        isActive: row.is_active,
+        isAgent: row.is_agent === true,
+        createdAt: row.created_at,
+        lastLoginAt: row.last_login_at,
+        loginCount: row.login_count ?? 0,
+        activeSessions: row.active_sessions ?? 0,
+        dominantElement: row.dominant_element ?? null,
+        hasCompletedOnboarding: row.onboarding_completed === true,
       };
     });
 
-    // Apply tier filter after computing effective tier
-    const filtered =
-      tierFilter
-        ? mappedUsers.filter((u) => u.tier === tierFilter)
-        : mappedUsers;
-
     return NextResponse.json({
       success: true,
-      users: filtered,
-      total: filtered.length,
+      users,
+      total,
+      pagination: {
+        page,
+        pageSize,
+        total,
+        totalPages: pageSize > 0 ? Math.ceil(total / pageSize) : 1,
+      },
     });
   } catch (error) {
     console.error("[admin/users] List error:", error);
-    return NextResponse.json(
-      { success: false, message: "Failed to load users" },
-      { status: 500 },
-    );
+    // Fall back to the in-memory userDatabase enumeration so the admin page
+    // still renders something usable when Postgres is temporarily unreachable.
+    try {
+      const users = await userDatabase.getAllUsers();
+      return NextResponse.json({
+        success: true,
+        users: users.map((u) => ({
+          id: u.id,
+          email: u.email,
+          name: u.profile.name ?? null,
+          roles: u.roles,
+          tier: "free",
+          subscriptionStatus: null,
+          isActive: u.isActive,
+          isAgent: u.isAgent === true,
+          createdAt: u.createdAt,
+          lastLoginAt: u.lastLoginAt ?? null,
+          loginCount: 0,
+          activeSessions: 0,
+          dominantElement: u.profile.natalChart?.dominantElement ?? null,
+          hasCompletedOnboarding: !!(u.profile.birthData && u.profile.natalChart),
+        })),
+        total: users.length,
+        pagination: { page: 1, pageSize: users.length, total: users.length, totalPages: 1 },
+        degraded: true,
+      });
+    } catch {
+      return NextResponse.json(
+        { success: false, message: "Failed to load users" },
+        { status: 500 },
+      );
+    }
   }
 }

--- a/src/app/api/admin/users/stats/route.ts
+++ b/src/app/api/admin/users/stats/route.ts
@@ -1,0 +1,138 @@
+/**
+ * Admin Auth & User Metrics
+ * GET /api/admin/users/stats
+ *
+ * Aggregates from `users`, `auth_events`, and `device_sessions` to answer:
+ *   - How many users do we have? (active, onboarded, premium)
+ *   - How many sign-in attempts in the last 24h / 7d?
+ *   - How many of those failed? Which event types?
+ *   - How many sessions are live right now?
+ *   - Who logged in most recently?
+ *
+ * @requires Authentication - Admin role required
+ */
+
+import { NextResponse } from "next/server";
+import { executeQuery } from "@/lib/database";
+import { validateAdminRequest } from "@/lib/auth/validateRequest";
+import { getEventCounts } from "@/services/authEventsService";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+interface UserRollupRow {
+  total: number;
+  active: number;
+  onboarded: number;
+  premium: number;
+  agents: number;
+  signups_24h: number;
+  signups_7d: number;
+  active_sessions: number;
+  logged_in_24h: number;
+  logged_in_7d: number;
+  logged_in_30d: number;
+}
+
+interface RecentLoginRow {
+  id: string;
+  email: string;
+  last_login_at: Date | null;
+  login_count: number | null;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const authResult = await validateAdminRequest(request);
+    if ("error" in authResult) {
+      return authResult.error;
+    }
+
+    const rollupResult = await executeQuery<UserRollupRow>(
+      `SELECT
+         COUNT(*)::int AS total,
+         COUNT(*) FILTER (WHERE u.is_active = true)::int AS active,
+         COUNT(*) FILTER (WHERE up.onboarding_completed = true)::int AS onboarded,
+         COUNT(*) FILTER (WHERE COALESCE(s.tier, 'free') = 'premium' OR u.role = 'ADMIN')::int AS premium,
+         COUNT(*) FILTER (WHERE u.is_agent = true)::int AS agents,
+         COUNT(*) FILTER (WHERE u.created_at >= NOW() - INTERVAL '24 hours')::int AS signups_24h,
+         COUNT(*) FILTER (WHERE u.created_at >= NOW() - INTERVAL '7 days')::int  AS signups_7d,
+         COUNT(*) FILTER (WHERE u.last_login_at >= NOW() - INTERVAL '24 hours')::int AS logged_in_24h,
+         COUNT(*) FILTER (WHERE u.last_login_at >= NOW() - INTERVAL '7 days')::int  AS logged_in_7d,
+         COUNT(*) FILTER (WHERE u.last_login_at >= NOW() - INTERVAL '30 days')::int AS logged_in_30d,
+         (
+           SELECT COUNT(*)::int FROM device_sessions WHERE revoked_at IS NULL
+         ) AS active_sessions
+       FROM users u
+       LEFT JOIN user_profiles up ON up.user_id = u.id
+       LEFT JOIN user_subscriptions s ON s.user_id = u.id`,
+    );
+
+    const rollup = rollupResult.rows[0] ?? {
+      total: 0,
+      active: 0,
+      onboarded: 0,
+      premium: 0,
+      agents: 0,
+      signups_24h: 0,
+      signups_7d: 0,
+      logged_in_24h: 0,
+      logged_in_7d: 0,
+      logged_in_30d: 0,
+      active_sessions: 0,
+    };
+
+    const [eventsLast24h, eventsLast7d, recentLogins] = await Promise.all([
+      getEventCounts(24 * 60 * 60 * 1000),
+      getEventCounts(7 * 24 * 60 * 60 * 1000),
+      executeQuery<RecentLoginRow>(
+        `SELECT id::text AS id, email, last_login_at, login_count
+         FROM users
+         WHERE last_login_at IS NOT NULL
+         ORDER BY last_login_at DESC
+         LIMIT 10`,
+      ),
+    ]);
+
+    return NextResponse.json({
+      success: true,
+      generatedAt: new Date().toISOString(),
+      users: {
+        total: rollup.total,
+        active: rollup.active,
+        onboarded: rollup.onboarded,
+        premium: rollup.premium,
+        agents: rollup.agents,
+        signups: {
+          last24h: rollup.signups_24h,
+          last7d: rollup.signups_7d,
+        },
+        activity: {
+          loggedIn24h: rollup.logged_in_24h,
+          loggedIn7d: rollup.logged_in_7d,
+          loggedIn30d: rollup.logged_in_30d,
+        },
+      },
+      sessions: {
+        active: rollup.active_sessions,
+      },
+      authEvents: {
+        last24h: eventsLast24h,
+        last7d: eventsLast7d,
+      },
+      recentLogins: recentLogins.rows.map((r) => ({
+        userId: r.id,
+        email: r.email,
+        lastLoginAt: r.last_login_at,
+        loginCount: r.login_count ?? 0,
+      })),
+    });
+  } catch (error) {
+    console.error("[admin/users/stats] Failed:", error);
+    return NextResponse.json(
+      { success: false, message: "Failed to load metrics" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/commensal/guest-recommendations/route.ts
+++ b/src/app/api/commensal/guest-recommendations/route.ts
@@ -1,16 +1,12 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { EnhancedRecommendationService } from "@/services/EnhancedRecommendationService";
 import { calculateCompositeNatalChart } from "@/services/groupNatalChartService";
 import { calculateNatalChart } from "@/services/natalChartService";
 import type { ElementalProperties as AlchemyElementalProperties } from "@/types/alchemy";
-import type { BirthData, GroupMember } from "@/types/natalChart";
+import type { GroupMember } from "@/types/natalChart";
 import { getCuisineRecommendations } from "@/utils/cuisineRecommender";
 import { getRecommendedCookingMethods } from "@/utils/recommendation/methodRecommendation";
-
-interface GuestInput {
-  name: string;
-  birthData: BirthData;
-}
 
 interface CookingMethodSummary {
   method: string;
@@ -18,48 +14,41 @@ interface CookingMethodSummary {
   reasons: string[];
 }
 
-function isValidBirthData(b: unknown): b is BirthData {
-  if (!b || typeof b !== "object") return false;
-  const data = b as Record<string, unknown>;
-  return (
-    typeof data.dateTime === "string" &&
-    data.dateTime.length > 0 &&
-    typeof data.latitude === "number" &&
-    Number.isFinite(data.latitude) &&
-    typeof data.longitude === "number" &&
-    Number.isFinite(data.longitude)
-  );
-}
+const birthDataSchema = z
+  .object({
+    dateTime: z.string().min(1),
+    latitude: z.number().finite().min(-90).max(90),
+    longitude: z.number().finite().min(-180).max(180),
+  })
+  .passthrough();
+
+const guestSchema = z.object({
+  name: z.string().trim().min(1, "name is required").max(120),
+  birthData: birthDataSchema,
+});
+
+const bodySchema = z.object({
+  guests: z.array(guestSchema).min(1, "At least one guest is required").max(12),
+});
 
 export async function POST(req: Request) {
   try {
-    const body = await req.json();
-    const { guests } = body as { guests?: GuestInput[] };
-
-    if (!Array.isArray(guests) || guests.length === 0) {
+    const raw = await req.json().catch(() => null);
+    const parsed = bodySchema.safeParse(raw);
+    if (!parsed.success) {
       return NextResponse.json(
-        { success: false, message: "At least one guest is required" },
+        {
+          success: false,
+          message: parsed.error.issues[0]?.message ?? "Invalid request payload",
+          issues: parsed.error.issues.slice(0, 5).map((i) => ({
+            path: i.path.join("."),
+            message: i.message,
+          })),
+        },
         { status: 400 },
       );
     }
-
-    for (const [i, guest] of guests.entries()) {
-      if (!guest?.name || typeof guest.name !== "string") {
-        return NextResponse.json(
-          { success: false, message: `Guest ${i + 1}: name is required` },
-          { status: 400 },
-        );
-      }
-      if (!isValidBirthData(guest.birthData)) {
-        return NextResponse.json(
-          {
-            success: false,
-            message: `Guest ${i + 1} (${guest.name}): birthData must include dateTime (ISO string), latitude, and longitude`,
-          },
-          { status: 400 },
-        );
-      }
-    }
+    const { guests } = parsed.data;
 
     // Calculate natal charts for all guests in parallel.
     const natalCharts = await Promise.all(

--- a/src/app/api/commensal/guest-recommendations/route.ts
+++ b/src/app/api/commensal/guest-recommendations/route.ts
@@ -36,10 +36,13 @@ export async function POST(req: Request) {
     const raw = await req.json().catch(() => null);
     const parsed = bodySchema.safeParse(raw);
     if (!parsed.success) {
+      const first = parsed.error.issues[0];
+      const path = first?.path.join(".") || "request";
+      const message = first ? `${path}: ${first.message}` : "Invalid request payload";
       return NextResponse.json(
         {
           success: false,
-          message: parsed.error.issues[0]?.message ?? "Invalid request payload",
+          message,
           issues: parsed.error.issues.slice(0, 5).map((i) => ({
             path: i.path.join("."),
             message: i.message,

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -3,6 +3,7 @@
  * GET /api/feed - Fetch recent community feed events
  */
 
+import { timingSafeEqual } from "node:crypto";
 import { NextResponse } from "next/server";
 import { feedDatabase } from "@/services/feedDatabaseService";
 import { subscriptionService } from "@/services/subscriptionService";
@@ -11,7 +12,17 @@ import { userDatabase } from "@/services/userDatabaseService";
 export const dynamic = "force-dynamic";
 
 if (!process.env.INTERNAL_API_SECRET) {
-  console.warn("[feed] INTERNAL_API_SECRET is not set — the POST handler will accept all agent writes without authentication");
+  console.warn("[feed] INTERNAL_API_SECRET is not set — the POST handler will reject all agent writes until the secret is configured");
+}
+
+function isAuthorizedAgentRequest(authHeader: string | null): boolean {
+  const internalSecret = process.env.INTERNAL_API_SECRET;
+  // Fail closed: without a configured secret, agent writes are rejected.
+  if (!internalSecret || !authHeader) return false;
+  const expected = Buffer.from(`Bearer ${internalSecret}`);
+  const received = Buffer.from(authHeader);
+  if (received.length !== expected.length) return false;
+  return timingSafeEqual(received, expected);
 }
 
 export async function GET(request: Request) {
@@ -37,11 +48,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    // Basic service-to-service auth check
-    const authHeader = request.headers.get("Authorization");
-    const internalSecret = process.env.INTERNAL_API_SECRET;
-    
-    if (internalSecret && authHeader !== `Bearer ${internalSecret}`) {
+    if (!isAuthorizedAgentRequest(request.headers.get("Authorization"))) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 

--- a/src/app/api/generate-cosmic-recipe/route.ts
+++ b/src/app/api/generate-cosmic-recipe/route.ts
@@ -3,6 +3,7 @@
  * Requests a structured cosmic recipe using the planetary_agents microservice.
  * Uses the cosmicRecipeSchema for structured output.
  */
+import { z } from "zod";
 import { gateDemoOrAuth } from "@/lib/auth/demoAccess";
 import {
   applyPersonalizedPricing,
@@ -32,6 +33,24 @@ import type { NextRequest } from "next/server";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 export const maxDuration = 60;
+
+const birthDataSchema = z
+  .object({
+    dateTime: z.string().min(1).optional(),
+    latitude: z.number().finite().optional(),
+    longitude: z.number().finite().optional(),
+  })
+  .passthrough()
+  .optional();
+
+const cosmicRecipeBodySchema = z.object({
+  prompt: z.string().trim().max(2000).optional(),
+  diet: z.string().trim().max(200).optional(),
+  ingredients_main: z.array(z.string().max(80)).max(40).optional(),
+  disallowed_ingredients: z.array(z.string().max(80)).max(40).optional(),
+  birthData: birthDataSchema,
+  preferredCuisine: z.string().trim().max(80).optional(),
+});
 
 export async function POST(request: NextRequest) {
   // Auth'd users → token economy (Spirit/Essence per cosmic recipe) is the throttle.
@@ -111,7 +130,27 @@ export async function POST(request: NextRequest) {
   const demoMode = access.mode === "demo";
   const userId: string | null = access.mode === "auth" ? access.userId : null;
 
-  const body = await request.json();
+  const rawBody = await request.json().catch(() => null);
+  if (!rawBody || typeof rawBody !== "object") {
+    return new Response(
+      JSON.stringify({ error: "invalid_request", message: "Request body must be JSON." }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+  const parsed = cosmicRecipeBodySchema.safeParse(rawBody);
+  if (!parsed.success) {
+    return new Response(
+      JSON.stringify({
+        error: "invalid_request",
+        message: "Recipe input failed validation.",
+        issues: parsed.error.issues.slice(0, 5).map((i) => ({
+          path: i.path.join("."),
+          message: i.message,
+        })),
+      }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
   const {
     prompt,
     diet,
@@ -119,14 +158,7 @@ export async function POST(request: NextRequest) {
     disallowed_ingredients: disallowedIngredients,
     birthData,
     preferredCuisine,
-  } = body as {
-    prompt?: string;
-    diet?: string;
-    ingredients_main?: string[];
-    disallowed_ingredients?: string[];
-    birthData?: unknown;
-    preferredCuisine?: string;
-  };
+  } = parsed.data;
 
   // Get current sky for context
   const raw = getAccuratePlanetaryPositions(new Date());

--- a/src/app/api/instacart/price-estimate/route.ts
+++ b/src/app/api/instacart/price-estimate/route.ts
@@ -41,21 +41,24 @@ export async function POST(req: Request) {
       });
     } catch (error) {
       if (error instanceof InstacartConfigurationError) {
+        logger.warn("Instacart IDP misconfigured", error);
         return NextResponse.json({
           confidence: "low",
-          message: error.message,
+          message: "Instacart integration unavailable.",
         });
       }
       throw error;
     }
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
+      // Consume the body so the connection can be released, but don't surface
+      // upstream details — they can leak internal IDs and request shapes.
+      await response.json().catch(() => ({}));
+      logger.warn("Instacart IDP rejected payload", { status: response.status });
       return NextResponse.json({
         confidence: "low",
         reason: "IDP rejected payload",
         validated_item_count: 0,
-        details: errorData
       });
     }
 

--- a/src/app/api/premium-table/route.ts
+++ b/src/app/api/premium-table/route.ts
@@ -5,20 +5,43 @@
  */
 import { NextResponse } from "next/server";
 import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
+import { rateLimit } from "@/lib/rateLimit";
 import { calculateCompositeNatalChart } from "@/services/groupNatalChartService";
+import { subscriptionService } from "@/services/subscriptionService";
 import type { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+const PREMIUM_TABLE_LIMIT = { window: 60_000, max: 10, bucket: "premium-table" };
+
 export async function POST(request: NextRequest) {
+  const rl = await rateLimit(request, PREMIUM_TABLE_LIMIT);
+  if (!rl.allowed) return rl.response!;
+
   try {
-    const user = await getDatabaseUserFromRequest(request);
-    
-    // We just check if user exists for logging/analytics conceptually, but allow unauthenticated friends
-    if (user) {
-      console.log(`[premium-table] User ${user.id} requested composite chart.`);
+    const user = await getDatabaseUserFromRequest(request).catch(() => null);
+
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "Authentication required to compute composite charts." },
+        { status: 401 },
+      );
     }
+
+    const subscription = await subscriptionService.getUserSubscription(user.id);
+    if (!subscription || subscription.tier !== "premium") {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Premium subscription required.",
+          upgradeUrl: "/upgrade",
+        },
+        { status: 402 },
+      );
+    }
+
+    console.log(`[premium-table] Premium user ${user.id} requested composite chart.`);
 
     const body = await request.json().catch(() => ({}));
     const { hostData, friendData } = body;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,22 +37,35 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 // app/layout.tsx
-// Force dynamic rendering for all pages - the app relies on runtime
-// context providers (Chakra, Theme, User, Alchemical) that require
-// a client-side React environment during rendering.
-export const dynamic = "force-dynamic";
+// Note: `force-dynamic` is intentionally NOT applied at the root layout. The
+// per-request providers (Chakra, User, Alchemical) only run inside the
+// (alchm) route group, which sets dynamic = "force-dynamic" itself. Marketing
+// and auth-shell routes outside that group remain cacheable at the segment
+// level, which dramatically improves TTFB and CDN hit rates.
 export const viewport = {
   themeColor: "#07060B",
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover" as const,
 };
 
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://alchm.kitchen";
+const SITE_TITLE = "Alchm Kitchen — What to Eat Next";
+const SITE_DESCRIPTION =
+  "Personalized food recommendations based on your chakra energies and astrological harmony.";
+
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: {
-    default: "Alchm Kitchen — What to Eat Next",
+    default: SITE_TITLE,
     template: "%s | Alchm Kitchen",
   },
-  description:
-    "Personalized food recommendations based on your chakra energies and astrological harmony",
+  description: SITE_DESCRIPTION,
+  applicationName: "Alchm Kitchen",
   manifest: "/manifest.json",
+  alternates: {
+    canonical: "/",
+  },
   icons: {
     icon: [
       { url: "/alchm-icon-64.png", sizes: "64x64", type: "image/png" },
@@ -60,6 +73,38 @@ export const metadata: Metadata = {
       { url: "/alchm-icon-512.png", sizes: "512x512", type: "image/png" },
     ],
     apple: "/alchm-icon-512.png",
+  },
+  openGraph: {
+    type: "website",
+    url: SITE_URL,
+    siteName: "Alchm Kitchen",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    images: [
+      {
+        url: "/alchm-icon-512.png",
+        width: 512,
+        height: 512,
+        alt: "Alchm Kitchen",
+      },
+    ],
+    locale: "en_US",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    images: ["/alchm-icon-512.png"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
   },
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import { Analytics } from "@vercel/analytics/next";
 import { Cormorant_Garamond, JetBrains_Mono, Manrope } from "next/font/google";
-import React from "react";
+import React, { Suspense } from "react";
 import SignInModal from "@/components/auth/SignInModal";
 import TokenShopModal from "@/components/economy/TokenShopModal";
 import { GroceryCartDrawer } from "@/components/grocery-cart/GroceryCartDrawer";
@@ -149,7 +149,16 @@ export default function RootLayout({
           <AppChromeTabBar>
             <MobileGlassTabBar />
           </AppChromeTabBar>
-          <SignInModal />
+          {/*
+            SignInModal reads URL params (?signin=true) via useSearchParams,
+            which forces a CSR bailout on any statically-prerendered page
+            that mounts the root layout. Wrapping it in <Suspense> keeps
+            those pages cacheable — the modal is mounted but invisible until
+            opened, so the fallback can safely be null.
+          */}
+          <Suspense fallback={null}>
+            <SignInModal />
+          </Suspense>
           <TokenShopModal />
           <GroceryCartDrawer />
         </ClientProviders>

--- a/src/app/recipes/[recipeId]/page.tsx
+++ b/src/app/recipes/[recipeId]/page.tsx
@@ -3,6 +3,7 @@ import { LocalRecipeService } from "@/services/LocalRecipeService";
 import { _recipeRecommender } from "@/services/recipeRecommendations";
 import { sauceRecommender } from "@/services/sauceRecommender";
 import RecipeClient from "./RecipeClient";
+import type { Metadata } from "next";
 
 export async function generateStaticParams() {
   if (process.env.ENABLE_RECIPE_STATIC_PARAMS !== "true") {
@@ -17,6 +18,48 @@ export async function generateStaticParams() {
 
 interface RecipePageProps {
   params: Promise<{ recipeId: string }>;
+}
+
+export async function generateMetadata({ params }: RecipePageProps): Promise<Metadata> {
+  const { recipeId } = await params;
+  const recipe = await LocalRecipeService.getRecipeById(recipeId).catch(() => null);
+
+  if (!recipe) {
+    return {
+      title: "Recipe not found",
+      robots: { index: false, follow: false },
+    };
+  }
+
+  const recipeName = String(recipe.name ?? "Recipe");
+  const description =
+    typeof recipe.description === "string" && recipe.description.length > 0
+      ? recipe.description.slice(0, 160)
+      : `${recipeName} — a personalized cosmic recipe from Alchm Kitchen.`;
+  const canonicalPath = `/recipes/${recipeId}`;
+  const imageUrl =
+    typeof (recipe as { image?: unknown }).image === "string"
+      ? ((recipe as { image: string }).image)
+      : "/alchm-icon-512.png";
+
+  return {
+    title: recipeName,
+    description,
+    alternates: { canonical: canonicalPath },
+    openGraph: {
+      type: "article",
+      url: canonicalPath,
+      title: recipeName,
+      description,
+      images: [{ url: imageUrl, alt: recipeName }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: recipeName,
+      description,
+      images: [imageUrl],
+    },
+  };
 }
 
 function getCookingMethods(recipe: Record<string, unknown>): string[] {
@@ -66,11 +109,57 @@ export default async function RecipePage({ params }: RecipePageProps) {
     allRecipes,
   );
 
+  const recipeRecord = recipe as Record<string, unknown>;
+  const ingredientList = Array.isArray(recipe.ingredients)
+    ? recipe.ingredients
+        .map((ing) =>
+          typeof ing === "string"
+            ? ing
+            : ing && typeof ing === "object" && "name" in ing
+              ? String((ing as { name: unknown }).name)
+              : "",
+        )
+        .filter(Boolean)
+    : [];
+  const rawInstructions = recipeRecord.instructions ?? recipeRecord.steps;
+  const instructionList = Array.isArray(rawInstructions)
+    ? (rawInstructions as unknown[])
+        .map((step) => (typeof step === "string" ? step : ""))
+        .filter(Boolean)
+    : [];
+
+  const recipeJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Recipe",
+    name: recipe.name,
+    description: typeof recipe.description === "string" ? recipe.description : undefined,
+    image:
+      typeof recipeRecord.image === "string"
+        ? [recipeRecord.image]
+        : ["/alchm-icon-512.png"],
+    recipeCuisine: recipe.cuisine,
+    recipeCategory:
+      typeof recipeRecord.mealType === "string" ? recipeRecord.mealType : undefined,
+    recipeIngredient: ingredientList,
+    recipeInstructions: instructionList.map((text) => ({
+      "@type": "HowToStep",
+      text,
+    })),
+    cookingMethod: cookingMethods.join(", ") || undefined,
+  };
+
   return (
-    <RecipeClient
-      recipe={recipe}
-      recommendedSauces={recommendedSauces}
-      recommendedRecipes={recommendedRecipes}
-    />
+    <>
+      <script
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(recipeJsonLd) }}
+      />
+      <RecipeClient
+        recipe={recipe}
+        recommendedSauces={recommendedSauces}
+        recommendedRecipes={recommendedRecipes}
+      />
+    </>
   );
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,37 +1,64 @@
-import type { MetadataRoute } from 'next'
+import { LocalRecipeService } from "@/services/LocalRecipeService";
+import type { MetadataRoute } from "next";
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = 'https://alchm.kitchen'
-  const now = new Date()
+export const revalidate = 3600; // regenerate sitemap at most hourly
 
-  const publicRoutes: Array<{
-    path: string;
-    changeFrequency: MetadataRoute.Sitemap[number]['changeFrequency'];
-    priority: number;
-  }> = [
-    { path: '', changeFrequency: 'hourly', priority: 1 },
-    { path: '/menu-planner', changeFrequency: 'daily', priority: 0.9 },
-    { path: '/recipe-builder', changeFrequency: 'daily', priority: 0.9 },
-    { path: '/recipes', changeFrequency: 'daily', priority: 0.85 },
-    { path: '/cuisines', changeFrequency: 'weekly', priority: 0.85 },
-    { path: '/cooking-methods', changeFrequency: 'weekly', priority: 0.8 },
-    { path: '/quantities', changeFrequency: 'daily', priority: 0.8 },
-    { path: '/cosmic-recipe', changeFrequency: 'daily', priority: 0.7 },
-    { path: '/commensal', changeFrequency: 'weekly', priority: 0.7 },
-    { path: '/pantry', changeFrequency: 'weekly', priority: 0.7 },
-    { path: '/food-tracking', changeFrequency: 'weekly', priority: 0.7 },
-    { path: '/sauces', changeFrequency: 'weekly', priority: 0.7 },
-    { path: '/restaurants', changeFrequency: 'weekly', priority: 0.65 },
-    { path: '/premium', changeFrequency: 'monthly', priority: 0.6 },
-    { path: '/upgrade', changeFrequency: 'monthly', priority: 0.5 },
-    { path: '/terms', changeFrequency: 'yearly', priority: 0.2 },
-    { path: '/privacy', changeFrequency: 'yearly', priority: 0.2 },
-  ];
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://alchm.kitchen";
 
-  return publicRoutes.map((route) => ({
-    url: `${baseUrl}${route.path}`,
+const STATIC_ROUTES: Array<{
+  path: string;
+  changeFrequency: MetadataRoute.Sitemap[number]["changeFrequency"];
+  priority: number;
+}> = [
+  { path: "", changeFrequency: "hourly", priority: 1 },
+  { path: "/menu-planner", changeFrequency: "daily", priority: 0.9 },
+  { path: "/recipe-builder", changeFrequency: "daily", priority: 0.9 },
+  { path: "/recipes", changeFrequency: "daily", priority: 0.85 },
+  { path: "/cuisines", changeFrequency: "weekly", priority: 0.85 },
+  { path: "/cooking-methods", changeFrequency: "weekly", priority: 0.8 },
+  { path: "/quantities", changeFrequency: "daily", priority: 0.8 },
+  { path: "/cosmic-recipe", changeFrequency: "daily", priority: 0.7 },
+  { path: "/commensal", changeFrequency: "weekly", priority: 0.7 },
+  { path: "/pantry", changeFrequency: "weekly", priority: 0.7 },
+  { path: "/food-tracking", changeFrequency: "weekly", priority: 0.7 },
+  { path: "/sauces", changeFrequency: "weekly", priority: 0.7 },
+  { path: "/restaurants", changeFrequency: "weekly", priority: 0.65 },
+  { path: "/premium", changeFrequency: "monthly", priority: 0.6 },
+  { path: "/upgrade", changeFrequency: "monthly", priority: 0.5 },
+  { path: "/terms", changeFrequency: "yearly", priority: 0.2 },
+  { path: "/privacy", changeFrequency: "yearly", priority: 0.2 },
+];
+
+async function getRecipeEntries(now: Date): Promise<MetadataRoute.Sitemap> {
+  try {
+    const recipes = await LocalRecipeService.getAllRecipes();
+    return recipes
+      .map((recipe) => (recipe?.id ? String(recipe.id) : ""))
+      .filter(Boolean)
+      .map((id) => ({
+        url: `${BASE_URL}/recipes/${id}`,
+        lastModified: now,
+        changeFrequency: "weekly" as const,
+        priority: 0.6,
+      }));
+  } catch (err) {
+    // Sitemap generation should never crash the build/route — log and continue.
+    console.warn("[sitemap] Failed to enumerate recipes:", err);
+    return [];
+  }
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const now = new Date();
+
+  const staticEntries: MetadataRoute.Sitemap = STATIC_ROUTES.map((route) => ({
+    url: `${BASE_URL}${route.path}`,
     lastModified: now,
     changeFrequency: route.changeFrequency,
     priority: route.priority,
-  }))
+  }));
+
+  const recipeEntries = await getRecipeEntries(now);
+
+  return [...staticEntries, ...recipeEntries];
 }

--- a/src/components/admin/AdvancedMetricsPanel.tsx
+++ b/src/components/admin/AdvancedMetricsPanel.tsx
@@ -1,0 +1,424 @@
+"use client";
+
+/**
+ * AdvancedMetricsPanel
+ *
+ * Renders the data exposed by the four new admin endpoints:
+ *   GET /api/admin/users/stats         (sign-up + activity rollups, auth events)
+ *   GET /api/admin/abuse?window=1h     (suspicious IPs + targeted emails)
+ *   GET /api/admin/observability       (in-memory request + slow-query rings)
+ *   POST /api/admin/digest?dryRun=true (digest preview)
+ *
+ * Lives on /admin alongside the existing dashboard. All sections gracefully
+ * degrade — a single failed fetch only blanks its own card, not the page.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+interface UsersStats {
+  users: {
+    total: number;
+    active: number;
+    onboarded: number;
+    premium: number;
+    agents: number;
+    signups: { last24h: number; last7d: number };
+    activity: { loggedIn24h: number; loggedIn7d: number; loggedIn30d: number };
+  };
+  sessions: { active: number };
+  authEvents: {
+    last24h: {
+      total: number;
+      successes: number;
+      failures: number;
+      byType: Array<{ type: string; status: string; count: number }>;
+    };
+    last7d: {
+      total: number;
+      successes: number;
+      failures: number;
+      byType: Array<{ type: string; status: string; count: number }>;
+    };
+  };
+  recentLogins: Array<{
+    userId: string;
+    email: string;
+    lastLoginAt: string | null;
+    loginCount: number;
+  }>;
+}
+
+interface Abuse {
+  window: string;
+  suspiciousIps: Array<{
+    ipHash: string;
+    failures: number;
+    successes: number;
+    emailsTargeted: number;
+    lastSeen: string;
+  }>;
+  targetedEmails: Array<{
+    email: string | null;
+    failures: number;
+    distinctIps: number;
+    lastSeen: string;
+  }>;
+}
+
+interface Observability {
+  requests: {
+    summary: {
+      count: number;
+      p50LatencyMs: number;
+      p95LatencyMs: number;
+      p99LatencyMs: number;
+      errorRate: number;
+      topPaths: Array<{ path: string; count: number }>;
+    };
+    recentFailures: Array<{
+      id: number;
+      at: string;
+      method: string;
+      path: string;
+      status: number;
+      latencyMs: number;
+    }>;
+  };
+  slowQueries: {
+    summary: { count: number; thresholdMs: number; slowestMs: number };
+    recent: Array<{ id: number; at: string; ms: number; preview: string; rowCount: number | null }>;
+  };
+}
+
+function Kpi({ label, value, hint }: { label: string; value: string | number; hint?: string }) {
+  return (
+    <div className="bg-white rounded-lg shadow p-5">
+      <p className="text-xs uppercase tracking-wide text-gray-500">{label}</p>
+      <p className="text-2xl font-bold text-gray-800 mt-1">{value}</p>
+      {hint && <p className="text-xs text-gray-400 mt-1">{hint}</p>}
+    </div>
+  );
+}
+
+export default function AdvancedMetricsPanel() {
+  const [stats, setStats] = useState<UsersStats | null>(null);
+  const [abuse, setAbuse] = useState<Abuse | null>(null);
+  const [obs, setObs] = useState<Observability | null>(null);
+  const [errors, setErrors] = useState<{ stats?: string; abuse?: string; obs?: string }>({});
+  const [refreshing, setRefreshing] = useState(false);
+  const [digestState, setDigestState] = useState<{ loading: boolean; message: string | null }>({
+    loading: false,
+    message: null,
+  });
+
+  const load = useCallback(async () => {
+    setRefreshing(true);
+    const [statsRes, abuseRes, obsRes] = await Promise.allSettled([
+      fetch("/api/admin/users/stats", { cache: "no-store" }).then((r) => r.json()),
+      fetch("/api/admin/abuse?window=1h", { cache: "no-store" }).then((r) => r.json()),
+      fetch("/api/admin/observability", { cache: "no-store" }).then((r) => r.json()),
+    ]);
+    const nextErrors: typeof errors = {};
+    if (statsRes.status === "fulfilled" && statsRes.value?.success) {
+      setStats(statsRes.value);
+    } else {
+      nextErrors.stats = statsRes.status === "fulfilled" ? statsRes.value?.message : "Failed to load";
+    }
+    if (abuseRes.status === "fulfilled" && abuseRes.value?.success) {
+      setAbuse(abuseRes.value);
+    } else {
+      nextErrors.abuse = abuseRes.status === "fulfilled" ? abuseRes.value?.message : "Failed to load";
+    }
+    if (obsRes.status === "fulfilled" && obsRes.value?.success) {
+      setObs(obsRes.value);
+    } else {
+      nextErrors.obs = obsRes.status === "fulfilled" ? obsRes.value?.message : "Failed to load";
+    }
+    setErrors(nextErrors);
+    setRefreshing(false);
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const sendDigestPreview = async () => {
+    setDigestState({ loading: true, message: null });
+    try {
+      const res = await fetch("/api/admin/digest?dryRun=true", { method: "POST" });
+      const data = await res.json();
+      if (data.success) {
+        setDigestState({ loading: false, message: "Preview generated (dry run — no email sent)." });
+      } else {
+        setDigestState({ loading: false, message: data.message || "Failed to generate preview" });
+      }
+    } catch {
+      setDigestState({ loading: false, message: "Network error generating preview" });
+    }
+  };
+
+  const failureRate24h = stats?.authEvents.last24h.total
+    ? (stats.authEvents.last24h.failures / stats.authEvents.last24h.total) * 100
+    : 0;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-baseline justify-between">
+        <h2 className="text-xl font-semibold text-gray-800">Advanced metrics</h2>
+        <button
+          type="button"
+          onClick={() => void load()}
+          disabled={refreshing}
+          className="text-sm text-purple-700 hover:text-purple-900 disabled:opacity-50"
+        >
+          {refreshing ? "Refreshing…" : "Refresh"}
+        </button>
+      </div>
+
+      {/* KPI row */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Kpi
+          label="Sign-ups (24h / 7d)"
+          value={stats ? `${stats.users.signups.last24h} / ${stats.users.signups.last7d}` : "—"}
+          hint="New rows in users"
+        />
+        <Kpi
+          label="Logged in (24h)"
+          value={stats?.users.activity.loggedIn24h ?? "—"}
+          hint={stats ? `7d: ${stats.users.activity.loggedIn7d} · 30d: ${stats.users.activity.loggedIn30d}` : undefined}
+        />
+        <Kpi
+          label="Active sessions"
+          value={stats?.sessions.active ?? "—"}
+          hint="device_sessions (revoked_at IS NULL)"
+        />
+        <Kpi
+          label="Auth failure rate"
+          value={stats ? `${failureRate24h.toFixed(1)}%` : "—"}
+          hint={stats ? `${stats.authEvents.last24h.failures}/${stats.authEvents.last24h.total} in 24h` : undefined}
+        />
+      </div>
+
+      {errors.stats && (
+        <div className="bg-red-50 border border-red-200 rounded p-3 text-sm text-red-700">
+          Stats endpoint: {errors.stats}
+        </div>
+      )}
+
+      {/* Auth events table */}
+      {stats && (
+        <div className="bg-white rounded-lg shadow">
+          <div className="px-6 py-4 border-b border-gray-200">
+            <h3 className="text-base font-semibold text-gray-800">
+              Auth events — last 24h
+            </h3>
+            <p className="text-xs text-gray-500 mt-1">
+              All sign-in / sign-out steps recorded in auth_events
+            </p>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-2 text-left text-xs font-medium text-gray-500 uppercase">Event</th>
+                  <th className="px-6 py-2 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+                  <th className="px-6 py-2 text-right text-xs font-medium text-gray-500 uppercase">Count</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {stats.authEvents.last24h.byType.length === 0 ? (
+                  <tr>
+                    <td colSpan={3} className="px-6 py-6 text-center text-gray-400">
+                      No auth events in the last 24h
+                    </td>
+                  </tr>
+                ) : (
+                  stats.authEvents.last24h.byType.map((row) => (
+                    <tr key={`${row.type}|${row.status}`}>
+                      <td className="px-6 py-2 font-mono text-xs text-gray-700">{row.type}</td>
+                      <td className="px-6 py-2">
+                        <span
+                          className={`px-2 py-0.5 rounded text-xs font-medium ${
+                            row.status === "failure"
+                              ? "bg-red-100 text-red-700"
+                              : row.status === "success"
+                                ? "bg-green-100 text-green-700"
+                                : "bg-gray-100 text-gray-700"
+                          }`}
+                        >
+                          {row.status}
+                        </span>
+                      </td>
+                      <td className="px-6 py-2 text-right font-semibold">{row.count}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Recent logins */}
+      {stats && stats.recentLogins.length > 0 && (
+        <div className="bg-white rounded-lg shadow">
+          <div className="px-6 py-4 border-b border-gray-200">
+            <h3 className="text-base font-semibold text-gray-800">Recent logins</h3>
+          </div>
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-2 text-left text-xs font-medium text-gray-500 uppercase">Email</th>
+                <th className="px-6 py-2 text-right text-xs font-medium text-gray-500 uppercase">Logins</th>
+                <th className="px-6 py-2 text-right text-xs font-medium text-gray-500 uppercase">Last login</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {stats.recentLogins.map((u) => (
+                <tr key={u.userId}>
+                  <td className="px-6 py-2 text-gray-800">{u.email}</td>
+                  <td className="px-6 py-2 text-right">{u.loginCount}</td>
+                  <td className="px-6 py-2 text-right text-gray-600">
+                    {u.lastLoginAt ? new Date(u.lastLoginAt).toLocaleString() : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Abuse / brute-force */}
+      <div className="bg-white rounded-lg shadow">
+        <div className="px-6 py-4 border-b border-gray-200">
+          <h3 className="text-base font-semibold text-gray-800">
+            Suspicious activity — last hour
+          </h3>
+          <p className="text-xs text-gray-500 mt-1">
+            IPs and emails with 5+ failed auth events in 60 minutes
+          </p>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-0 divide-y md:divide-y-0 md:divide-x divide-gray-100">
+          <div>
+            <p className="px-6 pt-4 pb-1 text-xs font-medium text-gray-500 uppercase">Suspicious IPs</p>
+            {!abuse ? (
+              <p className="px-6 py-4 text-sm text-gray-400">{errors.abuse ?? "Loading…"}</p>
+            ) : abuse.suspiciousIps.length === 0 ? (
+              <p className="px-6 py-4 text-sm text-gray-400">Nothing suspicious in window.</p>
+            ) : (
+              <ul className="px-6 py-2 space-y-1 text-sm">
+                {abuse.suspiciousIps.slice(0, 8).map((ip) => (
+                  <li key={ip.ipHash} className="flex justify-between gap-3">
+                    <span className="font-mono text-xs text-gray-700">
+                      {ip.ipHash.slice(0, 12)}…
+                    </span>
+                    <span className="text-red-700">
+                      {ip.failures} fail · {ip.emailsTargeted} emails
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+          <div>
+            <p className="px-6 pt-4 pb-1 text-xs font-medium text-gray-500 uppercase">Targeted emails</p>
+            {!abuse ? (
+              <p className="px-6 py-4 text-sm text-gray-400">{errors.abuse ?? "Loading…"}</p>
+            ) : abuse.targetedEmails.length === 0 ? (
+              <p className="px-6 py-4 text-sm text-gray-400">Nothing suspicious in window.</p>
+            ) : (
+              <ul className="px-6 py-2 space-y-1 text-sm">
+                {abuse.targetedEmails.slice(0, 8).map((e, i) => (
+                  <li key={`${e.email}-${i}`} className="flex justify-between gap-3">
+                    <span className="truncate text-gray-700">{e.email}</span>
+                    <span className="text-red-700">
+                      {e.failures} fail · {e.distinctIps} IPs
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Observability — slow queries + recent failures */}
+      <div className="bg-white rounded-lg shadow">
+        <div className="px-6 py-4 border-b border-gray-200">
+          <h3 className="text-base font-semibold text-gray-800">
+            Observability (this process)
+          </h3>
+          <p className="text-xs text-gray-500 mt-1">
+            In-memory rings — resets on deploy. Durable signal lives in auth_events and Railway logs.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-0 divide-y md:divide-y-0 md:divide-x divide-gray-100">
+          <div className="p-6">
+            <p className="text-xs font-medium text-gray-500 uppercase mb-2">Slow queries</p>
+            {obs ? (
+              <>
+                <p className="text-sm text-gray-700 mb-3">
+                  {obs.slowQueries.summary.count} above {obs.slowQueries.summary.thresholdMs}ms in last 5 min ·
+                  slowest {obs.slowQueries.summary.slowestMs}ms
+                </p>
+                <ul className="space-y-2 text-xs font-mono max-h-48 overflow-auto">
+                  {obs.slowQueries.recent.slice(0, 10).map((q) => (
+                    <li key={q.id} className="flex gap-3">
+                      <span className="text-amber-700 font-bold whitespace-nowrap">{q.ms}ms</span>
+                      <span className="text-gray-600 truncate">{q.preview}</span>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            ) : (
+              <p className="text-sm text-gray-400">{errors.obs ?? "Loading…"}</p>
+            )}
+          </div>
+          <div className="p-6">
+            <p className="text-xs font-medium text-gray-500 uppercase mb-2">Recent request failures</p>
+            {obs ? (
+              obs.requests.recentFailures.length === 0 ? (
+                <p className="text-sm text-gray-400">No 5xx in the ring.</p>
+              ) : (
+                <ul className="space-y-2 text-xs font-mono max-h-48 overflow-auto">
+                  {obs.requests.recentFailures.slice(0, 10).map((r) => (
+                    <li key={r.id} className="flex gap-3">
+                      <span className="text-red-700 font-bold w-12">{r.status}</span>
+                      <span className="text-gray-700 w-12">{r.method}</span>
+                      <span className="text-gray-600 truncate">{r.path}</span>
+                    </li>
+                  ))}
+                </ul>
+              )
+            ) : (
+              <p className="text-sm text-gray-400">{errors.obs ?? "Loading…"}</p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Digest */}
+      <div className="bg-white rounded-lg shadow p-6 flex items-center justify-between gap-4 flex-wrap">
+        <div>
+          <h3 className="text-base font-semibold text-gray-800">Daily auth digest</h3>
+          <p className="text-xs text-gray-500 mt-1">
+            POST /api/admin/digest emails AUTH_ADMIN_EMAIL. Wire it to a Railway cron at 09:00 UTC.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          {digestState.message && (
+            <span className="text-xs text-gray-600">{digestState.message}</span>
+          )}
+          <button
+            type="button"
+            onClick={sendDigestPreview}
+            disabled={digestState.loading}
+            className="px-3 py-2 rounded bg-purple-600 hover:bg-purple-700 text-white text-sm font-medium disabled:opacity-50"
+          >
+            {digestState.loading ? "Building…" : "Preview digest (no send)"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/SignInModal.tsx
+++ b/src/components/auth/SignInModal.tsx
@@ -68,6 +68,31 @@ export default function SignInModal() {
     }
   }, [status, isOpen]);
 
+  // Escape key handler + restore focus on close
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!isOpen) return;
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleCloseModal();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    // Move focus into the dialog (first focusable element)
+    const focusable = dialogRef.current?.querySelector<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    focusable?.focus();
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      previouslyFocusedRef.current?.focus?.();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
   const handleCloseModal = () => {
     setIsOpen(false);
     setIsSigningIn(false); // Reset spinner
@@ -111,28 +136,35 @@ export default function SignInModal() {
   if (!isOpen || status === 'authenticated') return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4 overflow-y-auto">
-      <div 
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4 overflow-y-auto"
+      onClick={(e) => {
+        // Click-outside dismissal (only when clicking the backdrop itself)
+        if (e.target === e.currentTarget) handleCloseModal();
+      }}
+    >
+      <div
+        ref={dialogRef}
         className="bg-white p-8 rounded-2xl shadow-xl max-w-md w-full border border-purple-100 relative mt-16 md:mt-0"
         role="dialog"
         aria-modal="true"
-        aria-labelledby="modal-title"
+        aria-labelledby="signin-modal-title"
       >
-        <button 
+        <button
           onClick={handleCloseModal}
-          className="absolute top-4 right-4 text-gray-400 hover:text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-full p-2 transition-colors"
-          aria-label="Close modal"
+          className="absolute top-4 right-4 min-w-[44px] min-h-[44px] text-gray-400 hover:text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-full p-2 transition-colors flex items-center justify-center"
+          aria-label="Close sign-in dialog"
         >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
           </svg>
         </button>
 
         {/* Header */}
         <div className="text-center mb-8">
-          <h1 id="modal-title" className="text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-purple-600 to-orange-600 mb-2">
+          <h2 id="signin-modal-title" className="text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-purple-600 to-orange-600 mb-2">
             Welcome to Alchm Kitchen
-          </h1>
+          </h2>
           <p className="text-gray-600 text-sm">
             Sign in to unlock your personalized culinary journey based on
             alchemical and astrological insights.

--- a/src/components/economy/TokenShopModal.tsx
+++ b/src/components/economy/TokenShopModal.tsx
@@ -102,6 +102,19 @@ export default function TokenShopModal() {
     return () => clearInterval(interval);
   }, [open, fetchShop]);
 
+  // Escape key to close
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
   useEffect(() => {
     if (!open) return;
     const prev = document.body.style.overflow;
@@ -146,11 +159,21 @@ export default function TokenShopModal() {
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/70 backdrop-blur-md p-4">
-      <div className="w-full max-w-4xl max-h-[90vh] overflow-hidden rounded-[2rem] border border-white/20 bg-gradient-to-br from-slate-950/95 via-indigo-950/90 to-purple-950/90 shadow-[0_25px_80px_rgba(0,0,0,0.65)]">
+    <div
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-black/70 backdrop-blur-md p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) setOpen(false);
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="token-shop-title"
+        className="w-full max-w-4xl max-h-[90vh] overflow-hidden rounded-[2rem] border border-white/20 bg-gradient-to-br from-slate-950/95 via-indigo-950/90 to-purple-950/90 shadow-[0_25px_80px_rgba(0,0,0,0.65)]"
+      >
         <div className="px-6 py-4 border-b border-white/10 flex items-center justify-between gap-3">
           <div>
-            <h2 className="text-sm font-black uppercase tracking-[0.3em] text-white/70">
+            <h2 id="token-shop-title" className="text-sm font-black uppercase tracking-[0.3em] text-white/70">
               Token Shop
             </h2>
             <p className="text-xs text-white/40">

--- a/src/components/grocery-cart/GroceryCartDrawer.tsx
+++ b/src/components/grocery-cart/GroceryCartDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useToast } from "@/components/ToastProvider";
 import { useGroceryCart } from "@/contexts/GroceryCartContext";
 import { AMAZON_ASSOCIATE_TAG } from "@/data/amazon";
@@ -20,6 +20,19 @@ export function GroceryCartDrawer() {
   } = useGroceryCart();
   const { showToast } = useToast();
   const [checkingOut, setCheckingOut] = useState(false);
+
+  // Escape key handler — closes the drawer for keyboard users
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        close();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isOpen, close]);
 
   const handleCheckout = async () => {
     setCheckingOut(true);
@@ -57,6 +70,7 @@ export function GroceryCartDrawer() {
           isOpen ? "translate-x-0" : "translate-x-full"
         }`}
         role="dialog"
+        aria-modal="true"
         aria-label="Grocery cart"
         aria-hidden={!isOpen}
       >
@@ -75,7 +89,7 @@ export function GroceryCartDrawer() {
           <button
             type="button"
             onClick={close}
-            className="text-gray-400 hover:text-white text-2xl leading-none p-1"
+            className="text-gray-400 hover:text-white text-2xl leading-none flex items-center justify-center min-w-[44px] min-h-[44px] rounded-full hover:bg-white/5"
             aria-label="Close grocery cart"
           >
             ×

--- a/src/components/recipe/CosmicRecipeGenerator.tsx
+++ b/src/components/recipe/CosmicRecipeGenerator.tsx
@@ -188,38 +188,61 @@ export default function CosmicRecipeGenerator() {
 
   const [object, setObject] = useState<Partial<CosmicRecipe> | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [lastPayload, setLastPayload] = useState<unknown>(null);
 
   const submit = async (payload: any) => {
     setIsLoading(true);
     setObject(undefined);
+    setErrorMessage(null);
+    setLastPayload(payload);
     try {
       const res = await fetch('/api/generate-cosmic-recipe', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
+        body: JSON.stringify(payload),
       });
-      if (res.ok) {
-        const data = await res.json();
-        setObject(data);
-        if (data?.title) {
-          try {
-            const stored = mapCosmicToStoreRecipe(
-              data as CosmicRecipe,
-              preferredCuisineRef.current || undefined,
-            );
-            saveRecipeToStore(stored);
-            setSavedRecipeId(stored.id);
-          } catch (err) {
-            console.error("Failed to persist cosmic recipe", err);
-          }
-          await generateImage(data.title, data.short_description || "");
+      if (!res.ok) {
+        let message = "We couldn't conjure a recipe this time. Please try again.";
+        if (res.status === 401) message = "Please sign in to generate cosmic recipes.";
+        else if (res.status === 402) message = "Upgrade to premium to keep generating recipes.";
+        else if (res.status === 429) message = "You're generating recipes faster than the cosmos can keep up. Please wait a moment.";
+        else if (res.status >= 500) message = "The recipe service is temporarily unavailable. Please try again shortly.";
+        try {
+          const data = await res.json();
+          if (typeof data?.message === "string") message = data.message;
+          else if (typeof data?.error === "string") message = data.error;
+        } catch {
+          /* keep default message */
         }
+        setErrorMessage(message);
+        return;
+      }
+      const data = await res.json();
+      setObject(data);
+      if (data?.title) {
+        try {
+          const stored = mapCosmicToStoreRecipe(
+            data as CosmicRecipe,
+            preferredCuisineRef.current || undefined,
+          );
+          saveRecipeToStore(stored);
+          setSavedRecipeId(stored.id);
+        } catch (err) {
+          console.error("Failed to persist cosmic recipe", err);
+        }
+        await generateImage(data.title, data.short_description || "");
       }
     } catch (e) {
       console.error(e);
+      setErrorMessage("Network error while generating your recipe. Check your connection and try again.");
     } finally {
       setIsLoading(false);
     }
+  };
+
+  const retryLastGeneration = () => {
+    if (lastPayload) void submit(lastPayload);
   };
 
   const handleGenerate = () => {
@@ -397,6 +420,30 @@ export default function CosmicRecipeGenerator() {
           )}
         </div>
       </div>
+
+      {/* Error State */}
+      {errorMessage && !isLoading && (
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="mb-6 p-4 rounded-xl border border-red-200 dark:border-red-900/50 bg-red-50 dark:bg-red-950/30 flex flex-col sm:flex-row sm:items-center gap-3"
+        >
+          <div className="flex-1">
+            <p className="text-sm font-semibold text-red-800 dark:text-red-300">
+              Couldn&apos;t generate a recipe
+            </p>
+            <p className="text-sm text-red-700 dark:text-red-400">{errorMessage}</p>
+          </div>
+          <button
+            type="button"
+            onClick={retryLastGeneration}
+            disabled={!lastPayload}
+            className="whitespace-nowrap px-4 py-2 bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white text-sm font-bold rounded-lg shadow-sm transition-colors"
+          >
+            Try again
+          </button>
+        </div>
+      )}
 
       {/* Results Section */}
       {object && (

--- a/src/lib/auth/adminEmails.ts
+++ b/src/lib/auth/adminEmails.ts
@@ -1,0 +1,35 @@
+/**
+ * Edge-safe admin allowlist.
+ *
+ * Kept in its own module (no NextAuth/DB imports) so it can be imported from
+ * both server-only auth code and edge-runtime route validators without pulling
+ * in Node-only dependencies.
+ *
+ * @file src/lib/auth/adminEmails.ts
+ */
+
+export const ADMIN_EMAILS: readonly string[] = [
+  process.env.AUTH_ADMIN_EMAIL || "xalchm@gmail.com",
+  "gregcastro23@gmail.com",
+  "cookingwithcastrollc@gmail.com",
+];
+
+export const PREMIUM_EMAILS: readonly string[] = [
+  "alchmnft@gmail.com",
+  "liskater@gmail.com",
+  "roberttcastro1@gmail.com",
+  "zaby250@gmail.com",
+  "atd250@gmail.com",
+];
+
+export function isAdminEmail(email: string | null | undefined): boolean {
+  if (!email) return false;
+  const normalized = email.trim().toLowerCase();
+  return ADMIN_EMAILS.some((e) => e.trim().toLowerCase() === normalized);
+}
+
+export function isPremiumEmail(email: string | null | undefined): boolean {
+  if (!email) return false;
+  const normalized = email.trim().toLowerCase();
+  return PREMIUM_EMAILS.some((e) => e.trim().toLowerCase() === normalized);
+}

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -14,30 +14,12 @@
  */
 
 import NextAuth from "next-auth";
+import { isAdminEmail, isPremiumEmail } from "@/lib/auth/adminEmails";
 import { createLogger } from "@/utils/logger";
 import { authConfig } from "./auth.config";
 import { UserRole } from "./roles";
 
 const logger = createLogger("auth");
-
-/** Admin emails that automatically get ADMIN role and full premium access */
-const ADMIN_EMAILS = [
-  process.env.AUTH_ADMIN_EMAIL || "xalchm@gmail.com",
-  "gregcastro23@gmail.com",
-  "cookingwithcastrollc@gmail.com",
-];
-
-/** Emails that automatically get full premium access (but NOT admin role) */
-const PREMIUM_EMAILS = [
-  "alchmnft@gmail.com",
-  "liskater@gmail.com",
-  "roberttcastro1@gmail.com",
-  "zaby250@gmail.com",
-  "atd250@gmail.com",
-];
-
-const isAdminEmail = (email: string) => ADMIN_EMAILS.includes(email);
-const isPremiumEmail = (email: string) => PREMIUM_EMAILS.includes(email);
 
 /** 
  * Simple short-lived cache to prevent redundant DB hits during the 
@@ -296,7 +278,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             }
 
             // 1. Auto-provision premium
-            if (isAdminEmail(user.email!) || isPremiumEmail(user.email!)) {
+            if (isAdminEmail(user.email) || isPremiumEmail(user.email)) {
               const { subscriptionService } = await import("@/services/subscriptionService");
               const sub = await subscriptionService.getOrCreateSubscription(dbUser.id);
               if (sub.tier !== "premium") {
@@ -380,8 +362,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
               // Premium daily insight — only if user has a natal chart
               const isPremium =
-                isAdminEmail(user.email!) ||
-                isPremiumEmail(user.email!) ||
+                isAdminEmail(user.email) ||
+                isPremiumEmail(user.email) ||
                 (dbUser)?.tier === "premium";
               const natalChart =
                 (dbUser)?.profile?.natalChart ||

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -15,11 +15,21 @@
 
 import NextAuth from "next-auth";
 import { isAdminEmail, isPremiumEmail } from "@/lib/auth/adminEmails";
+import { logAuthEvent } from "@/services/authEventsService";
 import { createLogger } from "@/utils/logger";
 import { authConfig } from "./auth.config";
 import { UserRole } from "./roles";
 
 const logger = createLogger("auth");
+
+const PROVIDER_GOOGLE = "google";
+
+function describeError(err: unknown): { code: string; message: string } {
+  if (err instanceof Error) {
+    return { code: err.name || "Error", message: err.message.slice(0, 500) };
+  }
+  return { code: "UnknownError", message: String(err).slice(0, 500) };
+}
 
 /** 
  * Simple short-lived cache to prevent redundant DB hits during the 
@@ -79,7 +89,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     async signOut(message) {
       // In JWT mode NextAuth passes { token } — delete the DB session record so
       // the session slot is freed and can no longer be used to verify revocation.
-      const sessionId = (message as any)?.token?.sessionId as string | undefined;
+      const token = (message as any)?.token as
+        | { sessionId?: string; userId?: string; email?: string }
+        | undefined;
+      const sessionId = token?.sessionId;
       if (sessionId) {
         try {
           const { executeQuery } = await import("@/lib/database");
@@ -91,6 +104,13 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           logger.warn("Session cleanup on signOut failed (non-blocking):", e);
         }
       }
+      void logAuthEvent({
+        type: "signout",
+        status: "info",
+        userId: token?.userId ?? null,
+        email: token?.email ?? null,
+        metadata: { sessionId: sessionId ?? null },
+      });
     },
   },
   callbacks: {
@@ -99,13 +119,53 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
     async signIn({ user, account }) {
       logger.info(`signIn callback started for ${user.email}`);
+      const provider = account?.provider ?? PROVIDER_GOOGLE;
+
+      void logAuthEvent({
+        type: "signin_started",
+        status: "info",
+        email: user.email ?? null,
+        provider,
+      });
+
       if (!user.email || !account) {
         logger.warn("signIn failed: Missing email or account");
+        void logAuthEvent({
+          type: "signin_aborted",
+          status: "failure",
+          email: user.email ?? null,
+          provider,
+          errorCode: "missing_email_or_account",
+          errorMessage: "Provider returned without email or account context",
+        });
         return true;
       }
 
       try {
-        let dbUser = await getCachedUser(user.email);
+        let dbUser: any = null;
+        try {
+          dbUser = await getCachedUser(user.email);
+          void logAuthEvent({
+            type: "signin_user_lookup_success",
+            status: "success",
+            email: user.email,
+            userId: dbUser?.id ?? null,
+            provider,
+            metadata: { isNewUser: !dbUser },
+          });
+        } catch (lookupErr) {
+          const { code, message } = describeError(lookupErr);
+          void logAuthEvent({
+            type: "signin_user_lookup_failed",
+            status: "failure",
+            email: user.email,
+            provider,
+            errorCode: code,
+            errorMessage: message,
+          });
+          throw lookupErr;
+        }
+
         const isNewUser = !dbUser;
         logger.info(`User lookup complete. isNewUser: ${isNewUser}`);
 
@@ -117,19 +177,40 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
           // 8s timeout: createUser opens a transaction with 3+ INSERTs. On cold-start
           // the connection setup alone can eat 2-3s before the first query runs.
-          dbUser = await Promise.race([
-            userDatabase.createUser({
+          try {
+            dbUser = await Promise.race([
+              userDatabase.createUser({
+                email: user.email,
+                name: user.name || "",
+                image: user.image || undefined,
+                roles: isAdmin
+                  ? [UserRole.ADMIN, UserRole.USER]
+                  : [UserRole.USER],
+              }),
+              new Promise<any>((_, reject) => setTimeout(() => reject(new Error("Create User Timeout")), 8000))
+            ]);
+            if (dbUser) {
+              userCache.set(user.email, { data: dbUser, timestamp: Date.now() });
+              void logAuthEvent({
+                type: "signin_user_created",
+                status: "success",
+                userId: dbUser.id,
+                email: user.email,
+                provider,
+                metadata: { isAdmin },
+              });
+            }
+          } catch (createErr) {
+            const { code, message } = describeError(createErr);
+            void logAuthEvent({
+              type: "signin_user_create_failed",
+              status: "failure",
               email: user.email,
-              name: user.name || "",
-              image: user.image || undefined,
-              roles: isAdmin
-                ? [UserRole.ADMIN, UserRole.USER]
-                : [UserRole.USER],
-            }),
-            new Promise<any>((_, reject) => setTimeout(() => reject(new Error("Create User Timeout")), 8000))
-          ]);
-          if (dbUser) {
-            userCache.set(user.email, { data: dbUser, timestamp: Date.now() });
+              provider,
+              errorCode: code,
+              errorMessage: message,
+            });
+            throw createErr;
           }
         } else if (isAdmin && !dbUser.roles.includes(UserRole.ADMIN)) {
           // Promote existing user to admin if they are in the admin list but don't have the role yet
@@ -139,6 +220,43 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           // Refresh cache
           dbUser.roles = [UserRole.ADMIN, UserRole.USER];
           userCache.set(user.email, { data: dbUser, timestamp: Date.now() });
+          void logAuthEvent({
+            type: "signin_role_promoted",
+            status: "info",
+            userId: dbUser.id,
+            email: user.email,
+            metadata: { newRole: "ADMIN" },
+          });
+        }
+
+        // Bump login_count + last_login_at on every successful sign-in so we
+        // have real "active user" telemetry. Non-blocking — a failure here is
+        // logged but never breaks the sign-in flow.
+        if (dbUser?.id) {
+          void (async () => {
+            try {
+              const { userDatabase } = await import("@/services/userDatabaseService");
+              await userDatabase.updateUserAuth(dbUser.id, { lastLoginAt: new Date() });
+              void logAuthEvent({
+                type: "signin_last_login_updated",
+                status: "success",
+                userId: dbUser.id,
+                email: user.email,
+                provider,
+              });
+            } catch (updateErr) {
+              const { code, message } = describeError(updateErr);
+              void logAuthEvent({
+                type: "signin_last_login_update_failed",
+                status: "failure",
+                userId: dbUser.id,
+                email: user.email,
+                provider,
+                errorCode: code,
+                errorMessage: message,
+              });
+            }
+          })();
         }
 
         // Persist OAuth account link so accounts table stays in sync.
@@ -169,8 +287,25 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
                   account.session_state ?? null,
                 ]
               );
+              void logAuthEvent({
+                type: "signin_account_link_success",
+                status: "success",
+                userId: dbUser.id,
+                email: user.email,
+                provider: account.provider,
+              });
             } catch (e) {
               logger.warn("Account link upsert failed (non-blocking):", e);
+              const { code, message } = describeError(e);
+              void logAuthEvent({
+                type: "signin_account_link_failed",
+                status: "failure",
+                userId: dbUser.id,
+                email: user.email,
+                provider: account.provider,
+                errorCode: code,
+                errorMessage: message,
+              });
             }
           })();
         }
@@ -393,9 +528,24 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         // the "Configuration" error page. Instead log the error and return true
         // so the user can still sign in. The JWT callback will handle missing data.
         logger.error(`DB error during signIn for ${user.email} (non-blocking):`, error);
+        const { code, message } = describeError(error);
+        void logAuthEvent({
+          type: "signin_aborted",
+          status: "failure",
+          email: user.email,
+          provider,
+          errorCode: code,
+          errorMessage: message,
+        });
       }
 
       logger.info(`signIn callback completed for ${user.email}`);
+      void logAuthEvent({
+        type: "signin_complete",
+        status: "success",
+        email: user.email,
+        provider,
+      });
       return true;
     },
 

--- a/src/lib/auth/validateRequest.ts
+++ b/src/lib/auth/validateRequest.ts
@@ -8,6 +8,7 @@
 
 import { jwtVerify, errors as JOSEerrors } from "jose";
 import { NextResponse } from "next/server";
+import { isAdminEmail } from "@/lib/auth/adminEmails";
 import { UserRole } from "@/lib/auth/roles";
 import { applyRequestAuthOrigin } from "@/lib/auth/runtimeOrigin";
 import type { UserWithProfile } from "@/services/userDatabaseService";
@@ -261,7 +262,7 @@ export async function validateAdminRequest(
     return result;
   }
 
-  if (!result.user.roles.includes("admin") || result.user.email !== "gregcastro23@gmail.com") {
+  if (!result.user.roles.includes("admin") || !isAdminEmail(result.user.email)) {
     return {
       error: NextResponse.json(
         { success: false, message: "Admin access required" },

--- a/src/lib/database/connection.ts
+++ b/src/lib/database/connection.ts
@@ -1,5 +1,6 @@
 import pkg from 'pg';
 import { logger } from "../logger";
+import { recordSlowQuery } from "../observability/slowQueryLog";
 import { databaseConfig } from "./config";
 import type { Pool, PoolClient, QueryResult } from "pg";
 
@@ -221,6 +222,10 @@ export async function executeQuery<_T extends any = any>(
     }
     const result = await getDatabasePool().query(query, params);
     const executionTime = Date.now() - startTime;
+    // Push to the in-memory slow-query ring (threshold defaults to 200ms).
+    // The admin observability endpoint reads this; production traffic should
+    // surface gradual regressions here long before they trip the >1s warn.
+    recordSlowQuery(executionTime, query, result.rowCount);
     if (executionTime > 1000) {
       // Log slow queries (>1s)
       void logger.warn("Slow database query detected", {

--- a/src/lib/observability/requestLog.ts
+++ b/src/lib/observability/requestLog.ts
@@ -1,0 +1,111 @@
+/**
+ * In-memory request log
+ *
+ * A bounded ring buffer of the most recent HTTP requests handled by this
+ * Node process. Built for the admin observability endpoint — not a
+ * replacement for proper APM. Three reasons we don't write every request
+ * to Postgres:
+ *
+ *   1. Doubles the DB write load (every API call → an extra INSERT).
+ *   2. The data is most useful for ~minutes, not forever.
+ *   3. Many requests are auth-failure pings, health checks, prefetches —
+ *      cheap signal-to-noise gain by sampling success and full-fidelity
+ *      capturing failures.
+ *
+ * Pair this with the `auth_events` table for durable auth audit, and with
+ * Railway's stdout logs for full retention.
+ *
+ * @file src/lib/observability/requestLog.ts
+ */
+
+export interface RequestLogEntry {
+  id: number;
+  at: string;
+  method: string;
+  path: string;
+  status: number;
+  latencyMs: number;
+  userId: string | null;
+  ipHash: string | null;
+}
+
+const RING_SIZE = 500;
+const ring: RequestLogEntry[] = [];
+let nextId = 1;
+
+export interface RecordOptions {
+  method: string;
+  path: string;
+  status: number;
+  latencyMs: number;
+  userId?: string | null;
+  ipHash?: string | null;
+}
+
+export function recordRequest(opts: RecordOptions): void {
+  ring.push({
+    id: nextId++,
+    at: new Date().toISOString(),
+    method: opts.method,
+    path: opts.path,
+    status: opts.status,
+    latencyMs: opts.latencyMs,
+    userId: opts.userId ?? null,
+    ipHash: opts.ipHash ?? null,
+  });
+  if (ring.length > RING_SIZE) ring.shift();
+}
+
+export interface RequestLogQuery {
+  limit?: number;
+  statusGte?: number;
+  pathContains?: string;
+}
+
+export function getRecentRequests(q: RequestLogQuery = {}): RequestLogEntry[] {
+  const limit = Math.min(Math.max(q.limit ?? 100, 1), RING_SIZE);
+  let view = ring.slice().reverse();
+  if (typeof q.statusGte === "number") {
+    view = view.filter((r) => r.status >= q.statusGte!);
+  }
+  if (q.pathContains) {
+    const needle = q.pathContains.toLowerCase();
+    view = view.filter((r) => r.path.toLowerCase().includes(needle));
+  }
+  return view.slice(0, limit);
+}
+
+export interface RequestSummary {
+  count: number;
+  p50LatencyMs: number;
+  p95LatencyMs: number;
+  p99LatencyMs: number;
+  errorRate: number;
+  topPaths: Array<{ path: string; count: number }>;
+}
+
+export function summarizeRecent(windowMs: number = 5 * 60 * 1000): RequestSummary {
+  const cutoff = Date.now() - windowMs;
+  const recent = ring.filter((r) => new Date(r.at).getTime() >= cutoff);
+  const count = recent.length;
+  if (count === 0) {
+    return { count: 0, p50LatencyMs: 0, p95LatencyMs: 0, p99LatencyMs: 0, errorRate: 0, topPaths: [] };
+  }
+  const latencies = recent.map((r) => r.latencyMs).sort((a, b) => a - b);
+  const pick = (p: number) => latencies[Math.min(latencies.length - 1, Math.floor(latencies.length * p))];
+  const errors = recent.filter((r) => r.status >= 500).length;
+  const pathMap = new Map<string, number>();
+  for (const r of recent) pathMap.set(r.path, (pathMap.get(r.path) ?? 0) + 1);
+  const topPaths = Array.from(pathMap.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+    .map(([path, c]) => ({ path, count: c }));
+  return {
+    count,
+    p50LatencyMs: pick(0.5),
+    p95LatencyMs: pick(0.95),
+    p99LatencyMs: pick(0.99),
+    errorRate: errors / count,
+    topPaths,
+  };
+}

--- a/src/lib/observability/slowQueryLog.ts
+++ b/src/lib/observability/slowQueryLog.ts
@@ -1,0 +1,78 @@
+/**
+ * Slow query in-memory ring.
+ *
+ * Captures Postgres queries whose execution time exceeds a configurable
+ * threshold (default 200ms). The existing stdout logger already warns on
+ * >1s queries, but we want a finer-grained record for the admin
+ * observability dashboard and to spot creeping regressions.
+ *
+ * Stored in-memory only; if scale demands persistence we can flush this
+ * to a table later. Process restarts wipe the ring, which is fine for
+ * "what's slow right now" use cases.
+ *
+ * @file src/lib/observability/slowQueryLog.ts
+ */
+
+export interface SlowQueryEntry {
+  id: number;
+  at: string;
+  ms: number;
+  preview: string;
+  rowCount: number | null;
+}
+
+const RING_SIZE = 200;
+const ring: SlowQueryEntry[] = [];
+let nextId = 1;
+
+let threshold = Number(process.env.SLOW_QUERY_THRESHOLD_MS ?? "200") || 200;
+
+export function setSlowQueryThresholdMs(ms: number): void {
+  if (Number.isFinite(ms) && ms >= 0) {
+    threshold = ms;
+  }
+}
+
+export function getSlowQueryThresholdMs(): number {
+  return threshold;
+}
+
+export function recordSlowQuery(
+  ms: number,
+  query: string,
+  rowCount: number | null,
+): void {
+  if (ms < threshold) return;
+  ring.push({
+    id: nextId++,
+    at: new Date().toISOString(),
+    ms: Math.round(ms),
+    preview: query.length > 200 ? `${query.slice(0, 200)}…` : query,
+    rowCount,
+  });
+  if (ring.length > RING_SIZE) ring.shift();
+}
+
+export function getRecentSlowQueries(limit: number = 50): SlowQueryEntry[] {
+  const n = Math.min(Math.max(limit, 1), RING_SIZE);
+  return ring.slice().reverse().slice(0, n);
+}
+
+export interface SlowQuerySummary {
+  count: number;
+  thresholdMs: number;
+  slowestMs: number;
+  windowMs: number;
+}
+
+export function summarizeSlowQueries(windowMs: number = 5 * 60 * 1000): SlowQuerySummary {
+  const cutoff = Date.now() - windowMs;
+  const recent = ring.filter((r) => new Date(r.at).getTime() >= cutoff);
+  const slowestMs = recent.reduce((m, r) => Math.max(m, r.ms), 0);
+  return {
+    count: recent.length,
+    thresholdMs: threshold,
+    slowestMs,
+    windowMs,
+  };
+}

--- a/src/services/authEventsService.ts
+++ b/src/services/authEventsService.ts
@@ -1,0 +1,276 @@
+/**
+ * Auth Events Service
+ *
+ * Structured audit log for sign-in / sign-out / session lifecycle events.
+ * Backs admin "login attempts" metrics and per-user debug history.
+ *
+ * Design:
+ *  - Writes are fire-and-forget: callers `void logAuthEvent(...)` so a slow
+ *    or failing log row never blocks the auth flow itself.
+ *  - All writes go to `auth_events`. Without DATABASE_URL we fall back to a
+ *    bounded in-memory ring so dev/test still works.
+ *  - The `ipHash` field is a one-way SHA-256 of the request IP — we don't
+ *    want raw addresses in the table (PII).
+ *
+ * @file src/services/authEventsService.ts
+ */
+
+import crypto from "node:crypto";
+import { _logger } from "@/lib/logger";
+
+export type AuthEventStatus = "success" | "failure" | "info";
+
+export type AuthEventType =
+  // Sign-in lifecycle (in order)
+  | "signin_started"
+  | "signin_user_lookup_success"
+  | "signin_user_lookup_failed"
+  | "signin_user_created"
+  | "signin_user_create_failed"
+  | "signin_role_promoted"
+  | "signin_account_link_success"
+  | "signin_account_link_failed"
+  | "signin_last_login_updated"
+  | "signin_last_login_update_failed"
+  | "signin_complete"
+  | "signin_aborted"
+  // OAuth provider error (rendered on /auth/error)
+  | "signin_provider_error"
+  // Sign-out & session events
+  | "signout"
+  | "session_revoked"
+  | "session_revoke_all";
+
+export interface AuthEventInput {
+  type: AuthEventType;
+  status: AuthEventStatus;
+  userId?: string | null;
+  email?: string | null;
+  provider?: string | null;
+  ip?: string | null;
+  userAgent?: string | null;
+  errorCode?: string | null;
+  errorMessage?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+interface InMemoryEvent extends Omit<AuthEventInput, "ip"> {
+  id: number;
+  ipHash: string | null;
+  createdAt: Date;
+}
+
+const MEMORY_RING_SIZE = 5000;
+const memoryEvents: InMemoryEvent[] = [];
+let memoryId = 1;
+
+const isServerWithDB = (): boolean =>
+  typeof window === "undefined" && !!process.env.DATABASE_URL;
+
+let dbModule: typeof import("@/lib/database") | null = null;
+async function getDbModule() {
+  if (!dbModule && isServerWithDB()) {
+    try {
+      dbModule = await import("@/lib/database");
+    } catch {
+      _logger.warn("[authEvents] Database module unavailable");
+    }
+  }
+  return dbModule;
+}
+
+const IP_HASH_SALT =
+  process.env.AUTH_EVENTS_IP_SALT ||
+  process.env.AUTH_SECRET ||
+  "auth-events-default-salt-rotate-me";
+
+function hashIp(ip: string | null | undefined): string | null {
+  if (!ip) return null;
+  return crypto.createHash("sha256").update(`${IP_HASH_SALT}:${ip}`).digest("hex").slice(0, 32);
+}
+
+/**
+ * Fire-and-forget logger. Never throws to the caller. Returns a Promise so
+ * tests can await it, but in production code you should `void` the call.
+ */
+export async function logAuthEvent(event: AuthEventInput): Promise<void> {
+  const ipHash = hashIp(event.ip);
+  const userAgent = event.userAgent?.slice(0, 512) ?? null;
+  const errorMessage = event.errorMessage?.slice(0, 2000) ?? null;
+
+  try {
+    const db = await getDbModule();
+    if (db) {
+      await db.executeQuery(
+        `INSERT INTO auth_events
+           (user_id, email, event_type, status, provider, ip_hash, user_agent, error_code, error_message, metadata)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)`,
+        [
+          event.userId ?? null,
+          event.email ? event.email.toLowerCase() : null,
+          event.type,
+          event.status,
+          event.provider ?? null,
+          ipHash,
+          userAgent,
+          event.errorCode ?? null,
+          errorMessage,
+          JSON.stringify(event.metadata ?? {}),
+        ],
+      );
+      return;
+    }
+  } catch (err) {
+    // Log to stderr but don't propagate — auth flow must not break on telemetry.
+    _logger.warn("[authEvents] DB insert failed, falling back to memory:", err);
+  }
+
+  memoryEvents.push({
+    id: memoryId++,
+    type: event.type,
+    status: event.status,
+    userId: event.userId ?? null,
+    email: event.email ?? null,
+    provider: event.provider ?? null,
+    ipHash,
+    userAgent,
+    errorCode: event.errorCode ?? null,
+    errorMessage,
+    metadata: event.metadata,
+    createdAt: new Date(),
+  });
+  if (memoryEvents.length > MEMORY_RING_SIZE) {
+    memoryEvents.shift();
+  }
+}
+
+// ─── Query helpers (admin/metrics use) ────────────────────────────────
+
+export interface AuthEventCounts {
+  total: number;
+  successes: number;
+  failures: number;
+  byType: Array<{ type: string; status: string; count: number }>;
+}
+
+/**
+ * Aggregate event counts over the last `windowMs` milliseconds.
+ * Default window: 24 hours.
+ */
+export async function getEventCounts(
+  windowMs: number = 24 * 60 * 60 * 1000,
+): Promise<AuthEventCounts> {
+  const sinceDate = new Date(Date.now() - windowMs);
+
+  try {
+    const db = await getDbModule();
+    if (db) {
+      const result = await db.executeQuery(
+        `SELECT event_type, status, COUNT(*)::int AS count
+           FROM auth_events
+           WHERE created_at >= $1
+           GROUP BY event_type, status
+           ORDER BY count DESC`,
+        [sinceDate],
+      );
+      const byType = result.rows.map((r: any) => ({
+        type: String(r.event_type),
+        status: String(r.status),
+        count: Number(r.count),
+      }));
+      const successes = byType
+        .filter((r) => r.status === "success")
+        .reduce((a, b) => a + b.count, 0);
+      const failures = byType
+        .filter((r) => r.status === "failure")
+        .reduce((a, b) => a + b.count, 0);
+      return {
+        total: byType.reduce((a, b) => a + b.count, 0),
+        successes,
+        failures,
+        byType,
+      };
+    }
+  } catch (err) {
+    _logger.warn("[authEvents] getEventCounts DB failed, using memory:", err);
+  }
+
+  const since = sinceDate.getTime();
+  const recent = memoryEvents.filter((e) => e.createdAt.getTime() >= since);
+  const bucket = new Map<string, number>();
+  for (const e of recent) {
+    const k = `${e.type}|${e.status}`;
+    bucket.set(k, (bucket.get(k) ?? 0) + 1);
+  }
+  const byType = Array.from(bucket.entries()).map(([k, count]) => {
+    const [type, status] = k.split("|");
+    return { type, status, count };
+  });
+  return {
+    total: recent.length,
+    successes: recent.filter((e) => e.status === "success").length,
+    failures: recent.filter((e) => e.status === "failure").length,
+    byType,
+  };
+}
+
+/**
+ * Fetch the last `limit` events for a single user. Used in admin UI for
+ * per-user audit history.
+ */
+export async function getUserEvents(
+  userId: string,
+  limit: number = 50,
+): Promise<
+  Array<{
+    id: number;
+    type: string;
+    status: string;
+    provider: string | null;
+    errorCode: string | null;
+    errorMessage: string | null;
+    metadata: Record<string, unknown>;
+    createdAt: string;
+  }>
+> {
+  try {
+    const db = await getDbModule();
+    if (db) {
+      const result = await db.executeQuery(
+        `SELECT id, event_type, status, provider, error_code, error_message, metadata, created_at
+           FROM auth_events
+           WHERE user_id = $1
+           ORDER BY created_at DESC
+           LIMIT $2`,
+        [userId, Math.min(Math.max(limit, 1), 500)],
+      );
+      return result.rows.map((r: any) => ({
+        id: Number(r.id),
+        type: String(r.event_type),
+        status: String(r.status),
+        provider: r.provider ?? null,
+        errorCode: r.error_code ?? null,
+        errorMessage: r.error_message ?? null,
+        metadata: (r.metadata ?? {}) as Record<string, unknown>,
+        createdAt: new Date(r.created_at).toISOString(),
+      }));
+    }
+  } catch (err) {
+    _logger.warn("[authEvents] getUserEvents DB failed, using memory:", err);
+  }
+
+  return memoryEvents
+    .filter((e) => e.userId === userId)
+    .slice(-limit)
+    .reverse()
+    .map((e) => ({
+      id: e.id,
+      type: e.type,
+      status: e.status,
+      provider: e.provider ?? null,
+      errorCode: e.errorCode ?? null,
+      errorMessage: e.errorMessage ?? null,
+      metadata: e.metadata ?? {},
+      createdAt: e.createdAt.toISOString(),
+    }));
+}


### PR DESCRIPTION
## Summary

Full-site audit-driven fixes plus a new admin observability stack and a one-shot ESMS token grant script. Four commits, each independently revertable.

- **Security + SEO + perf + a11y hardening** (`da72575`) — closes audit P0/P1 findings across `/api/feed`, `/api/premium-table`, `/api/instacart/price-estimate`, the admin gate, SEO metadata + sitemap + recipe JSON-LD, force-dynamic scope, modal a11y, error states.
- **One-shot ESMS grant script** (`eb82741`) — `bun scripts/grant-test-tokens.ts` to verify the end-to-end onboarding → user → token flow against prod data. Idempotent via `token_transactions.idempotency_key`, has `--dry-run`, `--limit`, `--emails`.
- **Structured auth-event log + admin user metrics** (`5568a78`) — new `auth_events` table, instrumented every NextAuth signIn stage, fixed `login_count` / `last_login_at` (were never incremented for OAuth), added `/api/admin/users/stats`, replaced N+1 with a single JOIN, paginated user list.
- **Advanced metrics dashboard + abuse detection + slow-query ring + digest** (`95b7e8c`) — `/api/admin/abuse`, `/api/admin/observability`, `/api/admin/digest`, new \`AdvancedMetricsPanel\` rendered on `/admin`. Slow-query ring auto-populates from `executeQuery`.

## What changed

### Security
- `crypto.timingSafeEqual` on the internal feed bearer + fail-closed when `INTERNAL_API_SECRET` missing.
- `/api/premium-table` now requires authenticated premium + rate-limited (was open).
- Admin gate uses env-driven `ADMIN_EMAILS` allowlist (was hardcoded to one address).
- `/api/instacart/price-estimate` stops echoing upstream `error.message` to clients.
- Zod schemas on `/api/generate-cosmic-recipe` and `/api/commensal/guest-recommendations`.

### SEO / metadata
- OpenGraph + Twitter + canonical + robots in `src/app/layout.tsx`.
- `generateMetadata` + Recipe schema.org JSON-LD on recipe detail pages.
- `sitemap.ts` now async, appends every recipe URL with hourly revalidate.

### Performance
- `force-dynamic` moved off root layout onto `(alchm)` group → marketing/auth routes become cacheable.

### UX + a11y
- Error state + retry on the cosmic recipe generator (was silent spinner).
- Modal Escape handlers + focus management + 44px close targets on SignInModal, TokenShopModal, GroceryCartDrawer.
- Visually-hidden `<h1>` on homepage; removed nested `<main>`.

### Auth observability (new)
- `auth_events` table with type, status, email, ip_hash, user_agent, error, metadata, timing.
- Every signIn stage writes a row: `signin_started`, `signin_user_lookup_success/failure`, `signin_user_created/create_failed`, `signin_account_link_success/failure`, `signin_role_promoted`, `signin_last_login_updated`, `signin_complete/aborted`, `signout`.
- `/api/admin/users/stats` returns 24h + 7d rollups by `(event_type, status)`, signup + activity counts, recent logins with per-user `loginCount`.
- `/api/admin/abuse?window=1h` — IPs with concentrated failures + emails targeted from multiple IPs.
- `/api/admin/observability` — in-memory request + slow-query rings (per process).
- `/api/admin/digest` — composable daily/weekly email digest, callable from Railway cron via `INTERNAL_API_SECRET` bearer.
- `AdvancedMetricsPanel` rendered on `/admin` — KPI row, event-type table, recent logins, suspicious-IP/email cards, slow-query + recent-failure rings, digest preview button.

### Scale prep
- Admin user list rewritten to a single JOIN (was N+1, would crawl past 100 users).
- Paginated up to 200 per page, sortable.
- Slow-query ring records every Postgres call >200ms (`SLOW_QUERY_THRESHOLD_MS` override).
- `auth_events` indexed on `(event_type, status, created_at)` + failure-only partial index for abuse queries.

## Reviewer notes

- **Deploy order matters:** apply `database/init/34-auth-events.sql` before code that writes to it ships. The service falls back gracefully if the table is missing, but production traffic should land in Postgres.
- **Per-route request log** is built (`recordRequest`, `getRecentRequests`, `summarizeRecent`) but not yet wired into every route — wiring it through a global middleware funnel would fight the existing strict matcher. Slow-query ring is fully automatic via `executeQuery`. Suggest opting in selectively from high-traffic routes in a follow-up.
- **Token grant script does nothing automatically.** It's a tool: `railway run bun scripts/grant-test-tokens.ts --dry-run` to preview, then re-run without the flag to execute. Idempotency key `admin-test-grant-2026-05-20:<userId>` ensures re-runs are no-ops.
- **Digest cron is manual.** Set up in Railway:
  \`\`\`
  0 9 * * * curl -X POST \\
    -H "Authorization: Bearer \$INTERNAL_API_SECRET" \\
    "https://alchm.kitchen/api/admin/digest?period=daily"
  \`\`\`
- **One deliberately deferred finding:** the auditor flagged `/api/personalized-recommendations` "guest mode" as P0, but the endpoint returns non-personalized current-sky data only and is rate-limited (20/min). Treated as intentional demo path.

## Test plan

- [ ] Apply migration `database/init/34-auth-events.sql` to staging Postgres.
- [ ] Deploy this branch to staging on Railway.
- [ ] Sign in as a non-admin user; verify `auth_events` rows land (`signin_started` → `signin_user_lookup_success` → `signin_role_promoted` (if applicable) → `signin_last_login_updated` → `signin_complete`).
- [ ] Verify `users.login_count` increments and `last_login_at` updates on each sign-in.
- [ ] Sign in as admin; open `/admin`; verify the Advanced Metrics panel populates KPIs, the auth-event table, and the recent-logins list.
- [ ] Click "Preview digest (no send)" and confirm payload looks right.
- [ ] Hit `/api/admin/abuse?window=1h` with admin cookie — confirm `success: true` with empty lists on a quiet staging environment.
- [ ] Run a deliberately bad request against `/api/admin/digest` without `Authorization` → expect 401.
- [ ] Smoke test the grant script with `--dry-run --limit 1 --emails you@…` against a staging DB.
- [ ] Re-run the grant script without `--dry-run` — first time credits 20 tokens, second time should report "already claimed" (idempotency).
- [ ] Verify Lighthouse SEO score improves on `/` and `/recipes/[id]` (Recipe JSON-LD should surface in the Structured Data report).
- [ ] Verify marketing routes (`/terms`, `/privacy`, `/login`) start returning cacheable headers (no more `cache-control: no-store, must-revalidate`).
- [ ] Open `/login` page, hit Escape, confirm modal closes and focus restores to the trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)