### PR TITLE
chore: lint baseline + flesh out placeholders

### DIFF
--- a/src/app/api/admin/abuse/route.ts
+++ b/src/app/api/admin/abuse/route.ts
@@ -14,8 +14,8 @@
  */
 
 import { NextResponse } from "next/server";
-import { executeQuery } from "@/lib/database";
 import { validateAdminRequest } from "@/lib/auth/validateRequest";
+import { executeQuery } from "@/lib/database";
 import type { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";

--- a/src/app/api/admin/digest/route.ts
+++ b/src/app/api/admin/digest/route.ts
@@ -20,8 +20,8 @@
 
 import { timingSafeEqual } from "node:crypto";
 import { NextResponse } from "next/server";
-import { executeQuery } from "@/lib/database";
 import { validateAdminRequest } from "@/lib/auth/validateRequest";
+import { executeQuery } from "@/lib/database";
 import { getEventCounts } from "@/services/authEventsService";
 import emailService from "@/services/emailService";
 import type { NextRequest } from "next/server";

--- a/src/app/api/admin/users/stats/route.ts
+++ b/src/app/api/admin/users/stats/route.ts
@@ -13,8 +13,8 @@
  */
 
 import { NextResponse } from "next/server";
-import { executeQuery } from "@/lib/database";
 import { validateAdminRequest } from "@/lib/auth/validateRequest";
+import { executeQuery } from "@/lib/database";
 import { getEventCounts } from "@/services/authEventsService";
 import type { NextRequest } from "next/server";
 

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import * as React from 'react'
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
-
-import { cn } from '@/lib/utils'
+import * as React from 'react'
 import { buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 
 const AlertDialog = AlertDialogPrimitive.Root
 

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,6 +1,5 @@
-import * as React from 'react'
 import { cva, type VariantProps } from 'class-variance-authority'
-
+import * as React from 'react'
 import { cn } from '@/lib/utils'
 
 const alertVariants = cva(
@@ -29,6 +28,7 @@ Alert.displayName = 'Alert'
 
 const AlertTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
+    // eslint-disable-next-line jsx-a11y/heading-has-content -- children come via {...props}
     <h5
       ref={ref}
       className={cn('mb-1 font-medium leading-none tracking-tight', className)}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-import * as React from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { X } from 'lucide-react'
-
+import * as React from 'react'
 import { cn } from '@/lib/utils'
 
 const Dialog = DialogPrimitive.Root

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import * as React from 'react'
 import * as SeparatorPrimitive from '@radix-ui/react-separator'
-
+import * as React from 'react'
 import { cn } from '@/lib/utils'
 
 const Separator = React.forwardRef<

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import * as React from 'react'
 import * as SwitchPrimitives from '@radix-ui/react-switch'
-
+import * as React from 'react'
 import { cn } from '@/lib/utils'
 
 const Switch = React.forwardRef<

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-
 import { cn } from '@/lib/utils'
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<'textarea'>>(

--- a/src/hooks/useGalileoLog.ts
+++ b/src/hooks/useGalileoLog.ts
@@ -22,32 +22,6 @@ export function useGalileoLog(defaultComponentName?: string) {
   const [lastResult, setLastResult] = useState<LogResult | null>(null)
   const [componentMounted, setComponentMounted] = useState(false)
 
-  // Set component as mounted in useEffect
-  useEffect(() => {
-    setComponentMounted(true)
-
-    // When component unmounts, log that event
-    return () => {
-      if (defaultComponentName) {
-        logEvent('Component unmounted', {
-          componentName: defaultComponentName,
-          level: 'info',
-        })
-      }
-      setComponentMounted(false)
-    }
-  }, [defaultComponentName])
-
-  // Log component mounted event
-  useEffect(() => {
-    if (componentMounted && defaultComponentName) {
-      logEvent('Component mounted', {
-        componentName: defaultComponentName,
-        level: 'info',
-      })
-    }
-  }, [componentMounted, defaultComponentName])
-
   // Internal function to log events
   const logEvent = useCallback(
     async (message: string, options: LogOptions = {}): Promise<LogResult> => {
@@ -80,6 +54,32 @@ export function useGalileoLog(defaultComponentName?: string) {
     },
     [defaultComponentName]
   )
+
+  // Set component as mounted in useEffect
+  useEffect(() => {
+    setComponentMounted(true)
+
+    // When component unmounts, log that event
+    return () => {
+      if (defaultComponentName) {
+        void logEvent('Component unmounted', {
+          componentName: defaultComponentName,
+          level: 'info',
+        })
+      }
+      setComponentMounted(false)
+    }
+  }, [defaultComponentName, logEvent])
+
+  // Log component mounted event
+  useEffect(() => {
+    if (componentMounted && defaultComponentName) {
+      void logEvent('Component mounted', {
+        componentName: defaultComponentName,
+        level: 'info',
+      })
+    }
+  }, [componentMounted, defaultComponentName, logEvent])
 
   const log = useCallback(
     async (message: string, options: LogOptions = {}): Promise<LogResult> => {

--- a/src/lib/alchemizer.ts
+++ b/src/lib/alchemizer.ts
@@ -304,7 +304,7 @@ export function combineElementObjects(
   return combined_object
 }
 
-// Get ranking of elements by value
+// Get ranking of elements by value (top `rank` slots, max 4)
 export function getElementRanking(
   element_object: Record<string, number>,
   rank = 1
@@ -316,21 +316,22 @@ export function getElementRanking(
     4: '',
   }
 
-  let largest_element_value = -Infinity
-  let largest_element = ''
+  const remaining = new Map(Object.entries(element_object))
+  const slots = Math.max(0, Math.min(rank, 4))
 
-  // Find the largest element
-  for (const element in element_object) {
-    if (element_object[element] > largest_element_value) {
-      largest_element_value = element_object[element]
-      largest_element = element
+  for (let i = 1; i <= slots; i++) {
+    let topElement = ''
+    let topValue = -Infinity
+    for (const [element, value] of remaining) {
+      if (value > topValue) {
+        topValue = value
+        topElement = element
+      }
     }
+    if (!topElement) break
+    element_rank_dict[i] = topElement
+    remaining.delete(topElement)
   }
-
-  element_rank_dict[1] = largest_element
-
-  // For a complete implementation, you would continue to find 2nd, 3rd, and 4th
-  // largest elements, but this simplified version just returns the dominant element
 
   return element_rank_dict
 }
@@ -394,20 +395,11 @@ export function alchemize(
 
   // Simplified implementation for UI integration
   const horoscope = horoscope_dict['tropical'] || horoscope_dict
-  const silent_mode = true
 
   // Determine if time is diurnal or nocturnal
   let diurnal_or_nocturnal = 'Diurnal'
   if (birth_info['hour'] < 5 || birth_info['hour'] > 17) {
     diurnal_or_nocturnal = 'Nocturnal'
-  }
-
-  // Create metadata and initial alchmInfo structure
-  const metadata: Record<string, any> = {
-    name: 'Alchm NFT',
-    description:
-      'Alchm is unlike any other NFT collection on Earth. Just like people, no two Alchm NFTs are the same, and there is no limit on how many can exist. Your Alchm NFT has no random features, and is completely customized and unique to you. By minting, you gain permanent access to limitless information about your astrology and identity through our sites and apps.',
-    attributes: [],
   }
 
   // Initialize the alchemical information object

--- a/src/lib/kinetics-integration.ts
+++ b/src/lib/kinetics-integration.ts
@@ -1,3 +1,9 @@
+import {
+  PlanetaryKineticsClient,
+  type KineticsLocation,
+  type KineticsOptions,
+} from '@/services/PlanetaryKineticsClient'
+
 export interface EnhancedKineticData {
   energy: number
   momentum: number
@@ -7,10 +13,28 @@ export class KineticsIntegration {
   static getInstance() {
     return new KineticsIntegration()
   }
-  async getAgentKinetics(agentId: string): Promise<EnhancedKineticData> {
+
+  // TODO: no agent-aware kinetics path exists yet. PlanetaryKineticsClient is
+  // location-based, and there is no agent→location/context mapping. Returns
+  // unit values until that data path is designed.
+  async getAgentKinetics(_agentId: string): Promise<EnhancedKineticData> {
     return { energy: 1.0, momentum: 1.0 }
   }
-  async getEnhancedKinetics(location: any, options: any): Promise<EnhancedKineticData> {
-    return { energy: 1.0, momentum: 1.0 }
+
+  async getEnhancedKinetics(
+    location: KineticsLocation,
+    options: KineticsOptions = {}
+  ): Promise<EnhancedKineticData> {
+    const response = await PlanetaryKineticsClient.getInstance().getEnhancedKinetics(
+      location,
+      options
+    )
+    if (!response.success || !response.data) {
+      return { energy: 1.0, momentum: 1.0 }
+    }
+    return {
+      energy: response.data.power,
+      momentum: response.data.forceMagnitude,
+    }
   }
 }

--- a/src/lib/observability-legacy.ts
+++ b/src/lib/observability-legacy.ts
@@ -4,7 +4,6 @@ export function recordElementalLogicMode(mode: ElementalLogicMode): void {
   try {
     // Placeholder analytics hook for A/B testing; wire to real telemetry later
     // Intentionally lightweight and non-blocking
-    // eslint-disable-next-line no-console
     console.log(`[analytics] elemental_logic_mode=${mode}`)
   } catch {
     // no-op


### PR DESCRIPTION
## Summary
Two-commit cleanup PR. First commit clears 10 pre-migration baseline lint warnings (purely mechanical). Second commit fleshes out three documented placeholders surfaced during the Session 5.5 validation pass and fixes the useGalileoLog hook warnings.

## Commit 1 — Baseline lint warnings
Cleans up 10 pre-existing lint warnings that have surfaced in every WTEN migration session's full-tree lint output. Behavior-neutral.

- 3 admin API routes: `import/order` (\`@/lib/auth/validateRequest\` before \`@/lib/database\`).
- 6 shadcn ui components (alert-dialog, alert, dialog, separator, switch, textarea): import-order + remove blank lines between import groups.
- `alert.tsx`: inline eslint-disable for \`jsx-a11y/heading-has-content\` on AlertTitle (children come via \`{...props}\`).
- `observability-legacy.ts`: remove stale unused eslint-disable directive.

## Commit 2 — Placeholders + hook fixes
**`src/lib/kinetics-integration.ts` — delegate to real client**
- `getEnhancedKinetics(location, options)` now delegates to `PlanetaryKineticsClient.getInstance().getEnhancedKinetics()` and maps the rich `KineticsResponse` → thin `{energy, momentum}`:
  - \`energy ← data.power\`
  - \`momentum ← data.forceMagnitude\`
  - Falls back to `{1.0, 1.0}` on non-success responses.
- `getAgentKinetics(_agentId)` keeps the `{1.0, 1.0}` hardcoded return with a TODO comment — PlanetaryKineticsClient is location-based and no agent→context mapping exists yet.
- Public signature tightened: `KineticsLocation` + `KineticsOptions` instead of `any, any`.

**`src/lib/alchemizer.ts` — honor the documented TODO in getElementRanking**
- Implements full top-N ranking: fills slots `1..min(rank,4)` with the top-ranked elements by value, instead of only filling slot 1. The source code itself had a comment saying "For a complete implementation, you would continue to find 2nd, 3rd, and 4th largest elements."
- Removes dead `silent_mode = true` (no console.log in the enclosing function ever gated on it).
- Removes unused `metadata = {name: 'Alchm NFT', ...}` (constructed but never attached to alchmInfo or returned).

**`src/hooks/useGalileoLog.ts` — fix exhaustive-deps + floating promises**
- Reorder: `logEvent` useCallback moved above the two useEffects that reference it (clearer to read; same runtime behavior).
- Add `logEvent` to both useEffect deps arrays (it's memoized via `useCallback([defaultComponentName])`, so no extra re-runs).
- Prepend `void` to two fire-and-forget `logEvent` calls in the mount/unmount effects to silence `no-floating-promises`.

## Verification
- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\`: **61 → 31 warnings** (30 cleared total across both commits; the remaining 31 are intentional snake_case scientific notation per the WTEN migration carry-over and `max-params` in `core-energy-rules.ts`)
- [x] Migration dep-chain smoke test passes — original 10 checksums from Session 5 close all still match exactly (Spirit=4.6, Dominant=Earth, Heat=0.03082570945749082, etc.), confirming the alchemizer cleanup broke nothing
- [x] Two new smoke-test assertions added:
  - `getElementRanking({Fire:3,Water:8,Air:5,Earth:1}, 4) == {1:Water, 2:Air, 3:Fire, 4:Earth}` ✓
  - `KineticsIntegration.getInstance().getAgentKinetics('x') == {energy:1.0, momentum:1.0}` ✓

## Why no consumer changes?
The fleshed-out modules (`kinetics-integration`, alchemizer's `getElementRanking`) currently have zero importers outside `src/lib/`. This PR fixes them in place; downstream wiring is Sessions 8–10's work per the migration plan.

## Test plan
- [ ] CI checks pass (Verify, Build, Test)
- [ ] Visual spot-check on admin pages and shadcn-using components (no behavior change expected from commit 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)