### PR TITLE
Live admin agent telemetry + feed hardening + auth screens

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
+import { useHardenedPolling } from "@/hooks/useHardenedPolling";
 import { Dashboard } from "../_dashboard/Dashboard";
 import { FALLBACK_DATA, type AdminDashboardData } from "../_dashboard/data";
 
@@ -18,33 +19,30 @@ export default function AdminDashboardPage() {
   const [data, setData] = useState<AdminDashboardData>(FALLBACK_DATA);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (): Promise<{ ok: boolean }> => {
     try {
       const res = await fetch("/api/admin/dashboard", { cache: "no-store" });
       if (!res.ok) {
         setError(`Failed to load dashboard (HTTP ${res.status})`);
-        return;
+        return { ok: false };
       }
       const json = (await res.json()) as { success: boolean; data?: AdminDashboardData };
       if (json.success && json.data) {
         setData(json.data);
         setError(null);
-      } else {
-        setError("Dashboard payload missing");
+        return { ok: true };
       }
+      setError("Dashboard payload missing");
+      return { ok: false };
     } catch (_err) {
       setError("Failed to connect to admin API");
+      return { ok: false };
     }
   }, []);
 
-  useEffect(() => {
-    void fetchData();
-    // Refresh every 30s for the rest of the page lifetime.
-    const id = setInterval(() => {
-      void fetchData();
-    }, 30_000);
-    return () => clearInterval(id);
-  }, [fetchData]);
+  // Visibility-aware polling with error backoff — pauses on hidden tabs,
+  // refreshes immediately on refocus, and slows down while the API is failing.
+  useHardenedPolling(fetchData, { baseIntervalMs: 30_000 });
 
   return (
     <>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import AdvancedMetricsPanel from "@/components/admin/AdvancedMetricsPanel";
+import { useHardenedPolling } from "@/hooks/useHardenedPolling";
 
 interface DashboardStats {
   totalUsers: number;
@@ -20,6 +21,25 @@ interface RecentUser {
   isActive: boolean;
 }
 
+interface TelemetryMetric {
+  /** Display-formatted value, e.g. "62.4%", "12 /hr", "0.43". */
+  value: string;
+  /** Raw numeric value behind the formatted string. */
+  raw: number;
+  /** true when computed from a real source; false when degraded to fallback. */
+  live: boolean;
+  /** Which real source feeds this metric. */
+  source: "database" | "ephemeris";
+}
+
+interface AgentTelemetry {
+  agentHarmony: TelemetryMetric;
+  transmutationRate: TelemetryMetric;
+  spiritualEntropy: TelemetryMetric;
+  generatedAt: string;
+  allLive: boolean;
+}
+
 interface PaIntegration {
   endpoints: {
     alchmNextApp: string;
@@ -35,10 +55,8 @@ interface PaIntegration {
     responseCode: number;
     timestamp: string;
   } | null;
-  meta: {
-    mockedFields: string[];
-    mockedTelemetry: Record<string, string>;
-  };
+  /** Live metaphysical telemetry; null when an older payload omits it. */
+  telemetry: AgentTelemetry | null;
 }
 
 /**
@@ -63,11 +81,7 @@ export default function AdminDashboardPage() {
     timestamp: string;
   } | null>(null);
 
-  useEffect(() => {
-    void fetchDashboardData();
-  }, []);
-
-  const fetchDashboardData = async () => {
+  const fetchDashboardData = async (): Promise<{ ok: boolean }> => {
     try {
       setLoading(true);
       const response = await fetch("/api/admin/dashboard");
@@ -78,15 +92,22 @@ export default function AdminDashboardPage() {
         setStats(data.stats);
         setRecentUsers(data.recentUsers);
         setPaIntegration(data.paIntegration || null);
-      } else {
-        setError(data.message || "Failed to load dashboard");
+        setError(null);
+        return { ok: true };
       }
+      setError(data.message || "Failed to load dashboard");
+      return { ok: false };
     } catch (_err) {
       setError("Failed to connect to server");
+      return { ok: false };
     } finally {
       setLoading(false);
     }
   };
+
+  // Live polling for the operator feed observability + telemetry panels:
+  // visibility-aware with error backoff. Replaces a single mount fetch.
+  useHardenedPolling(fetchDashboardData, { baseIntervalMs: 30_000 });
 
   const handleSyncAll = async () => {
     try {
@@ -478,35 +499,8 @@ export default function AdminDashboardPage() {
 
           </div>
 
-          {/* Simulated / Seeded Telemetry Panel */}
-          <div className="bg-yellow-50/75 border-t border-yellow-100 p-4">
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-[10px] font-extrabold uppercase tracking-widest text-amber-700 bg-amber-100 px-2.5 py-0.5 rounded-full">
-                Simulated Telemetry
-              </span>
-              <span className="text-[10px] text-amber-500 font-mono">meta.mockedFields</span>
-            </div>
-            <div className="grid grid-cols-3 gap-3 text-center">
-              <div className="p-2 bg-white/50 border border-yellow-100/50 rounded-lg">
-                <p className="text-[10px] text-amber-600 font-medium uppercase">Agent Harmony</p>
-                <p className="text-sm font-bold text-amber-900 mt-0.5">
-                  {paIntegration?.meta?.mockedTelemetry?.agentHarmony ?? "94.2%"}
-                </p>
-              </div>
-              <div className="p-2 bg-white/50 border border-yellow-100/50 rounded-lg">
-                <p className="text-[10px] text-amber-600 font-medium uppercase">Transmutation</p>
-                <p className="text-sm font-bold text-amber-900 mt-0.5">
-                  {paIntegration?.meta?.mockedTelemetry?.transmutationRate ?? "3.42 kg/h"}
-                </p>
-              </div>
-              <div className="p-2 bg-white/50 border border-yellow-100/50 rounded-lg">
-                <p className="text-[10px] text-amber-600 font-medium uppercase">Spiritual Entropy</p>
-                <p className="text-sm font-bold text-amber-900 mt-0.5">
-                  {paIntegration?.meta?.mockedTelemetry?.spiritualEntropy ?? "0.11"}
-                </p>
-              </div>
-            </div>
-          </div>
+          {/* Live Metaphysical Telemetry Panel */}
+          <TelemetryPanel telemetry={paIntegration?.telemetry ?? null} />
         </div>
 
         {/* Recent Users Card */}
@@ -597,6 +591,100 @@ export default function AdminDashboardPage() {
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+function TelemetryMetricTile({
+  label,
+  metric,
+}: {
+  label: string;
+  metric: TelemetryMetric | undefined;
+}) {
+  const live = metric?.live ?? false;
+  return (
+    <div
+      className={`p-2 bg-white/60 border rounded-lg ${
+        live ? "border-emerald-100" : "border-amber-100"
+      }`}
+    >
+      <p
+        className={`text-[10px] font-medium uppercase ${
+          live ? "text-emerald-700" : "text-amber-700"
+        }`}
+      >
+        {label}
+      </p>
+      <p className="text-sm font-bold text-gray-900 mt-0.5">
+        {metric?.value ?? "—"}
+      </p>
+      <p className="mt-1 flex items-center justify-center gap-1 text-[9px] font-mono uppercase tracking-wide text-gray-400">
+        <span
+          className={`h-1.5 w-1.5 rounded-full ${
+            live ? "bg-emerald-500" : "bg-amber-400"
+          }`}
+        />
+        {metric?.source ?? "offline"}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Live metaphysical telemetry — replaces the former "Simulated Telemetry"
+ * fixture. Emerald "Live" badge when every metric resolved from its real
+ * source, amber "Degraded" when a source fell back, neutral "Awaiting" before
+ * the first payload arrives.
+ */
+function TelemetryPanel({ telemetry }: { telemetry: AgentTelemetry | null }) {
+  const hasTelemetry = telemetry !== null;
+  const allLive = telemetry?.allLive ?? false;
+
+  const tone = !hasTelemetry
+    ? {
+        wrap: "bg-gray-50 border-gray-100",
+        badge: "text-gray-500 bg-gray-200",
+        dot: "bg-gray-400",
+        label: "Telemetry · Awaiting",
+      }
+    : allLive
+      ? {
+          wrap: "bg-emerald-50/70 border-emerald-100",
+          badge: "text-emerald-800 bg-emerald-100",
+          dot: "bg-emerald-500 animate-pulse",
+          label: "Live Telemetry",
+        }
+      : {
+          wrap: "bg-amber-50/70 border-amber-100",
+          badge: "text-amber-800 bg-amber-100",
+          dot: "bg-amber-500 animate-pulse",
+          label: "Telemetry · Degraded",
+        };
+
+  return (
+    <div className={`border-t p-4 ${tone.wrap}`}>
+      <div className="flex items-center justify-between mb-2">
+        <span
+          className={`flex items-center gap-1.5 text-[10px] font-extrabold uppercase tracking-widest px-2.5 py-0.5 rounded-full ${tone.badge}`}
+        >
+          <span className={`h-2 w-2 rounded-full ${tone.dot}`} />
+          {tone.label}
+        </span>
+        <span className="text-[10px] text-gray-400 font-mono">
+          {hasTelemetry ? "db · ephemeris" : "—"}
+        </span>
+      </div>
+      <div className="grid grid-cols-3 gap-3 text-center">
+        <TelemetryMetricTile label="Agent Harmony" metric={telemetry?.agentHarmony} />
+        <TelemetryMetricTile label="Transmutation" metric={telemetry?.transmutationRate} />
+        <TelemetryMetricTile label="Spiritual Entropy" metric={telemetry?.spiritualEntropy} />
+      </div>
+      {telemetry && (
+        <p className="mt-2 text-center text-[9px] font-mono text-gray-400">
+          updated {new Date(telemetry.generatedAt).toLocaleTimeString()}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/app/api/admin/dashboard/route.ts
+++ b/src/app/api/admin/dashboard/route.ts
@@ -14,6 +14,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import type { AdminDashboardData } from "@/app/admin/_dashboard/data";
 import { validateAdminRequest } from "@/lib/auth/validateRequest";
+import { getAgentNetworkTelemetry } from "@/services/agentTelemetryService";
 import { feedEmitTracker } from "@/services/feedEmitTracker";
 import { userDatabase } from "@/services/userDatabaseService";
 
@@ -113,6 +114,11 @@ export async function GET(request: NextRequest) {
         isActive: u.isActive,
       }));
 
+    // Kick off live telemetry aggregation in parallel with the PA backend
+    // probe below. getAgentNetworkTelemetry never rejects — degraded sources
+    // surface as `live: false` metrics.
+    const telemetryPromise = getAgentNetworkTelemetry();
+
     let paHealth = "offline";
     let paAgentCount = 0;
 
@@ -180,6 +186,11 @@ export async function GET(request: NextRequest) {
       },
     };
 
+    // Live metaphysical telemetry — feed-event rate + event-type entropy from
+    // the database, elemental harmony from the live ephemeris. Supersedes the
+    // former `meta.mockedTelemetry` seed fixture.
+    const telemetry = await telemetryPromise;
+
     const paIntegration = {
       endpoints: {
         alchmNextApp: "https://alchm.kitchen",
@@ -190,14 +201,7 @@ export async function GET(request: NextRequest) {
       health: paHealth,
       agentCount: paAgentCount,
       lastFeedEmit: feedEmitTracker.getLastEmit(),
-      meta: {
-        mockedFields: ["agentHarmony", "transmutationRate", "spiritualEntropy"],
-        mockedTelemetry: {
-          agentHarmony: "94.2%",
-          transmutationRate: "3.42 kg/hr",
-          spiritualEntropy: "0.11",
-        },
-      },
+      telemetry,
     };
 
     // Backwards-compatible response: legacy `/admin` reads `stats` and

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -29,6 +29,13 @@ export const dynamic = "force-dynamic";
 
 const AGENTIC_EMAIL_DOMAIN = "@agentic.alchm.kitchen";
 
+// Edge-case ceilings: bound agent-supplied fields so a malformed or hostile
+// payload fails fast with a 4xx instead of surfacing as a DB-level 500.
+const MAX_EVENT_TYPE_LENGTH = 50; // matches feed_events.event_type VARCHAR(50)
+const MAX_AGENT_EMAIL_LENGTH = 320; // RFC 5321 maximum addressable length
+const MAX_DISPLAY_NAME_LENGTH = 120;
+const MAX_METADATA_BYTES = 16_384; // 16 KB ceiling on a single event payload
+
 if (!process.env.INTERNAL_API_SECRET) {
   console.warn(
     "[feed] INTERNAL_API_SECRET is not set - the POST handler will reject all agent writes until the secret is configured",
@@ -128,7 +135,10 @@ export async function POST(request: Request) {
 
     const incomingAgentEmail = asString(body.agentEmail);
     const incomingEventType = asString(body.eventType);
-    const agentDisplayName = asString(body.agentDisplayName);
+    const agentDisplayName = asString(body.agentDisplayName)?.slice(
+      0,
+      MAX_DISPLAY_NAME_LENGTH,
+    );
     const metadataPayload = isRecord(body.metadataPayload) ? body.metadataPayload : {};
 
     agentEmail = incomingAgentEmail || agentEmail;
@@ -139,6 +149,40 @@ export async function POST(request: Request) {
       return NextResponse.json(
         { error: "Missing required fields", required: ["agentEmail", "eventType"] },
         { status: 400 },
+      );
+    }
+
+    // Field-size hardening — reject oversized input before it can overflow a
+    // VARCHAR column or bloat the JSONB payload at insert time.
+    if (incomingEventType.length > MAX_EVENT_TYPE_LENGTH) {
+      rememberFeedEmit(eventType, agentEmail, 400);
+      return NextResponse.json(
+        { error: "eventType exceeds maximum length", maxLength: MAX_EVENT_TYPE_LENGTH },
+        { status: 400 },
+      );
+    }
+
+    if (incomingAgentEmail.length > MAX_AGENT_EMAIL_LENGTH) {
+      rememberFeedEmit(eventType, agentEmail, 400);
+      return NextResponse.json(
+        { error: "agentEmail exceeds maximum length", maxLength: MAX_AGENT_EMAIL_LENGTH },
+        { status: 400 },
+      );
+    }
+
+    const metadataBytes = Buffer.byteLength(
+      JSON.stringify(metadataPayload),
+      "utf8",
+    );
+    if (metadataBytes > MAX_METADATA_BYTES) {
+      rememberFeedEmit(eventType, agentEmail, 413);
+      return NextResponse.json(
+        {
+          error: "metadataPayload exceeds maximum size",
+          maxBytes: MAX_METADATA_BYTES,
+          receivedBytes: metadataBytes,
+        },
+        { status: 413 },
       );
     }
 

--- a/src/components/auth/AuthScreens.tsx
+++ b/src/components/auth/AuthScreens.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { signIn } from 'next-auth/react';
+import { useState, type ReactNode } from 'react';
+import OnboardingWizard from './OnboardingWizard';
+
+function AuthShell({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle: string;
+  children: ReactNode;
+}) {
+  return (
+    <main className="lab min-h-screen flex items-center justify-center px-4 py-12">
+      <section className="w-full max-w-md rounded-2xl border border-purple-100 bg-white/95 p-8 text-center shadow-xl">
+        <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-purple-100 text-2xl text-purple-700">
+          al
+        </div>
+        <h1 className="text-2xl font-bold text-gray-900">{title}</h1>
+        <p className="mt-2 text-sm text-gray-600">{subtitle}</p>
+        <div className="mt-6">{children}</div>
+      </section>
+    </main>
+  );
+}
+
+export function SignInScreen() {
+  const [isSigningIn, setIsSigningIn] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleGoogleSignIn = async () => {
+    setIsSigningIn(true);
+    setError(null);
+
+    try {
+      await signIn('google', {
+        callbackUrl: '/profile',
+        redirect: true,
+      });
+    } catch (signInError) {
+      console.error('SignIn error:', signInError);
+      setError('Could not start Google sign-in. Please try again.');
+      setIsSigningIn(false);
+    }
+  };
+
+  return (
+    <AuthShell
+      title="Welcome to alchm.kitchen"
+      subtitle="Sign in to continue to your calibrated kitchen, profile, and admin tools."
+    >
+      <button
+        type="button"
+        onClick={() => { void handleGoogleSignIn(); }}
+        disabled={isSigningIn}
+        className="inline-flex w-full items-center justify-center rounded-xl bg-purple-700 px-4 py-3 text-sm font-semibold text-white transition hover:bg-purple-800 disabled:cursor-not-allowed disabled:opacity-70"
+      >
+        {isSigningIn ? 'Opening Google...' : 'Continue with Google'}
+      </button>
+      {error && <p className="mt-4 text-sm text-red-600">{error}</p>}
+    </AuthShell>
+  );
+}
+
+export function AuthErrorScreen() {
+  const searchParams = useSearchParams();
+  const error = searchParams?.get('error') || 'Authentication failed';
+
+  return (
+    <AuthShell
+      title="Sign-in needs another try"
+      subtitle="The authentication provider returned an error before completing your session."
+    >
+      <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>
+      <button
+        type="button"
+        onClick={() => { void signIn('google', { callbackUrl: '/profile', redirect: true }); }}
+        className="mt-5 inline-flex w-full items-center justify-center rounded-xl bg-purple-700 px-4 py-3 text-sm font-semibold text-white transition hover:bg-purple-800"
+      >
+        Try Google again
+      </button>
+    </AuthShell>
+  );
+}
+
+export function OnboardingFlow() {
+  return <OnboardingWizard />;
+}

--- a/src/hooks/useHardenedPolling.ts
+++ b/src/hooks/useHardenedPolling.ts
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * useHardenedPolling
+ *
+ * Drives a recurring async poll for live admin/operator surfaces. Hardens a
+ * naive `setInterval` loop in three ways:
+ *
+ *   - Visibility-aware  polling pauses while the tab is hidden and resumes
+ *                       with an immediate refresh when it regains focus, so
+ *                       backgrounded operator tabs stop hammering the API.
+ *   - Error backoff     a failed poll doubles the interval (capped) until a
+ *                       poll succeeds, which resets the cadence to the base.
+ *   - No overlap        a poll in flight is never re-entered.
+ *
+ * The `poll` callback owns its own data handling; this hook owns only the
+ * scheduling. It must report `{ ok }` so the hook can drive the backoff.
+ */
+export interface HardenedPollingOptions {
+  /** Cadence between polls while healthy. Default 30s. */
+  baseIntervalMs?: number;
+  /** Upper bound the backoff can stretch the interval to. Default 5m. */
+  maxIntervalMs?: number;
+}
+
+export function useHardenedPolling(
+  poll: () => Promise<{ ok: boolean }>,
+  options: HardenedPollingOptions = {},
+): { refreshNow: () => void } {
+  const { baseIntervalMs = 30_000, maxIntervalMs = 300_000 } = options;
+
+  // Keep the latest poll callback without restarting the schedule each render.
+  const pollRef = useRef(poll);
+  pollRef.current = poll;
+
+  const refreshRef = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let interval = baseIntervalMs;
+    let running = false;
+    let cancelled = false;
+
+    const clear = () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+
+    const schedule = () => {
+      clear();
+      if (cancelled) return;
+      timer = setTimeout(() => {
+        void run();
+      }, interval);
+    };
+
+    const run = async () => {
+      if (cancelled || running) return;
+      // Paused while hidden — the visibility handler resumes the loop.
+      if (typeof document !== "undefined" && document.hidden) return;
+
+      running = true;
+      let ok = false;
+      try {
+        ok = (await pollRef.current()).ok;
+      } catch {
+        ok = false;
+      } finally {
+        running = false;
+      }
+      if (cancelled) return;
+
+      interval = ok
+        ? baseIntervalMs
+        : Math.min(interval * 2, maxIntervalMs);
+      schedule();
+    };
+
+    const onVisibilityChange = () => {
+      if (typeof document === "undefined") return;
+      if (document.hidden) {
+        clear();
+      } else {
+        interval = baseIntervalMs;
+        void run();
+      }
+    };
+
+    refreshRef.current = () => {
+      interval = baseIntervalMs;
+      void run();
+    };
+
+    void run();
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      clear();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [baseIntervalMs, maxIntervalMs]);
+
+  return {
+    refreshNow: () => {
+      refreshRef.current();
+    },
+  };
+}

--- a/src/services/agentTelemetryService.ts
+++ b/src/services/agentTelemetryService.ts
@@ -1,0 +1,166 @@
+/**
+ * Agent Network Telemetry Service
+ *
+ * Computes the live metaphysical telemetry surfaced on the admin Planetary
+ * Agents panel. Replaces the seeded `meta.mockedTelemetry` fixture with real
+ * sources:
+ *
+ *   - transmutationRate  agent feed_events recorded in the last hour (DB)
+ *   - spiritualEntropy   normalized Shannon entropy of the trailing-24h
+ *                        event-type mix (DB) — 0 = a single ordered stream,
+ *                        1 = activity spread evenly across every event type
+ *   - agentHarmony       elemental balance of the live sky (ephemeris) —
+ *                        1 = Fire/Water/Earth/Air are perfectly even
+ *
+ * Each metric degrades independently: a failed source yields `live: false`
+ * with a neutral value so the dashboard never hard-fails.
+ */
+
+import { executeQuery } from "@/lib/database/connection";
+import { _logger } from "@/lib/logger";
+import { aggregateZodiacElementals } from "@/utils/planetaryAlchemyMapping";
+import { getCurrentPlanetaryPositionsServer } from "@/utils/serverPlanetaryCalculations";
+
+export interface TelemetryMetric {
+  /** Display-formatted value, e.g. "62.4%", "12 /hr", "0.43". */
+  value: string;
+  /** Raw numeric value behind the formatted string. */
+  raw: number;
+  /** true when computed from a real source; false when degraded to fallback. */
+  live: boolean;
+  /** Which real source feeds this metric. */
+  source: "database" | "ephemeris";
+}
+
+export interface AgentNetworkTelemetry {
+  agentHarmony: TelemetryMetric;
+  transmutationRate: TelemetryMetric;
+  spiritualEntropy: TelemetryMetric;
+  generatedAt: string;
+  /** true only when every metric resolved from its live source. */
+  allLive: boolean;
+}
+
+/**
+ * Normalized Shannon entropy (Pielou evenness) of a set of category counts.
+ * Returns 0..1: 0 when one category dominates, 1 when counts are uniform.
+ */
+function normalizedShannonEntropy(counts: number[]): number {
+  const positive = counts.filter((c) => c > 0);
+  const total = positive.reduce((sum, c) => sum + c, 0);
+  if (total === 0 || positive.length < 2) return 0;
+
+  let entropy = 0;
+  for (const count of positive) {
+    const p = count / total;
+    entropy -= p * Math.log(p);
+  }
+  return entropy / Math.log(positive.length);
+}
+
+/**
+ * DB-backed metrics: agent feed-event rate and event-type entropy.
+ * A single grouped query covers both the trailing hour and the trailing day.
+ */
+async function getFeedActivityTelemetry(): Promise<{
+  transmutationRate: number;
+  spiritualEntropy: number;
+  live: boolean;
+}> {
+  try {
+    const result = await executeQuery(
+      `SELECT
+         f.event_type,
+         COUNT(*)::int AS total,
+         COUNT(*) FILTER (WHERE f.created_at > NOW() - INTERVAL '1 hour')::int AS last_hour
+       FROM feed_events f
+       JOIN users u ON f.actor_id = u.id
+       WHERE u.is_agent = true
+         AND f.created_at > NOW() - INTERVAL '24 hours'
+       GROUP BY f.event_type`,
+    );
+
+    const rows = result.rows as Array<{ total: number; last_hour: number }>;
+    const transmutationRate = rows.reduce((sum, r) => sum + (r.last_hour || 0), 0);
+    const spiritualEntropy = normalizedShannonEntropy(rows.map((r) => r.total || 0));
+
+    return { transmutationRate, spiritualEntropy, live: true };
+  } catch (error) {
+    _logger.error("[agentTelemetry] feed activity aggregation failed:", error);
+    return { transmutationRate: 0, spiritualEntropy: 0, live: false };
+  }
+}
+
+/**
+ * Ephemeris-backed metric: elemental balance of the current sky. Harmony is
+ * 1 minus the normalized L1 deviation from a perfectly even Fire/Water/Earth/Air
+ * split (max possible L1 deviation from uniform is 1.5).
+ */
+async function getAgentHarmony(): Promise<{ raw: number; live: boolean }> {
+  try {
+    const positions = await getCurrentPlanetaryPositionsServer();
+
+    const signByPlanet: Record<string, string> = {};
+    for (const [planet, position] of Object.entries(positions)) {
+      const sign = position?.sign;
+      if (typeof sign === "string" && sign.length > 0) {
+        // serverPlanetaryCalculations emits lowercase signs; ZODIAC_ELEMENTS
+        // is keyed by capitalized sign names.
+        signByPlanet[planet] =
+          sign.charAt(0).toUpperCase() + sign.slice(1).toLowerCase();
+      }
+    }
+
+    if (Object.keys(signByPlanet).length === 0) {
+      return { raw: 0.5, live: false };
+    }
+
+    const elements = aggregateZodiacElementals(signByPlanet);
+    const values = [elements.Fire, elements.Water, elements.Earth, elements.Air];
+    const deviation = values.reduce((sum, v) => sum + Math.abs(v - 0.25), 0);
+    const harmony = Math.max(0, Math.min(1, 1 - deviation / 1.5));
+
+    return { raw: harmony, live: true };
+  } catch (error) {
+    _logger.error("[agentTelemetry] agent harmony ephemeris calc failed:", error);
+    return { raw: 0.5, live: false };
+  }
+}
+
+/**
+ * Resolve the full live telemetry block for the admin Planetary Agents panel.
+ * Never rejects — failed sources surface as degraded (`live: false`) metrics.
+ */
+export async function getAgentNetworkTelemetry(): Promise<AgentNetworkTelemetry> {
+  const [feed, harmony] = await Promise.all([
+    getFeedActivityTelemetry(),
+    getAgentHarmony(),
+  ]);
+
+  const agentHarmony: TelemetryMetric = {
+    value: `${(harmony.raw * 100).toFixed(1)}%`,
+    raw: harmony.raw,
+    live: harmony.live,
+    source: "ephemeris",
+  };
+  const transmutationRate: TelemetryMetric = {
+    value: `${feed.transmutationRate} /hr`,
+    raw: feed.transmutationRate,
+    live: feed.live,
+    source: "database",
+  };
+  const spiritualEntropy: TelemetryMetric = {
+    value: feed.spiritualEntropy.toFixed(2),
+    raw: feed.spiritualEntropy,
+    live: feed.live,
+    source: "database",
+  };
+
+  return {
+    agentHarmony,
+    transmutationRate,
+    spiritualEntropy,
+    generatedAt: new Date().toISOString(),
+    allLive: agentHarmony.live && transmutationRate.live && spiritualEntropy.live,
+  };
+}


### PR DESCRIPTION
## Summary

- Transitions the admin Planetary Agents panel from seeded mock telemetry to live data (database aggregation + sky ephemeris).
- Hardens the `POST /api/feed` webhook that ingests agent activity, and the polling that refreshes the operator dashboards.
- Lands the standalone `AuthScreens` client component module.

## What changed

**Live agent telemetry** — `agentTelemetryService.ts`, `GET /api/admin/dashboard`
Replaces `paIntegration.meta.mockedTelemetry` with real sources:
- **Transmutation Rate** — agent `feed_events` in the last hour (DB aggregation).
- **Spiritual Entropy** — normalized Shannon entropy (0–1) of the trailing-24h agent event-type mix (DB aggregation).
- **Agent Harmony** — elemental balance of the live sky via the server ephemeris.

Each metric degrades independently to `live: false` if its source fails; the endpoint never hard-fails. Telemetry runs in parallel with the existing PA-backend probe.

**Telemetry UI** — `/admin`
The amber "Simulated Telemetry" panel now renders live / degraded / awaiting states with per-metric source indicators (`database` / `ephemeris`).

**Feed webhook hardening** — `POST /api/feed`
Bounds agent-supplied field sizes so malformed payloads fail fast with 4xx instead of a DB-level 500: `eventType` ≤ 50 (matches `VARCHAR(50)`), `agentEmail` ≤ 320, `metadataPayload` ≤ 16 KB → 413, `displayName` truncated to 120.

**Hardened polling** — new `useHardenedPolling` hook
Visibility-aware (pauses on hidden tab, refreshes on refocus), error backoff, no overlapping polls. Applied to `/admin/dashboard` (was a flat 30s `setInterval`) and `/admin` (previously fetched only once on mount).

**Auth screens** — `AuthScreens.tsx`
New client component module exporting `SignInScreen`, `AuthErrorScreen`, `OnboardingFlow`.

## Test plan

- [x] `bun run build` — passes, 0 errors
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 new warnings (34 pre-existing, unchanged)
- [x] `bun run test` — 38/38 suites, 383 tests pass
- [ ] Verify `/admin` telemetry panel shows "Live Telemetry" against a real DB + admin session
- [ ] Confirm `POST /api/feed` rejects oversized payloads with 400/413

## Notes for reviewer

- **`AuthScreens.tsx` has no importers yet** — `auth/error/page.tsx` is already self-contained. The component is committed but not wired into a route; wiring was left out of scope.
- `feed_events` stores **both** human (`claim_daily`, `commensal_request`) and agent events, so the telemetry queries filter `is_agent = true`. No schema migration needed — the existing `idx_feed_events_created` index covers the new 24h aggregation.
- Real-time was implemented as hardened polling rather than SSE: the frontend runs on Vercel serverless, where long-lived SSE connections are unreliable.
- The live admin panels could not be browser-verified in the working environment (Google OAuth + admin role + Railway Postgres required); verification was build/typecheck/lint/test + code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)