### PR TITLE
fix(site-smoke): 4 runtime bugs from browser walk

### DIFF
--- a/src/app/api/nanobanana/generate/route.ts
+++ b/src/app/api/nanobanana/generate/route.ts
@@ -34,10 +34,10 @@ export async function POST(req: NextRequest) {
 
     // Try to get cached result
     try {
-      const cached = await redisGet(cacheKey);
+      const cached = await redisGet<unknown>(cacheKey);
       if (cached) {
         console.debug("[NanoBanana] Serving cached image result");
-        return NextResponse.json(JSON.parse(cached));
+        return NextResponse.json(cached);
       }
     } catch (err) {
       console.warn("[NanoBanana] Redis read failed:", err);
@@ -61,7 +61,7 @@ export async function POST(req: NextRequest) {
 
     // Cache the successful result
     if (data.url) {
-      await redisSet(cacheKey, JSON.stringify(data), CACHE_TTL).catch((err) =>
+      await redisSet(cacheKey, data, CACHE_TTL).catch((err) =>
         console.warn("[NanoBanana] Redis write failed:", err),
       );
     }

--- a/src/app/api/philosophers-stone/positions/route.ts
+++ b/src/app/api/philosophers-stone/positions/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
-import { alchemize } from "@/constants/alchemicalPillars";
 import { rateLimit } from "@/lib/rateLimit";
 import { getCurrentPlanetaryPositions } from "@/services/astrologizeApi";
+import { alchemize } from "@/services/RealAlchemizeService";
 import { logger } from "@/utils/logger";
 import { calculateEnhancedAlchemicalFromPlanets, isSectDiurnal } from "@/utils/planetaryAlchemyMapping";
 import type { NextRequest } from "next/server";
@@ -52,23 +52,16 @@ export async function GET(request: NextRequest) {
         );
 
         // Calculate thermodynamic metrics using the alchemizer engine
-        const thermodynamicMetrics = alchemize(planetaryPositions);
+        const alchemizeResult = alchemize(planetaryPositions);
+        const { heat, entropy, reactivity, gregsEnergy } =
+          alchemizeResult.thermodynamicProperties;
+        const { kalchm, monica } = alchemizeResult;
 
         // Derive elemental properties from thermodynamics
-        type WithMonicaKalchm = typeof thermodynamicMetrics & {
-          monica?: number;
-          kalchm?: number;
-        };
-        const t = thermodynamicMetrics as WithMonicaKalchm;
-        const Fire =
-          ((t as any)?.heat || 0) * 0.2 + ((t as any)?.reactivity || 0) * 0.2;
-        const Water =
-          (t.monica || 0) * 0.6 + (1 - thermodynamicMetrics.heat) * 0.4;
-        const Earth =
-          (t.kalchm || 0) * 0.5 + (1 - thermodynamicMetrics.entropy) * 0.5;
-        const Air =
-          ((t as any)?.entropy || 0) * 0.2 +
-          ((t as any)?.reactivity || 0) * 0.2;
+        const Fire = heat * 0.2 + reactivity * 0.2;
+        const Water = monica * 0.6 + (1 - heat) * 0.4;
+        const Earth = kalchm * 0.5 + (1 - entropy) * 0.5;
+        const Air = entropy * 0.2 + reactivity * 0.2;
         const total = Fire + Water + Earth + Air;
         const elementalBalance = {
           Fire: Fire / total,
@@ -78,7 +71,7 @@ export async function GET(request: NextRequest) {
         };
 
         response.alchemicalProperties = alchemicalProperties;
-        response.thermodynamicMetrics = thermodynamicMetrics;
+        response.thermodynamicMetrics = { heat, entropy, reactivity, gregsEnergy, kalchm, monica };
 
         // Add philosophers stone interpretation
         response.interpretation = {
@@ -87,12 +80,12 @@ export async function GET(request: NextRequest) {
           transformativePower: alchemicalProperties.Substance,
           elementalBalance,
           thermodynamicState: {
-            heat: thermodynamicMetrics.heat,
-            entropy: thermodynamicMetrics.entropy,
-            reactivity: thermodynamicMetrics.reactivity,
-            gregEnergy: thermodynamicMetrics.gregsEnergy,
-            kalchm: thermodynamicMetrics.kalchm,
-            monica: thermodynamicMetrics.monica,
+            heat,
+            entropy,
+            reactivity,
+            gregEnergy: gregsEnergy,
+            kalchm,
+            monica,
           },
         };
 
@@ -176,23 +169,20 @@ export async function POST(request: NextRequest) {
           signMap,
           diurnal
         );
-        const thermodynamicMetrics = alchemize(planetaryPositions);
+        const alchemizeResult2 = alchemize(planetaryPositions);
+        const {
+          heat: heat2,
+          entropy: entropy2,
+          reactivity: reactivity2,
+          gregsEnergy: gregsEnergy2,
+        } = alchemizeResult2.thermodynamicProperties;
+        const { kalchm: kalchm2, monica: monica2 } = alchemizeResult2;
 
         // Derive elemental properties from thermodynamics
-        type WithMonicaKalchm2 = typeof thermodynamicMetrics & {
-          monica?: number;
-          kalchm?: number;
-        };
-        const t2 = thermodynamicMetrics as WithMonicaKalchm2;
-        const Fire2 =
-          ((t2 as any)?.heat || 0) * 0.2 + ((t2 as any)?.reactivity || 0) * 0.2;
-        const Water2 =
-          (t2.monica || 0) * 0.6 + (1 - thermodynamicMetrics.heat) * 0.4;
-        const Earth2 =
-          (t2.kalchm || 0) * 0.5 + (1 - thermodynamicMetrics.entropy) * 0.5;
-        const Air2 =
-          ((t2 as any)?.entropy || 0) * 0.2 +
-          ((t2 as any)?.reactivity || 0) * 0.2;
+        const Fire2 = heat2 * 0.2 + reactivity2 * 0.2;
+        const Water2 = monica2 * 0.6 + (1 - heat2) * 0.4;
+        const Earth2 = kalchm2 * 0.5 + (1 - entropy2) * 0.5;
+        const Air2 = entropy2 * 0.2 + reactivity2 * 0.2;
         const total2 = Fire2 + Water2 + Earth2 + Air2;
         const elementalBalance2 = {
           Fire: Fire2 / total2,
@@ -202,7 +192,14 @@ export async function POST(request: NextRequest) {
         };
 
         response.alchemicalProperties = alchemicalProperties;
-        response.thermodynamicMetrics = thermodynamicMetrics;
+        response.thermodynamicMetrics = {
+          heat: heat2,
+          entropy: entropy2,
+          reactivity: reactivity2,
+          gregsEnergy: gregsEnergy2,
+          kalchm: kalchm2,
+          monica: monica2,
+        };
 
         // Enhanced interpretation for specific date/location
         response.philosophersStone = {
@@ -221,9 +218,9 @@ export async function POST(request: NextRequest) {
             dominantElement: getDominantElement(elementalBalance2),
           },
           alchemicalPotential: {
-            transformationReadiness: thermodynamicMetrics.reactivity,
-            stabilityIndex: 1 - thermodynamicMetrics.entropy,
-            energeticPotential: thermodynamicMetrics.gregsEnergy,
+            transformationReadiness: reactivity2,
+            stabilityIndex: 1 - entropy2,
+            energeticPotential: gregsEnergy2,
           },
         };
       } catch (alchemicalError) {

--- a/src/app/api/planetary-positions/route.ts
+++ b/src/app/api/planetary-positions/route.ts
@@ -188,10 +188,10 @@ export async function GET(request: NextRequest) {
     const cacheKey = `planetary_pos:${y}-${m}-${d}-${h}:${lat}:${lon}`;
 
     try {
-      const cached = await redisGet(cacheKey);
+      const cached = await redisGet<unknown>(cacheKey);
       if (cached) {
         console.debug("[PlanetaryPos] Serving cached positions");
-        return NextResponse.json(JSON.parse(cached));
+        return NextResponse.json(cached);
       }
     } catch (err) {
       console.warn("[PlanetaryPos] Redis read failed:", err);
@@ -201,7 +201,7 @@ export async function GET(request: NextRequest) {
     if (backendPositions) {
       const resp = toResponse(backendPositions, "backend-pyswisseph");
       const data = await resp.json();
-      await redisSet(cacheKey, JSON.stringify(data), 3600).catch(() => {});
+      await redisSet(cacheKey, data, 3600).catch(() => {});
       return NextResponse.json(data);
     }
 
@@ -219,7 +219,7 @@ export async function GET(request: NextRequest) {
     const fallbackPositions = calculateLocalPositions(fallbackDate);
     const resp = toResponse(fallbackPositions, "local-astronomy-engine");
     const data = await resp.json();
-    await redisSet(cacheKey, JSON.stringify(data), 3600).catch(() => {});
+    await redisSet(cacheKey, data, 3600).catch(() => {});
     return NextResponse.json(data);
   } catch (error) {
     console.error("[planetary-positions] Error:", error);

--- a/src/app/restaurants/[id]/menu/page.tsx
+++ b/src/app/restaurants/[id]/menu/page.tsx
@@ -22,16 +22,24 @@ interface RestaurantRow {
 }
 
 async function getRestaurant(id: string): Promise<RestaurantRow | null> {
-  const result = await executeQuery<RestaurantRow>(
-    `SELECT id, name, menu_url, external_provider, external_id,
-            stripe_connect_account_id, deliverect_location_id
-     FROM restaurants
-     WHERE id = $1
-     LIMIT 1`,
-    [id],
-  );
+  // Treat DB errors as "not found" — `notFound()` only triggers on a null
+  // return value, so any thrown error here would bubble up as a React Server
+  // Components crash instead of a clean 404.
+  try {
+    const result = await executeQuery<RestaurantRow>(
+      `SELECT id, name, menu_url, external_provider, external_id,
+              stripe_connect_account_id, deliverect_location_id
+       FROM restaurants
+       WHERE id = $1
+       LIMIT 1`,
+      [id],
+    );
 
-  return result.rows[0] ?? null;
+    return result.rows[0] ?? null;
+  } catch (err) {
+    console.error(`[restaurants/${id}/menu] DB lookup failed:`, err);
+    return null;
+  }
 }
 
 function appUrl(): string {

--- a/src/lib/api/alchm-client.ts
+++ b/src/lib/api/alchm-client.ts
@@ -97,6 +97,16 @@ export class AlchmAPIClient {
     url: string,
     init?: RequestInit,
   ): Promise<TResponse> {
+    // When NEXT_PUBLIC_BACKEND_URL is unset (typical local dev), URLs end up
+    // relative (e.g. "/api/v1/cuisines"). Node's fetch requires absolute URLs
+    // and throws ERR_INVALID_URL — surface a clearer error and let callers
+    // catch it without leaking the raw TypeError into server-rendered pages.
+    if (url.startsWith("/")) {
+      throw new Error(
+        `AlchmAPIClient: backend endpoint not configured (relative URL: ${url}). ` +
+          `Set NEXT_PUBLIC_BACKEND_URL or NEXT_PUBLIC_KITCHEN_BACKEND_URL.`,
+      );
+    }
     const response = await fetch(url, init);
     if (!response.ok) {
       const statusText = response.statusText || "Unknown Error";
@@ -189,6 +199,11 @@ export class AlchmAPIClient {
         method: "GET",
         headers: { "Content-Type": "application/json" },
       });
+      // Don't cache rejected promises — a single transient failure would
+      // permanently break the call site otherwise.
+      this._cache.cuisines.catch(() => {
+        this._cache.cuisines = undefined;
+      });
     }
     return this._cache.cuisines;
   }
@@ -211,6 +226,9 @@ export class AlchmAPIClient {
         method: "GET",
         headers: { "Content-Type": "application/json" },
       });
+      this._cache.sauces.catch(() => {
+        this._cache.sauces = undefined;
+      });
     }
     return this._cache.sauces;
   }
@@ -221,6 +239,9 @@ export class AlchmAPIClient {
       this._cache.ingredients = this.request<Record<string, any>>(url, {
         method: "GET",
         headers: { "Content-Type": "application/json" },
+      });
+      this._cache.ingredients.catch(() => {
+        this._cache.ingredients = undefined;
       });
     }
     return this._cache.ingredients;

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -14,9 +14,9 @@ export async function getValidatedAssetUrl(path: string | null | undefined): Pro
   const cacheKey = `asset_valid:${path}`;
   
   try {
-    const cached = await redisGet(cacheKey);
-    if (cached === "1") return `${ASSET_DOMAIN}/${path}`;
-    if (cached === "0") return undefined;
+    const cached = await redisGet<boolean>(cacheKey);
+    if (cached === true) return `${ASSET_DOMAIN}/${path}`;
+    if (cached === false) return undefined;
   } catch (err) {
     console.warn("[AssetCache] Redis lookup failed:", err);
   }
@@ -29,7 +29,7 @@ export async function getValidatedAssetUrl(path: string | null | undefined): Pro
   
   // Asynchronously "warm" the cache for this path as valid
   // In a real scenario, we'd do a HEAD request to R2 here.
-  void redisSet(cacheKey, "1", ASSET_CACHE_TTL).catch(() => {});
+  void redisSet(cacheKey, true, ASSET_CACHE_TTL).catch(() => {});
   
   return fullUrl;
 }
@@ -39,5 +39,5 @@ export async function getValidatedAssetUrl(path: string | null | undefined): Pro
  */
 export async function invalidateAsset(path: string): Promise<void> {
   const cacheKey = `asset_valid:${path}`;
-  await redisSet(cacheKey, "0", ASSET_CACHE_TTL * 7).catch(() => {});
+  await redisSet(cacheKey, false, ASSET_CACHE_TTL * 7).catch(() => {});
 }

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -25,11 +25,15 @@ export function getRedisClient(): Redis | null {
   }
 }
 
-export async function redisGet(key: string): Promise<string | null> {
+// NOTE: the Upstash REST client (@upstash/redis) auto-serializes objects on
+// SET and auto-parses JSON-shaped values on GET. Callers must not double-encode
+// with JSON.stringify/JSON.parse — the previous contract did, and the resulting
+// double-parse produced literal `"[object Object]"` strings on read.
+export async function redisGet<T = unknown>(key: string): Promise<T | null> {
   try {
     const client = getRedisClient();
     if (!client) return null;
-    return await client.get<string>(key);
+    return await client.get<T>(key);
   } catch (err) {
     console.error("[Redis] GET failed:", err);
     return null;
@@ -38,14 +42,13 @@ export async function redisGet(key: string): Promise<string | null> {
 
 export async function redisSet(
   key: string,
-  value: string,
+  value: unknown,
   ttlSeconds: number,
 ): Promise<void> {
   try {
     const client = getRedisClient();
     if (!client) return;
-    await client.set(key, value, { ex: ttlSeconds });
-    console.debug("[Redis] SET success:", key);
+    await client.set(key, value as never, { ex: ttlSeconds });
   } catch (err) {
     console.error("[Redis] SET failed:", err);
   }

--- a/src/services/LocalRecipeService.ts
+++ b/src/services/LocalRecipeService.ts
@@ -273,12 +273,11 @@ export class LocalRecipeService {
 
     // L2: Redis catalog cache (cross-instance — target <20ms)
     try {
-      const cached = await redisGet(REDIS_CATALOG_KEY);
-      if (cached) {
-        const recipes = JSON.parse(cached) as Recipe[];
-        this._allRecipes = recipes;
+      const cached = await redisGet<Recipe[]>(REDIS_CATALOG_KEY);
+      if (cached && Array.isArray(cached) && cached.length > 0) {
+        this._allRecipes = cached;
         this._allRecipesLoadedAt = Date.now();
-        return recipes;
+        return cached;
       }
     } catch (err) {
       logger.warn("Redis cache read failed, falling through to DB:", err);
@@ -290,8 +289,8 @@ export class LocalRecipeService {
 
       if (recipes.length === 0) {
         logger.warn("Database recipes table returned 0 rows, gracefully resolving local hardcoded payload fallback");
-        const { allRecipes } = await import("@/data/recipes/index");
-        this._allRecipes = allRecipes;
+        const { getServerRecipes } = await import("@/actions/recipes");
+        this._allRecipes = await getServerRecipes();
         this._allRecipesLoadedAt = Date.now();
         return this._allRecipes;
       }
@@ -300,7 +299,7 @@ export class LocalRecipeService {
       this._allRecipesLoadedAt = Date.now();
 
       // Populate Redis asynchronously so we don't block the response
-      redisSet(REDIS_CATALOG_KEY, JSON.stringify(recipes), REDIS_TTL_SECONDS).catch(() => {});
+      redisSet(REDIS_CATALOG_KEY, recipes, REDIS_TTL_SECONDS).catch(() => {});
 
       // Part 3: Warm Image Asset Cache
       this.warmImageAssetCache(recipes);
@@ -308,8 +307,8 @@ export class LocalRecipeService {
       return recipes;
     } catch (error) {
       logger.error("Error loading recipes from database, extracting raw local fallback:", error);
-      const { allRecipes } = await import("@/data/recipes/index");
-      return allRecipes;
+      const { getServerRecipes } = await import("@/actions/recipes");
+      return getServerRecipes();
     }
   }
 
@@ -361,8 +360,9 @@ export class LocalRecipeService {
       // Ultimate local fallback
       try {
         const decodedId = decodeURIComponent(recipeId);
-        const { allRecipes } = await import("@/data/recipes/index");
-        return allRecipes.find((r) => String(r.id) === decodedId || r.name === decodedId) || null;
+        const { getServerRecipes } = await import("@/actions/recipes");
+        const recipes = await getServerRecipes();
+        return recipes.find((r) => String(r.id) === decodedId || r.name === decodedId) || null;
       } catch (_innerError) {
         return null;
       }

--- a/src/services/sauceRecommender.ts
+++ b/src/services/sauceRecommender.ts
@@ -21,7 +21,13 @@ export class SauceRecommender {
       cookingMethod?: string;
     },
   ): Promise<string[]> {
-    const cuisinesMap = await alchmAPI.getCuisines();
+    let cuisinesMap: Record<string, any>;
+    try {
+      cuisinesMap = await alchmAPI.getCuisines();
+    } catch (err) {
+      console.warn("[SauceRecommender] cuisines fetch failed, skipping:", err);
+      return [];
+    }
     const cuisine = cuisinesMap[cuisineName];
     if (!cuisine || !cuisine.sauceRecommender) {
       return [];


### PR DESCRIPTION
## Summary

Session 5.7 was a runtime quality pass — boot the dev server, drive the site as an anonymous visitor through the 8 main routes, hunt errors, and fix the showstoppers before Sessions 6–11 build new surface on top. This PR bundles the 4 real bugs I found, each verified in the browser before/after.

### Bugs fixed

- **`/recipes/[id]` always 404'd in dev** — `LocalRecipeService`'s ultimate fallback imported the deprecated empty `allRecipes` constant from `@/data/recipes/index.ts` instead of the async `getAllRecipes()` (or `getServerRecipes()` like the listing route uses). When the DB was unreachable (typical local dev) the detail page couldn't find recipes whose IDs came from the cuisine-data extraction. Fix: route both `getAllRecipes` and `getRecipeById` fallbacks through `getServerRecipes()`, so listing and detail share one ID source.

- **Redis cache always missed in prod (\"[object Object]\" JSON.parse error)** — The Upstash REST client (`@upstash/redis` v1.38) auto-serializes objects on `set` and auto-parses JSON-shaped values on `get`. The helper was doing `JSON.stringify` on write + `JSON.parse` on read on top of that, so on read it received the array Upstash already parsed, coerced it to a string (`\"[object Object],[object Object],...\"`), and choked. Net effect: prod recipe/planetary/nanobanana caches always missed and fell through to DB. Fix: `redisGet<T>` returns `T | null`, `redisSet(key, value: unknown, ttl)`; callers stop double-encoding. `assets.ts` switches its truthy markers from `\"1\"/\"0\"` to `true`/`false` so the round-trip is unambiguous.

- **`/restaurants/[id]/menu` crashed with uncaught `AggregateError`** — The Server Component called `executeQuery` directly. Any DB error (e.g. bad id, transient pool issue) bubbled up as an uncaught throw instead of being caught and turned into a clean 404. Fix: wrap in try/catch and return `null` so `notFound()` triggers.

- **`/api/philosophers-stone/positions` returned random thermodynamic metrics** — Imported `alchemize` from `@/constants/alchemicalPillars` (a placeholder that returns `Math.random()` values; comment in that file even says so) instead of the real one in `@/services/RealAlchemizeService` that every other route uses. Switched the import and updated the accessors to the real return shape (`thermodynamicProperties.{heat,entropy,reactivity,gregsEnergy}` plus top-level `kalchm`/`monica`).

### Defensive hardening (related, same PR)

- `AlchmAPIClient.request`: throw a clear \"backend not configured\" error when called with a relative URL (Node `fetch` requires absolute; raw `TypeError: Invalid URL` was leaking into RSC pages in dev).
- `AlchmAPIClient.getCuisines/getSauces/getIngredients`: stop caching rejected promises so a transient failure no longer permanently breaks the call site.
- `SauceRecommender.recommendSauce`: catch backend failures and return `[]` instead of throwing, so a downstream service hiccup doesn't 500 the `/api/recipes/[recipeId]` route.

### What this is NOT

- Not migration work (Sessions 6–11 are tracked separately).
- Not a navigation refactor (deferred per user).
- Not a Phase 3 placeholder-fleshing-out — the only stub I touched was `philosophers-stone/positions` because its placeholder was actively producing wrong output in prod.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint`: **31 warnings, 0 errors** — matches pre-PR baseline exactly
- [x] `bun run build` succeeds
- [x] Browser walk re-run on all 8 routes; all return 200 (auth-gated `/restaurant-creator` redirects 302 as expected)
- [x] `/recipes/<id>` now loads the detail page (full ingredients, instructions, elemental properties, nutrition, 3 recommended recipes)
- [x] `/restaurants/<bad-id>/menu` now shows the 404 page instead of \"Alchemy Error\"
- [x] `/api/philosophers-stone/positions` returns deterministic computed metrics (heat=0.0538, kalchm=313.63, monica=0.0389 for the current sky) instead of `Math.random()` noise
- [x] No more `Redis cache read failed, falling through to DB: SyntaxError: Unexpected token 'o'` warning in dev logs

## Reflection

The session prompt warned: \"upstream stubs masquerading as migration debt — grep for the real implementation first.\" The philosophers-stone bug was the textbook case: `alchemize` exists as a real implementation in `RealAlchemizeService` and a `Math.random()` placeholder in `alchemicalPillars` with the same name, and a single route was importing the wrong one. Going forward, when grepping for ports/stubs it's worth treating same-named exports from multiple files as a special red flag — same lesson, slightly different shape than the recipe-index empty-array case in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)