### PR TITLE
fix(auth): unblock OAuth signup by supplying email_verified + login_count

### DIFF
--- a/database/init/41-restore-user-column-defaults.sql
+++ b/database/init/41-restore-user-column-defaults.sql
@@ -1,0 +1,15 @@
+-- database/init/41-restore-user-column-defaults.sql
+-- Restore NOT NULL defaults on users.email_verified and users.login_count.
+--
+-- These defaults were defined in 01-schema.sql but were lost on the production
+-- DB at some point along the migration history, leaving the columns NOT NULL
+-- with no DEFAULT. As of 2026-05-25 this blocks every fresh OAuth signup —
+-- userDatabaseService.createUser does not supply either column, so the INSERT
+-- fails with 23502 (not-null violation), which surfaces as a 503 on
+-- /api/onboarding for new users.
+--
+-- The application INSERT now passes both columns explicitly, but restoring the
+-- defaults closes the same hole for any other code path or direct SQL insert.
+
+ALTER TABLE users ALTER COLUMN email_verified SET DEFAULT false;
+ALTER TABLE users ALTER COLUMN login_count    SET DEFAULT 0;

--- a/src/services/userDatabaseService.ts
+++ b/src/services/userDatabaseService.ts
@@ -103,9 +103,11 @@ class UserDatabaseService {
           ? "ADMIN"
           : "USER";
         await db.withTransaction(async (client) => {
+          // email_verified + login_count are NOT NULL in prod with no DEFAULT —
+          // omitting them violates the not-null constraint and blocks signup.
           const insertUserResult = await client.query(
-            `INSERT INTO users (id, email, name, image, password_hash, role, is_active, profile, preferences, created_at)
-             VALUES ($1, $2, $3, $4, $5, $6::user_role, $7, $8, $9, $10)
+            `INSERT INTO users (id, email, name, image, password_hash, role, is_active, email_verified, login_count, profile, preferences, created_at)
+             VALUES ($1, $2, $3, $4, $5, $6::user_role, $7, $8, $9, $10, $11, $12)
              ON CONFLICT (email) DO NOTHING RETURNING id`,
             [
               userId,
@@ -115,6 +117,8 @@ class UserDatabaseService {
               user.passwordHash,
               primaryRole,
               true,
+              true,
+              0,
               JSON.stringify(user.profile),
               JSON.stringify(user.profile.preferences || {}),
               now,


### PR DESCRIPTION
## Summary

- New OAuth signups were hitting **`Server error (503)`** on the onboarding form. Existing users (admin, synthetic probes) worked fine; only fresh accounts broke.
- Root cause: `users.email_verified` and `users.login_count` are `NOT NULL` with **no `DEFAULT`** in production (defaults from `01-schema.sql` were lost along the migration history). `userDatabaseService.createUser` did not supply either column, so the `INSERT` failed with PG error **`23502`** (`null value in column "email_verified" ... violates not-null constraint`). That throw became `Failed to create user in database`, which the onboarding route surfaced as a 503 after 3 client retries.
- Fix:
  - `userDatabaseService.createUser` now passes `email_verified=true` (Google has verified the address by the time we hit OAuth callback) and `login_count=0` explicitly in the `users` INSERT.
  - New migration `database/init/41-restore-user-column-defaults.sql` puts `DEFAULT false` and `DEFAULT 0` back on the two columns. **Already applied out-of-band to prod (`tramway.proxy.rlwy.net`)** so signup works immediately on deploy without waiting for the next init run; the file remains in the tree as the canonical record and for fresh DBs.

## How it was verified

- Reproduced against prod DB: bare `createUser`-style `INSERT` failed first on `email_verified`, then on `login_count`. Test row was cleaned up.
- After applying the migration: the same bare INSERT (no `email_verified` / `login_count` columns) succeeds and the row materializes with `email_verified=false`, `login_count=0`.
- End-to-end mock of the full `createUser` transaction (users + user_profiles + token_balances + user_streaks) succeeded with the new columns supplied.
- `bun run verify` → 0 errors / 0 warnings.
- `bun run build` → passes.

## Test plan

- [ ] Sign in with a brand-new Google account (not in DB).
- [ ] Confirm the OAuth callback succeeds (no `PostgreSQL user creation failed` in Vercel logs).
- [ ] On `/onboarding`, fill birth date/time + location, submit → expect a 200 response, redirect to `/profile`.
- [ ] Verify the new user row in `users` has `email_verified=true`, `login_count=0`, and an entry in `user_profiles` / `token_balances` / `user_streaks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)