### PR TITLE
feat(feed): link agent actors to the PA chat UI

### DIFF
--- a/src/app/(alchm)/feed/page.tsx
+++ b/src/app/(alchm)/feed/page.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import Header from "@/components/Header";
+import { agentChatUrl } from "@/lib/agents/agentChatUrl";
 import { ELEMENT_COLORS } from "@/lib/elementColors";
 import { TOKEN_TYPES } from "@/types/economy";
 import type { TokenType } from "@/types/economy";
@@ -32,6 +33,7 @@ interface FeedEvent {
   actorName: string;
   actorImage?: string;
   actorIsAgent: boolean;
+  actorSlug?: string;
   eventType: string;
   metadataPayload: any;
   createdAt: string;
@@ -363,7 +365,11 @@ function FeedTab({ events, loading }: { events: FeedEvent[]; loading: boolean })
               <div className="flex-1 min-w-0">
                 <p className="text-sm text-white/80">
                   <Link
-                    href={`/profile/${event.actorId}`}
+                    href={
+                      event.actorIsAgent && event.actorSlug
+                        ? agentChatUrl(event.actorSlug)
+                        : `/profile/${event.actorId}`
+                    }
                     className={`font-bold mr-1 underline-offset-2 hover:underline transition-colors ${
                       event.actorIsAgent ? "text-amber-400 hover:text-amber-300" : "text-white hover:text-purple-200"
                     }`}

--- a/src/components/home/AgentsFeedThread.tsx
+++ b/src/components/home/AgentsFeedThread.tsx
@@ -3,6 +3,7 @@
 import { AnimatePresence, motion } from "framer-motion";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { agentChatUrl } from "@/lib/agents/agentChatUrl";
 import { ELEMENT_COLORS } from "@/lib/elementColors";
 
 type FeedMetadata = Record<string, unknown>;
@@ -29,6 +30,7 @@ interface FeedEvent {
   userId?: string;
   actorName?: string;
   actorImage?: string;
+  actorSlug?: string;
   user?: string;
   actorIsAgent?: boolean;
   isAgent?: boolean;
@@ -280,7 +282,15 @@ export function AgentsFeedThread() {
                       const isAgent =
                         item.actorIsAgent ?? item.isAgent === true;
                       const actorId = item.actorId || item.userId;
-                      const profileHref = actorId ? `/profile/${actorId}` : null;
+                      // Agents link out to their chat on the PA UI
+                      // (agents.alchm.kitchen); humans link to their local
+                      // alchm.kitchen profile.
+                      const actorHref =
+                        isAgent && item.actorSlug
+                          ? agentChatUrl(item.actorSlug)
+                          : actorId
+                            ? `/profile/${actorId}`
+                            : null;
                       const timeLabel = formatDistanceToNow(item.createdAt);
                       const signature = isAgent
                         ? getPlanetarySignature(item.metadataPayload)
@@ -326,9 +336,9 @@ export function AgentsFeedThread() {
                             <p className="text-xs text-white/90 font-medium leading-relaxed">
                               {actorName && (
                                 <>
-                                  {profileHref ? (
+                                  {actorHref ? (
                                     <Link
-                                      href={profileHref}
+                                      href={actorHref}
                                       className={`${isAgent ? "text-purple-300 hover:text-purple-200" : "text-emerald-300 hover:text-emerald-200"} font-bold underline-offset-2 hover:underline transition-colors`}
                                     >
                                       {actorName}

--- a/src/lib/agents/agentChatUrl.ts
+++ b/src/lib/agents/agentChatUrl.ts
@@ -1,0 +1,30 @@
+/**
+ * Links into the planetary_agents UI.
+ *
+ * Domain distinction — these are NOT the same host:
+ *   - agents.alchm.kitchen       → the PA Next.js UI (agent profiles + chat)
+ *   - api.agents.alchm.kitchen   → the PA backend API
+ *
+ * This module targets the UI domain only. The override env var is
+ * NEXT_PUBLIC_AGENTS_UI_URL; it defaults to the public UI domain.
+ */
+
+const AGENTS_UI_URL = (
+  process.env.NEXT_PUBLIC_AGENTS_UI_URL || "https://agents.alchm.kitchen"
+).replace(/\/+$/, "");
+
+/**
+ * Public chat URL for a planetary agent.
+ *
+ * `slug` is the agent id — the local-part of its `@agentic.alchm.kitchen`
+ * email (e.g. `socrates`, `nikola-tesla-1856`). Route confirmed against the
+ * PA UI: `/gallery/chat/[id]`.
+ */
+export function agentChatUrl(slug: string): string {
+  return `${AGENTS_UI_URL}/gallery/chat/${encodeURIComponent(slug)}`;
+}
+
+/** Agent slug from an `@agentic.alchm.kitchen` email — the local-part. */
+export function agentSlugFromEmail(email: string): string {
+  return email.split("@")[0];
+}

--- a/src/services/feedDatabaseService.ts
+++ b/src/services/feedDatabaseService.ts
@@ -15,6 +15,12 @@ export interface FeedEvent {
   actorName: string;
   actorImage?: string;
   actorIsAgent: boolean;
+  /**
+   * Agent slug (the `@agentic.alchm.kitchen` email local-part) — set ONLY for
+   * agent actors, so the feed UI can link them to the PA chat. Never populated
+   * for human actors: their email must not leak through this public endpoint.
+   */
+  actorSlug?: string;
 }
 
 class FeedDatabaseService {
@@ -42,7 +48,7 @@ class FeedDatabaseService {
   async getRecentEvents(limit: number = 50, offset: number = 0): Promise<FeedEvent[]> {
     try {
       const result = await executeQuery(
-        `SELECT f.*, u.is_agent, u.image as actor_image, up.name as actor_name
+        `SELECT f.*, u.is_agent, u.email as actor_email, u.image as actor_image, up.name as actor_name
          FROM feed_events f
          JOIN users u ON f.actor_id = u.id
          LEFT JOIN user_profiles up ON u.id = up.user_id
@@ -50,17 +56,27 @@ class FeedDatabaseService {
          LIMIT $1 OFFSET $2`,
         [limit, offset]
       );
-      
-      return result.rows.map(row => ({
-        id: row.id,
-        actorId: row.actor_id,
-        eventType: row.event_type,
-        metadataPayload: row.metadata_payload,
-        createdAt: new Date(row.created_at),
-        actorName: row.actor_name || 'Alchemist',
-        actorImage: row.actor_image,
-        actorIsAgent: row.is_agent
-      }));
+
+      return result.rows.map(row => {
+        const isAgent = row.is_agent === true;
+        // Agent slug is the email local-part — only for agents. Human emails
+        // are never surfaced through this public endpoint.
+        const actorSlug =
+          isAgent && typeof row.actor_email === "string" && row.actor_email.includes("@")
+            ? row.actor_email.split("@")[0]
+            : undefined;
+        return {
+          id: row.id,
+          actorId: row.actor_id,
+          eventType: row.event_type,
+          metadataPayload: row.metadata_payload,
+          createdAt: new Date(row.created_at),
+          actorName: row.actor_name || 'Alchemist',
+          actorImage: row.actor_image,
+          actorIsAgent: isAgent,
+          actorSlug,
+        };
+      });
     } catch (error) {
       _logger.error("Failed to fetch feed events:", error);
       return [];


### PR DESCRIPTION
## Summary

Clicking an agent's name in the Live Network Feed now routes the human to
that agent's chat on the **planetary_agents UI** (`agents.alchm.kitchen`) —
a separate host from this app. Previously every feed actor, agent or human,
linked to the local `/profile/<id>` route.

## Architecture note — the three hosts

| Host | Role |
|---|---|
| `alchm.kitchen` | this app — the feed lives here |
| `agents.alchm.kitchen` | planetary_agents **UI** — agent profiles + chat (`/gallery/chat/[id]`) |
| `api.agents.alchm.kitchen` | planetary_agents **backend API** |

This PR links into the **UI** host. The route `/gallery/chat/[id]` was
confirmed against the PA repo (`app/(app)/agent/[id]/page.tsx` links to it in
3 places as "Chat with …").

## Changes

| File | What |
|---|---|
| `src/lib/agents/agentChatUrl.ts` *(new)* | `agentChatUrl(slug)` → `agents.alchm.kitchen/gallery/chat/<slug>`. Override env var `NEXT_PUBLIC_AGENTS_UI_URL` — deliberately distinct from `NEXT_PUBLIC_PLANETARY_AGENTS_URL` (that one is the `api.` subdomain). |
| `src/services/feedDatabaseService.ts` | `getRecentEvents` selects `u.email` and derives `actorSlug` (email local-part) **for agent actors only**. Human emails are never surfaced through the public `/api/feed` endpoint. |
| `src/components/home/AgentsFeedThread.tsx` | floating feed widget — agent actors link to `agentChatUrl(slug)`; humans keep `/profile/<id>`. |
| `src/app/(alchm)/feed/page.tsx` | `/feed` page event list — same routing. |

Agents missing a slug fall back to `/profile/<id>` (the local profile page,
which already renders an `AgentProfile` for agents) — graceful, never broken.

## Privacy

`actorSlug` is set only when `is_agent = true`. The slug (`socrates`,
`nikola-tesla-1856`) is already a public identifier — it's in the PA UI's
static routes. Human emails never leave the server.

## Verification

- `bun run typecheck` — clean (0 errors).
- Logic verified by inspection: `isAgent && actorSlug ? agentChatUrl(slug) : /profile/<id>`.
- **Not yet visually verified**: the agent-link path can't be exercised until
  an `agent_chat` / `agent_registered` event exists in the feed — the feed
  currently has zero agent events (PA hasn't emitted since the integration
  deployed). Same gate as the rest of the PA feed work. Human actors render
  unchanged.

## Test plan

- [ ] CI green
- [ ] After deploy, a human feed event still links to `/profile/<id>`
- [ ] Once an agent posts to the feed, its name links to `https://agents.alchm.kitchen/gallery/chat/<slug>` and loads the agent chat
- [ ] `/api/feed` response includes `actorSlug` for agent rows, omits it for human rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)