### PR TITLE
feat(admin): Grant Tokens UI + ops follow-ups (migrations 33+34, digest cron)

### DIFF
--- a/src/components/admin/AdvancedMetricsPanel.tsx
+++ b/src/components/admin/AdvancedMetricsPanel.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
+import { TOKEN_TYPES, type TokenType } from "@/types/economy";
 
 interface UsersStats {
   users: {
@@ -100,6 +101,194 @@ function Kpi({ label, value, hint }: { label: string; value: string | number; hi
   );
 }
 
+interface GrantTarget {
+  userId: string;
+  email: string;
+}
+
+interface GrantResultBalances {
+  spirit: number;
+  essence: number;
+  matter: number;
+  substance: number;
+}
+
+interface GrantResponse {
+  success: boolean;
+  alreadyClaimed?: boolean;
+  balances?: GrantResultBalances;
+  message?: string;
+}
+
+function GrantTokensModal({
+  target,
+  onClose,
+  onGranted,
+}: {
+  target: GrantTarget;
+  onClose: () => void;
+  onGranted: () => void;
+}) {
+  const [amounts, setAmounts] = useState<Record<TokenType, number>>(() => ({
+    Spirit: 5,
+    Essence: 5,
+    Matter: 5,
+    Substance: 5,
+  }));
+  const [description, setDescription] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<GrantResponse | null>(null);
+
+  const totalRequested = TOKEN_TYPES.reduce((sum, t) => sum + (amounts[t] || 0), 0);
+  const canSubmit = !loading && !result?.success && totalRequested > 0;
+
+  const submit = async () => {
+    if (!canSubmit) return;
+    const credits = TOKEN_TYPES
+      .filter((t) => amounts[t] > 0)
+      .map((tokenType) => ({ tokenType, amount: amounts[tokenType] }));
+    if (credits.length === 0) return;
+
+    setLoading(true);
+    setResult(null);
+    try {
+      const res = await fetch(`/api/admin/users/${target.userId}/grant`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          credits,
+          idempotencyKey: `admin-ui-grant-${target.userId}-${Date.now()}`,
+          description: description.trim() || undefined,
+        }),
+      });
+      const data: GrantResponse = await res.json();
+      setResult(data);
+      if (data.success) {
+        // Surface fresh stats in the panel underneath.
+        onGranted();
+      }
+    } catch {
+      setResult({ success: false, message: "Network error" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="grant-modal-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !loading) onClose();
+      }}
+    >
+      <div className="w-full max-w-md bg-white rounded-lg shadow-xl">
+        <div className="px-6 py-4 border-b border-gray-200">
+          <h3 id="grant-modal-title" className="text-base font-semibold text-gray-800">
+            Grant tokens
+          </h3>
+          <p className="text-xs text-gray-600 mt-1 truncate" title={target.email}>
+            {target.email}
+            <span className="ml-2 font-mono text-gray-400">
+              {target.userId.slice(0, 8)}…
+            </span>
+          </p>
+        </div>
+
+        <div className="px-6 py-4 space-y-4">
+          <div className="grid grid-cols-2 gap-3">
+            {TOKEN_TYPES.map((t) => (
+              <label key={t} className="block">
+                <span className="block text-xs font-medium text-gray-700 mb-1">{t}</span>
+                <input
+                  type="number"
+                  min={0}
+                  max={10000}
+                  value={amounts[t]}
+                  onChange={(e) => {
+                    const next = Number(e.target.value);
+                    setAmounts((prev) => ({ ...prev, [t]: Number.isFinite(next) ? next : 0 }));
+                  }}
+                  disabled={loading || result?.success === true}
+                  className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-purple-500 disabled:bg-gray-50 disabled:text-gray-500"
+                />
+              </label>
+            ))}
+          </div>
+
+          <label className="block">
+            <span className="block text-xs font-medium text-gray-700 mb-1">
+              Reason (optional)
+            </span>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              disabled={loading || result?.success === true}
+              maxLength={500}
+              rows={2}
+              className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-purple-500 disabled:bg-gray-50 disabled:text-gray-500"
+              placeholder="e.g. compensation for failed daily claim"
+            />
+          </label>
+
+          {result && (
+            <div
+              className={`rounded p-3 text-sm ${
+                result.success
+                  ? result.alreadyClaimed
+                    ? "bg-amber-50 border border-amber-200 text-amber-800"
+                    : "bg-green-50 border border-green-200 text-green-800"
+                  : "bg-red-50 border border-red-200 text-red-700"
+              }`}
+            >
+              {result.success ? (
+                <>
+                  <p className="font-medium">
+                    {result.alreadyClaimed
+                      ? "Already granted with that key — balances unchanged."
+                      : "Granted. New balances:"}
+                  </p>
+                  {result.balances && (
+                    <p className="mt-1 font-mono text-xs">
+                      S {result.balances.spirit} · E {result.balances.essence} ·{" "}
+                      M {result.balances.matter} · Sub {result.balances.substance}
+                    </p>
+                  )}
+                </>
+              ) : (
+                <p>{result.message ?? "Grant failed"}</p>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="px-6 py-3 border-t border-gray-200 bg-gray-50 rounded-b-lg flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={loading}
+            className="px-3 py-1.5 text-sm rounded border border-gray-300 bg-white text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+          >
+            {result?.success ? "Close" : "Cancel"}
+          </button>
+          {!result?.success && (
+            <button
+              type="button"
+              onClick={() => void submit()}
+              disabled={!canSubmit}
+              className="px-3 py-1.5 text-sm rounded bg-purple-600 hover:bg-purple-700 text-white font-medium disabled:opacity-50"
+            >
+              {loading ? "Granting…" : `Grant ${totalRequested}`}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function AdvancedMetricsPanel() {
   const [stats, setStats] = useState<UsersStats | null>(null);
   const [abuse, setAbuse] = useState<Abuse | null>(null);
@@ -110,6 +299,7 @@ export default function AdvancedMetricsPanel() {
     loading: false,
     message: null,
   });
+  const [grantTarget, setGrantTarget] = useState<GrantTarget | null>(null);
 
   const load = useCallback(async () => {
     setRefreshing(true);
@@ -271,6 +461,7 @@ export default function AdvancedMetricsPanel() {
                 <th className="px-6 py-2 text-left text-xs font-medium text-gray-500 uppercase">Email</th>
                 <th className="px-6 py-2 text-right text-xs font-medium text-gray-500 uppercase">Logins</th>
                 <th className="px-6 py-2 text-right text-xs font-medium text-gray-500 uppercase">Last login</th>
+                <th className="px-6 py-2 text-right text-xs font-medium text-gray-500 uppercase">Action</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100">
@@ -280,6 +471,15 @@ export default function AdvancedMetricsPanel() {
                   <td className="px-6 py-2 text-right">{u.loginCount}</td>
                   <td className="px-6 py-2 text-right text-gray-600">
                     {u.lastLoginAt ? new Date(u.lastLoginAt).toLocaleString() : "—"}
+                  </td>
+                  <td className="px-6 py-2 text-right">
+                    <button
+                      type="button"
+                      onClick={() => setGrantTarget({ userId: u.userId, email: u.email })}
+                      className="text-xs font-medium text-purple-700 hover:text-purple-900"
+                    >
+                      Grant tokens
+                    </button>
                   </td>
                 </tr>
               ))}
@@ -421,6 +621,16 @@ export default function AdvancedMetricsPanel() {
           </button>
         </div>
       </div>
+
+      {grantTarget && (
+        <GrantTokensModal
+          target={grantTarget}
+          onClose={() => setGrantTarget(null)}
+          onGranted={() => {
+            void load();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -99,6 +99,7 @@
     "__tests__/**",
     "Alchm Kitchen/**",
     "alchm-app-integration/**",
+    "wten-migration-ui-components/**",
     "src/app/alchemicalEngine.ts",
     "src/app/personalized-ingredients/**",
     "src/components/PersonalizedIngredientPage.tsx",


### PR DESCRIPTION
## Summary

Picks up the loose ends from PR #413's brief:

- **Grant Tokens UI** wired into `AdvancedMetricsPanel`. Each row of "Recent logins" now has a "Grant tokens" button that opens a modal with per-token inputs (Spirit / Essence / Matter / Substance, default 5 each), an optional reason field, and a submit button. The request body uses the contract from `POST /api/admin/users/[userId]/grant`, including a per-click idempotency key. The `alreadyClaimed: true` response path surfaces as an amber notice showing current balances; success is green and reloads the panel.
- **`tsconfig.json` exclude** for `wten-migration-ui-components/**` so the in-progress migration source doesn't poison typecheck/lint. Same pattern already in place for `Alchm Kitchen/**` and `alchm-app-integration/**`.

## Ops already done out-of-band (not in this diff)

| | |
| :--- | :--- |
| **Migration 34 (auth_events)** | Applied to Railway Postgres. `auth_events` table + 5 indexes + 2 comments created. Unblocks `/api/admin/abuse` and `/api/admin/users/stats` rollups, and makes every signin-write actually durable. |
| **Migration 33 (device_sessions)** | Applied to Railway Postgres. This was a previously-unmerged migration that was blocking the digest endpoint and the active-sessions KPI. Idempotent (`CREATE TABLE IF NOT EXISTS` + 3 indexes). Verified `/api/admin/digest?dryRun=true` returns 200 with valid payload after this. |
| **Daily digest cron** | New Railway service `daily-digest-cron` (image `alpine:latest`, schedule `0 9 * * *` UTC, `restartPolicyType: NEVER`). Start command: `apk add --no-cache curl >/dev/null && curl -fsS --retry 3 --retry-delay 5 -X POST -H "Authorization: Bearer $INTERNAL_API_SECRET" "https://alchm.kitchen/api/admin/digest?period=daily"`. `INTERNAL_API_SECRET` is a reference variable pointing at `WhatToEatNext`'s value (no duplication). |

A first attempt used `curlimages/curl:latest` — that image has `ENTRYPOINT=["curl"]`, which made `sh -c '...'` arguments get parsed by curl itself. Switched to `alpine:latest` + `apk add curl` to get a real shell.

## Test plan

- [ ] Sign in to `/admin` as an admin user and confirm the Grant Tokens button appears on each row of "Recent logins".
- [ ] Click "Grant tokens" → confirm modal shows the user's email + truncated userId.
- [ ] Submit with defaults (5/5/5/5) → confirm green success state with new balances.
- [ ] Click "Grant tokens" on the same row again with the same defaults → submit → confirm amber "Already granted with that key" (the idempotency key is per-click so this should NOT trigger; instead, this confirms a fresh key produces a new grant).
- [ ] Wait for next 09:00 UTC (or trigger the cron from the Railway dashboard) → confirm `xalchm@gmail.com` receives the daily digest email.
- [ ] `railway logs --service daily-digest-cron` shows curl 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)