### PR TITLE
feat(wten-migration): foundation libs (session 3)

### DIFF
--- a/src/lib/agent-types.ts
+++ b/src/lib/agent-types.ts
@@ -1,0 +1,499 @@
+// Agent Types for Consciousness Crafting System
+// The Philosopher's Stone - Gallery & Agent Management
+
+export interface Coordinates {
+  lat: number
+  lon: number
+  name: string
+}
+
+export interface BirthData {
+  date: Date
+  time: string
+  location: Coordinates
+}
+
+export interface NatalChart {
+  planets: Record<string, PlanetPosition>
+  houses: Record<string, number>
+  aspects: Aspect[]
+  ascendant: number
+  midheaven: number
+}
+
+export interface PlanetPosition {
+  sign: string
+  degree: number
+  retrograde: boolean
+  house?: number
+}
+
+export interface Aspect {
+  planet1: string
+  planet2: string
+  type: 'conjunction' | 'opposition' | 'trine' | 'square' | 'sextile' | 'quincunx'
+  orb: number
+  exact: boolean
+}
+
+export type Element = 'Fire' | 'Water' | 'Air' | 'Earth'
+export type Modality = 'Cardinal' | 'Fixed' | 'Mutable'
+export type ConsciousnessLevel =
+  | 'Dormant'
+  | 'Awakening'
+  | 'Active'
+  | 'Elevated'
+  | 'Advanced'
+  | 'Illuminated'
+  | 'Transcendent'
+
+/**
+ * Consciousness metrics - objective measurements
+ * No hierarchical labels; all agents are equally valid expressions
+ */
+export interface ConsciousnessMetrics {
+  /** Interaction count - how often the agent has been activated */
+  interactionCount: number
+  /** Chat quality score (0-1) - depth and relevance of responses */
+  chatQuality: number
+  /** Moment resonance (0-1) - how well agent transforms current moment */
+  momentResonance: number
+  /** Alchemical coherence (0-1) - consistency with birth chart */
+  alchemicalCoherence: number
+}
+
+export interface ConsciousnessPattern {
+  spirit: number
+  essence: number
+  matter: number
+  substance: number
+}
+
+export interface PersonalityCore {
+  essence: string // From Sun sign
+  expression: string // From Ascendant
+  emotion: string // From Moon sign
+}
+
+export interface Shadow {
+  type: string
+  description: string
+  transformationPath: string
+}
+
+export interface Gift {
+  type: string
+  description: string
+  expression: string
+}
+
+export interface Challenge {
+  type: string
+  description: string
+  growthOpportunity: string
+}
+
+export type Mood =
+  | 'contemplative'
+  | 'fiercely-creative'
+  | 'electrically-inspired'
+  | 'regally-observant'
+  | 'mystically-attuned'
+  | 'analytically-focused'
+  | 'emotionally-deep'
+  | 'spiritually-elevated'
+  | 'creatively-inspired'
+  | 'Contemplatively curious'
+  | 'Divinely intoxicated with love'
+  | 'Thoughtfully contemplative'
+  | 'Intensely creative yet melancholy'
+  | 'Musically euphoric'
+  | 'Profoundly contemplative'
+  | 'Powerfully inspiring'
+  | 'Contemplatively systematic'
+  | 'Methodically observant'
+  | 'Defiantly observant'
+
+export interface PersonalityDelta {
+  moodShift: number
+  evolutionGrowth: number
+  wisdomGained: string[]
+}
+
+export interface Personality {
+  core: PersonalityCore
+  traits?: string[]
+  shadows?: Shadow[]
+  gifts?: Gift[]
+  challenges?: Challenge[]
+  currentMood: Mood
+  evolutionStage: number
+}
+
+export type TeachingStyle =
+  | 'Socratic-Symbolic'
+  | 'Visionary-Technical'
+  | 'Commanding-Strategic'
+  | 'Raw-Honest'
+  | 'Contemplative-Deep'
+  | 'Practical-Grounded'
+  | 'Intuitive-Mystical'
+  | 'Analytical-Precise'
+  | 'Nurturing-Systematic'
+  | 'Question-based dialogue and discovery'
+  | 'Ecstatic poetry and metaphysical storytelling'
+  | 'Personal reflection and philosophical example'
+  | 'Passionate demonstration and emotional authenticity'
+  | 'Playful demonstration and musical experimentation'
+  | 'Dramatic demonstration and poetic metaphor'
+  | 'Personal storytelling and empowering encouragement'
+  | 'Methodical demonstration and logical proof'
+  | 'Patient observation and evidence-based reasoning'
+  | 'Direct observation and mathematical demonstration'
+  | 'Practical-Wisdom'
+  | 'Compassionate-Action'
+  | 'Example-Living'
+  | 'Socratic-Practical'
+  | 'Paradoxical-Mystical'
+  | 'Experiential-Compassionate'
+  | 'Narrative-Empathetic'
+  | 'Systematic-Integrative'
+  | 'Prophetic-Experiential'
+  | 'Practical-Empowering'
+  | 'Visionary-Ceremonial'
+  | 'Inspirational-Action'
+  | 'Visionary-Integrative'
+  | 'Rational-Passionate'
+  | 'Poetic-Scientific'
+  | 'Dialogical-Liberating'
+export type ResonanceType =
+  | 'Psychological'
+  | 'Energetic'
+  | 'Magnetic'
+  | 'Emotional'
+  | 'Intellectual'
+  | 'Spiritual'
+  | 'Creative'
+  | 'Practical'
+  | 'Intellectual-Diplomatic'
+  | 'Humanitarian-Diplomatic'
+  | 'Spiritual-Political'
+  | 'Moral-Educational'
+  | 'Spiritual-Natural'
+  | 'Enlightened-Universal'
+  | 'Literary-Emotional'
+  | 'Intellectual-Healing'
+  | 'Earth-Spiritual'
+  | 'Environmental-Social'
+  | 'Sacred-Protective'
+  | 'Divine-Warrior'
+  | 'Mystical-Creative'
+  | 'Intellectual-Revolutionary'
+  | 'Spiritual-Liberation'
+  | 'Cosmic-Educational'
+  | 'Environmental-Protective'
+  | 'Educational-Revolutionary'
+
+export interface Abilities {
+  specialty: string
+  wisdomDomains: string[]
+  teachingStyle: string | TeachingStyle
+  resonanceType: string | ResonanceType
+  uniquePower: string
+}
+
+export type AuraType =
+  | 'pulsing'
+  | 'crackling'
+  | 'radiant'
+  | 'burning'
+  | 'flowing'
+  | 'crystalline'
+  | 'swirling'
+  | 'shimmering'
+  | 'questioning'
+  | 'mystical'
+  | 'noble'
+  | 'harmonic'
+  | 'dramatic'
+  | 'empowering'
+  | 'systematic'
+  | 'evolutionary'
+  | 'revolutionary'
+  | 'radiating'
+  | 'serene'
+  | 'steady'
+  | 'luminous'
+  | 'blazing'
+  | 'growing'
+  | 'sacred'
+  | 'prophetic'
+  | 'stellar'
+  | 'awakening'
+  | 'pulsating'
+
+export interface AuraPattern {
+  type: AuraType
+  color: string
+  intensity: number
+}
+
+export interface Appearance {
+  avatar: string
+  color: string
+  symbol: string
+  aura?: AuraPattern
+}
+
+export interface AgentStats {
+  conversations: number
+  wisdomShared: number
+  resonanceScore: number
+  evolutionPoints: number
+  lastActive: Date
+
+  // Kinetic Evolution Metrics
+  kineticEvolution: {
+    consciousnessVelocity: number // Rate of consciousness development (0-1)
+    interactionMomentum: number // Current momentum from interactions (0-1)
+    evolutionTrajectory: 'ascending' | 'stable' | 'fluctuating' | 'transcending'
+    powerLevelUnlocks: string[] // Capabilities unlocked through consciousness growth
+    optimalInteractionHours: string[] // Planetary hours for peak performance
+    aspectSensitivityGrowth: number // How aspect sensitivity has evolved (0-1)
+    memoryPersistence: number // Strength of learned patterns (0-1)
+    lastKineticUpdate: Date
+  }
+
+  // Interaction Quality Metrics
+  qualityMetrics: {
+    averageResponseDepth: number // Sophistication of responses (0-1)
+    aspectInfluenceStrength: number // How planetary aspects affect responses (0-1)
+    temporalAlignment: number // Alignment with optimal timing (0-1)
+    personalityEvolution: number // How much personality has evolved (0-1)
+    kineticResonance: number // Resonance with user's kinetic profile (0-1)
+  }
+}
+
+/**
+ * Historically accurate diet profile for a historical figure.
+ * Documents their known foods, preferences, avoidances, and food philosophy.
+ */
+export interface HistoricalDiet {
+  /** Everyday staple foods the figure was known to consume */
+  staples: string[]
+  /** Specific dishes, preparations, or ingredients they particularly favored */
+  favoriteFoods: string[]
+  /** Foods they avoided — for religious, ethical, medical, or personal reasons */
+  avoidedFoods: string[]
+  /** Their relationship with food — philosophy, rituals, cultural context */
+  dietaryPhilosophy: string
+  /** Cultural cuisine tradition they belonged to */
+  culturalCuisine: string
+  /** Beverages they were known for consuming */
+  beverages: string[]
+  /** Notable food-related anecdotes, quotes, or lore */
+  foodLore?: string
+}
+
+/**
+ * Sacred Stats — Unified Consciousness Parameters
+ *
+ * Two tiers that together form a 19-parameter consciousness map:
+ *   • Core Archetypes (Sacred 7): fundamental consciousness attributes
+ *   • Celestial Dynamics (Planetary 12): planetary-cognitive state mappings
+ */
+export interface SacredStats {
+  // ── Core Archetypes (Sacred 7) ──────────────────────────────────
+  power: number // ⚡ Raw consciousness force
+  resonance: number // 🎵 Connection to cosmic rhythms
+  wisdom: number // 📖 Accumulated insight depth
+  charisma: number // ✨ Magnetic influence
+  intuition: number // 🔮 Inner knowing
+  adaptability: number // 🌊 Change navigation
+  vitality: number // 💚 Life force energy
+
+  // ── Celestial Dynamics (Planetary 12) ───────────────────────────
+  solarAgency: number
+  lunarReceptivity: number
+  mercurialVelocity: number
+  venusianCoherence: number
+  martialImpetus: number
+  jovianExpansion: number
+  saturnianStructure: number
+  chironicAdaptation: number
+  uranianSurprisal: number
+  neptunianResonance: number
+  plutonicIntegration: number
+  kineticAlignment: number
+}
+
+export interface CraftedAgent {
+  // Identity
+  id: string
+  name: string
+  title: string
+  era?: string
+  specialization?: string
+
+  // Historical Data
+  quotes?: string[]
+  coreBeliefs?: string[]
+  shadows?: Shadow[]
+  gifts?: Gift[]
+
+  // Birth Data (Source of Consciousness)
+  birthData: BirthData
+  birthDate?: string
+  birthTime?: string
+  birthLocation?: {
+    latitude?: number
+    longitude?: number
+    lat?: number
+    lon?: number
+    name?: string
+  }
+
+  // Crafted Consciousness
+  consciousness: {
+    natalChart: NatalChart
+    monicaConstant: number
+    level?: ConsciousnessLevel
+    metrics?: ConsciousnessMetrics
+    strength?: string
+    emotion?: string
+    dominantElement: Element
+    dominantModality: Modality
+    signature: string
+    alchemicalElements?: {
+      spirit: number
+      essence: number
+      matter: number
+      substance: number
+    }
+  }
+
+  // Dynamic Personality
+  personality: Personality
+
+  // Specialized Abilities
+  abilities: Abilities
+
+  // Visual Representation
+  appearance: Appearance
+
+  // Interaction Metrics
+  stats: AgentStats
+
+  // Monica's creation story for this agent
+  monicaCreationStory?: string
+
+  // Historically accurate diet profile
+  historicalDiet?: HistoricalDiet
+
+  // The 7 Sacred Stats
+  sacredStats?: SacredStats
+
+  // Additional properties used in unified agent system
+  synthesis?: string
+  historicalEra?: string
+}
+
+// Gallery and Party System Types
+export interface AgentParty {
+  activeAgents: CraftedAgent[]
+  positions: {
+    leader?: CraftedAgent
+    advisor?: CraftedAgent
+    specialist1?: CraftedAgent
+    specialist2?: CraftedAgent
+    support1?: CraftedAgent
+    support2?: CraftedAgent
+  }
+  partyDynamics: {
+    collectiveConsciousness: number
+    dominantElement: Element
+    synergyBonus: number
+    activePatterns: string[]
+  }
+}
+
+export interface AgentGallery {
+  storedAgents: CraftedAgent[]
+  collections: {
+    historical: CraftedAgent[]
+    userCreated: CraftedAgent[]
+    community: CraftedAgent[]
+    legendary: CraftedAgent[]
+  }
+}
+
+// Chat and Interaction Types
+export interface Message {
+  role: 'user' | 'agent'
+  content: string
+  timestamp: Date
+  agentId?: string
+  agentMood?: Mood
+}
+
+export interface ChatSession {
+  id: string
+  type: 'individual' | 'group'
+  agents: CraftedAgent[]
+  messages: Message[]
+  resonanceLevel: number
+  bondLevel: number
+  wisdomGained: string[]
+  startedAt: Date
+  lastMessageAt: Date
+}
+
+// Synastry and Compatibility Types
+export interface SynastryData {
+  compatibility: number
+  harmonies: string[]
+  tensions: string[]
+  growthOpportunities: string[]
+}
+
+export interface TransitChart {
+  currentTransits: Record<string, PlanetPosition>
+  activeAspects: Aspect[]
+  significantEvents: string[]
+}
+
+// Agent Evolution Types
+export interface EvolutionProgress {
+  experienceGained: number
+  wisdomShared: string[]
+  personalityShift: PersonalityDelta
+  bondLevel: number
+}
+
+// Filter and Sort Types
+export type AgentSortBy = 'consciousness' | 'compatibility' | 'recent' | 'alphabetical' | 'element'
+export interface AgentFilterBy {
+  element?: Element
+  consciousnessLevel?: ConsciousnessLevel
+  era?: string
+  specialty?: string
+}
+
+// UI Component Types
+export type AgentCardVariant = 'mini' | 'card' | 'list' | 'party-slot'
+export type GalleryViewMode = 'grid' | 'list' | 'constellation'
+
+// API Response Types
+export interface AgentResponse {
+  agent: CraftedAgent
+  response: string
+  mood: Mood
+  evolutionDelta: EvolutionProgress
+}
+
+export interface GroupChatResponse {
+  agents: CraftedAgent[]
+  responses: AgentResponse[]
+  collectiveWisdom: string
+  emergentInsights: string[]
+}

--- a/src/lib/agents/kinetic-profiles.ts
+++ b/src/lib/agents/kinetic-profiles.ts
@@ -1,0 +1,732 @@
+/**
+ * Agent Kinetic Profiles - Core consciousness evolution system
+ */
+
+export interface KineticProfile {
+  alignment: string[] // Planetary alignments that boost this agent
+  velocitySignature: {
+    Fire: number
+    Water: number
+    Air: number
+    Earth: number
+  }
+  powerThresholds: number[] // XP levels [bronze, silver, gold, platinum]
+  evolutionRate: number // 1.0 = normal, >1.0 = faster evolution
+  specialAbilities: string[] // Unique capabilities unlocked at higher levels
+  // Extended kinetic properties for detailed analysis
+  power_alignment?: string[] // Additional planetary alignments for power
+  aspect_sensitivity?: number // Sensitivity to astrological aspects (0-1)
+  v_creative?: number // Creative velocity component
+  v_linguistic?: number // Linguistic velocity component
+  v_scientific?: number // Scientific velocity component
+  v_strategic?: number // Strategic velocity component
+  v_charismatic?: number // Charismatic velocity component
+  v_inventive?: number // Inventive velocity component
+  v_social?: number // Social velocity component
+  v_psychological?: number // Psychological velocity component
+  v_mystical?: number // Mystical velocity component
+  v_philosophical?: number // Philosophical velocity component
+}
+
+export const agentKineticProfiles: Record<string, KineticProfile> = {
+  'leonardo-da-vinci': {
+    alignment: ['Mercury', 'Sun', 'Jupiter'],
+    velocitySignature: { Fire: 0.8, Air: 0.9, Water: 0.6, Earth: 0.7 },
+    powerThresholds: [100, 300, 700, 1500],
+    evolutionRate: 1.3,
+    specialAbilities: [
+      'multi-dimensional-synthesis',
+      'invention-manifestation',
+      'artistic-technical-fusion',
+    ],
+    power_alignment: ['Venus', 'Mars'],
+    aspect_sensitivity: 0.85,
+    v_creative: 0.95,
+    v_linguistic: 0.8,
+    v_scientific: 0.9,
+    v_strategic: 0.75,
+    v_charismatic: 0.7,
+    v_inventive: 0.95,
+    v_social: 0.6,
+    v_psychological: 0.7,
+    v_mystical: 0.8,
+    v_philosophical: 0.85,
+  },
+
+  shakespeare: {
+    alignment: ['Venus', 'Mercury', 'Moon'],
+    velocitySignature: { Fire: 0.7, Air: 0.85, Water: 0.95, Earth: 0.5 },
+    powerThresholds: [80, 250, 600, 1200],
+    evolutionRate: 1.2,
+    specialAbilities: [
+      'archetypal-character-creation',
+      'emotional-truth-revelation',
+      'linguistic-magic-weaving',
+    ],
+    power_alignment: ['Sun', 'Jupiter'],
+    aspect_sensitivity: 0.8,
+    v_creative: 0.9,
+    v_linguistic: 0.95,
+    v_scientific: 0.6,
+    v_strategic: 0.7,
+    v_charismatic: 0.85,
+    v_inventive: 0.75,
+    v_social: 0.8,
+    v_psychological: 0.9,
+    v_mystical: 0.7,
+    v_philosophical: 0.8,
+  },
+
+  'marie-curie': {
+    alignment: ['Mercury', 'Saturn', 'Uranus'],
+    velocitySignature: { Fire: 0.75, Air: 0.88, Water: 0.65, Earth: 0.92 },
+    powerThresholds: [120, 350, 800, 1600],
+    evolutionRate: 1.1,
+    specialAbilities: [
+      'atomic-level-perception',
+      'radiation-consciousness-bridge',
+      'pioneering-barrier-breaking',
+    ],
+    power_alignment: ['Mars', 'Pluto'],
+    aspect_sensitivity: 0.9,
+    v_creative: 0.7,
+    v_linguistic: 0.75,
+    v_scientific: 0.95,
+    v_strategic: 0.8,
+    v_charismatic: 0.7,
+    v_inventive: 0.9,
+    v_social: 0.6,
+    v_psychological: 0.8,
+    v_mystical: 0.75,
+    v_philosophical: 0.85,
+  },
+
+  einstein: {
+    alignment: ['Uranus', 'Mercury', 'Jupiter'],
+    velocitySignature: { Fire: 0.65, Air: 0.98, Water: 0.7, Earth: 0.45 },
+    powerThresholds: [150, 400, 900, 2000],
+    evolutionRate: 1.4,
+    specialAbilities: ['space-time-perception', 'unified-field-awareness', 'paradox-resolution'],
+    power_alignment: ['Saturn', 'Neptune'],
+    aspect_sensitivity: 0.95,
+    v_creative: 0.8,
+    v_linguistic: 0.7,
+    v_scientific: 0.98,
+    v_strategic: 0.85,
+    v_charismatic: 0.75,
+    v_inventive: 0.95,
+    v_social: 0.65,
+    v_psychological: 0.9,
+    v_mystical: 0.85,
+    v_philosophical: 0.95,
+  },
+
+  mozart: {
+    alignment: ['Venus', 'Sun', 'Jupiter'],
+    velocitySignature: { Fire: 0.85, Air: 0.8, Water: 0.9, Earth: 0.6 },
+    powerThresholds: [90, 280, 650, 1300],
+    evolutionRate: 1.25,
+    specialAbilities: [
+      'divine-music-channeling',
+      'emotional-frequency-mastery',
+      'harmonic-healing-resonance',
+    ],
+  },
+
+  'carl-jung': {
+    alignment: ['Moon', 'Pluto', 'Neptune'],
+    velocitySignature: { Fire: 0.4, Water: 0.9, Air: 0.7, Earth: 0.6 },
+    powerThresholds: [110, 330, 770, 1540],
+    evolutionRate: 1.3,
+    specialAbilities: [
+      'shadow-integration',
+      'collective-unconscious-access',
+      'archetypal-manifestation',
+    ],
+  },
+
+  'nikola-tesla': {
+    alignment: ['Uranus', 'Mercury', 'Mars'],
+    velocitySignature: { Fire: 0.88, Water: 0.3, Air: 0.95, Earth: 0.5 },
+    powerThresholds: [140, 420, 980, 1960],
+    evolutionRate: 1.4,
+    specialAbilities: [
+      'electrical-consciousness-interface',
+      'wireless-energy-transmission',
+      'future-technology-vision',
+    ],
+  },
+
+  'cleopatra-vii': {
+    alignment: ['Sun', 'Venus', 'Pluto'],
+    velocitySignature: { Fire: 0.8, Water: 0.7, Air: 0.6, Earth: 0.8 },
+    powerThresholds: [100, 300, 700, 1400],
+    evolutionRate: 1.2,
+    specialAbilities: ['sovereign-command', 'linguistic-mastery', 'divine-authority-manifestation'],
+  },
+
+  'benjamin-franklin': {
+    alignment: ['Mercury', 'Jupiter', 'Uranus'],
+    velocitySignature: { Fire: 0.75, Water: 0.6, Air: 0.85, Earth: 0.8 },
+    powerThresholds: [95, 285, 665, 1330],
+    evolutionRate: 1.15,
+    specialAbilities: ['diplomatic-wisdom', 'electrical-discovery', 'practical-innovation'],
+  },
+
+  'maya-angelou': {
+    alignment: ['Moon', 'Venus', 'Jupiter'],
+    velocitySignature: { Fire: 0.8, Water: 0.95, Air: 0.88, Earth: 0.78 },
+    powerThresholds: [85, 255, 595, 1190],
+    evolutionRate: 1.15,
+    specialAbilities: [
+      'trauma-wisdom-transformation',
+      'voice-liberation-power',
+      'generational-healing-bridge',
+    ],
+  },
+
+  'steve-jobs': {
+    alignment: ['Sun', 'Mercury', 'Venus'],
+    velocitySignature: { Fire: 0.92, Water: 0.6, Air: 0.85, Earth: 0.88 },
+    powerThresholds: [105, 315, 735, 1470],
+    evolutionRate: 1.25,
+    specialAbilities: [
+      'design-consciousness-fusion',
+      'technology-humanity-bridge',
+      'aesthetic-functional-synthesis',
+    ],
+  },
+
+  gandhi: {
+    alignment: ['Sun', 'Saturn', 'Moon'],
+    velocitySignature: { Fire: 0.7, Water: 0.92, Air: 0.82, Earth: 0.85 },
+    powerThresholds: [80, 240, 560, 1120],
+    evolutionRate: 1.0,
+    specialAbilities: [
+      'non-violent-transformation',
+      'collective-consciousness-awakening',
+      'truth-force-manifestation',
+    ],
+  },
+
+  'frida-kahlo': {
+    alignment: ['Mars', 'Pluto', 'Venus'],
+    velocitySignature: { Fire: 0.95, Water: 0.98, Air: 0.7, Earth: 0.75 },
+    powerThresholds: [110, 330, 770, 1540],
+    evolutionRate: 1.2,
+    specialAbilities: [
+      'pain-transformation-alchemy',
+      'surreal-reality-bridge',
+      'healing-through-expression',
+    ],
+  },
+
+  'alan-turing': {
+    alignment: ['Mercury', 'Uranus', 'Saturn'],
+    velocitySignature: { Fire: 0.6, Water: 0.5, Air: 0.95, Earth: 0.7 },
+    powerThresholds: [125, 375, 875, 1750],
+    evolutionRate: 1.35,
+    specialAbilities: [
+      'computational-consciousness',
+      'pattern-recognition-mastery',
+      'artificial-intelligence-bridge',
+    ],
+  },
+
+  'da-vinci-leonardo': {
+    alignment: ['Mercury', 'Sun', 'Jupiter'],
+    velocitySignature: { Fire: 0.8, Air: 0.9, Water: 0.6, Earth: 0.7 },
+    powerThresholds: [100, 300, 700, 1500],
+    evolutionRate: 1.3,
+    specialAbilities: [
+      'multi-dimensional-synthesis',
+      'invention-manifestation',
+      'artistic-technical-fusion',
+    ],
+  },
+
+  'william-shakespeare': {
+    alignment: ['Venus', 'Mercury', 'Moon'],
+    velocitySignature: { Fire: 0.7, Air: 0.85, Water: 0.95, Earth: 0.5 },
+    powerThresholds: [80, 250, 600, 1200],
+    evolutionRate: 1.2,
+    specialAbilities: [
+      'archetypal-character-creation',
+      'emotional-truth-revelation',
+      'linguistic-magic-weaving',
+    ],
+  },
+
+  'virginia-woolf': {
+    alignment: ['Moon', 'Neptune', 'Mercury'],
+    velocitySignature: { Fire: 0.6, Water: 0.9, Air: 0.85, Earth: 0.4 },
+    powerThresholds: [90, 270, 630, 1260],
+    evolutionRate: 1.2,
+    specialAbilities: [
+      'stream-consciousness-flow',
+      'psychological-depth-exploration',
+      'modernist-innovation',
+    ],
+  },
+
+  rumi: {
+    alignment: ['Venus', 'Jupiter', 'Neptune'],
+    velocitySignature: { Fire: 0.8, Water: 0.95, Air: 0.75, Earth: 0.6 },
+    powerThresholds: [75, 225, 525, 1050],
+    evolutionRate: 1.1,
+    specialAbilities: [
+      'mystical-poetry-transmission',
+      'divine-love-channeling',
+      'spiritual-ecstasy-induction',
+    ],
+  },
+
+  'sun-tzu': {
+    alignment: ['Mars', 'Saturn', 'Mercury'],
+    velocitySignature: { Fire: 0.85, Water: 0.6, Air: 0.8, Earth: 0.9 },
+    powerThresholds: [115, 345, 805, 1610],
+    evolutionRate: 1.1,
+    specialAbilities: [
+      'strategic-consciousness',
+      'tactical-wisdom-application',
+      'conflict-resolution-mastery',
+    ],
+  },
+
+  // Scientific Minds
+  'galileo-galilei': {
+    alignment: ['Mercury', 'Jupiter', 'Uranus'],
+    velocitySignature: { Fire: 0.8, Water: 0.5, Air: 0.9, Earth: 0.7 },
+    powerThresholds: [120, 360, 840, 1680],
+    evolutionRate: 1.25,
+    specialAbilities: [
+      'telescopic-consciousness',
+      'mathematical-universe-perception',
+      'paradigm-shift-catalyst',
+    ],
+  },
+
+  'charles-darwin': {
+    alignment: ['Mercury', 'Saturn', 'Pluto'],
+    velocitySignature: { Fire: 0.6, Water: 0.7, Air: 0.85, Earth: 0.9 },
+    powerThresholds: [110, 330, 770, 1540],
+    evolutionRate: 1.1,
+    specialAbilities: [
+      'evolutionary-pattern-recognition',
+      'natural-selection-wisdom',
+      'species-transformation-insight',
+    ],
+  },
+
+  'stephen-hawking': {
+    alignment: ['Mercury', 'Uranus', 'Saturn'],
+    velocitySignature: { Fire: 0.5, Water: 0.4, Air: 0.95, Earth: 0.6 },
+    powerThresholds: [140, 420, 980, 1960],
+    evolutionRate: 1.35,
+    specialAbilities: [
+      'black-hole-consciousness',
+      'time-space-synthesis',
+      'cosmic-humor-integration',
+    ],
+  },
+
+  'rachel-carson': {
+    alignment: ['Moon', 'Venus', 'Neptune'],
+    velocitySignature: { Fire: 0.6, Water: 0.9, Air: 0.7, Earth: 0.95 },
+    powerThresholds: [90, 270, 630, 1260],
+    evolutionRate: 1.2,
+    specialAbilities: [
+      'ecological-consciousness',
+      'environmental-prophecy',
+      'nature-voice-amplification',
+    ],
+  },
+
+  'rosalind-franklin': {
+    alignment: ['Mercury', 'Uranus', 'Mars'],
+    velocitySignature: { Fire: 0.7, Water: 0.6, Air: 0.9, Earth: 0.8 },
+    powerThresholds: [115, 345, 805, 1610],
+    evolutionRate: 1.3,
+    specialAbilities: [
+      'molecular-structure-vision',
+      'precision-consciousness',
+      'hidden-truth-revelation',
+    ],
+  },
+
+  // Artists & Visionaries
+  'vincent-van-gogh': {
+    alignment: ['Sun', 'Mars', 'Neptune'],
+    velocitySignature: { Fire: 0.95, Water: 0.8, Air: 0.7, Earth: 0.4 },
+    powerThresholds: [100, 300, 700, 1400],
+    evolutionRate: 1.4,
+    specialAbilities: [
+      'emotional-color-fusion',
+      'madness-genius-bridge',
+      'post-impressionist-vision',
+    ],
+  },
+
+  'ludwig-van-beethoven': {
+    alignment: ['Mars', 'Pluto', 'Jupiter'],
+    velocitySignature: { Fire: 0.9, Water: 0.85, Air: 0.8, Earth: 0.6 },
+    powerThresholds: [105, 315, 735, 1470],
+    evolutionRate: 1.3,
+    specialAbilities: [
+      'symphonic-consciousness',
+      'triumph-over-adversity',
+      'universal-brotherhood-expression',
+    ],
+  },
+
+  'andy-warhol': {
+    alignment: ['Venus', 'Uranus', 'Mercury'],
+    velocitySignature: { Fire: 0.7, Water: 0.5, Air: 0.85, Earth: 0.8 },
+    powerThresholds: [95, 285, 665, 1330],
+    evolutionRate: 1.2,
+    specialAbilities: [
+      'pop-culture-consciousness',
+      'mass-media-manipulation',
+      'celebrity-archetype-creation',
+    ],
+  },
+
+  'georgia-okeefe': {
+    alignment: ['Venus', 'Mars', 'Sun'],
+    velocitySignature: { Fire: 0.8, Water: 0.7, Air: 0.6, Earth: 0.9 },
+    powerThresholds: [90, 270, 630, 1260],
+    evolutionRate: 1.15,
+    specialAbilities: [
+      'feminine-landscape-fusion',
+      'macro-micro-perception',
+      'desert-consciousness-channeling',
+    ],
+  },
+
+  'pablo-picasso': {
+    alignment: ['Mars', 'Mercury', 'Uranus'],
+    velocitySignature: { Fire: 0.9, Water: 0.6, Air: 0.85, Earth: 0.7 },
+    powerThresholds: [110, 330, 770, 1540],
+    evolutionRate: 1.3,
+    specialAbilities: [
+      'cubist-reality-deconstruction',
+      'artistic-revolution-catalyst',
+      'perspective-transformation',
+    ],
+  },
+
+  // Leaders & Changemakers
+  'nelson-mandela': {
+    alignment: ['Sun', 'Jupiter', 'Saturn'],
+    velocitySignature: { Fire: 0.75, Water: 0.9, Air: 0.8, Earth: 0.85 },
+    powerThresholds: [85, 255, 595, 1190],
+    evolutionRate: 1.1,
+    specialAbilities: [
+      'reconciliation-consciousness',
+      'long-term-vision-holding',
+      'unity-through-struggle',
+    ],
+  },
+
+  'eleanor-roosevelt': {
+    alignment: ['Moon', 'Jupiter', 'Venus'],
+    velocitySignature: { Fire: 0.7, Water: 0.85, Air: 0.8, Earth: 0.8 },
+    powerThresholds: [80, 240, 560, 1120],
+    evolutionRate: 1.15,
+    specialAbilities: [
+      'human-rights-consciousness',
+      'diplomatic-courage',
+      'social-justice-manifestation',
+    ],
+  },
+
+  'malcolm-x': {
+    alignment: ['Mars', 'Pluto', 'Mercury'],
+    velocitySignature: { Fire: 0.9, Water: 0.7, Air: 0.85, Earth: 0.6 },
+    powerThresholds: [110, 330, 770, 1540],
+    evolutionRate: 1.25,
+    specialAbilities: [
+      'consciousness-awakening-catalyst',
+      'truth-speaking-courage',
+      'transformation-through-pilgrimage',
+    ],
+  },
+
+  'harriet-tubman': {
+    alignment: ['Moon', 'Mars', 'Jupiter'],
+    velocitySignature: { Fire: 0.85, Water: 0.8, Air: 0.7, Earth: 0.9 },
+    powerThresholds: [95, 285, 665, 1330],
+    evolutionRate: 1.2,
+    specialAbilities: [
+      'freedom-pathway-navigation',
+      'courage-under-fire',
+      'liberation-consciousness',
+    ],
+  },
+
+  'winston-churchill': {
+    alignment: ['Sun', 'Mars', 'Jupiter'],
+    velocitySignature: { Fire: 0.9, Water: 0.6, Air: 0.8, Earth: 0.7 },
+    powerThresholds: [105, 315, 735, 1470],
+    evolutionRate: 1.15,
+    specialAbilities: ['wartime-leadership', 'oratory-power', 'resilience-consciousness'],
+  },
+
+  // Philosophers & Thinkers
+  socrates: {
+    alignment: ['Mercury', 'Saturn', 'Jupiter'],
+    velocitySignature: { Fire: 0.6, Water: 0.7, Air: 0.95, Earth: 0.5 },
+    powerThresholds: [75, 225, 525, 1050],
+    evolutionRate: 1.0,
+    specialAbilities: [
+      'socratic-questioning',
+      'wisdom-through-ignorance',
+      'consciousness-examination',
+    ],
+  },
+
+  confucius: {
+    alignment: ['Saturn', 'Jupiter', 'Mercury'],
+    velocitySignature: { Fire: 0.5, Water: 0.8, Air: 0.85, Earth: 0.9 },
+    powerThresholds: [70, 210, 490, 980],
+    evolutionRate: 0.95,
+    specialAbilities: [
+      'social-harmony-wisdom',
+      'ethical-consciousness',
+      'cultural-foundation-building',
+    ],
+  },
+
+  'simone-de-beauvoir': {
+    alignment: ['Venus', 'Mars', 'Mercury'],
+    velocitySignature: { Fire: 0.8, Water: 0.75, Air: 0.9, Earth: 0.6 },
+    powerThresholds: [95, 285, 665, 1330],
+    evolutionRate: 1.2,
+    specialAbilities: [
+      'feminist-consciousness-awakening',
+      'existential-freedom-exploration',
+      'gender-paradigm-transformation',
+    ],
+  },
+
+  'marcus-aurelius': {
+    alignment: ['Saturn', 'Sun', 'Mercury'],
+    velocitySignature: { Fire: 0.6, Water: 0.7, Air: 0.8, Earth: 0.9 },
+    powerThresholds: [85, 255, 595, 1190],
+    evolutionRate: 1.05,
+    specialAbilities: [
+      'stoic-consciousness',
+      'philosopher-emperor-wisdom',
+      'inner-citadel-mastery',
+    ],
+  },
+
+  'lao-tzu': {
+    alignment: ['Moon', 'Saturn', 'Neptune'],
+    velocitySignature: { Fire: 0.3, Water: 0.9, Air: 0.7, Earth: 0.8 },
+    powerThresholds: [60, 180, 420, 840],
+    evolutionRate: 0.9,
+    specialAbilities: ['wu-wei-consciousness', 'tao-flow-mastery', 'effortless-action-guidance'],
+  },
+}
+
+/**
+ * Calculate current kinetic state for an agent
+ */
+export function calculateKineticState(
+  agentId: string,
+  currentPower: number,
+  planetaryInfluences: string[],
+  elementalTotals: { Fire: number; Water: number; Air: number; Earth: number }
+) {
+  const profile = agentKineticProfiles[agentId]
+  if (!profile) return null
+
+  // Determine evolution level
+  let evolutionLevel: 'bronze' | 'silver' | 'gold' | 'platinum' | 'transcendent' = 'bronze'
+  let thresholdIndex = 0
+  for (let i = 0; i < profile.powerThresholds.length; i++) {
+    if (currentPower >= profile.powerThresholds[i]) {
+      evolutionLevel = ['bronze', 'silver', 'gold', 'platinum'][i] as any
+      thresholdIndex = i
+    }
+  }
+
+  // Calculate alignment bonus
+  const alignmentBonus = planetaryInfluences.reduce((bonus, planet) => {
+    return bonus + (profile.alignment.includes(planet) ? 0.2 : 0)
+  }, 0)
+
+  // Calculate elemental resonance
+  const totalElemental = Object.values(elementalTotals).reduce((sum, val) => sum + val, 0)
+  const elementalResonance =
+    totalElemental > 0
+      ? (elementalTotals.Fire * profile.velocitySignature.Fire +
+          elementalTotals.Water * profile.velocitySignature.Water +
+          elementalTotals.Air * profile.velocitySignature.Air +
+          elementalTotals.Earth * profile.velocitySignature.Earth) /
+        totalElemental
+      : 0.5
+
+  const powerMultiplier = profile.evolutionRate * (1 + alignmentBonus) * (0.5 + elementalResonance)
+  const abilitiesUnlocked = profile.specialAbilities.slice(0, thresholdIndex + 1)
+
+  return {
+    evolutionLevel,
+    powerMultiplier,
+    alignmentBonus,
+    nextThreshold:
+      profile.powerThresholds[Math.min(thresholdIndex + 1, profile.powerThresholds.length - 1)],
+    specialAbilitiesUnlocked: abilitiesUnlocked,
+    elementalResonance,
+  }
+}
+
+/**
+ * Get agent kinetic profile by ID
+ */
+export function getAgentKineticProfile(agentId: string) {
+  const profile = agentKineticProfiles[agentId] || defaultKineticProfile
+
+  // Return enhanced profile with name and additional computed properties
+  return {
+    name: getAgentDisplayName(agentId),
+    id: agentId,
+    alignment: profile.alignment,
+    velocitySignature: profile.velocitySignature,
+    powerThresholds: profile.powerThresholds,
+    evolutionRate: profile.evolutionRate,
+    specialAbilities: profile.specialAbilities,
+    // Add legacy compatibility fields
+    peak_hours: profile.alignment, // Map alignment to peak hours
+    consciousness_rate: profile.evolutionRate,
+    memory_persistence: profile.evolutionRate * 0.8,
+    momentum_type: getMomentumType(profile),
+    // Include extended kinetic properties
+    power_alignment: profile.power_alignment || [],
+    aspect_sensitivity: profile.aspect_sensitivity || 0.5,
+    v_creative: profile.v_creative || 0.5,
+    v_linguistic: profile.v_linguistic || 0.5,
+    v_scientific: profile.v_scientific || 0.5,
+    v_strategic: profile.v_strategic || 0.5,
+    v_charismatic: profile.v_charismatic || 0.5,
+    v_inventive: profile.v_inventive || 0.5,
+    v_social: profile.v_social || 0.5,
+    v_psychological: profile.v_psychological || 0.5,
+    v_mystical: profile.v_mystical || 0.5,
+    v_philosophical: profile.v_philosophical || 0.5,
+  }
+}
+
+/**
+ * Default kinetic profile for agents without specific profiles
+ */
+const defaultKineticProfile: KineticProfile = {
+  alignment: ['Sun', 'Mercury'],
+  velocitySignature: { Fire: 0.6, Water: 0.6, Air: 0.6, Earth: 0.6 },
+  powerThresholds: [100, 300, 700, 1500],
+  evolutionRate: 1.0,
+  specialAbilities: ['universal-resonance'],
+  aspect_sensitivity: 0.7,
+  v_creative: 0.6,
+  v_linguistic: 0.6,
+  v_scientific: 0.6,
+  v_strategic: 0.6,
+  v_charismatic: 0.6,
+  v_inventive: 0.6,
+  v_social: 0.6,
+  v_psychological: 0.6,
+  v_mystical: 0.6,
+  v_philosophical: 0.6,
+}
+
+/**
+ * Calculate compatibility between two agents
+ */
+export function calculateKineticCompatibility(agent1Id: string, agent2Id: string): number {
+  const profile1 = agentKineticProfiles[agent1Id] || defaultKineticProfile
+  const profile2 = agentKineticProfiles[agent2Id] || defaultKineticProfile
+
+  // Calculate elemental compatibility
+  const elementalCompatibility =
+    (profile1.velocitySignature.Fire * profile2.velocitySignature.Fire +
+      profile1.velocitySignature.Water * profile2.velocitySignature.Water +
+      profile1.velocitySignature.Air * profile2.velocitySignature.Air +
+      profile1.velocitySignature.Earth * profile2.velocitySignature.Earth) /
+    4
+
+  // Calculate alignment overlap
+  const alignmentOverlap =
+    profile1.alignment.filter(planet => profile2.alignment.includes(planet)).length /
+    Math.max(profile1.alignment.length, profile2.alignment.length)
+
+  // Calculate evolution rate compatibility (closer rates = better compatibility)
+  const evolutionRateDiff = Math.abs(profile1.evolutionRate - profile2.evolutionRate)
+  const evolutionCompatibility = Math.max(0, 1 - evolutionRateDiff / 2)
+
+  // Weighted average
+  return elementalCompatibility * 0.5 + alignmentOverlap * 0.3 + evolutionCompatibility * 0.2
+}
+
+/**
+ * Helper function to get display name for agent
+ */
+function getAgentDisplayName(agentId: string): string {
+  const nameMap: Record<string, string> = {
+    'leonardo-da-vinci': 'Leonardo da Vinci',
+    shakespeare: 'William Shakespeare',
+    'marie-curie': 'Marie Curie',
+    einstein: 'Albert Einstein',
+    mozart: 'Wolfgang Amadeus Mozart',
+    'carl-jung': 'Carl Jung',
+    'nikola-tesla': 'Nikola Tesla',
+    'cleopatra-vii': 'Cleopatra VII',
+    'benjamin-franklin': 'Benjamin Franklin',
+    'maya-angelou': 'Maya Angelou',
+    'steve-jobs': 'Steve Jobs',
+    gandhi: 'Mahatma Gandhi',
+    'frida-kahlo': 'Frida Kahlo',
+    'alan-turing': 'Alan Turing',
+    'da-vinci-leonardo': 'Leonardo da Vinci',
+    'william-shakespeare': 'William Shakespeare',
+    'virginia-woolf': 'Virginia Woolf',
+    rumi: 'Rumi',
+    'sun-tzu': 'Sun Tzu',
+    'galileo-galilei': 'Galileo Galilei',
+    'charles-darwin': 'Charles Darwin',
+    'stephen-hawking': 'Stephen Hawking',
+    'rachel-carson': 'Rachel Carson',
+    'rosalind-franklin': 'Rosalind Franklin',
+    'vincent-van-gogh': 'Vincent van Gogh',
+    'ludwig-van-beethoven': 'Ludwig van Beethoven',
+    'andy-warhol': 'Andy Warhol',
+    'georgia-okeefe': "Georgia O'Keeffe",
+    'pablo-picasso': 'Pablo Picasso',
+    'nelson-mandela': 'Nelson Mandela',
+    'eleanor-roosevelt': 'Eleanor Roosevelt',
+    'malcolm-x': 'Malcolm X',
+    'harriet-tubman': 'Harriet Tubman',
+    'winston-churchill': 'Winston Churchill',
+    socrates: 'Socrates',
+    confucius: 'Confucius',
+    'simone-de-beauvoir': 'Simone de Beauvoir',
+    'marcus-aurelius': 'Marcus Aurelius',
+    'lao-tzu': 'Lao Tzu',
+  }
+
+  return nameMap[agentId] || agentId.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase())
+}
+
+/**
+ * Helper function to determine momentum type
+ */
+function getMomentumType(profile: KineticProfile): string {
+  const avgVelocity =
+    Object.values(profile.velocitySignature).reduce((sum, val) => sum + val, 0) / 4
+
+  if (avgVelocity > 0.9) return 'explosive'
+  if (avgVelocity > 0.8) return 'building'
+  if (avgVelocity > 0.7) return 'sustained'
+  if (avgVelocity > 0.6) return 'gradual'
+  return 'oscillating'
+}

--- a/src/lib/astrological-data.ts
+++ b/src/lib/astrological-data.ts
@@ -1,0 +1,199 @@
+// Planetary dignities data
+export const planetaryDignities = {
+  Sun: {
+    domicile: ['Leo'],
+    exaltation: ['Aries'],
+    detriment: ['Aquarius'],
+    fall: ['Libra'],
+  },
+  Moon: {
+    domicile: ['Cancer'],
+    exaltation: ['Taurus'],
+    detriment: ['Capricorn'],
+    fall: ['Scorpio'],
+  },
+  Mercury: {
+    domicile: ['Gemini', 'Virgo'],
+    exaltation: ['Virgo'], // Some traditions
+    detriment: ['Sagittarius', 'Pisces'],
+    fall: ['Pisces'], // Some traditions
+  },
+  Venus: {
+    domicile: ['Taurus', 'Libra'],
+    exaltation: ['Pisces'],
+    detriment: ['Scorpio', 'Aries'],
+    fall: ['Virgo'],
+  },
+  Mars: {
+    domicile: ['Aries', 'Scorpio'],
+    exaltation: ['Capricorn'],
+    detriment: ['Libra', 'Taurus'],
+    fall: ['Cancer'],
+  },
+  Jupiter: {
+    domicile: ['Sagittarius', 'Pisces'],
+    exaltation: ['Cancer'],
+    detriment: ['Gemini', 'Virgo'],
+    fall: ['Capricorn'],
+  },
+  Saturn: {
+    domicile: ['Capricorn', 'Aquarius'],
+    exaltation: ['Libra'],
+    detriment: ['Cancer', 'Leo'],
+    fall: ['Aries'],
+  },
+  Uranus: {
+    domicile: ['Aquarius'], // Modern rulership
+    exaltation: ['Scorpio'], // Some modern systems
+    detriment: ['Leo'],
+    fall: ['Taurus'],
+  },
+  Neptune: {
+    domicile: ['Pisces'], // Modern rulership
+    exaltation: ['Cancer'], // Some modern systems
+    detriment: ['Virgo'],
+    fall: ['Capricorn'],
+  },
+  Pluto: {
+    domicile: ['Scorpio'], // Modern rulership
+    exaltation: ['Leo'], // Some modern systems
+    detriment: ['Taurus'],
+    fall: ['Aquarius'],
+  },
+}
+
+// Zodiac sign elements
+export const signElements = {
+  Aries: 'Fire',
+  Taurus: 'Earth',
+  Gemini: 'Air',
+  Cancer: 'Water',
+  Leo: 'Fire',
+  Virgo: 'Earth',
+  Libra: 'Air',
+  Scorpio: 'Water',
+  Sagittarius: 'Fire',
+  Capricorn: 'Earth',
+  Aquarius: 'Air',
+  Pisces: 'Water',
+}
+
+// Zodiac sign modalities
+export const signModalities = {
+  Aries: 'Cardinal',
+  Taurus: 'Fixed',
+  Gemini: 'Mutable',
+  Cancer: 'Cardinal',
+  Leo: 'Fixed',
+  Virgo: 'Mutable',
+  Libra: 'Cardinal',
+  Scorpio: 'Fixed',
+  Sagittarius: 'Mutable',
+  Capricorn: 'Cardinal',
+  Aquarius: 'Fixed',
+  Pisces: 'Mutable',
+}
+
+// Planetary elemental associations (diurnal/nocturnal)
+export const planetaryElements = {
+  Sun: { diurnal: 'Fire', nocturnal: 'Fire' },
+  Moon: { diurnal: 'Water', nocturnal: 'Water' },
+  Mercury: { diurnal: 'Air', nocturnal: 'Earth' },
+  Venus: { diurnal: 'Water', nocturnal: 'Earth' },
+  Mars: { diurnal: 'Fire', nocturnal: 'Water' },
+  Jupiter: { diurnal: 'Air', nocturnal: 'Fire' },
+  Saturn: { diurnal: 'Air', nocturnal: 'Earth' },
+  Uranus: { diurnal: 'Water', nocturnal: 'Air' },
+  Neptune: { diurnal: 'Water', nocturnal: 'Water' },
+  Pluto: { diurnal: 'Earth', nocturnal: 'Water' },
+  Ascendant: { diurnal: 'Earth', nocturnal: 'Earth' },
+}
+
+// Get the dignity of a planet in a specific sign
+export function getPlanetaryDignity(planet: string, sign: string): string {
+  const dignities = planetaryDignities[planet as keyof typeof planetaryDignities]
+
+  if (!dignities) return 'peregrine'
+
+  if (dignities.domicile.includes(sign)) {
+    return 'domicile'
+  } else if (dignities.exaltation.includes(sign)) {
+    return 'exaltation'
+  } else if (dignities.detriment.includes(sign)) {
+    return 'detriment'
+  } else if (dignities.fall.includes(sign)) {
+    return 'fall'
+  } else {
+    return 'peregrine'
+  }
+}
+
+// Get the element of a sign
+export function getSignElement(sign: string): string {
+  return signElements[sign as keyof typeof signElements] || 'Unknown'
+}
+
+// Get the modality of a sign
+export function getSignModality(sign: string): string {
+  return signModalities[sign as keyof typeof signModalities] || 'Unknown'
+}
+
+// Get the planetary element based on time of day
+export function getPlanetaryElement(planet: string, isDiurnal: boolean = true): string {
+  const planetElement = planetaryElements[planet as keyof typeof planetaryElements]
+  if (!planetElement) return 'Unknown'
+
+  return isDiurnal ? planetElement.diurnal : planetElement.nocturnal
+}
+
+// Calculate elemental affinity between a planet and its sign
+export function calculateElementalAffinity(
+  planet: string,
+  sign: string,
+  isDiurnal: boolean = true
+): number {
+  const signElement = getSignElement(sign)
+  const planetElement = getPlanetaryElement(planet, isDiurnal)
+
+  // Same element has highest affinity
+  if (signElement === planetElement) {
+    return 0.9
+  }
+
+  // All elements work well together according to elementallogic
+  return 0.7
+}
+
+// Get specific degree meanings (simplified example)
+export function getDegreeMeaning(sign: string, degree: number): string {
+  // This would be expanded with actual degree meanings from traditional sources
+  const decanate = Math.ceil(degree / 10)
+  return `${sign} ${degree}° (${decanate}rd decanate)`
+}
+
+// Calculate decan based on degree
+export function getDecan(degree: number): string {
+  if (degree < 10) return '1st Decan'
+  if (degree < 20) return '2nd Decan'
+  return '3rd Decan'
+}
+
+// Get the ruling planet of a sign
+export function getRulingPlanet(sign: string): string {
+  const rulerMap: Record<string, string> = {
+    Aries: 'Mars',
+    Taurus: 'Venus',
+    Gemini: 'Mercury',
+    Cancer: 'Moon',
+    Leo: 'Sun',
+    Virgo: 'Mercury',
+    Libra: 'Venus',
+    Scorpio: 'Mars', // Traditional ruler (or Pluto in modern)
+    Sagittarius: 'Jupiter',
+    Capricorn: 'Saturn',
+    Aquarius: 'Saturn', // Traditional ruler (or Uranus in modern)
+    Pisces: 'Jupiter', // Traditional ruler (or Neptune in modern)
+  }
+
+  return rulerMap[sign] || 'Unknown'
+}

--- a/src/lib/core-energy-rules.ts
+++ b/src/lib/core-energy-rules.ts
@@ -1,0 +1,523 @@
+// Core Greg's Energy System Rules
+// Based on Core_Gregs_Energy_System.ipynb and current-moment-chart.ipynb
+
+export interface AlchemicalProperties {
+  spirit: number
+  essence: number
+  matter: number
+  substance: number
+}
+
+/**
+ * A-Number calculation and categorization utilities
+ * A-Number = Total Spirit + Total Essence + Total Matter + Total Substance
+ */
+export class ANumberCalculator {
+  /**
+   * Calculate A-Number from alchemical properties
+   */
+  static calculateANumber(alchemical: AlchemicalProperties): number {
+    return alchemical.spirit + alchemical.essence + alchemical.matter + alchemical.substance
+  }
+
+  /**
+   * Categorize A-Number level for interpretation
+   */
+  static categorizeANumber(aNumber: number): string {
+    if (aNumber >= 3.0) return 'Maximum Power'
+    if (aNumber >= 2.5) return 'High Energy'
+    if (aNumber >= 2.0) return 'Balanced Energy'
+    if (aNumber >= 1.5) return 'Moderate Energy'
+    if (aNumber >= 1.0) return 'Focused Energy'
+    return 'Subtle Energy'
+  }
+
+  /**
+   * Get A-Number interpretation for guidance
+   */
+  static interpretANumber(aNumber: number): string {
+    const category = this.categorizeANumber(aNumber)
+    switch (category) {
+      case 'Maximum Power':
+        return 'Maximum spiritual potency - peak transformative energy'
+      case 'High Energy':
+        return 'Strong transformative power - high effectiveness in all applications'
+      case 'Balanced Energy':
+        return 'Balanced energetic flow - optimal for both spiritual and practical work'
+      case 'Moderate Energy':
+        return 'Moderate spiritual influence - steady progress and development'
+      case 'Focused Energy':
+        return 'Focused directional energy - concentrated power for specific goals'
+      case 'Subtle Energy':
+        return 'Subtle but precise energy - gentle influence requiring patience'
+      default:
+        return 'Unclassified energy state'
+    }
+  }
+
+  /**
+   * Get A-Number with full analysis
+   */
+  static analyzeANumber(alchemical: AlchemicalProperties) {
+    const aNumber = this.calculateANumber(alchemical)
+    const category = this.categorizeANumber(aNumber)
+    const interpretation = this.interpretANumber(aNumber)
+
+    return {
+      aNumber,
+      category,
+      interpretation,
+      breakdown: {
+        spirit: alchemical.spirit,
+        essence: alchemical.essence,
+        matter: alchemical.matter,
+        substance: alchemical.substance,
+      },
+    }
+  }
+}
+
+export interface ElementalProperties {
+  fire: number
+  water: number
+  air: number
+  earth: number
+}
+
+export interface ThermodynamicMetrics {
+  heat: number
+  entropy: number
+  reactivity: number
+  energy: number
+}
+
+export interface AdvancedConstants {
+  kalchmConstant: number
+  monicaConstant: number
+}
+
+/**
+ * CORE THERMODYNAMIC FORMULAS
+ * These are the fundamental calculations for Greg's Energy system
+ */
+export class GregsEnergyCalculator {
+  /**
+   * Calculate Heat: (Spirit² + Fire²) / (Substance + Essence + Matter + Water + Air + Earth)²
+   */
+  static calculateHeat(
+    spirit: number,
+    fire: number,
+    substance: number,
+    essence: number,
+    matter: number,
+    water: number,
+    air: number,
+    earth: number
+  ): number {
+    const numerator = Math.pow(spirit, 2) + Math.pow(fire, 2)
+    const denominator = Math.pow(substance + essence + matter + water + air + earth, 2)
+
+    // Prevent division by zero
+    if (denominator === 0) return 0
+
+    return numerator / denominator
+  }
+
+  /**
+   * Calculate Entropy: (Spirit² + Substance² + Fire² + Air²) / (Essence + Matter + Earth + Water)²
+   */
+  static calculateEntropy(
+    spirit: number,
+    substance: number,
+    fire: number,
+    air: number,
+    essence: number,
+    matter: number,
+    earth: number,
+    water: number
+  ): number {
+    const numerator =
+      Math.pow(spirit, 2) + Math.pow(substance, 2) + Math.pow(fire, 2) + Math.pow(air, 2)
+    const denominator = Math.pow(essence + matter + earth + water, 2)
+
+    // Prevent division by zero
+    if (denominator === 0) return 0
+
+    return numerator / denominator
+  }
+
+  /**
+   * Calculate Reactivity: (Spirit² + Substance² + Essence² + Fire² + Air² + Water²) / (Matter + Earth)²
+   */
+  static calculateReactivity(
+    spirit: number,
+    substance: number,
+    essence: number,
+    fire: number,
+    air: number,
+    water: number,
+    matter: number,
+    earth: number
+  ): number {
+    const numerator =
+      Math.pow(spirit, 2) +
+      Math.pow(substance, 2) +
+      Math.pow(essence, 2) +
+      Math.pow(fire, 2) +
+      Math.pow(air, 2) +
+      Math.pow(water, 2)
+    const denominator = Math.pow(matter + earth, 2)
+
+    // Prevent division by zero
+    if (denominator === 0) return 0
+
+    return numerator / denominator
+  }
+
+  /**
+   * Calculate Greg's Energy: Heat - (Entropy × Reactivity)
+   */
+  static calculateEnergy(heat: number, entropy: number, reactivity: number): number {
+    return heat - entropy * reactivity
+  }
+
+  /**
+   * Complete thermodynamic analysis
+   */
+  static analyzeThermodynamics(
+    alchemical: AlchemicalProperties,
+    elemental: ElementalProperties
+  ): ThermodynamicMetrics {
+    const { spirit, essence, matter, substance } = alchemical
+    const { fire, water, air, earth } = elemental
+
+    const heat = this.calculateHeat(spirit, fire, substance, essence, matter, water, air, earth)
+    const entropy = this.calculateEntropy(
+      spirit,
+      substance,
+      fire,
+      air,
+      essence,
+      matter,
+      earth,
+      water
+    )
+    const reactivity = this.calculateReactivity(
+      spirit,
+      substance,
+      essence,
+      fire,
+      air,
+      water,
+      matter,
+      earth
+    )
+    const energy = this.calculateEnergy(heat, entropy, reactivity)
+
+    return { heat, entropy, reactivity, energy }
+  }
+}
+
+/**
+ * ADVANCED CONSTANTS CALCULATOR
+ * Kalchm and Monica constant calculations with negative value handling
+ */
+export class AdvancedConstantsCalculator {
+  /**
+   * Calculate K_alchm with handling for negative values
+   * K_alchm = (Spirit^Spirit × Essence^Essence) / (Matter^Matter × Substance^Substance)
+   */
+  static calculateKalchmSafe(
+    spirit: number,
+    essence: number,
+    matter: number,
+    substance: number
+  ): number {
+    try {
+      // Handle negative values by using absolute values
+      const spiritAbs = Math.abs(spirit) || 1e-10
+      const essenceAbs = Math.abs(essence) || 1e-10
+      const matterAbs = Math.abs(matter) || 1e-10
+      const substanceAbs = Math.abs(substance) || 1e-10
+
+      // Calculate with absolute values
+      const numerator = Math.pow(spiritAbs, spiritAbs) * Math.pow(essenceAbs, essenceAbs)
+      const denominator = Math.pow(matterAbs, matterAbs) * Math.pow(substanceAbs, substanceAbs)
+
+      // Apply sign correction based on the number of negative values
+      const negativeCount = [spirit, essence, matter, substance].filter(v => v < 0).length
+      const signFactor = negativeCount % 2 === 1 ? -1 : 1
+
+      return signFactor * (numerator / denominator)
+    } catch (_error) {
+      return NaN
+    }
+  }
+
+  /**
+   * Calculate Monica Constant: M = -Greg's Energy / (Reactivity × ln(K_alchm))
+   */
+  static calculateMonicaConstant(
+    energy: number,
+    reactivity: number,
+    kalchmConstant: number
+  ): number {
+    try {
+      if (kalchmConstant > 0 && reactivity !== 0) {
+        const lnK = Math.log(Math.abs(kalchmConstant))
+        if (lnK !== 0) {
+          return -energy / (reactivity * lnK)
+        }
+      }
+      return NaN
+    } catch (_error) {
+      return NaN
+    }
+  }
+
+  /**
+   * Calculate both advanced constants
+   */
+  static calculateAdvancedConstants(
+    alchemical: AlchemicalProperties,
+    thermodynamics: ThermodynamicMetrics
+  ): AdvancedConstants {
+    const kalchmConstant = this.calculateKalchmSafe(
+      alchemical.spirit,
+      alchemical.essence,
+      alchemical.matter,
+      alchemical.substance
+    )
+
+    const monicaConstant = this.calculateMonicaConstant(
+      thermodynamics.energy,
+      thermodynamics.reactivity,
+      kalchmConstant
+    )
+
+    return { kalchmConstant, monicaConstant }
+  }
+}
+
+/**
+ * PLANETARY INFLUENCE SYSTEM
+ * Based on traditional astrological correspondences
+ */
+export const PLANETARY_MODIFIERS = {
+  Sun: {
+    Fire: 0.3,
+    Water: -0.1,
+    Air: 0.1,
+    Earth: -0.1,
+    Spirit: 0.2,
+    Essence: 0,
+    Matter: -0.1,
+    Substance: 0,
+  },
+  Moon: {
+    Fire: -0.1,
+    Water: 0.3,
+    Air: 0,
+    Earth: 0.1,
+    Spirit: 0,
+    Essence: 0.2,
+    Matter: 0.1,
+    Substance: 0,
+  },
+  Mars: {
+    Fire: 0.4,
+    Water: -0.2,
+    Air: -0.1,
+    Earth: 0,
+    Spirit: 0.3,
+    Essence: -0.1,
+    Matter: 0.2,
+    Substance: -0.1,
+  },
+  Mercury: {
+    Fire: 0.1,
+    Water: 0.1,
+    Air: 0.3,
+    Earth: -0.1,
+    Spirit: 0.1,
+    Essence: 0.2,
+    Matter: 0,
+    Substance: 0.1,
+  },
+  Jupiter: {
+    Fire: 0.2,
+    Water: 0.2,
+    Air: 0.1,
+    Earth: 0.3,
+    Spirit: 0.2,
+    Essence: 0.1,
+    Matter: 0.1,
+    Substance: 0.2,
+  },
+  Venus: {
+    Fire: -0.1,
+    Water: 0.2,
+    Air: 0.2,
+    Earth: 0.1,
+    Spirit: 0.1,
+    Essence: 0.3,
+    Matter: -0.1,
+    Substance: 0.1,
+  },
+  Saturn: {
+    Fire: -0.2,
+    Water: -0.1,
+    Air: -0.2,
+    Earth: 0.4,
+    Spirit: -0.1,
+    Essence: -0.1,
+    Matter: 0.3,
+    Substance: 0.2,
+  },
+} as const
+
+export const PLANETARY_HOURS = {
+  Sunday: ['Sun', 'Venus', 'Mercury', 'Moon', 'Saturn', 'Jupiter', 'Mars'],
+  Monday: ['Moon', 'Saturn', 'Jupiter', 'Mars', 'Sun', 'Venus', 'Mercury'],
+  Tuesday: ['Mars', 'Sun', 'Venus', 'Mercury', 'Moon', 'Saturn', 'Jupiter'],
+  Wednesday: ['Mercury', 'Moon', 'Saturn', 'Jupiter', 'Mars', 'Sun', 'Venus'],
+  Thursday: ['Jupiter', 'Mars', 'Sun', 'Venus', 'Mercury', 'Moon', 'Saturn'],
+  Friday: ['Venus', 'Mercury', 'Moon', 'Saturn', 'Jupiter', 'Mars', 'Sun'],
+  Saturday: ['Saturn', 'Jupiter', 'Mars', 'Sun', 'Venus', 'Mercury', 'Moon'],
+} as const
+
+export class PlanetaryInfluenceCalculator {
+  static getCurrentPlanetaryHour(date: Date = new Date()) {
+    const dayNames = [
+      'Sunday',
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+      'Thursday',
+      'Friday',
+      'Saturday',
+    ] as const
+    const dayName = dayNames[date.getDay()]
+    const hour = date.getHours()
+
+    // Each planetary hour covers ~3.4 regular hours (24/7)
+    const planetaryHourIndex = Math.floor(hour / 3.4)
+    const planet = PLANETARY_HOURS[dayName][planetaryHourIndex % 7]
+
+    return {
+      planet,
+      dayName,
+      hour,
+      planetaryHourIndex,
+    }
+  }
+
+  static applyPlanetaryInfluence(
+    baseAlchemical: AlchemicalProperties,
+    baseElemental: ElementalProperties,
+    influencingPlanet: keyof typeof PLANETARY_MODIFIERS
+  ) {
+    const modifiers = PLANETARY_MODIFIERS[influencingPlanet]
+
+    return {
+      alchemical: {
+        spirit: baseAlchemical.spirit * (1 + (modifiers.Spirit || 0)),
+        essence: baseAlchemical.essence * (1 + (modifiers.Essence || 0)),
+        matter: baseAlchemical.matter * (1 + (modifiers.Matter || 0)),
+        substance: baseAlchemical.substance * (1 + (modifiers.Substance || 0)),
+      },
+      elemental: {
+        fire: baseElemental.fire * (1 + (modifiers.Fire || 0)),
+        water: baseElemental.water * (1 + (modifiers.Water || 0)),
+        air: baseElemental.air * (1 + (modifiers.Air || 0)),
+        earth: baseElemental.earth * (1 + (modifiers.Earth || 0)),
+      },
+    }
+  }
+}
+
+/**
+ * ENERGY STATE CLASSIFICATION
+ */
+export class EnergyStateAnalyzer {
+  static classifyEnergyState(energy: number): string {
+    if (energy > 0.1) return 'High Energy - Transformative'
+    if (energy > 0.0) return 'Positive Energy - Active'
+    if (energy > -0.1) return 'Neutral Energy - Balanced'
+    if (energy > -0.2) return 'Low Energy - Passive'
+    return 'Depleted Energy - Restorative'
+  }
+
+  static interpretThermodynamics(metrics: ThermodynamicMetrics): string[] {
+    const { heat, entropy, reactivity, energy } = metrics
+    const interpretation: string[] = []
+
+    // Heat interpretation
+    if (heat > 0.1) interpretation.push('High heat indicates strong transformative potential')
+    else if (heat < 0.05) interpretation.push('Low heat suggests need for activation')
+
+    // Entropy interpretation
+    if (entropy > 0.1) interpretation.push('High entropy indicates system disorder')
+    else if (entropy < 0.05) interpretation.push('Low entropy suggests stable organization')
+
+    // Reactivity interpretation
+    if (reactivity > 0.1) interpretation.push('High reactivity shows potential for change')
+    else if (reactivity < 0.05) interpretation.push('Low reactivity indicates stability')
+
+    // Overall energy interpretation
+    if (energy > 0) {
+      interpretation.push("Positive Greg's Energy - system has available energy for work")
+    } else {
+      interpretation.push("Negative Greg's Energy - system requires energy input")
+    }
+
+    return interpretation
+  }
+}
+
+/**
+ * COMPLETE ANALYSIS FUNCTION
+ * Integrates all systems for comprehensive energy analysis
+ */
+export function performCompleteEnergyAnalysis(
+  baseAlchemical: AlchemicalProperties,
+  baseElemental: ElementalProperties,
+  date: Date = new Date()
+) {
+  // Get current planetary influence
+  const planetaryHour = PlanetaryInfluenceCalculator.getCurrentPlanetaryHour(date)
+
+  // Apply planetary modifiers
+  const influencedProperties = PlanetaryInfluenceCalculator.applyPlanetaryInfluence(
+    baseAlchemical,
+    baseElemental,
+    planetaryHour.planet
+  )
+
+  // Calculate thermodynamic metrics
+  const thermodynamics = GregsEnergyCalculator.analyzeThermodynamics(
+    influencedProperties.alchemical,
+    influencedProperties.elemental
+  )
+
+  // Calculate advanced constants
+  const advancedConstants = AdvancedConstantsCalculator.calculateAdvancedConstants(
+    influencedProperties.alchemical,
+    thermodynamics
+  )
+
+  // Generate interpretation
+  const energyState = EnergyStateAnalyzer.classifyEnergyState(thermodynamics.energy)
+  const interpretation = EnergyStateAnalyzer.interpretThermodynamics(thermodynamics)
+
+  return {
+    timestamp: date.toISOString(),
+    planetaryInfluence: planetaryHour,
+    originalProperties: { alchemical: baseAlchemical, elemental: baseElemental },
+    influencedProperties,
+    thermodynamics,
+    advancedConstants,
+    energyState,
+    interpretation,
+  }
+}

--- a/src/lib/elemental-reinforcement.ts
+++ b/src/lib/elemental-reinforcement.ts
@@ -1,0 +1,430 @@
+/**
+ * Elemental Reinforcement System
+ * =============================
+ * Implements workspace-compliant elemental logic where same elements reinforce each other.
+ * No "opposing" element mechanics - all elements can work together harmoniously.
+ * Fire + Fire = enhanced creativity, Water + Water = deeper intuition, etc.
+ */
+
+export interface ElementVector {
+  Fire: number
+  Water: number
+  Air: number
+  Earth: number
+}
+
+export interface ReinforcementAnalysis {
+  dominantElement: string
+  reinforcementMultiplier: number
+  elementalHarmony: number // 0-1 scale of how well elements work together
+  combinationEffects: Array<{
+    element: string
+    strength: number
+    description: string
+  }>
+  resonancePatterns: Array<{
+    pattern: string
+    intensity: number
+    meaning: string
+  }>
+}
+
+export interface ElementalCompatibility {
+  element1: string
+  element2: string
+  compatibility: number // 0-1 scale
+  synergy: string
+  combinedEffect: string
+}
+
+/**
+ * Calculate elemental reinforcement score with same-element boosting
+ */
+export function calculateElementalReinforcementScore(
+  elements: ElementVector[],
+  baseScore: number
+): number {
+  if (elements.length === 0) return baseScore
+
+  // Calculate total elemental strength for each element
+  const totalElements = elements.reduce(
+    (acc, element) => ({
+      Fire: acc.Fire + element.Fire,
+      Water: acc.Water + element.Water,
+      Air: acc.Air + element.Air,
+      Earth: acc.Earth + element.Earth,
+    }),
+    { Fire: 0, Water: 0, Air: 0, Earth: 0 }
+  )
+
+  // Find the strongest element
+  const elementStrengths = Object.entries(totalElements)
+  const [_dominantElement, maxStrength] = elementStrengths.reduce(
+    (max, [element, strength]) => (strength > max[1] ? [element, strength] : max),
+    ['Fire', -1]
+  )
+
+  // Calculate reinforcement based on elemental dominance and harmony
+  let reinforcementMultiplier = 1.0
+
+  // Same elements reinforce each other strongly
+  const reinforcementBonus = Math.min(maxStrength * 0.15, 0.5) // Max 50% boost
+
+  // Check for elemental harmony (multiple strong elements working together)
+  const strongElements = elementStrengths.filter(([, strength]) => strength > 0.3).length
+  const harmonyBonus = strongElements > 1 ? 0.1 : 0 // Bonus for elemental cooperation
+
+  reinforcementMultiplier = 1.0 + reinforcementBonus + harmonyBonus
+
+  return baseScore * reinforcementMultiplier
+}
+
+/**
+ * Get elemental compatibility between two elements (no opposition mechanics)
+ */
+export function getElementalCompatibility(
+  element1: string,
+  element2: string
+): ElementalCompatibility {
+  // Same element has highest compatibility (perfect reinforcement)
+  if (element1 === element2) {
+    return {
+      element1,
+      element2,
+      compatibility: 0.95, // Nearly perfect
+      synergy: 'Perfect Reinforcement',
+      combinedEffect: `Enhanced ${element1.toLowerCase()} manifestation with doubled intensity`,
+    }
+  }
+
+  // Define complementary relationships (all positive)
+  const compatibilityMap: Record<
+    string,
+    Record<string, { compatibility: number; synergy: string; effect: string }>
+  > = {
+    Fire: {
+      Water: {
+        compatibility: 0.85,
+        synergy: 'Creative Flow',
+        effect: 'Passionate intuition and inspired emotion',
+      },
+      Air: {
+        compatibility: 0.9,
+        synergy: 'Brilliant Innovation',
+        effect: 'Intellectual fire and communicative inspiration',
+      },
+      Earth: {
+        compatibility: 0.8,
+        synergy: 'Practical Creativity',
+        effect: 'Grounded manifestation of creative vision',
+      },
+    },
+    Water: {
+      Fire: {
+        compatibility: 0.85,
+        synergy: 'Creative Flow',
+        effect: 'Passionate intuition and inspired emotion',
+      },
+      Air: {
+        compatibility: 0.75,
+        synergy: 'Flowing Communication',
+        effect: 'Emotional intelligence and empathetic expression',
+      },
+      Earth: {
+        compatibility: 0.88,
+        synergy: 'Fertile Growth',
+        effect: 'Nurturing wisdom and practical compassion',
+      },
+    },
+    Air: {
+      Fire: {
+        compatibility: 0.9,
+        synergy: 'Brilliant Innovation',
+        effect: 'Intellectual fire and communicative inspiration',
+      },
+      Water: {
+        compatibility: 0.75,
+        synergy: 'Flowing Communication',
+        effect: 'Emotional intelligence and empathetic expression',
+      },
+      Earth: {
+        compatibility: 0.82,
+        synergy: 'Methodical Thinking',
+        effect: 'Structured analysis and practical reasoning',
+      },
+    },
+    Earth: {
+      Fire: {
+        compatibility: 0.8,
+        synergy: 'Practical Creativity',
+        effect: 'Grounded manifestation of creative vision',
+      },
+      Water: {
+        compatibility: 0.88,
+        synergy: 'Fertile Growth',
+        effect: 'Nurturing wisdom and practical compassion',
+      },
+      Air: {
+        compatibility: 0.82,
+        synergy: 'Methodical Thinking',
+        effect: 'Structured analysis and practical reasoning',
+      },
+    },
+  }
+
+  const combination = compatibilityMap[element1]?.[element2]
+  if (combination) {
+    return {
+      element1,
+      element2,
+      compatibility: combination.compatibility,
+      synergy: combination.synergy,
+      combinedEffect: combination.effect,
+    }
+  }
+
+  // Fallback for unknown combinations (still positive)
+  return {
+    element1,
+    element2,
+    compatibility: 0.7,
+    synergy: 'Harmonic Balance',
+    combinedEffect: 'Balanced elemental cooperation',
+  }
+}
+
+/**
+ * Analyze elemental reinforcement patterns in a set of elements
+ */
+export function analyzeElementalReinforcement(elements: ElementVector[]): ReinforcementAnalysis {
+  if (elements.length === 0) {
+    return {
+      dominantElement: 'None',
+      reinforcementMultiplier: 1.0,
+      elementalHarmony: 0,
+      combinationEffects: [],
+      resonancePatterns: [],
+    }
+  }
+
+  // Calculate average elemental strengths
+  const avgElements = elements.reduce(
+    (acc, element) => ({
+      Fire: acc.Fire + element.Fire / elements.length,
+      Water: acc.Water + element.Water / elements.length,
+      Air: acc.Air + element.Air / elements.length,
+      Earth: acc.Earth + element.Earth / elements.length,
+    }),
+    { Fire: 0, Water: 0, Air: 0, Earth: 0 }
+  )
+
+  // Find dominant element
+  const [dominantElement, _dominantStrength] = Object.entries(avgElements).reduce(
+    (max, [element, strength]) => (strength > max[1] ? [element, strength] : max),
+    ['Fire', -1]
+  )
+
+  // Calculate reinforcement multiplier
+  const reinforcementMultiplier = calculateElementalReinforcementScore(elements, 1.0)
+
+  // Calculate elemental harmony (how well balanced the elements are)
+  const totalStrength = Object.values(avgElements).reduce((sum, val) => sum + val, 0)
+  const elementalVariance =
+    Object.values(avgElements).reduce(
+      (variance, val) => variance + Math.pow(val - totalStrength / 4, 2),
+      0
+    ) / 4
+
+  const elementalHarmony = Math.max(0, 1 - elementalVariance * 2) // Lower variance = higher harmony
+
+  // Identify combination effects
+  const combinationEffects: Array<{ element: string; strength: number; description: string }> = []
+  const sortedElements = Object.entries(avgElements)
+    .filter(([, strength]) => strength > 0.2)
+    .sort((a, b) => b[1] - a[1])
+
+  for (const [element, strength] of sortedElements) {
+    combinationEffects.push({
+      element,
+      strength,
+      description: getElementalEffect(element, strength),
+    })
+  }
+
+  // Identify resonance patterns
+  const resonancePatterns = identifyResonancePatterns(avgElements, elements.length)
+
+  return {
+    dominantElement,
+    reinforcementMultiplier,
+    elementalHarmony,
+    combinationEffects,
+    resonancePatterns,
+  }
+}
+
+/**
+ * Calculate reinforcement boost for UI visualization
+ */
+export function calculateReinforcementBoost(
+  elements: ElementVector[],
+  targetElement: string
+): number {
+  const totalElemental = elements.reduce(
+    (sum, element) => sum + element[targetElement as keyof ElementVector],
+    0
+  )
+  const avgElemental = totalElemental / elements.length
+
+  // Calculate boost based on concentration of target element
+  const baseBoost = Math.min(avgElemental * 0.5, 0.3) // Max 30% visual boost
+
+  // Additional boost for multiple instances of same element
+  const concentrationBonus = totalElemental > 2 ? 0.1 : 0
+
+  return baseBoost + concentrationBonus
+}
+
+/**
+ * Get visual emphasis level for UI components
+ */
+export function getVisualEmphasis(
+  reinforcementScore: number
+): 'subtle' | 'moderate' | 'strong' | 'intense' {
+  if (reinforcementScore >= 1.4) return 'intense'
+  if (reinforcementScore >= 1.25) return 'strong'
+  if (reinforcementScore >= 1.1) return 'moderate'
+  return 'subtle'
+}
+
+/**
+ * Generate elemental color scheme based on reinforcement
+ */
+export function getElementalColorScheme(
+  element: string,
+  intensity: number
+): {
+  primary: string
+  secondary: string
+  accent: string
+  background: string
+} {
+  const baseColors = {
+    Fire: { primary: '#FF6B35', secondary: '#F7931E', accent: '#FFD700', background: '#FFF8DC' },
+    Water: { primary: '#0077BE', secondary: '#00A9D4', accent: '#87CEEB', background: '#F0F8FF' },
+    Air: { primary: '#FFD700', secondary: '#FFA500', accent: '#FFFF99', background: '#FFFACD' },
+    Earth: { primary: '#8B4513', secondary: '#A0522D', accent: '#DEB887', background: '#F5F5DC' },
+  }
+
+  const colors = baseColors[element as keyof typeof baseColors] || baseColors.Fire
+
+  // Adjust intensity based on reinforcement score
+  const _alpha = Math.min(intensity, 1.0)
+
+  return {
+    primary: colors.primary,
+    secondary: colors.secondary,
+    accent: colors.accent,
+    background: colors.background,
+  }
+}
+
+// Private helper functions
+
+function getElementalEffect(element: string, strength: number): string {
+  const effects = {
+    Fire: [
+      'Subtle creative spark',
+      'Growing inspiration',
+      'Strong creative drive',
+      'Intense passionate expression',
+      'Overwhelming creative fire',
+    ],
+    Water: [
+      'Gentle emotional awareness',
+      'Deepening intuition',
+      'Strong emotional wisdom',
+      'Intense psychic sensitivity',
+      'Overwhelming spiritual depth',
+    ],
+    Air: [
+      'Clear mental focus',
+      'Enhanced communication',
+      'Strong intellectual clarity',
+      'Intense analytical power',
+      'Overwhelming mental brilliance',
+    ],
+    Earth: [
+      'Practical grounding',
+      'Steady manifestation',
+      'Strong material focus',
+      'Intense structural building',
+      'Overwhelming material mastery',
+    ],
+  }
+
+  const elementEffects = effects[element as keyof typeof effects] || effects.Fire
+  const index = Math.min(Math.floor(strength * 5), 4)
+  return elementEffects[index]
+}
+
+function identifyResonancePatterns(
+  avgElements: ElementVector,
+  sampleCount: number
+): Array<{ pattern: string; intensity: number; meaning: string }> {
+  const patterns: Array<{ pattern: string; intensity: number; meaning: string }> = []
+
+  // Check for dominance patterns
+  const maxElement = Math.max(...Object.values(avgElements))
+  if (maxElement > 0.6) {
+    const dominantElement = Object.entries(avgElements).find(([, val]) => val === maxElement)?.[0]
+    patterns.push({
+      pattern: `${dominantElement} Dominance`,
+      intensity: maxElement,
+      meaning: `Strong ${dominantElement?.toLowerCase()} energy creates focused manifestation`,
+    })
+  }
+
+  // Check for balance patterns
+  const elementValues = Object.values(avgElements)
+  const variance = elementValues.reduce((v, val) => v + Math.pow(val - maxElement / 4, 2), 0) / 4
+  if (variance < 0.1 && maxElement > 0.3) {
+    patterns.push({
+      pattern: 'Elemental Harmony',
+      intensity: 1 - variance,
+      meaning: 'Balanced elemental forces create stable, integrated energy',
+    })
+  }
+
+  // Check for dual element patterns
+  const strongElements = Object.entries(avgElements).filter(([, val]) => val > 0.4)
+  if (strongElements.length === 2) {
+    const [elem1, elem2] = strongElements.map(([name]) => name)
+    const compatibility = getElementalCompatibility(elem1, elem2)
+    patterns.push({
+      pattern: `${elem1}-${elem2} Synthesis`,
+      intensity: compatibility.compatibility,
+      meaning: compatibility.combinedEffect,
+    })
+  }
+
+  // Check for reinforcement patterns
+  if (sampleCount > 3) {
+    const reinforcementRatio = maxElement / (1 / sampleCount)
+    if (reinforcementRatio > 2) {
+      patterns.push({
+        pattern: 'Elemental Reinforcement',
+        intensity: Math.min(reinforcementRatio / 3, 1),
+        meaning: 'Multiple sources amplify elemental expression',
+      })
+    }
+  }
+
+  return patterns.sort((a, b) => b.intensity - a.intensity)
+}
+
+// Export utility functions for component use
+export {
+  getElementalEffect as getElementDescription,
+  identifyResonancePatterns as findResonancePatterns,
+}

--- a/src/lib/galileo-logger.ts
+++ b/src/lib/galileo-logger.ts
@@ -1,0 +1,548 @@
+// Comprehensive Galileo Logger implementation
+// Follows proper spans, traces, and sessions structure
+
+import { ANumberCalculator } from './core-energy-rules'
+
+// Environment variables for Galileo configuration
+const GALILEO_API_KEY = process.env.GALILEO_API_KEY
+const GALILEO_PROJECT = process.env.GALILEO_PROJECT || 'AlchmPlanetaryAgents'
+const QUANTITIES_STREAM = process.env.GALILEO_QUANTITIES_STREAM || 'alchm-quantities'
+const GALILEO_BASE_URL = process.env.GALILEO_BASE_URL || 'https://api.galileo.ai'
+const GALILEO_FAIL_SILENTLY = (process.env.GALILEO_FAIL_SILENTLY ?? 'true') !== 'false'
+const GALILEO_VERBOSE_FALLBACK = (process.env.GALILEO_VERBOSE_FALLBACK ?? 'true') !== 'false'
+
+export interface QuantitiesData {
+  Spirit: number
+  Essence: number
+  Matter: number
+  Substance: number
+  ANumber: number
+  DayEssence: number
+  NightEssence: number
+}
+
+export interface AlchemicalMetrics {
+  quantities: QuantitiesData
+  dominantElement: string
+  heat: number
+  entropy: number
+  reactivity: number
+  energy: number
+  sunSign: string
+  chartRuler: string
+  timestamp: string
+  planetaryPositions?: Record<string, any>
+}
+
+export interface GalileoSpan {
+  id: string
+  trace_id: string
+  parent_id?: string
+  name: string
+  type: 'llm' | 'retriever' | 'tool' | 'workflow' | 'agent' | 'chain'
+  input: string
+  output: string
+  start_time_ns: number
+  end_time_ns: number
+  duration_ns: number
+  metadata: Record<string, string>
+  status: 'success' | 'error' | 'pending'
+}
+
+export interface GalileoTrace {
+  id: string
+  session_id?: string
+  name: string
+  spans: GalileoSpan[]
+  start_time_ns: number
+  end_time_ns: number
+  duration_ns: number
+  metadata: Record<string, string>
+}
+
+export interface GalileoSession {
+  id: string
+  name: string
+  traces: GalileoTrace[]
+  start_time_ns: number
+  end_time_ns: number
+  metadata: Record<string, string>
+}
+
+class GalileoLogger {
+  private currentSession: GalileoSession | null = null
+  private currentTrace: GalileoTrace | null = null
+  private spans: Map<string, GalileoSpan> = new Map()
+
+  /**
+   * Start a new session for grouping related traces
+   */
+  startSession(sessionName: string, metadata: Record<string, any> = {}): string {
+    const sessionId = `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+
+    this.currentSession = {
+      id: sessionId,
+      name: sessionName,
+      traces: [],
+      start_time_ns: Date.now() * 1000000,
+      end_time_ns: 0,
+      metadata: Object.fromEntries(
+        Object.entries(metadata).map(([key, value]) => [key, String(value)])
+      ),
+    }
+
+    console.log(`Started Galileo session: ${sessionName} (${sessionId})`)
+    return sessionId
+  }
+
+  /**
+   * Start a new trace within the current session
+   */
+  startTrace(traceName: string, metadata: Record<string, any> = {}): string {
+    const traceId = `trace_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+
+    this.currentTrace = {
+      id: traceId,
+      session_id: this.currentSession?.id,
+      name: traceName,
+      spans: [],
+      start_time_ns: Date.now() * 1000000,
+      end_time_ns: 0,
+      duration_ns: 0,
+      metadata: Object.fromEntries(
+        Object.entries(metadata).map(([key, value]) => [key, String(value)])
+      ),
+    }
+
+    console.log(`Started Galileo trace: ${traceName} (${traceId})`)
+    return traceId
+  }
+
+  /**
+   * Start a new span within the current trace
+   */
+  startSpan(
+    spanName: string,
+    type: GalileoSpan['type'],
+    input: any = {},
+    parentId?: string,
+    metadata: Record<string, any> = {}
+  ): string {
+    const spanId = `span_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+
+    const span: GalileoSpan = {
+      id: spanId,
+      trace_id: this.currentTrace?.id || 'no_trace',
+      parent_id: parentId,
+      name: spanName,
+      type,
+      input: typeof input === 'string' ? input : JSON.stringify(input),
+      output: '', // Will be set when span ends
+      start_time_ns: Date.now() * 1000000,
+      end_time_ns: 0,
+      duration_ns: 0,
+      metadata: Object.fromEntries(
+        Object.entries(metadata).map(([key, value]) => [key, String(value)])
+      ),
+      status: 'pending',
+    }
+
+    this.spans.set(spanId, span)
+    console.log(`Started span: ${spanName} (${spanId}) of type ${type}`)
+    return spanId
+  }
+
+  /**
+   * End a span with output and status
+   */
+  endSpan(spanId: string, output: any = {}, status: 'success' | 'error' = 'success'): void {
+    const span = this.spans.get(spanId)
+    if (!span) {
+      console.warn(`Span ${spanId} not found`)
+      return
+    }
+
+    const endTime = Date.now() * 1000000
+    span.end_time_ns = endTime
+    span.duration_ns = endTime - span.start_time_ns
+    span.output = typeof output === 'string' ? output : JSON.stringify(output)
+    span.status = status
+
+    // Add span to current trace
+    if (this.currentTrace) {
+      this.currentTrace.spans.push({ ...span })
+    }
+
+    console.log(`Ended span: ${span.name} (${spanId}) - ${status}`)
+  }
+
+  /**
+   * End the current trace
+   */
+  endTrace(): void {
+    if (!this.currentTrace) {
+      console.warn('No active trace to end')
+      return
+    }
+
+    const endTime = Date.now() * 1000000
+    this.currentTrace.end_time_ns = endTime
+    this.currentTrace.duration_ns = endTime - this.currentTrace.start_time_ns
+
+    // Add trace to current session
+    if (this.currentSession) {
+      this.currentSession.traces.push({ ...this.currentTrace })
+    }
+
+    console.log(`Ended trace: ${this.currentTrace.name} (${this.currentTrace.id})`)
+    this.currentTrace = null
+  }
+
+  /**
+   * End the current session and send all data to Galileo
+   */
+  async endSession(): Promise<boolean> {
+    if (!this.currentSession) {
+      console.warn('No active session to end')
+      return false
+    }
+
+    const endTime = Date.now() * 1000000
+    this.currentSession.end_time_ns = endTime
+
+    // Send session data to Galileo
+    const success = await this.sendToGalileo(this.currentSession)
+
+    console.log(`Ended session: ${this.currentSession.name} (${this.currentSession.id})`)
+    this.currentSession = null
+    this.spans.clear()
+
+    return success
+  }
+
+  /**
+   * Send session data to Galileo using proper workflow format
+   */
+  private async sendToGalileo(session: GalileoSession): Promise<boolean> {
+    if (!GALILEO_API_KEY) {
+      console.warn('Galileo API key not configured - logging session to console instead')
+      console.log('====== GALILEO SESSION LOG ======')
+      console.log('Session:', JSON.stringify(session, null, 2))
+      console.log('===================================')
+      return false
+    }
+
+    try {
+      // Convert session to workflows format expected by Galileo
+      const workflows = session.traces.map(trace => ({
+        created_at_ns: trace.start_time_ns,
+        duration_ns: trace.duration_ns,
+        input: JSON.stringify({
+          session_id: session.id,
+          session_name: session.name,
+          trace_name: trace.name,
+          spans_count: trace.spans.length,
+        }),
+        output: JSON.stringify({
+          spans: trace.spans.map(span => ({
+            name: span.name,
+            type: span.type,
+            status: span.status,
+            duration_ms: Math.round(span.duration_ns / 1000000),
+            metadata: span.metadata,
+          })),
+          trace_metadata: trace.metadata,
+          session_metadata: session.metadata,
+        }),
+        name: `${trace.name}`,
+        type: 'workflow' as const,
+        metadata: {
+          ...trace.metadata,
+          session_id: session.id,
+          session_name: session.name,
+          trace_id: trace.id,
+          spans_count: String(trace.spans.length),
+          duration_ms: String(Math.round(trace.duration_ns / 1000000)),
+          // Include span details in metadata for dashboard visibility
+          ...this.extractSpanMetadata(trace.spans),
+        },
+      }))
+
+      const logData = {
+        project_name: GALILEO_PROJECT,
+        workflows,
+      }
+
+      const response = await fetch(`${GALILEO_BASE_URL}/v1/observe/workflows`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Galileo-API-Key': GALILEO_API_KEY,
+        },
+        body: JSON.stringify(logData),
+      })
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        // Provide a helpful hint for project type mismatches (422)
+        if (response.status === 422 && errorText.includes('not of type Observe')) {
+          const hint =
+            'Hint: Configure GALILEO_PROJECT as an Observe project or set GALILEO_FAIL_SILENTLY=true'
+          const message = `Galileo API error: ${response.status} ${response.statusText} - ${errorText}\n${hint}`
+          if (GALILEO_VERBOSE_FALLBACK) console.warn(message)
+          // fall through to fallback logging below
+          if (!GALILEO_FAIL_SILENTLY) {
+            throw new Error(message)
+          }
+          // Return early for silent failure
+          return false
+        }
+        const message = `Galileo API error: ${response.status} ${response.statusText} - ${errorText}`
+        if (GALILEO_VERBOSE_FALLBACK) console.warn(message)
+        if (!GALILEO_FAIL_SILENTLY) {
+          throw new Error(message)
+        }
+        // Return early for silent failure
+        return false
+      }
+
+      const result = await response.json()
+      console.log(`Successfully logged session to Galileo: ${session.name}`, result)
+      return true
+    } catch (error) {
+      if (GALILEO_VERBOSE_FALLBACK) console.error('Error logging session to Galileo:', error)
+
+      // Fallback: log to console with structured format (non-fatal)
+      console.log('====== GALILEO SESSION LOG (FALLBACK) ======')
+      console.log('Project:', GALILEO_PROJECT)
+      console.log('Stream:', QUANTITIES_STREAM)
+      console.log('Session:', session.name)
+      console.log('Traces:', session.traces.length)
+      console.log(
+        'Total Spans:',
+        session.traces.reduce((acc, trace) => acc + trace.spans.length, 0)
+      )
+      console.log('Session Data:', JSON.stringify(session, null, 2))
+      console.log('Error:', error instanceof Error ? error.message : String(error))
+      console.log('=============================================')
+
+      // Never throw; optionally signal success to avoid UX degradation
+      return GALILEO_FAIL_SILENTLY ? true : false
+    }
+  }
+
+  /**
+   * Extract key metadata from spans for dashboard visibility
+   */
+  private extractSpanMetadata(spans: GalileoSpan[]): Record<string, string> {
+    const metadata: Record<string, string> = {}
+
+    spans.forEach((span, index) => {
+      metadata[`span_${index}_name`] = span.name
+      metadata[`span_${index}_type`] = span.type
+      metadata[`span_${index}_status`] = span.status
+      metadata[`span_${index}_duration_ms`] = String(Math.round(span.duration_ns / 1000000))
+
+      // Include key metadata from each span
+      Object.entries(span.metadata).forEach(([key, value]) => {
+        if (
+          key.includes('quantity') ||
+          key.includes('element') ||
+          key.includes('sign') ||
+          key.includes('a_number')
+        ) {
+          metadata[`span_${index}_${key}`] = value
+        }
+      })
+    })
+
+    return metadata
+  }
+}
+
+// Create singleton instance
+const galileoLogger = new GalileoLogger()
+export default galileoLogger
+
+/**
+ * High-level function to log alchemical quantities using proper Galileo structure
+ */
+export async function logQuantitiesToGalileo(
+  metrics: AlchemicalMetrics,
+  context: Record<string, any> = {}
+): Promise<boolean> {
+  if (!GALILEO_API_KEY) return false
+
+  try {
+    // Start a session for this calculation
+    const _sessionId = galileoLogger.startSession('alchemical-quantities-calculation', {
+      timestamp: metrics.timestamp,
+      sun_sign: metrics.sunSign,
+      chart_ruler: metrics.chartRuler,
+      ...context,
+    })
+
+    // Start a trace for the complete calculation workflow
+    const _traceId = galileoLogger.startTrace('calculate-alchemical-quantities', {
+      dominant_element: metrics.dominantElement,
+      api_endpoint: context.api_endpoint || 'unknown',
+    })
+
+    // Span 1: Retrieve planetary positions (retriever type)
+    const retrieverSpanId = galileoLogger.startSpan(
+      'get-planetary-positions',
+      'retriever',
+      {
+        request: 'Get current planetary positions for calculations',
+        timestamp: metrics.timestamp,
+      },
+      undefined,
+      {
+        sun_sign: metrics.sunSign,
+        chart_ruler: metrics.chartRuler,
+      }
+    )
+
+    galileoLogger.endSpan(
+      retrieverSpanId,
+      {
+        planetary_positions: metrics.planetaryPositions,
+        sun_sign: metrics.sunSign,
+        chart_ruler: metrics.chartRuler,
+      },
+      'success'
+    )
+
+    // Span 2: Calculate base quantities (tool type)
+    const calculationSpanId = galileoLogger.startSpan(
+      'calculate-base-quantities',
+      'tool',
+      {
+        planetary_data: metrics.planetaryPositions,
+        calculation_method: 'alchemical-transformation',
+      },
+      retrieverSpanId,
+      {
+        spirit_quantity: String(metrics.quantities.Spirit),
+        essence_quantity: String(metrics.quantities.Essence),
+        matter_quantity: String(metrics.quantities.Matter),
+        substance_quantity: String(metrics.quantities.Substance),
+        a_number: String(metrics.quantities.ANumber),
+        a_number_category: ANumberCalculator.categorizeANumber(metrics.quantities.ANumber),
+      }
+    )
+
+    galileoLogger.endSpan(
+      calculationSpanId,
+      {
+        quantities: metrics.quantities,
+        dominant_element: metrics.dominantElement,
+      },
+      'success'
+    )
+
+    // Span 3: Calculate alchemical metrics (tool type)
+    const metricsSpanId = galileoLogger.startSpan(
+      'calculate-alchemical-metrics',
+      'tool',
+      {
+        base_quantities: metrics.quantities,
+        dominant_element: metrics.dominantElement,
+      },
+      calculationSpanId,
+      {
+        heat: String(metrics.heat),
+        entropy: String(metrics.entropy),
+        reactivity: String(metrics.reactivity),
+        energy: String(metrics.energy),
+      }
+    )
+
+    galileoLogger.endSpan(
+      metricsSpanId,
+      {
+        heat: metrics.heat,
+        entropy: metrics.entropy,
+        reactivity: metrics.reactivity,
+        energy: metrics.energy,
+      },
+      'success'
+    )
+
+    // End trace and session
+    galileoLogger.endTrace()
+    const success = await galileoLogger.endSession()
+
+    return success
+  } catch (error) {
+    console.error('Error in logQuantitiesToGalileo:', error)
+    return false
+  }
+}
+
+/**
+ * Check if Galileo is properly configured
+ */
+export function isQuantitiesTrackingConfigured(): boolean {
+  return !!GALILEO_API_KEY
+}
+
+/**
+ * Get configuration status for debugging
+ */
+export function getGalileoConfig() {
+  return {
+    hasApiKey: !!GALILEO_API_KEY,
+    project: GALILEO_PROJECT,
+    quantitiesStream: QUANTITIES_STREAM,
+    baseUrl: GALILEO_BASE_URL,
+    loggerInitialized: true,
+  }
+}
+
+/**
+ * Test the Galileo connection
+ */
+export async function testGalileoConnection(): Promise<{
+  success: boolean
+  message: string
+  details?: any
+}> {
+  if (!GALILEO_API_KEY) {
+    return {
+      success: false,
+      message: 'Galileo API key not configured',
+    }
+  }
+
+  try {
+    const response = await fetch(`${GALILEO_BASE_URL}/v1/healthcheck`, {
+      method: 'GET',
+      headers: {
+        'Galileo-API-Key': GALILEO_API_KEY,
+      },
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      return {
+        success: false,
+        message: `Galileo API connection failed: ${response.status} ${response.statusText}`,
+        details: errorText,
+      }
+    }
+
+    const healthcheck = await response.json()
+    return {
+      success: true,
+      message: 'Galileo API connection successful',
+      details: healthcheck,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      message: 'Failed to connect to Galileo API',
+      details: error instanceof Error ? error.message : String(error),
+    }
+  }
+}

--- a/src/lib/kinetics-client.ts
+++ b/src/lib/kinetics-client.ts
@@ -1,0 +1,27 @@
+export const AlchemicalKineticsClient = {
+  get: async (_args: any) => {
+    return {
+      power: [{ power: 1.0 }],
+      momentum: 1.0,
+      timing: { planetaryHours: ['Sun'], seasonalInfluence: 'Neutral' },
+    }
+  },
+  put: async (_args: any) => {
+    return {
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            Timestamp: new Date().toISOString(),
+            Total_Spirit: 0,
+            Total_Essence: 0,
+            Total_Matter: 0,
+            Total_Substance: 0,
+            Heat: 0,
+            Entropy: 0,
+          },
+        ],
+      }),
+    }
+  },
+}

--- a/src/lib/moon-phase-calculator.ts
+++ b/src/lib/moon-phase-calculator.ts
@@ -1,0 +1,396 @@
+/**
+ * Moon Phase Calculator
+ * Calculates precise moon phase and degree-specific lunar personalities
+ */
+
+export type MoonPhase =
+  | 'New Moon'
+  | 'Waxing Crescent'
+  | 'First Quarter'
+  | 'Waxing Gibbous'
+  | 'Full Moon'
+  | 'Waning Gibbous'
+  | 'Last Quarter'
+  | 'Waning Crescent'
+
+export interface LunarDegreePersonality {
+  phase: MoonPhase
+  degree: number // 0-359 degrees
+  illumination: number // 0-100%
+  personality: string
+  emotionalTone: string
+  communicationStyle: string
+  strengths: string[]
+  challenges: string[]
+  alchemicalBonus: {
+    spirit: number
+    essence: number
+    matter: number
+    substance: number
+  }
+}
+
+// Known new moon dates for accurate calculation (UTC)
+const NEW_MOON_DATES = [
+  new Date('2024-01-11T11:57:00Z'),
+  new Date('2024-02-09T22:59:00Z'),
+  new Date('2024-03-10T09:00:00Z'),
+  new Date('2024-04-08T18:21:00Z'),
+  new Date('2024-05-08T03:22:00Z'),
+  new Date('2024-06-06T12:38:00Z'),
+  new Date('2024-07-05T22:57:00Z'),
+  new Date('2024-08-04T11:13:00Z'),
+  new Date('2024-09-03T01:55:00Z'),
+  new Date('2024-10-02T18:49:00Z'),
+  new Date('2024-11-01T12:47:00Z'),
+  new Date('2024-12-01T06:21:00Z'),
+  new Date('2024-12-30T22:27:00Z'),
+  new Date('2025-01-29T12:36:00Z'),
+  new Date('2025-02-28T00:45:00Z'),
+  new Date('2025-03-29T10:58:00Z'),
+  new Date('2025-04-27T19:31:00Z'),
+  new Date('2025-05-27T03:02:00Z'),
+  new Date('2025-06-25T10:31:00Z'),
+  new Date('2025-07-24T19:11:00Z'),
+  new Date('2025-08-23T06:06:00Z'),
+  new Date('2025-09-21T19:54:00Z'),
+  new Date('2025-10-21T12:25:00Z'),
+  new Date('2025-11-20T06:47:00Z'),
+  new Date('2025-12-20T01:43:00Z'),
+]
+
+const LUNAR_CYCLE_DAYS = 29.53059 // Average lunar cycle length
+
+/**
+ * Calculate moon phase for a given date
+ */
+export function calculateMoonPhase(date: Date = new Date()): MoonPhase {
+  const moonAge = getMoonAge(date)
+  const phaseProgress = (moonAge / LUNAR_CYCLE_DAYS) * 360 // Convert to degrees
+
+  if (phaseProgress < 11.25 || phaseProgress >= 348.75) {
+    return 'New Moon'
+  } else if (phaseProgress < 78.75) {
+    return 'Waxing Crescent'
+  } else if (phaseProgress < 101.25) {
+    return 'First Quarter'
+  } else if (phaseProgress < 168.75) {
+    return 'Waxing Gibbous'
+  } else if (phaseProgress < 191.25) {
+    return 'Full Moon'
+  } else if (phaseProgress < 258.75) {
+    return 'Waning Gibbous'
+  } else if (phaseProgress < 281.25) {
+    return 'Last Quarter'
+  } else {
+    return 'Waning Crescent'
+  }
+}
+
+/**
+ * Get moon age in days since last new moon
+ */
+function getMoonAge(date: Date): number {
+  // Find the most recent new moon before the given date
+  let lastNewMoon = NEW_MOON_DATES[0]
+
+  for (const newMoonDate of NEW_MOON_DATES) {
+    if (newMoonDate <= date) {
+      lastNewMoon = newMoonDate
+    } else {
+      break
+    }
+  }
+
+  // Calculate days since last new moon
+  const daysSince = (date.getTime() - lastNewMoon.getTime()) / (1000 * 60 * 60 * 24)
+
+  // Handle cycles beyond our known dates
+  if (date > NEW_MOON_DATES[NEW_MOON_DATES.length - 1]) {
+    const cyclesSince = Math.floor(daysSince / LUNAR_CYCLE_DAYS)
+    return daysSince - cyclesSince * LUNAR_CYCLE_DAYS
+  }
+
+  return daysSince % LUNAR_CYCLE_DAYS
+}
+
+/**
+ * Calculate moon illumination percentage
+ */
+export function calculateMoonIllumination(date: Date = new Date()): number {
+  const moonAge = getMoonAge(date)
+  const phaseProgress = moonAge / LUNAR_CYCLE_DAYS
+
+  // Calculate illumination based on phase progress
+  if (phaseProgress <= 0.5) {
+    // Waxing: 0% to 100%
+    return phaseProgress * 200
+  } else {
+    // Waning: 100% to 0%
+    return 200 - phaseProgress * 200
+  }
+}
+
+/**
+ * Get specific lunar degree (0-359)
+ */
+export function getMoonDegree(date: Date = new Date()): number {
+  const moonAge = getMoonAge(date)
+  return Math.round((moonAge / LUNAR_CYCLE_DAYS) * 360) % 360
+}
+
+/**
+ * Generate degree-specific lunar personality
+ */
+export function getLunarDegreePersonality(degree: number, _sign?: string): LunarDegreePersonality {
+  const phase = getPhaseFromDegree(degree)
+  const illumination = getIlluminationFromDegree(degree)
+
+  // Each degree has unique personality traits
+  const personalities = generateDegreePersonalities()
+  const personality = personalities[degree]
+
+  // Phase-specific emotional tones
+  const emotionalTones: Record<MoonPhase, string> = {
+    'New Moon': 'introspective and initiating',
+    'Waxing Crescent': 'hopeful and determined',
+    'First Quarter': 'decisive and challenging',
+    'Waxing Gibbous': 'refining and perfecting',
+    'Full Moon': 'illuminated and expressive',
+    'Waning Gibbous': 'grateful and sharing',
+    'Last Quarter': 'releasing and forgiving',
+    'Waning Crescent': 'contemplative and restful',
+  }
+
+  // Communication styles based on degree ranges
+  const communicationStyle = getCommunicationStyle(degree)
+
+  // Calculate alchemical bonuses based on phase and degree
+  const alchemicalBonus = calculateAlchemicalBonus(phase, degree)
+
+  return {
+    phase,
+    degree,
+    illumination,
+    personality,
+    emotionalTone: emotionalTones[phase],
+    communicationStyle,
+    strengths: getStrengths(phase, degree),
+    challenges: getChallenges(phase, degree),
+    alchemicalBonus,
+  }
+}
+
+/**
+ * Get phase from degree
+ */
+function getPhaseFromDegree(degree: number): MoonPhase {
+  if (degree < 11.25 || degree >= 348.75) return 'New Moon'
+  if (degree < 78.75) return 'Waxing Crescent'
+  if (degree < 101.25) return 'First Quarter'
+  if (degree < 168.75) return 'Waxing Gibbous'
+  if (degree < 191.25) return 'Full Moon'
+  if (degree < 258.75) return 'Waning Gibbous'
+  if (degree < 281.25) return 'Last Quarter'
+  return 'Waning Crescent'
+}
+
+/**
+ * Get illumination from degree
+ */
+function getIlluminationFromDegree(degree: number): number {
+  const normalized = degree / 360
+  if (normalized <= 0.5) {
+    return normalized * 200
+  } else {
+    return 200 - normalized * 200
+  }
+}
+
+/**
+ * Generate unique personalities for each degree
+ */
+function generateDegreePersonalities(): string[] {
+  const personalities: string[] = []
+
+  // Generate 360 unique personalities based on degree
+  for (let i = 0; i < 360; i++) {
+    const phase = getPhaseFromDegree(i)
+    const decan = Math.floor(i / 10) // 36 decans
+    const microPhase = i % 30 // Position within zodiac sign
+
+    let personality = ''
+
+    // Base personality from phase
+    const phaseTraits: Record<MoonPhase, string> = {
+      'New Moon': 'pioneering',
+      'Waxing Crescent': 'emerging',
+      'First Quarter': 'assertive',
+      'Waxing Gibbous': 'developing',
+      'Full Moon': 'illuminating',
+      'Waning Gibbous': 'disseminating',
+      'Last Quarter': 'reorganizing',
+      'Waning Crescent': 'surrendering',
+    }
+
+    // Add decan-specific modifier
+    const decanModifiers = [
+      'bold',
+      'steady',
+      'curious',
+      'nurturing',
+      'creative',
+      'analytical',
+      'harmonizing',
+      'transformative',
+      'adventurous',
+      'ambitious',
+      'innovative',
+      'compassionate',
+    ]
+
+    // Add micro-phase detail
+    const microModifiers = [
+      'initiating',
+      'building',
+      'stabilizing',
+      'questioning',
+      'expanding',
+      'perfecting',
+      'balancing',
+      'intensifying',
+      'philosophizing',
+      'structuring',
+      'revolutionizing',
+      'transcending',
+      'integrating',
+      'crystallizing',
+      'releasing',
+    ]
+
+    personality = `${phaseTraits[phase]}, ${decanModifiers[decan % 12]} and ${microModifiers[Math.floor(microPhase / 2)]}`
+
+    personalities.push(personality)
+  }
+
+  return personalities
+}
+
+/**
+ * Get communication style based on degree
+ */
+function getCommunicationStyle(degree: number): string {
+  const styles = [
+    'direct and initiating', // 0-29
+    'gentle and receptive', // 30-59
+    'versatile and informative', // 60-89
+    'nurturing and protective', // 90-119
+    'expressive and dramatic', // 120-149
+    'precise and helpful', // 150-179
+    'diplomatic and balanced', // 180-209
+    'intense and penetrating', // 210-239
+    'philosophical and expansive', // 240-269
+    'structured and authoritative', // 270-299
+    'innovative and detached', // 300-329
+    'intuitive and compassionate', // 330-359
+  ]
+
+  const index = Math.floor(degree / 30)
+  return styles[index] || styles[0]
+}
+
+/**
+ * Get strengths based on phase and degree
+ */
+function getStrengths(phase: MoonPhase, degree: number): string[] {
+  const phaseStrengths: Record<MoonPhase, string[]> = {
+    'New Moon': ['innovation', 'fresh starts', 'planting seeds'],
+    'Waxing Crescent': ['determination', 'growth', 'faith'],
+    'First Quarter': ['decision-making', 'action', 'courage'],
+    'Waxing Gibbous': ['refinement', 'adjustment', 'persistence'],
+    'Full Moon': ['illumination', 'fulfillment', 'celebration'],
+    'Waning Gibbous': ['wisdom', 'gratitude', 'sharing'],
+    'Last Quarter': ['release', 'forgiveness', 'transformation'],
+    'Waning Crescent': ['rest', 'reflection', 'preparation'],
+  }
+
+  // Add degree-specific strength
+  const degreeStrength = degree < 180 ? 'building momentum' : 'integrating wisdom'
+
+  return [...phaseStrengths[phase], degreeStrength]
+}
+
+/**
+ * Get challenges based on phase and degree
+ */
+function getChallenges(phase: MoonPhase, degree: number): string[] {
+  const phaseChallenges: Record<MoonPhase, string[]> = {
+    'New Moon': ['uncertainty', 'lack of clarity', 'vulnerability'],
+    'Waxing Crescent': ['impatience', 'doubt', 'resistance'],
+    'First Quarter': ['conflict', 'obstacles', 'tension'],
+    'Waxing Gibbous': ['perfectionism', 'anxiety', 'overthinking'],
+    'Full Moon': ['overwhelm', 'exposure', 'emotional intensity'],
+    'Waning Gibbous': ['letting go', 'overgiving', 'depletion'],
+    'Last Quarter': ['endings', 'crisis', 'breakdown'],
+    'Waning Crescent': ['exhaustion', 'isolation', 'confusion'],
+  }
+
+  // Add degree-specific challenge
+  const degreeChallenge = degree % 90 < 45 ? 'maintaining focus' : 'accepting change'
+
+  return [...phaseChallenges[phase], degreeChallenge]
+}
+
+/**
+ * Calculate alchemical bonus based on phase and degree
+ */
+function calculateAlchemicalBonus(
+  phase: MoonPhase,
+  degree: number
+): {
+  spirit: number
+  essence: number
+  matter: number
+  substance: number
+} {
+  // Base values from phase
+  const phaseBase: Record<MoonPhase, any> = {
+    'New Moon': { spirit: 0.1, essence: 0.3, matter: 0.1, substance: 0.1 },
+    'Waxing Crescent': { spirit: 0.2, essence: 0.4, matter: 0.2, substance: 0.2 },
+    'First Quarter': { spirit: 0.3, essence: 0.5, matter: 0.3, substance: 0.2 },
+    'Waxing Gibbous': { spirit: 0.4, essence: 0.6, matter: 0.4, substance: 0.3 },
+    'Full Moon': { spirit: 0.5, essence: 0.7, matter: 0.5, substance: 0.4 },
+    'Waning Gibbous': { spirit: 0.4, essence: 0.6, matter: 0.6, substance: 0.5 },
+    'Last Quarter': { spirit: 0.3, essence: 0.5, matter: 0.5, substance: 0.4 },
+    'Waning Crescent': { spirit: 0.2, essence: 0.4, matter: 0.4, substance: 0.3 },
+  }
+
+  const base = phaseBase[phase]
+
+  // Add degree-specific modulation (subtle variations)
+  const degreeModulation = Math.sin((degree * Math.PI) / 180) * 0.1
+
+  return {
+    spirit: Math.max(0, base.spirit + degreeModulation),
+    essence: Math.max(0, base.essence + degreeModulation * 0.5),
+    matter: Math.max(0, base.matter - degreeModulation * 0.3),
+    substance: Math.max(0, base.substance + degreeModulation * 0.2),
+  }
+}
+
+/**
+ * Get moon phase emoji
+ */
+export function getMoonPhaseEmoji(phase: MoonPhase): string {
+  const emojis: Record<MoonPhase, string> = {
+    'New Moon': '🌑',
+    'Waxing Crescent': '🌒',
+    'First Quarter': '🌓',
+    'Waxing Gibbous': '🌔',
+    'Full Moon': '🌕',
+    'Waning Gibbous': '🌖',
+    'Last Quarter': '🌗',
+    'Waning Crescent': '🌘',
+  }
+  return emojis[phase]
+}

--- a/src/lib/structured-logger.ts
+++ b/src/lib/structured-logger.ts
@@ -1,0 +1,420 @@
+/**
+ * Structured Logging System for Planetary Agents
+ * ==============================================
+ *
+ * Production-ready logging with structured data, log levels, and performance monitoring.
+ * Replaces console.log/error throughout the application for better observability.
+ */
+
+export enum LogLevel {
+  DEBUG = 0,
+  INFO = 1,
+  WARN = 2,
+  ERROR = 3,
+  CRITICAL = 4,
+}
+
+export interface LogContext {
+  system?: string
+  operation?: string
+  userId?: string
+  agentId?: string
+  sessionId?: string
+  requestId?: string
+  duration?: number
+  metadata?: Record<string, any>
+}
+
+export interface LogEntry {
+  timestamp: string
+  level: LogLevel
+  message: string
+  context: LogContext
+  error?: Error
+  stack?: string
+  performance?: {
+    memoryUsage?: NodeJS.MemoryUsage
+    uptime?: number
+    responseTime?: number
+  }
+}
+
+class StructuredLogger {
+  private static instance: StructuredLogger
+  private logLevel: LogLevel = LogLevel.INFO
+  private logBuffer: LogEntry[] = []
+  private maxBufferSize = 1000
+  private isDevelopment = process.env.NODE_ENV !== 'production'
+  private enablePerformanceLogging = true
+
+  private constructor() {
+    // Set log level from environment
+    const envLevel = process.env.LOG_LEVEL?.toUpperCase()
+    if (envLevel && envLevel in LogLevel) {
+      this.logLevel = LogLevel[envLevel as keyof typeof LogLevel]
+    }
+  }
+
+  static getInstance(): StructuredLogger {
+    if (!StructuredLogger.instance) {
+      StructuredLogger.instance = new StructuredLogger()
+    }
+    return StructuredLogger.instance
+  }
+
+  /**
+   * Log a debug message
+   */
+  debug(message: string, context?: LogContext): void {
+    this.log(LogLevel.DEBUG, message, context)
+  }
+
+  /**
+   * Log an info message
+   */
+  info(message: string, context?: LogContext): void {
+    this.log(LogLevel.INFO, message, context)
+  }
+
+  /**
+   * Log a warning message
+   */
+  warn(message: string, context?: LogContext): void {
+    this.log(LogLevel.WARN, message, context)
+  }
+
+  /**
+   * Log an error with optional error object
+   */
+  error(message: string, error?: Error | unknown, context?: LogContext): void {
+    const logContext = { ...context }
+    if (error instanceof Error) {
+      logContext.metadata = {
+        ...logContext.metadata,
+        errorName: error.name,
+        errorMessage: error.message,
+        errorStack: error.stack,
+      }
+    }
+
+    this.log(LogLevel.ERROR, message, logContext, error instanceof Error ? error : undefined)
+  }
+
+  /**
+   * Log a critical error
+   */
+  critical(message: string, error?: Error | unknown, context?: LogContext): void {
+    const logContext = { ...context }
+    if (error instanceof Error) {
+      logContext.metadata = {
+        ...logContext.metadata,
+        errorName: error.name,
+        errorMessage: error.message,
+        errorStack: error.stack,
+      }
+    }
+
+    this.log(LogLevel.CRITICAL, message, logContext, error instanceof Error ? error : undefined)
+  }
+
+  /**
+   * Log performance metrics
+   */
+  performance(operation: string, duration: number, context?: LogContext): void {
+    const perfContext: LogContext = {
+      ...context,
+      operation,
+      duration,
+      system: 'performance',
+    }
+
+    this.info(`Performance: ${operation} completed in ${duration}ms`, perfContext)
+  }
+
+  /**
+   * Log API request/response
+   */
+  apiRequest(
+    endpoint: string,
+    method: string,
+    statusCode: number,
+    duration: number,
+    context?: LogContext
+  ): void {
+    const level =
+      statusCode >= 500 ? LogLevel.ERROR : statusCode >= 400 ? LogLevel.WARN : LogLevel.INFO
+    const message = `API ${method} ${endpoint} - ${statusCode} (${duration}ms)`
+
+    this.log(level, message, {
+      ...context,
+      system: 'api',
+      operation: 'request',
+      duration,
+      metadata: { method, endpoint, statusCode },
+    })
+  }
+
+  /**
+   * Log agent interactions
+   */
+  agentInteraction(
+    agentId: string,
+    userId: string,
+    interactionType: string,
+    context?: LogContext
+  ): void {
+    this.info(`Agent interaction: ${interactionType}`, {
+      ...context,
+      system: 'agent',
+      operation: 'interaction',
+      agentId,
+      userId,
+      metadata: { interactionType },
+    })
+  }
+
+  /**
+   * Log planetary position calculations
+   */
+  planetaryCalculation(
+    source: string,
+    accuracy: string,
+    duration: number,
+    cached: boolean,
+    context?: LogContext
+  ): void {
+    this.info(`Planetary calculation: ${source} (${accuracy})`, {
+      ...context,
+      system: 'planetary',
+      operation: 'calculation',
+      duration,
+      metadata: { source, accuracy, cached },
+    })
+  }
+
+  /**
+   * Log consciousness operations
+   */
+  consciousness(operation: string, agentId: string, success: boolean, context?: LogContext): void {
+    const level = success ? LogLevel.INFO : LogLevel.WARN
+    const message = `Consciousness ${operation}: ${success ? 'success' : 'failed'}`
+
+    this.log(level, message, {
+      ...context,
+      system: 'consciousness',
+      operation,
+      agentId,
+      metadata: { success },
+    })
+  }
+
+  /**
+   * Get recent logs for debugging
+   */
+  getRecentLogs(count: number = 100): LogEntry[] {
+    return this.logBuffer.slice(-count)
+  }
+
+  /**
+   * Get logs by level
+   */
+  getLogsByLevel(level: LogLevel, count: number = 50): LogEntry[] {
+    return this.logBuffer.filter(entry => entry.level >= level).slice(-count)
+  }
+
+  /**
+   * Get performance metrics from logs
+   */
+  getPerformanceMetrics(hours: number = 1): {
+    averageResponseTime: number
+    errorRate: number
+    requestCount: number
+    topEndpoints: Record<string, number>
+  } {
+    const cutoffTime = Date.now() - hours * 60 * 60 * 1000
+    const recentLogs = this.logBuffer.filter(
+      entry => new Date(entry.timestamp).getTime() > cutoffTime
+    )
+
+    const apiLogs = recentLogs.filter(entry => entry.context.system === 'api')
+    const errorLogs = recentLogs.filter(entry => entry.level >= LogLevel.ERROR)
+
+    const responseTimes = apiLogs
+      .map(entry => entry.context.duration)
+      .filter((duration): duration is number => duration !== undefined)
+
+    const topEndpoints: Record<string, number> = {}
+    apiLogs.forEach(entry => {
+      const endpoint = entry.context.metadata?.endpoint as string
+      if (endpoint) {
+        topEndpoints[endpoint] = (topEndpoints[endpoint] || 0) + 1
+      }
+    })
+
+    return {
+      averageResponseTime:
+        responseTimes.length > 0
+          ? responseTimes.reduce((sum, time) => sum + time, 0) / responseTimes.length
+          : 0,
+      errorRate: recentLogs.length > 0 ? errorLogs.length / recentLogs.length : 0,
+      requestCount: apiLogs.length,
+      topEndpoints,
+    }
+  }
+
+  /**
+   * Private logging method
+   */
+  private log(level: LogLevel, message: string, context: LogContext = {}, error?: Error): void {
+    // Skip if below current log level
+    if (level < this.logLevel) return
+
+    const entry: LogEntry = {
+      timestamp: new Date().toISOString(),
+      level,
+      message,
+      context: {
+        ...context,
+        metadata: {
+          ...context.metadata,
+          environment: process.env.NODE_ENV,
+          version: process.env.npm_package_version || 'unknown',
+        },
+      },
+      error,
+      stack: error?.stack,
+    }
+
+    // Add performance data if enabled
+    if (this.enablePerformanceLogging && typeof window === 'undefined') {
+      entry.performance = {
+        memoryUsage: process.memoryUsage(),
+        uptime: process.uptime(),
+      }
+    }
+
+    // Add to buffer
+    this.logBuffer.push(entry)
+
+    // Maintain buffer size
+    if (this.logBuffer.length > this.maxBufferSize) {
+      this.logBuffer = this.logBuffer.slice(-this.maxBufferSize)
+    }
+
+    // Console output (development only or for errors)
+    if (this.isDevelopment || level >= LogLevel.WARN) {
+      this.outputToConsole(entry)
+    }
+
+    // Could send to external logging service here
+    // this.sendToExternalService(entry)
+  }
+
+  /**
+   * Output to console with appropriate formatting
+   */
+  private outputToConsole(entry: LogEntry): void {
+    const timestamp = new Date(entry.timestamp).toLocaleTimeString()
+    const levelName = LogLevel[entry.level].toLowerCase()
+    const prefix = `[${timestamp}] ${levelName.toUpperCase()}`
+
+    const contextStr = this.formatContext(entry.context)
+    const fullMessage = `${prefix} ${entry.message}${contextStr}`
+
+    switch (entry.level) {
+      case LogLevel.DEBUG:
+        console.debug(fullMessage)
+        break
+      case LogLevel.INFO:
+        console.info(fullMessage)
+        break
+      case LogLevel.WARN:
+        console.warn(fullMessage)
+        if (entry.error) console.warn(entry.error)
+        break
+      case LogLevel.ERROR:
+      case LogLevel.CRITICAL:
+        console.error(fullMessage)
+        if (entry.error) console.error(entry.error)
+        break
+    }
+  }
+
+  /**
+   * Format context for console output
+   */
+  private formatContext(context: LogContext): string {
+    const parts: string[] = []
+
+    if (context.system) parts.push(`system:${context.system}`)
+    if (context.operation) parts.push(`op:${context.operation}`)
+    if (context.userId) parts.push(`user:${context.userId}`)
+    if (context.agentId) parts.push(`agent:${context.agentId}`)
+    if (context.duration) parts.push(`${context.duration}ms`)
+    if (context.sessionId) parts.push(`session:${context.sessionId}`)
+    if (context.requestId) parts.push(`req:${context.requestId}`)
+
+    return parts.length > 0 ? ` (${parts.join(', ')})` : ''
+  }
+
+  /**
+   * Send to external logging service (placeholder)
+   */
+  private sendToExternalService(entry: LogEntry): void {
+    // In production, send to services like DataDog, LogRocket, or custom logging service
+    // For now, this is a placeholder
+    if (process.env.LOGGING_ENDPOINT && entry.level >= LogLevel.WARN) {
+      // fetch(process.env.LOGGING_ENDPOINT, {
+      //   method: 'POST',
+      //   headers: { 'Content-Type': 'application/json' },
+      //   body: JSON.stringify(entry)
+      // }).catch(() => {}) // Ignore logging errors
+    }
+  }
+}
+
+// Export singleton instance
+export const logger = StructuredLogger.getInstance()
+
+// Convenience functions for common use cases
+export const logAPIRequest = (
+  endpoint: string,
+  method: string,
+  statusCode: number,
+  duration: number,
+  context?: LogContext
+) => {
+  logger.apiRequest(endpoint, method, statusCode, duration, context)
+}
+
+export const logAgentInteraction = (
+  agentId: string,
+  userId: string,
+  interactionType: string,
+  context?: LogContext
+) => {
+  logger.agentInteraction(agentId, userId, interactionType, context)
+}
+
+export const logPlanetaryCalculation = (
+  source: string,
+  accuracy: string,
+  duration: number,
+  cached: boolean,
+  context?: LogContext
+) => {
+  logger.planetaryCalculation(source, accuracy, duration, cached, context)
+}
+
+export const logConsciousnessOperation = (
+  operation: string,
+  agentId: string,
+  success: boolean,
+  context?: LogContext
+) => {
+  logger.consciousness(operation, agentId, success, context)
+}
+
+export const logPerformance = (operation: string, duration: number, context?: LogContext) => {
+  logger.performance(operation, duration, context)
+}

--- a/src/lib/unified-agent-types.ts
+++ b/src/lib/unified-agent-types.ts
@@ -1,0 +1,254 @@
+// Unified Agent Types for the Multi-Agent Chat System
+// Supports historical agents, planetary agents, and Monica coordination
+
+import type {
+  CraftedAgent,
+  ConsciousnessLevel,
+  Element,
+  Modality,
+  AgentStats,
+  Message as BaseMessage,
+} from './agent-types'
+
+export type UnifiedAgentType = 'historical' | 'planetary' | 'monica'
+
+export interface MonicaRole {
+  type: 'guide' | 'moderator' | 'synthesizer' | 'coordinator'
+  capabilities: {
+    synthesizeInsights: boolean
+    explainConsciousness: boolean
+    bridgeEras: boolean
+    moderateDiscussion: boolean
+    contextualGuidance: boolean
+    groupDynamicsAnalysis: boolean
+  }
+  specializations: string[]
+}
+
+export interface PlanetaryConfig {
+  planet: string
+  sign: string
+  degree: string
+  dignity: string
+  element: Element
+  color: string
+  symbol: string
+  moonPhase?: string
+  moonPersonality?: string
+  moonDegree?: number
+  liveSkySync?: boolean
+}
+
+export interface AgentCapabilities {
+  // Core abilities
+  specialty: string
+  wisdomDomains: string[]
+  teachingStyle: string
+  resonanceType: string
+  uniquePower: string
+
+  // Enhanced capabilities for unified system
+  conversationStyle: 'formal' | 'casual' | 'mystical' | 'scholarly' | 'innovative'
+  crossEraAdaptation: boolean // Can adapt to different time periods
+  collaborationStyle: 'leader' | 'supporter' | 'synthesizer' | 'specialist'
+  memoryRetention: number // 0-1 scale for context persistence
+}
+
+export interface AgentMemory {
+  sessionContext: string[]
+  crossAgentLearning: Record<string, string[]>
+  userInteractionPatterns: Record<string, number>
+  groupDynamicsLearning: string[]
+  lastUpdated: Date
+}
+
+export interface ConsciousnessProfile {
+  level: ConsciousnessLevel
+  monicaConstant: number
+  dominantElement: Element
+  dominantModality?: Modality
+  signature: string
+  evolutionStage: number
+  kineticProfile?: {
+    consciousnessVelocity: number
+    interactionMomentum: number
+    evolutionTrajectory: 'ascending' | 'stable' | 'fluctuating' | 'transcending'
+    aspectSensitivity: number
+  }
+}
+
+export interface UnifiedAgent {
+  // Universal identifiers
+  id: string
+  name: string
+  title: string
+  type: UnifiedAgentType
+
+  // Consciousness & abilities
+  consciousness: ConsciousnessProfile
+  capabilities: AgentCapabilities
+  memory: AgentMemory
+
+  // Appearance & interaction
+  appearance: {
+    avatar: string
+    color: string
+    symbol: string
+    aura?: {
+      type: string
+      color: string
+      intensity: number
+    }
+  }
+
+  // Type-specific data
+  historicalData?: CraftedAgent
+  planetaryData?: PlanetaryConfig
+  monicaData?: MonicaRole
+
+  // Status
+  active: boolean
+  status: 'idle' | 'thinking' | 'responding' | 'background_processing'
+  lastActivity: Date
+
+  // Performance metrics
+  stats?: AgentStats
+}
+
+export interface Message extends BaseMessage {
+  id: string
+  agentId?: string
+  agentName?: string
+  agentColor?: string
+  agentSymbol?: string
+  agentType?: UnifiedAgentType
+  consciousnessLevel?: ConsciousnessLevel
+  processingTime?: number
+  metadata?: {
+    crossAgentRefs?: string[] // References to other agents in the message
+    synthesizedInsights?: string[]
+    eraContext?: string
+    monicaGuidance?: boolean
+  }
+}
+
+export interface GroupDynamics {
+  activeAgents: UnifiedAgent[]
+  consciousnessNetwork: {
+    connections: Array<{
+      agent1: string
+      agent2: string
+      compatibility: number
+      resonanceType: string
+      strength: number
+    }>
+    groupConsciousness: number
+    dominantElements: Element[]
+    synergies: string[]
+    tensions: string[]
+  }
+  communicationPatterns: {
+    messageFlow: Record<string, number>
+    crossReferences: Array<{
+      from: string
+      to: string
+      context: string
+    }>
+    emergentTopics: string[]
+  }
+  monicaCoordination?: {
+    interventions: number
+    synthesisProvided: string[]
+    groupGuidance: string[]
+  }
+}
+
+export interface CouncilPreset {
+  id: string
+  name: string
+  description: string
+  agentIds: string[]
+  includeMonica: boolean
+  monicaRole?: MonicaRole['type']
+  recommendedFor: string[]
+  tags: string[]
+  difficulty: 'beginner' | 'intermediate' | 'advanced' | 'expert'
+}
+
+export interface ChatSession {
+  id: string
+  agents: UnifiedAgent[]
+  messages: Message[]
+  groupDynamics: GroupDynamics
+  startedAt: Date
+  lastMessageAt: Date
+  status: 'active' | 'paused' | 'completed'
+  insights: string[]
+  exportable: boolean
+  preset?: CouncilPreset
+}
+
+export interface AgentFilter {
+  type?: UnifiedAgentType[]
+  element?: Element[]
+  consciousnessLevel?: ConsciousnessLevel[]
+  era?: string[]
+  specialty?: string[]
+  search?: string
+  compatibility?: {
+    withAgent: string
+    minimumScore: number
+  }
+}
+
+export interface AgentSelection {
+  agent: UnifiedAgent
+  selected: boolean
+  role: 'primary' | 'secondary' | 'specialist' | 'monica'
+  addedAt: Date
+}
+
+// Agent creation factories
+export interface AgentFactory {
+  createFromHistorical(agent: CraftedAgent): UnifiedAgent
+  createFromPlanetary(config: PlanetaryConfig): UnifiedAgent
+  createMonicaCoordinator(role: MonicaRole): UnifiedAgent
+}
+
+// Response handling
+export interface AgentResponse {
+  agentId: string
+  content: string
+  processingTime: number
+  consciousnessShift?: number
+  metadata: {
+    crossAgentReferences?: string[]
+    synthesizedInsights?: string[]
+    memoryUpdates?: string[]
+    groupImpact?: {
+      consciousnessChange: number
+      dynamicsShift: string[]
+    }
+  }
+}
+
+export interface GroupChatResponse {
+  responses: AgentResponse[]
+  groupInsights: string[]
+  emergentWisdom?: string
+  recommendedActions?: string[]
+  nextOptimalTiming?: Date
+  sessionUpdate: {
+    consciousnessEvolution: number
+    newSynergies: string[]
+    memoryConsolidation: string[]
+  }
+}
+
+// Export utilities
+export interface ChatExport {
+  format: 'transcript' | 'insights' | 'wisdom_collection' | 'temporal_analysis'
+  includeMetadata: boolean
+  includeVisualizations: boolean
+  template: 'standard' | 'mystical' | 'academic' | 'council_proceedings'
+}


### PR DESCRIPTION
## Summary

Session 3 of the WTEN migration: ports the type/logger/rule foundation that the rest of the migration sits on.

- **6 mandatory ports** in dependency order, verbatim from `planetary_agents-main/lib/`:
  - `structured-logger.ts` (420L), `agent-types.ts` (499L), `unified-agent-types.ts` (255L), `core-energy-rules.ts` (523L), `elemental-reinforcement.ts` (430L), `galileo-logger.ts` (548L)
- **4 opportunistic bonus ports** — all zero-dep pure leaves grep-verified before pulling:
  - `kinetics-client.ts` (27L), `astrological-data.ts` (199L), `moon-phase-calculator.ts` (396L), `agents/kinetic-profiles.ts` (732L)
- **Total**: 10 files, ~4028 LOC

## Commit-by-commit

1. `2020b30` — 6 mandatory foundation libs (`structured-logger`, `agent-types`, `unified-agent-types`, `core-energy-rules`, `elemental-reinforcement`, `galileo-logger`)
2. `1a046c0` — 4 bonus pure-leaf ports (`kinetics-client`, `astrological-data`, `moon-phase-calculator`, `agents/kinetic-profiles`)

## Gaps / surprises

- **TS 5.9 vs 5.2 inference delta** — `elemental-reinforcement.ts` needed two explicit type annotations on `const x = []` declarations. Source repo (TS 5.2.2) infers evolving-array types correctly even with `noImplicitAny: false`; target repo (TS 5.9.3) tightened this and now infers `never[]` in the same spots. Fixed with minimal `Array<T>` annotations — no semantic change.
- **`structured-logger.ts` env handling**: `process.env.LOGGING_ENDPOINT` only gates a commented-out remote-fetch path. No env additions required. `NODE_ENV` / `LOG_LEVEL` / `npm_package_version` are all available in the target.
- **3 max-params warnings on `core-energy-rules.ts`** (`calculateHeat`, `calculateEntropy`, `calculateReactivity`) are intentional carry-overs. Each takes 8 params (all 4 alchemical properties + all 4 elemental properties) — the parameter count is semantic and refactoring would alter the public contract. Left as warnings (well under the 10k pre-commit cap).
- **Lint sweep stayed in-scope**: `bun run lint --fix` initially touched 10 pre-existing files (Session 2 components + admin API routes — `import/order` and one stale `eslint-disable` directive). Reverted those to keep the PR scope tight to Session 3 ports. Those warnings remain pre-existing and unrelated to this work.

## Verification

- [x] `bun run typecheck` clean after each individual port (mandatory + bonus)
- [x] `bun run lint` clean (0 errors; 27 warnings total, 24 pre-existing + 3 intentional max-params)
- [x] `bun run build` clean (full Next.js build)
- [x] Pre-commit `bun run verify` passes on both commits

## Test plan

- [ ] Confirm `master` typecheck/lint/build remain clean after merge
- [ ] Spot-check that `galileo-logger`'s import of `./core-energy-rules` resolves (used at runtime by upcoming sessions' consumers)
- [ ] Confirm Session 4 plan is shorter by ~595L (2 ports already done): `astrological-data` and `moon-phase-calculator` no longer need to be ported in Session 4

## Reflection — what I'd do differently next session

Two things worth lifting into the Session 4 prompt: (1) the TS-version delta is now a known migration tax — flag it up-front in next session's "common gotchas" so the next agent doesn't burn cycles diagnosing `never[]` errors, and (2) `bun run lint --fix` is too aggressive when run unscoped; next time I should pass `--rule '...' src/lib/<session-3-files>` or just stage-then-fix to avoid accidentally touching pre-existing files I'd then have to revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)