### PR TITLE
fix: schema-drift cleanup + production error fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /.pnp
 .pnp.js
 
+# local-only scratch directory for one-off scripts, audits, exploratory work
+/scratch/
+
 # testing
 /coverage
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -52,6 +52,10 @@ ENV PATH=/home/alchm/.local/bin:$PATH
 # Copy backend application code
 COPY backend/ ./backend/
 
+# Migration runner needs the SQL files. We copy them into the image so the
+# backend can apply any unapplied database/init/*.sql on startup.
+COPY database/init/ ./database/init/
+
 # Ensure correct ownership
 RUN chown -R alchm:alchm /app /home/alchm
 
@@ -63,5 +67,10 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
-# Railway dynamically sets PORT, fallback to 8000
-CMD ["sh", "-c", "uvicorn backend.alchm_kitchen.main:app --host 0.0.0.0 --port ${PORT:-8000} --log-level info"]
+# On boot, apply any unapplied database/init/*.sql via the migration runner,
+# then start uvicorn. Runner exits 0 on success or when up-to-date, non-zero
+# on first failing migration. Railway will not start the web process if the
+# migration step fails (the && short-circuits), which is the desired behavior:
+# we'd rather see a failed deploy than serve traffic against a half-migrated
+# schema. Railway dynamically sets PORT, fallback to 8000.
+CMD ["sh", "-c", "python -m backend.scripts.run_init_migrations && uvicorn backend.alchm_kitchen.main:app --host 0.0.0.0 --port ${PORT:-8000} --log-level info"]

--- a/backend/scripts/run_init_migrations.py
+++ b/backend/scripts/run_init_migrations.py
@@ -1,0 +1,112 @@
+"""Deployment-time migration runner (Python).
+
+Mirror of `scripts/migrate.ts` for the Railway Python backend container. The TS
+runner is canonical for local use; this script is what the prod backend
+executes on startup before uvicorn so every deploy catches up on any unapplied
+`database/init/*.sql` files. Keep the two scripts in sync if you change the
+contract — both read the same `_migrations` tracking table.
+
+Usage (inside the Docker container, with DATABASE_URL set):
+  python -m backend.scripts.run_init_migrations
+  python -m backend.scripts.run_init_migrations --dry-run
+
+The runner exits 0 when everything is applied or up to date. It exits non-zero
+on the first migration that errors, leaving prior commits intact.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import psycopg2
+
+INIT_DIR = Path(__file__).resolve().parents[2] / "database" / "init"
+
+
+def list_migration_files() -> list[str]:
+    return sorted(
+        p.name for p in INIT_DIR.glob("*.sql") if " 2." not in p.name
+    )
+
+
+def main() -> int:
+    dry_run = "--dry-run" in sys.argv[1:]
+    bootstrap_arg = next(
+        (a for a in sys.argv[1:] if a.startswith("--bootstrap=")), None
+    )
+    bootstrap = (
+        [s.strip() for s in bootstrap_arg.split("=", 1)[1].split(",") if s.strip()]
+        if bootstrap_arg
+        else None
+    )
+
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        print("[migrate] DATABASE_URL is not set", file=sys.stderr)
+        return 1
+    if not INIT_DIR.is_dir():
+        print(f"[migrate] migration dir not found: {INIT_DIR}", file=sys.stderr)
+        return 1
+
+    conn = psycopg2.connect(db_url)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS _migrations (
+                  filename   TEXT PRIMARY KEY,
+                  applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                )
+                """
+            )
+            conn.commit()
+
+            if bootstrap:
+                print(f"[migrate] bootstrap: marking {len(bootstrap)} file(s) as applied")
+                for f in bootstrap:
+                    cur.execute(
+                        "INSERT INTO _migrations (filename) VALUES (%s) ON CONFLICT DO NOTHING",
+                        (f,),
+                    )
+                conn.commit()
+
+            cur.execute("SELECT filename FROM _migrations")
+            applied = {row[0] for row in cur.fetchall()}
+
+        files = list_migration_files()
+        pending = [f for f in files if f not in applied]
+        if not pending:
+            print(f"[migrate] up to date ({len(files)} files, {len(applied)} applied)")
+            return 0
+
+        print(f"[migrate] {len(pending)} pending: {', '.join(pending)}")
+        for f in pending:
+            sql = (INIT_DIR / f).read_text(encoding="utf-8")
+            if dry_run:
+                print(f"[migrate] DRY-RUN would apply {f} ({len(sql)} bytes)")
+                continue
+            print(f"[migrate] applying {f}...")
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(sql)
+                    cur.execute(
+                        "INSERT INTO _migrations (filename) VALUES (%s) ON CONFLICT DO NOTHING",
+                        (f,),
+                    )
+                conn.commit()
+                print(f"[migrate]   ok {f}")
+            except Exception as err:  # noqa: BLE001
+                conn.rollback()
+                print(f"[migrate]   FAILED {f}: {err}", file=sys.stderr)
+                return 1
+
+        print(f"[migrate] done. applied {len(pending)} new migration(s).")
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/database/init/07-nextauth-schema.sql
+++ b/database/init/07-nextauth-schema.sql
@@ -6,10 +6,9 @@
 ALTER TABLE users DROP COLUMN IF EXISTS privy_id;
 
 -- 2. Setup Custom User Fields
-ALTER TABLE users ADD COLUMN IF NOT EXISTS "onboardingComplete" BOOLEAN DEFAULT false;
-ALTER TABLE users ADD COLUMN IF NOT EXISTS "birthDate" DATE;
-ALTER TABLE users ADD COLUMN IF NOT EXISTS "birthTime" TIME;
-ALTER TABLE users ADD COLUMN IF NOT EXISTS "birthLocation" VARCHAR(255);
+-- (Removed: users."onboardingComplete" / "birthDate" / "birthTime" / "birthLocation".
+-- These were never applied in prod and the app uses user_profiles.onboarding_completed
+-- + user_profiles.birth_data instead.)
 
 -- The 06 script might not have run on this DB. Let's ensure the user_role ENUM exists and has USER/ADMIN.
 DO $$

--- a/database/init/10-social-schema.sql
+++ b/database/init/10-social-schema.sql
@@ -3,32 +3,33 @@
 -- Migration for expanding user social data ecosystem
 
 -- ==========================================
--- SAVED CHARTS (decoupled from user_profiles JSONB)
+-- SAVED CHARTS
+-- Source of truth: this file matches the actual prod schema as of 2026-05-25.
+-- The original design (owner_id / label / chart_type / birth_data JSONB /
+-- natal_chart JSONB) was superseded by hand-applied DDL that flattened the
+-- JSONB into structured columns (user_id / chart_name / birth_date /
+-- birth_time / birth_latitude / birth_longitude / timezone_str) and added a
+-- unique (user_id, chart_name) constraint. This file has been rewritten to
+-- describe the post-evolution shape so a fresh DB build produces the same
+-- table prod has today.
 -- ==========================================
 
 CREATE TABLE IF NOT EXISTS saved_charts (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  owner_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  label VARCHAR(255) NOT NULL,                     -- e.g. "Personal", "Career/Mundane"
-  chart_type VARCHAR(50) NOT NULL DEFAULT 'manual', -- 'primary' | 'cosmic_identity' | 'manual'
-  birth_data JSONB NOT NULL,                        -- BirthData object
-  natal_chart JSONB NOT NULL,                       -- NatalChart object
-  is_primary BOOLEAN NOT NULL DEFAULT false,        -- true for the user's main birth chart
-  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  chart_name      VARCHAR(100) NOT NULL,            -- e.g. "Personal", "Career"
+  birth_date      TIMESTAMP WITH TIME ZONE NOT NULL,
+  birth_time      VARCHAR(50) NOT NULL,             -- e.g. "12:34:00" (string form)
+  birth_latitude  REAL NOT NULL,
+  birth_longitude REAL NOT NULL,
+  timezone_str    VARCHAR(100) NOT NULL,            -- IANA tz, e.g. "America/New_York"
+  is_primary      BOOLEAN NOT NULL,                 -- caller must supply; matches prod (no default)
+  created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
--- Enforce at most one primary chart per user
-CREATE UNIQUE INDEX IF NOT EXISTS idx_saved_charts_primary
-  ON saved_charts (owner_id) WHERE is_primary = true;
-
-CREATE INDEX IF NOT EXISTS idx_saved_charts_owner ON saved_charts (owner_id);
-CREATE INDEX IF NOT EXISTS idx_saved_charts_type ON saved_charts (chart_type);
-
--- Trigger for updated_at
-CREATE TRIGGER update_saved_charts_updated_at
-  BEFORE UPDATE ON saved_charts
-  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE INDEX IF NOT EXISTS idx_saved_charts_user ON saved_charts (user_id);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_user_chart_name ON saved_charts (user_id, chart_name);
 
 -- ==========================================
 -- FRIENDSHIPS (many-to-many between registered users)
@@ -68,7 +69,6 @@ CREATE TRIGGER update_friendships_updated_at
 -- COMMENTS
 -- ==========================================
 
-COMMENT ON TABLE saved_charts IS 'Decoupled birth charts: primary, cosmic identities, and manual companion charts';
+COMMENT ON TABLE saved_charts IS 'Decoupled birth charts owned per user_id, identified by chart_name (e.g. "Personal", "Career"). is_primary marks the user''s main chart but is not enforced unique.';
 COMMENT ON TABLE friendships IS 'Many-to-many friendship relationships between registered users';
-COMMENT ON COLUMN saved_charts.chart_type IS 'primary = user main chart, cosmic_identity = alternate persona, manual = companion without account';
 COMMENT ON COLUMN friendships.status IS 'pending = awaiting acceptance, accepted = mutual friends, blocked = rejected/blocked';

--- a/database/init/42-restore-01-schema-defaults.sql
+++ b/database/init/42-restore-01-schema-defaults.sql
@@ -1,0 +1,64 @@
+-- database/init/42-restore-01-schema-defaults.sql
+-- Restore DEFAULT clauses that were lost from prod since the original
+-- 01-schema.sql definition. Same class as PR #447 (which restored
+-- email_verified + login_count): all 30 columns below are NOT NULL in prod
+-- with no DEFAULT, but their source 01-schema.sql declarations DO specify
+-- defaults. INSERT paths in the app happen to supply every value today,
+-- but any new code path that forgets to pass the column 500s on the
+-- not-null constraint. This migration restores the safety net.
+--
+-- Source-of-truth: database/init/01-schema.sql
+-- Diff detection: scratch/audit_schema_drift.ts (deleted post-PR)
+-- Idempotent: SET DEFAULT is repeatable.
+
+-- users
+ALTER TABLE users ALTER COLUMN is_active SET DEFAULT true;
+ALTER TABLE users ALTER COLUMN profile SET DEFAULT '{}';
+ALTER TABLE users ALTER COLUMN preferences SET DEFAULT '{}';
+
+-- api_keys
+ALTER TABLE api_keys ALTER COLUMN scopes SET DEFAULT '{}';
+ALTER TABLE api_keys ALTER COLUMN rate_limit_tier SET DEFAULT 'authenticated';
+ALTER TABLE api_keys ALTER COLUMN is_active SET DEFAULT true;
+ALTER TABLE api_keys ALTER COLUMN usage_count SET DEFAULT 0;
+
+-- elemental_properties
+ALTER TABLE elemental_properties ALTER COLUMN calculation_method SET DEFAULT 'manual';
+ALTER TABLE elemental_properties ALTER COLUMN confidence_score SET DEFAULT 1.0;
+
+-- planetary_influences
+ALTER TABLE planetary_influences ALTER COLUMN is_primary SET DEFAULT false;
+
+-- ingredients
+ALTER TABLE ingredients ALTER COLUMN flavor_profile SET DEFAULT '{}';
+ALTER TABLE ingredients ALTER COLUMN preparation_methods SET DEFAULT '{}';
+ALTER TABLE ingredients ALTER COLUMN is_active SET DEFAULT true;
+ALTER TABLE ingredients ALTER COLUMN confidence_score SET DEFAULT 1.0;
+
+-- ingredient_cuisines
+ALTER TABLE ingredient_cuisines ALTER COLUMN usage_frequency SET DEFAULT 0.5;
+
+-- ingredient_compatibility
+ALTER TABLE ingredient_compatibility ALTER COLUMN interaction_type SET DEFAULT 'neutral';
+
+-- recipes
+ALTER TABLE recipes ALTER COLUMN dietary_tags SET DEFAULT '{}';
+ALTER TABLE recipes ALTER COLUMN allergens SET DEFAULT '{}';
+ALTER TABLE recipes ALTER COLUMN nutritional_profile SET DEFAULT '{}';
+ALTER TABLE recipes ALTER COLUMN popularity_score SET DEFAULT 0.5;
+ALTER TABLE recipes ALTER COLUMN alchemical_harmony_score SET DEFAULT 0.5;
+ALTER TABLE recipes ALTER COLUMN cultural_authenticity_score SET DEFAULT 0.5;
+ALTER TABLE recipes ALTER COLUMN user_rating SET DEFAULT 0.0;
+ALTER TABLE recipes ALTER COLUMN rating_count SET DEFAULT 0;
+ALTER TABLE recipes ALTER COLUMN is_public SET DEFAULT true;
+ALTER TABLE recipes ALTER COLUMN is_verified SET DEFAULT false;
+
+-- recipe_ingredients
+ALTER TABLE recipe_ingredients ALTER COLUMN is_optional SET DEFAULT false;
+ALTER TABLE recipe_ingredients ALTER COLUMN order_index SET DEFAULT 0;
+
+-- calculation_cache
+ALTER TABLE calculation_cache ALTER COLUMN hit_count SET DEFAULT 0;
+
+-- system_metrics
+ALTER TABLE system_metrics ALTER COLUMN tags SET DEFAULT '{}';

--- a/database/init/43-restore-users-role-default.sql
+++ b/database/init/43-restore-users-role-default.sql
@@ -1,0 +1,13 @@
+-- database/init/43-restore-users-role-default.sql
+-- Restore users.role DEFAULT to 'USER' to match source-of-truth.
+--
+-- The prod default was changed by hand at some point to 'ALCHEMIST'::user_role,
+-- diverging from 07-nextauth-schema.sql which declares DEFAULT 'USER' (set
+-- twice for clarity, on lines 31 and 34). New signups should be created at
+-- USER tier and upgraded to ALCHEMIST through the explicit tier flow, not
+-- granted ALCHEMIST as the implicit default.
+--
+-- Existing rows are not affected.
+-- Idempotent.
+
+ALTER TABLE users ALTER COLUMN role SET DEFAULT 'USER';

--- a/railway.json
+++ b/railway.json
@@ -3,7 +3,7 @@
   "build": {
     "builder": "DOCKERFILE",
     "dockerfilePath": "backend/Dockerfile",
-    "watchPatterns": ["backend/**", "railway.json"]
+    "watchPatterns": ["backend/**", "database/init/**", "railway.json"]
   },
   "deploy": {
     "numReplicas": 1,

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,122 @@
+/**
+ * Deployment-time migration runner.
+ *
+ * Reads database/init/*.sql in numeric order, applies any that haven't been
+ * recorded in the _migrations tracking table, marks them on success. The
+ * tracking table is bootstrapped on first run with whatever filenames are
+ * passed via --bootstrap=<comma,separated,list> so existing prod state isn't
+ * re-applied.
+ *
+ * Single statement per file is wrapped in a transaction. If any file errors
+ * the runner aborts and leaves prior commits intact — the next run picks up
+ * where the failure happened.
+ *
+ * Usage:
+ *   DATABASE_URL=postgresql://... bun scripts/migrate.ts
+ *   DATABASE_URL=... bun scripts/migrate.ts --dry-run
+ *   DATABASE_URL=... bun scripts/migrate.ts --bootstrap=01-schema.sql,02-...
+ *
+ * This is the canonical runner. The Railway backend Dockerfile installs Bun
+ * and invokes this at container start, before uvicorn, so every prod deploy
+ * catches up on any unapplied database/init/*.sql files.
+ */
+
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import pkg from "pg";
+
+const { Client } = pkg;
+
+const ROOT = resolve(import.meta.dir, "..");
+const INIT_DIR = join(ROOT, "database", "init");
+
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has("--dry-run");
+const bootstrapArg = process.argv
+  .find((a) => a.startsWith("--bootstrap="))
+  ?.split("=", 2)[1];
+const bootstrap = bootstrapArg ? bootstrapArg.split(",").map((s) => s.trim()).filter(Boolean) : null;
+
+function listMigrationFiles(): string[] {
+  return readdirSync(INIT_DIR)
+    .filter((f) => f.endsWith(".sql") && !f.includes(" 2."))
+    .sort();
+}
+
+async function main() {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) {
+    console.error("[migrate] DATABASE_URL is not set");
+    process.exit(1);
+  }
+  if (!existsSync(INIT_DIR)) {
+    console.error(`[migrate] migration dir not found: ${INIT_DIR}`);
+    process.exit(1);
+  }
+
+  const client = new Client({ connectionString: dbUrl });
+  await client.connect();
+  try {
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS _migrations (
+        filename   TEXT PRIMARY KEY,
+        applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+
+    if (bootstrap && bootstrap.length > 0) {
+      console.log(`[migrate] bootstrap: marking ${bootstrap.length} file(s) as applied`);
+      for (const f of bootstrap) {
+        await client.query(
+          `INSERT INTO _migrations (filename) VALUES ($1) ON CONFLICT DO NOTHING`,
+          [f],
+        );
+      }
+    }
+
+    const applied = new Set(
+      (await client.query<{ filename: string }>(`SELECT filename FROM _migrations`)).rows.map(
+        (r) => r.filename,
+      ),
+    );
+
+    const files = listMigrationFiles();
+    const pending = files.filter((f) => !applied.has(f));
+    if (pending.length === 0) {
+      console.log(`[migrate] up to date (${files.length} files, ${applied.size} applied)`);
+      return;
+    }
+    console.log(`[migrate] ${pending.length} pending: ${pending.join(", ")}`);
+
+    for (const f of pending) {
+      const sql = readFileSync(join(INIT_DIR, f), "utf8");
+      if (dryRun) {
+        console.log(`[migrate] DRY-RUN would apply ${f} (${sql.length} bytes)`);
+        continue;
+      }
+      console.log(`[migrate] applying ${f}...`);
+      try {
+        await client.query("BEGIN");
+        await client.query(sql);
+        await client.query(
+          `INSERT INTO _migrations (filename) VALUES ($1) ON CONFLICT DO NOTHING`,
+          [f],
+        );
+        await client.query("COMMIT");
+        console.log(`[migrate]   ok ${f}`);
+      } catch (err) {
+        await client.query("ROLLBACK");
+        console.error(`[migrate]   FAILED ${f}:`, err instanceof Error ? err.message : err);
+        process.exit(1);
+      }
+    }
+    console.log(`[migrate] done. applied ${pending.length} new migration(s).`);
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/(alchm)/birth-chart/page.tsx
+++ b/src/app/(alchm)/birth-chart/page.tsx
@@ -5,6 +5,7 @@ import { AlchemicalConstitutionPanel } from '@/components/profile/AlchemicalCons
 import { CosmicAlignmentCard } from '@/components/profile/CosmicAlignmentCard';
 import { ElementalWheel } from '@/components/profile/ElementalWheel';
 import { auth } from '@/lib/auth/auth';
+import { withTimeout } from '@/lib/performance/withTimeout';
 import { userDatabase } from '@/services/userDatabaseService';
 
 
@@ -15,7 +16,15 @@ export default async function BirthChartPage() {
     redirect('/login');
   }
 
-  const profile = await userDatabase.getUserByEmail(session.user.email);
+  // 8s ceiling so a slow Railway lookup can't wedge the Vercel function until
+  // its 60s hard limit. On timeout we fall through the same redirect as a
+  // genuinely missing chart.
+  const profile = await withTimeout(
+    userDatabase.getUserByEmail(session.user.email),
+    8000,
+    null,
+    'birth-chart getUserByEmail',
+  );
   if (!profile?.profile?.natalChart) {
     redirect('/profile'); // Go to onboarding
   }

--- a/src/app/(alchm)/current-chart/page.tsx
+++ b/src/app/(alchm)/current-chart/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { auth } from '@/lib/auth/auth';
+import { withTimeout } from '@/lib/performance/withTimeout';
 import { userDatabase } from '@/services/userDatabaseService';
 import { CurrentChartClient } from './CurrentChartClient';
 
@@ -11,7 +12,15 @@ export default async function CurrentChartPage() {
     redirect('/login');
   }
 
-  const profile = await userDatabase.getUserByEmail(session.user.email);
+  // 8s ceiling so a slow Railway lookup can't wedge the Vercel function until
+  // its 60s hard limit. On timeout we fall through the same redirect as a
+  // genuinely missing chart.
+  const profile = await withTimeout(
+    userDatabase.getUserByEmail(session.user.email),
+    8000,
+    null,
+    'current-chart getUserByEmail',
+  );
   if (!profile?.profile?.natalChart) {
     redirect('/profile'); // Go to onboarding
   }

--- a/src/app/(alchm)/layout.tsx
+++ b/src/app/(alchm)/layout.tsx
@@ -16,6 +16,13 @@ import type { ReactNode } from "react";
  */
 export const dynamic = "force-dynamic";
 
+// Cap the server function at 30s instead of inheriting the Vercel default 60s.
+// Every page in this group is either a 'use client' shell (no server-side
+// awaits) or wraps a single DB read that we already cap at 8s. 30s is more
+// than 3x the worst legitimate case, so any longer hang is a bug worth
+// surfacing fast — and a 30s failure is much better UX than 60s.
+export const maxDuration = 30;
+
 export default function AlchmLayout({ children }: { children: ReactNode }) {
   return (
     <div data-alchm-route="true" className="alchm-root lab">

--- a/src/app/(alchm)/loading.tsx
+++ b/src/app/(alchm)/loading.tsx
@@ -1,0 +1,60 @@
+/**
+ * Route-group loading state for (alchm)/*.
+ *
+ * Next.js streams this immediately while the page-tree renders. Without it,
+ * a slow render (e.g. cold-start tail latency on /profile or
+ * /restaurant-creator) leaves the user looking at a blank page until either
+ * SSR completes or the 60s function timeout fires. With it, the loading
+ * skeleton ships in the first chunk and the user sees motion.
+ *
+ * Intentionally minimal so it's small and renders instantly without pulling
+ * in heavy client modules.
+ */
+export default function AlchmLoading() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Loading"
+      className="alchm-loading"
+      style={{
+        minHeight: "60vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        color: "rgba(255,255,255,0.5)",
+        fontFamily: "var(--font-mono, ui-monospace, monospace)",
+        fontSize: "0.75rem",
+        letterSpacing: "0.15em",
+        textTransform: "uppercase",
+      }}
+    >
+      <span
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "0.75rem",
+        }}
+      >
+        <span
+          aria-hidden="true"
+          style={{
+            width: "8px",
+            height: "8px",
+            borderRadius: "999px",
+            background: "currentColor",
+            opacity: 0.6,
+            animation: "alchm-pulse 1.4s ease-in-out infinite",
+          }}
+        />
+        Aligning
+      </span>
+      <style>{`
+        @keyframes alchm-pulse {
+          0%, 100% { opacity: 0.25; transform: scale(0.9); }
+          50% { opacity: 0.85; transform: scale(1.15); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/app/admin/_dashboard/Dashboard.tsx
+++ b/src/app/admin/_dashboard/Dashboard.tsx
@@ -32,7 +32,15 @@ import {
   SecurityPanel,
 } from "./panels";
 import { AdminShell, ArchitectCard } from "./shell";
-import { SkyConditions, AstronomicalEngine, SEMSDistribution } from "./sky";
+import { AstronomicalEngine, SEMSDistribution, SkyConditions } from "./sky";
+
+function shortSha(): string {
+  return (
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(0, 7) ??
+    process.env.NEXT_PUBLIC_BUILD_ID ??
+    "local"
+  );
+}
 
 interface DashboardProps {
   data: AdminDashboardData;
@@ -117,14 +125,16 @@ export function Dashboard({ data }: DashboardProps) {
         `}
       </style>
 
-      <AdminShell density={density} showGrid={showGrid} user={data.user} pulse={data.pulse}>
+      <AdminShell density={density} showGrid={showGrid} user={data.user} pulse={data.pulse} data={data}>
         <MasterLineHero
           greeting={`Good ${data.skyConditions.planetaryHour.planet} hour, ${data.user.name.split(" ")[0]}`}
+          data={data}
         />
-        <KPIStrip />
+        <KPIStrip data={data} />
         <SkyConditions data={data.skyConditions} />
 
         <div
+          className="dash-stack"
           style={{
             display: "grid",
             gridTemplateColumns: "320px 1.4fr 1fr",
@@ -132,19 +142,23 @@ export function Dashboard({ data }: DashboardProps) {
             marginBottom: 12,
           }}
         >
-          <ArchitectCard user={data.user} />
+          <ArchitectCard user={data.user} recentAlerts={data.recentAlerts} />
           <ServiceMatrix systemStatus={data.systemStatus} />
           <LiveEventStream liveActivity={data.liveActivity} />
         </div>
 
         <AgentFeedControlRoom />
 
-        <div style={{ display: "grid", gridTemplateColumns: "1.2fr 1fr", gap: 12, marginBottom: 12 }}>
+        <div className="dash-stack" style={{ display: "grid", gridTemplateColumns: "1.2fr 1fr", gap: 12, marginBottom: 12 }}>
           <SEMSDistribution />
-          <AstronomicalEngine live={data.skyConditions.live} />
+          <AstronomicalEngine
+            live={data.skyConditions.live}
+            pageTelemetry={data.pageTelemetry}
+          />
         </div>
 
         <div
+          className="dash-stack"
           style={{
             display: "grid",
             gridTemplateColumns: "1fr 1.4fr 1fr",
@@ -157,17 +171,18 @@ export function Dashboard({ data }: DashboardProps) {
           <IncidentsPanel recentAlerts={data.recentAlerts} />
         </div>
 
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1.3fr", gap: 12, marginBottom: 12 }}>
+        <div className="dash-stack" style={{ display: "grid", gridTemplateColumns: "1fr 1.3fr", gap: 12, marginBottom: 12 }}>
           <SubdomainMatrix pageTelemetry={data.pageTelemetry} />
           <APIHeatmap db={data.dbObservability} />
         </div>
 
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, marginBottom: 12 }}>
+        <div className="dash-stack" style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, marginBottom: 12 }}>
           <EngineHealth enginePerformance={data.enginePerformance} />
           <RecipeQualityInspector trending={data.catalogTrending} />
         </div>
 
         <div
+          className="dash-stack"
           style={{
             display: "grid",
             gridTemplateColumns: "1fr 0.9fr 1fr",
@@ -180,12 +195,13 @@ export function Dashboard({ data }: DashboardProps) {
           <CommercePanel commerceSummary={data.commerce} />
         </div>
 
-        <div style={{ display: "grid", gridTemplateColumns: "1.4fr 1fr", gap: 12, marginBottom: 12 }}>
+        <div className="dash-stack" style={{ display: "grid", gridTemplateColumns: "1.4fr 1fr", gap: 12, marginBottom: 12 }}>
           <CosmicYieldEconomy data={data.cosmicYield} />
           <PractitionerGeo />
         </div>
 
         <div
+          className="dash-stack"
           style={{
             display: "grid",
             gridTemplateColumns: "1.2fr 1fr 1fr",
@@ -198,12 +214,12 @@ export function Dashboard({ data }: DashboardProps) {
           <CostBurndown />
         </div>
 
-        <div style={{ display: "grid", gridTemplateColumns: "1.2fr 1fr", gap: 12, marginBottom: 12 }}>
+        <div className="dash-stack" style={{ display: "grid", gridTemplateColumns: "1.2fr 1fr", gap: 12, marginBottom: 12 }}>
           <ModerationQueue />
           <SecurityPanel security={data.security} />
         </div>
 
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 12, marginBottom: 12 }}>
+        <div className="dash-stack" style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 12, marginBottom: 12 }}>
           <DeploysPanel />
           <FeatureFlagsPanel />
           <AuditLogPanel data={data.auditEvents} />
@@ -218,16 +234,27 @@ export function Dashboard({ data }: DashboardProps) {
             border: "1px solid var(--line)",
             borderRadius: 10,
             background: "rgba(255,255,255,0.012)",
+            flexWrap: "wrap",
+            gap: 12,
           }}
         >
-          <div style={{ display: "flex", gap: 18 }}>
+          <div style={{ display: "flex", gap: 18, flexWrap: "wrap" }}>
             <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>
-              alchm.kitchen · admin v2.7.4 · agentic.alchm.kitchen
+              alchm.kitchen · admin · agentic.alchm.kitchen
             </span>
-            <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>region · us-east-1</span>
-            <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>build · #c8f1ad</span>
+            <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>
+              region · {process.env.NEXT_PUBLIC_VERCEL_REGION ?? "—"}
+            </span>
+            <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>
+              build · #{shortSha()}
+            </span>
+            {data.meta.mockedFields.length > 0 && (
+              <span className="t-mono" style={{ fontSize: 9.5, color: "var(--el-fire)" }}>
+                mocked: {data.meta.mockedFields.join(", ")}
+              </span>
+            )}
           </div>
-          <div style={{ display: "flex", gap: 18 }}>
+          <div style={{ display: "flex", gap: 18, flexWrap: "wrap" }}>
             <span
               className="t-mono"
               style={{
@@ -237,12 +264,12 @@ export function Dashboard({ data }: DashboardProps) {
             >
               ● {data.skyConditions.planetaryHour.planet.toLowerCase()} hour
               {" · "}
-              {new Date(data.skyConditions.generatedAt)
-                .toISOString()
-                .slice(11, 16)} UTC
-            </span>
-            <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>
-              JD 2460814.71 · VSOP87/DE440
+              {data.skyConditions.live
+                ? new Date(data.skyConditions.generatedAt)
+                    .toISOString()
+                    .slice(11, 16)
+                : "—"}{" "}
+              UTC
             </span>
             <span
               className="t-mono"
@@ -251,7 +278,22 @@ export function Dashboard({ data }: DashboardProps) {
                 color: data.skyConditions.live ? "var(--el-earth)" : "var(--fg-mute)",
               }}
             >
-              {data.skyConditions.live ? "● all systems · live" : "○ ephemeris · degraded"}
+              {data.skyConditions.live ? "● ephemeris · live" : "○ ephemeris · degraded"}
+            </span>
+            <span
+              className="t-mono"
+              style={{
+                fontSize: 9.5,
+                color:
+                  data.pulse.state === "NOMINAL"
+                    ? "var(--el-earth)"
+                    : data.pulse.state === "DEGRADED"
+                      ? "var(--el-fire)"
+                      : "#FF5252",
+              }}
+            >
+              {data.pulse.state === "NOMINAL" ? "● " : "○ "}
+              systems · {data.pulse.state.toLowerCase()}
             </span>
           </div>
         </footer>

--- a/src/app/admin/_dashboard/dashboard.css
+++ b/src/app/admin/_dashboard/dashboard.css
@@ -448,3 +448,127 @@
 .dashboard-root ::-webkit-scrollbar-track {
   background: transparent;
 }
+
+/* =========================================================
+   RESPONSIVE / MOBILE
+   The dashboard ships with a 232px left rail, 56px top bar
+   and several 3-column inline grids. Below 960px we collapse
+   the rail into an off-canvas drawer toggled by a hamburger
+   button in the top bar, hide non-essential top-bar metrics,
+   and force inline-styled multi-col grids (tagged with the
+   .dash-stack helper) into a single column.
+   ========================================================= */
+.dash-hamburger {
+  display: none;
+}
+@media (max-width: 960px) {
+  /* shell: collapse the side rail into a drawer */
+  .admin-shell {
+    grid-template-rows: 56px 1fr;
+  }
+  .admin-shell > div[data-shell-body] {
+    grid-template-columns: 1fr !important;
+  }
+  .admin-shell aside[data-shell-rail] {
+    position: fixed;
+    top: 56px;
+    left: 0;
+    bottom: 0;
+    width: 260px;
+    z-index: 20;
+    background: var(--bg);
+    transform: translateX(-100%);
+    transition: transform 0.22s ease;
+    border-right: 1px solid var(--line-hi);
+  }
+  .admin-shell.nav-open aside[data-shell-rail] {
+    transform: translateX(0);
+    box-shadow: 0 0 60px 0 var(--accent-glow);
+  }
+  .admin-shell.nav-open::after {
+    content: "";
+    position: fixed;
+    inset: 56px 0 0 0;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 15;
+    backdrop-filter: blur(2px);
+  }
+  .dash-hamburger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    border: 1px solid var(--line);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--fg);
+    cursor: pointer;
+  }
+
+  /* hide top-bar clutter and the center metrics */
+  .admin-shell [data-shell-topbar-metrics],
+  .admin-shell [data-shell-time],
+  .admin-shell [data-shell-deploy-btn] {
+    display: none !important;
+  }
+  .admin-shell header[data-shell-topbar] {
+    grid-template-columns: auto 1fr auto !important;
+    gap: 8px !important;
+    padding: 0 12px !important;
+  }
+  .admin-shell main[data-shell-main] {
+    padding: 12px 12px 96px !important;
+  }
+
+  /* stack helpers — applied to inline-styled grids in Dashboard.tsx */
+  .dash-stack {
+    grid-template-columns: 1fr !important;
+  }
+  .dash-stack-2 {
+    grid-template-columns: 1fr !important;
+  }
+  .dash-hero-grid {
+    grid-template-columns: 1fr !important;
+  }
+  .dash-hero-aside {
+    display: none !important;
+  }
+  .dash-hero-tickers {
+    grid-template-columns: repeat(2, 1fr) !important;
+  }
+  .dash-kpi-grid {
+    grid-template-columns: repeat(2, 1fr) !important;
+  }
+  .dash-kpi-grid > div:nth-child(2n) {
+    border-right: none !important;
+  }
+  .dash-kpi-grid > div:nth-child(-n + 10) {
+    border-bottom: 1px solid var(--line) !important;
+  }
+
+  /* tighten panel internals */
+  .dashboard-root .panel,
+  .dashboard-root .panel-glow,
+  .dashboard-root .panel-flat {
+    min-width: 0;
+  }
+  .dashboard-root .panel > div,
+  .dashboard-root .panel-glow > div {
+    min-width: 0;
+  }
+
+  /* never let the master-line greeting bleed off-screen */
+  .dashboard-root .t-display {
+    font-size: 22px !important;
+  }
+}
+
+@media (max-width: 600px) {
+  .dash-kpi-grid {
+    grid-template-columns: 1fr !important;
+  }
+  .dash-kpi-grid > div {
+    border-right: none !important;
+  }
+}

--- a/src/app/admin/_dashboard/hero.tsx
+++ b/src/app/admin/_dashboard/hero.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { ScanLine, Sparkline } from "./atoms";
-import { seeded } from "./data";
+import type { AdminDashboardData } from "./data";
 
 // ============================================================
 // CARD — reusable framed panel
@@ -39,9 +39,10 @@ export function Card({
             justifyContent: "space-between",
             padding: "12px 14px 8px",
             borderBottom: subtitle === false ? "none" : "1px solid var(--line)",
+            gap: 8,
           }}
         >
-          <div>
+          <div style={{ minWidth: 0 }}>
             {title && <div className="t-tag" style={{ fontSize: 9 }}>{title}</div>}
             {subtitle && <div style={{ fontSize: 12, color: "var(--fg-dim)", marginTop: 2 }}>{subtitle}</div>}
           </div>
@@ -105,26 +106,53 @@ export function Legend({ color, label }: { color: string; label: string }) {
 }
 
 // ============================================================
-// MASTER LINE HERO
+// MASTER LINE HERO — wired to pulse + recentAlerts + systemStatus
 // ============================================================
 interface HeroEvent {
   i: number;
-  kind: "deploy" | "warn" | "inc" | "ok";
+  kind: "alert" | "incident" | "ok";
   label: string;
 }
 
-export function MasterLineHero({ greeting = "Good Mars hour, Greg" }: { greeting?: string }) {
-  const reqs = seeded(7, 96, 0.35, 0.92);
-  const errs = seeded(13, 96, 0.05, 0.2).map((v, i) =>
-    i > 70 && i < 78 ? v * 2.4 : i > 30 && i < 34 ? v * 1.6 : v,
-  );
-  const events: HeroEvent[] = [
-    { i: 16, kind: "deploy", label: "deploy · 2.7.3" },
-    { i: 32, kind: "warn", label: "queue spike · planner" },
-    { i: 54, kind: "deploy", label: "deploy · 2.7.4" },
-    { i: 74, kind: "inc", label: "INC-2207 · cart 5xx" },
-    { i: 86, kind: "ok", label: "engine v17.4 cutover" },
-  ];
+interface MasterLineHeroProps {
+  greeting?: string;
+  data: AdminDashboardData;
+}
+
+export function MasterLineHero({ greeting = "Good Mars hour, Greg", data }: MasterLineHeroProps) {
+  const { pulse, recentAlerts, systemStatus, commerce } = data;
+
+  // Distribute the recent alerts across the 0..96 sample window as visual
+  // event markers. We don't try to time-align them — just show that they
+  // exist on the timeline as anchors operators can scan.
+  const alerts = recentAlerts.entries.slice(0, 5);
+  const events: HeroEvent[] = alerts.map((a, idx) => ({
+    i: Math.round(((idx + 0.5) / Math.max(1, alerts.length)) * 92),
+    kind:
+      a.severity === "error"
+        ? "incident"
+        : a.severity === "warn"
+          ? "alert"
+          : "ok",
+    label: a.title.length > 28 ? `${a.title.slice(0, 26)}…` : a.title,
+  }));
+
+  // Synthesize a flat baseline trace; we don't yet capture per-minute request
+  // counts. The events markers carry the signal; the trace is just chrome.
+  const baseline = pulse.errRate > 0.5 ? 0.65 : 0.4;
+  const reqs = Array.from({ length: 96 }, (_, i) => {
+    const wave = 0.15 * Math.sin((i / 96) * Math.PI * 4);
+    return Math.max(0.15, Math.min(0.95, baseline + wave));
+  });
+  const errs = Array.from({ length: 96 }, () => Math.min(0.4, pulse.errRate / 5));
+
+  const incidentCount = systemStatus.flows.filter((f) => f.status === "INCIDENT").length;
+  const subtitle =
+    pulse.activeIncidents > 0 || incidentCount > 0
+      ? `${pulse.activeIncidents || incidentCount} active incident${(pulse.activeIncidents || incidentCount) === 1 ? "" : "s"}`
+      : recentAlerts.entries.length > 0
+        ? `${recentAlerts.entries.length} recent alert${recentAlerts.entries.length === 1 ? "" : "s"}`
+        : "all systems quiet";
 
   return (
     <section
@@ -132,7 +160,10 @@ export function MasterLineHero({ greeting = "Good Mars hour, Greg" }: { greeting
       style={{ padding: 18, marginBottom: 14, position: "relative", overflow: "hidden" }}
     >
       <ScanLine />
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 320px", gap: 22 }}>
+      <div
+        className="dash-hero-grid"
+        style={{ display: "grid", gridTemplateColumns: "1fr 320px", gap: 22 }}
+      >
         <div style={{ minWidth: 0 }}>
           <div
             style={{
@@ -140,11 +171,21 @@ export function MasterLineHero({ greeting = "Good Mars hour, Greg" }: { greeting
               alignItems: "baseline",
               justifyContent: "space-between",
               marginBottom: 6,
+              gap: 8,
+              flexWrap: "wrap",
             }}
           >
-            <div>
+            <div style={{ minWidth: 0 }}>
               <div className="t-tag">MASTER LINE · 24H · SITE-WIDE</div>
-              <div style={{ display: "flex", alignItems: "baseline", gap: 14, marginTop: 2 }}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "baseline",
+                  gap: 14,
+                  marginTop: 2,
+                  flexWrap: "wrap",
+                }}
+              >
                 <h2 className="t-display" style={{ margin: 0, fontSize: 30, letterSpacing: "-0.005em" }}>
                   {greeting}
                 </h2>
@@ -152,7 +193,7 @@ export function MasterLineHero({ greeting = "Good Mars hour, Greg" }: { greeting
                   className="t-mono"
                   style={{ fontSize: 11, color: "var(--fg-mute)", letterSpacing: "0.12em" }}
                 >
-                  3 items want your sign-off · 1 active incident
+                  {subtitle}
                 </span>
               </div>
             </div>
@@ -167,30 +208,52 @@ export function MasterLineHero({ greeting = "Good Mars hour, Greg" }: { greeting
           <Heartbeat reqs={reqs} errs={errs} events={events} />
 
           <div
+            className="dash-hero-tickers"
             style={{
               marginTop: 12,
               display: "grid",
-              gridTemplateColumns: "repeat(8, 1fr)",
+              gridTemplateColumns: "repeat(6, 1fr)",
               border: "1px solid var(--line)",
               borderRadius: 8,
               overflow: "hidden",
               background: "rgba(0,0,0,0.25)",
             }}
           >
-            <Ticker label="REQ/s" value="1,284" delta="+4.2%" up />
-            <Ticker label="ACTIVE" value="3,917" delta="+1.1%" up />
-            <Ticker label="P50" value="42ms" delta="-3ms" up />
-            <Ticker label="P95" value="184ms" delta="+8ms" warn />
-            <Ticker label="ERR" value="0.04%" delta="-0.01" up />
-            <Ticker label="QUEUE" value="14" delta="+6" warn />
-            <Ticker label="MRR" value="$84.2k" delta="+$1.6k" up />
-            <Ticker label="MESH" value="412/440" delta="-2" warn last />
+            <Ticker label="AVAIL" value={`${pulse.availability.toFixed(2)}%`} delta="rolling" up={pulse.availability >= 99} warn={pulse.availability < 99} />
+            <Ticker label="P95" value={`${pulse.p95}ms`} delta="req log" warn={pulse.p95 > 500} up={pulse.p95 <= 500} />
+            <Ticker
+              label="ERR"
+              value={`${pulse.errRate.toFixed(2)}%`}
+              delta={pulse.errRate > 0 ? "active" : "nominal"}
+              warn={pulse.errRate > 0.5}
+              up={pulse.errRate <= 0.5}
+            />
+            <Ticker
+              label="INC"
+              value={String(pulse.activeIncidents || incidentCount)}
+              delta={pulse.state}
+              warn={pulse.activeIncidents > 0 || incidentCount > 0}
+              up={pulse.activeIncidents === 0 && incidentCount === 0}
+            />
+            <Ticker
+              label="MRR"
+              value={
+                commerce.live
+                  ? commerce.mrr >= 1000
+                    ? `$${(commerce.mrr / 1000).toFixed(1).replace(/\.0$/, "")}k`
+                    : `$${commerce.mrr.toLocaleString()}`
+                  : "—"
+              }
+              delta="active subs"
+              up={commerce.mrr > 0}
+            />
+            <Ticker label="DEPLOY" value={pulse.deployFreshness} delta="fresh" up last />
           </div>
         </div>
 
-        <div>
+        <div className="dash-hero-aside">
           <div className="t-tag" style={{ marginBottom: 6 }}>SYSTEM STANDING CHART</div>
-          <SystemStandingChart />
+          <SystemStandingChart systemStatus={systemStatus} />
         </div>
       </div>
     </section>
@@ -260,13 +323,11 @@ function Heartbeat({
         {events.map((e, idx) => {
           const x = xOf(e.i);
           const color =
-            e.kind === "inc"
+            e.kind === "incident"
               ? "#FF5252"
-              : e.kind === "warn"
+              : e.kind === "alert"
                 ? "var(--el-fire)"
-                : e.kind === "deploy"
-                  ? "var(--accent-2)"
-                  : "var(--el-earth)";
+                : "var(--el-earth)";
           return (
             <g key={idx}>
               <line
@@ -299,36 +360,36 @@ function Heartbeat({
           </text>
         ))}
       </svg>
-      <div style={{ position: "absolute", left: 12, top: 10, display: "flex", gap: 8, flexWrap: "wrap" }}>
-        {events.map((e, i) => {
-          const color =
-            e.kind === "inc"
-              ? "#FF5252"
-              : e.kind === "warn"
-                ? "var(--el-fire)"
-                : e.kind === "deploy"
-                  ? "var(--accent-2)"
+      {events.length > 0 && (
+        <div style={{ position: "absolute", left: 12, top: 10, display: "flex", gap: 8, flexWrap: "wrap" }}>
+          {events.map((e, i) => {
+            const color =
+              e.kind === "incident"
+                ? "#FF5252"
+                : e.kind === "alert"
+                  ? "var(--el-fire)"
                   : "var(--el-earth)";
-          return (
-            <span
-              key={i}
-              style={{
-                fontFamily: "JetBrains Mono",
-                fontSize: 9,
-                letterSpacing: "0.1em",
-                padding: "2px 8px",
-                borderRadius: 999,
-                background: "rgba(0,0,0,0.5)",
-                border: `1px solid ${color}`,
-                color,
-                textTransform: "uppercase",
-              }}
-            >
-              {e.label}
-            </span>
-          );
-        })}
-      </div>
+            return (
+              <span
+                key={i}
+                style={{
+                  fontFamily: "JetBrains Mono",
+                  fontSize: 9,
+                  letterSpacing: "0.1em",
+                  padding: "2px 8px",
+                  borderRadius: 999,
+                  background: "rgba(0,0,0,0.5)",
+                  border: `1px solid ${color}`,
+                  color,
+                  textTransform: "uppercase",
+                }}
+              >
+                {e.label}
+              </span>
+            );
+          })}
+        </div>
+      )}
       <div
         style={{
           position: "absolute",
@@ -384,22 +445,40 @@ function Ticker({
 }
 
 // ----- System standing chart (services as planets) -----
-function SystemStandingChart() {
+const SVC_COLOR_BY_STATUS: Record<string, string> = {
+  OK: "var(--el-earth)",
+  DEGRADED: "var(--el-fire)",
+  INCIDENT: "#FF5252",
+  UNKNOWN: "var(--fg-mute)",
+};
+
+function SystemStandingChart({
+  systemStatus,
+}: {
+  systemStatus: AdminDashboardData["systemStatus"];
+}) {
   const size = 280;
   const c = size / 2;
   const services = [
-    { id: "api", sym: "A", color: "var(--accent)", health: 0.99, orbit: 0, tier: 1, label: "API" },
-    { id: "db", sym: "D", color: "var(--el-earth)", health: 0.98, orbit: 1, tier: 1, label: "PG" },
-    { id: "engine", sym: "E", color: "var(--accent-2)", health: 0.96, orbit: 2, tier: 1, label: "ENG" },
-    { id: "auth", sym: "Z", color: "var(--el-air)", health: 0.97, orbit: 1, tier: 1, label: "AUTH" },
-    { id: "queue", sym: "Q", color: "var(--el-fire)", health: 0.82, orbit: 2, tier: 2, label: "QUE", warn: true },
-    { id: "mesh", sym: "M", color: "var(--accent)", health: 0.94, orbit: 3, tier: 2, label: "MESH" },
-    { id: "cdn", sym: "C", color: "var(--el-water)", health: 0.99, orbit: 3, tier: 2, label: "CDN" },
-    { id: "search", sym: "S", color: "var(--el-earth)", health: 0.95, orbit: 2, tier: 2, label: "SRCH" },
-    { id: "ml", sym: "L", color: "var(--accent-2)", health: 0.9, orbit: 3, tier: 3, label: "ML" },
-    { id: "amz", sym: "Z", color: "var(--el-air)", health: 0.93, orbit: 4, tier: 3, label: "AMZ" },
-    { id: "billing", sym: "B", color: "var(--el-earth)", health: 0.97, orbit: 4, tier: 3, label: "STR" },
+    ...systemStatus.flows.map((f, i) => ({
+      id: f.id,
+      label: f.label.slice(0, 6).toUpperCase(),
+      status: f.status,
+      orbit: i < 4 ? 1 : 2,
+      tier: 1,
+      warn: f.status === "DEGRADED" || f.status === "INCIDENT",
+    })),
+    ...systemStatus.dependencies.map((d, i) => ({
+      id: d.id,
+      label: d.label.slice(0, 6).toUpperCase(),
+      status: d.status,
+      orbit: 3 + (i % 2),
+      tier: 2,
+      warn: d.status === "DEGRADED" || d.status === "INCIDENT",
+    })),
   ];
+  const totalGreen = services.filter((s) => s.status === "OK").length;
+  const totalDegraded = services.filter((s) => s.status === "DEGRADED").length;
   const radii = [60, 84, 108, 132];
   return (
     <div
@@ -443,87 +522,234 @@ function SystemStandingChart() {
         <text x={c} y={c + 3} fill="var(--accent)" fontSize="10" fontFamily="JetBrains Mono" textAnchor="middle">
           CORE
         </text>
-        {services.map((s, i) => {
-          const r = radii[s.orbit] || radii[0];
-          const a = (i / services.length) * 2 * Math.PI - Math.PI / 2;
-          const x = c + Math.cos(a) * r;
-          const y = c + Math.sin(a) * r;
-          return (
-            <g key={s.id}>
-              {s.tier === 1 && (
-                <line x1={c} y1={c} x2={x} y2={y} stroke={s.color} strokeWidth="0.4" opacity="0.4" />
-              )}
-              <circle
-                cx={x}
-                cy={y}
-                r={s.warn ? 9 : 7}
-                fill={`color-mix(in oklch, ${s.color}, black 30%)`}
-                stroke={s.color}
-                strokeWidth={s.warn ? 1.2 : 0.8}
-                style={{ filter: s.warn ? `drop-shadow(0 0 6px ${s.color})` : "none" }}
-              />
-              <text
-                x={x}
-                y={y + 3}
-                fill="rgba(0,0,0,0.7)"
-                fontSize="8"
-                fontFamily="JetBrains Mono"
-                textAnchor="middle"
-                fontWeight="600"
-              >
-                {s.sym}
-              </text>
-              <text
-                x={x}
-                y={y + (s.orbit > 1 ? 20 : -12)}
-                fill={s.warn ? s.color : "var(--fg-mute)"}
-                fontSize="7"
-                fontFamily="JetBrains Mono"
-                textAnchor="middle"
-                letterSpacing="1"
-              >
-                {s.label}
-              </text>
-            </g>
-          );
-        })}
+        {services.length === 0 ? (
+          <text
+            x={c}
+            y={c + 50}
+            fill="var(--fg-mute)"
+            fontSize="9"
+            fontFamily="JetBrains Mono"
+            textAnchor="middle"
+          >
+            no systemStatus data
+          </text>
+        ) : (
+          services.map((s, i) => {
+            const r = radii[Math.min(s.orbit, radii.length - 1)] || radii[0];
+            const a = (i / services.length) * 2 * Math.PI - Math.PI / 2;
+            const x = c + Math.cos(a) * r;
+            const y = c + Math.sin(a) * r;
+            const color = SVC_COLOR_BY_STATUS[s.status] ?? "var(--fg-mute)";
+            return (
+              <g key={s.id}>
+                {s.tier === 1 && (
+                  <line x1={c} y1={c} x2={x} y2={y} stroke={color} strokeWidth="0.4" opacity="0.4" />
+                )}
+                <circle
+                  cx={x}
+                  cy={y}
+                  r={s.warn ? 9 : 7}
+                  fill={`color-mix(in oklch, ${color}, black 30%)`}
+                  stroke={color}
+                  strokeWidth={s.warn ? 1.2 : 0.8}
+                  style={{ filter: s.warn ? `drop-shadow(0 0 6px ${color})` : "none" }}
+                />
+                <text
+                  x={x}
+                  y={y + (s.orbit > 1 ? 20 : -12)}
+                  fill={s.warn ? color : "var(--fg-mute)"}
+                  fontSize="7"
+                  fontFamily="JetBrains Mono"
+                  textAnchor="middle"
+                  letterSpacing="1"
+                >
+                  {s.label}
+                </text>
+              </g>
+            );
+          })
+        )}
       </svg>
       <div style={{ position: "absolute", top: 8, left: 10 }} className="t-mono">
         <div style={{ fontSize: 9, color: "var(--fg-mute)", letterSpacing: "0.14em" }}>T1 · CRITICAL</div>
       </div>
       <div style={{ position: "absolute", top: 8, right: 10, textAlign: "right" }} className="t-mono">
-        <div style={{ fontSize: 9, color: "var(--accent)", letterSpacing: "0.14em" }}>11 / 12 GREEN</div>
+        <div style={{ fontSize: 9, color: "var(--accent)", letterSpacing: "0.14em" }}>
+          {totalGreen} / {services.length} GREEN
+        </div>
       </div>
-      <div style={{ position: "absolute", bottom: 8, left: 10 }} className="t-mono">
-        <div style={{ fontSize: 9, color: "var(--el-fire)", letterSpacing: "0.14em" }}>QUE · DEGRADED</div>
-      </div>
+      {totalDegraded > 0 && (
+        <div style={{ position: "absolute", bottom: 8, left: 10 }} className="t-mono">
+          <div style={{ fontSize: 9, color: "var(--el-fire)", letterSpacing: "0.14em" }}>
+            {totalDegraded} DEGRADED
+          </div>
+        </div>
+      )}
       <div style={{ position: "absolute", bottom: 8, right: 10, textAlign: "right" }} className="t-mono">
-        <div style={{ fontSize: 9, color: "var(--fg-mute)", letterSpacing: "0.14em" }}>T3 · AUX</div>
+        <div style={{ fontSize: 9, color: "var(--fg-mute)", letterSpacing: "0.14em" }}>T2 · DEP</div>
       </div>
     </div>
   );
 }
 
 // ============================================================
-// KPI STRIP
+// KPI STRIP — wired to real telemetry
+// Drops the prototype's 12 fabricated tiles in favor of 10 metrics
+// that all come from real sources. Layout: 5 per row on desktop.
 // ============================================================
-export function KPIStrip() {
-  const kpis = [
-    { label: "Practitioners · DAU", v: "12,847", d: "+612 · 24h", spark: seeded(1, 36, 0.4, 0.95), tone: "ok" },
-    { label: "Recipes/min · Tier II", v: "184", d: "↑ peak 21:32", spark: seeded(2, 36, 0.3, 0.9), tone: "ok" },
-    { label: "MRR", v: "$84,210", d: "+$1.6k MoM", spark: seeded(3, 36, 0.4, 0.9), tone: "ok" },
-    { label: "Engine v17.4 NDCG@10", v: "0.742", d: "+0.018 vs v17.3", spark: seeded(5, 36, 0.5, 0.95), tone: "ok" },
-    { label: "Calibration · R²", v: "0.942", d: "obs vs pred", spark: seeded(31, 36, 0.85, 0.96), tone: "ok" },
-    { label: "Agent dispatches/min", v: "1,284", d: "+118 · across mesh", spark: seeded(7, 36, 0.5, 0.92), tone: "ok" },
-    { label: "Galileo · gen/min", v: "22", d: "GPU 78% · 0.6% fail", spark: seeded(8, 36, 0.6, 0.95), tone: "ok" },
-    { label: "Substitution fidelity", v: "0.864", d: "86 swaps/min", spark: seeded(12, 36, 0.7, 0.9), tone: "ok" },
-    { label: "Ephemeris drift", v: "0.38″", d: "vs JPL Horizons", spark: seeded(15, 36, 0.1, 0.4), tone: "ok" },
-    { label: "Cosmic Yield velocity", v: "2.4x", d: "MoM · inflationary", spark: seeded(17, 36, 0.4, 0.9), tone: "ok" },
-    { label: "SEMS · Substance", v: "−11pts", d: "below band", spark: seeded(19, 36, 0.2, 0.5), tone: "warn" },
-    { label: "Mesh uptime", v: "412/440", d: "-2 idle · 92% role", spark: seeded(9, 36, 0.5, 0.95), tone: "warn" },
+function fmtCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1).replace(/\.0$/, "")}k`;
+  return n.toLocaleString();
+}
+
+function fmtCurrency(n: number): string {
+  if (n >= 1000) return `$${(n / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  return `$${n.toLocaleString()}`;
+}
+
+// 12-bar deterministic mini-trend so we have something for the sparkline
+// even when we don't yet have a time series. Centered around 0.5.
+function flatTrend(value: number, scale: number, len = 24): number[] {
+  const v = Math.max(0.2, Math.min(0.9, value / Math.max(scale, 1)));
+  return Array.from({ length: len }, (_, i) => v + 0.05 * Math.sin((i / len) * Math.PI * 2));
+}
+
+export function KPIStrip({ data }: { data: AdminDashboardData }) {
+  const { stats, commerce, cosmicYield, dbObservability, enginePerformance, security, recentAlerts, errorGroups, pageTelemetry } = data;
+  const onboardingRate =
+    stats.totalUsers > 0 ? stats.completedOnboarding / stats.totalUsers : 0;
+
+  const kpis: Array<{
+    label: string;
+    v: string;
+    d: string;
+    spark: number[];
+    tone: "ok" | "warn" | "neutral";
+    live?: boolean;
+  }> = [
+    {
+      label: "Practitioners · total",
+      v: fmtCount(stats.totalUsers),
+      d: `+${stats.newUsersToday} · 24h`,
+      spark: flatTrend(stats.totalUsers, 200),
+      tone: stats.newUsersToday > 0 ? "ok" : "neutral",
+      live: true,
+    },
+    {
+      label: "Active · 24h",
+      v: fmtCount(stats.activeUsers),
+      d: `${Math.round((stats.activeUsers / Math.max(stats.totalUsers, 1)) * 100)}% of base`,
+      spark: flatTrend(stats.activeUsers, Math.max(stats.totalUsers, 1)),
+      tone: "ok",
+      live: true,
+    },
+    {
+      label: "Onboarded",
+      v: fmtCount(stats.completedOnboarding),
+      d: `${(onboardingRate * 100).toFixed(1)}% complete`,
+      spark: flatTrend(onboardingRate, 1),
+      tone: onboardingRate < 0.3 ? "warn" : "ok",
+      live: true,
+    },
+    {
+      label: "Recipes · catalog",
+      v: fmtCount(stats.totalRecipes),
+      d: `${fmtCount(stats.totalIngredients)} ingredients`,
+      spark: flatTrend(stats.totalRecipes, 5000),
+      tone: "ok",
+      live: true,
+    },
+    {
+      label: "MRR · active subs",
+      v: commerce.live ? fmtCurrency(commerce.mrr) : "—",
+      d: `${stats.totalSubscriptions} subs`,
+      spark: flatTrend(commerce.mrr, 5000),
+      tone: commerce.live ? "ok" : "neutral",
+      live: commerce.live,
+    },
+    {
+      label: "Cosmic yield · circ.",
+      v: cosmicYield.live ? fmtCount(Math.round(cosmicYield.inCirculation)) : "—",
+      d: cosmicYield.live ? `${cosmicYield.netFlow30d >= 0 ? "+" : ""}${fmtCount(Math.round(cosmicYield.netFlow30d))} · 30d` : "offline",
+      spark: flatTrend(cosmicYield.inCirculation, 10000),
+      tone: cosmicYield.live ? "ok" : "neutral",
+      live: cosmicYield.live,
+    },
+    {
+      label: "Engine · click→cook",
+      v: enginePerformance.live ? `${(enginePerformance.clickToCookRate * 100).toFixed(1)}%` : "—",
+      d: enginePerformance.live ? `${fmtCount(enginePerformance.totalCalculations)} calc` : "offline",
+      spark: flatTrend(enginePerformance.clickToCookRate, 0.1),
+      tone: enginePerformance.live ? "ok" : "neutral",
+      live: enginePerformance.live,
+    },
+    {
+      label: "Engine · avg latency",
+      v: enginePerformance.live ? `${enginePerformance.averageLatencyMs}ms` : "—",
+      d: enginePerformance.averageLatencyMs > 200 ? "above SLO" : "within SLO",
+      spark: flatTrend(Math.max(50, 200 - enginePerformance.averageLatencyMs), 200),
+      tone: enginePerformance.averageLatencyMs > 200 ? "warn" : "ok",
+      live: enginePerformance.live,
+    },
+    {
+      label: "Auth · 24h failures",
+      v: security.live ? String(security.signinFailure24h) : "—",
+      d: security.live ? `${security.signinSuccess24h} success` : "offline",
+      spark: security.hourlyAttempts.map((c) =>
+        c === 0 ? 0.18 : Math.min(0.95, 0.2 + c / Math.max(...security.hourlyAttempts, 1) * 0.7),
+      ),
+      tone: security.signinFailure24h > 0 ? "warn" : "ok",
+      live: security.live,
+    },
+    {
+      label: "DB · pool",
+      v: dbObservability.live ? `${dbObservability.pool.total - dbObservability.pool.idle}/${dbObservability.pool.max}` : "—",
+      d:
+        dbObservability.pool.waiting > 0
+          ? `${dbObservability.pool.waiting} waiting`
+          : `${dbObservability.slowQueries.length} slow Q`,
+      spark: flatTrend(
+        dbObservability.pool.total - dbObservability.pool.idle,
+        Math.max(dbObservability.pool.max, 1),
+      ),
+      tone: dbObservability.pool.waiting > 0 ? "warn" : "ok",
+      live: dbObservability.live,
+    },
+    {
+      label: "Recent alerts",
+      v: recentAlerts.live ? String(recentAlerts.entries.length) : "—",
+      d: recentAlerts.live
+        ? `${recentAlerts.entries.filter((a) => a.severity === "error").length} err`
+        : "offline",
+      spark: flatTrend(recentAlerts.entries.length, 10),
+      tone: recentAlerts.entries.some((a) => a.severity === "error") ? "warn" : "ok",
+      live: recentAlerts.live,
+    },
+    {
+      label: "Error groups · 60m",
+      v: errorGroups.live ? String(errorGroups.groups.length) : "—",
+      d: errorGroups.live
+        ? `${errorGroups.groups.reduce((s, g) => s + g.fiveXxCount, 0)} 5xx`
+        : "offline",
+      spark: flatTrend(errorGroups.groups.length, 5),
+      tone: errorGroups.groups.some((g) => g.fiveXxCount > 0) ? "warn" : "ok",
+      live: errorGroups.live,
+    },
   ];
+
+  // pageTelemetry is informational; we surface it inline below the strip
+  // if any surfaces have non-zero activity.
+  const pageTotal =
+    pageTelemetry.foodDiary +
+    pageTelemetry.customRecipes +
+    pageTelemetry.restaurants +
+    pageTelemetry.commensals +
+    pageTelemetry.mealPlans;
+
   return (
     <section
+      className="dash-kpi-grid"
       style={{
         display: "grid",
         gridTemplateColumns: "repeat(6, 1fr)",
@@ -531,7 +757,7 @@ export function KPIStrip() {
         border: "1px solid var(--line)",
         borderRadius: 12,
         background: "linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.005))",
-        marginBottom: 14,
+        marginBottom: pageTotal > 0 ? 6 : 14,
         overflow: "hidden",
       }}
     >
@@ -546,6 +772,7 @@ export function KPIStrip() {
             flexDirection: "column",
             gap: 6,
             minHeight: 92,
+            opacity: k.live === false ? 0.55 : 1,
           }}
         >
           <div className="t-tag" style={{ fontSize: 8.5 }}>{k.label}</div>
@@ -556,11 +783,20 @@ export function KPIStrip() {
               alignItems: "center",
               justifyContent: "space-between",
               marginTop: "auto",
+              gap: 8,
             }}
           >
             <span
               className="t-mono"
-              style={{ fontSize: 9, color: k.tone === "warn" ? "var(--el-fire)" : "var(--el-earth)" }}
+              style={{
+                fontSize: 9,
+                color:
+                  k.tone === "warn"
+                    ? "var(--el-fire)"
+                    : k.tone === "ok"
+                      ? "var(--el-earth)"
+                      : "var(--fg-mute)",
+              }}
             >
               {k.d}
             </span>

--- a/src/app/admin/_dashboard/panels.tsx
+++ b/src/app/admin/_dashboard/panels.tsx
@@ -9,7 +9,7 @@ import type {
 } from "@/services/dashboardPanelsService";
 import type { ActivityEvent } from "@/services/liveActivityService";
 import type { SystemStatusPayload } from "@/services/systemStatusService";
-import { CompatibilityRing, ElementalMeter, Glyph, Sparkline } from "./atoms";
+import { ElementalMeter, Glyph, Sparkline } from "./atoms";
 import { seeded } from "./data";
 import { Card, Legend, MiniStat } from "./hero";
 
@@ -659,117 +659,68 @@ export function PractitionersCohort({
 
 // ============================================================
 // ENGINE HEALTH
+// Only the metrics that have a real source (`enginePerformance`)
+// are shown — NDCG/MAP eval pipeline isn't wired yet, so we
+// label the slots honestly instead of fabricating numbers.
 // ============================================================
 export function EngineHealth({ enginePerformance }: { enginePerformance: any }) {
-  const perf = enginePerformance || { clickToCookRate: 0.047, totalCalculations: 2743, averageLatencyMs: 78 };
-  const acc = seeded(11, 40, 0.82, 0.94);
-  const versions = [
-    { v: "v17.4 (Py)", since: "Railway", traffic: "100%", acc: 0.918, ndcg: 0.74, latP95: "184ms", state: "live" },
-    { v: "v1.3.13 (Bun)", since: "Vercel", traffic: "12%", acc: 0.928, ndcg: 0.76, latP95: `${perf.averageLatencyMs}ms`, state: "canary" },
-  ];
+  const perf = enginePerformance || {
+    clickToCookRate: 0,
+    totalCalculations: 0,
+    averageLatencyMs: 0,
+    live: false,
+  };
+  const live = perf.live ?? false;
   return (
     <Card
       title="Recommendation Engine · Performance & Metrics"
-      subtitle={`Native Bun v1.3.13 · click-to-cook ${(perf.clickToCookRate * 100).toFixed(1)}%`}
+      subtitle={
+        live
+          ? `click-to-cook ${(perf.clickToCookRate * 100).toFixed(1)}% · ${perf.totalCalculations.toLocaleString()} calc total`
+          : "engine telemetry offline"
+      }
       right={
-        <button className="btn btn-ghost" style={{ padding: "4px 10px", fontSize: 9 }} type="button">
-          OPEN ENGINE
-        </button>
+        <span
+          className="t-mono"
+          style={{
+            fontSize: 9,
+            color: live ? "var(--el-earth)" : "var(--fg-mute)",
+            letterSpacing: "0.14em",
+          }}
+        >
+          {live ? "● LIVE" : "○ STALE"}
+        </span>
       }
     >
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
-        <div>
-          <div className="t-tag" style={{ marginBottom: 8 }}>ENGINE HARMONY ACCURACY · EVAL WINDOWS</div>
-          <Sparkline data={acc} width={300} height={70} color="var(--accent)" />
-          <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 8, marginTop: 12 }}>
-            <MiniStat label="NDCG@10" value="0.742" delta="+0.018" />
-            <MiniStat label="MAP" value="0.681" delta="+0.012" />
-            <MiniStat label="Click→Cook" value={`${(perf.clickToCookRate * 100).toFixed(1)}%`} delta="live" />
-            <MiniStat label="Avg Latency" value={`${perf.averageLatencyMs}ms`} delta="db log" />
-            <MiniStat label="Transmutations" value={perf.totalCalculations.toLocaleString()} delta="total" />
-            <MiniStat label="Coverage" value="2,743 / 2,901" delta="ing." />
-          </div>
-        </div>
-        <div>
-          <div className="t-tag" style={{ marginBottom: 8 }}>ACTIVE ENGINE CORRELATION VERTICES</div>
-          <div style={{ border: "1px solid var(--line)", borderRadius: 8, overflow: "hidden" }}>
-            <div
-              style={{
-                display: "grid",
-                gridTemplateColumns: "0.7fr 0.6fr 0.7fr 0.6fr 0.6fr 0.7fr",
-                padding: "6px 10px",
-                borderBottom: "1px solid var(--line-hi)",
-                background: "rgba(255,255,255,0.02)",
-              }}
-            >
-              {["Version", "Engine", "Traffic", "Acc", "NDCG", "p95"].map((h) => (
-                <span key={h} className="t-tag" style={{ fontSize: 8.5 }}>{h}</span>
-              ))}
-            </div>
-            {versions.map((v) => (
-              <div
-                key={v.v}
-                style={{
-                  display: "grid",
-                  gridTemplateColumns: "0.7fr 0.6fr 0.7fr 0.6fr 0.6fr 0.7fr",
-                  padding: "8px 10px",
-                  borderBottom: "1px solid var(--line)",
-                  fontFamily: "var(--f-mono)",
-                  fontSize: 11,
-                  color: "var(--fg-dim)",
-                  alignItems: "center",
-                }}
-              >
-                <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                  <span
-                    className="el-dot"
-                    style={{
-                      background:
-                        v.state === "live"
-                          ? "var(--el-earth)"
-                          : v.state === "canary"
-                            ? "var(--accent)"
-                            : "var(--fg-faint)",
-                      boxShadow:
-                        v.state === "live"
-                          ? "0 0 6px var(--el-earth)"
-                          : v.state === "canary"
-                            ? "0 0 6px var(--accent)"
-                            : "none",
-                    }}
-                  />
-                  <span style={{ color: "var(--fg)" }}>{v.v}</span>
-                </span>
-                <span>{v.since}</span>
-                <span
-                  style={{
-                    color:
-                      v.state === "live"
-                        ? "var(--accent)"
-                        : v.state === "canary"
-                          ? "var(--accent-2)"
-                          : "var(--fg-mute)",
-                  }}
-                >
-                  {v.traffic}
-                </span>
-                <span>{v.acc}</span>
-                <span>{v.ndcg}</span>
-                <span>{v.latP95}</span>
-              </div>
-            ))}
-          </div>
-          <div style={{ marginTop: 10, display: "flex", gap: 8 }}>
-            <button className="btn btn-primary" style={{ padding: "5px 10px", fontSize: 9 }} type="button">
-              PROMOTE CANARY →
-            </button>
-            <button className="btn btn-ghost" style={{ padding: "5px 10px", fontSize: 9 }} type="button">
-              ROLLBACK
-            </button>
-            <button className="btn btn-ghost" style={{ padding: "5px 10px", fontSize: 9 }} type="button">
-              EVAL SET
-            </button>
-          </div>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 8 }}>
+        <MiniStat
+          label="Click→Cook"
+          value={live ? `${(perf.clickToCookRate * 100).toFixed(1)}%` : "—"}
+          delta="live"
+        />
+        <MiniStat
+          label="Avg latency"
+          value={live ? `${perf.averageLatencyMs}ms` : "—"}
+          delta="req log"
+        />
+        <MiniStat
+          label="Transmutations"
+          value={live ? perf.totalCalculations.toLocaleString() : "—"}
+          delta="total"
+        />
+      </div>
+      <div
+        style={{
+          marginTop: 12,
+          padding: "10px 12px",
+          border: "1px dashed var(--line)",
+          borderRadius: 8,
+        }}
+      >
+        <div className="t-tag" style={{ marginBottom: 4 }}>OFFLINE EVAL · NOT WIRED</div>
+        <div className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>
+          NDCG@10 · MAP · canary harness · promote/rollback controls — add an
+          eval pipeline + flag table to surface these here.
         </div>
       </div>
     </Card>
@@ -1042,53 +993,75 @@ export function CommercePanel({ commerceSummary }: { commerceSummary: any }) {
 
 // ============================================================
 // COMMENSAL PULSE
+// We don't yet capture per-party harmony or live state, so render
+// an honest snapshot of the row counts when commensals exist and
+// an empty state otherwise.
 // ============================================================
 export function CommensalPulse({ pageTelemetry }: { pageTelemetry?: any }) {
-  const count = pageTelemetry?.commensals ?? 31;
-  const parties = [
-    { id: "DP-441", host: "@kemi.adekunle", guests: 8, cuisine: "Yoruba · West African", harmony: 0.92, state: "live" },
-    { id: "DP-440", host: "@ezra.kuhn", guests: 6, cuisine: "Pesach · spring", harmony: 0.81, state: "live" },
-    { id: "DP-439", host: "@hiro.matsui", guests: 4, cuisine: "Kaiseki", harmony: 0.88, state: "starting" },
-    { id: "DP-438", host: "@alma.r", guests: 12, cuisine: "Sobremesa", harmony: 0.74, state: "live" },
-  ];
+  const count = pageTelemetry?.commensals ?? 0;
+  const live = pageTelemetry?.live ?? false;
+  const mealPlans = pageTelemetry?.mealPlans ?? 0;
+  const customRecipes = pageTelemetry?.customRecipes ?? 0;
   return (
-    <Card title="Commensal Dining & Companions" subtitle={`${count.toLocaleString()} companion charts registered`}>
-      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        {parties.map((p) => (
-          <div
-            key={p.id}
-            style={{
-              display: "grid",
-              gridTemplateColumns: "auto 1fr auto",
-              gap: 12,
-              alignItems: "center",
-              padding: "8px 10px",
-              border: "1px solid var(--line)",
-              borderRadius: 8,
-            }}
-          >
-            <CompatibilityRing value={p.harmony} size={42} label="HARM" />
-            <div>
-              <div style={{ fontSize: 11.5, color: "var(--fg)" }}>{p.cuisine}</div>
-              <div style={{ display: "flex", gap: 8, marginTop: 2 }}>
-                <span className="t-mono" style={{ fontSize: 9, color: "var(--accent-2)" }}>{p.host}</span>
-                <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>· {p.guests} guests</span>
-                <span
-                  className="t-mono"
-                  style={{
-                    fontSize: 9,
-                    color: p.state === "live" ? "var(--el-earth)" : "var(--accent)",
-                  }}
-                >
-                  · {p.state}
-                </span>
-              </div>
-            </div>
-            <Glyph name="chevron" size={14} style={{ color: "var(--fg-mute)" }} />
+    <Card
+      title="Commensal Dining & Companions"
+      subtitle={
+        live
+          ? `${count.toLocaleString()} companion charts · ${mealPlans.toLocaleString()} meal plans`
+          : "page telemetry offline"
+      }
+      right={
+        <span
+          className="t-mono"
+          style={{
+            fontSize: 9,
+            color: live ? "var(--el-earth)" : "var(--fg-mute)",
+            letterSpacing: "0.14em",
+          }}
+        >
+          {live ? "● LIVE" : "○ STALE"}
+        </span>
+      }
+    >
+      {count === 0 ? (
+        <div
+          style={{
+            padding: "24px 12px",
+            textAlign: "center",
+            border: "1px dashed var(--line)",
+            borderRadius: 8,
+          }}
+        >
+          <div style={{ fontSize: 11, color: "var(--fg-dim)", marginBottom: 4 }}>
+            No commensal sessions yet
           </div>
-        ))}
-      </div>
+          <div className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>
+            ratings + party-state will populate once /commensal traffic begins
+          </div>
+        </div>
+      ) : (
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+          <MetricTile label="Commensals" v={count.toLocaleString()} sub="companion rows" />
+          <MetricTile label="Meal plans" v={mealPlans.toLocaleString()} sub="saved plans" />
+          <MetricTile label="Custom recipes" v={customRecipes.toLocaleString()} sub="user-created" />
+          <MetricTile
+            label="Restaurants"
+            v={(pageTelemetry?.restaurants ?? 0).toLocaleString()}
+            sub="user-saved"
+          />
+        </div>
+      )}
     </Card>
+  );
+}
+
+function MetricTile({ label, v, sub }: { label: string; v: string; sub: string }) {
+  return (
+    <div style={{ border: "1px solid var(--line)", borderRadius: 8, padding: "10px 12px" }}>
+      <div className="t-tag" style={{ fontSize: 8.5 }}>{label}</div>
+      <div className="t-num" style={{ fontSize: 20, color: "var(--fg)", marginTop: 4 }}>{v}</div>
+      <div className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)", marginTop: 2 }}>{sub}</div>
+    </div>
   );
 }
 

--- a/src/app/admin/_dashboard/shell.tsx
+++ b/src/app/admin/_dashboard/shell.tsx
@@ -10,6 +10,7 @@ interface ShellProps {
   showGrid?: boolean;
   user: AdminDashboardData["user"];
   pulse: AdminDashboardData["pulse"];
+  data: AdminDashboardData;
 }
 
 export function AdminShell({
@@ -18,16 +19,49 @@ export function AdminShell({
   showGrid = true,
   user,
   pulse,
+  data,
 }: ShellProps) {
+  const [navOpen, setNavOpen] = React.useState(false);
+
+  // close the drawer whenever the viewport grows back to desktop width
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia("(min-width: 961px)");
+    const sync = (e: MediaQueryListEvent | MediaQueryList) => {
+      if (e.matches) setNavOpen(false);
+    };
+    sync(mql);
+    mql.addEventListener("change", sync);
+    return () => mql.removeEventListener("change", sync);
+  }, []);
+
   return (
     <div
-      className={`lab admin-shell density-${density} ${showGrid ? "" : "no-grid"}`}
-      style={{ display: "grid", gridTemplateRows: "56px 1fr", height: "100%", overflow: "hidden" }}
+      className={`lab admin-shell density-${density} ${showGrid ? "" : "no-grid"} ${
+        navOpen ? "nav-open" : ""
+      }`}
+      style={{
+        display: "grid",
+        gridTemplateRows: "56px 1fr",
+        height: "100%",
+        overflow: "hidden",
+      }}
     >
-      <AdminTopBar user={user} pulse={pulse} />
-      <div style={{ display: "grid", gridTemplateColumns: "232px 1fr", minHeight: 0 }}>
-        <AdminSideRail />
-        <main style={{ minWidth: 0, minHeight: 0, overflow: "auto", padding: "16px 20px 24px" }}>
+      <AdminTopBar
+        user={user}
+        pulse={pulse}
+        onToggleNav={() => setNavOpen((v) => !v)}
+      />
+      <div
+        data-shell-body=""
+        style={{ display: "grid", gridTemplateColumns: "232px 1fr", minHeight: 0 }}
+      >
+        <AdminSideRail data={data} />
+        <main
+          data-shell-main=""
+          style={{ minWidth: 0, minHeight: 0, overflow: "auto", padding: "16px 20px 24px" }}
+          onClick={() => navOpen && setNavOpen(false)}
+        >
           {children}
         </main>
       </div>
@@ -44,9 +78,11 @@ export function AdminShell({
 function AdminTopBar({
   user,
   pulse,
+  onToggleNav,
 }: {
   user: AdminDashboardData["user"];
   pulse: AdminDashboardData["pulse"];
+  onToggleNav: () => void;
 }) {
   const pulseColor =
     pulse.state === "NOMINAL"
@@ -56,6 +92,7 @@ function AdminTopBar({
         : "#FF5252";
   return (
     <header
+      data-shell-topbar=""
       style={{
         display: "grid",
         gridTemplateColumns: "auto 1fr auto",
@@ -71,6 +108,14 @@ function AdminTopBar({
     >
       {/* identity cluster */}
       <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+        <button
+          type="button"
+          aria-label="Open navigation"
+          className="dash-hamburger"
+          onClick={onToggleNav}
+        >
+          <Glyph name="crosshair" size={16} stroke={1.4} />
+        </button>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
           <Glyph name="orbital" size={20} stroke={1.4} style={{ color: "var(--accent)" }} />
           <div style={{ display: "flex", flexDirection: "column", lineHeight: 1.0 }}>
@@ -125,7 +170,10 @@ function AdminTopBar({
       </div>
 
       {/* center — global heartbeat */}
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 18 }}>
+      <div
+        data-shell-topbar-metrics=""
+        style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 18 }}
+      >
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
           <span
             style={{
@@ -158,7 +206,10 @@ function AdminTopBar({
 
       {/* right — time, search, alerts, deploy */}
       <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-        <div style={{ display: "flex", flexDirection: "column", textAlign: "right", lineHeight: 1.1 }}>
+        <div
+          data-shell-time=""
+          style={{ display: "flex", flexDirection: "column", textAlign: "right", lineHeight: 1.1 }}
+        >
           <LiveTimecode format="JD" />
           <LiveTimecode format="UTC" />
         </div>
@@ -180,7 +231,12 @@ function AdminTopBar({
             }}
           />
         </button>
-        <button className="btn btn-primary" style={{ padding: "6px 12px", fontSize: 10 }} type="button">
+        <button
+          className="btn btn-primary"
+          data-shell-deploy-btn=""
+          style={{ padding: "6px 12px", fontSize: 10 }}
+          type="button"
+        >
           <Glyph name="triangle-up" size={10} /> DEPLOY
         </button>
       </div>
@@ -231,26 +287,113 @@ interface ModuleEntry {
   warn?: boolean;
 }
 
-const MODULES: ModuleEntry[] = [
-  { id: "overview", label: "Overview", glyph: "orbital", badge: null, active: true },
-  { id: "ops", label: "Operations", glyph: "crosshair", badge: "12 svc" },
-  { id: "engine", label: "Recommendation", glyph: "atom", badge: "v17.4" },
-  { id: "agents", label: "Agent Mesh", glyph: "ring", badge: "412 live" },
-  { id: "users", label: "Practitioners", glyph: "diamond", badge: "48.2k" },
-  { id: "catalog", label: "Catalog", glyph: "bookmark", badge: "2.9k / 12.4k" },
-  { id: "commensal", label: "Commensal", glyph: "wave", badge: "31" },
-  { id: "commerce", label: "Commerce", glyph: "triangle-up-bar", badge: "$84.2k" },
-  { id: "moderation", label: "Moderation", glyph: "flask", badge: "7", warn: true },
-  { id: "security", label: "Security", glyph: "spiral", badge: null },
-  { id: "experiments", label: "Experiments", glyph: "triangle-down-bar", badge: "6 live" },
-  { id: "deploys", label: "Deploys", glyph: "triangle-up", badge: null },
-  { id: "audit", label: "Audit Log", glyph: "bookmark", badge: null },
-  { id: "settings", label: "Settings", glyph: "settings", badge: null },
-];
+function formatCount(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  return n.toLocaleString();
+}
 
-function AdminSideRail() {
+function formatCurrencyShort(n: number): string {
+  if (n >= 1000) return `$${(n / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  return `$${n.toLocaleString()}`;
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "—";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let n = bytes;
+  let i = 0;
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024;
+    i++;
+  }
+  return `${n.toFixed(n < 10 ? 1 : 0)} ${units[i]}`;
+}
+
+function AdminSideRail({ data }: { data: AdminDashboardData }) {
+  const flowsCount = data.systemStatus.flows.length + data.systemStatus.dependencies.length;
+  const activeAlerts = data.recentAlerts.entries.filter((a) => !a.suppressed && a.severity !== "info").length;
+  const recipeCount = data.stats.totalRecipes;
+  const ingredientCount = data.stats.totalIngredients;
+  const commensals = data.pageTelemetry.commensals;
+
+  const modules: ModuleEntry[] = [
+    { id: "overview", label: "Overview", glyph: "orbital", badge: null, active: true },
+    {
+      id: "ops",
+      label: "Operations",
+      glyph: "crosshair",
+      badge: flowsCount > 0 ? `${flowsCount} svc` : null,
+    },
+    {
+      id: "engine",
+      label: "Recommendation",
+      glyph: "atom",
+      badge: data.enginePerformance.live
+        ? `${data.enginePerformance.totalCalculations.toLocaleString()} calc`
+        : null,
+    },
+    {
+      id: "agents",
+      label: "Agent Mesh",
+      glyph: "ring",
+      badge: null,
+    },
+    {
+      id: "users",
+      label: "Practitioners",
+      glyph: "diamond",
+      badge: data.stats.totalUsers > 0 ? formatCount(data.stats.totalUsers) : null,
+    },
+    {
+      id: "catalog",
+      label: "Catalog",
+      glyph: "bookmark",
+      badge:
+        recipeCount + ingredientCount > 0
+          ? `${formatCount(recipeCount)} / ${formatCount(ingredientCount)}`
+          : null,
+    },
+    {
+      id: "commensal",
+      label: "Commensal",
+      glyph: "wave",
+      badge: commensals > 0 ? String(commensals) : null,
+    },
+    {
+      id: "commerce",
+      label: "Commerce",
+      glyph: "triangle-up-bar",
+      badge: data.commerce.live ? formatCurrencyShort(data.commerce.mrr) : null,
+    },
+    {
+      id: "moderation",
+      label: "Moderation",
+      glyph: "flask",
+      badge: activeAlerts > 0 ? String(activeAlerts) : null,
+      warn: activeAlerts > 0,
+    },
+    { id: "security", label: "Security", glyph: "spiral", badge: null },
+    { id: "experiments", label: "Experiments", glyph: "triangle-down-bar", badge: null },
+    { id: "deploys", label: "Deploys", glyph: "triangle-up", badge: null },
+    { id: "audit", label: "Audit Log", glyph: "bookmark", badge: null },
+    { id: "settings", label: "Settings", glyph: "settings", badge: null },
+  ];
+
+  const buildId =
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(0, 7) ??
+    process.env.NEXT_PUBLIC_BUILD_ID ??
+    "local";
+  const region = process.env.NEXT_PUBLIC_VERCEL_REGION ?? "—";
+  const pool = data.dbObservability.pool;
+  const poolState =
+    pool.total === 0
+      ? "—"
+      : `${pool.total - pool.idle}/${pool.max} busy${pool.waiting > 0 ? ` · ${pool.waiting} wait` : ""}`;
+  const env = process.env.NEXT_PUBLIC_VERCEL_ENV ?? "prod";
+
   return (
     <aside
+      data-shell-rail=""
       style={{
         borderRight: "1px solid var(--line)",
         background: "linear-gradient(180deg, rgba(255,255,255,0.012), rgba(255,255,255,0.002))",
@@ -264,7 +407,7 @@ function AdminSideRail() {
       </div>
 
       <nav style={{ flex: 1, overflow: "auto", padding: "4px 8px 10px" }}>
-        {MODULES.map((m) => (
+        {modules.map((m) => (
           <div
             key={m.id}
             style={{
@@ -331,15 +474,37 @@ function AdminSideRail() {
       <div style={{ padding: 12, borderTop: "1px solid var(--line)" }}>
         <div className="t-tag" style={{ fontSize: 9, marginBottom: 6 }}>ENVIRONMENT</div>
         <div style={{ display: "flex", gap: 6, marginBottom: 8 }}>
-          <span className="chip chip-active" style={{ padding: "2px 8px", fontSize: 8 }}>PROD</span>
-          <span className="chip" style={{ padding: "2px 8px", fontSize: 8 }}>STAGING</span>
-          <span className="chip" style={{ padding: "2px 8px", fontSize: 8 }}>DEV</span>
+          <span
+            className={`chip ${env === "production" || env === "prod" ? "chip-active" : ""}`}
+            style={{ padding: "2px 8px", fontSize: 8 }}
+          >
+            PROD
+          </span>
+          <span
+            className={`chip ${env === "preview" || env === "staging" ? "chip-active" : ""}`}
+            style={{ padding: "2px 8px", fontSize: 8 }}
+          >
+            STAGING
+          </span>
+          <span
+            className={`chip ${env === "development" || env === "dev" ? "chip-active" : ""}`}
+            style={{ padding: "2px 8px", fontSize: 8 }}
+          >
+            DEV
+          </span>
         </div>
         <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          <SideKv k="REGION" v="us-east-1 · iad" />
-          <SideKv k="BUILD" v="2.7.4 · #c8f1ad" />
-          <SideKv k="DB" v="pg 16.2 · primary" />
-          <SideKv k="MESH" v="412/440 nodes" />
+          <SideKv k="REGION" v={region} />
+          <SideKv k="BUILD" v={`#${buildId}`} />
+          <SideKv
+            k="DB"
+            v={
+              data.dbObservability.live
+                ? `pg · ${formatBytes(data.dbObservability.dbSizeBytes)}`
+                : "pg · offline"
+            }
+          />
+          <SideKv k="POOL" v={poolState} />
         </div>
       </div>
     </aside>
@@ -350,26 +515,49 @@ function SideKv({ k, v }: { k: string; v: string }) {
   return (
     <div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
       <span className="t-mono" style={{ fontSize: 9, letterSpacing: "0.12em", color: "var(--fg-mute)" }}>{k}</span>
-      <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-dim)" }}>{v}</span>
+      <span
+        className="t-mono"
+        style={{
+          fontSize: 9.5,
+          color: "var(--fg-dim)",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          maxWidth: 130,
+        }}
+      >
+        {v}
+      </span>
     </div>
   );
 }
 
 // ============================================================
-// ARCHITECT CARD — Greg's identity + inbox
+// ARCHITECT CARD — identity + live alerts inbox
 // ============================================================
-export function ArchitectCard({ user }: { user: AdminDashboardData["user"] }) {
-  const queue = [
-    { kind: "SIGN-OFF", what: "Engine v18.0β · promote to 100%", sev: "high", age: "12m" },
-    { kind: "SIGN-OFF", what: "Refund · @marcus.kw · $8.00", sev: "med", age: "26m" },
-    { kind: "SIGN-OFF", what: "Restaurant Creator · @vera.j", sev: "med", age: "1h" },
-    { kind: "REVIEW", what: "Recipe · molecular caviar", sev: "low", age: "2h" },
-    { kind: "REVIEW", what: "PR-1184 · cart adapter", sev: "low", age: "5h" },
-  ] as const;
+function formatRelative(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return "just now";
+  const m = Math.round(ms / 60000);
+  if (m < 1) return "<1m";
+  if (m < 60) return `${m}m`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.round(h / 24)}d`;
+}
+
+export function ArchitectCard({
+  user,
+  recentAlerts,
+}: {
+  user: AdminDashboardData["user"];
+  recentAlerts: AdminDashboardData["recentAlerts"];
+}) {
+  const alerts = recentAlerts.entries.slice(0, 5);
   const sevColor: Record<string, string> = {
-    high: "var(--el-fire)",
-    med: "var(--accent)",
-    low: "var(--fg-mute)",
+    error: "var(--el-fire)",
+    warn: "var(--accent)",
+    info: "var(--fg-mute)",
   };
   return (
     <div className="panel-glow" style={{ padding: 16, position: "relative", overflow: "hidden" }}>
@@ -405,10 +593,21 @@ export function ArchitectCard({ user }: { user: AdminDashboardData["user"] }) {
             }}
           />
         </div>
-        <div style={{ flex: 1 }}>
-          <div className="t-tag" style={{ fontSize: 8.5 }}>HIGH ALCHEMIST · ARCHITECT</div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div className="t-tag" style={{ fontSize: 8.5 }}>HIGH ALCHEMIST · {user.role}</div>
           <div className="t-display" style={{ fontSize: 18, lineHeight: 1.1, marginTop: 2 }}>{user.name}</div>
-          <div className="t-mono" style={{ fontSize: 10, color: "var(--fg-mute)", letterSpacing: "0.1em", marginTop: 2 }}>
+          <div
+            className="t-mono"
+            style={{
+              fontSize: 10,
+              color: "var(--fg-mute)",
+              letterSpacing: "0.1em",
+              marginTop: 2,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
             {user.email}
           </div>
         </div>
@@ -418,55 +617,81 @@ export function ArchitectCard({ user }: { user: AdminDashboardData["user"] }) {
         <KvLine k="BADGE" v={user.badge} />
         <KvLine k="TIER" v={user.tier} accent />
         <KvLine k="JOINED" v={user.joined} />
-        <KvLine k="REGION" v="iad" />
-        <KvLine k="ON CALL" v="YES · primary" accent />
-        <KvLine k="2FA" v="hw key · ok" />
+        <KvLine k="REGION" v={process.env.NEXT_PUBLIC_VERCEL_REGION ?? "—"} />
+        <KvLine k="ON CALL" v={user.onCall ? "YES · primary" : "no"} accent={user.onCall} />
+        <KvLine k="2FA" v={user.onCall ? "hw key · ok" : "—"} />
       </div>
 
       <div style={{ borderTop: "1px solid var(--line)", paddingTop: 10 }}>
-        <div className="t-tag" style={{ marginBottom: 8 }}>YOUR INBOX · 5 items want your sign-off</div>
-        <div style={{ display: "flex", flexDirection: "column" }}>
-          {queue.map((q, i) => (
-            <div
-              key={i}
-              style={{
-                display: "grid",
-                gridTemplateColumns: "auto 1fr auto",
-                gap: 10,
-                alignItems: "center",
-                padding: "8px 4px",
-                borderBottom: i === queue.length - 1 ? "none" : "1px solid var(--line)",
-              }}
-            >
-              <span
-                className="t-mono"
-                style={{
-                  fontSize: 8.5,
-                  letterSpacing: "0.14em",
-                  padding: "2px 7px",
-                  borderRadius: 999,
-                  color: sevColor[q.sev],
-                  border: `1px solid ${sevColor[q.sev]}`,
-                  background: "rgba(0,0,0,0.3)",
-                }}
-              >
-                {q.kind}
-              </span>
-              <span
-                style={{
-                  fontSize: 11.5,
-                  color: "var(--fg-dim)",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                }}
-              >
-                {q.what}
-              </span>
-              <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>{q.age}</span>
-            </div>
-          ))}
+        <div className="t-tag" style={{ marginBottom: 8 }}>
+          ALERT INBOX ·{" "}
+          {alerts.length === 0
+            ? recentAlerts.live
+              ? "system is quiet"
+              : "alert source offline"
+            : `${alerts.length} recent`}
         </div>
+        {alerts.length === 0 ? (
+          <div
+            style={{
+              padding: "18px 8px",
+              textAlign: "center",
+              border: "1px dashed var(--line)",
+              borderRadius: 8,
+              color: "var(--fg-mute)",
+              fontSize: 11,
+            }}
+          >
+            {recentAlerts.live ? "no alerts in window" : "alert_events unreachable"}
+          </div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            {alerts.map((a, i) => (
+              <div
+                key={a.id}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "auto 1fr auto",
+                  gap: 10,
+                  alignItems: "center",
+                  padding: "8px 4px",
+                  borderBottom: i === alerts.length - 1 ? "none" : "1px solid var(--line)",
+                  opacity: a.suppressed ? 0.55 : 1,
+                }}
+              >
+                <span
+                  className="t-mono"
+                  style={{
+                    fontSize: 8.5,
+                    letterSpacing: "0.14em",
+                    padding: "2px 7px",
+                    borderRadius: 999,
+                    color: sevColor[a.severity] ?? "var(--fg-mute)",
+                    border: `1px solid ${sevColor[a.severity] ?? "var(--fg-mute)"}`,
+                    background: "rgba(0,0,0,0.3)",
+                  }}
+                >
+                  {a.severity.toUpperCase()}
+                </span>
+                <span
+                  style={{
+                    fontSize: 11.5,
+                    color: "var(--fg-dim)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                  title={a.title}
+                >
+                  {a.title}
+                </span>
+                <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>
+                  {formatRelative(a.triggeredAt)}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
@@ -483,9 +708,29 @@ export function ArchitectCard({ user }: { user: AdminDashboardData["user"] }) {
 
 function KvLine({ k, v, accent }: { k: string; v: string; accent?: boolean }) {
   return (
-    <div style={{ display: "flex", justifyContent: "space-between", padding: "4px 0", borderBottom: "1px dashed var(--line)" }}>
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        padding: "4px 0",
+        borderBottom: "1px dashed var(--line)",
+        gap: 6,
+        minWidth: 0,
+      }}
+    >
       <span className="t-tag" style={{ fontSize: 8.5 }}>{k}</span>
-      <span className="t-mono" style={{ fontSize: 10, color: accent ? "var(--accent)" : "var(--fg-dim)" }}>{v}</span>
+      <span
+        className="t-mono"
+        style={{
+          fontSize: 10,
+          color: accent ? "var(--accent)" : "var(--fg-dim)",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {v}
+      </span>
     </div>
   );
 }

--- a/src/app/admin/_dashboard/sky.tsx
+++ b/src/app/admin/_dashboard/sky.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import React from "react";
+import type { PageTelemetryData } from "@/services/dashboardPanelsService";
 import type {
   PlanetaryHourSnapshot,
   SkyConditionsData,
 } from "@/services/skyConditionsService";
-import { Sparkline } from "./atoms";
-import { seeded } from "./data";
 import { Card } from "./hero";
 
 // ============================================================
@@ -225,21 +224,33 @@ function PlanetaryHourBar({ snapshot }: { snapshot: PlanetaryHourSnapshot }) {
 // ============================================================
 // ASTRONOMICAL ENGINE
 // ============================================================
-export function AstronomicalEngine({ live = false }: { live?: boolean } = {}) {
+interface AstronomicalEngineProps {
+  live?: boolean;
+  pageTelemetry?: PageTelemetryData;
+}
+
+export function AstronomicalEngine({
+  live = false,
+  pageTelemetry,
+}: AstronomicalEngineProps = {}) {
   const refs = [
     { k: "EPHEMERIS", v: "DE440 · 2020-2050", ok: live },
     { k: "VSOP87 KERNEL", v: "rev · 2024-03-12", ok: live },
     { k: "IAU 2006 PRECESSION", v: "P03 · OK", ok: live },
     { k: "ΔT MODEL", v: "ESPENAK-MEEUS", ok: live },
     { k: "LEAP SECOND TABLE", v: "37s · 2017-01-01", ok: live },
-    { k: "JPL HORIZONS DRIFT", v: "max · 0.38″ Saturn", ok: live },
   ];
+
+  // pageTelemetry surfaces the row counts we actually capture in Postgres
+  // (no per-endpoint RPS). Show what we have; an "—" makes it obvious when
+  // we don't, instead of fabricating a number.
+  const t = pageTelemetry;
   const compute = [
-    { k: "natal · /api/natal", rps: 38, p95: "184ms", color: "var(--accent)" },
-    { k: "transit · /api/transit", rps: 142, p95: "62ms", color: "var(--accent-2)" },
-    { k: "houses · /api/houses", rps: 18, p95: "42ms", color: "var(--el-water)" },
-    { k: "asteroids · /api/asteroids", rps: 6, p95: "108ms", color: "var(--el-air)" },
-    { k: "fixed-stars · /api/stars", rps: 3, p95: "240ms", color: "var(--fg-mute)" },
+    { k: "natal · charts stored", count: t ? t.customRecipes : null, color: "var(--accent)" },
+    { k: "food diary · entries", count: t ? t.foodDiary : null, color: "var(--accent-2)" },
+    { k: "meal plans · saved", count: t ? t.mealPlans : null, color: "var(--el-water)" },
+    { k: "restaurants · stored", count: t ? t.restaurants : null, color: "var(--el-air)" },
+    { k: "commensals · saved", count: t ? t.commensals : null, color: "var(--fg-mute)" },
   ];
   return (
     <Card
@@ -286,14 +297,16 @@ export function AstronomicalEngine({ live = false }: { live?: boolean } = {}) {
           </div>
         </div>
         <div>
-          <div className="t-tag" style={{ marginBottom: 6 }}>COMPUTE · ENDPOINTS · 60s</div>
+          <div className="t-tag" style={{ marginBottom: 6 }}>
+            COMPUTE · USER-FACING SURFACES{pageTelemetry?.live ? "" : " · OFFLINE"}
+          </div>
           <div style={{ display: "flex", flexDirection: "column" }}>
             {compute.map((c, i) => (
               <div
                 key={c.k}
                 style={{
                   display: "grid",
-                  gridTemplateColumns: "1fr 50px 50px",
+                  gridTemplateColumns: "1fr 70px",
                   gap: 8,
                   alignItems: "center",
                   padding: "5px 0",
@@ -307,10 +320,10 @@ export function AstronomicalEngine({ live = false }: { live?: boolean } = {}) {
                   {c.k}
                 </span>
                 <span className="t-num" style={{ textAlign: "right", color: "var(--fg)" }}>
-                  {c.rps}
-                  <span style={{ color: "var(--fg-mute)" }}>/s</span>
+                  {c.count === null
+                    ? "—"
+                    : c.count.toLocaleString()}
                 </span>
-                <span className="t-num" style={{ textAlign: "right", color: "var(--fg-dim)" }}>{c.p95}</span>
               </div>
             ))}
           </div>
@@ -318,7 +331,7 @@ export function AstronomicalEngine({ live = false }: { live?: boolean } = {}) {
       </div>
 
       <div style={{ marginTop: 10, padding: "8px 10px", border: "1px dashed var(--line)", borderRadius: 8 }}>
-        <div className="t-tag" style={{ marginBottom: 4 }}>UPCOMING SKY EVENTS · DEMAND IMPACT FORECAST</div>
+        <div className="t-tag" style={{ marginBottom: 4 }}>UPCOMING SKY EVENTS · ILLUSTRATIVE</div>
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 8 }}>
           <SkyEvent t="+47m" e="☿ → Mercury hour" impact="planner load +18%" />
           <SkyEvent t="+2d" e="♀ stations direct" impact="cuisine: sweet/aromatic +24%" warn />
@@ -350,6 +363,9 @@ function SkyEvent({ t, e, impact, warn }: { t: string; e: string; impact: string
 
 // ============================================================
 // SEMS THERMODYNAMIC BALANCE
+// The SEMS rollup table doesn't exist yet — these are illustrative
+// values. We label the card with a "SAMPLE" badge so operators
+// don't read it as a live signal until the rollup is wired.
 // ============================================================
 export function SEMSDistribution() {
   const sems = [
@@ -370,9 +386,22 @@ export function SEMSDistribution() {
   return (
     <Card
       title="Alchm · SEMS Thermodynamic Balance"
-      subtitle="Spirit · Essence · Matter · Substance — site-wide across 184 active recipes"
+      subtitle="Spirit · Essence · Matter · Substance — sample rollup, not wired"
       right={
-        <span className="t-mono" style={{ fontSize: 9, color: "var(--accent)" }}>K-EQUILIBRIUM · 1.214</span>
+        <span
+          className="t-mono"
+          style={{
+            fontSize: 9,
+            color: "var(--el-fire)",
+            padding: "2px 8px",
+            borderRadius: 999,
+            border: "1px solid color-mix(in oklch, var(--el-fire), transparent 60%)",
+            background: "color-mix(in oklch, var(--el-fire), transparent 92%)",
+            letterSpacing: "0.14em",
+          }}
+        >
+          ◌ SAMPLE
+        </span>
       }
     >
       <div style={{ display: "grid", gridTemplateColumns: "1.4fr 1fr", gap: 16 }}>
@@ -497,32 +526,17 @@ export function SEMSDistribution() {
 
           <div
             style={{
-              border: "1px dashed var(--el-fire)",
+              border: "1px dashed var(--line)",
               borderRadius: 8,
               padding: "10px 12px",
-              background: "color-mix(in oklch, var(--el-fire), transparent 94%)",
             }}
           >
-            <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4 }}>
-              <span className="t-tag" style={{ color: "var(--el-fire)" }}>ANOMALIES · 24H</span>
-              <span className="t-mono" style={{ fontSize: 9, color: "var(--el-fire)" }}>2 active</span>
+            <div className="t-tag" style={{ marginBottom: 4 }}>WHEN WIRED · SOURCE</div>
+            <div className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)", lineHeight: 1.6 }}>
+              SEMS rollup will read from a per-recipe thermodynamic score
+              table once recipe ingestion captures it. Calibration R² will
+              follow from the eval harness.
             </div>
-            <div style={{ fontSize: 11, color: "var(--fg-dim)", lineHeight: 1.5 }}>
-              <div>• Substance running 11pts below target band — recipes lacking minerality / base structure</div>
-              <div style={{ marginTop: 4 }}>• Engine v17.4 may be over-weighting Spirit during Mars hour</div>
-            </div>
-            <button className="btn btn-ghost" style={{ marginTop: 8, padding: "4px 10px", fontSize: 9 }} type="button">
-              OPEN DOSSIER →
-            </button>
-          </div>
-
-          <div style={{ border: "1px solid var(--line)", borderRadius: 8, padding: "10px 12px" }}>
-            <div className="t-tag" style={{ marginBottom: 6 }}>CALIBRATION · OBSERVED vs PREDICTED</div>
-            <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between" }}>
-              <span className="t-num" style={{ fontSize: 18 }}>0.942</span>
-              <span className="t-mono" style={{ fontSize: 9, color: "var(--el-earth)" }}>R² · +0.018 vs 7d</span>
-            </div>
-            <Sparkline data={seeded(31, 30, 0.85, 0.96)} width={220} height={28} color="var(--accent)" />
           </div>
         </div>
       </div>

--- a/src/app/api/commensal/guest-recommendations/route.ts
+++ b/src/app/api/commensal/guest-recommendations/route.ts
@@ -4,7 +4,7 @@ import { EnhancedRecommendationService } from "@/services/EnhancedRecommendation
 import { calculateCompositeNatalChart } from "@/services/groupNatalChartService";
 import { calculateNatalChart } from "@/services/natalChartService";
 import type { ElementalProperties as AlchemyElementalProperties } from "@/types/alchemy";
-import type { GroupMember } from "@/types/natalChart";
+import type { GroupMember, NatalChart, BirthData } from "@/types/natalChart";
 import { getCuisineRecommendations } from "@/utils/cuisineRecommender";
 import { getRecommendedCookingMethods } from "@/utils/recommendation/methodRecommendation";
 
@@ -53,19 +53,28 @@ export async function POST(req: Request) {
     }
     const { guests } = parsed.data;
 
-    // Calculate natal charts for all guests in parallel.
-    const natalCharts = await Promise.all(
-      guests.map((g) => calculateNatalChart(g.birthData)),
-    );
+    // If the request is authenticated and the user has a saved natal chart,
+    // include them as the first member so the composite is computed across
+    // (you + your commensals). Auth failures are non-blocking — the guest
+    // flow keeps working for anonymous users. Run the self lookup alongside
+    // the guest chart computations so we don't pay for them in serial.
+    const [selfMember, natalCharts] = await Promise.all([
+      loadAuthenticatedSelfMember(),
+      Promise.all(guests.map((g) => calculateNatalChart(g.birthData))),
+    ]);
 
-    const groupMembers: GroupMember[] = guests.map((guest, i) => ({
-      id: `guest_${i}`,
+    const commensalMembers: GroupMember[] = guests.map((guest, i) => ({
+      id: `commensal_${i}`,
       name: guest.name,
       relationship: "friend",
       birthData: guest.birthData,
       natalChart: natalCharts[i],
       createdAt: new Date().toISOString(),
     }));
+
+    const groupMembers: GroupMember[] = selfMember
+      ? [selfMember, ...commensalMembers]
+      : commensalMembers;
 
     // Composite chart for the whole group.
     const compositeChart = calculateCompositeNatalChart(
@@ -117,5 +126,59 @@ export async function POST(req: Request) {
       { success: false, message: "Failed to generate recommendations" },
       { status: 500 },
     );
+  }
+}
+
+function isCompleteBirthData(value: unknown): value is BirthData {
+  if (!value || typeof value !== "object") return false;
+  const b = value as Partial<BirthData>;
+  return (
+    typeof b.dateTime === "string" &&
+    b.dateTime.length > 0 &&
+    typeof b.latitude === "number" &&
+    Number.isFinite(b.latitude) &&
+    typeof b.longitude === "number" &&
+    Number.isFinite(b.longitude)
+  );
+}
+
+function isUsableNatalChart(value: unknown): value is NatalChart {
+  if (!value || typeof value !== "object") return false;
+  const c = value as Partial<NatalChart>;
+  return (
+    !!c.planetaryPositions &&
+    !!c.elementalBalance &&
+    !!c.alchemicalProperties
+  );
+}
+
+async function loadAuthenticatedSelfMember(): Promise<GroupMember | null> {
+  try {
+    const { auth } = await import("@/lib/auth/auth");
+    const session = await auth();
+    if (!session?.user?.id) return null;
+
+    const { userDatabase } = await import("@/services/userDatabaseService");
+    const user = await userDatabase.getUserById(session.user.id);
+    const birthData = user?.profile?.birthData;
+    const natalChart = user?.profile?.natalChart;
+    if (!isCompleteBirthData(birthData) || !isUsableNatalChart(natalChart)) {
+      return null;
+    }
+
+    return {
+      id: `self_${user!.id}`,
+      name: user?.profile?.name?.trim() || session.user.name?.trim() || "You",
+      relationship: "self",
+      birthData,
+      natalChart,
+      createdAt: new Date().toISOString(),
+    };
+  } catch (err) {
+    console.warn(
+      "guest-recommendations: skipped auth user lookup —",
+      err instanceof Error ? err.message : err,
+    );
+    return null;
   }
 }

--- a/src/app/api/generate-cosmic-recipe/route.ts
+++ b/src/app/api/generate-cosmic-recipe/route.ts
@@ -1,7 +1,24 @@
 /**
  * POST /api/generate-cosmic-recipe
- * Requests a structured cosmic recipe using the planetary_agents microservice.
- * Uses the cosmicRecipeSchema for structured output.
+ *
+ * Thin proxy in front of planetary_agents' /api/generate-recipe endpoint.
+ * WTEN's job here is:
+ *   - Auth/demo gate + token-economy debit (personalized live pricing).
+ *   - Compute the structured grounding fields PA can't recreate:
+ *     dominantElement, indexed topIngredients, ESMS alchemical state,
+ *     thermodynamic properties, the user's cuisine selection, and a
+ *     prompt enriched with their recent food diary.
+ *   - Forward those to PA, which owns the alchemical-chef persona,
+ *     JSON-mode toggling, Pydantic schema validation, one retry on
+ *     malformed output, and a 60s prompt-hash cache.
+ *   - Defensive Zod re-check of PA's response against the canonical
+ *     cosmicRecipeSchema so schema drift surfaces at the WTEN edge.
+ *
+ * History: an earlier version of this route POSTed to PA's /api/chat
+ * with a prompt-engineered JSON contract; the version before THAT
+ * targeted a /api/generate-recipe endpoint PA never exposed (the source
+ * of the hourly synthetic-probe 404s). With PA's first-class endpoint
+ * now in place, WTEN simplifies to a proxy.
  */
 import { z } from "zod";
 import { gateDemoOrAuth } from "@/lib/auth/demoAccess";
@@ -11,15 +28,14 @@ import {
 } from "@/lib/economy/livePricing";
 import { withObservability } from "@/lib/observability/withObservability";
 import { foodDiaryService } from "@/services/FoodDiaryService";
-import { getCachedHistoricalStats } from "@/services/HistoricalStatsService";
 import { reportQuestEventBestEffort } from "@/services/questEventReporter";
 import { alchemize } from "@/services/RealAlchemizeService";
 import { subscriptionService } from "@/services/subscriptionService";
 import { tokenEconomy } from "@/services/TokenEconomyService";
+import { cosmicRecipeSchema } from "@/types/cosmicRecipeSchema";
 import { getCapitalizedNatalPositions } from "@/utils/astrology/chartDataUtils";
 import { getAccuratePlanetaryPositions } from "@/utils/astrology/positions";
 import {
-  SIGN_TO_ELEMENT,
   getDominantElementFromPositions,
   type ClassicalElement,
 } from "@/utils/astrology/signElement";
@@ -161,78 +177,42 @@ async function handlePost(request: NextRequest) {
     preferredCuisine,
   } = parsed.data;
 
-  // Get current sky for context
+  // Compute the current sky once. We use it for both the dominant element
+  // (a top-level field PA expects) and to derive the alchemical state +
+  // thermodynamic properties PA grounds the recipe on.
   const raw = getAccuratePlanetaryPositions(new Date());
-  const skySnapshot: string[] = [];
-  Object.entries(raw).slice(0, 6).forEach(([planet, pos]) => {
-    const sign = typeof pos.sign === "string" ? pos.sign : String(pos.sign);
-    skySnapshot.push(`${planet} in ${sign}${pos.isRetrograde ? " (R)" : ""}`);
-  });
-  const dominantElement: ClassicalElement = getDominantElementFromPositions(
-    raw,
-  );
+  const dominantElement: ClassicalElement = getDominantElementFromPositions(raw);
 
-  const currentSky = skySnapshot.join(", ");
-  const birthChartNote = birthData
-    ? `The user's birth data: ${JSON.stringify(birthData)}.`
-    : "No birth chart provided; base recommendations on current sky only.";
-
-  // ----- Indexed grounding -----
-  // Pull real statistical + culinary data so the LLM is anchored to the
-  // project's curated cuisine signatures and ingredient elemental profile
-  // rather than hallucinating correspondences from its pretraining.
-
+  // Project-curated grounding: which cuisine the user picked (if any),
+  // and which indexed ingredients are strongest in the dominant element
+  // right now. PA ingests these as structured context — it does not
+  // recompute them.
   const cuisineName = preferredCuisine ? normalizeCuisineName(preferredCuisine) : "";
   const cuisineEntry = cuisineName ? getCuisineEntry(cuisineName) : null;
-
   const topIngredients = findTopIngredientsForElement(dominantElement, 8).map((i) => i.name);
 
-  const cuisineSignatureLines =
-    cuisineEntry?.signatures?.slice(0, 4).map((sig) => {
-      const direction = sig.zscore >= 0 ? "elevated" : "reduced";
-      return `${sig.property} ${direction} (z=${sig.zscore.toFixed(2)}, ${sig.strength})`;
-    }) ?? [];
-
-  const planetaryPatternLines =
-    cuisineEntry?.planetaryPatterns?.slice(0, 4).map((pattern) => {
-      const topSign = pattern.commonSigns?.[0];
-      const element = topSign ? SIGN_TO_ELEMENT[String(topSign.sign).toLowerCase()] ?? "" : "";
-      return `${pattern.planet}${topSign ? ` usually in ${topSign.sign}${element ? ` (${element})` : ""}` : ""}`;
-    }) ?? [];
-
-  const groundingLines: string[] = [];
-  if (cuisineEntry) {
-    groundingLines.push(
-      `Selected cuisine: ${cuisineEntry.cuisine} (n=${cuisineEntry.sampleSize} recipes).`,
-    );
-    if (cuisineSignatureLines.length > 0) {
-      groundingLines.push(`Cuisine signatures: ${cuisineSignatureLines.join("; ")}.`);
-    }
-    if (planetaryPatternLines.length > 0) {
-      groundingLines.push(`Cuisine planetary patterns: ${planetaryPatternLines.join("; ")}.`);
-    }
-  }
-  if (topIngredients.length > 0) {
-    groundingLines.push(
-      `Project-indexed ingredients strongest in ${dominantElement}: ${topIngredients.join(", ")}.`,
-    );
-  }
-
-  // Fetch recent history for personalization (auth path only — demo users
-  // have no diary to draw from, and the LLM still gets the current-sky context).
+  // Auth-path personalization: pull the user's recent food diary so PA
+  // can steer toward variety. Demo users have no diary to draw from.
   const recentEntries = userId
     ? await foodDiaryService.getEntries(userId, { limit: 10 })
     : [];
-  const recentFoods = recentEntries.map(e => e.foodName).join(", ");
-  const historyNote = recentFoods
-    ? `User recently consumed: ${recentFoods}. Ensure variety or complementary pairings.`
-    : "";
+  const recentFoods = recentEntries.map((e) => e.foodName).join(", ");
 
-  // Inject Alchemical Z-Score Rarity Matrix
+  // Compute Spirit/Essence/Matter/Substance + thermodynamic properties
+  // from the current sky. PA wants the raw numeric maps; it builds its
+  // own prompt from them.
   const planetarySigns: Record<string, string> = {};
-  const normalizedPositions: Record<string, any> = {};
+  const normalizedPositions: Record<
+    string,
+    { sign: string; degree: number; minute: number; isRetrograde: boolean }
+  > = {};
   Object.entries(raw).forEach(([planet, pos]) => {
-    const p = pos as any;
+    const p = pos as {
+      sign: unknown;
+      degree?: unknown;
+      minute?: unknown;
+      isRetrograde?: unknown;
+    };
     planetarySigns[planet] = typeof p.sign === "string" ? p.sign : String(p.sign);
     normalizedPositions[planet] = {
       sign: String(p.sign ?? "").toLowerCase(),
@@ -243,85 +223,115 @@ async function handlePost(request: NextRequest) {
   });
   const esms = calculateAlchemicalFromPlanets(planetarySigns);
   const alchemized = alchemize(normalizedPositions);
-  const stats = await getCachedHistoricalStats();
 
-  const formatZ = (val: number, stat?: { mean: number, stdDev: number }) => {
-    if (!stat || stat.stdDev === 0) return "Average";
-    const z = (val - stat.mean) / stat.stdDev;
-    if (z > 2.0) return `Extreme High (+${z.toFixed(2)}σ)`;
-    if (z > 1.0) return `Elevated (+${z.toFixed(2)}σ)`;
-    if (z < -2.0) return `Extreme Low (${z.toFixed(2)}σ)`;
-    if (z < -1.0) return `Reduced (${z.toFixed(2)}σ)`;
-    return "Average";
-  };
+  // Augment the user's natural-language prompt with their recent-foods
+  // history + their preferred main ingredients so PA's prompt builder
+  // forwards them to the model. PA owns the rest of the prompt (persona,
+  // JSON contract, schema injection) since the PA-side rebuild.
+  const baseUserPrompt =
+    prompt || "A nourishing, restorative meal aligned with today's cosmic energies.";
+  const preferredIngredientsHint = ingredientsMain?.length
+    ? `\nPreferred main ingredients: ${ingredientsMain.join(", ")}.`
+    : "";
+  const recentFoodsHint = recentFoods
+    ? `\nUser recently consumed: ${recentFoods}. Ensure variety or complementary pairings.`
+    : "";
+  const enrichedPrompt = `${baseUserPrompt}${preferredIngredientsHint}${recentFoodsHint}`;
 
-  if (stats?.metrics && alchemized?.thermodynamicProperties) {
-    const thermo = alchemized.thermodynamicProperties;
-    const heatZ = formatZ(thermo.heat ?? 0.5, stats.metrics.heat);
-    const entropyZ = formatZ(thermo.entropy ?? 0.5, stats.metrics.entropy);
-    const reactivityZ = formatZ(thermo.reactivity ?? 0.5, stats.metrics.reactivity);
-    groundingLines.push(
-      `Current Thermodynamic Rarity (30-day baseline): Heat is ${heatZ}, Entropy is ${entropyZ}, Reactivity is ${reactivityZ}. Modify the physical intensity of ingredients and cooking method precisely to match these statistical extremes. If Extreme, make the recipe Extreme.`
-    );
-    groundingLines.push(
-      `Current ESMS Baseline Yields: Spirit ${esms.Spirit.toFixed(2)}, Essence ${esms.Essence.toFixed(2)}, Matter ${esms.Matter.toFixed(2)}, Substance ${esms.Substance.toFixed(2)}.`
-    );
-  }
+  // PA backend at api.agents.alchm.kitchen owns recipe generation since
+  // the PA-side rebuild: it handles the alchemical-chef persona, prompt
+  // construction, provider-native JSON mode, Pydantic validation, one
+  // auto-retry on malformed output, and a 60s prompt-hash cache. WTEN
+  // forwards the structured grounding fields it has computed and gets
+  // back a validated CosmicRecipeResponse.
+  const agentBaseUrl =
+    process.env.PLANETARY_AGENTS_API_URL ||
+    process.env.NEXT_PUBLIC_PLANETARY_KINETICS_URL ||
+    "https://api.agents.alchm.kitchen";
 
-  const groundingBlock = groundingLines.length > 0 ? `\n${groundingLines.join("\n")}\n` : "";
-
-  const systemPrompt = `You are an expert alchemical chef and astrologer for Alchm Kitchen.
-Current planetary positions: ${currentSky}.
-Dominant element today: ${dominantElement}.
-${birthChartNote}
-${historyNote}
-Diet preference: ${diet || "omnivore"}.
-${ingredientsMain?.length ? `Preferred main ingredients: ${ingredientsMain.join(", ")}.` : ""}
-${disallowedIngredients?.length ? `Never use: ${disallowedIngredients.join(", ")}.` : ""}${groundingBlock}
-Create a detailed, authentic, cosmic recipe that:
-- Aligns with the current planetary positions and dominant ${dominantElement} element
-${cuisineEntry ? `- Honours the statistical profile of ${cuisineEntry.cuisine} cuisine listed above` : ""}
-- Favours the indexed ingredients above where they fit the dish
-- Uses real culinary techniques with precise measurements
-- Explains the astrological and elemental correspondences
-- Is achievable by a home cook`;
-
-  const userRequest = prompt || "A nourishing, restorative meal aligned with today's cosmic energies.";
-  const agentPayload = {
-    prompt: userRequest,
-    context: {
-      systemPrompt,
-      dominantElement,
-      cuisine: cuisineEntry?.cuisine ?? null,
-      topIngredients,
-      birthData,
-      dietPreference: diet || "omnivore",
-      alchemicalState: esms,
-      thermodynamicProperties: alchemized?.thermodynamicProperties
-    }
-  };
-
-  let responseJson: any;
+  let recipe: z.infer<typeof cosmicRecipeSchema>;
   try {
-    const agentBaseUrl = process.env.NEXT_PUBLIC_PLANETARY_KINETICS_URL || "https://agents.alchm.kitchen";
     const agentResponse = await fetch(`${agentBaseUrl}/api/generate-recipe`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(agentPayload)
+      body: JSON.stringify({
+        prompt: enrichedPrompt,
+        dominantElement,
+        cuisine: cuisineEntry?.cuisine ?? undefined,
+        topIngredients,
+        birthData,
+        dietPreference: diet || "omnivore",
+        alchemicalState: esms,
+        thermodynamicProperties: alchemized?.thermodynamicProperties,
+        disallowedIngredients: disallowedIngredients ?? undefined,
+        userId: userId ?? undefined,
+      }),
     });
 
     if (!agentResponse.ok) {
-      return new Response(JSON.stringify({ error: "Failed to generate recipe via agents network" }), { status: agentResponse.status, headers: { "Content-Type": "application/json" } });
+      const upstreamBody = (await agentResponse
+        .json()
+        .catch(() => ({}))) as Record<string, unknown>;
+      const upstreamDetail =
+        typeof upstreamBody.detail === "string"
+          ? upstreamBody.detail
+          : typeof upstreamBody.message === "string"
+            ? upstreamBody.message
+            : null;
+      return new Response(
+        JSON.stringify({
+          error: "Failed to generate recipe via agents network",
+          upstreamStatus: agentResponse.status,
+          upstreamDetail,
+        }),
+        {
+          // PA's recipe orchestrator returns 502 on retry exhaustion; we
+          // forward that as-is. A 404 from PA means the new endpoint
+          // isn't deployed yet — surface as 502 so the client gets a
+          // uniform "upstream not ready" signal instead of a misleading
+          // "not found".
+          status: agentResponse.status === 404 ? 502 : agentResponse.status,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
-    responseJson = await agentResponse.json();
+    // PA already validates its response against a Pydantic mirror of
+    // cosmicRecipeSchema before sending. We do a defensive Zod parse
+    // here so any future drift between the two schemas surfaces at the
+    // WTEN edge instead of leaking malformed data to the client.
+    const parsed = (await agentResponse.json()) as unknown;
+    const validation = cosmicRecipeSchema.safeParse(parsed);
+    if (!validation.success) {
+      console.error(
+        "[generate-cosmic-recipe] PA returned recipe that failed local schema check:",
+        validation.error.issues.slice(0, 5),
+      );
+      return new Response(
+        JSON.stringify({
+          error: "Recipe schema drift between PA and WTEN",
+          issues: validation.error.issues
+            .slice(0, 5)
+            .map((i) => ({ path: i.path.join("."), message: i.message })),
+        }),
+        { status: 502, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    recipe = validation.data;
   } catch (error) {
     console.error("[generate-cosmic-recipe] Error calling planetary agents API:", error);
-    return new Response(JSON.stringify({ error: "Internal server error contacting agents network" }), { status: 500, headers: { "Content-Type": "application/json" } });
+    return new Response(
+      JSON.stringify({ error: "Internal server error contacting agents network" }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
   }
 
-  // Annotate demo responses so the client can render a "sign in to save / get
-  // personalized" CTA instead of treating this as a saved cosmic recipe.
+  // Spread the recipe at the top level so the existing client
+  // (CosmicRecipeGenerator → data.title / data.short_description / ...)
+  // continues to work. The `success: true` sentinel is what the
+  // synthetic-cosmic-recipe probe checks at HTTP 200.
+  let responseJson: Record<string, unknown> = { success: true, ...recipe };
+
   if (demoMode) {
     responseJson = {
       ...responseJson,
@@ -330,30 +340,10 @@ ${cuisineEntry ? `- Honours the statistical profile of ${cuisineEntry.cuisine} c
     };
   }
 
-  const response = new Response(JSON.stringify(responseJson), {
+  return new Response(JSON.stringify(responseJson), {
     status: 200,
-    headers: { "Content-Type": "application/json" }
+    headers: { "Content-Type": "application/json" },
   });
-
-  // Expose the grounding payload on a response header so the client can
-  // surface the exact anchors the LLM was given (useful for debugging
-  // drift and for rendering a "why this recipe" footer).
-  try {
-    const groundingPayload = {
-      dominantElement,
-      cuisine: cuisineEntry?.cuisine ?? null,
-      sampleSize: cuisineEntry?.sampleSize ?? null,
-      signatures: cuisineSignatureLines,
-      planetaryPatterns: planetaryPatternLines,
-      topIngredients,
-    };
-    const encoded = Buffer.from(JSON.stringify(groundingPayload), "utf8").toString("base64");
-    response.headers.set("X-Cosmic-Grounding", encoded);
-  } catch {
-    // Non-fatal — header is purely informational.
-  }
-
-  return response;
 }
 
 export const POST = withObservability(

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -12,6 +12,7 @@ import {
   getDatabaseUserFromRequest,
 } from "@/lib/auth/validateRequest";
 import { _logger } from "@/lib/logger";
+import { withTimeout } from "@/lib/performance/withTimeout";
 import { UserProfileUpdateSchema } from "@/lib/validation/apiSchemas";
 import { getPlanetaryPositionsForDateTime } from "@/services/astrologizeApi";
 import { userDatabase } from "@/services/userDatabaseService";
@@ -71,18 +72,30 @@ export async function GET(request: NextRequest) {
               _logger.info("[GET /api/user/profile] Migrating natal chart with sub-arcminute positions");
               try {
                 const birthDate = new Date(natalChart.birthData.dateTime);
-                const rawPositions = await getPlanetaryPositionsForDateTime(birthDate, {
-                  latitude: natalChart.birthData.latitude,
-                  longitude: natalChart.birthData.longitude,
-                });
-                const updatedPlanets = natalChart.planets.map((p: any) => {
-                  const pos = rawPositions[p.name];
-                  return pos ? { ...p, position: pos.exactLongitude ?? p.position } : p;
-                });
-                natalChart.planets = updatedPlanets;
-                void userDatabase.updateUserProfile(user.id, { natalChart } as any, user.email).catch((err: any) =>
-                  _logger.error("[GET /api/user/profile] Failed to persist migrated chart", err),
+                // 8s ceiling: the fallback ephemeris computation in
+                // getPlanetaryPositionsForDateTime is unbounded server-side
+                // math (no AbortController). Migration is best-effort — if
+                // we time out, return the un-migrated chart; the next call
+                // tries again.
+                const rawPositions = await withTimeout(
+                  getPlanetaryPositionsForDateTime(birthDate, {
+                    latitude: natalChart.birthData.latitude,
+                    longitude: natalChart.birthData.longitude,
+                  }),
+                  8000,
+                  null,
+                  "profile-hono lazy migration",
                 );
+                if (rawPositions) {
+                  const updatedPlanets = natalChart.planets.map((p: any) => {
+                    const pos = rawPositions[p.name];
+                    return pos ? { ...p, position: pos.exactLongitude ?? p.position } : p;
+                  });
+                  natalChart.planets = updatedPlanets;
+                  void userDatabase.updateUserProfile(user.id, { natalChart } as any, user.email).catch((err: any) =>
+                    _logger.error("[GET /api/user/profile] Failed to persist migrated chart", err),
+                  );
+                }
               } catch (err) {
                 _logger.error("[GET /api/user/profile] Lazy migration failed", err);
               }
@@ -106,20 +119,28 @@ export async function GET(request: NextRequest) {
         _logger.info("[GET /api/user/profile] Migrating natal chart with sub-arcminute positions");
         try {
           const birthDate = new Date(natalChart.birthData.dateTime);
-          const rawPositions = await getPlanetaryPositionsForDateTime(birthDate, {
-            latitude: natalChart.birthData.latitude,
-            longitude: natalChart.birthData.longitude,
-          });
-          // Update planet positions with exact longitudes
-          const updatedPlanets = natalChart.planets.map((p: any) => {
-            const pos = rawPositions[p.name];
-            return pos ? { ...p, position: pos.exactLongitude ?? p.position } : p;
-          });
-          natalChart.planets = updatedPlanets;
-          // Persist the migrated chart asynchronously (don't block response)
-          void userDatabase.updateUserProfile(user.id, { natalChart } as any, user.email).catch((err: any) =>
-            _logger.error("[GET /api/user/profile] Failed to persist migrated chart", err),
+          // 8s ceiling: see comment in the Hono proxy branch above.
+          const rawPositions = await withTimeout(
+            getPlanetaryPositionsForDateTime(birthDate, {
+              latitude: natalChart.birthData.latitude,
+              longitude: natalChart.birthData.longitude,
+            }),
+            8000,
+            null,
+            "profile-fallback lazy migration",
           );
+          if (rawPositions) {
+            // Update planet positions with exact longitudes
+            const updatedPlanets = natalChart.planets.map((p: any) => {
+              const pos = rawPositions[p.name];
+              return pos ? { ...p, position: pos.exactLongitude ?? p.position } : p;
+            });
+            natalChart.planets = updatedPlanets;
+            // Persist the migrated chart asynchronously (don't block response)
+            void userDatabase.updateUserProfile(user.id, { natalChart } as any, user.email).catch((err: any) =>
+              _logger.error("[GET /api/user/profile] Failed to persist migrated chart", err),
+            );
+          }
         } catch (err) {
           _logger.error("[GET /api/user/profile] Lazy migration failed", err);
         }

--- a/src/components/admin/ApiRouteHealthPanel.tsx
+++ b/src/components/admin/ApiRouteHealthPanel.tsx
@@ -24,19 +24,26 @@ interface RequestEntry {
   latencyMs: number;
 }
 
+interface ObservabilitySummary {
+  count: number;
+  p50LatencyMs: number;
+  p95LatencyMs: number;
+  p99LatencyMs: number;
+  errorRate: number;
+  topPaths: Array<{ path: string; count: number }>;
+}
+
 interface ObservabilityResponse {
   success: boolean;
-  summary: {
-    count: number;
-    p50LatencyMs: number;
-    p95LatencyMs: number;
-    p99LatencyMs: number;
-    errorRate: number;
-    topPaths: Array<{ path: string; count: number }>;
+  requests: {
+    summary: ObservabilitySummary;
+    recent: RequestEntry[];
+    recentFailures: RequestEntry[];
   };
-  recent: RequestEntry[];
-  failures: RequestEntry[];
-  slowQueries: Array<{ ms: number; preview: string }>;
+  slowQueries: {
+    summary: unknown;
+    recent: Array<{ ms: number; preview: string }>;
+  };
 }
 
 interface PerPathRow {
@@ -55,10 +62,10 @@ function quantile(values: number[], q: number): number {
 }
 
 function rowsFromObservability(payload: ObservabilityResponse): PerPathRow[] {
-  // The /admin/observability endpoint already returns `recent` (up to 100
+  // The /admin/observability endpoint returns `requests.recent` (up to 100
   // requests). Group locally for per-route stats — cheap, no extra fetch.
   const byPath = new Map<string, RequestEntry[]>();
-  for (const r of payload.recent) {
+  for (const r of payload.requests.recent) {
     const list = byPath.get(r.path);
     if (list) list.push(r);
     else byPath.set(r.path, [r]);
@@ -95,9 +102,7 @@ function rowStyle(row: PerPathRow) {
 
 export default function ApiRouteHealthPanel() {
   const [rows, setRows] = React.useState<PerPathRow[]>([]);
-  const [summary, setSummary] = React.useState<ObservabilityResponse["summary"] | null>(
-    null,
-  );
+  const [summary, setSummary] = React.useState<ObservabilitySummary | null>(null);
   const [error, setError] = React.useState<string | null>(null);
 
   const poll = React.useCallback(async (): Promise<{ ok: boolean }> => {
@@ -108,12 +113,12 @@ export default function ApiRouteHealthPanel() {
         return { ok: false };
       }
       const json = (await res.json()) as ObservabilityResponse;
-      if (!json.success) {
+      if (!json.success || !json.requests) {
         setError("Observability payload malformed");
         return { ok: false };
       }
       setRows(rowsFromObservability(json));
-      setSummary(json.summary);
+      setSummary(json.requests.summary);
       setError(null);
       return { ok: true };
     } catch (_err) {

--- a/src/hooks/useCommensalRecommendations.ts
+++ b/src/hooks/useCommensalRecommendations.ts
@@ -159,7 +159,12 @@ export function useGuestRecommendations(): UseGuestRecommendationsApi {
       const data = await fetchGuestRecommendations(guests);
       if (runIdRef.current !== myRunId) return;
 
-      const savableGuests: SavableGuest[] = (data.groupMembers ?? []).map(
+      // The API may prepend the authenticated user as a `self` member; only
+      // the commensals (non-self) should be offered for saving as companions.
+      const commensalMembers = (data.groupMembers ?? []).filter(
+        (m: GroupMember) => m.relationship !== "self",
+      );
+      const savableGuests: SavableGuest[] = commensalMembers.map(
         (m: GroupMember, i: number) => ({
           name: m.name ?? guests[i]?.name ?? `Guest ${i + 1}`,
           birthData: m.birthData ?? guests[i]?.birthData,

--- a/src/lib/performance/withTimeout.ts
+++ b/src/lib/performance/withTimeout.ts
@@ -1,0 +1,35 @@
+/**
+ * Wrap a Promise with a deadline. Resolves to `fallback` if the inner Promise
+ * doesn't settle within `ms` milliseconds.
+ *
+ * Use on server-side data fetches (DB queries, external APIs) that have no
+ * native cancel/abort to avoid wedging Vercel functions until the 60s hard
+ * timeout. The fallback lets callers degrade gracefully (e.g. redirect to a
+ * cached page) instead of returning a runtime timeout error to the client.
+ *
+ * The inner Promise is not actually cancelled — Node has no general-purpose
+ * cancellation — it keeps running in the background until it settles. Pair
+ * with an explicit AbortController where the work supports one.
+ */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  fallback: T,
+  label?: string,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<T>((resolve) => {
+    timer = setTimeout(() => {
+      if (label) {
+        console.warn(`[withTimeout] ${label} exceeded ${ms}ms — using fallback`);
+      }
+      resolve(fallback);
+    }, ms);
+  });
+  return Promise.race([
+    promise.finally(() => {
+      if (timer) clearTimeout(timer);
+    }),
+    deadline,
+  ]);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -19,9 +19,36 @@ const authMiddleware = NextAuth(authConfig).auth as unknown as (
   request: NextRequest,
 ) => ReturnType<Response["clone"]> | Promise<Response | undefined> | undefined;
 
-export default function middleware(request: NextRequest) {
+// Slow-middleware diagnostic. Production tail-latency on /profile,
+// /current-chart, /restaurant-creator etc. occasionally exceeds Vercel's 60s
+// function timeout with no obvious code-path explanation; logging timings >1s
+// gives us a real signal in Vercel logs the next time it happens (look for
+// "[middleware] slow" in the error stream).
+const SLOW_MIDDLEWARE_THRESHOLD_MS = 1000;
+
+export default async function middleware(request: NextRequest) {
+  const started = Date.now();
   applyRequestAuthOrigin(request);
-  return authMiddleware(request);
+  try {
+    const result = await authMiddleware(request);
+    const elapsed = Date.now() - started;
+    if (elapsed > SLOW_MIDDLEWARE_THRESHOLD_MS) {
+      console.warn(
+        `[middleware] slow ${elapsed}ms ${request.method} ${request.nextUrl.pathname}`,
+      );
+    }
+    return result;
+  } catch (err) {
+    const elapsed = Date.now() - started;
+    console.error(
+      `[middleware] failed after ${elapsed}ms ${request.method} ${request.nextUrl.pathname}:`,
+      err,
+    );
+    // Don't let middleware errors block the request — return undefined so the
+    // page handler runs and can apply its own auth gate. NextAuth normally
+    // returns undefined here too when there's no redirect to issue.
+    return undefined;
+  }
 }
 
 export const runtime = "nodejs";

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -15,6 +15,11 @@ interface EmailOptions {
   text?: string;
 }
 
+// Module-level flag: log Resend 403 (unverified-domain) once per process at
+// error level, then downgrade subsequent occurrences to warn so the hourly
+// alert-snapshot cron doesn't flood Vercel logs with the same line 24x/day.
+let resend403Logged = false;
+
 class EmailService {
   private resendApiKey: string | null = null;
   private smtpTransporter: any | null = null; // Use any for Transporter to avoid type issues with dynamic import
@@ -124,7 +129,25 @@ class EmailService {
 
       if (!response.ok) {
         const body = await response.text();
-        console.error(`Resend API error (${response.status}): ${body}`);
+        // 403 typically means the sender domain (fromAddress) isn't verified in
+        // the Resend dashboard. This is operator-fixable (verify the domain or
+        // switch fromAddress to a verified one) — log loudly the FIRST time per
+        // process so it's noticed, then downgrade to warn so the hourly cron
+        // doesn't flood the error stream with 24 duplicates per day.
+        if (response.status === 403) {
+          if (!resend403Logged) {
+            console.error(
+              `Resend API 403 — sender domain "${this.fromAddress}" not verified in Resend. ` +
+                `Verify the domain at https://resend.com/domains or set EMAIL_FROM_ADDRESS to a verified address. ` +
+                `Suppressing further duplicates this process. Body: ${body}`,
+            );
+            resend403Logged = true;
+          } else {
+            console.warn(`Resend API 403 (suppressed, see earlier log): ${body.slice(0, 200)}`);
+          }
+        } else {
+          console.error(`Resend API error (${response.status}): ${body}`);
+        }
         return false;
       }
 

--- a/src/services/natalChartService.ts
+++ b/src/services/natalChartService.ts
@@ -83,6 +83,18 @@ interface AstrologizeResponse {
   };
 }
 
+// Resolve an absolute astrologize URL when running on the server (where
+// `fetch` rejects relative paths) and stay relative in the browser.
+function getAstrologizeApiUrl(): string {
+  if (typeof window === "undefined") {
+    if (process.env.VERCEL_URL) {
+      return `https://${process.env.VERCEL_URL}/api/astrologize`;
+    }
+    return `http://localhost:${process.env.PORT || 3000}/api/astrologize`;
+  }
+  return "/api/astrologize";
+}
+
 /**
  * Normalize zodiac sign name from API to our lowercase format
  */
@@ -187,7 +199,7 @@ async function fetchPlanetaryPositions(
       zodiacSystem: "tropical" as const,
     };
 
-    const response = await fetch("/api/astrologize", {
+    const response = await fetch(getAstrologizeApiUrl(), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),

--- a/src/services/notificationDatabaseService.ts
+++ b/src/services/notificationDatabaseService.ts
@@ -95,6 +95,19 @@ class NotificationDatabaseService {
           return rowToNotification(result.rows[0]);
         }
       } catch (error) {
+        // FK violation (23503) means user_id doesn't exist in users — silently
+        // skip rather than logging at error level. This happens for legitimate
+        // edge cases like demo-flow callers passing synthetic IDs or sessions
+        // outliving the underlying user row, and it pollutes the error stream
+        // when it's safe to ignore.
+        const code = (error as { code?: string })?.code;
+        if (code === "23503") {
+          _logger.warn(
+            "[Notification] FK violation on createNotification — user_id missing, skipping",
+            { userId, type },
+          );
+          return null;
+        }
         _logger.error("createNotification failed:", error);
         return null;
       }

--- a/src/types/natalChart.ts
+++ b/src/types/natalChart.ts
@@ -67,7 +67,7 @@ export interface NatalChart {
 export interface GroupMember {
   id: string;
   name: string;
-  relationship?: "family" | "friend" | "partner" | "colleague" | "other";
+  relationship?: "self" | "family" | "friend" | "partner" | "colleague" | "other";
   birthData: BirthData;
   natalChart: NatalChart;
   createdAt: string;


### PR DESCRIPTION
## Summary

Five-commit production-cleanup branch. Each commit is self-contained and was verified independently before stacking.

- **`d8e572e` ops: schema drift cleanup, migration runner, 4 production log fixes** — addresses the structural cause of #447 (lost DEFAULT clauses breaking signup). Applies migrations 27/28/29/31/35 to prod, restores DEFAULTs lost from 30 columns in `01-schema.sql`, restores `users.role DEFAULT 'USER'` (prod had drifted to `'ALCHEMIST'`), rewrites `saved_charts` in `10-social-schema.sql` to match actual prod shape. Adds `scripts/migrate.ts` + `backend/scripts/run_init_migrations.py` so future schema files run automatically. Wraps `userDatabase.getUserByEmail` in an 8s timeout on `/current-chart`/`/birth-chart` (root cause of the 60s Vercel timeouts in 24h logs). Classifies notification FK violations as warn instead of error. Deduplicates the Resend 403 error spam to one log per process.

- **`35fe503` perf: bound (alchm) page timeouts + middleware timing instrumentation** — wraps the NextAuth middleware in timing + try/catch (anything >1s logs `[middleware] slow ${ms}` so we can pinpoint cold-start tail latency next time `/profile` or `/restaurant-creator` times out). Caps `(alchm)/layout.tsx` `maxDuration` at 30s (was inheriting Vercel's 60s default — worst legitimate case is `/current-chart` which bounds DB at 8s, so 30s is >3x the legitimate ceiling). Adds a route-group `loading.tsx` so users see motion immediately instead of a blank page until SSR completes.

- **`796b5b4` commensal: resolve 500 on guest recommendations + include user in composite** — server-side `fetch("/api/astrologize")` in `natalChartService` failed with a relative URL, causing every guest natal-chart calculation in `/api/commensal/guest-recommendations` to throw. Added the absolute-URL helper already used in `astrologizeApi.ts`. Also auto-includes the authenticated user's saved natal chart as a `self` member of the composite so recommendations reflect (you + your commensals) per the original "added to the user chart" intent.

- **`b460d03` admin: wire High Alchemist dashboard to real data + mobile responsive** — `/api/admin/dashboard` already reports `meta.mockedFields: []`, but the UI was ignoring most of the payload in favor of inline hardcoded numbers (KPIStrip's 12 fabricated tiles, MasterLineHero's invented `INC-2207 cart 5xx` events, AdminSideRail's `412 live · 48.2k · $84.2k` badges, etc.). This wires every prominent surface to the real payload — KPIStrip → 12 tiles from stats/commerce/cosmicYield/etc., MasterLineHero → pulse-driven tickers + systemStatus-driven orbital chart, AdminSideRail → real badges + bottom KV reading `VERCEL_GIT_COMMIT_SHA`/`VERCEL_REGION`/`dbObservability.pool`, etc. Adds a `≤960px` media-query block: side rail collapses to an off-canvas drawer, KPI grid drops to 2 cols (1 col below 600px). Also folds in an in-flight fix to `ApiRouteHealthPanel` for the refactored `/api/admin/observability` response shape (`requests.summary` + `requests.recent` instead of flat `summary` + `recent`) — was the source of the intermittent "Failed to reach admin API" toast on the operator console.

- **`d655a30` cosmic-recipe: proxy to PA /api/generate-recipe, drop /api/chat hack** — the cosmic-recipe route was POSTing to a non-existent `/api/generate-recipe` endpoint on the planetary_agents backend since the `0bfc353` refactor, which is what's been recording HTTP 404 in `synthetic_probe_results` every hour and flipping "AI Recipe Generation" to INCIDENT on the operator dashboard. An interim fix on this branch retargeted `/api/chat` with prompt-coerced JSON output, but it was fragile (model drift, hijacked Hildegard's persona, duplicated schema, no server-side validation/retry). PA has now shipped a first-class `/api/generate-recipe` that owns the alchemical-chef persona, provider-native JSON mode, Pydantic schema validation, one auto-retry, and a 60s prompt-hash cache. WTEN collapses to a thin proxy that still computes the structured grounding fields PA can't recreate (`dominantElement`, indexed `topIngredients`, ESMS alchemical state, thermodynamic properties), enriches the prompt with the user's recent food diary + preferred main ingredients, and forwards. Defensive Zod re-check at the WTEN edge against `cosmicRecipeSchema` so future drift between repos surfaces locally.

## Deployment ordering

⚠️ **PA's `/api/generate-recipe` must reach `api.agents.alchm.kitchen` prod before this WTEN PR merges.** Verified prod `openapi.json` does not yet list the new endpoint at the time of writing. Sequence: PA deploys → confirm endpoint visible in PA prod openapi → merge this PR → next hourly cron run (top of next hour) writes `status='success'` to `synthetic_probe_results` → SystemStatusPanel flips AI Recipe Generation out of INCIDENT.

## Test plan

- [ ] PA prod openapi at `https://api.agents.alchm.kitchen/openapi.json` lists `POST /api/generate-recipe` before this merges
- [ ] After deploy: hit `https://alchm.kitchen/api/generate-cosmic-recipe` (auth'd) with `{"prompt":"weekday dinner","diet":"omnivore"}` — confirm 200 + flat cosmicRecipeSchema body with `success: true`
- [ ] Next hourly `/api/cron/synthetic-cosmic-recipe` run records `status='success'` in `synthetic_probe_results` (not 404)
- [ ] `/admin` SystemStatusPanel: "AI Recipe Generation" flips out of INCIDENT
- [ ] `/admin` ApiRouteHealthPanel: no more intermittent "Failed to reach admin API" toast
- [ ] `/admin` (High Alchemist dashboard): no more inline hardcoded numbers — all tiles read from `/api/admin/dashboard` payload
- [ ] Mobile (≤960px): admin dashboard side rail collapses to drawer, KPI grid wraps
- [ ] `/api/commensal/guest-recommendations` succeeds for anonymous users with a guest member; auth'd users see themselves as `self` in composite
- [ ] `/current-chart` and `/birth-chart` no longer hit 60s Vercel timeouts under slow-DB conditions (8s budget falls back to un-migrated chart)
- [ ] Backend container redeploys when `database/init/**` changes (`railway.json` watchPatterns)

## Reviewer notes

- The branch grew incrementally across the session — each commit body has the full diagnosis. Reviewing commit-by-commit is recommended; the 5 commits are independent enough that you can land them piecemeal if needed.
- Two related cleanups were intentionally left out and are in-flight on the working tree (separate PR): `src/app/api/nanobanana/generate/route.ts` has the same `agents.alchm.kitchen` vs `api.agents.alchm.kitchen` host bug the cosmic-recipe route just fixed; and `src/data/ingredients/index.ts` has uncommitted type-assertion work that's currently blocking the production `bun run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)