### PR TITLE
feat: alert dedupe + observability prune + admin dashboard wiring + 2 production bug fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ SYNTHETIC_PROBE_BASE_URL=https://alchm.kitchen                   # optional over
 
 # Alerting (system-health snapshot cron uses these — all optional, each sink degrades independently)
 ALERT_SLACK_WEBHOOK_URL=<slack-incoming-webhook-url>             # optional; alerts skip Slack when unset
+ALERT_COOLDOWN_MINUTES=60                                         # per (component, current_status) cooldown; 0 disables dedupe
 SLOW_QUERY_THRESHOLD_MS=200                                       # tunable threshold for slow_query_log
 
 # Auth (NextAuth.js v5)
@@ -162,7 +163,7 @@ All compute from existing signals — no new instrumentation required. Each serv
 
   All results land in `synthetic_probe_results` keyed by `probe_name`. `systemStatusService` reads latest-per-name via `evaluateSyntheticProbe()` and downgrades each flow to INCIDENT on fresh failure, DEGRADED on stale probe (cron broken). Requires `CRON_SECRET` + `SYNTHETIC_PROBE_TOKEN` env vars. Shared auth helper at `src/app/api/cron/_lib/cronAuth.ts`.
 - **`src/services/healthSnapshotService.ts`** — `writeSnapshot()` persists hourly captures of the full `SystemStatusPayload` to `system_health_snapshots` (JSONB). `getLatestSnapshot()` powers transition detection; `getRecentSnapshotOverall()` powers drift / week-over-week views.
-- **`src/services/alertService.ts`** — fires operator alerts on status transitions. Pure `classifyTransition()` + `diffPayloadsForAlerts()` (unit-tested). `dispatchAlert()` writes to three sinks in parallel: DB (`alert_events` table) + Slack webhook (`ALERT_SLACK_WEBHOOK_URL`) + email via Resend (to `ADMIN_EMAILS`). Each sink dispatches independently; one broken webhook never blocks the others. UNKNOWN transitions don't alert (monitoring loss, not health). Recoveries to OK alert as `info`.
+- **`src/services/alertService.ts`** — fires operator alerts on status transitions. Pure `classifyTransition()` + `diffPayloadsForAlerts()` + `shouldSuppressAlert()` (all unit-tested). `dispatchAlert()` writes to three sinks in parallel: DB (`alert_events` table) + Slack webhook (`ALERT_SLACK_WEBHOOK_URL`) + email via Resend (to `ADMIN_EMAILS`). Each sink dispatches independently; one broken webhook never blocks the others. UNKNOWN transitions don't alert (monitoring loss, not health). Recoveries to OK alert as `info`. **Cooldown** (`ALERT_COOLDOWN_MINUTES`, default 60): a repeat alert for the same `(component, current_status)` pair within the window records to DB with `dispatch.suppressed = true` but skips Slack + email. Prevents flapping from spamming operators while preserving the audit trail.
 - **`src/lib/observability/requestLog.ts`** — extended with `summarizePath()` (per-prefix health) and `summarizeAllPaths()` (per-distinct-path stats). Writes are mirrored to `request_log_entries` via fire-and-forget; on cold start the in-memory ring hydrates from the last 500 DB rows on first read.
 - **`src/lib/observability/slowQueryLog.ts`** — same persistence pattern against `slow_query_log_entries` (uses raw pool to avoid recursion). Threshold tunable via `SLOW_QUERY_THRESHOLD_MS`.
 - **`src/lib/observability/alertLog.ts`** — in-memory ring of the last 100 dispatched alerts, hydrated from `alert_events` on cold start (`hydrateAlertRingFromDb()`). Backs the recent-alerts admin panel without paying a DB round-trip per poll.
@@ -177,6 +178,7 @@ All compute from existing signals — no new instrumentation required. Each serv
 | `/api/cron/synthetic-auth-handshake` | `*/15 * * * *` | auth-handshake probe |
 | `/api/cron/synthetic-cosmic-recipe` | `0 * * * *` | cosmic-recipe gen probe (hourly — spends tokens) |
 | `/api/cron/system-health-snapshot` | `0 * * * *` | hourly status snapshot + transition-based alert dispatch |
+| `/api/cron/observability-prune` | `0 3 * * *` | daily prune of `request_log_entries` + `slow_query_log_entries` older than 7 days (override via `?retain=N`) |
 
 ### Planetary Agents (PA) integration
 

--- a/src/app/admin/_dashboard/Dashboard.tsx
+++ b/src/app/admin/_dashboard/Dashboard.tsx
@@ -133,8 +133,8 @@ export function Dashboard({ data }: DashboardProps) {
           }}
         >
           <ArchitectCard user={data.user} />
-          <ServiceMatrix />
-          <LiveEventStream />
+          <ServiceMatrix systemStatus={data.systemStatus} />
+          <LiveEventStream liveActivity={data.liveActivity} />
         </div>
 
         <AgentFeedControlRoom />
@@ -154,7 +154,7 @@ export function Dashboard({ data }: DashboardProps) {
         >
           <ElementalTraffic cohorts={data.practitionerCohorts} />
           <PractitionersCohort realFunnel={realFunnel} />
-          <IncidentsPanel />
+          <IncidentsPanel recentAlerts={data.recentAlerts} />
         </div>
 
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1.3fr", gap: 12, marginBottom: 12 }}>
@@ -194,13 +194,13 @@ export function Dashboard({ data }: DashboardProps) {
           }}
         >
           <DatabaseStorage data={data.dbObservability} />
-          <ErrorGroups />
+          <ErrorGroups errorGroups={data.errorGroups} />
           <CostBurndown />
         </div>
 
         <div style={{ display: "grid", gridTemplateColumns: "1.2fr 1fr", gap: 12, marginBottom: 12 }}>
           <ModerationQueue />
-          <SecurityPanel />
+          <SecurityPanel security={data.security} />
         </div>
 
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 12, marginBottom: 12 }}>

--- a/src/app/admin/_dashboard/data.ts
+++ b/src/app/admin/_dashboard/data.ts
@@ -14,11 +14,16 @@ import type {
   CosmicYieldData,
   DatabaseObservabilityData,
   EnginePerformanceData,
+  ErrorGroupsData,
   PractitionerCohortsData,
   CommerceSummaryData,
   PageTelemetryData,
+  RecentAlertsData,
+  SecuritySummaryData,
 } from "@/services/dashboardPanelsService";
+import type { ActivityEvent } from "@/services/liveActivityService";
 import type { SkyConditionsData } from "@/services/skyConditionsService";
+import type { SystemStatusPayload } from "@/services/systemStatusService";
 
 // ============================================================
 // DETERMINISTIC PSEUDO-RANDOM — used for sparkline / heatmap fill
@@ -131,6 +136,16 @@ export interface AdminDashboardData {
   commerce: CommerceSummaryData;
   /** Live row counts/usage mapped to routes. */
   pageTelemetry: PageTelemetryData;
+  /** Per-flow + dependency health from systemStatusService. */
+  systemStatus: SystemStatusPayload;
+  /** Recent merged activity feed (auth + recipe + token + agent events). */
+  liveActivity: { entries: ActivityEvent[]; live: boolean };
+  /** Recent alert_events rows for the IncidentsPanel. */
+  recentAlerts: RecentAlertsData;
+  /** request_log_entries aggregated 5xx/4xx by path for ErrorGroups. */
+  errorGroups: ErrorGroupsData;
+  /** auth_events rollup for SecurityPanel. */
+  security: SecuritySummaryData;
   /**
    * Generation metadata. `mockedFields` lists any panels still served
    * from seeded fixtures rather than a live source — currently empty.
@@ -243,6 +258,23 @@ export const FALLBACK_DATA: AdminDashboardData = {
     live: false,
   },
   pageTelemetry: { foodDiary: 0, customRecipes: 0, restaurants: 0, commensals: 0, mealPlans: 0, live: false },
+  systemStatus: {
+    generatedAt: new Date(0).toISOString(),
+    overall: "UNKNOWN",
+    flows: [],
+    dependencies: [],
+  },
+  liveActivity: { entries: [], live: false },
+  recentAlerts: { entries: [], live: false },
+  errorGroups: { groups: [], windowMinutes: 60, live: false },
+  security: {
+    signinSuccess24h: 0,
+    signinFailure24h: 0,
+    uniqueIps24h: 0,
+    failingIps: [],
+    hourlyAttempts: Array.from({ length: 24 }, () => 0),
+    live: false,
+  },
   meta: {
     generatedAt: new Date(0).toISOString(),
     mockedFields: [],

--- a/src/app/admin/_dashboard/extras.tsx
+++ b/src/app/admin/_dashboard/extras.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import type {
   CosmicYieldData,
   DatabaseObservabilityData,
+  ErrorGroupsData,
   PageTelemetryData,
   CatalogTrendingData,
 } from "@/services/dashboardPanelsService";
@@ -802,127 +803,41 @@ function Stat2({ k, v, d, accent }: { k: string; v: string; d: string; accent?: 
 // ============================================================
 // PRACTITIONER GEO
 // ============================================================
+// ============================================================
+// PRACTITIONER GEO
+// Empty placeholder — no geo data captured yet (we store lat/lon on
+// birth charts but don't aggregate by location). Wire this up when
+// there's enough sample to draw something honest.
+// ============================================================
 export function PractitionerGeo() {
-  const hotspots = [
-    { name: "New York", x: 26, y: 38, n: 4120, intensity: 0.9 },
-    { name: "London", x: 48, y: 32, n: 3240, intensity: 0.8 },
-    { name: "Tokyo", x: 84, y: 42, n: 2840, intensity: 0.75 },
-    { name: "Berlin", x: 51, y: 30, n: 1820, intensity: 0.65 },
-    { name: "Mumbai", x: 68, y: 50, n: 1240, intensity: 0.55 },
-    { name: "Lagos", x: 49, y: 56, n: 980, intensity: 0.5 },
-    { name: "São Paulo", x: 32, y: 70, n: 760, intensity: 0.42 },
-    { name: "Seoul", x: 82, y: 40, n: 1340, intensity: 0.6 },
-    { name: "LA", x: 14, y: 42, n: 1820, intensity: 0.62 },
-    { name: "Sydney", x: 88, y: 76, n: 540, intensity: 0.35 },
-    { name: "Cairo", x: 56, y: 46, n: 480, intensity: 0.3 },
-    { name: "Mexico City", x: 18, y: 50, n: 720, intensity: 0.4 },
-  ];
-  const dots = seeded(61, 120, 0.05, 0.95).map((v, i) => {
-    const x = seeded(63 + i, 1, 5, 95)[0];
-    const y = seeded(67 + i, 1, 15, 85)[0];
-    return { x, y, v };
-  });
   return (
     <Card
       title="Practitioner Geography"
-      subtitle="12,847 active · last 24h · 96 countries"
+      subtitle="geo aggregation not configured"
       right={
-        <button className="btn btn-ghost" style={{ padding: "4px 10px", fontSize: 9 }} type="button">
-          OPEN MAP
-        </button>
+        <span
+          className="t-mono"
+          style={{ fontSize: 9, color: "var(--fg-mute)", letterSpacing: "0.14em" }}
+        >
+          ○ NO SOURCE
+        </span>
       }
     >
       <div
         style={{
-          position: "relative",
-          height: 240,
-          border: "1px solid var(--line)",
+          padding: "60px 12px",
+          textAlign: "center",
+          border: "1px dashed var(--line)",
           borderRadius: 8,
           background:
-            "radial-gradient(ellipse 80% 60% at 50% 50%, rgba(140,100,255,0.05), transparent 70%), rgba(0,0,0,0.25)",
-          overflow: "hidden",
+            "radial-gradient(ellipse 80% 60% at 50% 50%, rgba(140,100,255,0.04), transparent 70%)",
         }}
       >
-        <svg
-          viewBox="0 0 100 60"
-          width="100%"
-          height="100%"
-          preserveAspectRatio="none"
-          style={{ display: "block" }}
-        >
-          <defs>
-            <pattern id="mapdots" width="2" height="2" patternUnits="userSpaceOnUse">
-              <circle cx="1" cy="1" r="0.25" fill="rgba(255,255,255,0.06)" />
-            </pattern>
-          </defs>
-          <rect width="100" height="60" fill="url(#mapdots)" />
-          {[15, 30, 45].map((y) => (
-            <line key={y} x1="0" x2="100" y1={y} y2={y} stroke="rgba(255,255,255,0.04)" strokeWidth="0.2" />
-          ))}
-          {[25, 50, 75].map((x) => (
-            <line key={x} x1={x} x2={x} y1="0" y2="60" stroke="rgba(255,255,255,0.04)" strokeWidth="0.2" />
-          ))}
-          {dots.map((d, i) => (
-            <circle
-              key={i}
-              cx={d.x}
-              cy={(d.y / 100) * 60}
-              r={d.v * 0.4}
-              fill="var(--accent)"
-              opacity={d.v * 0.4}
-            />
-          ))}
-          {hotspots.map((h) => (
-            <g key={h.name}>
-              <circle
-                cx={h.x}
-                cy={(h.y / 100) * 60}
-                r={2 + h.intensity * 3}
-                fill="var(--accent)"
-                opacity={h.intensity * 0.5}
-              />
-              <circle
-                cx={h.x}
-                cy={(h.y / 100) * 60}
-                r={0.8 + h.intensity * 1.2}
-                fill="var(--accent-2)"
-                style={{ filter: "drop-shadow(0 0 2px var(--accent-2))" }}
-              />
-              <text
-                x={h.x + 3}
-                y={(h.y / 100) * 60 + 1}
-                fill="var(--fg-dim)"
-                fontSize="2"
-                fontFamily="JetBrains Mono"
-              >
-                {h.name}
-              </text>
-            </g>
-          ))}
-        </svg>
-        <div style={{ position: "absolute", top: 8, left: 10, display: "flex", flexDirection: "column", gap: 2 }}>
-          <span className="t-mono" style={{ fontSize: 8.5, color: "var(--fg-mute)", letterSpacing: "0.14em" }}>
-            WORLD · DOT DENSITY
-          </span>
-          <span className="t-mono" style={{ fontSize: 9, color: "var(--accent)" }}>● 12 hot · NA/EU/EA</span>
+        <div style={{ fontSize: 12, color: "var(--fg-dim)", marginBottom: 4 }}>
+          No location aggregation yet
         </div>
-        <div style={{ position: "absolute", top: 8, right: 10, textAlign: "right" }}>
-          <span className="t-mono" style={{ fontSize: 8.5, color: "var(--fg-mute)", letterSpacing: "0.14em" }}>
-            BY REGION
-          </span>
-          <div style={{ display: "flex", flexDirection: "column", gap: 1, alignItems: "flex-end", marginTop: 2 }}>
-            {[
-              { r: "NA", n: "5,420", p: 42 },
-              { r: "EU", n: "3,240", p: 25 },
-              { r: "APAC", n: "2,840", p: 22 },
-              { r: "LATAM", n: "820", p: 6 },
-              { r: "MEA", n: "520", p: 4 },
-            ].map((r) => (
-              <span key={r.r} className="t-mono" style={{ fontSize: 9, color: "var(--fg-dim)" }}>
-                <span style={{ color: "var(--fg-mute)" }}>{r.r}</span> {r.n} · {r.p}%
-              </span>
-            ))}
-          </div>
+        <div className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>
+          birth charts store coordinates · roll up by city / region when we have a sample
         </div>
       </div>
     </Card>
@@ -932,243 +847,176 @@ export function PractitionerGeo() {
 // ============================================================
 // ERROR GROUPS
 // ============================================================
-export function ErrorGroups() {
-  const errs = [
-    {
-      id: "E-7741",
-      title: "AmazonFreshAdapterError: tax mismatch on multi-state cart",
-      count: 184,
-      trend: "▲ 4.2x",
-      last: "2m",
-      fp: "amz-fresh",
-      recent: true,
-    },
-    {
-      id: "E-7740",
-      title: "TimeoutError: /api/transit > 8s",
-      count: 64,
-      trend: "▼ -22%",
-      last: "12m",
-      fp: "transit-svc",
-      recent: false,
-    },
-    {
-      id: "E-7738",
-      title: "GalileoQueueError: model overload retry",
-      count: 41,
-      trend: "▲ +18%",
-      last: "4m",
-      fp: "galileo",
-      recent: true,
-    },
-    {
-      id: "E-7735",
-      title: "PantryPushFailed: APNS rejected device token",
-      count: 22,
-      trend: "—",
-      last: "31m",
-      fp: "pantry-push",
-      recent: false,
-    },
-    {
-      id: "E-7728",
-      title: "AuthFlowError: OAuthCallback nonce mismatch",
-      count: 14,
-      trend: "▼ -8",
-      last: "1h",
-      fp: "auth",
-      recent: false,
-    },
-  ];
+function formatRelativeShort(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return "now";
+  const m = Math.round(ms / 60000);
+  if (m < 1) return "<1m";
+  if (m < 60) return `${m}m`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.round(h / 24)}d`;
+}
+
+export function ErrorGroups({ errorGroups }: { errorGroups: ErrorGroupsData }) {
+  const groups = errorGroups.groups;
+  const fiveXxTotal = groups.reduce((sum, g) => sum + g.fiveXxCount, 0);
   return (
     <Card
       title="Error Groups"
-      subtitle="top 5 · last 24h · grouped by stack fingerprint"
+      subtitle={
+        groups.length === 0
+          ? errorGroups.live
+            ? `no 4xx/5xx in last ${errorGroups.windowMinutes}m`
+            : "request log offline"
+          : `top ${groups.length} paths · ${fiveXxTotal} 5xx · ${errorGroups.windowMinutes}m window`
+      }
       right={
-        <button className="btn btn-ghost" style={{ padding: "4px 10px", fontSize: 9 }} type="button">
-          SENTRY
-        </button>
+        <span
+          className="t-mono"
+          style={{
+            fontSize: 9,
+            color: errorGroups.live ? "var(--el-earth)" : "var(--fg-mute)",
+            letterSpacing: "0.14em",
+          }}
+        >
+          {errorGroups.live ? "● LIVE" : "○ STALE"}
+        </span>
       }
     >
-      <div style={{ display: "flex", flexDirection: "column" }}>
-        {errs.map((e, i) => (
-          <div
-            key={e.id}
-            style={{
-              display: "grid",
-              gridTemplateColumns: "auto 1fr 60px 60px 36px",
-              gap: 8,
-              alignItems: "center",
-              padding: "10px 0",
-              borderBottom: i === errs.length - 1 ? "none" : "1px solid var(--line)",
-            }}
-          >
-            <span
-              style={{
-                width: 5,
-                height: 32,
-                borderRadius: 999,
-                background: e.recent ? "var(--el-fire)" : "var(--fg-faint)",
-                boxShadow: e.recent ? "0 0 6px var(--el-fire)" : "none",
-              }}
-            />
-            <div style={{ minWidth: 0 }}>
-              <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
-                <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>{e.id}</span>
+      {groups.length === 0 ? (
+        <div style={{ padding: "16px 0", textAlign: "center" }}>
+          <span className="t-mono" style={{ fontSize: 10, color: "var(--fg-mute)" }}>
+            {errorGroups.live ? "all green" : "request_log_entries unavailable"}
+          </span>
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          {groups.map((g, i) => {
+            const recent = Date.now() - new Date(g.lastSeenAt).getTime() < 5 * 60 * 1000;
+            const hot = g.fiveXxCount > 0;
+            return (
+              <div
+                key={g.path}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "auto 1fr 56px 56px 56px",
+                  gap: 8,
+                  alignItems: "center",
+                  padding: "10px 0",
+                  borderBottom: i === groups.length - 1 ? "none" : "1px solid var(--line)",
+                }}
+              >
                 <span
                   style={{
-                    fontSize: 11.5,
-                    color: "var(--fg)",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
+                    width: 5,
+                    height: 32,
+                    borderRadius: 999,
+                    background: hot ? "#FF5252" : recent ? "var(--el-fire)" : "var(--fg-faint)",
+                    boxShadow: hot ? "0 0 6px #FF5252" : recent ? "0 0 6px var(--el-fire)" : "none",
                   }}
+                />
+                <div style={{ minWidth: 0 }}>
+                  <span
+                    className="t-mono"
+                    style={{
+                      fontSize: 11,
+                      color: "var(--fg)",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                      display: "block",
+                    }}
+                  >
+                    {g.path}
+                  </span>
+                  <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>
+                    last · {formatRelativeShort(g.lastSeenAt)}
+                  </span>
+                </div>
+                <span
+                  className="t-num"
+                  style={{
+                    textAlign: "right",
+                    color: g.fiveXxCount > 0 ? "#FF5252" : "var(--fg-mute)",
+                    fontSize: 11,
+                  }}
+                  title="5xx responses"
                 >
-                  {e.title}
+                  {g.fiveXxCount}
+                </span>
+                <span
+                  className="t-num"
+                  style={{
+                    textAlign: "right",
+                    color: g.fourXxCount > 0 ? "var(--el-fire)" : "var(--fg-mute)",
+                    fontSize: 11,
+                  }}
+                  title="4xx responses"
+                >
+                  {g.fourXxCount}
+                </span>
+                <span
+                  className="t-num"
+                  style={{ textAlign: "right", color: "var(--fg-dim)", fontSize: 11 }}
+                  title="total in window"
+                >
+                  {g.totalCount}
                 </span>
               </div>
-              <div style={{ display: "flex", gap: 8, marginTop: 2 }}>
-                <span className="t-mono" style={{ fontSize: 9, color: "var(--accent-2)" }}>fp · {e.fp}</span>
-                <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>last · {e.last}</span>
-              </div>
-            </div>
-            <span className="t-num" style={{ textAlign: "right", color: "var(--fg)" }}>{e.count.toLocaleString()}</span>
-            <span
-              className="t-mono"
-              style={{
-                textAlign: "right",
-                fontSize: 10,
-                color: e.trend.startsWith("▲") ? "var(--el-fire)" : "var(--el-earth)",
-              }}
-            >
-              {e.trend}
-            </span>
-            <button className="btn btn-ghost" style={{ padding: "3px 8px", fontSize: 8 }} type="button">
-              OPEN
-            </button>
+            );
+          })}
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "auto 1fr 56px 56px 56px",
+              gap: 8,
+              padding: "6px 0 0 13px",
+            }}
+          >
+            <span />
+            <span />
+            <span className="t-tag" style={{ fontSize: 8, textAlign: "right" }}>5XX</span>
+            <span className="t-tag" style={{ fontSize: 8, textAlign: "right" }}>4XX</span>
+            <span className="t-tag" style={{ fontSize: 8, textAlign: "right" }}>TOTAL</span>
           </div>
-        ))}
-      </div>
+        </div>
+      )}
     </Card>
   );
 }
 
 // ============================================================
 // COST BURNDOWN
+// Empty placeholder until we wire billing data (Vercel, Railway, Stripe).
 // ============================================================
 export function CostBurndown() {
-  const buckets = [
-    { k: "Compute · API + engine", v: 1840, b: 3000, color: "var(--accent)" },
-    { k: "Galileo · GPU image gen", v: 1240, b: 1500, color: "var(--accent-2)", warn: true },
-    { k: "LLM · agent reasoning", v: 982, b: 1800, color: "var(--el-water)" },
-    { k: "Postgres + Vector store", v: 612, b: 800, color: "var(--el-earth)" },
-    { k: "Astronomical ephemeris", v: 184, b: 240, color: "var(--el-air)" },
-    { k: "CDN · edge", v: 420, b: 600, color: "var(--el-fire)" },
-    { k: "Amazon Fresh adapter", v: 84, b: 200, color: "#D6CFE8" },
-  ];
-  const total = buckets.reduce((s, b) => s + b.v, 0);
-  const budget = buckets.reduce((s, b) => s + b.b, 0);
   return (
     <Card
       title="Cost Burndown · MTD"
-      subtitle={`$${total.toLocaleString()} of $${budget.toLocaleString()} budgeted · ${Math.round((total / budget) * 100)}% utilized`}
+      subtitle="billing source not configured"
       right={
-        <button className="btn btn-ghost" style={{ padding: "4px 10px", fontSize: 9 }} type="button">
-          EXPORT
-        </button>
+        <span
+          className="t-mono"
+          style={{ fontSize: 9, color: "var(--fg-mute)", letterSpacing: "0.14em" }}
+        >
+          ○ NO SOURCE
+        </span>
       }
     >
-      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        {buckets.map((b) => {
-          const pct = b.v / b.b;
-          const projected = Math.round(b.v * 2.1);
-          return (
-            <div key={b.k}>
-              <div
-                style={{
-                  display: "grid",
-                  gridTemplateColumns: "16px 1fr 60px 80px 80px",
-                  gap: 8,
-                  alignItems: "center",
-                  marginBottom: 2,
-                }}
-              >
-                <span className="el-dot" style={{ background: b.color, boxShadow: `0 0 6px ${b.color}` }} />
-                <span style={{ fontSize: 11, color: "var(--fg-dim)" }}>{b.k}</span>
-                <span className="t-num" style={{ fontSize: 11, color: "var(--fg)", textAlign: "right" }}>
-                  ${b.v.toLocaleString()}
-                </span>
-                <span
-                  className="t-mono"
-                  style={{
-                    fontSize: 9,
-                    color: b.warn ? "var(--el-fire)" : "var(--fg-mute)",
-                    textAlign: "right",
-                  }}
-                >
-                  of ${b.b.toLocaleString()}
-                </span>
-                <span
-                  className="t-mono"
-                  style={{
-                    fontSize: 9,
-                    color: projected > b.b ? "var(--el-fire)" : "var(--fg-mute)",
-                    textAlign: "right",
-                  }}
-                >
-                  proj ${projected.toLocaleString()}
-                </span>
-              </div>
-              <div
-                style={{
-                  position: "relative",
-                  height: 6,
-                  background: "rgba(255,255,255,0.03)",
-                  borderRadius: 999,
-                  overflow: "hidden",
-                }}
-              >
-                <div
-                  style={{
-                    width: `${Math.min(pct, 1) * 100}%`,
-                    height: "100%",
-                    background: b.color,
-                    boxShadow: `0 0 8px ${b.color}`,
-                    opacity: 0.85,
-                  }}
-                />
-                {pct > 0.9 && (
-                  <div
-                    style={{
-                      position: "absolute",
-                      right: 0,
-                      top: -1,
-                      bottom: -1,
-                      width: 2,
-                      background: "var(--el-fire)",
-                      boxShadow: "0 0 6px var(--el-fire)",
-                    }}
-                  />
-                )}
-              </div>
-            </div>
-          );
-        })}
-      </div>
       <div
         style={{
-          marginTop: 10,
-          padding: "8px 10px",
-          border: "1px dashed var(--el-fire)",
+          padding: "32px 12px",
+          textAlign: "center",
+          border: "1px dashed var(--line)",
           borderRadius: 8,
-          background: "color-mix(in oklch, var(--el-fire), transparent 94%)",
         }}
       >
-        <div className="t-tag" style={{ color: "var(--el-fire)", fontSize: 8.5 }}>OVERAGE FORECAST</div>
-        <div style={{ fontSize: 11, color: "var(--fg-dim)", marginTop: 2 }}>
-          Galileo on track for <span style={{ color: "var(--el-fire)" }}>$2,604</span> ·{" "}
-          <span style={{ color: "var(--el-fire)" }}>+74%</span> over budget. Throttle option: cap free-tier image renders
-          at 3/recipe.
+        <div style={{ fontSize: 11, color: "var(--fg-dim)", marginBottom: 4 }}>
+          No billing aggregation wired
+        </div>
+        <div className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>
+          connect Vercel + Railway billing APIs to populate
         </div>
       </div>
     </Card>

--- a/src/app/admin/_dashboard/panels.tsx
+++ b/src/app/admin/_dashboard/panels.tsx
@@ -4,122 +4,142 @@ import React from "react";
 import type {
   AuditEventsData,
   CatalogTrendingData,
+  RecentAlertsData,
+  SecuritySummaryData,
 } from "@/services/dashboardPanelsService";
+import type { ActivityEvent } from "@/services/liveActivityService";
+import type { SystemStatusPayload } from "@/services/systemStatusService";
 import { CompatibilityRing, ElementalMeter, Glyph, Sparkline } from "./atoms";
 import { seeded } from "./data";
 import { Card, Legend, MiniStat } from "./hero";
 
 // ============================================================
-// SERVICE MATRIX
+// SERVICE MATRIX — wired to systemStatusService (8 flows + 3 deps)
 // ============================================================
-export function ServiceMatrix() {
-  const services = [
-    { name: "alchm-api", tier: "T1", health: "OK", p50: 28, p95: 184, qps: 1284, err: 0.04, instances: "8/8", color: "var(--el-earth)" },
-    { name: "alchm-engine-v17", tier: "T1", health: "OK", p50: 62, p95: 240, qps: 412, err: 0.02, instances: "6/6", color: "var(--accent-2)" },
-    { name: "alchm-auth", tier: "T1", health: "OK", p50: 18, p95: 96, qps: 187, err: 0.0, instances: "3/3", color: "var(--el-air)" },
-    { name: "pg-primary · 16.2", tier: "T1", health: "OK", p50: 4, p95: 18, qps: 3120, err: 0.0, instances: "1/1 · 2 replicas", color: "var(--el-earth)" },
-    { name: "redis-hot", tier: "T1", health: "OK", p50: 1, p95: 3, qps: 8120, err: 0.0, instances: "3/3", color: "var(--el-water)" },
-    { name: "queue · planner", tier: "T2", health: "WARN", p50: 220, p95: 1840, qps: 14, err: 0.18, instances: "2/2", color: "var(--el-fire)", note: "backlog · 318 jobs" },
-    { name: "search · meilisearch", tier: "T2", health: "OK", p50: 8, p95: 42, qps: 540, err: 0.01, instances: "2/2", color: "var(--el-water)" },
-    { name: "cdn · cf workers", tier: "T2", health: "OK", p50: 12, p95: 60, qps: 5240, err: 0.0, instances: "global · 312 PoPs", color: "var(--el-air)" },
-    { name: "ml · recsys-batch", tier: "T2", health: "OK", p50: 0, p95: 0, qps: 0, err: 0.0, instances: "nightly · 03:00 UTC", color: "var(--accent-2)" },
-    { name: "agents · mesh edge", tier: "T2", health: "WARN", p50: 84, p95: 320, qps: 218, err: 0.06, instances: "412/440", color: "var(--accent)", note: "28 nodes idle > 5m" },
-    { name: "stripe · billing", tier: "T3", health: "OK", p50: 142, p95: 510, qps: 9.4, err: 0.0, instances: "external · webhook q=0", color: "var(--el-earth)" },
-    { name: "amazon · fresh", tier: "T3", health: "OK", p50: 220, p95: 980, qps: 6.2, err: 0.01, instances: "external", color: "var(--el-air)" },
+const STATUS_COLOR: Record<string, string> = {
+  OK: "var(--el-earth)",
+  DEGRADED: "var(--el-fire)",
+  INCIDENT: "#FF5252",
+  UNKNOWN: "var(--fg-mute)",
+};
+
+export function ServiceMatrix({ systemStatus }: { systemStatus: SystemStatusPayload }) {
+  const items: Array<{
+    id: string;
+    name: string;
+    tier: "Flow" | "Dep";
+    status: string;
+    summary: string;
+    metrics?: Array<{ label: string; value: string }>;
+  }> = [
+    ...systemStatus.flows.map((f) => ({
+      id: f.id,
+      name: f.label,
+      tier: "Flow" as const,
+      status: f.status,
+      summary: f.summary,
+      metrics: f.metrics?.slice(0, 2),
+    })),
+    ...systemStatus.dependencies.map((d) => ({
+      id: d.id,
+      name: d.label,
+      tier: "Dep" as const,
+      status: d.status,
+      summary: d.summary,
+      metrics: typeof d.latencyMs === "number"
+        ? [{ label: "ping", value: `${Math.round(d.latencyMs)}ms` }]
+        : undefined,
+    })),
   ];
+  const warnCount = items.filter((i) => i.status === "DEGRADED").length;
+  const incidentCount = items.filter((i) => i.status === "INCIDENT").length;
+
   return (
     <Card
       title="Service Matrix"
-      subtitle="12 services · 2 warnings"
+      subtitle={`${items.length} components · ${incidentCount} incident${incidentCount === 1 ? "" : "s"} · ${warnCount} degraded`}
       right={
         <div style={{ display: "flex", gap: 8 }}>
           <Legend color="var(--el-earth)" label="OK" />
-          <Legend color="var(--el-fire)" label="WARN" />
-          <Legend color="#FF5252" label="DOWN" />
+          <Legend color="var(--el-fire)" label="DEGRADED" />
+          <Legend color="#FF5252" label="INCIDENT" />
         </div>
       }
     >
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "1.6fr 0.4fr 0.5fr 0.6fr 0.6fr 0.6fr 0.6fr 1fr",
-          rowGap: 0,
-          fontSize: 11.5,
-        }}
-      >
-        <SvcHeader label="Service" />
-        <SvcHeader label="Tier" />
-        <SvcHeader label="State" />
-        <SvcHeader label="P50" right />
-        <SvcHeader label="P95" right />
-        <SvcHeader label="QPS" right />
-        <SvcHeader label="Err%" right />
-        <SvcHeader label="Instances" />
-        {services.map((s) => (
-          <React.Fragment key={s.name}>
-            <SvcCell>
-              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                <span className="el-dot" style={{ background: s.color, boxShadow: `0 0 8px ${s.color}` }} />
-                <span style={{ color: "var(--fg)" }}>{s.name}</span>
-              </div>
-              {s.note && (
-                <div
-                  className="t-mono"
-                  style={{ fontSize: 9, color: "var(--el-fire)", marginTop: 2, letterSpacing: "0.1em" }}
-                >
-                  {s.note}
-                </div>
-              )}
-            </SvcCell>
-            <SvcCell>
-              <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>{s.tier}</span>
-            </SvcCell>
-            <SvcCell>
-              <span
-                className="t-mono"
-                style={{
-                  fontSize: 9,
-                  padding: "2px 7px",
-                  borderRadius: 999,
-                  background:
-                    s.health === "OK"
-                      ? "color-mix(in oklch, var(--el-earth), transparent 80%)"
-                      : "color-mix(in oklch, var(--el-fire), transparent 75%)",
-                  color: s.health === "OK" ? "var(--el-earth)" : "var(--el-fire)",
-                  border: `1px solid ${
-                    s.health === "OK"
-                      ? "color-mix(in oklch, var(--el-earth), transparent 60%)"
-                      : "color-mix(in oklch, var(--el-fire), transparent 50%)"
-                  }`,
-                }}
-              >
-                {s.health}
-              </span>
-            </SvcCell>
-            <SvcCell right>
-              <span className="t-num" style={{ color: "var(--fg-dim)" }}>
-                {s.p50}<span style={{ color: "var(--fg-faint)" }}>ms</span>
-              </span>
-            </SvcCell>
-            <SvcCell right>
-              <span className="t-num" style={{ color: s.p95 > 500 ? "var(--el-fire)" : "var(--fg)" }}>
-                {s.p95}<span style={{ color: "var(--fg-faint)" }}>ms</span>
-              </span>
-            </SvcCell>
-            <SvcCell right>
-              <span className="t-num" style={{ color: "var(--fg-dim)" }}>{s.qps.toLocaleString()}</span>
-            </SvcCell>
-            <SvcCell right>
-              <span className="t-num" style={{ color: s.err > 0.1 ? "var(--el-fire)" : "var(--fg-dim)" }}>
-                {s.err.toFixed(2)}
-              </span>
-            </SvcCell>
-            <SvcCell>
-              <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>{s.instances}</span>
-            </SvcCell>
-          </React.Fragment>
-        ))}
-      </div>
+      {items.length === 0 ? (
+        <div style={{ padding: 16, textAlign: "center" }}>
+          <span className="t-mono" style={{ fontSize: 10, color: "var(--fg-mute)" }}>
+            system status unavailable
+          </span>
+        </div>
+      ) : (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1.6fr 0.5fr 0.7fr 2fr 1fr",
+            rowGap: 0,
+            fontSize: 11.5,
+          }}
+        >
+          <SvcHeader label="Component" />
+          <SvcHeader label="Kind" />
+          <SvcHeader label="State" />
+          <SvcHeader label="Summary" />
+          <SvcHeader label="Metrics" />
+          {items.map((it) => {
+            const color = STATUS_COLOR[it.status] ?? "var(--fg-mute)";
+            return (
+              <React.Fragment key={it.id}>
+                <SvcCell>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                    <span className="el-dot" style={{ background: color, boxShadow: `0 0 8px ${color}` }} />
+                    <span style={{ color: "var(--fg)" }}>{it.name}</span>
+                  </div>
+                </SvcCell>
+                <SvcCell>
+                  <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>{it.tier}</span>
+                </SvcCell>
+                <SvcCell>
+                  <span
+                    className="t-mono"
+                    style={{
+                      fontSize: 9,
+                      padding: "2px 7px",
+                      borderRadius: 999,
+                      background: `color-mix(in oklch, ${color}, transparent 78%)`,
+                      color,
+                      border: `1px solid color-mix(in oklch, ${color}, transparent 55%)`,
+                    }}
+                  >
+                    {it.status}
+                  </span>
+                </SvcCell>
+                <SvcCell>
+                  <span style={{ color: "var(--fg-dim)", fontSize: 10.5 }}>{it.summary}</span>
+                </SvcCell>
+                <SvcCell>
+                  {it.metrics && it.metrics.length > 0 ? (
+                    <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                      {it.metrics.map((m) => (
+                        <span
+                          key={m.label}
+                          className="t-mono"
+                          style={{ fontSize: 9.5, color: "var(--fg-mute)" }}
+                        >
+                          {m.label}:&nbsp;
+                          <span style={{ color: "var(--fg-dim)" }}>{m.value}</span>
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-faint)" }}>—</span>
+                  )}
+                </SvcCell>
+              </React.Fragment>
+            );
+          })}
+        </div>
+      )}
     </Card>
   );
 }
@@ -157,246 +177,266 @@ function SvcCell({ children, right }: { children: React.ReactNode; right?: boole
 }
 
 // ============================================================
-// LIVE EVENT STREAM
+// LIVE EVENT STREAM — wired to liveActivityService
 // ============================================================
-export function LiveEventStream() {
-  const events = [
-    { t: "21:46:08", k: "auth.signin", sev: "info", who: "@lila.fontana", msg: "Google · session est · IAD" },
-    { t: "21:46:04", k: "engine.predict", sev: "info", who: "engine-v17", msg: "score=0.918 · acc-cluster=warm" },
-    { t: "21:46:01", k: "cart.add", sev: "info", who: "@marcus.kw", msg: "+ heirloom tomato · $4.20 · Amz" },
-    { t: "21:45:58", k: "queue.spike", sev: "warn", who: "planner", msg: "backlog 318 > 200 threshold" },
-    { t: "21:45:54", k: "mesh.node.idle", sev: "warn", who: "mesh-edge", msg: "sous-chef-209 idle 6m · drain" },
-    { t: "21:45:50", k: "admin.signoff", sev: "ok", who: "@gregcastro23", msg: "approved · recipe #c8f1ad" },
-    { t: "21:45:47", k: "moderation.flag", sev: "warn", who: "auto", msg: "recipe #84a210 · profanity score 0.62" },
-    { t: "21:45:42", k: "billing.charge", sev: "info", who: "stripe", msg: "+$24.00 · pro · 0xc2…" },
-    { t: "21:45:39", k: "engine.canary", sev: "ok", who: "engine-v17", msg: "canary @ 12% · delta +0.014 acc" },
-    { t: "21:45:35", k: "auth.signup", sev: "ok", who: "@noor.eldin", msg: "onboarding · step Palate" },
-    { t: "21:45:31", k: "agent.dispatch", sev: "info", who: "agents.alchm.kit", msg: "sous-chef · dinner-party-441" },
-    { t: "21:45:28", k: "incident.update", sev: "err", who: "INC-2207", msg: "cart 5xx · 4 occurrences · mitigating" },
-    { t: "21:45:24", k: "search.reindex", sev: "info", who: "meili", msg: "ingredients +12 · re-rank" },
-    { t: "21:45:21", k: "deploy.preview", sev: "info", who: "@gregcastro23", msg: "branch fix/cart-checkout @ pr-1184" },
-    { t: "21:45:18", k: "auth.signin", sev: "info", who: "@kazu.tanaka", msg: "Google · NRT · returning" },
-    { t: "21:45:14", k: "engine.feedback", sev: "info", who: "@isobel.r", msg: "★ 5 · pad krapow · acc++" },
-    { t: "21:45:11", k: "feature.flag", sev: "ok", who: "@gregcastro23", msg: "cosmic-recipe-v2 → 100%" },
-    { t: "21:45:07", k: "auth.fail", sev: "warn", who: "203.0.113.7", msg: "OAuthCallback ×3 · throttled" },
-  ];
-  const sevColor: Record<string, string> = {
-    info: "var(--fg-dim)",
-    ok: "var(--el-earth)",
-    warn: "var(--el-fire)",
-    err: "#FF5252",
-  };
+const CATEGORY_COLOR: Record<string, string> = {
+  signup: "var(--el-earth)",
+  auth: "var(--accent-2)",
+  onboarding: "var(--el-water)",
+  recipe: "var(--accent)",
+  economy: "var(--el-fire)",
+  agent: "var(--el-air)",
+  diary: "var(--fg-dim)",
+};
+
+const STATUS_TINT: Record<string, string> = {
+  success: "var(--el-earth)",
+  failure: "#FF5252",
+  info: "var(--fg-dim)",
+};
+
+export function LiveEventStream({
+  liveActivity,
+}: {
+  liveActivity: { entries: ActivityEvent[]; live: boolean };
+}) {
+  const events = liveActivity.entries;
   return (
     <Card
       title="Live Event Stream"
-      subtitle={false}
+      subtitle={`${events.length} events · 6h window${liveActivity.live ? "" : " · degraded"}`}
       right={
-        <div style={{ display: "flex", gap: 6 }}>
-          <span className="chip chip-active" style={{ padding: "2px 8px", fontSize: 8 }}>ALL</span>
-          <span className="chip" style={{ padding: "2px 8px", fontSize: 8 }}>WARN+</span>
-          <span className="chip" style={{ padding: "2px 8px", fontSize: 8 }}>ADMIN</span>
-        </div>
+        <span
+          className="t-mono"
+          style={{
+            fontSize: 9,
+            color: liveActivity.live ? "var(--el-earth)" : "var(--fg-mute)",
+            letterSpacing: "0.14em",
+          }}
+        >
+          {liveActivity.live ? "● LIVE" : "○ STALE"}
+        </span>
       }
       padded={false}
       style={{ height: 480 }}
     >
       <div style={{ height: "100%", overflow: "auto", padding: "4px 0" }}>
-        {events.map((e, i) => (
-          <div
-            key={i}
-            style={{
-              display: "grid",
-              gridTemplateColumns: "62px 8px 88px 1fr",
-              gap: 8,
-              alignItems: "baseline",
-              padding: "6px 14px",
-              fontFamily: "var(--f-mono)",
-              fontSize: 10.5,
-              borderBottom:
-                i === events.length - 1
-                  ? "none"
-                  : "1px solid color-mix(in oklch, var(--line), transparent 30%)",
-              color: "var(--fg-dim)",
-            }}
-          >
-            <span style={{ color: "var(--fg-mute)", fontSize: 9.5 }}>{e.t}</span>
-            <span
-              style={{
-                width: 4,
-                height: 4,
-                borderRadius: 999,
-                background: sevColor[e.sev],
-                boxShadow: `0 0 6px ${sevColor[e.sev]}`,
-              }}
-            />
-            <span style={{ color: sevColor[e.sev], fontSize: 9.5, letterSpacing: "0.08em" }}>{e.k}</span>
-            <span style={{ display: "flex", gap: 8, minWidth: 0 }}>
-              <span style={{ color: "var(--fg)", whiteSpace: "nowrap" }}>{e.who}</span>
-              <span style={{ color: "var(--fg-mute)" }}>·</span>
-              <span
-                style={{
-                  color: "var(--fg-dim)",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                }}
-              >
-                {e.msg}
-              </span>
+        {events.length === 0 ? (
+          <div style={{ padding: 16, textAlign: "center" }}>
+            <span className="t-mono" style={{ fontSize: 10, color: "var(--fg-mute)" }}>
+              no activity in the last 6h
             </span>
           </div>
-        ))}
+        ) : (
+          events.map((e, i) => {
+            const dot = STATUS_TINT[e.status] ?? CATEGORY_COLOR[e.category] ?? "var(--fg-mute)";
+            const cat = CATEGORY_COLOR[e.category] ?? "var(--accent)";
+            const time = new Date(e.at).toISOString().slice(11, 19);
+            return (
+              <div
+                key={`${e.category}-${e.id}-${i}`}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "62px 8px 88px 1fr",
+                  gap: 8,
+                  alignItems: "baseline",
+                  padding: "6px 14px",
+                  fontFamily: "var(--f-mono)",
+                  fontSize: 10.5,
+                  borderBottom:
+                    i === events.length - 1
+                      ? "none"
+                      : "1px solid color-mix(in oklch, var(--line), transparent 30%)",
+                  color: "var(--fg-dim)",
+                }}
+              >
+                <span style={{ color: "var(--fg-mute)", fontSize: 9.5 }}>{time}</span>
+                <span
+                  style={{
+                    width: 4,
+                    height: 4,
+                    borderRadius: 999,
+                    background: dot,
+                    boxShadow: `0 0 6px ${dot}`,
+                  }}
+                />
+                <span style={{ color: cat, fontSize: 9.5, letterSpacing: "0.08em" }}>
+                  {e.category}.{e.type}
+                </span>
+                <span style={{ display: "flex", gap: 8, minWidth: 0 }}>
+                  <span style={{ color: "var(--fg)", whiteSpace: "nowrap" }}>
+                    {e.actor?.name || e.actor?.email || "system"}
+                  </span>
+                  <span style={{ color: "var(--fg-mute)" }}>·</span>
+                  <span
+                    style={{
+                      color: "var(--fg-dim)",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {e.description}
+                  </span>
+                </span>
+              </div>
+            );
+          })
+        )}
       </div>
     </Card>
   );
 }
 
 // ============================================================
-// INCIDENTS
+// INCIDENTS — wired to alert_events (from alertService dispatch)
 // ============================================================
-export function IncidentsPanel() {
-  interface Incident {
-    id: string;
-    sev: "MAJOR" | "MINOR";
-    title: string;
-    svc: string;
-    started: string;
-    assignee: string;
-    step: string;
-    progress: number;
-    timeline?: Array<{ t: string; e: string }>;
-  }
-  const items: Incident[] = [
-    {
-      id: "INC-2207",
-      sev: "MAJOR",
-      title: "Cart checkout 5xx · Amazon Fresh adapter",
-      svc: "amazon-fresh · stripe-bridge",
-      started: "21:31 UTC · 14m",
-      assignee: "@gregcastro23",
-      step: "Mitigating",
-      progress: 0.6,
-      timeline: [
-        { t: "21:31", e: "Pageduty paged · 4 alerts · 5xx rate 2.4%" },
-        { t: "21:33", e: "Greg ack · started rollback of #c8f1ad" },
-        { t: "21:38", e: "Adapter restored to v2.7.3 · errors -82%" },
-        { t: "21:45", e: "Monitoring · awaiting 5m clear window" },
-      ],
-    },
-    {
-      id: "INC-2204",
-      sev: "MINOR",
-      title: "Planner queue backlog · planetary refresh job",
-      svc: "queue.planner",
-      started: "21:18 UTC · 27m",
-      assignee: "auto",
-      step: "Auto-scaling",
-      progress: 0.3,
-    },
-  ];
+const SEVERITY_COLOR: Record<string, string> = {
+  error: "#FF5252",
+  warn: "var(--el-fire)",
+  info: "var(--el-water)",
+};
+
+function formatRelative(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return "just now";
+  const m = Math.round(ms / 60000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.round(h / 24);
+  return `${d}d ago`;
+}
+
+export function IncidentsPanel({
+  recentAlerts,
+}: {
+  recentAlerts: RecentAlertsData;
+}) {
+  const alerts = recentAlerts.entries;
+  const errorCount = alerts.filter((a) => a.severity === "error").length;
+  const warnCount = alerts.filter((a) => a.severity === "warn").length;
+  const subtitle =
+    alerts.length === 0
+      ? recentAlerts.live
+        ? "no alerts in window"
+        : "alert source offline"
+      : `${errorCount} error · ${warnCount} warn`;
+
   return (
     <Card
-      title="Active Incidents"
-      subtitle="1 major · 1 minor"
+      title="Recent Alerts"
+      subtitle={subtitle}
       right={
-        <button className="btn btn-ghost" style={{ padding: "4px 10px", fontSize: 9 }} type="button">
-          RUNBOOK
-        </button>
+        <span
+          className="t-mono"
+          style={{
+            fontSize: 9,
+            color: recentAlerts.live ? "var(--el-earth)" : "var(--fg-mute)",
+            letterSpacing: "0.14em",
+          }}
+        >
+          {recentAlerts.live ? "● LIVE" : "○ STALE"}
+        </span>
       }
     >
-      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-        {items.map((inc) => {
-          const sevColor = inc.sev === "MAJOR" ? "#FF5252" : "var(--el-fire)";
-          return (
-            <div
-              key={inc.id}
-              style={{
-                border: `1px solid color-mix(in oklch, ${sevColor}, transparent 60%)`,
-                background: `linear-gradient(180deg, color-mix(in oklch, ${sevColor}, transparent 92%), transparent)`,
-                borderRadius: 10,
-                padding: 12,
-                position: "relative",
-              }}
-            >
-              <div style={{ display: "flex", alignItems: "baseline", gap: 10, marginBottom: 6 }}>
-                <span
-                  className="t-mono"
-                  style={{
-                    fontSize: 9,
-                    padding: "2px 8px",
-                    borderRadius: 999,
-                    color: sevColor,
-                    border: `1px solid ${sevColor}`,
-                    background: "rgba(0,0,0,0.3)",
-                    letterSpacing: "0.16em",
-                  }}
-                >
-                  {inc.sev}
-                </span>
-                <span className="t-mono" style={{ fontSize: 10, color: "var(--fg-mute)" }}>{inc.id}</span>
-                <span style={{ marginLeft: "auto", fontFamily: "var(--f-mono)", fontSize: 9.5, color: "var(--fg-mute)" }}>
-                  {inc.started}
-                </span>
-              </div>
-              <div style={{ fontSize: 13, color: "var(--fg)", marginBottom: 4 }}>{inc.title}</div>
-              <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 8 }}>
-                <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)", letterSpacing: "0.1em" }}>
-                  {inc.svc}
-                </span>
-                <span className="t-mono" style={{ fontSize: 9.5, color: "var(--accent-2)" }}>{inc.assignee}</span>
-              </div>
+      {alerts.length === 0 ? (
+        <div style={{ padding: "16px 0", textAlign: "center" }}>
+          <span className="t-mono" style={{ fontSize: 10, color: "var(--fg-mute)" }}>
+            {recentAlerts.live ? "system is quiet" : "could not reach alert_events"}
+          </span>
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          {alerts.map((alert) => {
+            const sevColor = SEVERITY_COLOR[alert.severity] ?? "var(--fg-mute)";
+            return (
               <div
+                key={alert.id}
                 style={{
-                  position: "relative",
-                  height: 4,
-                  background: "rgba(255,255,255,0.04)",
-                  borderRadius: 999,
-                  overflow: "hidden",
+                  border: `1px solid color-mix(in oklch, ${sevColor}, transparent 60%)`,
+                  background: `linear-gradient(180deg, color-mix(in oklch, ${sevColor}, transparent 92%), transparent)`,
+                  borderRadius: 10,
+                  padding: 10,
+                  opacity: alert.suppressed ? 0.55 : 1,
                 }}
               >
-                <div
-                  style={{
-                    position: "absolute",
-                    left: 0,
-                    top: 0,
-                    bottom: 0,
-                    width: `${inc.progress * 100}%`,
-                    background: `linear-gradient(90deg, ${sevColor}, color-mix(in oklch, ${sevColor}, transparent 50%))`,
-                    boxShadow: `0 0 12px ${sevColor}`,
-                  }}
-                />
-              </div>
-              <div style={{ display: "flex", justifyContent: "space-between", marginTop: 6 }}>
-                <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-dim)", letterSpacing: "0.14em" }}>
-                  {inc.step.toUpperCase()}
-                </span>
-                <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>
-                  {Math.round(inc.progress * 100)}%
-                </span>
-              </div>
-              {inc.timeline && (
-                <div style={{ marginTop: 10, paddingTop: 10, borderTop: "1px dashed var(--line)" }}>
-                  {inc.timeline.map((t, i) => (
-                    <div
-                      key={i}
+                <div style={{ display: "flex", alignItems: "baseline", gap: 10, marginBottom: 4 }}>
+                  <span
+                    className="t-mono"
+                    style={{
+                      fontSize: 9,
+                      padding: "2px 8px",
+                      borderRadius: 999,
+                      color: sevColor,
+                      border: `1px solid ${sevColor}`,
+                      background: "rgba(0,0,0,0.3)",
+                      letterSpacing: "0.16em",
+                    }}
+                  >
+                    {alert.severity.toUpperCase()}
+                  </span>
+                  <span className="t-mono" style={{ fontSize: 10, color: "var(--fg-mute)" }}>
+                    #{alert.id}
+                  </span>
+                  {alert.suppressed && (
+                    <span
+                      className="t-mono"
                       style={{
-                        display: "grid",
-                        gridTemplateColumns: "44px 1fr",
-                        gap: 8,
-                        fontSize: 10.5,
-                        padding: "2px 0",
+                        fontSize: 9,
+                        color: "var(--fg-mute)",
+                        letterSpacing: "0.14em",
                       }}
                     >
-                      <span className="t-mono" style={{ color: "var(--fg-mute)", fontSize: 9.5 }}>{t.t}</span>
-                      <span style={{ color: "var(--fg-dim)" }}>{t.e}</span>
-                    </div>
-                  ))}
+                      SUPPRESSED
+                    </span>
+                  )}
+                  <span
+                    style={{
+                      marginLeft: "auto",
+                      fontFamily: "var(--f-mono)",
+                      fontSize: 9.5,
+                      color: "var(--fg-mute)",
+                    }}
+                  >
+                    {formatRelative(alert.triggeredAt)}
+                  </span>
                 </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
+                <div style={{ fontSize: 12.5, color: "var(--fg)", marginBottom: 4 }}>{alert.title}</div>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+                  <span
+                    className="t-mono"
+                    style={{
+                      fontSize: 9.5,
+                      color: "var(--fg-mute)",
+                      letterSpacing: "0.08em",
+                    }}
+                  >
+                    {alert.previousStatus} → {alert.currentStatus} · {alert.component}
+                  </span>
+                </div>
+                {alert.message && alert.message !== alert.title && (
+                  <div
+                    style={{
+                      marginTop: 6,
+                      fontSize: 10.5,
+                      color: "var(--fg-dim)",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      display: "-webkit-box",
+                      WebkitLineClamp: 2,
+                      WebkitBoxOrient: "vertical",
+                    }}
+                  >
+                    {alert.message}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
     </Card>
   );
 }
@@ -1054,165 +1094,71 @@ export function CommensalPulse({ pageTelemetry }: { pageTelemetry?: any }) {
 
 // ============================================================
 // DEPLOYS · FEATURE FLAGS · AUDIT
+// Deploys + Feature flags have no live source yet — render an honest
+// empty state with a hint about how to wire them up. We avoid fake
+// SHAs and fake flags that look real but aren't.
 // ============================================================
 export function DeploysPanel() {
-  const deploys = [
-    { sha: "c8f1ad", branch: "main", who: "@gregcastro23", t: "23m", s: "live", note: "engine v17.4 cutover" },
-    { sha: "84a210", branch: "main", who: "@gregcastro23", t: "2h", s: "live", note: "fix · planner queue" },
-    { sha: "192bb7", branch: "fix/cart-checkout", who: "@gregcastro23", t: "5h", s: "preview", note: "pr-1184 · cart adapter" },
-    { sha: "7c3091", branch: "main", who: "@deploybot", t: "9h", s: "live", note: "deps · pg client" },
-    { sha: "412de8", branch: "main", who: "@gregcastro23", t: "1d", s: "rolled", note: "rollback · billing webhook" },
-    { sha: "ee920f", branch: "main", who: "@gregcastro23", t: "1d", s: "live", note: "nav IA · 5 primary" },
-  ];
-  const stateColor: Record<string, string> = {
-    live: "var(--el-earth)",
-    preview: "var(--accent)",
-    rolled: "var(--el-fire)",
-  };
   return (
-    <Card title="Deploys · last 7 days" subtitle="6 prod · 1 preview · 1 rollback">
-      <div style={{ display: "flex", flexDirection: "column" }}>
-        {deploys.map((d, i) => (
-          <div
-            key={d.sha}
-            style={{
-              display: "grid",
-              gridTemplateColumns: "8px 70px 1fr 70px 50px",
-              gap: 10,
-              alignItems: "center",
-              padding: "8px 0",
-              borderBottom: i === deploys.length - 1 ? "none" : "1px solid var(--line)",
-              fontSize: 11,
-            }}
-          >
-            <span className="el-dot" style={{ background: stateColor[d.s], boxShadow: `0 0 6px ${stateColor[d.s]}` }} />
-            <span className="t-mono" style={{ color: "var(--fg)", fontSize: 10.5 }}>#{d.sha}</span>
-            <span
-              style={{
-                color: "var(--fg-dim)",
-                minWidth: 0,
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
-            >
-              {d.note}
-            </span>
-            <span className="t-mono" style={{ fontSize: 9.5, color: "var(--accent-2)" }}>{d.who}</span>
-            <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)", textAlign: "right" }}>{d.t}</span>
-          </div>
-        ))}
+    <Card
+      title="Deploys"
+      subtitle="Vercel deployments API not wired"
+      right={
+        <span
+          className="t-mono"
+          style={{ fontSize: 9, color: "var(--fg-mute)", letterSpacing: "0.14em" }}
+        >
+          ○ NO SOURCE
+        </span>
+      }
+    >
+      <div
+        style={{
+          padding: "32px 12px",
+          textAlign: "center",
+          border: "1px dashed var(--line)",
+          borderRadius: 8,
+        }}
+      >
+        <div style={{ fontSize: 11, color: "var(--fg-dim)", marginBottom: 4 }}>
+          No deploy history wired
+        </div>
+        <div className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>
+          attach Vercel API token + query <code>/v6/deployments</code>
+        </div>
       </div>
     </Card>
   );
 }
 
 export function FeatureFlagsPanel() {
-  const flags = [
-    { key: "cosmic-recipe-v2", pct: 100, env: "prod", state: "on", owner: "@greg" },
-    { key: "engine-canary", pct: 12, env: "prod", state: "canary", owner: "@greg" },
-    { key: "agent-sync-badge", pct: 100, env: "prod", state: "on", owner: "@greg" },
-    { key: "commensal-12-guests", pct: 25, env: "prod", state: "ramp", owner: "@greg" },
-    { key: "amz-fresh-tax-fix", pct: 0, env: "prod", state: "off", owner: "@greg" },
-    { key: "barcode-scan-quick", pct: 50, env: "stg", state: "ramp", owner: "@greg" },
-  ];
-  const stateColor: Record<string, string> = {
-    on: "var(--el-earth)",
-    canary: "var(--accent)",
-    ramp: "var(--accent-2)",
-    off: "var(--fg-mute)",
-  };
   return (
     <Card
       title="Feature Flags"
-      subtitle="6 active · 1 ramping"
+      subtitle="no flag service configured"
       right={
-        <button className="btn btn-ghost" style={{ padding: "4px 10px", fontSize: 9 }} type="button">
-          NEW
-        </button>
+        <span
+          className="t-mono"
+          style={{ fontSize: 9, color: "var(--fg-mute)", letterSpacing: "0.14em" }}
+        >
+          ○ NO SOURCE
+        </span>
       }
     >
-      <div style={{ display: "flex", flexDirection: "column" }}>
-        {flags.map((f, i) => (
-          <div
-            key={f.key}
-            style={{
-              display: "grid",
-              gridTemplateColumns: "1fr 56px 50px 40px",
-              alignItems: "center",
-              gap: 8,
-              padding: "8px 0",
-              borderBottom: i === flags.length - 1 ? "none" : "1px solid var(--line)",
-              fontSize: 11,
-            }}
-          >
-            <div>
-              <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                <span
-                  className="el-dot"
-                  style={{ background: stateColor[f.state], boxShadow: `0 0 6px ${stateColor[f.state]}` }}
-                />
-                <span className="t-mono" style={{ color: "var(--fg)", fontSize: 11 }}>{f.key}</span>
-              </div>
-              <div
-                style={{
-                  position: "relative",
-                  height: 3,
-                  background: "rgba(255,255,255,0.04)",
-                  borderRadius: 999,
-                  marginTop: 4,
-                  overflow: "hidden",
-                }}
-              >
-                <div
-                  style={{
-                    width: `${f.pct}%`,
-                    height: "100%",
-                    background: stateColor[f.state],
-                    boxShadow: `0 0 6px ${stateColor[f.state]}`,
-                  }}
-                />
-              </div>
-            </div>
-            <span className="t-num" style={{ fontSize: 11, fontStyle: "normal", textAlign: "right", color: "var(--fg)" }}>{f.pct}%</span>
-            <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)", letterSpacing: "0.14em" }}>
-              {f.env.toUpperCase()}
-            </span>
-            <span
-              role="switch"
-              aria-checked={f.state !== "off"}
-              aria-label={`Feature flag ${f.key} · ${f.state}`}
-              style={{ display: "inline-flex", alignItems: "center", justifyContent: "flex-end" }}
-            >
-              <span
-                style={{
-                  width: 26,
-                  height: 14,
-                  borderRadius: 999,
-                  background:
-                    f.state === "off"
-                      ? "rgba(255,255,255,0.08)"
-                      : "color-mix(in oklch, var(--accent), transparent 60%)",
-                  position: "relative",
-                  border: "1px solid var(--line-hi)",
-                }}
-              >
-                <span
-                  style={{
-                    position: "absolute",
-                    top: 1,
-                    left: f.state === "off" ? 1 : 12,
-                    width: 10,
-                    height: 10,
-                    borderRadius: 999,
-                    background: "var(--fg)",
-                    transition: "left 200ms ease",
-                  }}
-                />
-              </span>
-            </span>
-          </div>
-        ))}
+      <div
+        style={{
+          padding: "32px 12px",
+          textAlign: "center",
+          border: "1px dashed var(--line)",
+          borderRadius: 8,
+        }}
+      >
+        <div style={{ fontSize: 11, color: "var(--fg-dim)", marginBottom: 4 }}>
+          No feature flag service
+        </div>
+        <div className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>
+          flags are env-var-only today · add a <code>feature_flags</code> table to surface them here
+        </div>
       </div>
     </Card>
   );
@@ -1295,73 +1241,87 @@ export function AuditLogPanel({ data }: { data: AuditEventsData }) {
 
 // ============================================================
 // MODERATION · SECURITY
+// Moderation queue has no live source yet — there's no user-generated
+// content moderation pipeline. Honest empty state until we add one.
 // ============================================================
 export function ModerationQueue() {
-  const items = [
-    { id: "MOD-441", kind: "recipe", who: "@silas.t", reason: "profanity · 0.62", at: "12m", sev: "warn" },
-    { id: "MOD-440", kind: "comment", who: "@anon.4192", reason: "spam · 0.91", at: "21m", sev: "warn" },
-    { id: "MOD-439", kind: "image", who: "@kavi.s", reason: "blurred · QC", at: "33m", sev: "info" },
-    { id: "MOD-438", kind: "report", who: "by @ana.p", reason: "abuse · DM", at: "1h", sev: "high" },
-    { id: "MOD-437", kind: "recipe", who: "@hyun.j", reason: "allergen flag", at: "1h", sev: "info" },
-    { id: "MOD-436", kind: "comment", who: "@anon.7811", reason: "spam · 0.84", at: "2h", sev: "warn" },
-    { id: "MOD-435", kind: "recipe", who: "@bea.l", reason: "duplicate", at: "3h", sev: "info" },
-  ];
-  const sevColor: Record<string, string> = { info: "var(--fg-mute)", warn: "var(--el-fire)", high: "#FF5252" };
   return (
     <Card
       title="Moderation Queue"
-      subtitle="7 pending · 2 high"
+      subtitle="no moderation pipeline configured"
       right={
-        <button className="btn btn-primary" style={{ padding: "5px 10px", fontSize: 9 }} type="button">
-          TRIAGE
-        </button>
+        <span
+          className="t-mono"
+          style={{ fontSize: 9, color: "var(--fg-mute)", letterSpacing: "0.14em" }}
+        >
+          ○ NO SOURCE
+        </span>
       }
     >
-      <div style={{ display: "flex", flexDirection: "column" }}>
-        {items.map((m, i) => (
-          <div
-            key={m.id}
-            style={{
-              display: "grid",
-              gridTemplateColumns: "64px 64px 1fr 1fr 40px",
-              gap: 8,
-              alignItems: "center",
-              padding: "8px 0",
-              borderBottom: i === items.length - 1 ? "none" : "1px solid var(--line)",
-              fontSize: 11,
-            }}
-          >
-            <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>{m.id}</span>
-            <span className="t-mono" style={{ fontSize: 9, color: "var(--accent-2)", letterSpacing: "0.14em" }}>
-              {m.kind.toUpperCase()}
-            </span>
-            <span style={{ color: "var(--fg-dim)" }}>{m.who}</span>
-            <span style={{ color: sevColor[m.sev] }}>{m.reason}</span>
-            <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)", textAlign: "right" }}>{m.at}</span>
-          </div>
-        ))}
+      <div
+        style={{
+          padding: "32px 12px",
+          textAlign: "center",
+          border: "1px dashed var(--line)",
+          borderRadius: 8,
+        }}
+      >
+        <div style={{ fontSize: 11, color: "var(--fg-dim)", marginBottom: 4 }}>
+          No user content moderation pipeline
+        </div>
+        <div className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>
+          add a <code>moderation_queue</code> table + classifier when UGC ships
+        </div>
       </div>
     </Card>
   );
 }
 
-export function SecurityPanel() {
+export function SecurityPanel({ security }: { security: SecuritySummaryData }) {
+  const maxHourly = Math.max(...security.hourlyAttempts, 1);
   const items = [
-    { label: "Failed sign-ins · 24h", v: "84", delta: "+12", tone: "warn" },
-    { label: "Throttled IPs", v: "6", delta: "+1", tone: "warn" },
-    { label: "Suspicious sessions", v: "0", delta: "—", tone: "ok" },
-    { label: "Active root sessions", v: "1", delta: "you", tone: "ok" },
-    { label: "Linked agents · OAuth", v: "42", delta: "+2", tone: "ok" },
-    { label: "Secrets rotation due", v: "2", delta: "stripe · sendgrid", tone: "warn" },
+    {
+      label: "Sign-in failures · 24h",
+      v: security.signinFailure24h.toLocaleString(),
+      delta: security.signinFailure24h > 0 ? `${security.signinFailure24h} attempt${security.signinFailure24h === 1 ? "" : "s"}` : "clean",
+      tone: security.signinFailure24h > 0 ? "warn" : "ok",
+    },
+    {
+      label: "Sign-in successes · 24h",
+      v: security.signinSuccess24h.toLocaleString(),
+      delta: security.signinSuccess24h > 0 ? "live" : "quiet",
+      tone: "ok",
+    },
+    {
+      label: "Unique IPs · 24h",
+      v: security.uniqueIps24h.toLocaleString(),
+      delta: "auth_events",
+      tone: "ok",
+    },
+    {
+      label: "Top failing IP · 24h",
+      v: security.failingIps[0] ? `…${security.failingIps[0].ipHash}` : "—",
+      delta: security.failingIps[0]
+        ? `${security.failingIps[0].failures} fail${security.failingIps[0].failures === 1 ? "" : "s"}`
+        : "none",
+      tone: security.failingIps[0] ? "warn" : "ok",
+    },
   ];
   return (
     <Card
       title="Security"
-      subtitle="auth · sessions · keys"
+      subtitle={security.live ? "auth_events · 24h window" : "auth_events offline"}
       right={
-        <button className="btn btn-ghost" style={{ padding: "4px 10px", fontSize: 9 }} type="button">
-          SECRETS
-        </button>
+        <span
+          className="t-mono"
+          style={{
+            fontSize: 9,
+            color: security.live ? "var(--el-earth)" : "var(--fg-mute)",
+            letterSpacing: "0.14em",
+          }}
+        >
+          {security.live ? "● LIVE" : "○ STALE"}
+        </span>
       }
     >
       <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 8 }}>
@@ -1381,23 +1341,30 @@ export function SecurityPanel() {
         ))}
       </div>
       <div style={{ marginTop: 10, padding: "8px 10px", border: "1px dashed var(--line)", borderRadius: 8 }}>
-        <div className="t-tag" style={{ marginBottom: 6 }}>SIGN-IN ATTEMPTS · 24H × 12 HOUR BUCKETS</div>
+        <div className="t-tag" style={{ marginBottom: 6 }}>SIGN-IN ATTEMPTS · LAST 24H × HOUR</div>
         <div style={{ display: "grid", gridTemplateColumns: "repeat(24, 1fr)", gap: 2 }}>
-          {seeded(99, 24, 0.1, 0.9).map((v, i) => (
-            <div
-              key={i}
-              style={{
-                height: 16,
-                borderRadius: 2,
-                background: `color-mix(in oklch, var(--accent), transparent ${(1 - v) * 92}%)`,
-                border: "1px solid var(--line)",
-              }}
-            />
-          ))}
+          {security.hourlyAttempts.map((count, i) => {
+            const v = count / maxHourly;
+            return (
+              <div
+                key={i}
+                title={`${count} attempt${count === 1 ? "" : "s"}`}
+                style={{
+                  height: 16,
+                  borderRadius: 2,
+                  background:
+                    count === 0
+                      ? "rgba(255,255,255,0.03)"
+                      : `color-mix(in oklch, var(--accent), transparent ${(1 - v) * 92}%)`,
+                  border: "1px solid var(--line)",
+                }}
+              />
+            );
+          })}
         </div>
         <div style={{ display: "flex", justifyContent: "space-between", marginTop: 4 }}>
-          <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>00</span>
-          <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>12</span>
+          <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>−24h</span>
+          <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>−12h</span>
           <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>now</span>
         </div>
       </div>

--- a/src/app/api/admin/dashboard/route.ts
+++ b/src/app/api/admin/dashboard/route.ts
@@ -21,14 +21,19 @@ import {
   getCatalogTrending,
   getCosmicYield,
   getDatabaseObservability,
+  getErrorGroupSummary,
   getPlatformPulse,
   getEnginePerformance,
   getPractitionerCohorts,
   getCommerceTelemetry,
   getPageTelemetry,
+  getRecentAlerts,
+  getSecuritySummary,
 } from "@/services/dashboardPanelsService";
 import { feedEmitTracker } from "@/services/feedEmitTracker";
+import { getLiveActivity } from "@/services/liveActivityService";
 import { getSkyConditions } from "@/services/skyConditionsService";
+import { getSystemStatus } from "@/services/systemStatusService";
 import { userDatabase } from "@/services/userDatabaseService";
 
 export const dynamic = "force-dynamic";
@@ -165,6 +170,11 @@ export async function GET(request: NextRequest) {
     const practitionerCohortsPromise = getPractitionerCohorts();
     const commerceTelemetryPromise = getCommerceTelemetry();
     const pageTelemetryPromise = getPageTelemetry();
+    const systemStatusPromise = getSystemStatus();
+    const liveActivityPromise = getLiveActivity();
+    const recentAlertsPromise = getRecentAlerts();
+    const errorGroupsPromise = getErrorGroupSummary();
+    const securityPromise = getSecuritySummary();
 
     let paHealth = "offline";
     let paAgentCount = 0;
@@ -212,6 +222,11 @@ export async function GET(request: NextRequest) {
     const practitionerCohorts = await practitionerCohortsPromise;
     const commerce = await commerceTelemetryPromise;
     const pageTelemetry = await pageTelemetryPromise;
+    const systemStatus = await systemStatusPromise;
+    const liveActivityResult = await liveActivityPromise;
+    const recentAlerts = await recentAlertsPromise;
+    const errorGroups = await errorGroupsPromise;
+    const security = await securityPromise;
 
     // Resolve the admin identity from the validated session rather than
     // hardcoding a single operator. Falls back to the session token payload
@@ -268,6 +283,14 @@ export async function GET(request: NextRequest) {
       practitionerCohorts,
       commerce,
       pageTelemetry,
+      systemStatus,
+      liveActivity: {
+        entries: liveActivityResult.events,
+        live: liveActivityResult.live,
+      },
+      recentAlerts,
+      errorGroups,
+      security,
       meta: {
         generatedAt: now.toISOString(),
         mockedFields: [],

--- a/src/app/api/auth/sessions/route.ts
+++ b/src/app/api/auth/sessions/route.ts
@@ -58,11 +58,30 @@ function jwtFallback(
 
 export async function GET(request: Request) {
   const session = await auth();
-  const user = session?.user as
+  let user = session?.user as
     | { id?: string; tier?: string }
     | undefined;
+
+  // Bearer JWT fallback so API clients (and the synthetic auth-handshake
+  // probe) can hit this endpoint without a NextAuth cookie. Cookie path
+  // stays primary for real users.
   if (!user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const authHeader = request.headers.get("authorization") ?? "";
+    if (authHeader.startsWith("Bearer ")) {
+      try {
+        const { validateToken } = await import("@/lib/auth/validateRequest");
+        const result = await validateToken(authHeader.slice(7));
+        if (result.valid && result.user) {
+          user = { id: result.user.userId };
+        }
+      } catch {
+        /* token rejected — fall through to 401 */
+      }
+    }
+  }
+
+  if (!user?.id) {
+    return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
   }
 
   // Resolve the current jti from the JWT so we can mark the corresponding

--- a/src/app/api/cron/observability-prune/route.ts
+++ b/src/app/api/cron/observability-prune/route.ts
@@ -1,0 +1,75 @@
+/**
+ * Observability Log Prune — cron endpoint
+ *
+ * Calls `prune_observability_logs(retain_days)` to delete rows older than
+ * `retain_days` (default 7) from `request_log_entries` and
+ * `slow_query_log_entries`. The pg function is defined in
+ * `database/init/39-observability-persistence.sql`.
+ *
+ * Triggered daily at 03:00 UTC by Vercel cron (see vercel.json). Volume
+ * is low right now (low-traffic site, ~hundreds of rows/day), so a single
+ * daily sweep is plenty. Revisit if volume grows.
+ *
+ * Auth: `Authorization: Bearer <CRON_SECRET>` (shared cron auth).
+ *
+ * @file src/app/api/cron/observability-prune/route.ts
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import { isAuthorizedCron } from "@/app/api/cron/_lib/cronAuth";
+import { executeQuery } from "@/lib/database/connection";
+import { _logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+const DEFAULT_RETAIN_DAYS = 7;
+
+export async function GET(request: NextRequest) {
+  if (!isAuthorizedCron(request)) {
+    return NextResponse.json(
+      { success: false, message: "Unauthorized" },
+      { status: 401 },
+    );
+  }
+
+  // Allow ?retain=N for manual one-off runs (e.g. emergency cleanup).
+  const url = new URL(request.url);
+  const retainParam = url.searchParams.get("retain");
+  let retainDays = DEFAULT_RETAIN_DAYS;
+  if (retainParam) {
+    const parsed = Number.parseInt(retainParam, 10);
+    if (Number.isFinite(parsed) && parsed >= 1 && parsed <= 365) {
+      retainDays = parsed;
+    }
+  }
+
+  try {
+    const result = await executeQuery<{
+      request_log_deleted: string;
+      slow_query_log_deleted: string;
+    }>(`SELECT * FROM prune_observability_logs($1)`, [retainDays]);
+
+    // pg returns BIGINT as string — coerce for the JSON response.
+    const row = result.rows[0];
+    const requestLogDeleted = row ? Number(row.request_log_deleted) : 0;
+    const slowQueryLogDeleted = row ? Number(row.slow_query_log_deleted) : 0;
+
+    return NextResponse.json({
+      success: true,
+      retainDays,
+      requestLogDeleted,
+      slowQueryLogDeleted,
+    });
+  } catch (err) {
+    _logger.error("[cron/observability-prune] failed:", err);
+    return NextResponse.json(
+      {
+        success: false,
+        message: err instanceof Error ? err.message : "unknown",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/observability/alertLog.ts
+++ b/src/lib/observability/alertLog.ts
@@ -30,6 +30,12 @@ export interface AlertLogEntry {
 export interface AlertDispatchSummary {
   slack?: { ok: boolean; error?: string };
   email?: { ok: boolean; error?: string };
+  // Set when alertService skipped Slack/email because this (component,
+  // current_status) pair was already dispatched within the cooldown window.
+  // The DB row + ring entry are still recorded so the audit trail catches
+  // flapping; the sinks just don't fire.
+  suppressed?: boolean;
+  suppressionReason?: string;
 }
 
 const RING_SIZE = 100;

--- a/src/services/TokenEconomyService.ts
+++ b/src/services/TokenEconomyService.ts
@@ -704,11 +704,17 @@ class TokenEconomyService {
             RETURNING id
           ),
           updated AS (
+            -- Qualify token_balances.<col> on the right-hand side of each
+            -- SET so the planner doesn't see the bare column name as
+            -- ambiguous between token_balances and balance_check (both
+            -- have spirit/essence/matter/substance columns). Without
+            -- these qualifiers Postgres raises 42702 and the whole CTE
+            -- rolls back, surfacing as purchase_failed in the caller.
             UPDATE token_balances
-            SET spirit = spirit - $2,
-                essence = essence - $3,
-                matter = matter - $4,
-                substance = substance - $5,
+            SET spirit = token_balances.spirit - $2,
+                essence = token_balances.essence - $3,
+                matter = token_balances.matter - $4,
+                substance = token_balances.substance - $5,
                 updated_at = now()
             FROM balance_check bc
             WHERE token_balances.user_id = $1

--- a/src/services/__tests__/alertService.test.ts
+++ b/src/services/__tests__/alertService.test.ts
@@ -10,6 +10,7 @@ jest.mock("@/lib/database/connection", () => ({
 import {
   classifyTransition,
   diffPayloadsForAlerts,
+  shouldSuppressAlert,
 } from "@/services/alertService";
 import type {
   DependencyHealth,
@@ -165,5 +166,73 @@ describe("alertService.diffPayloadsForAlerts", () => {
     const b = makePayload("OK", [makeFlow("auth", "OK"), makeFlow("new", "DEGRADED")]);
     const candidates = diffPayloadsForAlerts(a, b);
     expect(candidates.map((c) => c.component)).not.toContain("new");
+  });
+});
+
+describe("alertService.shouldSuppressAlert", () => {
+  const now = new Date("2026-06-01T12:00:00Z");
+  const cooldownMs = 60 * 60_000; // 1 hour
+
+  it("does not suppress when there is no prior dispatch", () => {
+    expect(
+      shouldSuppressAlert({ lastDispatchAt: null, now, cooldownMs }),
+    ).toEqual({ suppressed: false });
+  });
+
+  it("suppresses when the last dispatch is within the cooldown window", () => {
+    const tenMinutesAgo = new Date(now.getTime() - 10 * 60_000).toISOString();
+    const result = shouldSuppressAlert({
+      lastDispatchAt: tenMinutesAgo,
+      now,
+      cooldownMs,
+    });
+    expect(result.suppressed).toBe(true);
+    expect(result.reason).toMatch(/Cooldown active/);
+    expect(result.reason).toMatch(/50m left/);
+  });
+
+  it("does NOT suppress when the cooldown window has elapsed", () => {
+    const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60_000).toISOString();
+    expect(
+      shouldSuppressAlert({
+        lastDispatchAt: twoHoursAgo,
+        now,
+        cooldownMs,
+      }),
+    ).toEqual({ suppressed: false });
+  });
+
+  it("disables suppression entirely when cooldownMs is 0", () => {
+    const fiveMinutesAgo = new Date(now.getTime() - 5 * 60_000).toISOString();
+    expect(
+      shouldSuppressAlert({
+        lastDispatchAt: fiveMinutesAgo,
+        now,
+        cooldownMs: 0,
+      }),
+    ).toEqual({ suppressed: false });
+  });
+
+  it("returns no suppression on malformed lastDispatchAt", () => {
+    expect(
+      shouldSuppressAlert({
+        lastDispatchAt: "not-a-date",
+        now,
+        cooldownMs,
+      }),
+    ).toEqual({ suppressed: false });
+  });
+
+  it("treats the cooldown boundary as expired (not suppressed)", () => {
+    const exactlyOneHourAgo = new Date(
+      now.getTime() - cooldownMs,
+    ).toISOString();
+    expect(
+      shouldSuppressAlert({
+        lastDispatchAt: exactlyOneHourAgo,
+        now,
+        cooldownMs,
+      }),
+    ).toEqual({ suppressed: false });
   });
 });

--- a/src/services/alertService.ts
+++ b/src/services/alertService.ts
@@ -17,6 +17,10 @@
  *     dashboard.
  *   - Worsenings (OK -> DEGRADED, OK -> INCIDENT, DEGRADED -> INCIDENT)
  *     alert as `warn` or `error` based on terminal status.
+ *   - Cooldown: a (component, current_status) pair that already fired
+ *     within ALERT_COOLDOWN_MINUTES (default 60) records the new alert
+ *     event to DB but skips Slack + email. Prevents flapping from
+ *     spamming operators while preserving the audit trail.
  *
  * Each sink (DB, Slack, email) dispatches independently with try/catch
  * — a broken webhook URL doesn't block the email and vice versa.
@@ -65,6 +69,78 @@ const SEVERITY_BY_TERMINAL: Record<FlowStatus, AlertSeverity> = {
   INCIDENT: "error",
   UNKNOWN: "info",
 };
+
+const DEFAULT_COOLDOWN_MINUTES = 60;
+
+function getCooldownMs(): number {
+  const raw = process.env.ALERT_COOLDOWN_MINUTES;
+  if (!raw) return DEFAULT_COOLDOWN_MINUTES * 60_000;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_COOLDOWN_MINUTES * 60_000;
+  }
+  return parsed * 60_000;
+}
+
+/**
+ * Pure cooldown decision: given the timestamp of the most recent
+ * non-suppressed dispatch for the same (component, current_status) pair,
+ * decide whether THIS candidate should be suppressed. Exported for tests.
+ *
+ * Suppression preserves the DB audit trail (the alert event still
+ * persists, just with `dispatch.suppressed = true`) but skips Slack +
+ * email so flapping doesn't spam operators.
+ *
+ * A cooldown of 0 disables suppression entirely (every transition alerts).
+ */
+export function shouldSuppressAlert(args: {
+  lastDispatchAt: string | null;
+  now: Date;
+  cooldownMs: number;
+}): { suppressed: boolean; reason?: string } {
+  if (args.cooldownMs <= 0) return { suppressed: false };
+  if (!args.lastDispatchAt) return { suppressed: false };
+  const lastMs = Date.parse(args.lastDispatchAt);
+  if (!Number.isFinite(lastMs)) return { suppressed: false };
+  const elapsed = args.now.getTime() - lastMs;
+  if (elapsed >= args.cooldownMs) return { suppressed: false };
+  const remainingMinutes = Math.ceil((args.cooldownMs - elapsed) / 60_000);
+  return {
+    suppressed: true,
+    reason: `Cooldown active — last alert ${args.lastDispatchAt}; ${remainingMinutes}m left of ${Math.round(args.cooldownMs / 60_000)}m window`,
+  };
+}
+
+async function getLastNonSuppressedDispatchAt(
+  component: string,
+  currentStatus: FlowStatus,
+  cooldownMs: number,
+): Promise<string | null> {
+  // No need to query when cooldown is disabled.
+  if (cooldownMs <= 0) return null;
+  try {
+    const result = await executeQuery<{ triggered_at: Date }>(
+      // Only consider dispatches that ACTUALLY went out — suppressed rows
+      // shouldn't extend the cooldown indefinitely (otherwise one alert
+      // followed by N suppressed snapshots would never re-fire).
+      `SELECT triggered_at FROM alert_events
+       WHERE component = $1
+         AND current_status = $2
+         AND COALESCE((dispatch->>'suppressed')::boolean, false) = false
+         AND triggered_at > NOW() - make_interval(secs => $3)
+       ORDER BY triggered_at DESC
+       LIMIT 1`,
+      [component, currentStatus, cooldownMs / 1000],
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+    return new Date(row.triggered_at).toISOString();
+  } catch (err) {
+    // Fail open: a broken cooldown lookup must not drop real alerts.
+    _logger.warn("[alertService] cooldown lookup failed:", err);
+    return null;
+  }
+}
 
 /**
  * Decide whether a (previous, current) pair warrants an alert and, if
@@ -184,28 +260,49 @@ export async function dispatchAlert(
 ): Promise<DispatchedAlert> {
   const triggeredAt = new Date().toISOString();
 
-  const [slackResult, emailResult] = await Promise.all([
-    sendSlackAlert({
-      title: candidate.title,
-      message: candidate.message,
-      component: candidate.componentLabel,
-      previous: candidate.previous,
-      current: candidate.current,
-      severity: candidate.severity,
-    }).catch((err) => ({
-      ok: false,
-      error: err instanceof Error ? err.message : "unknown",
-    })),
-    sendAlertEmail(candidate).catch((err) => ({
-      ok: false,
-      error: err instanceof Error ? err.message : "unknown",
-    })),
-  ]);
+  const cooldownMs = getCooldownMs();
+  const lastDispatchAt = await getLastNonSuppressedDispatchAt(
+    candidate.component,
+    candidate.current,
+    cooldownMs,
+  );
+  const cooldown = shouldSuppressAlert({
+    lastDispatchAt,
+    now: new Date(triggeredAt),
+    cooldownMs,
+  });
 
-  const dispatch: AlertDispatchSummary = {
-    slack: slackResult,
-    email: emailResult,
-  };
+  let dispatch: AlertDispatchSummary;
+  if (cooldown.suppressed) {
+    dispatch = {
+      slack: { ok: false, error: "Suppressed by cooldown" },
+      email: { ok: false, error: "Suppressed by cooldown" },
+      suppressed: true,
+      suppressionReason: cooldown.reason,
+    };
+  } else {
+    const [slackResult, emailResult] = await Promise.all([
+      sendSlackAlert({
+        title: candidate.title,
+        message: candidate.message,
+        component: candidate.componentLabel,
+        previous: candidate.previous,
+        current: candidate.current,
+        severity: candidate.severity,
+      }).catch((err) => ({
+        ok: false,
+        error: err instanceof Error ? err.message : "unknown",
+      })),
+      sendAlertEmail(candidate).catch((err) => ({
+        ok: false,
+        error: err instanceof Error ? err.message : "unknown",
+      })),
+    ]);
+    dispatch = {
+      slack: slackResult,
+      email: emailResult,
+    };
+  }
 
   const dbId = await persistAlertEvent({
     triggeredAt,

--- a/src/services/dashboardPanelsService.ts
+++ b/src/services/dashboardPanelsService.ts
@@ -725,3 +725,230 @@ export async function getPageTelemetry(): Promise<PageTelemetryData> {
     };
   }
 }
+
+// ─── Recent Alerts · alert_events table ────────────────────────────────
+
+export type AlertSeverityValue = "info" | "warn" | "error";
+
+export interface RecentAlertEntry {
+  id: number;
+  triggeredAt: string;
+  component: string;
+  previousStatus: string;
+  currentStatus: string;
+  severity: AlertSeverityValue;
+  title: string;
+  message: string;
+  suppressed: boolean;
+}
+
+export interface RecentAlertsData {
+  entries: RecentAlertEntry[];
+  live: boolean;
+}
+
+/**
+ * Pull the latest N rows from `alert_events` (PR #445 schema) so the
+ * IncidentsPanel can show real operator alerts instead of mock incidents.
+ * Returns `live: false` with an empty list when the table is missing or
+ * the query fails — never throws.
+ */
+export async function getRecentAlerts(
+  limit: number = 8,
+): Promise<RecentAlertsData> {
+  try {
+    const result = await executeQuery<{
+      id: number;
+      triggered_at: Date;
+      component: string;
+      previous_status: string;
+      current_status: string;
+      severity: AlertSeverityValue;
+      title: string;
+      message: string;
+      suppressed: boolean | null;
+    }>(
+      `SELECT id, triggered_at, component, previous_status, current_status,
+              severity, title, message,
+              COALESCE((dispatch->>'suppressed')::boolean, false) AS suppressed
+       FROM alert_events
+       ORDER BY triggered_at DESC
+       LIMIT $1`,
+      [limit],
+    );
+
+    return {
+      entries: result.rows.map((row) => ({
+        id: Number(row.id),
+        triggeredAt: new Date(row.triggered_at).toISOString(),
+        component: row.component,
+        previousStatus: row.previous_status,
+        currentStatus: row.current_status,
+        severity: row.severity,
+        title: row.title,
+        message: row.message,
+        suppressed: Boolean(row.suppressed),
+      })),
+      live: true,
+    };
+  } catch (error) {
+    _logger.warn("[getRecentAlerts] failed:", error);
+    return { entries: [], live: false };
+  }
+}
+
+// ─── Error Groups · request_log_entries rollup ────────────────────────
+
+export interface ErrorGroupEntry {
+  path: string;
+  fiveXxCount: number;
+  fourXxCount: number;
+  totalCount: number;
+  lastSeenAt: string;
+}
+
+export interface ErrorGroupsData {
+  groups: ErrorGroupEntry[];
+  windowMinutes: number;
+  live: boolean;
+}
+
+/**
+ * Bucket non-2xx requests over the last hour by path, ranked by 5xx
+ * count then total. Powers the ErrorGroups panel — replaces hardcoded
+ * E-7741 / E-7740 fixtures with the real recent error footprint.
+ */
+export async function getErrorGroupSummary(
+  windowMinutes: number = 60,
+): Promise<ErrorGroupsData> {
+  try {
+    const result = await executeQuery<{
+      path: string;
+      five_xx: number;
+      four_xx: number;
+      total: number;
+      last_seen: Date;
+    }>(
+      `SELECT path,
+              COUNT(*) FILTER (WHERE status >= 500)::int AS five_xx,
+              COUNT(*) FILTER (WHERE status >= 400 AND status < 500)::int AS four_xx,
+              COUNT(*)::int AS total,
+              MAX(at) AS last_seen
+       FROM request_log_entries
+       WHERE at > NOW() - make_interval(mins => $1) AND status >= 400
+       GROUP BY path
+       ORDER BY five_xx DESC, total DESC
+       LIMIT 8`,
+      [windowMinutes],
+    );
+
+    return {
+      groups: result.rows.map((row) => ({
+        path: row.path,
+        fiveXxCount: row.five_xx,
+        fourXxCount: row.four_xx,
+        totalCount: row.total,
+        lastSeenAt: new Date(row.last_seen).toISOString(),
+      })),
+      windowMinutes,
+      live: true,
+    };
+  } catch (error) {
+    _logger.warn("[getErrorGroupSummary] failed:", error);
+    return { groups: [], windowMinutes, live: false };
+  }
+}
+
+// ─── Security Summary · auth_events rollup ─────────────────────────────
+
+export interface SecurityFailingIp {
+  ipHash: string;
+  failures: number;
+}
+
+export interface SecuritySummaryData {
+  signinSuccess24h: number;
+  signinFailure24h: number;
+  uniqueIps24h: number;
+  failingIps: SecurityFailingIp[];
+  /** 24 hourly buckets, oldest first, of total sign-in attempts. */
+  hourlyAttempts: number[];
+  live: boolean;
+}
+
+/**
+ * Aggregate auth_events over the last 24h: success/failure counts,
+ * unique IP count, the top 5 failure-IPs, and a 24-bucket hourly
+ * histogram of attempts. Powers the SecurityPanel — replaces the
+ * "84 failed sign-ins" / "6 throttled IPs" fixtures.
+ */
+export async function getSecuritySummary(): Promise<SecuritySummaryData> {
+  const emptyHourly = Array.from({ length: 24 }, () => 0);
+  try {
+    const [counts, ips, hourly] = await Promise.all([
+      executeQuery<{
+        success: number;
+        failure: number;
+        unique_ips: number;
+      }>(
+        `SELECT
+           COUNT(*) FILTER (WHERE status = 'success')::int AS success,
+           COUNT(*) FILTER (WHERE status = 'failure')::int AS failure,
+           COUNT(DISTINCT ip_hash) FILTER (WHERE ip_hash IS NOT NULL)::int AS unique_ips
+         FROM auth_events
+         WHERE created_at > NOW() - INTERVAL '24 hours'`,
+      ),
+      executeQuery<{ ip_hash: string; failures: number }>(
+        `SELECT ip_hash, COUNT(*)::int AS failures
+         FROM auth_events
+         WHERE created_at > NOW() - INTERVAL '24 hours'
+           AND status = 'failure'
+           AND ip_hash IS NOT NULL
+         GROUP BY ip_hash
+         ORDER BY failures DESC
+         LIMIT 5`,
+      ),
+      executeQuery<{ hour_bucket: number; count: number }>(
+        // Bucket attempts into 24 hourly slots from oldest to newest.
+        `SELECT FLOOR(EXTRACT(EPOCH FROM (NOW() - created_at)) / 3600)::int AS hour_bucket,
+                COUNT(*)::int AS count
+         FROM auth_events
+         WHERE created_at > NOW() - INTERVAL '24 hours'
+         GROUP BY hour_bucket
+         ORDER BY hour_bucket`,
+      ),
+    ]);
+
+    const countsRow = counts.rows[0];
+    for (const row of hourly.rows) {
+      const idx = 23 - row.hour_bucket;
+      if (idx >= 0 && idx < 24) {
+        emptyHourly[idx] = row.count;
+      }
+    }
+
+    return {
+      signinSuccess24h: countsRow?.success ?? 0,
+      signinFailure24h: countsRow?.failure ?? 0,
+      uniqueIps24h: countsRow?.unique_ips ?? 0,
+      failingIps: ips.rows.map((row) => ({
+        // Show only the last 6 chars of the hash so the UI surfaces something
+        // identifiable without leaking the full hash.
+        ipHash: row.ip_hash.slice(-6),
+        failures: row.failures,
+      })),
+      hourlyAttempts: emptyHourly,
+      live: true,
+    };
+  } catch (error) {
+    _logger.warn("[getSecuritySummary] failed:", error);
+    return {
+      signinSuccess24h: 0,
+      signinFailure24h: 0,
+      uniqueIps24h: 0,
+      failingIps: [],
+      hourlyAttempts: emptyHourly,
+      live: false,
+    };
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -34,6 +34,10 @@
     {
       "path": "/api/cron/system-health-snapshot",
       "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/cron/observability-prune",
+      "schedule": "0 3 * * *"
     }
   ],
   "env": {


### PR DESCRIPTION
## Summary

Started as two follow-ups to the operational hardening shipped in #445; grew during the session as the new System Status panel surfaced latent issues, and the user asked for `/admin/dashboard` to be wired with proper data.

### Original scope (2 items)

- **Alert dedupe with cooldown** — same `(component, current_status)` won't re-email/Slack for `ALERT_COOLDOWN_MINUTES` (default 60). DB row + audit trail still written (`dispatch.suppressed = true`); only the noisy sinks are skipped.
- **Daily observability log prune** — new `/api/cron/observability-prune` runs at 03:00 UTC, calls `prune_observability_logs(7)` so `request_log_entries` + `slow_query_log_entries` don't grow forever.

### Production bug fixes surfaced by the new probes (2 items)

- **`fix(auth)`: `/api/auth/sessions` now accepts Bearer JWT.** Was cookie-only via NextAuth `auth()`. The synthetic auth-handshake probe (and any API client) needs Bearer; cookie path stays primary for real users.

- **`fix(economy)`: `purchaseShopItem` SQL had `column reference "spirit" is ambiguous`.** The `UPDATE token_balances SET spirit = spirit - $2 FROM balance_check bc` was ambiguous — both `token_balances` and `balance_check` expose `spirit`. Postgres returned 42702; the catch-block surfaced it as `purchase_failed`; the cosmic-recipe route translated to a misleading 402 "Insufficient tokens". **Audit: 0 successful shop-item purchases in production since this CTE shipped.** Fix: qualify `token_balances.<col>` on RHS of each SET.

### Admin dashboard wiring (1 commit, 8 panels live, 5 honest empty)

The High Alchemist dashboard at `/admin/dashboard` had 14 panels rendering hardcoded fake data — INC-2207, E-7741, c8f1ad deploy hashes, MOD-441 moderation rows, fake services with synthetic latency numbers. Replaced with real sources or honest empty states.

**Wired to live sources:**
- `ServiceMatrix` → `systemStatusService` (8 flows + 3 deps)
- `LiveEventStream` → `liveActivityService` (real 6-source merged feed)
- `IncidentsPanel` → `alert_events` table (last 8 rows; suppressed alerts dimmed)
- `ErrorGroups` → `request_log_entries` 5xx/4xx aggregation by path
- `SecurityPanel` → `auth_events` 24h rollup + real hourly histogram

**Honest empty states (no source available yet):**
- `DeploysPanel`, `FeatureFlagsPanel`, `ModerationQueue`, `CostBurndown`, `PractitionerGeo`

Each panel adds a small chip indicating `● LIVE` / `○ STALE` / `○ NO SOURCE` so operators can tell at a glance which panels are connected.

**Contract + service additions:**
- `dashboardPanelsService.ts`: added `getRecentAlerts`, `getErrorGroupSummary`, `getSecuritySummary` (each degrades to `{ live: false, ... }` on failure)
- `data.ts`: `AdminDashboardData` gains 5 new fields
- `/api/admin/dashboard` route: fetches the 5 new sources in parallel

## Test plan

- [x] `bun run verify` — 0 errors / 0 warnings
- [x] `bun run build` — production build clean; 7 cron routes register
- [x] `bun run jest src/services` — 69 tests passing (incl. 6 new for `shouldSuppressAlert`)
- [x] Reproduced the SQL ambiguity bug locally against prod DB; confirmed fix returns the row and debits correctly (500 → 492.8 with 7.2 cost)
- [x] Verified `/api/auth/sessions` accepts Bearer JWT against prod (after route fix deployed)
- [ ] **Post-merge: cosmic-recipe probe flips from `failure` (402) to `success`** within next hourly cycle
- [ ] **Post-merge: auth-handshake probe flips from `failure` (401) to `success`** within 15 min
- [ ] **Post-merge: `/admin/dashboard` panels show real data** instead of INC-2207 / E-7741 / c8f1ad fixtures
- [ ] Confirm cooldown active on next snapshot — repeat transitions land in `alert_events` with `dispatch.suppressed = true`
- [ ] First observability-prune run at 03:00 UTC returns 200 with `requestLogDeleted` + `slowQueryLogDeleted` counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)