### PR TITLE
feat(admin): live planetary hour bar + slow-query threshold defense-in-depth

### DIFF
--- a/src/app/admin/_dashboard/Dashboard.tsx
+++ b/src/app/admin/_dashboard/Dashboard.tsx
@@ -118,7 +118,9 @@ export function Dashboard({ data }: DashboardProps) {
       </style>
 
       <AdminShell density={density} showGrid={showGrid} user={data.user} pulse={data.pulse}>
-        <MasterLineHero greeting={`Good Mars hour, ${data.user.name.split(" ")[0]}`} />
+        <MasterLineHero
+          greeting={`Good ${data.skyConditions.planetaryHour.planet} hour, ${data.user.name.split(" ")[0]}`}
+        />
         <KPIStrip />
         <SkyConditions data={data.skyConditions} />
 
@@ -139,7 +141,7 @@ export function Dashboard({ data }: DashboardProps) {
 
         <div style={{ display: "grid", gridTemplateColumns: "1.2fr 1fr", gap: 12, marginBottom: 12 }}>
           <SEMSDistribution />
-          <AstronomicalEngine />
+          <AstronomicalEngine live={data.skyConditions.live} />
         </div>
 
         <div
@@ -226,11 +228,31 @@ export function Dashboard({ data }: DashboardProps) {
             <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>build · #c8f1ad</span>
           </div>
           <div style={{ display: "flex", gap: 18 }}>
-            <span className="t-mono" style={{ fontSize: 9.5, color: "var(--accent)" }}>● mars hour · 21:46 UTC</span>
+            <span
+              className="t-mono"
+              style={{
+                fontSize: 9.5,
+                color: data.skyConditions.planetaryHour.live ? "var(--accent)" : "var(--fg-mute)",
+              }}
+            >
+              ● {data.skyConditions.planetaryHour.planet.toLowerCase()} hour
+              {" · "}
+              {new Date(data.skyConditions.generatedAt)
+                .toISOString()
+                .slice(11, 16)} UTC
+            </span>
             <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>
               JD 2460814.71 · VSOP87/DE440
             </span>
-            <span className="t-mono" style={{ fontSize: 9.5, color: "var(--el-earth)" }}>● all systems · 98.7%</span>
+            <span
+              className="t-mono"
+              style={{
+                fontSize: 9.5,
+                color: data.skyConditions.live ? "var(--el-earth)" : "var(--fg-mute)",
+              }}
+            >
+              {data.skyConditions.live ? "● all systems · live" : "○ ephemeris · degraded"}
+            </span>
           </div>
         </footer>
       </AdminShell>

--- a/src/app/admin/_dashboard/data.ts
+++ b/src/app/admin/_dashboard/data.ts
@@ -147,6 +147,15 @@ const SKY_SEED: SkyConditionsData = {
     { symbol: "♄", name: "Saturn", position: "—", speed: "—", retrograde: false, stationing: false },
   ],
   aspects: [],
+  planetaryHour: {
+    symbol: "—",
+    planet: "Sun",
+    dayRuler: "Sun",
+    hourNumber: 0,
+    isDaytime: true,
+    segments: [],
+    live: false,
+  },
 };
 
 export const FALLBACK_DATA: AdminDashboardData = {
@@ -198,6 +207,7 @@ export const FALLBACK_DATA: AdminDashboardData = {
     activeConnections: 0,
     tables: [],
     slowQueries: [],
+    slowQueryThresholdMs: 200,
     live: false,
   },
   catalogTrending: { recipes: [], live: false },

--- a/src/app/admin/_dashboard/extras.tsx
+++ b/src/app/admin/_dashboard/extras.tsx
@@ -1112,7 +1112,7 @@ function formatBytes(bytes: number): string {
 }
 
 export function DatabaseStorage({ data }: { data: DatabaseObservabilityData }) {
-  const { pool, slowQueries, tables, live } = data;
+  const { pool, slowQueries, slowQueryThresholdMs, tables, live } = data;
   const poolLoad = pool.max > 0 ? pool.total / pool.max : 0;
   const maxTableSize = Math.max(1, ...tables.map((t) => t.sizeBytes));
   return (
@@ -1152,11 +1152,13 @@ export function DatabaseStorage({ data }: { data: DatabaseObservabilityData }) {
         <Stat2 k="DB size" v={formatBytes(data.dbSizeBytes)} d="current database" />
       </div>
 
-      <div className="t-tag" style={{ marginBottom: 4 }}>SLOW QUERIES · ACTIVE &gt; 200MS</div>
+      <div className="t-tag" style={{ marginBottom: 4 }}>
+        SLOW QUERIES · LAST 24H &gt; {slowQueryThresholdMs}MS
+      </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 3, marginBottom: 10 }}>
         {slowQueries.length === 0 ? (
           <span className="t-mono" style={{ fontSize: 9, color: "var(--el-earth)" }}>
-            none — all active queries under 200ms
+            none — all logged queries under {slowQueryThresholdMs}ms
           </span>
         ) : (
           slowQueries.map((q, i) => (

--- a/src/app/admin/_dashboard/sky.tsx
+++ b/src/app/admin/_dashboard/sky.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import React from "react";
-import type { SkyConditionsData } from "@/services/skyConditionsService";
+import type {
+  PlanetaryHourSnapshot,
+  SkyConditionsData,
+} from "@/services/skyConditionsService";
 import { Sparkline } from "./atoms";
 import { seeded } from "./data";
 import { Card } from "./hero";
@@ -20,7 +23,7 @@ const PLANET_COLOR: Record<string, string> = {
 };
 
 export function SkyConditions({ data }: { data: SkyConditionsData }) {
-  const { planets, aspects, headline, live } = data;
+  const { planets, aspects, headline, live, planetaryHour } = data;
   const retrogradeCount = planets.filter((p) => p.retrograde).length;
   return (
     <section
@@ -143,8 +146,10 @@ export function SkyConditions({ data }: { data: SkyConditionsData }) {
           alignItems: "center",
         }}
       >
-        <div className="t-tag" style={{ fontSize: 8 }}>PLANETARY HOUR · 60-MIN BAR</div>
-        <PlanetaryHourBar />
+        <div className="t-tag" style={{ fontSize: 8 }}>
+          PLANETARY HOUR · {planetaryHour.live ? "LIVE" : "CACHED"}
+        </div>
+        <PlanetaryHourBar snapshot={planetaryHour} />
         <div className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)", letterSpacing: "0.12em" }}>
           {planets.length} BODIES · {retrogradeCount} Rx · {aspects.length} ASPECTS
         </div>
@@ -153,23 +158,29 @@ export function SkyConditions({ data }: { data: SkyConditionsData }) {
   );
 }
 
-function PlanetaryHourBar() {
-  const planets = ["♂", "☉", "♀", "☿", "☽", "♄", "♃"];
-  const segs = Array.from({ length: 24 }, (_, i) => {
-    const idx = (i + 3) % 7;
-    const isLive = i === 8;
-    const isPast = i < 8;
-    return { sym: planets[idx], isLive, isPast };
-  });
-  const colors: Record<string, string> = {
-    "♂": "var(--el-fire)",
-    "☉": "var(--accent-2)",
-    "♀": "var(--el-water)",
-    "☿": "var(--el-air)",
-    "☽": "#D6CFE8",
-    "♄": "var(--fg-mute)",
-    "♃": "var(--el-earth)",
-  };
+const PLANETARY_HOUR_COLORS: Record<string, string> = {
+  "♂": "var(--el-fire)",
+  "☉": "var(--accent-2)",
+  "♀": "var(--el-water)",
+  "☿": "var(--el-air)",
+  "☽": "#D6CFE8",
+  "♄": "var(--fg-mute)",
+  "♃": "var(--el-earth)",
+};
+
+function PlanetaryHourBar({ snapshot }: { snapshot: PlanetaryHourSnapshot }) {
+  // Empty segments (degraded state) — render a uniform muted strip so the
+  // bar doesn't collapse layout while the ephemeris recovers.
+  const segs = snapshot.segments.length > 0
+    ? snapshot.segments
+    : Array.from({ length: 24 }, (_, hour) => ({
+        hour,
+        symbol: "·",
+        planet: snapshot.dayRuler,
+        isLive: false,
+        isPast: false,
+      }));
+
   return (
     <div
       style={{
@@ -180,29 +191,33 @@ function PlanetaryHourBar() {
         height: 22,
       }}
     >
-      {segs.map((s, i) => (
-        <div
-          key={i}
-          style={{
-            background: s.isLive
-              ? "var(--accent)"
-              : s.isPast
-                ? `color-mix(in oklch, ${colors[s.sym]}, transparent 70%)`
-                : "rgba(255,255,255,0.04)",
-            border: `1px solid ${s.isLive ? "var(--accent)" : "var(--line)"}`,
-            borderRadius: 2,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            fontFamily: "JetBrains Mono",
-            fontSize: 9,
-            color: s.isLive ? "#0A0712" : s.isPast ? "var(--fg-dim)" : "var(--fg-mute)",
-            boxShadow: s.isLive ? "0 0 12px var(--accent)" : "none",
-          }}
-        >
-          {s.sym}
-        </div>
-      ))}
+      {segs.map((s) => {
+        const color = PLANETARY_HOUR_COLORS[s.symbol] ?? "var(--fg-mute)";
+        return (
+          <div
+            key={s.hour}
+            title={`${String(s.hour).padStart(2, "0")}:00 · ${s.planet}`}
+            style={{
+              background: s.isLive
+                ? "var(--accent)"
+                : s.isPast
+                  ? `color-mix(in oklch, ${color}, transparent 70%)`
+                  : "rgba(255,255,255,0.04)",
+              border: `1px solid ${s.isLive ? "var(--accent)" : "var(--line)"}`,
+              borderRadius: 2,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontFamily: "JetBrains Mono",
+              fontSize: 9,
+              color: s.isLive ? "#0A0712" : s.isPast ? "var(--fg-dim)" : "var(--fg-mute)",
+              boxShadow: s.isLive ? "0 0 12px var(--accent)" : "none",
+            }}
+          >
+            {s.symbol}
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -210,14 +225,14 @@ function PlanetaryHourBar() {
 // ============================================================
 // ASTRONOMICAL ENGINE
 // ============================================================
-export function AstronomicalEngine() {
+export function AstronomicalEngine({ live = false }: { live?: boolean } = {}) {
   const refs = [
-    { k: "EPHEMERIS", v: "DE440 · 2020-2050", ok: true },
-    { k: "VSOP87 KERNEL", v: "rev · 2024-03-12", ok: true },
-    { k: "IAU 2006 PRECESSION", v: "P03 · OK", ok: true },
-    { k: "ΔT MODEL", v: "ESPENAK-MEEUS", ok: true },
-    { k: "LEAP SECOND TABLE", v: "37s · 2017-01-01", ok: true },
-    { k: "JPL HORIZONS DRIFT", v: "max · 0.38″ Saturn", ok: true },
+    { k: "EPHEMERIS", v: "DE440 · 2020-2050", ok: live },
+    { k: "VSOP87 KERNEL", v: "rev · 2024-03-12", ok: live },
+    { k: "IAU 2006 PRECESSION", v: "P03 · OK", ok: live },
+    { k: "ΔT MODEL", v: "ESPENAK-MEEUS", ok: live },
+    { k: "LEAP SECOND TABLE", v: "37s · 2017-01-01", ok: live },
+    { k: "JPL HORIZONS DRIFT", v: "max · 0.38″ Saturn", ok: live },
   ];
   const compute = [
     { k: "natal · /api/natal", rps: 38, p95: "184ms", color: "var(--accent)" },
@@ -231,7 +246,12 @@ export function AstronomicalEngine() {
       title="Astronomical Engine · astrologize"
       subtitle="planetary truth source · sub-ms hot path"
       right={
-        <span className="t-mono" style={{ fontSize: 9, color: "var(--el-earth)" }}>● HEALTHY · 99.998%</span>
+        <span
+          className="t-mono"
+          style={{ fontSize: 9, color: live ? "var(--el-earth)" : "var(--fg-mute)" }}
+        >
+          {live ? "● LIVE EPHEMERIS" : "○ DEGRADED"}
+        </span>
       }
     >
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14 }}>

--- a/src/services/dashboardPanelsService.ts
+++ b/src/services/dashboardPanelsService.ts
@@ -10,7 +10,10 @@ import { checkDatabaseHealth, executeQuery } from "@/lib/database";
 import { getDatabasePool } from "@/lib/database/connection";
 import { _logger } from "@/lib/logger";
 import { summarizeRecent } from "@/lib/observability/requestLog";
-import { getRecentSlowQueries } from "@/lib/observability/slowQueryLog";
+import {
+  getRecentSlowQueries,
+  getSlowQueryThresholdMs,
+} from "@/lib/observability/slowQueryLog";
 
 // ─── Cosmic Yield · token economy ──────────────────────────────────────
 
@@ -136,8 +139,10 @@ export interface DatabaseObservabilityData {
   activeConnections: number;
   /** largest tables by total relation size */
   tables: DatabaseTable[];
-  /** active queries currently running longer than 200ms */
+  /** persisted slow queries from the last 24h above `slowQueryThresholdMs`, worst first */
   slowQueries: SlowQuery[];
+  /** the latency threshold (ms) above which a query is treated as slow */
+  slowQueryThresholdMs: number;
   /** true when the Postgres stat views resolved; false when degraded. */
   live: boolean;
 }
@@ -145,10 +150,15 @@ export interface DatabaseObservabilityData {
 /**
  * Postgres observability for the Database panel — connection-pool usage
  * (read from the in-process pg.Pool), database size, active connections,
- * largest tables, and active queries exceeding a 200ms latency threshold.
- * Uses only standard stat views — no pg_stat_statements extension required.
+ * largest tables, and persisted slow queries over the last 24h that
+ * exceed `getSlowQueryThresholdMs()` (default 200ms, Railway dyno pool
+ * defaults to 5 — see DB_MAX_CONNECTIONS). Uses only standard stat views
+ * — no pg_stat_statements extension required. Each source degrades
+ * independently so the dashboard never hard-fails.
  */
 export async function getDatabaseObservability(): Promise<DatabaseObservabilityData> {
+  const slowQueryThresholdMs = getSlowQueryThresholdMs();
+
   // Pool counters live on the in-process pool — readable without a query.
   const pool = { total: 0, idle: 0, waiting: 0, max: 0 };
   try {
@@ -172,15 +182,21 @@ export async function getDatabaseObservability(): Promise<DatabaseObservabilityD
         `SELECT COUNT(*)::int AS count FROM pg_stat_activity
          WHERE datname = current_database()`,
       ),
+      // Filter on metric_value explicitly: the write side gates at the same
+      // threshold, but a future env override on either side would otherwise
+      // silently desynchronize the panel. Sort by duration so operators see
+      // the worst offenders first, not just the most recent.
       executeQuery(
-        `SELECT 
+        `SELECT
            tags->>'query' AS query,
            metric_value::float8 AS duration_ms
          FROM system_metrics
          WHERE metric_name = 'slow_query_duration_ms'
+           AND metric_value >= $1
            AND timestamp > now() - INTERVAL '24 hours'
-         ORDER BY timestamp DESC
-         LIMIT 5`
+         ORDER BY metric_value DESC
+         LIMIT 5`,
+        [slowQueryThresholdMs],
       ).catch(err => {
         _logger.warn("[dbObservability] failed to query system_metrics for slow queries, falling back:", err);
         return { rows: [] };
@@ -201,7 +217,8 @@ export async function getDatabaseObservability(): Promise<DatabaseObservabilityD
       durationMs: Math.round(Number(r.duration_ms ?? 0)),
     }));
 
-    // Merge with in-memory slow queries if fewer than 5 rows returned
+    // Merge with in-memory slow queries if fewer than 5 rows returned. The
+    // in-memory ring uses the same threshold, so values are already filtered.
     let finalSlowQueries = [...dbSlowQueries];
     if (finalSlowQueries.length < 5) {
       const needed = 5 - finalSlowQueries.length;
@@ -211,6 +228,7 @@ export async function getDatabaseObservability(): Promise<DatabaseObservabilityD
       }));
       finalSlowQueries = [...finalSlowQueries, ...inMemorySlows];
     }
+    finalSlowQueries.sort((a, b) => b.durationMs - a.durationMs);
 
     const tableRows = tablesRes.rows as Array<{
       name: string;
@@ -223,6 +241,7 @@ export async function getDatabaseObservability(): Promise<DatabaseObservabilityD
       dbSizeBytes: Number(sizeRes.rows[0]?.bytes ?? 0),
       activeConnections: Number(connRes.rows[0]?.count ?? 0),
       slowQueries: finalSlowQueries,
+      slowQueryThresholdMs,
       tables: tableRows.map((r) => ({
         name: String(r.name),
         rows: Math.round(Number(r.rows ?? 0)),
@@ -232,8 +251,7 @@ export async function getDatabaseObservability(): Promise<DatabaseObservabilityD
     };
   } catch (error) {
     _logger.error("[dbObservability] stat-view query failed, falling back to in-memory slow queries:", error);
-    
-    // Fall back completely to in-memory slow queries when query fails
+
     const fallbackSlowQueries = getRecentSlowQueries(5).map(entry => ({
       query: entry.preview,
       durationMs: entry.ms,
@@ -245,6 +263,7 @@ export async function getDatabaseObservability(): Promise<DatabaseObservabilityD
       activeConnections: 0,
       tables: [],
       slowQueries: fallbackSlowQueries,
+      slowQueryThresholdMs,
       live: false,
     };
   }

--- a/src/services/skyConditionsService.ts
+++ b/src/services/skyConditionsService.ts
@@ -12,6 +12,8 @@
  */
 
 import { _logger } from "@/lib/logger";
+import { PlanetaryHourCalculator } from "@/lib/PlanetaryHourCalculator";
+import type { Planet } from "@/types/celestial";
 import type { PlanetPosition } from "@/utils/astrologyUtils";
 import { getCurrentPlanetaryPositionsServer } from "@/utils/serverPlanetaryCalculations";
 
@@ -42,11 +44,42 @@ export interface SkyAspect {
   applying: boolean;
 }
 
+export interface PlanetaryHourSegment {
+  /** clock hour 0-23 */
+  hour: number;
+  /** planet ruling this hour, as an astrological glyph */
+  symbol: string;
+  /** planet name (e.g. "Mars") */
+  planet: Planet;
+  /** true for the segment containing now */
+  isLive: boolean;
+  /** true for hours earlier today than now */
+  isPast: boolean;
+}
+
+export interface PlanetaryHourSnapshot {
+  /** glyph of the current planetary hour ruler */
+  symbol: string;
+  /** name of the current planetary hour ruler */
+  planet: Planet;
+  /** planetary day ruler (e.g. "Mars" on a Tuesday) */
+  dayRuler: Planet;
+  /** day-or-night index of the current planetary hour, 0-11 */
+  hourNumber: number;
+  isDaytime: boolean;
+  /** 24-clock-hour view used by the dashboard's planetary-hour bar */
+  segments: PlanetaryHourSegment[];
+  /** true when computed from the calculator; false when degraded. */
+  live: boolean;
+}
+
 export interface SkyConditionsData {
   /** short derived summary, e.g. "Mercury stationing · 2 planets retrograde" */
   headline: string;
   planets: SkyPlanet[];
   aspects: SkyAspect[];
+  /** current planetary day/hour + 24-hour bar for the planetary-hour widget */
+  planetaryHour: PlanetaryHourSnapshot;
   /** true when computed from the live ephemeris; false when degraded. */
   live: boolean;
   generatedAt: string;
@@ -103,8 +136,18 @@ const ASPECT_ORB = 6;
 /** Daily motion (deg/day) below which a non-luminary is "stationing". */
 const STATIONING_SPEED = 0.08;
 
+const DEGRADED_PLANETARY_HOUR: PlanetaryHourSnapshot = {
+  symbol: "—",
+  planet: "Sun",
+  dayRuler: "Sun",
+  hourNumber: 0,
+  isDaytime: true,
+  segments: [],
+  live: false,
+};
+
 /** Neutral snapshot returned when the ephemeris is unavailable. */
-const DEGRADED_SKY: Omit<SkyConditionsData, "generatedAt"> = {
+const DEGRADED_SKY: Omit<SkyConditionsData, "generatedAt" | "planetaryHour"> = {
   headline: "Sky telemetry unavailable",
   live: false,
   planets: TRADITIONAL_PLANETS.map((name) => ({
@@ -117,6 +160,49 @@ const DEGRADED_SKY: Omit<SkyConditionsData, "generatedAt"> = {
   })),
   aspects: [],
 };
+
+/**
+ * Resolve the current planetary hour bar from `PlanetaryHourCalculator`,
+ * including the 24-clock-hour view consumed by the dashboard widget.
+ * Degrades independently — a failure here doesn't bring down the rest of
+ * the sky snapshot.
+ */
+function buildPlanetaryHourSnapshot(now: Date): PlanetaryHourSnapshot {
+  try {
+    const calc = new PlanetaryHourCalculator();
+    const current = calc.getCurrentPlanetaryHour();
+    const dayRuler = calc.getCurrentPlanetaryDay();
+    const dailyHours = calc.getDailyPlanetaryHours(now);
+    const liveClockHour = now.getHours();
+
+    const segments: PlanetaryHourSegment[] = Array.from(
+      { length: 24 },
+      (_, hour) => {
+        const planet: Planet = dailyHours.get(hour) ?? dayRuler;
+        return {
+          hour,
+          symbol: PLANET_GLYPH[planet] ?? "?",
+          planet,
+          isLive: hour === liveClockHour,
+          isPast: hour < liveClockHour,
+        };
+      },
+    );
+
+    return {
+      symbol: PLANET_GLYPH[current.planet] ?? "?",
+      planet: current.planet,
+      dayRuler,
+      hourNumber: current.hourNumber,
+      isDaytime: current.isDaytime,
+      segments,
+      live: true,
+    };
+  } catch (error) {
+    _logger.error("[skyConditions] planetary-hour calculation failed:", error);
+    return DEGRADED_PLANETARY_HOUR;
+  }
+}
 
 function formatPosition(p: PlanetPosition): string {
   const degree = Number.isFinite(p.degree) ? p.degree : 0;
@@ -223,10 +309,16 @@ function buildHeadline(planets: SkyPlanet[]): string {
 
 /**
  * Resolve the live sky-conditions snapshot for the admin dashboard.
- * Never rejects — a failed ephemeris degrades to `live: false`.
+ * Never rejects — ephemeris and planetary-hour sources degrade
+ * independently to `live: false` so the dashboard never hard-fails.
  */
 export async function getSkyConditions(): Promise<SkyConditionsData> {
-  const generatedAt = new Date().toISOString();
+  const now = new Date();
+  const generatedAt = now.toISOString();
+  // Planetary-hour data is local-only and cheap — compute it first so it can
+  // ship even when the ephemeris call fails.
+  const planetaryHour = buildPlanetaryHourSnapshot(now);
+
   try {
     const positions = await getCurrentPlanetaryPositionsServer();
 
@@ -253,18 +345,19 @@ export async function getSkyConditions(): Promise<SkyConditionsData> {
 
     if (planets.length === 0) {
       _logger.error("[skyConditions] ephemeris returned no traditional planets");
-      return { ...DEGRADED_SKY, generatedAt };
+      return { ...DEGRADED_SKY, planetaryHour, generatedAt };
     }
 
     return {
       headline: buildHeadline(planets),
       planets,
       aspects: computeAspects(positions),
+      planetaryHour,
       live: true,
       generatedAt,
     };
   } catch (error) {
     _logger.error("[skyConditions] ephemeris computation failed:", error);
-    return { ...DEGRADED_SKY, generatedAt };
+    return { ...DEGRADED_SKY, planetaryHour, generatedAt };
   }
 }

--- a/src/utils/cuisineRecommender.ts
+++ b/src/utils/cuisineRecommender.ts
@@ -8,20 +8,6 @@ import type { AstrologicalState } from "@/types/celestial";
 import { compatibilityToMatchPercentage } from "@/utils/enhancedCompatibilityScoring";
 // Removed unused culinary type-only imports
 
-// Mock planetary data for calculations
-const _mockPlanetaryData = {
-  flavorProfiles: {
-    sweet: 0.7,
-    _sour: 0.4,
-    _salty: 0.5,
-    _bitter: 0.2,
-    _umami: 0.6,
-    _spicy: 0.3,
-  },
-  _foodAssociations: ["vegetables", "grains", "fruits", "proteins"],
-  _herbalAssociations: { Herbs: ["basil", "thyme", "mint", "rosemary"] },
-};
-
 /**
  * Generates top sauce recommendations based on elemental and astrological alignments.
  * @param currentElementalProfile The user's current elemental profile.


### PR DESCRIPTION
## Summary

- **Task A · admin transit/ephemeris widgets** — wire `PlanetaryHourBar` to a live snapshot from `PlanetaryHourCalculator` (was a static rotation); `AstronomicalEngine` status badge now reflects the real `skyConditions.live`; greeting + footer planetary hour follow the live ruler. Each source degrades independently — planetary-hour data is computed local-only and ships even when the ephemeris call fails.
- **Task B · slow-query 200ms threshold** — explicit `metric_value >= $1` filter on the `system_metrics` read so the panel stays honest if `SLOW_QUERY_THRESHOLD_MS` is overridden on either side. Sort by duration DESC so operators see the worst offenders first; surface `slowQueryThresholdMs` to the UI label.
- **Task C · MenuPlanner extracts** — already shipped; verified `useCostEstimation` and `useGenerationPreferences` are extracted into [src/contexts/menu-planner/](src/contexts/menu-planner/) and wired into [MenuPlannerProvider.tsx](src/contexts/menu-planner/MenuPlannerProvider.tsx) (lines 309, 849). No further extraction needed in this PR.
- **Task D · Stripe webhook** — audited; the checkout-completed path intentionally does not write to `token_transactions` (model is "pay-as-you-go with cosmic tokens" — bought separately, not granted on tier upgrade). No code change.
- Cleanup: drop dead `_mockPlanetaryData` from [src/utils/cuisineRecommender.ts](src/utils/cuisineRecommender.ts).

## Test plan

- [x] \`bun run build\` — 0 errors / 0 warnings
- [x] \`bun run verify\` — typecheck + lint clean
- [ ] \`/admin/dashboard\` — confirm planetary hour bar highlights the current clock hour, AstronomicalEngine shows LIVE EPHEMERIS when the ephemeris resolves and DEGRADED when it doesn't, footer shows the current planet hour
- [ ] \`/admin/dashboard\` — confirm Database panel label reads "SLOW QUERIES · LAST 24H > 200MS" and slowest queries appear first

🤖 Generated with [Claude Code](https://claude.com/claude-code)