### PR TITLE
refactor(ui): replace button stub with full shadcn Button

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,26 +1,47 @@
-import { cva } from "class-variance-authority";
+import { Slot } from '@radix-ui/react-slot'
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
+import { cn } from '@/lib/utils'
 
-export const Button = ({ children, className = "", ...props }: any) => <button className={`px-4 py-2 rounded ${className}`} {...props}>{children}</button>;
-
-export const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
       },
     },
-    defaultVariants: { variant: "default", size: "default" },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
   }
-);
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button'
+    return (
+      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    )
+  }
+)
+Button.displayName = 'Button'
+
+export { Button, buttonVariants }


### PR DESCRIPTION
## Summary
- Replaces the 1-line stub `Button` in `src/components/ui/button.tsx` with the canonical shadcn Button: `React.forwardRef<HTMLButtonElement, ButtonProps>`, `asChild` via `@radix-ui/react-slot`, and a `displayName`.
- `buttonVariants` is updated to the upstream shadcn version — gains `[&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0` so icon children sit correctly inside buttons. Variant/size definitions are otherwise identical to what #417 added.
- Follow-up surfaced by #417, which added `buttonVariants` alongside the stub (because `alert-dialog.tsx` imports it) but left the stub `Button` in place. This PR finishes that swap.

## Why this is safe
- Existing consumers (all in `src/components/time-laboratory/*`) already call `<Button size="..." variant="..." className="..." onClick={...}>` — i.e., they're already passing shadcn-shape props. The stub's `(...props: any)` accepted them by accident; the new typed signature accepts them on purpose. No call site changed.
- `@radix-ui/react-slot@^1.2.4` and `class-variance-authority@^0.7.1` are already in `package.json` (installed by #417 / earlier sessions).
- `cn` is imported from `@/lib/utils` — already canonical after the session 2 fix-up that moved it there.

## Test plan
- [x] `bun run typecheck` — clean (0 errors)
- [x] `bun run lint` — 0 errors; warning count dropped 26 → 24 after fixing the two import-order warnings introduced by the verbatim port
- [x] `bun run build` — production build succeeds, all routes generated
- [ ] Spot-check Time Laboratory UI in dev once merged — the existing `<Button>` call sites should render identically (same default variant/size classes)

## Reflection
Going forward, when a shadcn component pulls in a co-located helper (here, `buttonVariants` from `button`), it's worth doing the full-component swap in the same session rather than leaving a stub + helper split. The split worked but left a footgun: any later caller using `asChild`, `forwardRef`, or the typed props would have silently failed against the stub. One follow-up PR is cheap; a confusing partial migration in the tree is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)