### PR TITLE
feat(pa-integration): wire alchm.kitchen to planetary_agents backend

### DIFF
--- a/src/app/admin/_dashboard/PaAgentSyncPanel.tsx
+++ b/src/app/admin/_dashboard/PaAgentSyncPanel.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+/**
+ * PA Agent Sync Panel — admin control to manually re-sync agents to the
+ * planetary_agents backend.
+ *
+ * Backed by POST /api/admin/agent-sync (validateAdminRequest enforces auth).
+ * Two modes:
+ *   - "all": pushes every is_agent=true user from the WTEN DB to PA in
+ *     batches of 4. Use for first-time backfill or drift repair.
+ *   - "one": single user by email. Use for spot fixes after a profile edit.
+ *
+ * Designed to render inside src/app/admin/_dashboard/agents.tsx alongside the
+ * existing AgentFeedControlRoom card.
+ */
+
+import React, { useState } from "react";
+
+type SyncResult = {
+  agentId: string;
+  email: string;
+  ok: boolean;
+  status?: number;
+  error?: string;
+};
+
+type SyncResponse = {
+  success: boolean;
+  synced?: number;
+  failed?: number;
+  results?: SyncResult[];
+  note?: string;
+  error?: string;
+};
+
+const AGENTIC_DOMAIN = "@agentic.alchm.kitchen";
+
+export function PaAgentSyncPanel() {
+  const [email, setEmail] = useState("");
+  const [busy, setBusy] = useState<"all" | "one" | null>(null);
+  const [result, setResult] = useState<SyncResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function trigger(body: Record<string, unknown>, mode: "all" | "one") {
+    setBusy(mode);
+    setError(null);
+    setResult(null);
+    try {
+      const resp = await fetch("/api/admin/agent-sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = (await resp.json()) as SyncResponse;
+      if (!resp.ok || !data.success) {
+        setError(data.error || `HTTP ${resp.status}`);
+      } else {
+        setResult(data);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const failures = (result?.results ?? []).filter((r) => !r.ok);
+
+  return (
+    <section
+      style={{
+        marginBottom: 14,
+        border: "1px solid color-mix(in oklch, var(--accent), transparent 60%)",
+        borderRadius: 10,
+        background: "rgba(0,0,0,0.18)",
+        padding: 12,
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: 10,
+        }}
+      >
+        <div>
+          <div className="t-tag" style={{ color: "var(--accent)", fontSize: 9 }}>
+            PA RE-SYNC · MANUAL
+          </div>
+          <div className="t-display" style={{ fontSize: 14, marginTop: -2 }}>
+            push WTEN is_agent=true users to api.agents.alchm.kitchen
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => void trigger({ all: true }, "all")}
+          disabled={busy !== null}
+          style={{
+            background:
+              busy === "all"
+                ? "color-mix(in oklch, var(--accent), transparent 40%)"
+                : "var(--accent)",
+            border: "none",
+            color: "var(--bg)",
+            padding: "6px 14px",
+            borderRadius: 6,
+            cursor: busy ? "wait" : "pointer",
+            fontSize: 12,
+            fontWeight: 600,
+            letterSpacing: 0.4,
+          }}
+        >
+          {busy === "all" ? "SYNCING…" : "SYNC ALL"}
+        </button>
+      </header>
+
+      <div style={{ display: "flex", gap: 8, marginBottom: 10 }}>
+        <input
+          type="email"
+          placeholder={`agent${AGENTIC_DOMAIN}`}
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          disabled={busy !== null}
+          style={{
+            flex: 1,
+            background: "rgba(0,0,0,0.3)",
+            border: "1px solid color-mix(in oklch, var(--fg-mute), transparent 60%)",
+            color: "var(--fg)",
+            padding: "6px 10px",
+            borderRadius: 6,
+            fontSize: 12,
+            fontFamily: "inherit",
+          }}
+        />
+        <button
+          type="button"
+          onClick={() => {
+            const trimmed = email.trim();
+            if (!trimmed.endsWith(AGENTIC_DOMAIN)) {
+              setError(`email must end in ${AGENTIC_DOMAIN}`);
+              return;
+            }
+            void trigger({ email: trimmed }, "one");
+          }}
+          disabled={busy !== null || email.trim().length === 0}
+          style={{
+            background:
+              busy === "one"
+                ? "color-mix(in oklch, var(--accent-2), transparent 40%)"
+                : "var(--accent-2)",
+            border: "none",
+            color: "var(--bg)",
+            padding: "6px 14px",
+            borderRadius: 6,
+            cursor: busy ? "wait" : "pointer",
+            fontSize: 12,
+            fontWeight: 600,
+            letterSpacing: 0.4,
+          }}
+        >
+          {busy === "one" ? "SYNCING…" : "SYNC ONE"}
+        </button>
+      </div>
+
+      {error && (
+        <div
+          style={{
+            color: "var(--el-fire)",
+            fontSize: 11,
+            padding: "6px 10px",
+            background: "color-mix(in oklch, var(--el-fire), transparent 88%)",
+            borderRadius: 6,
+            marginBottom: 6,
+          }}
+        >
+          error: {error}
+        </div>
+      )}
+
+      {result && (
+        <div style={{ fontSize: 11, color: "var(--fg-mute)" }}>
+          {result.note ? (
+            <span>{result.note}</span>
+          ) : (
+            <span>
+              <strong style={{ color: "var(--el-earth)" }}>
+                {result.synced ?? 0} synced
+              </strong>
+              {" · "}
+              <strong
+                style={{
+                  color: (result.failed ?? 0) > 0 ? "var(--el-fire)" : "var(--fg-mute)",
+                }}
+              >
+                {result.failed ?? 0} failed
+              </strong>
+            </span>
+          )}
+          {failures.length > 0 && (
+            <details style={{ marginTop: 6 }}>
+              <summary style={{ cursor: "pointer", color: "var(--accent)" }}>
+                show {failures.length} failure{failures.length === 1 ? "" : "s"}
+              </summary>
+              <ul style={{ margin: "6px 0 0", paddingLeft: 18 }}>
+                {failures.slice(0, 10).map((f) => (
+                  <li key={f.agentId}>
+                    <code>{f.email}</code>: {f.status ?? "—"} {f.error ?? ""}
+                  </li>
+                ))}
+                {failures.length > 10 && (
+                  <li>…and {failures.length - 10} more</li>
+                )}
+              </ul>
+            </details>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/app/admin/_dashboard/agents.tsx
+++ b/src/app/admin/_dashboard/agents.tsx
@@ -4,12 +4,15 @@ import React from "react";
 import { Glyph, Sparkline } from "./atoms";
 import { seeded } from "./data";
 import { Card } from "./hero";
+import { PaAgentSyncPanel } from "./PaAgentSyncPanel";
 
 // ============================================================
 // AGENT FEED CONTROL ROOM
 // ============================================================
 export function AgentFeedControlRoom() {
   return (
+    <>
+    <PaAgentSyncPanel />
     <section style={{ marginBottom: 14 }}>
       <div
         style={{
@@ -89,6 +92,7 @@ export function AgentFeedControlRoom() {
         <AgentReasoningTrace />
       </div>
     </section>
+    </>
   );
 }
 

--- a/src/app/api/admin/agent-sync/route.ts
+++ b/src/app/api/admin/agent-sync/route.ts
@@ -1,0 +1,233 @@
+/**
+ * Admin: manual agent re-sync to PA (planetary_agents).
+ *
+ * POST /api/admin/agent-sync
+ *
+ * Body (one of):
+ *   { email:    "<agent>@agentic.alchm.kitchen" }   // re-sync a single user
+ *   { agentId:  "<agent>"                       }   // re-sync by agentId
+ *   { all:      true                            }   // re-sync ALL is_agent=true users
+ *
+ * Requires admin role. POSTs to PA's /api/internal/agent-sync with
+ * X-Sync-Secret: INTERNAL_API_SECRET. PA forwards updates to alchm.kitchen
+ * internally.
+ *
+ * @file src/app/api/admin/agent-sync/route.ts
+ */
+
+import { NextResponse } from "next/server";
+import { validateAdminRequest } from "@/lib/auth/validateRequest";
+import { executeQuery } from "@/lib/database";
+import { userDatabase } from "@/services/userDatabaseService";
+import { logger } from "@/utils/logger";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const AGENTIC_EMAIL_DOMAIN = "@agentic.alchm.kitchen";
+const PA_SYNC_TIMEOUT_MS = 5000;
+const BATCH_CONCURRENCY = 4;
+
+interface SyncTarget {
+  agentId: string;
+  email: string;
+  displayName: string | null;
+}
+
+interface SyncResult {
+  agentId: string;
+  email: string;
+  ok: boolean;
+  status?: number;
+  error?: string;
+}
+
+function getPaConfig(): { url: string; secret: string } | { error: string } {
+  const secret = process.env.INTERNAL_API_SECRET;
+  // PA Python backend is at api.agents.alchm.kitchen — the bare
+  // agents.alchm.kitchen domain is the Next.js UI and does NOT serve
+  // /api/internal/agent-sync (would silently 404).
+  const base = (
+    process.env.NEXT_PUBLIC_PLANETARY_AGENTS_URL ||
+    process.env.NEXT_PUBLIC_PLANETARY_KINETICS_URL ||
+    "https://api.agents.alchm.kitchen"
+  ).replace(/\/+$/, "");
+  if (!secret) return { error: "INTERNAL_API_SECRET not configured" };
+  if (!base) return { error: "PA base URL not configured" };
+  return { url: `${base}/api/internal/agent-sync`, secret };
+}
+
+async function postOne(
+  url: string,
+  secret: string,
+  target: SyncTarget,
+): Promise<SyncResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PA_SYNC_TIMEOUT_MS);
+  try {
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Sync-Secret": secret,
+      },
+      body: JSON.stringify({
+        agentId: target.agentId,
+        displayName: target.displayName ?? target.agentId,
+        email: target.email,
+      }),
+      signal: controller.signal,
+    });
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => "(unreadable)");
+      return {
+        agentId: target.agentId,
+        email: target.email,
+        ok: false,
+        status: resp.status,
+        error: text.slice(0, 200),
+      };
+    }
+    return { agentId: target.agentId, email: target.email, ok: true, status: resp.status };
+  } catch (err) {
+    return {
+      agentId: target.agentId,
+      email: target.email,
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function runBatched(
+  url: string,
+  secret: string,
+  targets: SyncTarget[],
+): Promise<SyncResult[]> {
+  const results: SyncResult[] = [];
+  for (let i = 0; i < targets.length; i += BATCH_CONCURRENCY) {
+    const chunk = targets.slice(i, i + BATCH_CONCURRENCY);
+    const settled = await Promise.all(chunk.map((t) => postOne(url, secret, t)));
+    results.push(...settled);
+  }
+  return results;
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = await validateAdminRequest(request);
+  if ("error" in authResult) return authResult.error;
+
+  let body: { agentId?: string; email?: string; all?: boolean };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { success: false, error: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const cfg = getPaConfig();
+  if ("error" in cfg) {
+    return NextResponse.json(
+      { success: false, error: cfg.error },
+      { status: 503 },
+    );
+  }
+
+  let targets: SyncTarget[] = [];
+
+  if (body.all) {
+    // Pull every is_agent=true user from the DB.
+    try {
+      const result = await executeQuery(
+        `SELECT email, name FROM users WHERE is_agent = true ORDER BY email`,
+        [],
+      );
+      const rows = (result.rows ?? []) as Array<{ email: string; name: string | null }>;
+      targets = rows
+        .filter((r) => r.email.endsWith(AGENTIC_EMAIL_DOMAIN))
+        .map((r) => ({
+          agentId: r.email.split("@")[0],
+          email: r.email,
+          displayName: r.name,
+        }));
+    } catch (err) {
+      logger.error("[admin/agent-sync] DB enumerate failed", err);
+      return NextResponse.json(
+        { success: false, error: "Failed to enumerate agentic users" },
+        { status: 500 },
+      );
+    }
+  } else if (body.email) {
+    const email = body.email.toLowerCase().trim();
+    if (!email.endsWith(AGENTIC_EMAIL_DOMAIN)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `email must end in ${AGENTIC_EMAIL_DOMAIN}`,
+        },
+        { status: 400 },
+      );
+    }
+    const user = await userDatabase.getUserByEmail(email);
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "User not found" },
+        { status: 404 },
+      );
+    }
+    // UserWithProfile carries the name on its profile sub-object; the SELECT
+    // alias in getUserByEmail also exposes a top-level `name`. Cover both
+    // shapes without forcing a hard cast.
+    const userWithName = user as { profile?: { name?: string | null }; name?: string | null };
+    const displayName =
+      userWithName.profile?.name ?? userWithName.name ?? null;
+    targets = [{ agentId: email.split("@")[0], email, displayName }];
+  } else if (body.agentId) {
+    const agentId = body.agentId.trim();
+    const email = `${agentId}${AGENTIC_EMAIL_DOMAIN}`;
+    const user = await userDatabase
+      .getUserByEmail(email)
+      .catch(() => null);
+    const userWithName = user as
+      | { profile?: { name?: string | null }; name?: string | null }
+      | null;
+    const displayName =
+      userWithName?.profile?.name ?? userWithName?.name ?? null;
+    targets = [{ agentId, email, displayName }];
+  } else {
+    return NextResponse.json(
+      { success: false, error: "Provide one of: email, agentId, all=true" },
+      { status: 400 },
+    );
+  }
+
+  if (targets.length === 0) {
+    return NextResponse.json({
+      success: true,
+      synced: 0,
+      failed: 0,
+      results: [],
+      note: "No agentic users matched",
+    });
+  }
+
+  const results = await runBatched(cfg.url, cfg.secret, targets);
+  const synced = results.filter((r) => r.ok).length;
+  const failed = results.length - synced;
+
+  logger.info(
+    `[admin/agent-sync] complete: synced=${synced} failed=${failed} adminEmail=${authResult.user.email}`,
+  );
+
+  return NextResponse.json({
+    success: true,
+    synced,
+    failed,
+    results,
+  });
+}

--- a/src/app/api/philosophers-stone/positions/route.ts
+++ b/src/app/api/philosophers-stone/positions/route.ts
@@ -1,15 +1,103 @@
 import { NextResponse } from "next/server";
 import { rateLimit } from "@/lib/rateLimit";
 import { getCurrentPlanetaryPositions } from "@/services/astrologizeApi";
-import { alchemize } from "@/services/RealAlchemizeService";
+import { alchemizeDetailed } from "@/services/RealAlchemizeService";
 import { logger } from "@/utils/logger";
-import { calculateEnhancedAlchemicalFromPlanets, isSectDiurnal } from "@/utils/planetaryAlchemyMapping";
 import type { NextRequest } from "next/server";
 
 const RATE_LIMIT = { window: 60_000, max: 30, bucket: "philosophers-stone-positions" };
 
+// alchm.kitchen is the canonical math owner — it calculates all alchemical
+// quantities. The philosophers-stone endpoint lives there (or will be added
+// there). PA is for agent-keyed state only. Local alchemizeDetailed() fallback
+// kicks in if alchm.kitchen hasn't shipped the endpoint yet — the math is
+// equivalent.
+const ALCHM_KITCHEN_URL = (
+  process.env.NEXT_PUBLIC_BACKEND_URL ||
+  process.env.API_BASE_URL ||
+  process.env.BACKEND_URL ||
+  ""
+).replace(/\/+$/, "");
+
+const PROXY_TIMEOUT_MS = 4000;
+
+type StoneResponse = {
+  elementalProperties: Record<string, number>;
+  thermodynamicProperties: Record<string, number>;
+  esms: Record<string, number>;
+  planetaryMomentum: Record<string, number>;
+  kalchm: number;
+  monica: number;
+  score: number;
+  normalized: boolean;
+  confidence: number;
+  metadata: Record<string, unknown>;
+  perPlanet?: Record<string, unknown>;
+};
+
+function dtToBackendParams(dt: Date): URLSearchParams {
+  const p = new URLSearchParams();
+  p.set("year", String(dt.getUTCFullYear()));
+  p.set("month", String(dt.getUTCMonth() + 1));
+  p.set("day", String(dt.getUTCDate()));
+  p.set("hour", String(dt.getUTCHours()));
+  p.set("minute", String(dt.getUTCMinutes()));
+  return p;
+}
+
+async function fetchFromBackend(
+  init: { method: "GET"; dt: Date } | { method: "POST"; body: unknown },
+): Promise<StoneResponse | null> {
+  if (!ALCHM_KITCHEN_URL) return null;
+  const url = `${ALCHM_KITCHEN_URL}/api/philosophers-stone/positions`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PROXY_TIMEOUT_MS);
+  try {
+    const res =
+      init.method === "GET"
+        ? await fetch(`${url}?${dtToBackendParams(init.dt).toString()}`, {
+            signal: controller.signal,
+            cache: "no-store",
+          })
+        : await fetch(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(init.body),
+            signal: controller.signal,
+            cache: "no-store",
+          });
+    if (!res.ok) {
+      logger.warn(
+        `philosophers-stone proxy: backend returned ${res.status}, falling back to local`,
+      );
+      return null;
+    }
+    return (await res.json()) as StoneResponse;
+  } catch (err) {
+    logger.warn("philosophers-stone proxy: backend unreachable, falling back", err);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function computeLocally(dt: Date): Promise<StoneResponse> {
+  const positions = await getCurrentPlanetaryPositions();
+  // alchemizeDetailed returns DetailedAlchemicalResult whose elementalProperties
+  // uses the strictly-typed ElementalProperties (Fire/Water/Earth/Air without
+  // an index signature) — incompatible with our wider Record<string, number>
+  // contract by structural typing. The shape is correct at runtime, just
+  // narrower at the type level, so cast through unknown.
+  return alchemizeDetailed(positions, null, dt) as unknown as StoneResponse;
+}
+
 /**
- * GET /api/philosophers-stone/positions - Get planetary positions with alchemical calculations
+ * GET /api/philosophers-stone/positions
+ *
+ * Proxies the FastAPI backend's identical endpoint and returns its canonical
+ * schema (elementalProperties / thermodynamicProperties / esms / perPlanet / ...).
+ * Falls back to a local `alchemizeDetailed()` calculation if the backend is
+ * unreachable or returns a non-2xx.
  */
 export async function GET(request: NextRequest) {
   const rl = await rateLimit(request, RATE_LIMIT);
@@ -17,89 +105,22 @@ export async function GET(request: NextRequest) {
 
   try {
     const { searchParams } = new URL(request.url);
-    const date = searchParams.get("date");
-    const includeAlchemical = searchParams.get("alchemical") !== "false"; // Default to true
-
-    logger.info(
-      `Philosophers stone positions requested for date: ${date || "current"}`,
-    );
-
-    // Get current planetary positions
-    const planetaryPositions = await getCurrentPlanetaryPositions();
-
-    const response: any = {
-      timestamp: new Date().toISOString(),
-      date: date || new Date().toISOString().split("T")[0],
-      planetaryPositions,
-      source: "calculated",
-    };
-
-    // Add alchemical calculations if requested
-    if (includeAlchemical) {
-      try {
-        // Calculate alchemical properties from planetary positions
-        const requestDate = date ? new Date(date) : new Date();
-        const diurnal = isSectDiurnal(requestDate);
-        
-        const signMap: Record<string, string> = {};
-        for (const [planet, data] of Object.entries(planetaryPositions)) {
-          signMap[planet] = typeof data === 'object' && data !== null ? (data as any).sign : String(data);
-        }
-        
-        const alchemicalProperties = calculateEnhancedAlchemicalFromPlanets(
-          signMap,
-          diurnal
-        );
-
-        // Calculate thermodynamic metrics using the alchemizer engine
-        const alchemizeResult = alchemize(planetaryPositions);
-        const { heat, entropy, reactivity, gregsEnergy } =
-          alchemizeResult.thermodynamicProperties;
-        const { kalchm, monica } = alchemizeResult;
-
-        // Derive elemental properties from thermodynamics
-        const Fire = heat * 0.2 + reactivity * 0.2;
-        const Water = monica * 0.6 + (1 - heat) * 0.4;
-        const Earth = kalchm * 0.5 + (1 - entropy) * 0.5;
-        const Air = entropy * 0.2 + reactivity * 0.2;
-        const total = Fire + Water + Earth + Air;
-        const elementalBalance = {
-          Fire: Fire / total,
-          Water: Water / total,
-          Earth: Earth / total,
-          Air: Air / total,
-        };
-
-        response.alchemicalProperties = alchemicalProperties;
-        response.thermodynamicMetrics = { heat, entropy, reactivity, gregsEnergy, kalchm, monica };
-
-        // Add philosophers stone interpretation
-        response.interpretation = {
-          spiritualEssence: alchemicalProperties.Spirit,
-          materialManifestation: alchemicalProperties.Matter,
-          transformativePower: alchemicalProperties.Substance,
-          elementalBalance,
-          thermodynamicState: {
-            heat,
-            entropy,
-            reactivity,
-            gregEnergy: gregsEnergy,
-            kalchm,
-            monica,
-          },
-        };
-
-        logger.info("Alchemical calculations completed successfully");
-      } catch (alchemicalError) {
-        logger.warn("Alchemical calculation failed:", alchemicalError);
-        response.alchemicalError = "Failed to calculate alchemical properties";
-        // Continue without alchemical data rather than failing the request
-      }
+    const dateParam = searchParams.get("date");
+    const dt = dateParam ? new Date(dateParam) : new Date();
+    if (Number.isNaN(dt.getTime())) {
+      return NextResponse.json(
+        { success: false, error: "Invalid `date` parameter" },
+        { status: 400 },
+      );
     }
+
+    const proxied = await fetchFromBackend({ method: "GET", dt });
+    const data = proxied ?? (await computeLocally(dt));
 
     return NextResponse.json({
       success: true,
-      ...response,
+      source: proxied ? "proxy" : "fallback",
+      ...data,
     });
   } catch (error) {
     logger.error("Philosophers stone positions error:", error);
@@ -108,7 +129,6 @@ export async function GET(request: NextRequest) {
         success: false,
         error: "Failed to retrieve planetary positions",
         details: error instanceof Error ? error.message : "Unknown error",
-        timestamp: new Date().toISOString(),
       },
       { status: 500 },
     );
@@ -116,149 +136,73 @@ export async function GET(request: NextRequest) {
 }
 
 /**
- * POST /api/philosophers-stone/positions - Calculate positions for specific date/location
+ * POST /api/philosophers-stone/positions
+ *
+ * Forwards the request body (year/month/day/hour/minute/customPlanets) to the
+ * backend. Accepts a legacy `date` field as well, which is split into
+ * year/month/day/hour/minute before forwarding.
  */
 export async function POST(request: NextRequest) {
   const rl = await rateLimit(request, RATE_LIMIT);
   if (!rl.allowed) return rl.response!;
 
   try {
-    const body = await request.json();
-    const {
-      date,
-      latitude,
-      longitude,
-      includeAlchemical = true,
-      customPlanets, // Optional: override with custom planetary positions
-    } = body;
+    const body = (await request.json()) as Record<string, unknown>;
 
-    logger.info(`Custom philosophers stone calculation requested`, {
-      date,
-      hasLocation: !!(latitude && longitude),
-      includeAlchemical,
-    });
-
-    let planetaryPositions = customPlanets;
-
-    // If no custom planets provided, calculate for the given date/location
-    if (!planetaryPositions) {
-      // For now, use the default calculation
-      // In a full implementation, this would calculate positions for specific date/location
-      planetaryPositions = await getCurrentPlanetaryPositions();
+    let dt: Date;
+    if (typeof body.date === "string") {
+      dt = new Date(body.date);
+    } else if (
+      typeof body.year === "number" ||
+      typeof body.month === "number" ||
+      typeof body.day === "number"
+    ) {
+      const now = new Date();
+      dt = new Date(
+        Date.UTC(
+          (body.year as number) ?? now.getUTCFullYear(),
+          ((body.month as number) ?? now.getUTCMonth() + 1) - 1,
+          (body.day as number) ?? now.getUTCDate(),
+          (body.hour as number) ?? 0,
+          (body.minute as number) ?? 0,
+        ),
+      );
+    } else {
+      dt = new Date();
+    }
+    if (Number.isNaN(dt.getTime())) {
+      return NextResponse.json(
+        { success: false, error: "Invalid date payload" },
+        { status: 400 },
+      );
     }
 
-    const response: any = {
-      timestamp: new Date().toISOString(),
-      requestDate: date,
-      location: latitude && longitude ? { latitude, longitude } : null,
-      planetaryPositions,
+    const backendBody = {
+      year: dt.getUTCFullYear(),
+      month: dt.getUTCMonth() + 1,
+      day: dt.getUTCDate(),
+      hour: dt.getUTCHours(),
+      minute: dt.getUTCMinutes(),
+      customPlanets: body.customPlanets,
     };
 
-    // Add alchemical calculations
-    if (includeAlchemical) {
-      try {
-        const requestDate = date ? new Date(date) : new Date();
-        const diurnal = isSectDiurnal(requestDate);
-        
-        const signMap: Record<string, string> = {};
-        for (const [planet, data] of Object.entries(planetaryPositions)) {
-          signMap[planet] = typeof data === 'object' && data !== null ? (data as any).sign : String(data);
-        }
-        
-        const alchemicalProperties = calculateEnhancedAlchemicalFromPlanets(
-          signMap,
-          diurnal
-        );
-        const alchemizeResult2 = alchemize(planetaryPositions);
-        const {
-          heat: heat2,
-          entropy: entropy2,
-          reactivity: reactivity2,
-          gregsEnergy: gregsEnergy2,
-        } = alchemizeResult2.thermodynamicProperties;
-        const { kalchm: kalchm2, monica: monica2 } = alchemizeResult2;
-
-        // Derive elemental properties from thermodynamics
-        const Fire2 = heat2 * 0.2 + reactivity2 * 0.2;
-        const Water2 = monica2 * 0.6 + (1 - heat2) * 0.4;
-        const Earth2 = kalchm2 * 0.5 + (1 - entropy2) * 0.5;
-        const Air2 = entropy2 * 0.2 + reactivity2 * 0.2;
-        const total2 = Fire2 + Water2 + Earth2 + Air2;
-        const elementalBalance2 = {
-          Fire: Fire2 / total2,
-          Water: Water2 / total2,
-          Earth: Earth2 / total2,
-          Air: Air2 / total2,
-        };
-
-        response.alchemicalProperties = alchemicalProperties;
-        response.thermodynamicMetrics = {
-          heat: heat2,
-          entropy: entropy2,
-          reactivity: reactivity2,
-          gregsEnergy: gregsEnergy2,
-          kalchm: kalchm2,
-          monica: monica2,
-        };
-
-        // Enhanced interpretation for specific date/location
-        response.philosophersStone = {
-          stone: {
-            essence: alchemicalProperties.Spirit > 0.5 ? "refined" : "raw",
-            matter: alchemicalProperties.Matter > 0.5 ? "purified" : "impure",
-            substance:
-              alchemicalProperties.Substance > 0.5 ? "transmuted" : "base",
-          },
-          elementalProfile: {
-            // Elements reinforce themselves - no opposing forces
-            Fire: elementalBalance2.Fire,
-            Water: elementalBalance2.Water,
-            Earth: elementalBalance2.Earth,
-            Air: elementalBalance2.Air,
-            dominantElement: getDominantElement(elementalBalance2),
-          },
-          alchemicalPotential: {
-            transformationReadiness: reactivity2,
-            stabilityIndex: 1 - entropy2,
-            energeticPotential: gregsEnergy2,
-          },
-        };
-      } catch (alchemicalError) {
-        logger.warn("Alchemical calculation failed:", alchemicalError);
-        response.alchemicalError = "Failed to calculate alchemical properties";
-      }
-    }
+    const proxied = await fetchFromBackend({ method: "POST", body: backendBody });
+    const data = proxied ?? (await computeLocally(dt));
 
     return NextResponse.json({
       success: true,
-      ...response,
+      source: proxied ? "proxy" : "fallback",
+      ...data,
     });
   } catch (error) {
     logger.error("Custom philosophers stone calculation error:", error);
     return NextResponse.json(
       {
         success: false,
-        error: "Failed to calculate custom planetary positions",
+        error: "Failed to calculate planetary positions",
         details: error instanceof Error ? error.message : "Unknown error",
-        timestamp: new Date().toISOString(),
       },
       { status: 500 },
     );
   }
-}
-
-/**
- * Helper function to determine dominant element
- */
-function getDominantElement(properties: any): string {
-  const elements = [
-    { name: "Fire", value: properties.Fire || 0 },
-    { name: "Water", value: properties.Water || 0 },
-    { name: "Earth", value: properties.Earth || 0 },
-    { name: "Air", value: properties.Air || 0 },
-  ];
-
-  return elements.reduce((max, current) =>
-    current.value > max.value ? current : max,
-  ).name;
 }

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -371,44 +371,62 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
               }
             }
             
-            // On first sign-in for an @agentic.alchm.kitchen email, ping the
-            // backend's /api/internal/agent-sync so the WTEN user row gets
-            // is_agent=true and a clean display_name immediately, rather than
-            // waiting for the next scripts/backfill-agent-sync.ts run. Fire
-            // and forget — must never block sign-in.
+            // On first sign-in for an @agentic.alchm.kitchen email, POST to
+            // PA's /api/internal/agent-sync. PA is the authority for agent
+            // identities and propagates downstream to alchm.kitchen itself
+            // (WTEN → PA → alchm.kitchen). Fire and forget — must never block
+            // sign-in.
             if (isNewUser && user.email!.endsWith("@agentic.alchm.kitchen")) {
-              const syncSecret = process.env.ALCHM_KITCHEN_SYNC_SECRET;
-              const apiBase = (
-                process.env.API_BASE_URL || process.env.BACKEND_URL || ""
+              const email = user.email!;
+              const displayName = user.name ?? undefined;
+              const agentId = email.split("@")[0]; // e.g. "monica-001"
+
+              const paSecret = process.env.INTERNAL_API_SECRET;
+              // PA Python backend is at api.agents.alchm.kitchen — the bare
+              // agents.alchm.kitchen domain is the Next.js UI and would 404.
+              const paBase = (
+                process.env.NEXT_PUBLIC_PLANETARY_AGENTS_URL ||
+                process.env.NEXT_PUBLIC_PLANETARY_KINETICS_URL ||
+                "https://api.agents.alchm.kitchen"
               ).replace(/\/$/, "");
-              if (syncSecret && apiBase) {
-                try {
-                  const resp = await fetch(`${apiBase}/api/internal/agent-sync`, {
-                    method: "POST",
-                    headers: {
-                      "Content-Type": "application/json",
-                      "X-Sync-Secret": syncSecret,
-                    },
-                    body: JSON.stringify({
-                      email: user.email,
-                      displayName: user.name ?? undefined,
-                    }),
-                  });
-                  if (resp.ok) {
-                    logger.info(`agent-sync ok for ${user.email}`);
-                  } else {
-                    const text = await resp.text().catch(() => "(unreadable)");
+
+              if (!paSecret || !paBase) {
+                logger.warn(
+                  `agent-sync skipped for ${email}: missing INTERNAL_API_SECRET or PA base URL`,
+                );
+              } else {
+                void (async () => {
+                  try {
+                    const resp = await fetch(
+                      `${paBase}/api/internal/agent-sync`,
+                      {
+                        method: "POST",
+                        headers: {
+                          "Content-Type": "application/json",
+                          "X-Sync-Secret": paSecret,
+                        },
+                        body: JSON.stringify({
+                          agentId,
+                          displayName: displayName ?? agentId,
+                          email,
+                        }),
+                      },
+                    );
+                    if (resp.ok) {
+                      logger.info(`agent-sync ok for ${email} → PA`);
+                    } else {
+                      const text = await resp.text().catch(() => "(unreadable)");
+                      logger.warn(
+                        `agent-sync HTTP ${resp.status} for ${email} → PA: ${text}`,
+                      );
+                    }
+                  } catch (syncErr) {
                     logger.warn(
-                      `agent-sync HTTP ${resp.status} for ${user.email}: ${text}`,
+                      `agent-sync request failed for ${email} → PA (non-blocking):`,
+                      syncErr,
                     );
                   }
-                } catch (syncErr) {
-                  logger.warn("agent-sync request failed (non-blocking):", syncErr);
-                }
-              } else {
-                logger.warn(
-                  `agent-sync skipped for ${user.email}: missing ALCHM_KITCHEN_SYNC_SECRET or API_BASE_URL/BACKEND_URL`,
-                );
+                })();
               }
             }
 

--- a/src/lib/kinetics-integration.ts
+++ b/src/lib/kinetics-integration.ts
@@ -3,10 +3,33 @@ import {
   type KineticsLocation,
   type KineticsOptions,
 } from '@/services/PlanetaryKineticsClient'
+import { logger } from '@/utils/logger'
 
 export interface EnhancedKineticData {
   energy: number
   momentum: number
+}
+
+// Agent-keyed kinetics lives on the planetary_agents backend (PA owns the
+// KINETICS_STATE cache keyed by agentId and the agent's birth location). PA
+// internally fetches raw quantities from alchm.kitchen when needed.
+//
+// NOTE: the PYTHON backend is at api.agents.alchm.kitchen (and equivalently
+// at passionate-vibrancy-production-2e31.up.railway.app). The bare
+// agents.alchm.kitchen domain is the Next.js UI and does NOT serve
+// /api/agents/{id}/kinetics — would 404 silently if used here.
+const PA_URL = (
+  process.env.NEXT_PUBLIC_PLANETARY_AGENTS_URL ||
+  process.env.NEXT_PUBLIC_PLANETARY_KINETICS_URL ||
+  'https://api.agents.alchm.kitchen'
+).replace(/\/+$/, '')
+
+const AGENT_KINETICS_TIMEOUT_MS = 3500
+const DEFAULT_KINETICS: EnhancedKineticData = { energy: 1.0, momentum: 1.0 }
+
+interface BackendKineticsResponse {
+  power?: number
+  forceMagnitude?: number
 }
 
 export class KineticsIntegration {
@@ -14,11 +37,42 @@ export class KineticsIntegration {
     return new KineticsIntegration()
   }
 
-  // TODO: no agent-aware kinetics path exists yet. PlanetaryKineticsClient is
-  // location-based, and there is no agent→location/context mapping. Returns
-  // unit values until that data path is designed.
-  async getAgentKinetics(_agentId: string): Promise<EnhancedKineticData> {
-    return { energy: 1.0, momentum: 1.0 }
+  /**
+   * Fetch agent-keyed kinetics from the FastAPI backend
+   * (GET /api/agents/{agent_id}/kinetics). Returns DEFAULT_KINETICS if no
+   * backend URL is configured or the request fails — callers can treat that
+   * as "no signal" without special-casing errors.
+   */
+  async getAgentKinetics(agentId: string): Promise<EnhancedKineticData> {
+    if (!PA_URL || !agentId) return DEFAULT_KINETICS
+
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), AGENT_KINETICS_TIMEOUT_MS)
+    try {
+      const res = await fetch(
+        `${PA_URL}/api/agents/${encodeURIComponent(agentId)}/kinetics`,
+        { signal: controller.signal, cache: 'no-store' },
+      )
+      if (!res.ok) {
+        logger.warn(
+          `getAgentKinetics: backend returned ${res.status} for agent ${agentId}`,
+        )
+        return DEFAULT_KINETICS
+      }
+      const data = (await res.json()) as BackendKineticsResponse
+      return {
+        energy: typeof data.power === 'number' ? data.power : DEFAULT_KINETICS.energy,
+        momentum:
+          typeof data.forceMagnitude === 'number'
+            ? data.forceMagnitude
+            : DEFAULT_KINETICS.momentum,
+      }
+    } catch (err) {
+      logger.warn(`getAgentKinetics: backend unreachable for agent ${agentId}`, err)
+      return DEFAULT_KINETICS
+    } finally {
+      clearTimeout(timer)
+    }
   }
 
   async getEnhancedKinetics(


### PR DESCRIPTION
Establish the WTEN side of the alchm.kitchen ↔ planetary_agents (PA) data flow: WTEN → PA, then PA → alchm.kitchen for canonical math + event surfacing.

- philosophers-stone proxy: forward GET/POST to alchm.kitchen with local alchemizeDetailed() fallback. Returns the canonical schema (elementalProperties / thermodynamicProperties / esms / perPlanet / ...).
- kinetics-integration: getAgentKinetics(agentId) calls PA's /api/agents/{id}/kinetics at api.agents.alchm.kitchen (NOT the bare agents.alchm.kitchen domain, which is the Next.js UI and would 404).
- auth.ts: on first sign-in for @agentic.alchm.kitchen emails, fire-and-forget POST to PA's /api/internal/agent-sync with X-Sync-Secret. PA propagates to alchm.kitchen internally.
- /api/admin/agent-sync: new admin-only route accepting {email}, {agentId}, or {all:true}. Batches at concurrency=4 and returns per-target results.
- PaAgentSyncPanel: admin UI (SYNC ALL / SYNC ONE inputs) mounted above the agent control room. Surfaces synced/failed counts and a collapsible failure list.