### PR TITLE
feat(wten-migration): astronomy + ephemeris (session 4)

### DIFF
--- a/src/lib/ephemeris/degree-calendar-map.ts
+++ b/src/lib/ephemeris/degree-calendar-map.ts
@@ -1,0 +1,411 @@
+/**
+ * Degree-to-Calendar Mapping Service
+ * ===================================
+ *
+ * Provides fast lookups and caching for zodiac degree to calendar date mappings
+ * Accounts for yearly variations in Sun's position due to leap years and orbital mechanics
+ */
+
+import {
+  getZodiacPositionForDate,
+  getDatesForZodiacDegree,
+  generateYearlyDegreeMap,
+  getZodiacIngresses,
+  getCardinalPoints,
+} from './solar-ephemeris'
+import type { DateRange } from './solar-ephemeris'
+
+export interface DegreeMapEntry {
+  degree: number // 0-359
+  sign: string // Zodiac sign name
+  signDegree: number // 0-30 within sign
+  decan: number // 1-3
+  dateRange: DateRange // When Sun is at this degree
+  keywords: string[] // Sabian symbols or keywords
+}
+
+export interface SignPeriod {
+  sign: string
+  startDate: Date
+  endDate: Date
+  durationDays: number
+  decans: {
+    first: DateRange
+    second: DateRange
+    third: DateRange
+  }
+}
+
+export interface AnnualZodiacCalendar {
+  year: number
+  springEquinox: Date
+  summerSolstice: Date
+  autumnEquinox: Date
+  winterSolstice: Date
+  signPeriods: SignPeriod[]
+  degreeMap: Map<number, DegreeMapEntry>
+}
+
+// Cache for yearly degree maps to avoid recalculation
+const yearlyMapCache = new Map<number, AnnualZodiacCalendar>()
+
+// Sabian symbols or keywords for each degree (simplified - you could expand this)
+const DEGREE_KEYWORDS: Record<string, string[]> = {
+  Aries_0: ['New beginnings', 'Pioneer spirit', 'Cardinal fire'],
+  Aries_15: ['Warrior energy', 'Mid-sign strength', 'Pure action'],
+  Aries_29: ['Completion', 'Transition', 'Final push'],
+  Taurus_0: ['Grounding', 'Material foundation', 'Fixed earth'],
+  Gemini_0: ['Communication', 'Mutable air', 'Curiosity'],
+  Cancer_0: ['Nurturing', 'Cardinal water', 'Emotional security'],
+  Leo_0: ['Creative expression', 'Fixed fire', 'Solar power'],
+  Virgo_0: ['Analysis', 'Mutable earth', 'Perfectionism'],
+  Libra_0: ['Balance', 'Cardinal air', 'Relationships'],
+  Scorpio_0: ['Transformation', 'Fixed water', 'Deep psychology'],
+  Sagittarius_0: ['Philosophy', 'Mutable fire', 'Expansion'],
+  Capricorn_0: ['Ambition', 'Cardinal earth', 'Structure'],
+  Aquarius_0: ['Innovation', 'Fixed air', 'Humanitarian'],
+  Pisces_0: ['Transcendence', 'Mutable water', 'Universal love'],
+}
+
+/**
+ * Get keywords for a specific zodiac degree
+ */
+function getKeywordsForDegree(sign: string, signDegree: number): string[] {
+  // Check for specific degree keywords
+  const key = `${sign}_${Math.floor(signDegree)}`
+  if (DEGREE_KEYWORDS[key]) {
+    return DEGREE_KEYWORDS[key]
+  }
+
+  // Default keywords based on decan
+  const decan = Math.floor(signDegree / 10) + 1
+  const element = getSignElement(sign)
+  const modality = getSignModality(sign)
+
+  return [
+    `${sign} ${decan === 1 ? 'early' : decan === 2 ? 'middle' : 'late'} degrees`,
+    `Decan ${decan}`,
+    `${modality} ${element}`,
+  ]
+}
+
+/**
+ * Get element for zodiac sign
+ */
+function getSignElement(sign: string): string {
+  const elements: Record<string, string> = {
+    Aries: 'Fire',
+    Leo: 'Fire',
+    Sagittarius: 'Fire',
+    Taurus: 'Earth',
+    Virgo: 'Earth',
+    Capricorn: 'Earth',
+    Gemini: 'Air',
+    Libra: 'Air',
+    Aquarius: 'Air',
+    Cancer: 'Water',
+    Scorpio: 'Water',
+    Pisces: 'Water',
+  }
+  return elements[sign] || 'Unknown'
+}
+
+/**
+ * Get modality for zodiac sign
+ */
+function getSignModality(sign: string): string {
+  const modalities: Record<string, string> = {
+    Aries: 'Cardinal',
+    Cancer: 'Cardinal',
+    Libra: 'Cardinal',
+    Capricorn: 'Cardinal',
+    Taurus: 'Fixed',
+    Leo: 'Fixed',
+    Scorpio: 'Fixed',
+    Aquarius: 'Fixed',
+    Gemini: 'Mutable',
+    Virgo: 'Mutable',
+    Sagittarius: 'Mutable',
+    Pisces: 'Mutable',
+  }
+  return modalities[sign] || 'Unknown'
+}
+
+/**
+ * Build complete annual zodiac calendar with all mappings
+ */
+export function buildAnnualCalendar(year: number): AnnualZodiacCalendar {
+  // Check cache first
+  if (yearlyMapCache.has(year)) {
+    return yearlyMapCache.get(year)!
+  }
+
+  // Get cardinal points (equinoxes and solstices)
+  const cardinalPoints = getCardinalPoints(year)
+
+  // Get sign ingress dates
+  const ingresses = getZodiacIngresses(year)
+  const nextYearIngresses = getZodiacIngresses(year + 1)
+
+  // Build sign periods with decan dates
+  const signPeriods: SignPeriod[] = []
+  const signs = Object.keys(ingresses)
+
+  for (let i = 0; i < signs.length; i++) {
+    const sign = signs[i]
+    const nextSign = signs[(i + 1) % signs.length]
+
+    const startDate = ingresses[sign]
+    const endDate = i === signs.length - 1 ? nextYearIngresses[signs[0]] : ingresses[nextSign]
+
+    const durationMs = endDate.getTime() - startDate.getTime()
+    const durationDays = durationMs / (1000 * 60 * 60 * 24)
+
+    // Calculate decan periods (each roughly 1/3 of sign duration)
+    const decanDuration = durationMs / 3
+
+    const firstDecanEnd = new Date(startDate.getTime() + decanDuration)
+    const secondDecanEnd = new Date(startDate.getTime() + 2 * decanDuration)
+
+    signPeriods.push({
+      sign,
+      startDate,
+      endDate,
+      durationDays,
+      decans: {
+        first: {
+          start: startDate,
+          end: firstDecanEnd,
+          duration_hours: decanDuration / (1000 * 60 * 60),
+        },
+        second: {
+          start: firstDecanEnd,
+          end: secondDecanEnd,
+          duration_hours: decanDuration / (1000 * 60 * 60),
+        },
+        third: {
+          start: secondDecanEnd,
+          end: endDate,
+          duration_hours: decanDuration / (1000 * 60 * 60),
+        },
+      },
+    })
+  }
+
+  // Generate degree map with enriched data
+  const basicDegreeMap = generateYearlyDegreeMap(year)
+  const enrichedDegreeMap = new Map<number, DegreeMapEntry>()
+
+  for (const [degree, dateRange] of basicDegreeMap.entries()) {
+    const signIndex = Math.floor(degree / 30)
+    const signDegree = degree % 30
+    const sign = signs[signIndex]
+    const decan = Math.floor(signDegree / 10) + 1
+
+    enrichedDegreeMap.set(degree, {
+      degree,
+      sign,
+      signDegree,
+      decan,
+      dateRange,
+      keywords: getKeywordsForDegree(sign, signDegree),
+    })
+  }
+
+  const calendar: AnnualZodiacCalendar = {
+    year,
+    springEquinox: cardinalPoints.spring_equinox,
+    summerSolstice: cardinalPoints.summer_solstice,
+    autumnEquinox: cardinalPoints.autumn_equinox,
+    winterSolstice: cardinalPoints.winter_solstice,
+    signPeriods,
+    degreeMap: enrichedDegreeMap,
+  }
+
+  // Cache the result
+  yearlyMapCache.set(year, calendar)
+
+  return calendar
+}
+
+/**
+ * Find what zodiac degree the Sun is at for a given date
+ * Returns enriched information including keywords and decan
+ */
+export function getDegreeForDate(date: Date): DegreeMapEntry {
+  const year = date.getFullYear()
+  const calendar = buildAnnualCalendar(year)
+
+  const zodiacPos = getZodiacPositionForDate(date)
+  const degree = Math.floor(zodiacPos.absolute_longitude)
+
+  // Get the entry from our pre-calculated map
+  let entry = calendar.degreeMap.get(degree)
+
+  // If not found (shouldn't happen), create on the fly
+  if (!entry) {
+    const dateRange = getDatesForZodiacDegree(year, degree)
+    entry = {
+      degree,
+      sign: zodiacPos.sign,
+      signDegree: zodiacPos.degree_in_sign,
+      decan: zodiacPos.decan,
+      dateRange,
+      keywords: getKeywordsForDegree(zodiacPos.sign, zodiacPos.degree_in_sign),
+    }
+  }
+
+  return entry
+}
+
+/**
+ * Find all dates in a year when Sun is at a specific degree
+ * Useful for anniversary calculations
+ */
+export function findDatesForDegree(degree: number, year: number): DateRange {
+  const calendar = buildAnnualCalendar(year)
+  const entry = calendar.degreeMap.get(Math.floor(degree))
+
+  if (!entry) {
+    // Fallback to calculation
+    return getDatesForZodiacDegree(year, degree)
+  }
+
+  return entry.dateRange
+}
+
+/**
+ * Get the current zodiac period information
+ */
+export function getCurrentZodiacPeriod(): SignPeriod | null {
+  const now = new Date()
+  const year = now.getFullYear()
+  const calendar = buildAnnualCalendar(year)
+
+  for (const period of calendar.signPeriods) {
+    if (now >= period.startDate && now < period.endDate) {
+      return period
+    }
+  }
+
+  return null
+}
+
+/**
+ * Calculate how many days until the next sign ingress
+ */
+export function daysUntilNextIngress(): { sign: string; days: number; date: Date } {
+  const now = new Date()
+  const year = now.getFullYear()
+  const calendar = buildAnnualCalendar(year)
+
+  for (const period of calendar.signPeriods) {
+    if (now < period.startDate) {
+      const days = (period.startDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+      return {
+        sign: period.sign,
+        days: Math.ceil(days),
+        date: period.startDate,
+      }
+    }
+  }
+
+  // If we're in the last sign of the year, get next year's Aries
+  const nextYearCalendar = buildAnnualCalendar(year + 1)
+  const nextAries = nextYearCalendar.signPeriods[0]
+  const days = (nextAries.startDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+
+  return {
+    sign: 'Aries',
+    days: Math.ceil(days),
+    date: nextAries.startDate,
+  }
+}
+
+/**
+ * Get a formatted calendar view of zodiac periods for a month
+ */
+export function getMonthlyZodiacCalendar(
+  year: number,
+  month: number
+): {
+  month: string
+  days: Array<{
+    date: number
+    zodiacDegree: number
+    sign: string
+    signDegree: number
+    decan: number
+    isIngress: boolean
+    isCardinal: boolean
+  }>
+} {
+  const monthNames = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ]
+
+  const _calendar = buildAnnualCalendar(year)
+  const daysInMonth = new Date(year, month, 0).getDate()
+  const days: Array<{
+    date: number
+    zodiacDegree: number
+    sign: string
+    signDegree: number
+    decan: number
+    isIngress: boolean
+    isCardinal: boolean
+  }> = []
+
+  for (let day = 1; day <= daysInMonth; day++) {
+    const date = new Date(year, month - 1, day, 12, 0, 0) // Noon to avoid DST issues
+    const zodiacPos = getZodiacPositionForDate(date)
+    const degree = Math.floor(zodiacPos.absolute_longitude)
+
+    // Check if this is an ingress day (0° of any sign)
+    const isIngress = zodiacPos.degree_in_sign < 1 && day > 1
+
+    // Check if this is a cardinal point
+    const isCardinal = [0, 90, 180, 270].includes(degree)
+
+    days.push({
+      date: day,
+      zodiacDegree: degree,
+      sign: zodiacPos.sign,
+      signDegree: Math.floor(zodiacPos.degree_in_sign),
+      decan: zodiacPos.decan,
+      isIngress,
+      isCardinal,
+    })
+  }
+
+  return {
+    month: monthNames[month - 1],
+    days,
+  }
+}
+
+/**
+ * Invalidate cache for a specific year
+ * Useful if calculations need to be refreshed
+ */
+export function invalidateYearCache(year: number): void {
+  yearlyMapCache.delete(year)
+}
+
+/**
+ * Clear entire cache
+ */
+export function clearCache(): void {
+  yearlyMapCache.clear()
+}

--- a/src/lib/ephemeris/solar-ephemeris.ts
+++ b/src/lib/ephemeris/solar-ephemeris.ts
@@ -1,0 +1,357 @@
+/**
+ * Solar Ephemeris Calculator
+ * ==========================
+ *
+ * High-precision solar position calculations using VSOP87 algorithms
+ * Achieves ±0.01° accuracy for tropical zodiac calculations
+ * Properly accounts for Earth's orbital variations and leap years
+ */
+
+export interface SolarPosition {
+  longitude: number // 0-360° ecliptic longitude
+  latitude: number // Should be ~0 for Sun
+  distance: number // AU from Earth
+  speed: number // degrees per day
+  equation_of_time: number // minutes
+  declination: number // degrees
+  right_ascension: number // degrees
+}
+
+export interface ZodiacPosition {
+  absolute_longitude: number // 0-360°
+  sign: string // Zodiac sign name
+  sign_index: number // 0-11
+  degree_in_sign: number // 0-30°
+  minute_in_degree: number // 0-60'
+  decan: number // 1-3
+  decan_ruler: string // Planetary ruler of decan
+}
+
+export interface DateRange {
+  start: Date
+  end: Date
+  duration_hours: number
+}
+
+// Zodiac signs in order
+const ZODIAC_SIGNS = [
+  'Aries',
+  'Taurus',
+  'Gemini',
+  'Cancer',
+  'Leo',
+  'Virgo',
+  'Libra',
+  'Scorpio',
+  'Sagittarius',
+  'Capricorn',
+  'Aquarius',
+  'Pisces',
+]
+
+// Decan rulers (Chaldean order)
+const DECAN_RULERS = {
+  Aries: ['Mars', 'Sun', 'Jupiter'],
+  Taurus: ['Venus', 'Mercury', 'Saturn'],
+  Gemini: ['Mercury', 'Venus', 'Uranus'],
+  Cancer: ['Moon', 'Pluto', 'Neptune'],
+  Leo: ['Sun', 'Jupiter', 'Mars'],
+  Virgo: ['Mercury', 'Saturn', 'Venus'],
+  Libra: ['Venus', 'Uranus', 'Mercury'],
+  Scorpio: ['Pluto', 'Neptune', 'Moon'],
+  Sagittarius: ['Jupiter', 'Mars', 'Sun'],
+  Capricorn: ['Saturn', 'Venus', 'Mercury'],
+  Aquarius: ['Uranus', 'Mercury', 'Venus'],
+  Pisces: ['Neptune', 'Moon', 'Pluto'],
+}
+
+// J2000.0 epoch (January 1, 2000, 12:00 TT)
+const J2000_JD = 2451545.0
+const DAYS_PER_CENTURY = 36525
+
+/**
+ * Convert Date to Julian Day Number
+ */
+export function dateToJulianDay(date: Date): number {
+  const year = date.getUTCFullYear()
+  const month = date.getUTCMonth() + 1
+  const day = date.getUTCDate()
+  const hour = date.getUTCHours()
+  const minute = date.getUTCMinutes()
+  const second = date.getUTCSeconds()
+
+  const a = Math.floor((14 - month) / 12)
+  const y = year + 4800 - a
+  const m = month + 12 * a - 3
+
+  let jdn =
+    day +
+    Math.floor((153 * m + 2) / 5) +
+    365 * y +
+    Math.floor(y / 4) -
+    Math.floor(y / 100) +
+    Math.floor(y / 400) -
+    32045
+
+  // Add time fraction
+  jdn += (hour - 12) / 24 + minute / 1440 + second / 86400
+
+  return jdn
+}
+
+/**
+ * Calculate centuries since J2000.0
+ */
+function centuriesSinceJ2000(jd: number): number {
+  return (jd - J2000_JD) / DAYS_PER_CENTURY
+}
+
+/**
+ * Normalize angle to 0-360 degrees
+ */
+function normalizeDegrees(degrees: number): number {
+  degrees = degrees % 360
+  return degrees < 0 ? degrees + 360 : degrees
+}
+
+/**
+ * Calculate precise solar position using VSOP87 theory
+ * This is a simplified but accurate implementation
+ */
+export function calculateSolarPosition(date: Date): SolarPosition {
+  const jd = dateToJulianDay(date)
+  const T = centuriesSinceJ2000(jd)
+  const T2 = T * T
+  const T3 = T2 * T
+
+  // Mean longitude of the Sun
+  const L0 = 280.46646 + 36000.76983 * T + 0.0003032 * T2
+
+  // Mean anomaly of the Sun
+  const M = 357.52911 + 35999.05029 * T - 0.0001537 * T2
+  const M_rad = (M * Math.PI) / 180
+
+  // Eccentricity of Earth's orbit
+  const e = 0.016708634 - 0.000042037 * T - 0.0000001267 * T2
+
+  // Sun's equation of center (accurate to 0.0001°)
+  const C =
+    (1.914602 - 0.004817 * T - 0.000014 * T2) * Math.sin(M_rad) +
+    (0.019993 - 0.000101 * T) * Math.sin(2 * M_rad) +
+    0.000289 * Math.sin(3 * M_rad)
+
+  // True longitude of the Sun
+  const true_longitude = L0 + C
+
+  // True anomaly
+  const v = M + C
+
+  // Distance from Earth to Sun in AU
+  const R = (1.000001018 * (1 - e * e)) / (1 + e * Math.cos((v * Math.PI) / 180))
+
+  // Apparent longitude (including aberration)
+  const aberration = -0.00569 - 0.00478 * Math.sin(((259.2 - 1934.134 * T) * Math.PI) / 180)
+  const apparent_longitude = normalizeDegrees(true_longitude + aberration)
+
+  // Obliquity of the ecliptic
+  const epsilon = 23.439291 - 0.0130042 * T - 0.00000016 * T2 + 0.000000504 * T3
+  const epsilon_rad = (epsilon * Math.PI) / 180
+
+  // Right ascension and declination
+  const lambda_rad = (apparent_longitude * Math.PI) / 180
+  const alpha = Math.atan2(Math.cos(epsilon_rad) * Math.sin(lambda_rad), Math.cos(lambda_rad))
+  const delta = Math.asin(Math.sin(epsilon_rad) * Math.sin(lambda_rad))
+
+  // Equation of time (in minutes)
+  const y = Math.tan(epsilon_rad / 2) ** 2
+  const eq_time =
+    (4 *
+      (y * Math.sin((2 * L0 * Math.PI) / 180) -
+        2 * e * Math.sin(M_rad) +
+        4 * e * y * Math.sin(M_rad) * Math.cos((2 * L0 * Math.PI) / 180) -
+        0.5 * y * y * Math.sin((4 * L0 * Math.PI) / 180) -
+        1.25 * e * e * Math.sin(2 * M_rad)) *
+      180) /
+    Math.PI
+
+  // Daily motion (approximate)
+  const daily_motion = 360 / 365.25 // More precise calculation would account for orbital position
+
+  return {
+    longitude: apparent_longitude,
+    latitude: 0, // Sun's latitude is essentially 0
+    distance: R,
+    speed: daily_motion * (1 / R ** 2), // Kepler's law adjustment
+    equation_of_time: eq_time,
+    declination: (delta * 180) / Math.PI,
+    right_ascension: normalizeDegrees((alpha * 180) / Math.PI),
+  }
+}
+
+/**
+ * Convert solar longitude to zodiac position
+ */
+export function longitudeToZodiac(longitude: number): ZodiacPosition {
+  const normalized = normalizeDegrees(longitude)
+  const sign_index = Math.floor(normalized / 30)
+  const degree_in_sign = normalized % 30
+  const minute_in_degree = (degree_in_sign % 1) * 60
+  const decan = Math.floor(degree_in_sign / 10) + 1
+  const sign = ZODIAC_SIGNS[sign_index]
+
+  return {
+    absolute_longitude: normalized,
+    sign,
+    sign_index,
+    degree_in_sign,
+    minute_in_degree,
+    decan,
+    decan_ruler: DECAN_RULERS[sign as keyof typeof DECAN_RULERS][decan - 1],
+  }
+}
+
+/**
+ * Get exact zodiac position for a specific date/time
+ */
+export function getZodiacPositionForDate(date: Date): ZodiacPosition {
+  const solar = calculateSolarPosition(date)
+  return longitudeToZodiac(solar.longitude)
+}
+
+/**
+ * Find when Sun enters a specific zodiac degree in a given year
+ * Returns the date range when Sun is within that degree
+ */
+export function getDatesForZodiacDegree(
+  year: number,
+  zodiacDegree: number // 0-359
+): DateRange {
+  // Normalize degree
+  const targetDegree = normalizeDegrees(zodiacDegree)
+
+  // Start searching from approximate date
+  // Sun moves ~1 degree per day, starting from ~0° Aries around March 20
+  const daysFromAries = targetDegree
+  const approxDate = new Date(Date.UTC(year, 2, 20)) // March 20
+  approxDate.setUTCDate(approxDate.getUTCDate() + Math.floor(daysFromAries))
+
+  // Binary search for exact entry time
+  const searchDate = new Date(approxDate)
+  searchDate.setUTCDate(searchDate.getUTCDate() - 2) // Start 2 days before
+
+  let entryTime: Date | null = null
+  let exitTime: Date | null = null
+
+  // Search with hourly precision
+  for (let hours = 0; hours < 120; hours++) {
+    // Search 5 days
+    const checkDate = new Date(searchDate)
+    checkDate.setUTCHours(searchDate.getUTCHours() + hours)
+
+    const pos = calculateSolarPosition(checkDate)
+    const currentDegree = Math.floor(pos.longitude)
+
+    if (!entryTime && currentDegree === Math.floor(targetDegree)) {
+      entryTime = new Date(checkDate)
+    } else if (entryTime && currentDegree !== Math.floor(targetDegree)) {
+      exitTime = new Date(checkDate)
+      break
+    }
+  }
+
+  // If we didn't find exit time, Sun is still in this degree at end of search
+  if (entryTime && !exitTime) {
+    exitTime = new Date(entryTime)
+    exitTime.setUTCHours(exitTime.getUTCHours() + 24) // Approximate 1 day
+  }
+
+  // Fallback if we didn't find entry
+  if (!entryTime) {
+    entryTime = approxDate
+    exitTime = new Date(approxDate)
+    exitTime.setUTCDate(exitTime.getUTCDate() + 1)
+  }
+
+  const duration = (exitTime!.getTime() - entryTime.getTime()) / (1000 * 60 * 60)
+
+  return {
+    start: entryTime,
+    end: exitTime!,
+    duration_hours: duration,
+  }
+}
+
+/**
+ * Get dates for when Sun enters each sign in a given year
+ */
+export function getZodiacIngresses(year: number): Record<string, Date> {
+  const ingresses: Record<string, Date> = {}
+
+  for (let signIndex = 0; signIndex < 12; signIndex++) {
+    const degree = signIndex * 30 // 0, 30, 60, 90, etc.
+    const dateRange = getDatesForZodiacDegree(year, degree)
+    ingresses[ZODIAC_SIGNS[signIndex]] = dateRange.start
+  }
+
+  return ingresses
+}
+
+/**
+ * Calculate exact equinox and solstice dates for a year
+ */
+export function getCardinalPoints(year: number): {
+  spring_equinox: Date
+  summer_solstice: Date
+  autumn_equinox: Date
+  winter_solstice: Date
+} {
+  // These correspond to 0° Aries, 0° Cancer, 0° Libra, 0° Capricorn
+  const spring = getDatesForZodiacDegree(year, 0).start // 0° Aries
+  const summer = getDatesForZodiacDegree(year, 90).start // 0° Cancer
+  const autumn = getDatesForZodiacDegree(year, 180).start // 0° Libra
+  const winter = getDatesForZodiacDegree(year, 270).start // 0° Capricorn
+
+  return {
+    spring_equinox: spring,
+    summer_solstice: summer,
+    autumn_equinox: autumn,
+    winter_solstice: winter,
+  }
+}
+
+/**
+ * Generate a complete degree-to-date mapping for a year
+ * This is useful for caching and quick lookups
+ */
+export function generateYearlyDegreeMap(year: number): Map<number, DateRange> {
+  const degreeMap = new Map<number, DateRange>()
+
+  for (let degree = 0; degree < 360; degree++) {
+    degreeMap.set(degree, getDatesForZodiacDegree(year, degree))
+  }
+
+  return degreeMap
+}
+
+/**
+ * Calculate how many days the Sun spends in each sign for a given year
+ * This varies due to Earth's elliptical orbit
+ */
+export function getSignDurations(year: number): Record<string, number> {
+  const durations: Record<string, number> = {}
+  const ingresses = getZodiacIngresses(year)
+  const nextYearIngresses = getZodiacIngresses(year + 1)
+
+  for (let i = 0; i < ZODIAC_SIGNS.length; i++) {
+    const sign = ZODIAC_SIGNS[i]
+    const nextSign = ZODIAC_SIGNS[(i + 1) % 12]
+
+    const start = ingresses[sign]
+    const end = i === 11 ? nextYearIngresses['Aries'] : ingresses[nextSign]
+
+    const days = (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)
+    durations[sign] = Math.round(days * 100) / 100
+  }
+
+  return durations
+}

--- a/src/lib/planetary-api-client.ts
+++ b/src/lib/planetary-api-client.ts
@@ -1,0 +1,291 @@
+/**
+ * Planetary API Client
+ *
+ * Alchemical Principle: This service acts as the "channel" through which
+ * elemental energies (astronomical data) flow from the Earth vessel (backend)
+ * to the Air vessel (frontend).
+ *
+ * All planetary calculations are performed on the backend using Swiss Ephemeris,
+ * ensuring proper separation of native compilation (Earth) from distributed
+ * visualization (Air).
+ */
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000'
+
+export interface PlanetaryPosition {
+  longitude: number // Ecliptic longitude in degrees (0-360)
+  latitude: number // Ecliptic latitude in degrees
+  distance: number // Distance from Earth in AU
+  speed: number // Degrees per day (negative = retrograde)
+}
+
+export interface PlanetaryPositions {
+  [planet: string]: PlanetaryPosition
+}
+
+export interface HouseSystem {
+  houses: number[] // 12 house cusps in degrees
+  ascendant: number // Rising sign degree
+  mc: number // Midheaven degree
+}
+
+export interface ConsciousnessParameters {
+  spirit: number // Fire element (0-1)
+  essence: number // Air element (0-1)
+  matter: number // Water element (0-1)
+  substance: number // Earth element (0-1)
+  monicaConstant: number // (Spirit × φ + Essence) / (Matter + Substance + 1)
+  planetaryInfluences: Record<string, { element: string; strength: number }>
+}
+
+export interface BackendResponse<T> {
+  success: boolean
+  data: T
+  metadata?: {
+    computeTime?: number
+    requestDate?: string
+    totalPlanets?: number
+    coordinates?: { latitude: number; longitude: number } | null
+    [key: string]: any
+  }
+  error?: string
+}
+
+export class PlanetaryAPIClient {
+  private baseUrl: string
+
+  constructor(baseUrl: string = BACKEND_URL) {
+    this.baseUrl = baseUrl
+  }
+
+  /**
+   * Get planetary positions for a given moment in time
+   * Traditional correspondence: Queries the celestial sphere positions
+   */
+  async getPlanetaryPositions(
+    date: Date,
+    latitude?: number,
+    longitude?: number,
+    planets?: string[]
+  ): Promise<PlanetaryPositions> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/planets/positions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          date: date.toISOString(),
+          latitude,
+          longitude,
+          planets: planets || [
+            'sun',
+            'moon',
+            'mercury',
+            'venus',
+            'mars',
+            'jupiter',
+            'saturn',
+            'uranus',
+            'neptune',
+            'pluto',
+          ],
+        }),
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        throw new Error(
+          `Failed to fetch planetary positions: ${response.statusText} - ${errorData.error || ''}`
+        )
+      }
+
+      const result: BackendResponse<PlanetaryPositions> = await response.json()
+
+      if (!result.success) {
+        throw new Error(result.error || 'Backend returned unsuccessful response')
+      }
+
+      return result.data
+    } catch (error) {
+      console.error('[PlanetaryAPIClient] getPlanetaryPositions error:', error)
+      throw error
+    }
+  }
+
+  /**
+   * Get planetary positions in batch
+   */
+  async getBatchPlanetaryPositions(
+    requests: Array<{ date: Date; planet: string }>
+  ): Promise<Array<{ date: string; planet: string; position: PlanetaryPosition | null }>> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/planets/batch-positions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          requests: requests.map(req => ({
+            date: req.date.toISOString(),
+            planet: req.planet,
+          })),
+        }),
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        throw new Error(
+          `Failed to fetch batch planetary positions: ${response.statusText} - ${errorData.error || ''}`
+        )
+      }
+
+      const result: BackendResponse<any> = await response.json()
+
+      if (!result.success) {
+        throw new Error(result.error || 'Backend returned unsuccessful response')
+      }
+
+      return result.data
+    } catch (error) {
+      console.error('[PlanetaryAPIClient] getBatchPlanetaryPositions error:', error)
+      throw error
+    }
+  }
+
+  /**
+   * Calculate house system for a birth chart
+   * Traditional correspondence: Divides the celestial sphere into 12 houses
+   */
+  async getHouseSystem(
+    date: Date,
+    latitude: number,
+    longitude: number,
+    houseSystem: string = 'P' // Placidus
+  ): Promise<HouseSystem> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/planets/houses`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          date: date.toISOString(),
+          latitude,
+          longitude,
+          houseSystem,
+        }),
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        throw new Error(
+          `Failed to fetch house system: ${response.statusText} - ${errorData.error || ''}`
+        )
+      }
+
+      const result: BackendResponse<HouseSystem> = await response.json()
+
+      if (!result.success) {
+        throw new Error(result.error || 'Backend returned unsuccessful response')
+      }
+
+      return result.data
+    } catch (error) {
+      console.error('[PlanetaryAPIClient] getHouseSystem error:', error)
+      throw error
+    }
+  }
+
+  /**
+   * Calculate consciousness parameters from birth data and current transits
+   * Traditional correspondence: Synthesizes elemental energies from planetary configurations
+   */
+  async calculateConsciousness(
+    birthDate: Date,
+    birthLatitude?: number,
+    birthLongitude?: number,
+    currentDate?: Date
+  ): Promise<ConsciousnessParameters> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/planets/calculate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          birthData: {
+            date: birthDate.toISOString(),
+            latitude: birthLatitude,
+            longitude: birthLongitude,
+          },
+          currentDate: (currentDate || new Date()).toISOString(),
+        }),
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        throw new Error(
+          `Failed to calculate consciousness: ${response.statusText} - ${errorData.error || ''}`
+        )
+      }
+
+      const result: BackendResponse<ConsciousnessParameters> = await response.json()
+
+      if (!result.success) {
+        throw new Error(result.error || 'Backend returned unsuccessful response')
+      }
+
+      return result.data
+    } catch (error) {
+      console.error('[PlanetaryAPIClient] calculateConsciousness error:', error)
+      throw error
+    }
+  }
+
+  /**
+   * Get available planets for calculation
+   */
+  async getAvailablePlanets(): Promise<
+    Array<{
+      id: string
+      name: string
+      element: string
+      alchemy: { spirit: number; essence: number; matter: number; substance: number }
+    }>
+  > {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/planets/available`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch available planets: ${response.statusText}`)
+      }
+
+      const result: BackendResponse<any[]> = await response.json()
+
+      if (!result.success) {
+        throw new Error(result.error || 'Backend returned unsuccessful response')
+      }
+
+      return result.data
+    } catch (error) {
+      console.error('[PlanetaryAPIClient] getAvailablePlanets error:', error)
+      throw error
+    }
+  }
+
+  /**
+   * Health check for backend connection
+   */
+  async healthCheck(): Promise<boolean> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/health`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+      return response.ok
+    } catch (error) {
+      console.error('[PlanetaryAPIClient] Health check failed:', error)
+      return false
+    }
+  }
+}
+
+// Export singleton instance
+export const planetaryAPI = new PlanetaryAPIClient()

--- a/src/lib/planetary-config-helper.ts
+++ b/src/lib/planetary-config-helper.ts
@@ -1,0 +1,240 @@
+// Planetary Configuration Helper for Unified Chat
+// Converts MultiAgentChat planetary configs to unified format
+
+import { getSignElement, getPlanetaryDignity } from './astrological-data'
+import { calculateMoonPhase, getMoonDegree } from './moon-phase-calculator'
+import type { Element } from './agent-types'
+import type { PlanetaryConfig } from './unified-agent-types'
+
+export type { PlanetaryConfig } from './unified-agent-types'
+
+export const PLANET_SYMBOLS: Record<string, string> = {
+  Sun: '☉',
+  Moon: '☽',
+  Mercury: '☿',
+  Venus: '♀',
+  Mars: '♂',
+  Jupiter: '♃',
+  Saturn: '♄',
+  Uranus: '♅',
+  Neptune: '♆',
+  Pluto: '♇',
+}
+
+export const PLANET_COLORS: Record<string, string> = {
+  Sun: '#f59e0b',
+  Moon: '#9ca3af',
+  Mercury: '#f97316',
+  Venus: '#ec4899',
+  Mars: '#ef4444',
+  Jupiter: '#8b5cf6',
+  Saturn: '#4b5563',
+  Uranus: '#06b6d4',
+  Neptune: '#3b82f6',
+  Pluto: '#1f2937',
+}
+
+export function createDefaultPlanetaryConfigs(): PlanetaryConfig[] {
+  const currentMoonPhase = calculateMoonPhase(new Date())
+  const currentMoonDegree = getMoonDegree(new Date())
+
+  return [
+    {
+      planet: 'Sun',
+      sign: 'Leo',
+      degree: '15',
+      dignity: getPlanetaryDignity('Sun', 'Leo'),
+      element: getSignElement('Leo') as Element,
+      color: PLANET_COLORS.Sun,
+      symbol: PLANET_SYMBOLS.Sun,
+      liveSkySync: true,
+    },
+    {
+      planet: 'Moon',
+      sign: 'Cancer',
+      degree: '10',
+      dignity: getPlanetaryDignity('Moon', 'Cancer'),
+      element: getSignElement('Cancer') as Element,
+      color: PLANET_COLORS.Moon,
+      symbol: PLANET_SYMBOLS.Moon,
+      moonPhase: currentMoonPhase,
+      moonDegree: currentMoonDegree,
+      liveSkySync: true,
+    },
+    {
+      planet: 'Mercury',
+      sign: 'Gemini',
+      degree: '20',
+      dignity: getPlanetaryDignity('Mercury', 'Gemini'),
+      element: getSignElement('Gemini') as Element,
+      color: PLANET_COLORS.Mercury,
+      symbol: PLANET_SYMBOLS.Mercury,
+      liveSkySync: true,
+    },
+    {
+      planet: 'Venus',
+      sign: 'Taurus',
+      degree: '12',
+      dignity: getPlanetaryDignity('Venus', 'Taurus'),
+      element: getSignElement('Taurus') as Element,
+      color: PLANET_COLORS.Venus,
+      symbol: PLANET_SYMBOLS.Venus,
+      liveSkySync: true,
+    },
+    {
+      planet: 'Mars',
+      sign: 'Aries',
+      degree: '8',
+      dignity: getPlanetaryDignity('Mars', 'Aries'),
+      element: getSignElement('Aries') as Element,
+      color: PLANET_COLORS.Mars,
+      symbol: PLANET_SYMBOLS.Mars,
+      liveSkySync: true,
+    },
+    {
+      planet: 'Jupiter',
+      sign: 'Sagittarius',
+      degree: '25',
+      dignity: getPlanetaryDignity('Jupiter', 'Sagittarius'),
+      element: getSignElement('Sagittarius') as Element,
+      color: PLANET_COLORS.Jupiter,
+      symbol: PLANET_SYMBOLS.Jupiter,
+      liveSkySync: true,
+    },
+    {
+      planet: 'Saturn',
+      sign: 'Capricorn',
+      degree: '5',
+      dignity: getPlanetaryDignity('Saturn', 'Capricorn'),
+      element: getSignElement('Capricorn') as Element,
+      color: PLANET_COLORS.Saturn,
+      symbol: PLANET_SYMBOLS.Saturn,
+      liveSkySync: true,
+    },
+    {
+      planet: 'Uranus',
+      sign: 'Aquarius',
+      degree: '18',
+      dignity: getPlanetaryDignity('Uranus', 'Aquarius'),
+      element: getSignElement('Aquarius') as Element,
+      color: PLANET_COLORS.Uranus,
+      symbol: PLANET_SYMBOLS.Uranus,
+      liveSkySync: true,
+    },
+    {
+      planet: 'Neptune',
+      sign: 'Pisces',
+      degree: '22',
+      dignity: getPlanetaryDignity('Neptune', 'Pisces'),
+      element: getSignElement('Pisces') as Element,
+      color: PLANET_COLORS.Neptune,
+      symbol: PLANET_SYMBOLS.Neptune,
+      liveSkySync: true,
+    },
+    {
+      planet: 'Pluto',
+      sign: 'Capricorn',
+      degree: '28',
+      dignity: getPlanetaryDignity('Pluto', 'Capricorn'),
+      element: getSignElement('Capricorn') as Element,
+      color: PLANET_COLORS.Pluto,
+      symbol: PLANET_SYMBOLS.Pluto,
+      liveSkySync: true,
+    },
+  ]
+}
+
+export function updatePlanetaryConfigWithLiveSky(
+  config: PlanetaryConfig,
+  planetaryPositions: any
+): PlanetaryConfig {
+  if (!config.liveSkySync || !planetaryPositions) {
+    return config
+  }
+
+  let planetData: any = null
+  if (Array.isArray(planetaryPositions)) {
+    planetData = planetaryPositions.find(
+      (p: any) => p.planet.toLowerCase() === config.planet.toLowerCase()
+    )
+  } else if (typeof planetaryPositions === 'object') {
+    planetData = planetaryPositions[config.planet.toLowerCase()]
+  }
+
+  if (!planetData) {
+    return config
+  }
+
+  return {
+    ...config,
+    sign: planetData.sign || config.sign,
+    degree: planetData.degree?.toString() || config.degree,
+    dignity: getPlanetaryDignity(config.planet, planetData.sign || config.sign),
+    element: getSignElement(planetData.sign || config.sign) as Element,
+  }
+}
+
+export function getDefaultActivePlanets(): string[] {
+  return ['Sun', 'Moon', 'Mercury']
+}
+
+export function convertLegacyAgentConfig(legacyConfig: any): PlanetaryConfig {
+  return {
+    planet: legacyConfig.planet,
+    sign: legacyConfig.sign,
+    degree: legacyConfig.degree,
+    dignity: getPlanetaryDignity(legacyConfig.planet, legacyConfig.sign),
+    element: getSignElement(legacyConfig.sign) as Element,
+    color: legacyConfig.color || PLANET_COLORS[legacyConfig.planet] || '#6b7280',
+    symbol: legacyConfig.symbol || PLANET_SYMBOLS[legacyConfig.planet] || '●',
+    moonPhase: legacyConfig.moonPhase,
+    moonDegree: legacyConfig.moonDegree,
+    liveSkySync: false,
+  }
+}
+
+export function getPlanetaryCouncilPresets(): Array<{
+  id: string
+  name: string
+  description: string
+  planets: string[]
+  includeMonica: boolean
+}> {
+  return [
+    {
+      id: 'inner-planets',
+      name: 'Inner Planets Council',
+      description: 'Quick, responsive guidance from personal planets',
+      planets: ['Sun', 'Moon', 'Mercury', 'Venus', 'Mars'],
+      includeMonica: false,
+    },
+    {
+      id: 'classical-seven',
+      name: 'Classical Seven',
+      description: 'Traditional planetary wisdom with Monica as guide',
+      planets: ['Sun', 'Moon', 'Mercury', 'Venus', 'Mars', 'Jupiter', 'Saturn'],
+      includeMonica: true,
+    },
+    {
+      id: 'outer-mysteries',
+      name: 'Outer Mysteries',
+      description: 'Transform through generational and transcendent energies',
+      planets: ['Jupiter', 'Saturn', 'Uranus', 'Neptune', 'Pluto'],
+      includeMonica: true,
+    },
+    {
+      id: 'elemental-balance',
+      name: 'Elemental Balance',
+      description: 'Fire, Earth, Air, Water - complete elemental perspective',
+      planets: ['Mars', 'Saturn', 'Mercury', 'Moon'],
+      includeMonica: false,
+    },
+    {
+      id: 'consciousness-accelerator',
+      name: 'Consciousness Accelerator',
+      description: 'Maximum awareness expansion with Monica coordination',
+      planets: ['Sun', 'Jupiter', 'Uranus', 'Neptune'],
+      includeMonica: true,
+    },
+  ]
+}

--- a/src/lib/planetary-motion-tracker.ts
+++ b/src/lib/planetary-motion-tracker.ts
@@ -1,0 +1,473 @@
+/**
+ * Planetary Motion Tracker
+ *
+ * Tracks planetary velocities and predicts future positions for dynamic aspect analysis.
+ * Uses traditional astrological daily motion rates enhanced with real-time calculations.
+ */
+
+export interface PlanetaryMotion {
+  planet: string
+  currentPosition: number // degrees (0-360)
+  dailyMotion: number // degrees per day
+  velocity: number // current speed relative to average
+  retrograde: boolean
+  motionTrend: 'accelerating' | 'decelerating' | 'stable'
+  lastUpdated: Date
+}
+
+export interface PlanetaryVelocityProfile {
+  planet: string
+  averageDailyMotion: number
+  maxDailyMotion: number
+  minDailyMotion: number
+  retrogradeFrequency: number // times per year
+  stationaryOrbDuration: number // days near stationary
+}
+
+// Traditional astrological daily motion rates (degrees per day)
+const PLANETARY_VELOCITY_PROFILES: Record<string, PlanetaryVelocityProfile> = {
+  Sun: {
+    planet: 'Sun',
+    averageDailyMotion: 0.9856, // ~59 arcminutes
+    maxDailyMotion: 1.0192, // perihelion
+    minDailyMotion: 0.9529, // aphelion
+    retrogradeFrequency: 0, // never retrograde
+    stationaryOrbDuration: 0,
+  },
+  Moon: {
+    planet: 'Moon',
+    averageDailyMotion: 13.1764, // ~13° 11'
+    maxDailyMotion: 15.4085, // perigee
+    minDailyMotion: 11.9603, // apogee
+    retrogradeFrequency: 0, // never retrograde
+    stationaryOrbDuration: 0,
+  },
+  Mercury: {
+    planet: 'Mercury',
+    averageDailyMotion: 1.383, // ~1° 23'
+    maxDailyMotion: 2.2, // elongation
+    minDailyMotion: -1.4, // retrograde
+    retrogradeFrequency: 3, // ~3 times per year
+    stationaryOrbDuration: 3, // ~3 days stationary
+  },
+  Venus: {
+    planet: 'Venus',
+    averageDailyMotion: 1.2021, // ~1° 12'
+    maxDailyMotion: 1.27, // elongation
+    minDailyMotion: -0.7, // retrograde
+    retrogradeFrequency: 0.625, // ~19 months
+    stationaryOrbDuration: 5, // ~5 days stationary
+  },
+  Mars: {
+    planet: 'Mars',
+    averageDailyMotion: 0.524, // ~31'
+    maxDailyMotion: 0.8, // opposition approach
+    minDailyMotion: -0.5, // retrograde
+    retrogradeFrequency: 1, // ~26 months
+    stationaryOrbDuration: 7, // ~7 days stationary
+  },
+  Jupiter: {
+    planet: 'Jupiter',
+    averageDailyMotion: 0.0831, // ~5'
+    maxDailyMotion: 0.25, // fastest direct
+    minDailyMotion: -0.1, // retrograde
+    retrogradeFrequency: 1, // ~13 months
+    stationaryOrbDuration: 10, // ~10 days stationary
+  },
+  Saturn: {
+    planet: 'Saturn',
+    averageDailyMotion: 0.0335, // ~2'
+    maxDailyMotion: 0.13, // fastest direct
+    minDailyMotion: -0.05, // retrograde
+    retrogradeFrequency: 1, // ~12.5 months
+    stationaryOrbDuration: 12, // ~12 days stationary
+  },
+  Uranus: {
+    planet: 'Uranus',
+    averageDailyMotion: 0.0117, // ~42"
+    maxDailyMotion: 0.06, // fastest direct
+    minDailyMotion: -0.02, // retrograde
+    retrogradeFrequency: 1, // ~12 months
+    stationaryOrbDuration: 15, // ~15 days stationary
+  },
+  Neptune: {
+    planet: 'Neptune',
+    averageDailyMotion: 0.006, // ~22"
+    maxDailyMotion: 0.03, // fastest direct
+    minDailyMotion: -0.01, // retrograde
+    retrogradeFrequency: 1, // ~12 months
+    stationaryOrbDuration: 17, // ~17 days stationary
+  },
+  Pluto: {
+    planet: 'Pluto',
+    averageDailyMotion: 0.0039, // ~14"
+    maxDailyMotion: 0.025, // fastest direct
+    minDailyMotion: -0.008, // retrograde
+    retrogradeFrequency: 1, // ~12 months
+    stationaryOrbDuration: 20, // ~20 days stationary
+  },
+}
+
+export class PlanetaryMotionTracker {
+  private motionCache: Map<string, { data: PlanetaryMotion; timestamp: number }> = new Map()
+  private readonly CACHE_TTL = 1800000 // 30 minutes for most planets
+  private readonly MOON_CACHE_TTL = 300000 // 5 minutes for Moon
+  private readonly SUN_CACHE_TTL = 3600000 // 1 hour for Sun
+
+  /**
+   * Calculate current daily motion for a planet at a given date
+   */
+  async calculateDailyMotion(planet: string, date: Date): Promise<number> {
+    const profile = PLANETARY_VELOCITY_PROFILES[planet]
+    if (!profile) {
+      throw new Error(`Unknown planet: ${planet}`)
+    }
+
+    // For now, use average motion with orbital variation
+    // In production, this would integrate with astronomical APIs
+    const orbitalPhase = this.calculateOrbitalPhase(planet, date)
+    const seasonalVariation = this.calculateSeasonalVariation(planet, orbitalPhase)
+
+    return profile.averageDailyMotion * seasonalVariation
+  }
+
+  /**
+   * Predict planetary position at a future date
+   */
+  async predictPosition(
+    planet: string,
+    currentPosition: number,
+    targetDate: Date,
+    currentDate: Date = new Date()
+  ): Promise<number> {
+    const daysDiff = (targetDate.getTime() - currentDate.getTime()) / (1000 * 60 * 60 * 24)
+    const dailyMotion = await this.calculateDailyMotion(planet, currentDate)
+
+    // Account for retrograde periods
+    const retrogradeAdjustment = this.calculateRetrogradeAdjustment(planet, currentDate, daysDiff)
+    const totalMotion = dailyMotion * daysDiff * retrogradeAdjustment
+
+    // Normalize to 0-360 range
+    let predictedPosition = currentPosition + totalMotion
+    while (predictedPosition < 0) predictedPosition += 360
+    while (predictedPosition >= 360) predictedPosition -= 360
+
+    return predictedPosition
+  }
+
+  /**
+   * Get velocity profile for a planet over a date range
+   */
+  async getVelocityProfile(
+    planet: string,
+    daysRange: number,
+    startDate: Date = new Date()
+  ): Promise<number[]> {
+    const profile: number[] = []
+
+    for (let i = 0; i < daysRange; i++) {
+      const checkDate = new Date(startDate.getTime() + i * 24 * 60 * 60 * 1000)
+      const velocity = await this.calculateDailyMotion(planet, checkDate)
+      profile.push(velocity)
+    }
+
+    return profile
+  }
+
+  /**
+   * Get comprehensive planetary motion data
+   */
+  async getPlanetaryMotion(
+    planet: string,
+    currentPosition: number,
+    date: Date = new Date()
+  ): Promise<PlanetaryMotion> {
+    const cacheKey = `${planet}-${date.toISOString().split('T')[0]}`
+    const ttl = this.getCacheTTL(planet)
+    const cached = this.motionCache.get(cacheKey)
+
+    if (cached && Date.now() - cached.timestamp < ttl) {
+      return cached.data
+    }
+
+    const dailyMotion = await this.calculateDailyMotion(planet, date)
+    const profile = PLANETARY_VELOCITY_PROFILES[planet]
+
+    // Calculate velocity relative to average
+    const velocity = Math.abs(dailyMotion) / profile.averageDailyMotion
+
+    // Determine if retrograde
+    const retrograde = dailyMotion < 0
+
+    // Calculate motion trend
+    const motionTrend = await this.calculateMotionTrend(planet, date)
+
+    const motion: PlanetaryMotion = {
+      planet,
+      currentPosition,
+      dailyMotion,
+      velocity,
+      retrograde,
+      motionTrend,
+      lastUpdated: date,
+    }
+
+    // Cache the result
+    this.motionCache.set(cacheKey, { data: motion, timestamp: Date.now() })
+
+    return motion
+  }
+
+  /**
+   * Calculate the separation velocity between two planets
+   * Positive = separating, Negative = applying
+   */
+  async calculateSeparationVelocity(
+    planet1: string,
+    position1: number,
+    planet2: string,
+    position2: number,
+    aspectAngle: number = 0,
+    date: Date = new Date()
+  ): Promise<number> {
+    const motion1 = await this.getPlanetaryMotion(planet1, position1, date)
+    const motion2 = await this.getPlanetaryMotion(planet2, position2, date)
+
+    // Calculate current angular separation
+    let currentSeparation = Math.abs(position1 - position2)
+    if (currentSeparation > 180) {
+      currentSeparation = 360 - currentSeparation
+    }
+
+    // Calculate how this separation will change
+    // Faster planet "catches up" to slower planet
+    const _relativeVelocity = motion1.dailyMotion - motion2.dailyMotion
+
+    // Determine if the aspect is forming (applying) or separating
+    const targetSeparation = Math.abs(aspectAngle)
+    const currentOrbFromExact = Math.abs(currentSeparation - targetSeparation)
+
+    // Project one day ahead to see if orb is tightening or widening
+    const futurePosition1 = await this.predictPosition(
+      planet1,
+      position1,
+      new Date(date.getTime() + 24 * 60 * 60 * 1000),
+      date
+    )
+    const futurePosition2 = await this.predictPosition(
+      planet2,
+      position2,
+      new Date(date.getTime() + 24 * 60 * 60 * 1000),
+      date
+    )
+
+    let futureSeparation = Math.abs(futurePosition1 - futurePosition2)
+    if (futureSeparation > 180) {
+      futureSeparation = 360 - futureSeparation
+    }
+
+    const futureOrbFromExact = Math.abs(futureSeparation - targetSeparation)
+
+    // Velocity of orb change (negative = applying, positive = separating)
+    return futureOrbFromExact - currentOrbFromExact
+  }
+
+  /**
+   * Predict when an aspect will be exact
+   */
+  async predictExactAspectTiming(
+    planet1: string,
+    position1: number,
+    planet2: string,
+    position2: number,
+    aspectAngle: number,
+    maxDays: number = 90,
+    date: Date = new Date()
+  ): Promise<{ date: Date; orb: number } | null> {
+    const separationVelocity = await this.calculateSeparationVelocity(
+      planet1,
+      position1,
+      planet2,
+      position2,
+      aspectAngle,
+      date
+    )
+
+    // If separating, aspect won't become exact
+    if (separationVelocity > 0) {
+      return null
+    }
+
+    // Calculate current orb
+    let currentSeparation = Math.abs(position1 - position2)
+    if (currentSeparation > 180) {
+      currentSeparation = 360 - currentSeparation
+    }
+    const currentOrb = Math.abs(currentSeparation - Math.abs(aspectAngle))
+
+    // Estimate days to exact using separation velocity
+    const daysToExact = Math.abs(currentOrb / separationVelocity)
+
+    if (daysToExact > maxDays) {
+      return null
+    }
+
+    const exactDate = new Date(date.getTime() + daysToExact * 24 * 60 * 60 * 1000)
+
+    return {
+      date: exactDate,
+      orb: 0, // Will be exact
+    }
+  }
+
+  private getCacheTTL(planet: string): number {
+    switch (planet) {
+      case 'Moon':
+        return this.MOON_CACHE_TTL
+      case 'Sun':
+        return this.SUN_CACHE_TTL
+      default:
+        return this.CACHE_TTL
+    }
+  }
+
+  private calculateOrbitalPhase(planet: string, date: Date): number {
+    // Simplified orbital phase calculation
+    const dayOfYear = this.getDayOfYear(date)
+    return (dayOfYear / 365.25) * 2 * Math.PI
+  }
+
+  private calculateSeasonalVariation(planet: string, orbitalPhase: number): number {
+    // Planets move faster at perihelion, slower at aphelion
+    const _profile = PLANETARY_VELOCITY_PROFILES[planet]
+    const eccentricity = this.getOrbitalEccentricity(planet)
+
+    // Simplified seasonal variation based on orbital mechanics
+    const variation = 1 + eccentricity * Math.cos(orbitalPhase)
+    return Math.max(0.1, Math.min(2.0, variation))
+  }
+
+  private calculateRetrogradeAdjustment(planet: string, date: Date, _daysDiff: number): number {
+    const profile = PLANETARY_VELOCITY_PROFILES[planet]
+    if (profile.retrogradeFrequency === 0) return 1.0
+
+    // Simplified retrograde calculation
+    // In production, this would use accurate retrograde ephemeris
+    const retrogradePhase = this.calculateRetrogradePhase(planet, date)
+
+    if (retrogradePhase > 0.4 && retrogradePhase < 0.6) {
+      return -0.5 // Retrograde motion
+    }
+
+    return 1.0 // Direct motion
+  }
+
+  private calculateRetrogradePhase(planet: string, date: Date): number {
+    // Simplified retrograde phase calculation
+    const profile = PLANETARY_VELOCITY_PROFILES[planet]
+    const daysSinceEpoch =
+      (date.getTime() - new Date('2000-01-01').getTime()) / (1000 * 60 * 60 * 24)
+    const cycleDays = 365.25 / profile.retrogradeFrequency
+
+    return (daysSinceEpoch % cycleDays) / cycleDays
+  }
+
+  private async calculateMotionTrend(
+    planet: string,
+    date: Date
+  ): Promise<'accelerating' | 'decelerating' | 'stable'> {
+    // Compare velocity over a 3-day window
+    const prevDate = new Date(date.getTime() - 3 * 24 * 60 * 60 * 1000)
+    const nextDate = new Date(date.getTime() + 3 * 24 * 60 * 60 * 1000)
+
+    const prevMotion = await this.calculateDailyMotion(planet, prevDate)
+    const _currentMotion = await this.calculateDailyMotion(planet, date)
+    const nextMotion = await this.calculateDailyMotion(planet, nextDate)
+
+    const trend = (nextMotion - prevMotion) / 6 // 6-day span
+
+    if (trend > 0.01) return 'accelerating'
+    if (trend < -0.01) return 'decelerating'
+    return 'stable'
+  }
+
+  private getOrbitalEccentricity(planet: string): number {
+    const eccentricities: Record<string, number> = {
+      Sun: 0.0167, // Earth's orbit
+      Moon: 0.0549, // Moon's orbit around Earth
+      Mercury: 0.2056,
+      Venus: 0.0067,
+      Mars: 0.0934,
+      Jupiter: 0.0489,
+      Saturn: 0.0565,
+      Uranus: 0.0463,
+      Neptune: 0.0095,
+      Pluto: 0.2488,
+    }
+    return eccentricities[planet] || 0.05
+  }
+
+  private getDayOfYear(date: Date): number {
+    const start = new Date(date.getFullYear(), 0, 0)
+    const diff = date.getTime() - start.getTime()
+    return Math.floor(diff / (1000 * 60 * 60 * 24))
+  }
+
+  /**
+   * Clear motion cache (useful for testing or forced refresh)
+   */
+  clearCache(): void {
+    this.motionCache.clear()
+  }
+
+  /**
+   * Get cache statistics
+   */
+  getCacheStats(): { size: number; oldestEntry: number; newestEntry: number } {
+    const timestamps = Array.from(this.motionCache.values()).map(v => v.timestamp)
+    return {
+      size: this.motionCache.size,
+      oldestEntry: timestamps.length > 0 ? Math.min(...timestamps) : 0,
+      newestEntry: timestamps.length > 0 ? Math.max(...timestamps) : 0,
+    }
+  }
+}
+
+// Singleton instance
+export const planetaryMotionTracker = new PlanetaryMotionTracker()
+
+// Convenience functions
+export async function calculatePlanetaryVelocity(
+  planet: string,
+  position: number,
+  date: Date = new Date()
+): Promise<PlanetaryMotion> {
+  return planetaryMotionTracker.getPlanetaryMotion(planet, position, date)
+}
+
+export async function predictPlanetaryPosition(
+  planet: string,
+  currentPosition: number,
+  targetDate: Date,
+  currentDate: Date = new Date()
+): Promise<number> {
+  return planetaryMotionTracker.predictPosition(planet, currentPosition, targetDate, currentDate)
+}
+
+export async function calculateAspectSeparationRate(
+  planet1: string,
+  position1: number,
+  planet2: string,
+  position2: number,
+  aspectAngle: number = 0,
+  date: Date = new Date()
+): Promise<number> {
+  return planetaryMotionTracker.calculateSeparationVelocity(
+    planet1,
+    position1,
+    planet2,
+    position2,
+    aspectAngle,
+    date
+  )
+}


### PR DESCRIPTION
## Summary

Session 4 of the WTEN migration: ports the astronomy math layer + ephemeris.

**Stacked on PR #419 (Session 3)** — review/merge that first; this PR's base will auto-retarget to `master` once #419 merges.

- **5 ports** (the original Session 4 plan called for 7 — 2 were taken in Session 3's bonus pass):
  - `planetary-motion-tracker.ts` (473L)
  - `planetary-api-client.ts` (291L)
  - `ephemeris/solar-ephemeris.ts` (357L) — first file in new `src/lib/ephemeris/` dir
  - `ephemeris/degree-calendar-map.ts` (405L) — depends on solar-ephemeris
  - `planetary-config-helper.ts` (240L) — depends on Session 3's agent-types, unified-agent-types, astrological-data, moon-phase-calculator
- **Total**: 5 files, ~1772 LOC
- **Skipped** (already in target at identical content): `enhanced-astronomical-calculator.ts` (881L) and `calculate-transits.ts` (56L) — ported in an earlier session

## Commit-by-commit

1. `381a229` — 4 astronomy/ephemeris leaves (`planetary-motion-tracker`, `planetary-api-client`, `ephemeris/solar-ephemeris`, `ephemeris/degree-calendar-map`)
2. `0ec9b7a` — `planetary-config-helper` (after Session 3 deps available)

## Gaps / surprises

- **TS 5.9 inference gotcha returned** — `ephemeris/degree-calendar-map.ts` needed one explicit `Array<T>` annotation on a `const days = []`, same pattern as Session 3's `elemental-reinforcement`. Now confirmed-recurring; Session 5 prompt notes this up-front.
- **`planetary-api-client.ts` env**: uses `NEXT_PUBLIC_BACKEND_URL` which is already wired in CLAUDE.md (`https://whattoeatnext-production.up.railway.app`). No env additions.
- **10 naming-convention warnings on `solar-ephemeris.ts`** (`M_rad`, `eq_time`, `lambda_rad`, etc.) are intentional carry-overs. These are snake_case astronomical variables that match published formula notation; renaming would obscure the math. Left as warnings.
- **`lint --fix` scope creep (confirmed pattern)** — for the second time, `bun run lint --fix` touched 10 pre-existing files (Session 2 components + admin API routes). Reverted to keep PR scope tight. Worth fixing properly in a one-off cleanup PR rather than repeating this dance every session — flagged in the Session 5 prompt.

## Verification

- [x] `bun run typecheck` clean after each individual port
- [x] `bun run lint` clean (0 errors; 37 warnings under the 10k cap, 13 in Session 3/4 ports, all intentional or pre-existing)
- [x] `bun run build` clean
- [x] Pre-commit `bun run verify` passes on both commits

## Test plan

- [ ] Merge #419 (Session 3) first; this PR's base auto-retargets to `master`
- [ ] Confirm `master` typecheck/lint/build remain clean after both merge
- [ ] Spot-check `planetary-api-client` against production `NEXT_PUBLIC_BACKEND_URL` endpoint
- [ ] Session 5 plan needs adjustment — see followup prompt for the updated scope

## Reflection — what I'd do differently next session

Two patterns worth lifting up: (1) `bun run lint --fix` on the whole codebase is a tax — twice now I've had to revert 10 pre-existing files. Next session, scope the fix to the new files only (`eslint --fix src/lib/<new-files>`) or stage-then-fix. (2) The TS 5.9 evolving-array issue is now predictable: any verbatim port containing `const x = []` needs proactive annotation. Worth a sed-grep check before each port instead of waiting for the typecheck failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)