### PR TITLE
fix(security): remove hardcoded DB credentials from tracked files

### DIFF
--- a/NEXT_SESSION_PROMPT.md
+++ b/NEXT_SESSION_PROMPT.md
@@ -13,7 +13,7 @@ The local development environment has been equipped with a NextAuth admin bypass
    lsof -ti:3002 | xargs kill -9 2>/dev/null || true
    ```
 3. **Live Database Access**: Connects directly to the live Railway PostgreSQL database.
-   - Connection URL: `postgresql://postgres:PsVTYtMbsWtMhykqZbzgzJUpMmrzKKoD@tramway.proxy.rlwy.net:35670/railway`
+   - Connection URL: `postgresql://postgres:<password>@tramway.proxy.rlwy.net:35670/railway` — the password is supplied via `.env.local` / Railway env, never committed
    - *Note*: Always verify that env variables are loaded correctly by Bun modules without hoisting interference.
 
 ---

--- a/backend/database/config.py
+++ b/backend/database/config.py
@@ -64,12 +64,13 @@ class DatabaseConfig(BaseSettings):
             
             # Ensure hostname is postgres.railway.internal
             v = re.sub(r'@[^:/]+', '@postgres.railway.internal', v)
-            if "@" not in v:
-                v = v.replace("://", "://postgres:PsVTYtMbsWtMhykqZbzgzJUpMmrzKKoD@")
+            db_password = os.getenv("DB_PASSWORD", "")
+            if db_password and "@" not in v:
+                v = v.replace("://", f"://postgres:{db_password}@")
             
             # Ensure password is present if user is postgres
-            if "postgresql://postgres@" in v:
-                v = v.replace("://postgres@", "://postgres:PsVTYtMbsWtMhykqZbzgzJUpMmrzKKoD@")
+            if db_password and "postgresql://postgres@" in v:
+                v = v.replace("://postgres@", f"://postgres:{db_password}@")
             
             is_internal_railway = True
 

--- a/backend/scripts/migrate_neon_to_railway.py
+++ b/backend/scripts/migrate_neon_to_railway.py
@@ -11,8 +11,12 @@ sys.path.insert(0, str(backend_dir))
 
 from database.models import Base, Ingredient, Recipe, RecipeIngredient, RecipeContext, ElementalProperties, PlanetaryInfluence, ZodiacAffinity, SeasonalAssociation
 
-NEON_URL = "postgresql://neondb_owner:npg_kHLuO2D3wZEg@ep-patient-bread-amcjoqiw-pooler.c-5.us-east-1.aws.neon.tech/neondb?sslmode=require"
-RAILWAY_URL = "postgresql://postgres:PsVTYtMbsWtMhykqZbzgzJUpMmrzKKoD@tramway.proxy.rlwy.net:35670/railway"
+NEON_URL = os.environ.get("NEON_DATABASE_URL", "")
+RAILWAY_URL = os.environ.get("RAILWAY_DATABASE_URL", "")
+if not NEON_URL or not RAILWAY_URL:
+    raise SystemExit(
+        "Set NEON_DATABASE_URL and RAILWAY_DATABASE_URL before running this migration."
+    )
 
 source_engine = create_engine(NEON_URL)
 dest_engine = create_engine(RAILWAY_URL)


### PR DESCRIPTION
## Summary

Removes hardcoded database credentials from tracked source files, replacing them with environment-variable reads.

- **`backend/database/config.py`** — the Railway-internal `DATABASE_URL` password fallback read a hardcoded literal; it now reads `DB_PASSWORD` from the environment and only injects when set.
- **`backend/scripts/migrate_neon_to_railway.py`** — `NEON_URL` and `RAILWAY_URL` were hardcoded connection strings (Railway *and* Neon passwords); they now read `NEON_DATABASE_URL` / `RAILWAY_DATABASE_URL` and fail fast if unset.
- **`NEXT_SESSION_PROMPT.md`** — the example connection string now shows a `<password>` placeholder.

## ⚠️ Rotation still required

This stops the credentials being in the **current tree**, but the leaked strings remain in prior git history (including the now-merged #430). They must be **rotated** to be fully neutralized — rotate both the Railway Postgres password and the Neon password.

## Test plan
- [x] `git grep` confirms 0 occurrences of either password in the tree
- [x] `python3 -m py_compile` passes for both backend files
- [ ] Confirm `DB_PASSWORD` is set in the Railway/Vercel environments (and `NEON_DATABASE_URL` / `RAILWAY_DATABASE_URL` if the migration script is rerun)

🤖 Generated with [Claude Code](https://claude.com/claude-code)