### PR TITLE
feat(wten-migration): monica + alchemy core (session 5)

### DIFF
--- a/src/lib/alchemizer.ts
+++ b/src/lib/alchemizer.ts
@@ -1,0 +1,1124 @@
+// Alchemizer Engine
+// This module implements the core alchemical calculation system
+
+import { generateAccurateHoroscope } from './monica/horoscope-generator'
+import { recordElementalLogicMode } from './observability-legacy'
+import { performanceCache, createBirthInfoHash } from './performance-cache'
+
+// Zodiac signs indexed by number
+export const signs: Record<number, string> = {
+  0: 'Aries',
+  1: 'Taurus',
+  2: 'Gemini',
+  3: 'Cancer',
+  4: 'Leo',
+  5: 'Virgo',
+  6: 'Libra',
+  7: 'Scorpio',
+  8: 'Sagittarius',
+  9: 'Capricorn',
+  10: 'Aquarius',
+  11: 'Pisces',
+}
+
+// Reverse mapping for convenience
+export const signIndices: Record<string, number> = Object.entries(signs).reduce(
+  (acc, [key, value]) => ({ ...acc, [value]: parseInt(key, 10) }),
+  {}
+)
+
+// Planet information including dignity effects and elemental properties
+export const planetInfo: Record<string, any> = {
+  Sun: {
+    'Dignity Effect': {
+      Leo: 1,
+      Aries: 2,
+      Aquarius: -1,
+      Libra: -2,
+    },
+    Elements: ['Fire', 'Fire'],
+    Alchemy: {
+      Spirit: 1,
+      Essence: 0,
+      Matter: 0,
+      Substance: 0,
+    },
+    'Diurnal Element': 'Fire',
+    'Nocturnal Element': 'Fire',
+  },
+  Moon: {
+    'Dignity Effect': {
+      Cancer: 1,
+      Taurus: 2,
+      Capricorn: -1,
+      Scorpio: -2,
+    },
+    Elements: ['Water', 'Water'],
+    Alchemy: {
+      Spirit: 0,
+      Essence: 1,
+      Matter: 1,
+      Substance: 0,
+    },
+    'Diurnal Element': 'Water',
+    'Nocturnal Element': 'Water',
+  },
+  Mercury: {
+    'Dignity Effect': {
+      Gemini: 1,
+      Virgo: 3,
+      Sagittarius: 1,
+      Pisces: -3,
+    },
+    Elements: ['Air', 'Earth'],
+    Alchemy: {
+      Spirit: 1,
+      Essence: 0,
+      Matter: 0,
+      Substance: 1,
+    },
+    'Diurnal Element': 'Air',
+    'Nocturnal Element': 'Earth',
+  },
+  Venus: {
+    'Dignity Effect': {
+      Libra: 1,
+      Taurus: 1,
+      Pisces: 2,
+      Aries: -1,
+      Scorpio: -1,
+      Virgo: -2,
+    },
+    Elements: ['Water', 'Earth'],
+    Alchemy: {
+      Spirit: 0,
+      Essence: 1,
+      Matter: 1,
+      Substance: 0,
+    },
+    'Diurnal Element': 'Water',
+    'Nocturnal Element': 'Earth',
+  },
+  Mars: {
+    'Dignity Effect': {
+      Aries: 1,
+      Scorpio: 1,
+      Capricorn: 2,
+      Taurus: -1,
+      Libra: -1,
+      Cancer: -2,
+    },
+    Elements: ['Fire', 'Water'],
+    Alchemy: {
+      Spirit: 0,
+      Essence: 1,
+      Matter: 1,
+      Substance: 0,
+    },
+    'Diurnal Element': 'Fire',
+    'Nocturnal Element': 'Water',
+  },
+  Jupiter: {
+    'Dignity Effect': {
+      Pisces: 1,
+      Sagittarius: 1,
+      Cancer: 2,
+      Gemini: -1,
+      Virgo: -1,
+      Capricorn: -2,
+    },
+    Elements: ['Air', 'Fire'],
+    Alchemy: {
+      Spirit: 1,
+      Essence: 1,
+      Matter: 0,
+      Substance: 0,
+    },
+    'Diurnal Element': 'Air',
+    'Nocturnal Element': 'Fire',
+  },
+  Saturn: {
+    'Dignity Effect': {
+      Aquarius: 1,
+      Capricorn: 1,
+      Libra: 2,
+      Cancer: -1,
+      Leo: -1,
+      Aries: -2,
+    },
+    Elements: ['Air', 'Earth'],
+    Alchemy: {
+      Spirit: 1,
+      Essence: 0,
+      Matter: 1,
+      Substance: 0,
+    },
+    'Diurnal Element': 'Air',
+    'Nocturnal Element': 'Earth',
+  },
+  Uranus: {
+    'Dignity Effect': {
+      Aquarius: 1,
+      Scorpio: 2,
+      Taurus: -3,
+    },
+    Elements: ['Water', 'Air'],
+    Alchemy: {
+      Spirit: 0,
+      Essence: 1,
+      Matter: 1,
+      Substance: 0,
+    },
+    'Diurnal Element': 'Water',
+    'Nocturnal Element': 'Air',
+  },
+  Neptune: {
+    'Dignity Effect': {
+      Pisces: 1,
+      Cancer: 2,
+      Virgo: -1,
+      Capricorn: -2,
+    },
+    Elements: ['Water', 'Water'],
+    Alchemy: {
+      Spirit: 0,
+      Essence: 1,
+      Matter: 0,
+      Substance: 1,
+    },
+    'Diurnal Element': 'Water',
+    'Nocturnal Element': 'Water',
+  },
+  Pluto: {
+    'Dignity Effect': {
+      Scorpio: 1,
+      Leo: 2,
+      Taurus: -1,
+      Aquarius: -2,
+    },
+    Elements: ['Earth', 'Water'],
+    Alchemy: {
+      Spirit: 0,
+      Essence: 1,
+      Matter: 1,
+      Substance: 0,
+    },
+    'Diurnal Element': 'Earth',
+    'Nocturnal Element': 'Water',
+  },
+  Ascendant: {
+    'Diurnal Element': 'Earth',
+    'Nocturnal Element': 'Earth',
+  },
+}
+
+// Sign information
+export const signInfo: Record<string, any> = {
+  Aries: {
+    Element: 'Fire',
+    Ruler: 'Mars',
+    Modality: 'Cardinal',
+  },
+  Taurus: {
+    Element: 'Earth',
+    Ruler: 'Venus',
+    Modality: 'Fixed',
+  },
+  Gemini: {
+    Element: 'Air',
+    Ruler: 'Mercury',
+    Modality: 'Mutable',
+  },
+  Cancer: {
+    Element: 'Water',
+    Ruler: 'Moon',
+    Modality: 'Cardinal',
+  },
+  Leo: {
+    Element: 'Fire',
+    Ruler: 'Sun',
+    Modality: 'Fixed',
+  },
+  Virgo: {
+    Element: 'Earth',
+    Ruler: 'Mercury',
+    Modality: 'Mutable',
+  },
+  Libra: {
+    Element: 'Air',
+    Ruler: 'Venus',
+    Modality: 'Cardinal',
+  },
+  Scorpio: {
+    Element: 'Water',
+    Ruler: 'Mars',
+    Modality: 'Fixed',
+  },
+  Sagittarius: {
+    Element: 'Fire',
+    Ruler: 'Jupiter',
+    Modality: 'Mutable',
+  },
+  Capricorn: {
+    Element: 'Earth',
+    Ruler: 'Saturn',
+    Modality: 'Cardinal',
+  },
+  Aquarius: {
+    Element: 'Air',
+    Ruler: 'Saturn',
+    Modality: 'Fixed',
+  },
+  Pisces: {
+    Element: 'Water',
+    Ruler: 'Jupiter',
+    Modality: 'Mutable',
+  },
+}
+
+// Helper function to capitalize strings
+export function capitalize(string: string): string {
+  return string.charAt(0).toUpperCase() + string.slice(1)
+}
+
+// Create an empty element object
+export function createElementObject(): Record<string, number> {
+  return {
+    Fire: 0,
+    Water: 0,
+    Air: 0,
+    Earth: 0,
+  }
+}
+
+// Combine two element objects
+export function combineElementObjects(
+  element_object_1: Record<string, number>,
+  element_object_2: Record<string, number>
+): Record<string, number> {
+  const combined_object = createElementObject()
+  combined_object['Fire'] = element_object_1['Fire'] + element_object_2['Fire']
+  combined_object['Water'] = element_object_1['Water'] + element_object_2['Water']
+  combined_object['Air'] = element_object_1['Air'] + element_object_2['Air']
+  combined_object['Earth'] = element_object_1['Earth'] + element_object_2['Earth']
+  return combined_object
+}
+
+// Get ranking of elements by value
+export function getElementRanking(
+  element_object: Record<string, number>,
+  rank = 1
+): Record<number, string> {
+  const element_rank_dict: Record<number, string> = {
+    1: '',
+    2: '',
+    3: '',
+    4: '',
+  }
+
+  let largest_element_value = -Infinity
+  let largest_element = ''
+
+  // Find the largest element
+  for (const element in element_object) {
+    if (element_object[element] > largest_element_value) {
+      largest_element_value = element_object[element]
+      largest_element = element
+    }
+  }
+
+  element_rank_dict[1] = largest_element
+
+  // For a complete implementation, you would continue to find 2nd, 3rd, and 4th
+  // largest elements, but this simplified version just returns the dominant element
+
+  return element_rank_dict
+}
+
+// Get sum of all element values
+export function getAbsoluteElementValue(element_object: Record<string, number>): number {
+  return (
+    element_object['Fire'] +
+    element_object['Water'] +
+    element_object['Air'] +
+    element_object['Earth']
+  )
+}
+
+// Calculate elemental compatibility according to elementallogic principles
+export function getElementalCompatibility(element1: string, element2: string): number {
+  // Same element has highest compatibility
+  if (element1 === element2) {
+    return 0.9 // Same element has high compatibility
+  }
+
+  // All different element combinations have good compatibility
+  return 0.7 // Different elements have good compatibility
+}
+
+// Get the complementary element (according to elementallogic, each element complements itself)
+export function getComplementaryElement(element: string): string {
+  return element // Each element complements itself most strongly
+}
+
+// Main alchemizer function
+export function alchemize(
+  birth_info: Record<string, any>,
+  horoscope_dict: Record<string, any>
+): Record<string, any> {
+  // Feature flag: additive-only elemental logic (no negative penalties)
+  // Prefer env var if present; default false to preserve legacy behavior until rollout
+  // Runtime UI override via localStorage if available
+  let uiOverride: boolean | null = null
+  try {
+    if (typeof window !== 'undefined' && window?.localStorage) {
+      const v = window.localStorage.getItem('additiveOnlyElements')
+      if (v === 'true') uiOverride = true
+      else if (v === 'false') uiOverride = false
+    }
+  } catch {}
+
+  const envFlag =
+    (typeof process !== 'undefined' &&
+      process.env?.NEXT_PUBLIC_ADDITIVE_ONLY_ELEMENTS === 'true') ||
+    false
+  const ADDITIVE_ONLY_ELEMENTS = uiOverride !== null ? uiOverride : envFlag
+  // Emit analytics for A/B tracking
+  recordElementalLogicMode(ADDITIVE_ONLY_ELEMENTS ? 'additive' : 'legacy')
+  // Check cache first
+  const birthInfoHash = createBirthInfoHash(birth_info)
+  const cachedResult = performanceCache.getAlchemicalData(birthInfoHash)
+  if (cachedResult) {
+    return cachedResult
+  }
+
+  // Simplified implementation for UI integration
+  const horoscope = horoscope_dict['tropical'] || horoscope_dict
+  const silent_mode = true
+
+  // Determine if time is diurnal or nocturnal
+  let diurnal_or_nocturnal = 'Diurnal'
+  if (birth_info['hour'] < 5 || birth_info['hour'] > 17) {
+    diurnal_or_nocturnal = 'Nocturnal'
+  }
+
+  // Create metadata and initial alchmInfo structure
+  const metadata: Record<string, any> = {
+    name: 'Alchm NFT',
+    description:
+      'Alchm is unlike any other NFT collection on Earth. Just like people, no two Alchm NFTs are the same, and there is no limit on how many can exist. Your Alchm NFT has no random features, and is completely customized and unique to you. By minting, you gain permanent access to limitless information about your astrology and identity through our sites and apps.',
+    attributes: [],
+  }
+
+  // Initialize the alchemical information object
+  const alchmInfo: Record<string, any> = {
+    'Sun Sign': '',
+    'Major Arcana': { Sun: '', Ascendant: '' },
+    'Minor Arcana': { Decan: '', Cusp: 'None' },
+    'Alchemy Effects': {
+      'Total Spirit': 0,
+      'Total Essence': 0,
+      'Total Day Essence': 0,
+      'Total Matter': 0,
+      'Total Substance': 0,
+      'Total Night Essence': 0,
+    },
+    'Chart Ruler': '',
+    'Total Dignity Effect': createElementObject(),
+    'Total Decan Effect': createElementObject(),
+    'Total Degree Effect': createElementObject(),
+    'Total Aspect Effect': createElementObject(),
+    'Total Elemental Effect': createElementObject(),
+    'Total Effect Value': createElementObject(),
+    'Dominant Element': '',
+    'Total Chart Absolute Effect': 0,
+    Heat: 0,
+    Entropy: 0,
+    Reactivity: 0,
+    Energy: 0,
+    '# Cardinal': 0,
+    '# Fixed': 0,
+    '# Mutable': 0,
+    '% Cardinal': 0,
+    '% Fixed': 0,
+    '% Mutable': 0,
+    'Dominant Modality': '',
+    'All Conjunctions': [],
+    'All Trines': [],
+    'All Squares': [],
+    'All Oppositions': [],
+    Stelliums: [],
+    Signs: {},
+    Planets: {},
+  }
+
+  // Initialize the Signs and Planets objects
+  Object.values(signs).forEach(sign => {
+    alchmInfo['Signs'][sign] = {}
+  })
+
+  Object.keys(planetInfo).forEach(planet => {
+    alchmInfo['Planets'][planet] = {}
+  })
+
+  // Add Ascendant to Planets if not already present
+  if (!alchmInfo['Planets']['Ascendant']) {
+    alchmInfo['Planets']['Ascendant'] = {}
+  }
+
+  // Process Ascendant information first (if available)
+  if (horoscope.Ascendant?.Sign?.label) {
+    const rising_sign = horoscope.Ascendant.Sign.label
+    // Set Ascendant element based on rising sign
+    const rising_element = signInfo[rising_sign]?.Element || 'Earth'
+
+    // Update alchmInfo with Ascendant data
+    alchmInfo['Planets']['Ascendant']['Diurnal Element'] = rising_element
+    alchmInfo['Planets']['Ascendant']['Nocturnal Element'] = rising_element
+
+    // Set Major Arcana for Ascendant if available
+    if (signInfo[rising_sign]?.['Major Tarot Card']) {
+      alchmInfo['Major Arcana']['Ascendant'] = signInfo[rising_sign]['Major Tarot Card']
+    }
+  }
+
+  // Process Sun placement to get Sun Sign and Chart Ruler
+  let sun_sign = ''
+  if (horoscope.CelestialBodies?.all) {
+    const sunData = horoscope.CelestialBodies.all.find((p: any) => p.label === 'Sun')
+    if (sunData?.Sign?.label) {
+      sun_sign = sunData.Sign.label
+      alchmInfo['Sun Sign'] = sun_sign
+      alchmInfo['Chart Ruler'] = signInfo[sun_sign]?.Ruler || ''
+
+      // Set Major Arcana for Sun if available
+      if (signInfo[sun_sign]?.['Major Tarot Card']) {
+        alchmInfo['Major Arcana']['Sun'] = signInfo[sun_sign]['Major Tarot Card']
+      }
+    }
+  }
+
+  // Calculate elemental values and alchemy effects from planetary positions
+  if (horoscope.CelestialBodies?.all) {
+    horoscope.CelestialBodies.all.forEach((planet_data: any) => {
+      const planet = planet_data.label
+      const sign = planet_data.Sign?.label
+
+      if (planet && sign && signInfo[sign]) {
+        const element = signInfo[sign].Element
+        const modality = signInfo[sign].Modality
+
+        // Update modality counts
+        if (modality === 'Cardinal') alchmInfo['# Cardinal'] += 1
+        else if (modality === 'Fixed') alchmInfo['# Fixed'] += 1
+        else if (modality === 'Mutable') alchmInfo['# Mutable'] += 1
+
+        // Update element values
+        if (element) {
+          alchmInfo['Total Effect Value'][element] += 1
+
+          // Add elemental effect from planet-sign affinity (using core alchemizer logic)
+          if (planetInfo[planet]) {
+            let elemental_effect_value = 0
+
+            // Different logic for Sun/Moon vs other planets
+            if (planet === 'Sun' || planet === 'Moon') {
+              // For Sun/Moon: use time-based diurnal/nocturnal element
+              const planetElement =
+                diurnal_or_nocturnal === 'Diurnal'
+                  ? planetInfo[planet]['Diurnal Element']
+                  : planetInfo[planet]['Nocturnal Element']
+
+              if (planetElement === element) {
+                elemental_effect_value = 1
+              }
+            } else {
+              // For other planets: check both diurnal and nocturnal elements
+              if (planetInfo[planet]['Diurnal Element'] === element) {
+                elemental_effect_value = 1
+              } else if (planetInfo[planet]['Nocturnal Element'] === element) {
+                elemental_effect_value = 1
+              } else {
+                // Elemental logic compliance: if additive-only is enabled, do not penalize mismatches
+                elemental_effect_value = ADDITIVE_ONLY_ELEMENTS ? 0 : -1
+              }
+            }
+
+            // Apply the elemental effect
+            alchmInfo['Total Effect Value'][element] += elemental_effect_value
+
+            // Store the planet's sign and element
+            if (!alchmInfo['Planets'][planet]) {
+              alchmInfo['Planets'][planet] = {}
+            }
+            alchmInfo['Planets'][planet]['Sign'] = sign
+            alchmInfo['Planets'][planet]['Element'] = element
+
+            // Calculate planetary dignities and effects
+            const dignity_effect = planetInfo[planet]['Dignity Effect']?.[sign] || 0
+            let total_effect_multiplier = 1
+
+            // Apply dignity effect to total multiplier
+            if (dignity_effect) {
+              total_effect_multiplier += Math.abs(dignity_effect) * 0.1
+            }
+
+            // Store the total effect multiplier
+            alchmInfo['Planets'][planet]['Total Effect Multiplier'] = total_effect_multiplier
+
+            // Calculate alchemical values for this planet (following core alchemizer logic)
+            if (planetInfo[planet]['Alchemy']) {
+              const base_alchemy_values = planetInfo[planet]['Alchemy']
+              const alchemy_values: Record<string, any> = {}
+
+              // Initialize Day/Night Alchemy tracking for this planet
+              if (!alchmInfo['Planets'][planet]['Alchemy Effects']) {
+                alchmInfo['Planets'][planet]['Alchemy Effects'] = {}
+              }
+
+              // Spirit - goes to Day Alchemy
+              if (base_alchemy_values['Spirit']) {
+                const spirit_bonus = base_alchemy_values['Spirit'] * total_effect_multiplier
+                alchemy_values['Spirit'] = spirit_bonus
+                alchmInfo['Alchemy Effects']['Total Spirit'] += spirit_bonus
+                alchemy_values['Day Alchemy'] = { Spirit: spirit_bonus }
+              }
+
+              // Essence - goes to Night if planet has Spirit, Day if not
+              if (base_alchemy_values['Essence']) {
+                const essence_bonus = base_alchemy_values['Essence'] * total_effect_multiplier
+                alchemy_values['Essence'] = essence_bonus
+                alchmInfo['Alchemy Effects']['Total Essence'] += essence_bonus
+
+                if (alchemy_values['Spirit']) {
+                  alchemy_values['Night Alchemy'] = { Essence: essence_bonus }
+                  alchmInfo['Alchemy Effects']['Total Night Essence'] += essence_bonus
+                } else {
+                  alchemy_values['Day Alchemy'] = { Essence: essence_bonus }
+                  alchmInfo['Alchemy Effects']['Total Day Essence'] += essence_bonus
+                }
+              }
+
+              // Matter - goes to Night Alchemy
+              if (base_alchemy_values['Matter']) {
+                const matter_bonus = base_alchemy_values['Matter'] * total_effect_multiplier
+                alchemy_values['Matter'] = matter_bonus
+                alchmInfo['Alchemy Effects']['Total Matter'] += matter_bonus
+                alchemy_values['Night Alchemy'] = { Matter: matter_bonus }
+              }
+
+              // Substance - goes to Night Alchemy
+              if (base_alchemy_values['Substance']) {
+                const substance_bonus = base_alchemy_values['Substance'] * total_effect_multiplier
+                alchemy_values['Substance'] = substance_bonus
+                alchmInfo['Alchemy Effects']['Total Substance'] += substance_bonus
+                alchemy_values['Night Alchemy'] = { Substance: substance_bonus }
+              }
+
+              // Store the planet's alchemy effects
+              alchmInfo['Planets'][planet]['Alchemy Effects'] = alchemy_values
+            }
+          }
+        }
+      }
+    })
+  }
+
+  // Handle aspects to further modify alchemical values
+  if (horoscope.Aspects?.points) {
+    Object.entries(horoscope.Aspects.points).forEach(([_planetKey, aspects]) => {
+      if (Array.isArray(aspects)) {
+        aspects.forEach((aspect: any) => {
+          const aspectType = aspect.aspectKey
+          const planet1 = aspect.point1Label
+          const planet2 = aspect.point2Label
+
+          // Apply aspect effects to alchemical values
+          // Conjunctions enhance, squares challenge, trines harmonize, oppositions polarize
+          let aspectMultiplier = 1.0
+
+          if (aspectType === 'conjunction') aspectMultiplier = 1.2
+          else if (aspectType === 'trine') aspectMultiplier = 1.1
+          else if (aspectType === 'square') aspectMultiplier = 0.9
+          else if (aspectType === 'opposition') aspectMultiplier = 0.8
+
+          // Only apply if both planets have alchemical values
+          if (planetInfo[planet1]?.['Alchemy'] && planetInfo[planet2]?.['Alchemy']) {
+            // Get the average of both planets' alchemical values and apply the aspect multiplier
+            for (const key of ['Spirit', 'Essence', 'Matter', 'Substance']) {
+              const value1 = planetInfo[planet1]['Alchemy'][key] || 0
+              const value2 = planetInfo[planet2]['Alchemy'][key] || 0
+
+              // Add a small bonus for aspects between planets with matching alchemical properties
+              if (value1 > 0 && value2 > 0) {
+                alchmInfo['Alchemy Effects'][`Total ${key}`] += 0.1 * aspectMultiplier
+              }
+            }
+          }
+        })
+      }
+    })
+  }
+
+  // Determine dominant element
+  alchmInfo['Dominant Element'] = getElementRanking(alchmInfo['Total Effect Value'])[1]
+
+  // Calculate percentages for modalities
+  const total_planets = alchmInfo['# Cardinal'] + alchmInfo['# Fixed'] + alchmInfo['# Mutable']
+  if (total_planets > 0) {
+    alchmInfo['% Cardinal'] = alchmInfo['# Cardinal'] / total_planets
+    alchmInfo['% Fixed'] = alchmInfo['# Fixed'] / total_planets
+    alchmInfo['% Mutable'] = alchmInfo['# Mutable'] / total_planets
+
+    // Determine dominant modality
+    if (
+      alchmInfo['% Cardinal'] >= alchmInfo['% Fixed'] &&
+      alchmInfo['% Cardinal'] >= alchmInfo['% Mutable']
+    ) {
+      alchmInfo['Dominant Modality'] = 'Cardinal'
+    } else if (
+      alchmInfo['% Fixed'] >= alchmInfo['% Cardinal'] &&
+      alchmInfo['% Fixed'] >= alchmInfo['% Mutable']
+    ) {
+      alchmInfo['Dominant Modality'] = 'Fixed'
+    } else if (
+      alchmInfo['% Mutable'] >= alchmInfo['% Cardinal'] &&
+      alchmInfo['% Mutable'] >= alchmInfo['% Fixed']
+    ) {
+      alchmInfo['Dominant Modality'] = 'Mutable'
+    }
+  }
+
+  // Calculate Heat, Entropy, Reactivity and Energy
+  const fire = alchmInfo['Total Effect Value']['Fire'] || 0
+  const water = alchmInfo['Total Effect Value']['Water'] || 0
+  const air = alchmInfo['Total Effect Value']['Air'] || 0
+  const earth = alchmInfo['Total Effect Value']['Earth'] || 0
+  const spirit = alchmInfo['Alchemy Effects']['Total Spirit'] || 0
+  const essence = alchmInfo['Alchemy Effects']['Total Essence'] || 0
+  const matter = alchmInfo['Alchemy Effects']['Total Matter'] || 0
+  const substance = alchmInfo['Alchemy Effects']['Total Substance'] || 0
+
+  // Prevent division by zero in calculations
+  const denominator = substance + essence + matter + water + air + earth || 1
+  const earthWaterDenominator = matter + earth + water || 1
+
+  alchmInfo['Heat'] = (spirit ** 2 + fire ** 2) / denominator ** 2 || 0
+  alchmInfo['Entropy'] =
+    (spirit ** 2 + substance ** 2 + fire ** 2 + air ** 2) / earthWaterDenominator ** 2 || 0
+  alchmInfo['Reactivity'] =
+    (spirit ** 2 + substance ** 2 + essence ** 2 + fire ** 2 + air ** 2 + water ** 2) /
+      ((matter + earth) ** 2 || 1) || 0
+  alchmInfo['Energy'] = alchmInfo['Heat'] - alchmInfo['Reactivity'] * alchmInfo['Entropy'] || 0
+
+  // Calculate A-Number: Total Spirit + Total Essence + Total Matter + Total Substance
+  alchmInfo['Alchemy Effects']['A #'] = spirit + essence + matter + substance
+
+  // Cache the result before returning
+  performanceCache.setAlchemicalData(birthInfoHash, alchmInfo)
+
+  return alchmInfo
+}
+
+// Function to generate alchemical data for the current moment
+// Simple cache for current moment calculations (5-minute TTL)
+const currentMomentCache = new Map<string, { data: any; timestamp: number }>()
+const CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
+export async function generateAlchmForCurrentMoment(): Promise<Record<string, any>> {
+  try {
+    console.log('Generating alchemical data for current moment...')
+
+    // Get current date and time
+    const now = new Date()
+
+    // Create cache key (rounded to 5-minute intervals for efficiency)
+    const roundedTime = Math.floor(now.getTime() / (5 * 60 * 1000)) * (5 * 60 * 1000)
+    const cacheKey = `current-moment-${roundedTime}`
+
+    // Check cache first
+    const cached = currentMomentCache.get(cacheKey)
+    if (cached && now.getTime() - cached.timestamp < CACHE_TTL) {
+      console.log('Using cached alchemical data for current moment')
+      return cached.data
+    }
+
+    // Format date as YYYY-MM-DD
+    const year = now.getFullYear()
+    const month = String(now.getMonth() + 1).padStart(2, '0')
+    const day = String(now.getDate()).padStart(2, '0')
+    const dateString = `${year}-${month}-${day}`
+
+    // Format time as HH:MM
+    const hour = String(now.getHours()).padStart(2, '0')
+    const minute = String(now.getMinutes()).padStart(2, '0')
+    const timeString = `${hour}:${minute}`
+
+    console.log(`Current datetime: ${dateString} ${timeString}`)
+
+    // Create birth info object for the current moment
+    const currentMomentInfo = {
+      year,
+      month: parseInt(month, 10),
+      day: parseInt(day, 10),
+      hour: parseInt(hour, 10),
+      minute: parseInt(minute, 10),
+      latitude: 0, // Using equator as default
+      longitude: 0, // Using prime meridian as default
+    }
+
+    // Import the getCurrentPlanetaryPositions function to get accurate positions
+    const { getCurrentPlanetaryPositions } = await import('./calculate-transits')
+
+    console.log('Fetching current planetary positions...')
+    const currentPositions = getCurrentPlanetaryPositions()
+
+    if (!currentPositions || Object.keys(currentPositions).length === 0) {
+      throw new Error('Failed to get current planetary positions')
+    }
+
+    console.log('Current positions obtained:', Object.keys(currentPositions).join(', '))
+
+    // Ensure all required planets are present
+    const requiredPlanets = [
+      'Sun',
+      'Moon',
+      'Mercury',
+      'Venus',
+      'Mars',
+      'Jupiter',
+      'Saturn',
+      'Uranus',
+      'Neptune',
+      'Pluto',
+      'Ascendant',
+    ]
+    for (const planet of requiredPlanets) {
+      if (!currentPositions[planet]) {
+        console.error(`Missing position data for ${planet}`)
+        currentPositions[planet] = { sign: 'Aries', degree: 0, retrograde: false } // Fallback only if absolutely necessary
+      }
+    }
+
+    // Ensure each planet has a sign and degree
+    Object.entries(currentPositions).forEach(([planet, data]) => {
+      if (!data.sign) {
+        console.error(`Missing sign for ${planet}, using fallback`)
+        currentPositions[planet].sign = 'Aries' // Fallback
+      }
+      if (data.degree === undefined) {
+        console.error(`Missing degree for ${planet}, using fallback`)
+        currentPositions[planet].degree = 0 // Fallback
+      }
+    })
+
+    // Log what we're working with
+    console.log('Building horoscope with the following positions:')
+    Object.entries(currentPositions).forEach(([planet, data]) => {
+      console.log(`${planet}: ${data.sign} ${data.degree}°`)
+    })
+
+    // Create a horoscope object using the calculated positions
+    const horoscope = {
+      tropical: {
+        Ascendant: {
+          Sign: {
+            label: currentPositions['Ascendant'].sign,
+          },
+        },
+        CelestialBodies: {
+          all: [
+            { label: 'Sun', Sign: { label: currentPositions['Sun'].sign }, House: { label: '10' } },
+            {
+              label: 'Moon',
+              Sign: { label: currentPositions['Moon'].sign },
+              House: { label: '9' },
+            },
+            {
+              label: 'Mercury',
+              Sign: { label: currentPositions['Mercury'].sign },
+              House: { label: '11' },
+            },
+            {
+              label: 'Venus',
+              Sign: { label: currentPositions['Venus'].sign },
+              House: { label: '12' },
+            },
+            {
+              label: 'Mars',
+              Sign: { label: currentPositions['Mars'].sign },
+              House: { label: '7' },
+            },
+            {
+              label: 'Jupiter',
+              Sign: { label: currentPositions['Jupiter'].sign },
+              House: { label: '4' },
+            },
+            {
+              label: 'Saturn',
+              Sign: { label: currentPositions['Saturn'].sign },
+              House: { label: '5' },
+            },
+            {
+              label: 'Uranus',
+              Sign: { label: currentPositions['Uranus'].sign },
+              House: { label: '6' },
+            },
+            {
+              label: 'Neptune',
+              Sign: { label: currentPositions['Neptune'].sign },
+              House: { label: '7' },
+            },
+            {
+              label: 'Pluto',
+              Sign: { label: currentPositions['Pluto'].sign },
+              House: { label: '2' },
+            },
+          ],
+          sun: {
+            ChartPosition: {
+              Ecliptic: { ArcDegreesFormatted30: `${currentPositions['Sun'].degree}°` },
+            },
+          },
+          moon: {
+            ChartPosition: {
+              Ecliptic: { ArcDegreesFormatted30: `${currentPositions['Moon'].degree}°` },
+            },
+          },
+          mercury: {
+            ChartPosition: {
+              Ecliptic: { ArcDegreesFormatted30: `${currentPositions['Mercury'].degree}°` },
+            },
+          },
+          venus: {
+            ChartPosition: {
+              Ecliptic: { ArcDegreesFormatted30: `${currentPositions['Venus'].degree}°` },
+            },
+          },
+          mars: {
+            ChartPosition: {
+              Ecliptic: { ArcDegreesFormatted30: `${currentPositions['Mars'].degree}°` },
+            },
+          },
+          jupiter: {
+            ChartPosition: {
+              Ecliptic: { ArcDegreesFormatted30: `${currentPositions['Jupiter'].degree}°` },
+            },
+          },
+          saturn: {
+            ChartPosition: {
+              Ecliptic: { ArcDegreesFormatted30: `${currentPositions['Saturn'].degree}°` },
+            },
+          },
+          uranus: {
+            ChartPosition: {
+              Ecliptic: { ArcDegreesFormatted30: `${currentPositions['Uranus'].degree}°` },
+            },
+          },
+          neptune: {
+            ChartPosition: {
+              Ecliptic: { ArcDegreesFormatted30: `${currentPositions['Neptune'].degree}°` },
+            },
+          },
+          pluto: {
+            ChartPosition: {
+              Ecliptic: { ArcDegreesFormatted30: `${currentPositions['Pluto'].degree}°` },
+            },
+          },
+        },
+        Aspects: {
+          points: generateCurrentAspects(currentPositions),
+        },
+      },
+    }
+
+    console.log('Calculating alchemical data...')
+    // Calculate alchemical data using the alchemize function
+    const alchmData = alchemize(currentMomentInfo, horoscope)
+
+    // Log the calculated values
+    console.log('Alchemical calculations complete:')
+    console.log(`Spirit: ${alchmData['Alchemy Effects']['Total Spirit']}`)
+    console.log(`Essence: ${alchmData['Alchemy Effects']['Total Essence']}`)
+    console.log(`Matter: ${alchmData['Alchemy Effects']['Total Matter']}`)
+    console.log(`Substance: ${alchmData['Alchemy Effects']['Total Substance']}`)
+
+    // Cache the result for future requests
+    currentMomentCache.set(cacheKey, {
+      data: alchmData,
+      timestamp: now.getTime(),
+    })
+
+    // Clean up old cache entries (keep only last 10)
+    if (currentMomentCache.size > 10) {
+      const oldestKey = currentMomentCache.keys().next().value
+      if (oldestKey !== undefined) {
+        currentMomentCache.delete(oldestKey)
+      }
+    }
+
+    return alchmData
+  } catch (error) {
+    console.error('Error generating alchemical data:', error)
+    throw error
+  }
+}
+
+// Helper function to generate aspects based on current planetary positions
+function generateCurrentAspects(positions: Record<string, any>): Record<string, any> {
+  const aspects: Record<string, any> = {}
+  const planets = [
+    'sun',
+    'moon',
+    'mercury',
+    'venus',
+    'mars',
+    'jupiter',
+    'saturn',
+    'uranus',
+    'neptune',
+    'pluto',
+  ]
+
+  // Initialize aspect arrays for each planet
+  planets.forEach(planet => {
+    aspects[planet] = []
+  })
+
+  // Calculate aspects between planets
+  for (let i = 0; i < planets.length; i++) {
+    const planet1 = planets[i]
+    const planet1Cap = planet1.charAt(0).toUpperCase() + planet1.slice(1)
+
+    for (let j = i + 1; j < planets.length; j++) {
+      const planet2 = planets[j]
+      const planet2Cap = planet2.charAt(0).toUpperCase() + planet2.slice(1)
+
+      // Skip if either planet's position is missing
+      if (!positions[planet1Cap] || !positions[planet2Cap]) continue
+
+      // Get sign indices (0-11 for Aries-Pisces)
+      const signIndices = getSignIndices()
+      const planet1SignIndex = signIndices[positions[planet1Cap].sign] || 0
+      const planet2SignIndex = signIndices[positions[planet2Cap].sign] || 0
+
+      // Calculate aspect type based on sign relationship
+      const difference = Math.abs(planet1SignIndex - planet2SignIndex)
+
+      let aspectType = ''
+
+      // Simple aspect calculation based on sign relationships
+      if (difference === 0) {
+        aspectType = 'conjunction'
+      } else if (difference === 4 || difference === 8) {
+        aspectType = 'trine'
+      } else if (difference === 3 || difference === 9) {
+        aspectType = 'square'
+      } else if (difference === 6) {
+        aspectType = 'opposition'
+      } else {
+        continue // No significant aspect
+      }
+
+      // Add the aspect to both planets' arrays
+      aspects[planet1].push({
+        aspectKey: aspectType,
+        point1Label: planet1Cap,
+        point2Label: planet2Cap,
+      })
+
+      aspects[planet2].push({
+        aspectKey: aspectType,
+        point1Label: planet2Cap,
+        point2Label: planet1Cap,
+      })
+    }
+  }
+
+  return aspects
+}
+
+// Helper function to get sign indices
+function getSignIndices(): Record<string, number> {
+  return {
+    Aries: 0,
+    Taurus: 1,
+    Gemini: 2,
+    Cancer: 3,
+    Leo: 4,
+    Virgo: 5,
+    Libra: 6,
+    Scorpio: 7,
+    Sagittarius: 8,
+    Capricorn: 9,
+    Aquarius: 10,
+    Pisces: 11,
+  }
+}
+
+// Export the main alchemizer function
+const alchemizerExport = { alchemize, generateAlchmForCurrentMoment }
+export default alchemizerExport
+
+// Generate alchemical data for a provided birth date/time/location
+// Accepts flexible string inputs and normalizes to BirthInfo used by horoscope generator
+export async function generateAlchmForBirthInfo(input: {
+  birthDate: string // YYYY-MM-DD or any Date-parsable string
+  birthTime?: string // HH:MM
+  birthLocation?: string // Optional (not geocoded in this helper)
+}): Promise<Record<string, any>> {
+  try {
+    const dateObj = new Date(input.birthDate)
+    if (isNaN(dateObj.getTime())) {
+      // Try manual parse for YYYY-MM-DD
+      const [y, m, d] = input.birthDate.split('-').map(v => parseInt(v, 10))
+      if (!y || !m || !d) throw new Error('Invalid birthDate format')
+      // month expected 1-12 by horoscope generator
+      dateObj.setFullYear(y)
+      dateObj.setMonth(m - 1)
+      dateObj.setDate(d)
+    }
+
+    const time = input.birthTime || '12:00'
+    const [hhStr, mmStr] = time.split(':')
+    const hour = Math.max(0, Math.min(23, parseInt(hhStr || '12', 10)))
+    const minute = Math.max(0, Math.min(59, parseInt(mmStr || '0', 10)))
+
+    const year = dateObj.getFullYear()
+    const month = dateObj.getMonth() + 1 // horoscope generator expects 1-12
+    const day = dateObj.getDate()
+
+    const birthInfo = {
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      // Default coordinates; future enhancement: parse input.birthLocation
+      latitude: 0,
+      longitude: 0,
+    }
+
+    const horoscope = generateAccurateHoroscope(birthInfo)
+    const alchmData = alchemize(birthInfo as any, horoscope as any)
+    return alchmData
+  } catch (error) {
+    console.error('generateAlchmForBirthInfo error:', error)
+    // Provide a minimal fallback to avoid breaking callers
+    return {
+      'Alchemy Effects': {
+        'Total Spirit': 0,
+        'Total Essence': 0,
+        'Total Matter': 0,
+        'Total Substance': 0,
+        'A #': 0,
+      },
+      'Total Effect Value': createElementObject(),
+      'Dominant Element': 'Fire',
+      Heat: 0,
+      Entropy: 0,
+      Reactivity: 0,
+      Energy: 0,
+    }
+  }
+}

--- a/src/lib/celestial-energy-calculator.ts
+++ b/src/lib/celestial-energy-calculator.ts
@@ -1,0 +1,729 @@
+/**
+ * Celestial Energy Calculator - State-of-the-Art Implementation
+ * ============================================================
+ *
+ * Advanced system for calculating and quantifying celestial energy over time
+ * Integrates A#, SMES, Kinetic, and Thermodynamic metrics with real planetary positions
+ */
+
+import { generateAccurateHoroscope, type HoroscopeData } from './monica/horoscope-generator'
+
+export interface ElementVector {
+  Fire: number
+  Water: number
+  Air: number
+  Earth: number
+}
+export interface MetricVector {
+  Heat: number
+  Entropy: number
+  Reactivity: number
+  Energy: number
+}
+export type ElementKey = keyof ElementVector
+
+function computeInertia(_elements: ElementVector): number {
+  return 0
+}
+
+async function sampleHourlyAlchm(
+  _location: Location,
+  _timestamp: Date,
+  _options: any
+): Promise<any[]> {
+  return [
+    {
+      spirit: 50,
+      matter: 50,
+      essence: 50,
+      substance: 50,
+      Heat: 50,
+      Entropy: 50,
+      Reactivity: 50,
+      Energy: 50,
+      totals: { Fire: 25, Water: 25, Air: 25, Earth: 25 },
+    },
+  ]
+}
+
+export interface Location {
+  lat: number
+  lon: number
+  name?: string
+  timezone?: string
+}
+
+export interface CelestialMoment {
+  timestamp: Date
+  planetaryDegrees: Record<string, number>
+  alchemical: {
+    A_number: number
+    spirit: number
+    matter: number
+    essence: number
+    substance: number
+  }
+  kinetic: {
+    velocity: ElementVector
+    momentum: ElementVector
+    power: number
+    inertia: number
+    metricVelocity: MetricVector
+  }
+  thermodynamic: {
+    heat: number
+    entropy: number
+    reactivity: number
+    energy: number
+  }
+  elemental: ElementVector
+  planetary: {
+    dominantPlanet: string
+    dominantSign: string
+    moonPhase: number
+    retrogradeCount: number
+  }
+  consciousness: {
+    resonanceLevel: number
+    evolutionPhase: string
+    spiritualAmplitude: number
+  }
+}
+
+export interface TimeSeriesOptions {
+  startDate: Date
+  endDate: Date
+  interval: 'minute' | 'hour' | 'day' | 'week'
+  location: Location
+  includeRetrogrades: boolean
+  smoothingWindow?: number
+  highPrecision?: boolean
+}
+
+export interface CelestialTimeSeries {
+  moments: CelestialMoment[]
+  statistics: {
+    duration: number // milliseconds
+    totalMoments: number
+    peakEnergy: CelestialMoment
+    averageValues: Partial<CelestialMoment>
+    trends: {
+      alchemical: 'rising' | 'falling' | 'stable'
+      kinetic: 'accelerating' | 'decelerating' | 'stable'
+      consciousness: 'evolving' | 'stabilizing' | 'transforming'
+    }
+  }
+  patterns: Array<{
+    type: string
+    description: string
+    timeWindow: { start: Date; end: Date }
+    significance: number
+  }>
+}
+
+/**
+ * Advanced Celestial Energy Calculator
+ */
+export class CelestialEnergyCalculator {
+  private cache = new Map<string, CelestialMoment>()
+  private readonly CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
+  /**
+   * Calculate celestial energy for a specific moment
+   */
+  async calculateMoment(timestamp: Date, location: Location): Promise<CelestialMoment> {
+    const cacheKey = `${timestamp.getTime()}-${location.lat}-${location.lon}`
+
+    // Check cache first
+    if (this.cache.has(cacheKey)) {
+      const cached = this.cache.get(cacheKey)!
+      if (Date.now() - timestamp.getTime() < this.CACHE_TTL) {
+        return cached
+      }
+    }
+
+    try {
+      // Generate accurate horoscope for the moment
+      const horoscope = generateAccurateHoroscope({
+        year: timestamp.getFullYear(),
+        month: timestamp.getMonth() + 1,
+        day: timestamp.getDate(),
+        hour: timestamp.getHours(),
+        minute: timestamp.getMinutes(),
+        latitude: location.lat,
+        longitude: location.lon,
+      })
+
+      // Validate horoscope data
+      const planets = horoscope?.tropical?.CelestialBodies?.all
+      if (!horoscope || !planets) {
+        console.error('Invalid horoscope generated:', horoscope)
+        throw new Error('Failed to generate valid horoscope data')
+      }
+
+      // Sample alchemical data
+      const alchemicalSample = await sampleHourlyAlchm(
+        {
+          lat: location.lat,
+          lon: location.lon,
+        },
+        timestamp,
+        {
+          includePlanetaryHours: true,
+          validateTiming: true,
+          hoursToSample: 1,
+          startHour: timestamp.getHours(),
+        }
+      )
+
+      const sample = alchemicalSample[0] // Get the single sample for this moment
+
+      if (!sample) {
+        throw new Error('Failed to generate alchemical sample')
+      }
+
+      // Calculate planetary degrees
+      const planetaryDegrees = this.extractPlanetaryDegrees(horoscope)
+
+      // Calculate enhanced alchemical metrics
+      const alchemical = this.calculateAlchemicalMetrics(sample, horoscope)
+
+      // Calculate kinetic derivatives
+      const kinetic = this.calculateKineticMetrics(sample, alchemicalSample)
+
+      // Calculate thermodynamic values
+      const thermodynamic = {
+        heat: sample.Heat,
+        entropy: sample.Entropy,
+        reactivity: sample.Reactivity,
+        energy: sample.Energy,
+      }
+
+      // Calculate elemental distribution
+      const elemental: ElementVector = {
+        Fire: sample.totals.Fire,
+        Water: sample.totals.Water,
+        Air: sample.totals.Air,
+        Earth: sample.totals.Earth,
+      }
+
+      // Calculate planetary context
+      const planetary = this.calculatePlanetaryContext(horoscope)
+
+      // Calculate consciousness metrics
+      const consciousness = this.calculateConsciousnessMetrics(alchemical, kinetic, planetary)
+
+      const moment: CelestialMoment = {
+        timestamp,
+        planetaryDegrees,
+        alchemical,
+        kinetic,
+        thermodynamic,
+        elemental,
+        planetary,
+        consciousness,
+      }
+
+      // Cache the result
+      this.cache.set(cacheKey, moment)
+
+      return moment
+    } catch (error) {
+      console.error('Error calculating celestial moment:', error)
+      throw new Error(
+        `Failed to calculate celestial energy: ${error instanceof Error ? error.message : 'Unknown error'}`
+      )
+    }
+  }
+
+  /**
+   * Generate time series of celestial energy
+   */
+  async generateTimeSeries(options: TimeSeriesOptions): Promise<CelestialTimeSeries> {
+    const moments: CelestialMoment[] = []
+    const timeSteps = this.generateTimeSteps(options.startDate, options.endDate, options.interval)
+
+    // Calculate moments in parallel for performance
+    const batchSize = 10 // Process in batches to avoid overwhelming the system
+    for (let i = 0; i < timeSteps.length; i += batchSize) {
+      const batch = timeSteps.slice(i, i + batchSize)
+      const batchPromises = batch.map(timestamp =>
+        this.calculateMoment(timestamp, options.location)
+      )
+
+      try {
+        const batchResults = await Promise.all(batchPromises)
+        moments.push(...batchResults)
+      } catch (error) {
+        console.error(`Error processing batch ${i}-${i + batchSize}:`, error)
+        // Continue with other batches
+      }
+    }
+
+    // Apply smoothing if requested
+    const smoothedMoments = options.smoothingWindow
+      ? this.applySmoothing(moments, options.smoothingWindow)
+      : moments
+
+    // Calculate statistics and patterns (only if we have moments)
+    const statistics = smoothedMoments.length > 0 ? this.calculateStatistics(smoothedMoments) : null
+    const patterns = smoothedMoments.length > 0 ? this.detectPatterns(smoothedMoments) : []
+
+    return {
+      moments: smoothedMoments,
+      statistics,
+      patterns,
+    }
+  }
+
+  /**
+   * Extract planetary degrees from horoscope
+   */
+  private extractPlanetaryDegrees(horoscope: HoroscopeData): Record<string, number> {
+    const degrees: Record<string, number> = {}
+
+    // Extract planets from horoscope structure
+    const planets = horoscope?.tropical?.CelestialBodies?.all
+
+    if (!horoscope || !planets) {
+      console.error('Invalid horoscope data: planets is null or undefined')
+      return degrees
+    }
+
+    // Handle array format
+    if (Array.isArray(planets)) {
+      for (const planet of planets) {
+        if (planet.label && typeof planet.degrees === 'number') {
+          degrees[planet.label] = planet.degrees
+        }
+      }
+    }
+
+    // Add angles
+    if (horoscope.tropical?.Ascendant?.degrees) {
+      degrees['Ascendant'] = horoscope.tropical.Ascendant.degrees
+    }
+
+    // Add midheaven if available
+    if (horoscope.tropical?.Houses?.[10]?.degree) {
+      degrees['Midheaven'] = horoscope.tropical.Houses[10].degree
+    }
+
+    return degrees
+  }
+
+  /**
+   * Calculate enhanced alchemical metrics including A#
+   */
+  private calculateAlchemicalMetrics(sample: any, horoscope: HoroscopeData) {
+    // Calculate A# (Alchemical Number) using advanced formula
+    const A_number = this.calculateAlchemicalNumber(sample, horoscope)
+
+    return {
+      A_number,
+      spirit: sample.spirit || 0,
+      matter: sample.matter || 0,
+      essence: sample.essence || 0,
+      substance: sample.substance || 0,
+    }
+  }
+
+  /**
+   * Calculate advanced A# using planetary positions and alchemical ratios
+   */
+  private calculateAlchemicalNumber(sample: any, horoscope: HoroscopeData): number {
+    // Get alchemical values directly from sample (capitalized for consistency)
+    const Spirit = sample.spirit || 0
+    const Matter = sample.matter || 0
+    const Essence = sample.essence || 0
+    const Substance = sample.substance || 0
+
+    // Base A# calculation
+    let A_number = Spirit + Matter + Essence + Substance
+
+    // Planetary amplifications
+    const sunDegree = this.extractPlanetaryDegrees(horoscope)['Sun']
+    const moonDegree = this.extractPlanetaryDegrees(horoscope)['Moon']
+
+    // Solar amplification (fire principle)
+    const solarAmplification = 1 + Math.sin((sunDegree * Math.PI) / 180) * 0.1
+
+    // Lunar modulation (water principle)
+    const lunarModulation = 1 + Math.cos((moonDegree * Math.PI) / 180) * 0.08
+
+    // Golden ratio enhancement for consciousness resonance
+    const PHI = 1.618033988749
+    const consciousnessEnhancement = (Spirit / (Matter + 1)) * PHI * 0.05
+
+    A_number = A_number * solarAmplification * lunarModulation + consciousnessEnhancement
+
+    return Math.round(A_number * 1000) / 1000 // Round to 3 decimal places
+  }
+
+  /**
+   * Calculate kinetic metrics with enhanced derivatives
+   */
+  private calculateKineticMetrics(currentSample: any, _timeSeries: any[]) {
+    const elements: ElementVector = {
+      Fire: currentSample.totals.Fire,
+      Water: currentSample.totals.Water,
+      Air: currentSample.totals.Air,
+      Earth: currentSample.totals.Earth,
+    }
+
+    const metrics: MetricVector = {
+      Heat: currentSample.Heat,
+      Entropy: currentSample.Entropy,
+      Reactivity: currentSample.Reactivity,
+      Energy: currentSample.Energy,
+    }
+
+    // For single moment calculation, use current element values as velocity
+    const velocity: ElementVector = { ...elements }
+
+    // Calculate momentum as weighted elements
+    const momentum: ElementVector = {
+      Fire: elements.Fire * 1.2,
+      Water: elements.Water * 0.8,
+      Air: elements.Air * 1.1,
+      Earth: elements.Earth * 0.9,
+    }
+
+    // Calculate power as sum of thermodynamic values
+    const power = metrics.Heat + metrics.Entropy + metrics.Reactivity + metrics.Energy
+
+    const inertia = computeInertia(elements)
+
+    // For single moment, use current metrics as metric velocity
+    const metricVelocity: MetricVector = { ...metrics }
+
+    return {
+      velocity,
+      momentum,
+      power,
+      inertia,
+      metricVelocity,
+    }
+  }
+
+  /**
+   * Calculate planetary context
+   */
+  private calculatePlanetaryContext(horoscope: HoroscopeData) {
+    // Null check for (horoscope as any).planets
+    if (!horoscope || !(horoscope as any).planets) {
+      console.error('Invalid horoscope data: planets is null or undefined')
+      return {
+        dominantPlanet: 'Sun',
+        dominantSign: 'Aries',
+        moonPhase: 0,
+        retrogradeCount: 0,
+      }
+    }
+
+    const planets = Object.entries((horoscope as any).planets)
+
+    // Find dominant planet (most aspects or strongest dignity)
+    let dominantPlanet = 'Sun' // default
+    let maxStrength = 0
+
+    for (const [planet, data] of planets) {
+      const strength = this.calculatePlanetaryStrength(planet, data)
+      if (strength > maxStrength) {
+        maxStrength = strength
+        dominantPlanet = planet
+      }
+    }
+
+    // Find dominant sign (most planets)
+    const signCounts: Record<string, number> = {}
+    for (const [, data] of planets) {
+      if (data && (data as any).sign) {
+        signCounts[(data as any).sign] = (signCounts[(data as any).sign] || 0) + 1
+      }
+    }
+    const dominantSign = Object.entries(signCounts).sort(([, a], [, b]) => b - a)[0]?.[0] || 'Aries'
+
+    // Calculate moon phase (simplified)
+    const sunDegree = this.extractPlanetaryDegrees(horoscope)['Sun'] || 0
+    const moonDegree = this.extractPlanetaryDegrees(horoscope)['Moon'] || 0
+    const moonPhase =
+      isNaN(sunDegree) || isNaN(moonDegree) ? 0 : ((moonDegree - sunDegree + 360) % 360) / 360
+
+    // Count retrograde planets
+    const retrogradeCount = planets.filter(([, data]) => (data as any).retrograde).length
+
+    return {
+      dominantPlanet,
+      dominantSign,
+      moonPhase,
+      retrogradeCount,
+    }
+  }
+
+  /**
+   * Calculate consciousness metrics
+   */
+  private calculateConsciousnessMetrics(alchemical: any, kinetic: any, planetary: any) {
+    // Resonance level based on A# and elemental harmony
+    const resonanceLevel =
+      Math.min(1.0, alchemical.A_number / 100) * (1 + (kinetic.power / 10) * 0.1)
+
+    // Evolution phase based on planetary context
+    const evolutionPhase = this.determineEvolutionPhase(planetary, alchemical)
+
+    // Spiritual amplitude based on spirit-to-matter ratio
+    const spiritualAmplitude =
+      (alchemical.spirit / (alchemical.matter + 1)) * (1 + planetary.moonPhase * 0.2)
+
+    return {
+      resonanceLevel: Math.min(1.0, Math.max(0.0, resonanceLevel)),
+      evolutionPhase,
+      spiritualAmplitude: Math.max(0.0, spiritualAmplitude),
+    }
+  }
+
+  /**
+   * Determine evolution phase based on planetary and alchemical factors
+   */
+  private determineEvolutionPhase(planetary: any, alchemical: any): string {
+    const phases = [
+      'Initiation',
+      'Development',
+      'Integration',
+      'Mastery',
+      'Transcendence',
+      'Illumination',
+      'Unity',
+    ]
+
+    // Base phase on A# level
+    const basePhase = Math.floor((alchemical.A_number / 20) % phases.length)
+
+    // Modify based on planetary factors
+    let phaseModifier = 0
+    if (planetary.dominantPlanet === 'Jupiter') phaseModifier += 1
+    if (planetary.dominantPlanet === 'Saturn') phaseModifier -= 1
+    if (planetary.retrogradeCount > 3) phaseModifier += 1
+
+    const finalPhase = Math.max(0, Math.min(phases.length - 1, basePhase + phaseModifier))
+    return phases[finalPhase]
+  }
+
+  /**
+   * Generate time steps for the specified interval
+   */
+  private generateTimeSteps(startDate: Date, endDate: Date, interval: string): Date[] {
+    const steps: Date[] = []
+    const current = new Date(startDate)
+
+    const intervalMs =
+      {
+        minute: 60 * 1000,
+        hour: 60 * 60 * 1000,
+        day: 24 * 60 * 60 * 1000,
+        week: 7 * 24 * 60 * 60 * 1000,
+      }[interval] || 60 * 60 * 1000
+
+    while (current <= endDate) {
+      steps.push(new Date(current))
+      current.setTime(current.getTime() + intervalMs)
+    }
+
+    return steps
+  }
+
+  /**
+   * Apply smoothing to time series data
+   */
+  private applySmoothing(moments: CelestialMoment[], window: number): CelestialMoment[] {
+    if (window <= 1 || moments.length < window) return moments
+
+    return moments.map((moment, index) => {
+      const start = Math.max(0, index - Math.floor(window / 2))
+      const end = Math.min(moments.length, start + window)
+      const subset = moments.slice(start, end)
+
+      // Calculate smoothed values
+      const smoothed = { ...moment }
+
+      // Smooth alchemical values
+      smoothed.alchemical.A_number = this.average(subset.map(m => m.alchemical.A_number))
+      smoothed.alchemical.spirit = this.average(subset.map(m => m.alchemical.spirit))
+      smoothed.alchemical.matter = this.average(subset.map(m => m.alchemical.matter))
+      smoothed.alchemical.essence = this.average(subset.map(m => m.alchemical.essence))
+      smoothed.alchemical.substance = this.average(subset.map(m => m.alchemical.substance))
+
+      // Smooth thermodynamic values
+      smoothed.thermodynamic.heat = this.average(subset.map(m => m.thermodynamic.heat))
+      smoothed.thermodynamic.entropy = this.average(subset.map(m => m.thermodynamic.entropy))
+      smoothed.thermodynamic.reactivity = this.average(subset.map(m => m.thermodynamic.reactivity))
+      smoothed.thermodynamic.energy = this.average(subset.map(m => m.thermodynamic.energy))
+
+      return smoothed
+    })
+  }
+
+  /**
+   * Calculate comprehensive statistics
+   */
+  private calculateStatistics(moments: CelestialMoment[]) {
+    if (moments.length === 0) {
+      throw new Error('Cannot calculate statistics for empty moment series')
+    }
+
+    const duration =
+      moments[moments.length - 1].timestamp.getTime() - moments[0].timestamp.getTime()
+
+    // Find peak energy moment
+    const peakEnergy = moments.reduce((peak, current) =>
+      current.alchemical.A_number > peak.alchemical.A_number ? current : peak
+    )
+
+    // Calculate averages
+    const averageValues = {
+      alchemical: {
+        A_number: this.average(moments.map(m => m.alchemical.A_number)),
+        spirit: this.average(moments.map(m => m.alchemical.spirit)),
+        matter: this.average(moments.map(m => m.alchemical.matter)),
+        essence: this.average(moments.map(m => m.alchemical.essence)),
+        substance: this.average(moments.map(m => m.alchemical.substance)),
+      },
+      kinetic: {
+        power: this.average(moments.map(m => m.kinetic.power)),
+        inertia: this.average(moments.map(m => m.kinetic.inertia)),
+      },
+      consciousness: {
+        resonanceLevel: this.average(moments.map(m => m.consciousness.resonanceLevel)),
+        spiritualAmplitude: this.average(moments.map(m => m.consciousness.spiritualAmplitude)),
+      },
+    }
+
+    // Analyze trends
+    const trends = this.analyzeTrends(moments)
+
+    return {
+      duration,
+      totalMoments: moments.length,
+      peakEnergy,
+      averageValues,
+      trends,
+    } as any
+  }
+
+  /**
+   * Analyze trends in the time series
+   */
+  private analyzeTrends(moments: CelestialMoment[]) {
+    if (moments.length < 3) {
+      return {
+        alchemical: 'stable' as const,
+        kinetic: 'stable' as const,
+        consciousness: 'stable' as const,
+      }
+    }
+
+    const first = moments[0]
+    const last = moments[moments.length - 1]
+
+    // Alchemical trend
+    const alchemicalChange = last.alchemical.A_number - first.alchemical.A_number
+    const alchemicalTrend =
+      Math.abs(alchemicalChange) < 0.1 ? 'stable' : alchemicalChange > 0 ? 'rising' : 'falling'
+
+    // Kinetic trend
+    const kineticChange = last.kinetic.power - first.kinetic.power
+    const kineticTrend =
+      Math.abs(kineticChange) < 0.1 ? 'stable' : kineticChange > 0 ? 'accelerating' : 'decelerating'
+
+    // Consciousness trend
+    const consciousnessChange =
+      last.consciousness.resonanceLevel - first.consciousness.resonanceLevel
+    const consciousnessTrend =
+      Math.abs(consciousnessChange) < 0.05
+        ? 'stabilizing'
+        : consciousnessChange > 0
+          ? 'evolving'
+          : 'transforming'
+
+    return {
+      alchemical: alchemicalTrend,
+      kinetic: kineticTrend,
+      consciousness: consciousnessTrend,
+    }
+  }
+
+  /**
+   * Detect patterns in the time series
+   */
+  private detectPatterns(moments: CelestialMoment[]) {
+    const patterns: any[] = []
+
+    // Peak detection
+    const peaks = this.findPeaks(moments.map(m => m.alchemical.A_number))
+    if (peaks.length > 0) {
+      patterns.push({
+        type: 'A# Peaks',
+        description: `Detected ${peaks.length} significant alchemical peaks`,
+        timeWindow: {
+          start: moments[Math.min(...peaks)].timestamp,
+          end: moments[Math.max(...peaks)].timestamp,
+        },
+        significance: peaks.length / moments.length,
+      })
+    }
+
+    // Consciousness evolution patterns
+    const evolutionPhases = moments.map(m => m.consciousness.evolutionPhase)
+    const uniquePhases = [...new Set(evolutionPhases)]
+    if (uniquePhases.length > 1) {
+      patterns.push({
+        type: 'Consciousness Evolution',
+        description: `Progression through phases: ${uniquePhases.join(' → ')}`,
+        timeWindow: {
+          start: moments[0].timestamp,
+          end: moments[moments.length - 1].timestamp,
+        },
+        significance: uniquePhases.length / 7, // 7 total phases
+      })
+    }
+
+    return patterns
+  }
+
+  /**
+   * Helper methods
+   */
+
+  private calculatePlanetaryStrength(_planet: string, data: any): number {
+    // Simplified strength calculation with null checks
+    let strength = 1
+    if (data && typeof data === 'object') {
+      if (data.dignity && data.dignity > 0) strength += data.dignity
+      if (data.retrograde === false) strength += 0.5
+    }
+    return strength
+  }
+
+  private average(values: number[]): number {
+    return values.reduce((sum, val) => sum + val, 0) / values.length
+  }
+
+  private findPeaks(values: number[]): number[] {
+    const peaks: number[] = []
+    const threshold = this.average(values) * 1.2 // 20% above average
+
+    for (let i = 1; i < values.length - 1; i++) {
+      if (values[i] > values[i - 1] && values[i] > values[i + 1] && values[i] > threshold) {
+        peaks.push(i)
+      }
+    }
+
+    return peaks
+  }
+}
+
+// Export singleton instance
+export const celestialEnergyCalculator = new CelestialEnergyCalculator()
+
+// Export types

--- a/src/lib/monica/horoscope-generator.ts
+++ b/src/lib/monica/horoscope-generator.ts
@@ -1,0 +1,687 @@
+// lib/monica/horoscope-generator.ts
+// Accurate horoscope generation with real astronomical data
+
+import {
+  calculateAllPlanets,
+  type EnhancedBirthInfo,
+} from '../enhanced-astronomical-calculator'
+import { getZodiacPositionForDate } from '../ephemeris/solar-ephemeris'
+
+export interface BirthInfo {
+  year: number
+  month: number
+  day: number
+  hour: number
+  minute: number
+  latitude: number
+  longitude: number
+}
+
+// Accurate zodiac date ranges (tropical zodiac)
+const ZODIAC_DATES = [
+  { sign: 'Aries', start: { month: 3, day: 21 }, end: { month: 4, day: 19 } },
+  { sign: 'Taurus', start: { month: 4, day: 20 }, end: { month: 5, day: 20 } },
+  { sign: 'Gemini', start: { month: 5, day: 21 }, end: { month: 6, day: 20 } },
+  { sign: 'Cancer', start: { month: 6, day: 21 }, end: { month: 7, day: 22 } },
+  { sign: 'Leo', start: { month: 7, day: 23 }, end: { month: 8, day: 22 } },
+  { sign: 'Virgo', start: { month: 8, day: 23 }, end: { month: 9, day: 22 } },
+  { sign: 'Libra', start: { month: 9, day: 23 }, end: { month: 10, day: 22 } },
+  { sign: 'Scorpio', start: { month: 10, day: 23 }, end: { month: 11, day: 21 } },
+  { sign: 'Sagittarius', start: { month: 11, day: 22 }, end: { month: 12, day: 21 } },
+  { sign: 'Capricorn', start: { month: 12, day: 22 }, end: { month: 1, day: 19 } },
+  { sign: 'Aquarius', start: { month: 1, day: 20 }, end: { month: 2, day: 18 } },
+  { sign: 'Pisces', start: { month: 2, day: 19 }, end: { month: 3, day: 20 } },
+]
+
+// Planetary orbital periods in days (for position calculations)
+const ORBITAL_PERIODS = {
+  Sun: 365.25, // Earth's orbit
+  Moon: 27.32, // Lunar month
+  Mercury: 87.97,
+  Venus: 224.7,
+  Mars: 686.98,
+  Jupiter: 4332.59,
+  Saturn: 10759.22,
+  Uranus: 30688.5,
+  Neptune: 60195.0,
+  Pluto: 90560.0,
+}
+
+// Average daily motion in degrees
+const DAILY_MOTION = {
+  Sun: 0.9856, // ~1 degree per day
+  Moon: 13.176, // ~13 degrees per day
+  Mercury: 4.092, // Variable due to retrograde
+  Venus: 1.602, // Variable due to retrograde
+  Mars: 0.524,
+  Jupiter: 0.083,
+  Saturn: 0.033,
+  Uranus: 0.012,
+  Neptune: 0.006,
+  Pluto: 0.004,
+}
+
+// Reference positions for Jan 1, 2024 (approximate)
+const REFERENCE_POSITIONS = {
+  Sun: { sign: 'Capricorn', degree: 10 },
+  Moon: { sign: 'Leo', degree: 15 },
+  Mercury: { sign: 'Sagittarius', degree: 22 },
+  Venus: { sign: 'Scorpio', degree: 28 },
+  Mars: { sign: 'Capricorn', degree: 5 },
+  Jupiter: { sign: 'Taurus', degree: 5 },
+  Saturn: { sign: 'Pisces', degree: 3 },
+  Uranus: { sign: 'Taurus', degree: 19 },
+  Neptune: { sign: 'Pisces', degree: 25 },
+  Pluto: { sign: 'Capricorn', degree: 29 },
+}
+
+export interface PlanetPosition {
+  label: string
+  Sign: { label: string }
+  degrees: number
+  retrograde?: boolean
+}
+
+export interface GeneratedHoroscope {
+  tropical: {
+    Ascendant: {
+      Sign: { label: string }
+      degrees: number
+    }
+    CelestialBodies: {
+      all: PlanetPosition[]
+    }
+    Houses?: Record<number, { sign: string; degree: number }>
+  }
+  metadata?: {
+    generatedAt: Date
+    method: string
+    accuracy: string
+    synchronized?: boolean
+    julianDay?: number
+    enhancedCalculations?: boolean
+    algorithms?: string[]
+  }
+}
+
+// Alias export for compatibility
+export type HoroscopeData = GeneratedHoroscope
+
+/**
+ * Get the zodiac sign for a given date using precise astronomical calculations
+ */
+function getZodiacSign(month: number, day: number, year?: number): string {
+  // Use current year if not provided
+  const currentYear = year || new Date().getFullYear()
+  const date = new Date(currentYear, month - 1, day, 12, 0, 0) // Noon to avoid timezone issues
+
+  try {
+    const zodiacPos = getZodiacPositionForDate(date)
+    return zodiacPos.sign
+  } catch (error) {
+    console.warn('Failed to calculate precise zodiac sign, falling back to approximation:', error)
+
+    // Fallback to the old approximation method
+    for (const zodiac of ZODIAC_DATES) {
+      if (zodiac.sign === 'Capricorn') {
+        if ((month === 12 && day >= 22) || (month === 1 && day <= 19)) {
+          return 'Capricorn'
+        }
+      } else {
+        if (month === zodiac.start.month && day >= zodiac.start.day) {
+          return zodiac.sign
+        } else if (month === zodiac.end.month && day <= zodiac.end.day) {
+          return zodiac.sign
+        } else if (zodiac.start.month < month && month < zodiac.end.month) {
+          return zodiac.sign
+        }
+      }
+    }
+    return 'Aries'
+  }
+}
+
+/**
+ * Calculate planet position based on date difference from reference
+ * Enhanced with more accurate formulas for planetary motion
+ */
+function calculatePlanetPosition(
+  planet: string,
+  birthDate: Date,
+  referenceDate: Date = new Date(2024, 0, 1)
+): { sign: string; degree: number; retrograde: boolean } {
+  const daysDiff = Math.floor(
+    (birthDate.getTime() - referenceDate.getTime()) / (1000 * 60 * 60 * 24)
+  )
+  const dailyMotion = DAILY_MOTION[planet as keyof typeof DAILY_MOTION] || 1
+  const refPosition = REFERENCE_POSITIONS[planet as keyof typeof REFERENCE_POSITIONS]
+
+  if (!refPosition) {
+    return { sign: 'Aries', degree: 0, retrograde: false }
+  }
+
+  // Enhanced calculation with elliptical orbit variations
+  const orbitalPeriod = ORBITAL_PERIODS[planet as keyof typeof ORBITAL_PERIODS]
+  let totalDegrees = dailyMotion * daysDiff
+
+  // Add sinusoidal variation for more realistic orbital motion
+  if (orbitalPeriod) {
+    const orbitalPhase = ((daysDiff % orbitalPeriod) / orbitalPeriod) * 2 * Math.PI
+    const eccentricity = planet === 'Mercury' ? 0.205 : planet === 'Mars' ? 0.093 : 0.05
+    const variation = eccentricity * Math.sin(orbitalPhase) * 30 // Max 30° variation for Mercury
+    totalDegrees += variation
+  }
+
+  // Enhanced retrograde detection using velocity-based approach
+  let retrograde = false
+  if (['Mercury', 'Venus', 'Mars'].includes(planet)) {
+    // Synodic periods for retrograde cycles (Earth-relative)
+    const synodicPeriod = planet === 'Mercury' ? 115.88 : planet === 'Venus' ? 583.92 : 779.96
+    const cyclePosition = (daysDiff % synodicPeriod) / synodicPeriod
+
+    // Retrograde occurs near inferior/superior conjunction
+    const retrogradePhase = planet === 'Mercury' ? 0.2 : planet === 'Venus' ? 0.07 : 0.1
+    const retrogradeStart = 0.5 - retrogradePhase
+    const retrogradeEnd = 0.5 + retrogradePhase
+
+    if (cyclePosition > retrogradeStart && cyclePosition < retrogradeEnd) {
+      retrograde = true
+      // More accurate retrograde velocity
+      const retrogradeIntensity = Math.sin(
+        ((cyclePosition - retrogradeStart) / (2 * retrogradePhase)) * Math.PI
+      )
+      totalDegrees -=
+        dailyMotion *
+        retrogradeIntensity *
+        (planet === 'Mercury' ? 1.5 : 0.7) *
+        daysDiff *
+        retrogradePhase
+    }
+  }
+
+  // Convert reference sign to degrees
+  const signs = [
+    'Aries',
+    'Taurus',
+    'Gemini',
+    'Cancer',
+    'Leo',
+    'Virgo',
+    'Libra',
+    'Scorpio',
+    'Sagittarius',
+    'Capricorn',
+    'Aquarius',
+    'Pisces',
+  ]
+  const refSignIndex = signs.indexOf(refPosition.sign)
+  const refAbsoluteDegrees = refSignIndex * 30 + refPosition.degree
+
+  // Calculate new position
+  let newAbsoluteDegrees = (refAbsoluteDegrees + totalDegrees) % 360
+  if (newAbsoluteDegrees < 0) newAbsoluteDegrees += 360
+
+  const newSignIndex = Math.floor(newAbsoluteDegrees / 30)
+  const newDegree = newAbsoluteDegrees % 30
+
+  return {
+    sign: signs[newSignIndex],
+    degree: newDegree,
+    retrograde,
+  }
+}
+
+/**
+ * Calculate ascendant based on birth time and location
+ * Enhanced with more accurate astronomical calculations
+ */
+function calculateAscendant(birthInfo: BirthInfo): { sign: string; degree: number } {
+  // Enhanced ascendant calculation using sidereal time approximation
+  const hour = birthInfo.hour
+  const minute = birthInfo.minute
+  const latitude = birthInfo.latitude || 0
+  const longitude = birthInfo.longitude || 0
+
+  // Calculate days since J2000.0 (Jan 1, 2000, 12:00 UTC)
+  const birthDate = new Date(birthInfo.year, birthInfo.month, birthInfo.day)
+  const j2000 = new Date(2000, 0, 1, 12, 0, 0)
+  const daysSinceJ2000 = (birthDate.getTime() - j2000.getTime()) / (1000 * 60 * 60 * 24)
+
+  // Calculate Greenwich Mean Sidereal Time (GMST) at 0h UT
+  const T = daysSinceJ2000 / 36525
+  const GMST0 = 280.46061837 + 360.98564736629 * daysSinceJ2000 + 0.000387933 * T * T
+
+  // Convert local time to UTC (simplified - assumes no DST)
+  const timezoneOffset = Math.round(longitude / 15) // Approximate timezone from longitude
+  const utcHour = hour - timezoneOffset
+  const utcTime = utcHour + minute / 60
+
+  // Calculate Local Sidereal Time (LST)
+  let LST = GMST0 + 15 * utcTime + longitude
+  LST = LST % 360
+  if (LST < 0) LST += 360
+
+  // Calculate the ecliptic longitude of the Ascendant
+  // Using simplified formula for obliquity of ecliptic (23.44°)
+  const obliquity = (23.44 * Math.PI) / 180
+  const latRad = (latitude * Math.PI) / 180
+
+  // Calculate RAMC (Right Ascension of Medium Coeli)
+  const RAMC = (LST * Math.PI) / 180
+
+  // Simplified ascendant calculation using house cusps
+  const tanLat = Math.tan(latRad)
+  const cosObliquity = Math.cos(obliquity)
+
+  // Calculate ascendant longitude
+  let ascendantLongitude =
+    (Math.atan2(-Math.cos(RAMC), Math.sin(RAMC) * cosObliquity + tanLat * Math.sin(obliquity)) *
+      180) /
+    Math.PI
+
+  // Normalize to 0-360 degrees
+  ascendantLongitude = (ascendantLongitude + 360) % 360
+
+  // Convert to sign and degree
+  const signs = [
+    'Aries',
+    'Taurus',
+    'Gemini',
+    'Cancer',
+    'Leo',
+    'Virgo',
+    'Libra',
+    'Scorpio',
+    'Sagittarius',
+    'Capricorn',
+    'Aquarius',
+    'Pisces',
+  ]
+  const signIndex = Math.floor(ascendantLongitude / 30)
+  const degreeInSign = ascendantLongitude % 30
+
+  return {
+    sign: signs[signIndex],
+    degree: degreeInSign,
+  }
+}
+
+/**
+ * Calculate house positions (simplified)
+ */
+function calculateHouses(ascendant: {
+  sign: string
+  degree: number
+}): Record<number, { sign: string; degree: number }> {
+  const signs = [
+    'Aries',
+    'Taurus',
+    'Gemini',
+    'Cancer',
+    'Leo',
+    'Virgo',
+    'Libra',
+    'Scorpio',
+    'Sagittarius',
+    'Capricorn',
+    'Aquarius',
+    'Pisces',
+  ]
+  const ascIndex = signs.indexOf(ascendant.sign)
+  const houses: Record<number, { sign: string; degree: number }> = {}
+
+  // Equal house system (each house is 30 degrees)
+  for (let i = 0; i < 12; i++) {
+    const houseNumber = i + 1
+    const signIndex = (ascIndex + i) % 12
+    houses[houseNumber] = {
+      sign: signs[signIndex],
+      degree: ascendant.degree,
+    }
+  }
+
+  return houses
+}
+
+// Simple planetary calculation cache (10-minute TTL)
+const planetaryCache = new Map<string, { data: any; timestamp: number }>()
+const PLANETARY_CACHE_TTL = 10 * 60 * 1000 // 10 minutes
+
+/**
+ * Generate a comprehensive horoscope with all planets
+ */
+export function generateAccurateHoroscope(birthInfo: BirthInfo): GeneratedHoroscope {
+  // Create cache key for this birth info (rounded to hour for efficiency)
+  const cacheKey = `${birthInfo.year}-${birthInfo.month}-${birthInfo.day}-${birthInfo.hour}`
+
+  // Check cache first for planetary positions
+  const cached = planetaryCache.get(cacheKey)
+  if (cached && Date.now() - cached.timestamp < PLANETARY_CACHE_TTL) {
+    return cached.data
+  }
+  const birthDate = new Date(
+    birthInfo.year,
+    birthInfo.month - 1,
+    birthInfo.day,
+    birthInfo.hour,
+    birthInfo.minute
+  )
+
+  // Calculate Sun sign accurately
+  const sunSign = getZodiacSign(birthInfo.month, birthInfo.day)
+
+  // Calculate more accurate sun degree within sign
+  const sunPosition = calculatePlanetPosition('Sun', birthDate)
+  const sunDegree = sunPosition.degree
+
+  // Calculate ascendant
+  const ascendant = calculateAscendant(birthInfo)
+
+  // Calculate all planetary positions
+  const planets = [
+    'Sun',
+    'Moon',
+    'Mercury',
+    'Venus',
+    'Mars',
+    'Jupiter',
+    'Saturn',
+    'Uranus',
+    'Neptune',
+    'Pluto',
+  ]
+  const celestialBodies: PlanetPosition[] = []
+
+  // Special handling for Sun (already calculated)
+  celestialBodies.push({
+    label: 'Sun',
+    Sign: { label: sunSign },
+    degrees: sunDegree,
+    retrograde: false,
+  })
+
+  // Calculate other planets
+  for (const planet of planets.slice(1)) {
+    // Skip Sun as it's already added
+    const position = calculatePlanetPosition(planet, birthDate)
+    celestialBodies.push({
+      label: planet,
+      Sign: { label: position.sign },
+      degrees: position.degree,
+      retrograde: position.retrograde,
+    })
+  }
+
+  // Calculate houses
+  const houses = calculateHouses(ascendant)
+
+  const result = {
+    tropical: {
+      Ascendant: {
+        Sign: { label: ascendant.sign },
+        degrees: ascendant.degree,
+      },
+      CelestialBodies: {
+        all: celestialBodies,
+      },
+      Houses: houses,
+    },
+    metadata: {
+      generatedAt: new Date(),
+      method: 'Enhanced astronomical calculation',
+      accuracy: 'Moderate (simplified ephemeris)',
+    },
+  }
+
+  // Cache the result
+  planetaryCache.set(cacheKey, {
+    data: result,
+    timestamp: Date.now(),
+  })
+
+  // Clean up old cache entries (keep only last 20)
+  if (planetaryCache.size > 20) {
+    const oldestKey = planetaryCache.keys().next().value
+    if (oldestKey !== undefined) {
+      planetaryCache.delete(oldestKey)
+    }
+  }
+
+  return result
+}
+
+/**
+ * Validate birth info
+ */
+export function validateBirthInfo(birthInfo: BirthInfo): { valid: boolean; errors: string[] } {
+  const errors: string[] = []
+  const currentYear = new Date().getFullYear()
+
+  // Validate year
+  if (birthInfo.year < 1900 || birthInfo.year > currentYear) {
+    errors.push(`Year must be between 1900 and ${currentYear}`)
+  }
+
+  // Validate month
+  if (birthInfo.month < 1 || birthInfo.month > 12) {
+    errors.push('Month must be between 1 and 12')
+  }
+
+  // Validate day
+  const daysInMonth = new Date(birthInfo.year, birthInfo.month, 0).getDate()
+  if (birthInfo.day < 1 || birthInfo.day > daysInMonth) {
+    errors.push(`Day must be between 1 and ${daysInMonth} for month ${birthInfo.month}`)
+  }
+
+  // Validate hour
+  if (birthInfo.hour < 0 || birthInfo.hour > 23) {
+    errors.push('Hour must be between 0 and 23')
+  }
+
+  // Validate minute
+  if (birthInfo.minute < 0 || birthInfo.minute > 59) {
+    errors.push('Minute must be between 0 and 59')
+  }
+
+  // Validate coordinates
+  if (birthInfo.latitude < -90 || birthInfo.latitude > 90) {
+    errors.push('Latitude must be between -90 and 90')
+  }
+
+  if (birthInfo.longitude < -180 || birthInfo.longitude > 180) {
+    errors.push('Longitude must be between -180 and 180')
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  }
+}
+
+/**
+ * Enhanced horoscope generation with professional astronomical accuracy
+ * Uses VSOP87-like calculations for ±0.1° precision vs ±2-5° of legacy system
+ */
+export function generateProfessionalHoroscope(
+  birthInfo: BirthInfo,
+  options: {
+    useLegacyFallback?: boolean
+    includeAccuracyMetadata?: boolean
+    synchronizedPositions?: Record<string, any> // Synchronized planetary positions from cross-backend sync
+  } = {}
+): GeneratedHoroscope {
+  try {
+    // Convert BirthInfo to EnhancedBirthInfo format
+    const enhancedBirthInfo: EnhancedBirthInfo = {
+      year: birthInfo.year,
+      month: birthInfo.month,
+      day: birthInfo.day,
+      hour: birthInfo.hour,
+      minute: birthInfo.minute,
+      second: 0,
+      latitude: birthInfo.latitude || 40.7128, // Default to NYC if not provided
+      longitude: birthInfo.longitude || -74.006,
+    }
+
+    // Create birth date for solar ephemeris calculations
+    const birthDate = new Date(
+      Date.UTC(
+        enhancedBirthInfo.year,
+        enhancedBirthInfo.month - 1,
+        enhancedBirthInfo.day,
+        enhancedBirthInfo.hour,
+        enhancedBirthInfo.minute,
+        enhancedBirthInfo.second || 0
+      )
+    )
+
+    // Calculate enhanced positions (but override Sun with accurate solar ephemeris)
+    const enhancedResults = calculateAllPlanets(enhancedBirthInfo)
+
+    // Get accurate Sun position from solar ephemeris
+    const accurateSunPos = getZodiacPositionForDate(birthDate)
+
+    // Convert enhanced positions to our existing format
+    const celestialBodies: PlanetPosition[] = []
+
+    // Check if we have synchronized positions to use
+    const useSynchronizedPositions =
+      options.synchronizedPositions && Object.keys(options.synchronizedPositions).length > 0
+
+    Object.entries(enhancedResults.planets).forEach(([planetName, position]) => {
+      let planetPosition: PlanetPosition
+
+      if (useSynchronizedPositions && options.synchronizedPositions![planetName]) {
+        // Use synchronized position for highest accuracy
+        const syncPos = options.synchronizedPositions![planetName]
+        planetPosition = {
+          label: planetName,
+          Sign: { label: syncPos.sign },
+          degrees: syncPos.degree,
+          retrograde: syncPos.is_retrograde || false,
+        }
+      } else if (planetName === 'Sun') {
+        // Use accurate Sun position from solar ephemeris
+        planetPosition = {
+          label: 'Sun',
+          Sign: { label: accurateSunPos.sign },
+          degrees: accurateSunPos.degree_in_sign,
+          retrograde: false, // Sun never retrograde
+        }
+      } else {
+        // Use enhanced astronomical calculator results
+        planetPosition = {
+          label: planetName,
+          Sign: { label: position.sign },
+          degrees: position.signDegree,
+          retrograde: position.retrograde,
+        }
+      }
+
+      celestialBodies.push(planetPosition)
+    })
+
+    const result: GeneratedHoroscope = {
+      tropical: {
+        Ascendant: {
+          Sign: { label: enhancedResults.ascendant.sign },
+          degrees: enhancedResults.ascendant.signDegree,
+        },
+        CelestialBodies: {
+          all: celestialBodies,
+        },
+      },
+      metadata: {
+        generatedAt: new Date(),
+        method: useSynchronizedPositions
+          ? 'Cross-backend synchronized VSOP87 + rectification'
+          : 'Enhanced VSOP87-like calculations',
+        accuracy: useSynchronizedPositions
+          ? 'Revolutionary ±0.01° synchronized precision'
+          : 'Professional grade ±0.1° precision',
+        synchronized: useSynchronizedPositions,
+      },
+    }
+
+    if (options.includeAccuracyMetadata && result.metadata) {
+      result.metadata = {
+        generatedAt: result.metadata.generatedAt,
+        method: result.metadata.method,
+        accuracy: result.metadata.accuracy,
+        synchronized: result.metadata.synchronized,
+        julianDay: enhancedResults.julianDay,
+        enhancedCalculations: true,
+        algorithms: [
+          'VSOP87-like planetary positions',
+          'IAU 2000A sidereal time',
+          'Proper equation of center',
+          'Enhanced lunar theory (ELP2000 approximation)',
+        ],
+      }
+    }
+
+    return result
+  } catch (error) {
+    console.warn('Enhanced calculations failed, falling back to legacy system:', error)
+
+    if (options.useLegacyFallback !== false) {
+      // Fall back to legacy system
+      const legacyResult = generateAccurateHoroscope(birthInfo)
+      if (legacyResult.metadata) {
+        legacyResult.metadata.method = 'Legacy fallback (enhanced calculations failed)'
+        legacyResult.metadata.accuracy = 'Simplified calculations ±2-5° precision'
+      }
+      return legacyResult
+    } else {
+      throw error
+    }
+  }
+}
+
+/**
+ * Professional accuracy testing and comparison
+ */
+export function testAstronomicalAccuracy(birthInfo: BirthInfo): {
+  legacy: GeneratedHoroscope
+  enhanced: GeneratedHoroscope
+  improvements: Record<string, number>
+  summary: {
+    averageImprovement: number
+    maxImprovement: number
+    method: string
+  }
+} {
+  const legacy = generateAccurateHoroscope(birthInfo)
+  const enhanced = generateProfessionalHoroscope(birthInfo, {
+    useLegacyFallback: false,
+    includeAccuracyMetadata: true,
+  })
+
+  // Calculate improvements (simplified for demo)
+  const improvements: Record<string, number> = {}
+  const expectedImprovements = {
+    Sun: 0.1,
+    Moon: 0.5,
+    Mercury: 2.0,
+    Venus: 1.0,
+    Mars: 1.5,
+    Jupiter: 0.5,
+    Saturn: 0.3,
+    Ascendant: 1.0,
+  }
+
+  Object.assign(improvements, expectedImprovements)
+
+  const values = Object.values(improvements)
+
+  return {
+    legacy,
+    enhanced,
+    improvements,
+    summary: {
+      averageImprovement: values.reduce((a, b) => a + b, 0) / values.length,
+      maxImprovement: Math.max(...values),
+      method: 'VSOP87-like vs simplified linear motion',
+    },
+  }
+}


### PR DESCRIPTION
## Summary
Session 5 of the planetary_agents migration. Ports the alchemical calculation engine and its horoscope-generation layer (3 files, ~2540 LOC).

## Ports (in dep order)
- **`src/lib/monica/horoscope-generator.ts`** (679 LOC) — accurate horoscope generation with real astronomical data.
- **`src/lib/alchemizer.ts`** (1122 LOC) — core alchemical calculation engine (signs, planetary dignities, elemental properties, alchemical values).
- **`src/lib/celestial-energy-calculator.ts`** (729 LOC) — celestial energy quantification over time (A#, SMES, kinetic, thermodynamic metrics).

## Adaptations vs. source
- **BirthInfo inlined** in `horoscope-generator.ts` — severs the circular `alchemical-trainer.ts` dep chain (alchemical-trainer imports alchemizer, planetary-hour, monica-constant, planetary-position-sync — none in target and out of scope).
- **`./observability` → `./observability-legacy`** in `alchemizer.ts` — Session 2 renamed the analytics stub to make way for the modular `observability/` directory.
- **Map.keys().next().value guards** added in 2 places — target's stricter TS rejects `string | undefined → string` in `Map.delete()`. Same root cause both files; safe `!== undefined` guards.
- **`parseInt()` radix-10 explicit** in 5 call sites — eslint `radix` rule.
- **4 unused imports removed** in `horoscope-generator.ts` (`EnhancedPlanetPosition`, `EnhancedAscendant`, `getDegreeForDate`, `calculateSolarPosition`).
- **1 spurious `await` removed** in `celestial-energy-calculator.ts` — `generateAccurateHoroscope` is sync.
- **`planetKey` → `_planetKey`** for unused destructured var in `alchemizer.ts`.

## Verification
- [x] `bun run typecheck` clean
- [x] `bun run lint` — 0 errors, 61 warnings (24 in new files, all intentional snake_case for scientific notation: `M_rad`, `lambda_rad`, `sun_sign`, `total_effect_multiplier`, etc.; rest are pre-existing baseline)
- [x] `bun run build` clean (production build)

## Test plan
- [ ] Confirm no regression on dev server startup (`bun run dev`)
- [ ] Verify `alchemizer` consumers in app continue to work as wired up by downstream sessions
- [ ] Sanity-check `generateAccurateHoroscope` callers in `celestial-energy-calculator` produce expected shape

## Surprises / corrections for future sessions
1. **The migration plan was wrong about `observability-legacy.ts`'s state.** Plan said "rewrite to `./observability-legacy`" was needed; Session 5 prompt claimed the file existed in target. Both are correct — Session 2 already ported it. My initial `find` invocations missed it (case-sensitive vs `-iname` mismatch in repeated greps); the lint output after commit revealed the duplicate. Soft-reset, deleted duplicate, redirected the alchemizer import. **Lesson**: always `git ls-files src/lib/<file>` to confirm tracking state — `ls`/`find` results can be incomplete with cached results or path-globbing edge cases.
2. **`performance-cache.ts` was also already ported in Session 2.** Byte-identical to source — my copy was a no-op. Same caveat as above.
3. **`Map.keys().next().value` is the new strict-mode tax** — successor to the TS 5.9 evolving-array gotcha from Sessions 3/4. Pattern: source code was written against looser TS; target's stricter inference reveals possibly-undefined cases that look fine but aren't. Guard before delete.
4. **Spurious `await` on a sync function** went unnoticed in source (TS doesn't flag it; eslint does). Worth a sweep on remaining ports.

## Reflection
Three large files, but mechanical adaptations dominated — Map guards + radix params + observability rename + import cleanup. The genuinely-tricky part was untangling the prompt's outdated assumptions about target state (carry-overs from Sessions 1–4 baked in incorrect facts about `observability-legacy` and `performance-cache`). Trusting `git ls-files` over `ls`/`find` would have saved one commit-and-reset cycle.

Stacked on `master` (PRs #419, #420 both merged). Ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)