### PR TITLE
feat(mcp): phase 2 — api keys, stripe top-up, synthetic-mcp 401 fix

### DIFF
--- a/apply_migration_45.cjs
+++ b/apply_migration_45.cjs
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const path = require('path');
+const { Client } = require('pg');
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error('DATABASE_URL environment variable is required to run this migration.');
+  process.exit(1);
+}
+
+async function main() {
+  console.log('Connecting to PostgreSQL database...');
+  const client = new Client({
+    connectionString: DATABASE_URL,
+    ssl: DATABASE_URL.includes('localhost') ? false : { rejectUnauthorized: false },
+  });
+
+  try {
+    await client.connect();
+    console.log('Successfully connected to database.');
+
+    const sqlPath = path.join(__dirname, 'database', 'init', '45-agent-forge-schema.sql');
+    console.log(`Reading migration script from: ${sqlPath}`);
+    const sql = fs.readFileSync(sqlPath, 'utf8');
+
+    console.log('Executing Agent Forge SQL migration (45-agent-forge-schema.sql)...');
+    await client.query(sql);
+    console.log('Agent Forge schema applied and indices created successfully.');
+
+    console.log('Verifying tables inside database information_schema...');
+    const verification = await client.query(`
+      SELECT table_name 
+      FROM information_schema.tables 
+      WHERE table_schema = 'public' 
+        AND table_name IN ('alchemical_constitutions', 'celestial_pantries', 'cart_handoff_intents')
+      ORDER BY table_name;
+    `);
+    
+    console.log('Verification Success! Live tables verified:');
+    verification.rows.forEach(row => {
+      console.log(` - ${row.table_name}`);
+    });
+
+    if (verification.rows.length !== 3) {
+      console.warn(`WARNING: Expected 3 tables, but found ${verification.rows.length}. Please check the output.`);
+    }
+  } catch (error) {
+    console.error('Migration failed during execution:', error);
+    process.exit(1);
+  } finally {
+    await client.end();
+    console.log('Database connection closed.');
+  }
+}
+
+main();

--- a/apply_migration_46.cjs
+++ b/apply_migration_46.cjs
@@ -1,0 +1,97 @@
+/**
+ * Apply migration 46: mcp_invocations table + extended prune function.
+ *
+ * Usage:
+ *   DATABASE_URL=postgresql://... node apply_migration_46.cjs
+ *
+ * The whole migration runs inside one transaction so a partial apply
+ * (table created but function drop/recreate failed) can't leave the
+ * schema in a broken state.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { Client } = require("pg");
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error("DATABASE_URL environment variable is required.");
+  process.exit(1);
+}
+
+async function main() {
+  console.log("Connecting to PostgreSQL…");
+  const client = new Client({
+    connectionString: DATABASE_URL,
+    ssl: DATABASE_URL.includes("localhost") ? false : { rejectUnauthorized: false },
+  });
+
+  try {
+    await client.connect();
+    console.log("Connected.");
+
+    const sqlPath = path.join(__dirname, "database", "init", "46-mcp-invocations.sql");
+    const sql = fs.readFileSync(sqlPath, "utf8");
+    console.log(`Loaded ${sqlPath} (${sql.length} bytes).`);
+
+    console.log("BEGIN");
+    await client.query("BEGIN");
+    await client.query(sql);
+    console.log("COMMIT");
+    await client.query("COMMIT");
+    console.log("Migration applied.");
+
+    console.log("\nVerification:");
+    const tableCheck = await client.query(`
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = 'mcp_invocations'
+    `);
+    console.log(`  mcp_invocations table present: ${tableCheck.rows.length === 1}`);
+
+    const indexCheck = await client.query(`
+      SELECT indexname
+      FROM pg_indexes
+      WHERE schemaname = 'public' AND tablename = 'mcp_invocations'
+      ORDER BY indexname
+    `);
+    console.log(`  Indexes:`);
+    indexCheck.rows.forEach((r) => console.log(`    - ${r.indexname}`));
+
+    const functionCheck = await client.query(`
+      SELECT pg_get_function_result(p.oid) AS result_signature
+      FROM pg_proc p
+      JOIN pg_namespace n ON p.pronamespace = n.oid
+      WHERE n.nspname = 'public' AND p.proname = 'prune_observability_logs'
+    `);
+    console.log(`  prune_observability_logs returns:`);
+    functionCheck.rows.forEach((r) =>
+      console.log(`    ${r.result_signature}`),
+    );
+
+    const colCheck = await client.query(`
+      SELECT column_name, data_type, is_nullable
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'mcp_invocations'
+      ORDER BY ordinal_position
+    `);
+    console.log(`  mcp_invocations columns:`);
+    colCheck.rows.forEach((r) =>
+      console.log(
+        `    ${r.column_name.padEnd(20)} ${r.data_type.padEnd(28)} nullable=${r.is_nullable}`,
+      ),
+    );
+  } catch (err) {
+    console.error("Migration failed:", err.message);
+    try {
+      await client.query("ROLLBACK");
+      console.error("Rolled back.");
+    } catch {}
+    process.exit(1);
+  } finally {
+    await client.end();
+    console.log("\nConnection closed.");
+  }
+}
+
+main();

--- a/database/init/47-synastry-cache.sql
+++ b/database/init/47-synastry-cache.sql
@@ -1,0 +1,130 @@
+-- Migration: 47-synastry-cache.sql
+-- Cache layer for the synastry MCP tools (compute_synastry_overlay,
+-- get_transit_natal_overlay). One row per agent×planet keeps natal
+-- positions joinable; two materialized views precompute the pairwise
+-- inter-aspects and a single tension/harmony/intensification score per
+-- pair, so the desktop Jing Arena hot path is one indexed SELECT.
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 1. Natal positions per agent
+-- ─────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS agent_natal_positions (
+    agent_id       TEXT             NOT NULL,
+    planet         TEXT             NOT NULL,  -- 'Sun', 'Moon', 'Mercury', ..., 'ASC', 'MC'
+    longitude      DOUBLE PRECISION NOT NULL,  -- absolute ecliptic, 0..360
+    sign           TEXT             NOT NULL,
+    degree_in_sign DOUBLE PRECISION NOT NULL,  -- 0..30
+    house          SMALLINT,
+    retrograde     BOOLEAN          NOT NULL DEFAULT FALSE,
+    updated_at     TIMESTAMPTZ      NOT NULL DEFAULT now(),
+    PRIMARY KEY (agent_id, planet)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_natal_positions_planet
+    ON agent_natal_positions(planet);
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 2. Pairwise inter-aspects (canonicalized so each unordered pair
+--    appears exactly once via agent_id < join condition)
+-- ─────────────────────────────────────────────────────────────────────
+
+DROP MATERIALIZED VIEW IF EXISTS synastry_aspects CASCADE;
+
+CREATE MATERIALIZED VIEW synastry_aspects AS
+WITH pairs AS (
+    SELECT
+        a.agent_id     AS agent_a,
+        b.agent_id     AS agent_b,
+        a.planet       AS planet_a,
+        b.planet       AS planet_b,
+        a.longitude    AS lon_a,
+        b.longitude    AS lon_b,
+        LEAST(
+            ABS(a.longitude - b.longitude),
+            360.0 - ABS(a.longitude - b.longitude)
+        )              AS delta_lon
+    FROM agent_natal_positions a
+    JOIN agent_natal_positions b
+        ON a.agent_id < b.agent_id  -- dedupe ordering, exclude self-pairs
+)
+SELECT
+    agent_a, agent_b, planet_a, planet_b, lon_a, lon_b, delta_lon,
+    CASE
+        WHEN delta_lon              <= 8  THEN 'conjunction'
+        WHEN ABS(delta_lon - 60)    <= 6  THEN 'sextile'
+        WHEN ABS(delta_lon - 90)    <= 8  THEN 'square'
+        WHEN ABS(delta_lon - 120)   <= 8  THEN 'trine'
+        WHEN ABS(delta_lon - 180)   <= 10 THEN 'opposition'
+    END AS aspect_type,
+    CASE
+        WHEN delta_lon              <= 8  THEN delta_lon
+        WHEN ABS(delta_lon - 60)    <= 6  THEN ABS(delta_lon - 60)
+        WHEN ABS(delta_lon - 90)    <= 8  THEN ABS(delta_lon - 90)
+        WHEN ABS(delta_lon - 120)   <= 8  THEN ABS(delta_lon - 120)
+        WHEN ABS(delta_lon - 180)   <= 10 THEN ABS(delta_lon - 180)
+    END AS orb,
+    CASE
+        WHEN delta_lon              <= 8  THEN 'intensification'
+        WHEN ABS(delta_lon - 60)    <= 6  THEN 'harmony'
+        WHEN ABS(delta_lon - 90)    <= 8  THEN 'friction'
+        WHEN ABS(delta_lon - 120)   <= 8  THEN 'harmony'
+        WHEN ABS(delta_lon - 180)   <= 10 THEN 'friction'
+    END AS harmonic
+FROM pairs
+WHERE delta_lon              <= 8
+   OR ABS(delta_lon - 60)    <= 6
+   OR ABS(delta_lon - 90)    <= 8
+   OR ABS(delta_lon - 120)   <= 8
+   OR ABS(delta_lon - 180)   <= 10;
+
+CREATE UNIQUE INDEX idx_synastry_aspects_pk
+    ON synastry_aspects(agent_a, agent_b, planet_a, planet_b);
+CREATE INDEX idx_synastry_aspects_pair
+    ON synastry_aspects(agent_a, agent_b);
+CREATE INDEX idx_synastry_aspects_harmonic
+    ON synastry_aspects(harmonic);
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 3. One-row-per-pair scores (the hot path for castJingDuel)
+--    Orb-decay weighting: exact aspect = 1.0, max orb = 0.0
+-- ─────────────────────────────────────────────────────────────────────
+
+DROP MATERIALIZED VIEW IF EXISTS synastry_scores;
+
+CREATE MATERIALIZED VIEW synastry_scores AS
+SELECT
+    agent_a,
+    agent_b,
+    COALESCE(SUM(CASE WHEN harmonic = 'friction'
+                      THEN 1.0 - (orb / 10.0) END), 0)::float       AS tension_score,
+    COALESCE(SUM(CASE WHEN harmonic = 'harmony'
+                      THEN 1.0 - (orb / 8.0) END), 0)::float         AS harmony_score,
+    COALESCE(SUM(CASE WHEN harmonic = 'intensification'
+                      THEN 1.0 - (orb / 8.0) END), 0)::float         AS intensification_score,
+    COUNT(*)                                                          AS aspect_count,
+    now()                                                             AS computed_at
+FROM synastry_aspects
+GROUP BY agent_a, agent_b;
+
+CREATE UNIQUE INDEX idx_synastry_scores_pk
+    ON synastry_scores(agent_a, agent_b);
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 4. Refresh helper. Call from synastryTools after upserting natal
+--    positions; safe to call concurrently after the views exist.
+-- ─────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION refresh_synastry_views() RETURNS void AS $$
+BEGIN
+    -- CONCURRENTLY requires the view to be populated at least once; on
+    -- first run, fall back to a blocking refresh.
+    BEGIN
+        REFRESH MATERIALIZED VIEW CONCURRENTLY synastry_aspects;
+        REFRESH MATERIALIZED VIEW CONCURRENTLY synastry_scores;
+    EXCEPTION WHEN OTHERS THEN
+        REFRESH MATERIALIZED VIEW synastry_aspects;
+        REFRESH MATERIALIZED VIEW synastry_scores;
+    END;
+END;
+$$ LANGUAGE plpgsql;

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -12,6 +12,12 @@ An [MCP server](https://modelcontextprotocol.io) exposing three alchemical tools
 
 `generate_cosmic_recipe` debits tokens only when called with a valid `_meta.apiKey`. Anonymous callers receive a `QUOTA` error rather than a free recipe.
 
+## Mint an API key
+
+End users mint, list, and revoke their own keys at [`/profile/api-keys`](https://alchm.kitchen/profile/api-keys). The plaintext is shown exactly once — paste it into the MCP client config immediately. The public onboarding doc lives at [`/docs/mcp`](https://alchm.kitchen/docs/mcp).
+
+Keys are stored as `sha256(plaintext)` in the `api_keys` table; the only place the plaintext ever appears is the `POST /api/account/api-keys` response body.
+
 ## Run
 
 ```bash

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -99,6 +99,80 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
         },
       },
+      {
+        name: "compute_synastry_overlay",
+        description: `Compute the inter-aspect ledger between two agents' natal charts: pairwise planet-to-planet aspects (conjunction, sextile, square, trine, opposition) with orb/exactness, plus tension / harmony / intensification scores and a recommended target stance (clash | absorb | mirror). Drives the desktop Jing Arena's counter-move pool selection. Pure math; pg cache used when seeded. ${META_DOC}`,
+        inputSchema: {
+          type: "object",
+          required: ["agentA", "agentB"],
+          properties: {
+            agentA: {
+              type: "object",
+              required: ["id", "natalChart"],
+              properties: {
+                id: { type: "string", description: "Stable agent identifier" },
+                natalChart: {
+                  type: "object",
+                  description: "Natal chart with planets keyed by name, each having {sign, degree, retrograde?, house?}",
+                },
+              },
+            },
+            agentB: {
+              type: "object",
+              required: ["id", "natalChart"],
+              properties: {
+                id: { type: "string" },
+                natalChart: { type: "object" },
+              },
+            },
+            focusPlanets: {
+              type: "array",
+              items: { type: "string" },
+              description: "Planets to include (default: Sun, Moon, Mercury, Venus, Mars, Saturn, Jupiter)",
+            },
+            cacheStrategy: {
+              type: "string",
+              enum: ["read", "write", "bypass"],
+              description: "read = use synastry_scores if present; write = compute and upsert; bypass = compute, skip pg. Default: read.",
+            },
+          },
+        },
+      },
+      {
+        name: "get_transit_natal_overlay",
+        description: `Compute the current sky × one agent's natal chart: which transiting planets are activating which natal points, with aspect type/orb/exactness, dominant boost element, and continuous boost magnitude (0..1). Replaces the global 'Transit Active' badge with per-agent overlays. ${META_DOC}`,
+        inputSchema: {
+          type: "object",
+          required: ["agent"],
+          properties: {
+            agent: {
+              type: "object",
+              required: ["id", "natalChart"],
+              properties: {
+                id: { type: "string" },
+                natalChart: { type: "object" },
+              },
+            },
+            transitTime: {
+              type: "string",
+              description: "ISO 8601 timestamp for the transit moment (default: now)",
+            },
+            latitude: {
+              type: "number",
+              description: "Latitude for the transit chart (default: 40.7498 NYC)",
+            },
+            longitude: {
+              type: "number",
+              description: "Longitude for the transit chart (default: -73.7976 NYC)",
+            },
+            focusPlanets: {
+              type: "array",
+              items: { type: "string" },
+              description: "Transiting planets to include (default: Sun, Moon, Mars, Saturn, Jupiter, Pluto)",
+            },
+          },
+        },
+      },
     ],
   };
 });
@@ -143,7 +217,7 @@ async function main() {
   console.error("\n================ ALCHM.KITCHEN MCP SERVER STARTED ================");
   console.error("Engine: Bun v1.3.13 / Native TypeScript Support");
   console.error("Communication Protocol: Model Context Protocol (Stdio)");
-  console.error("Tools Loaded: get_live_sky_transits, alchemize_ingredients, generate_cosmic_recipe");
+  console.error("Tools Loaded: get_live_sky_transits, alchemize_ingredients, generate_cosmic_recipe, compute_synastry_overlay, get_transit_natal_overlay");
   console.error(
     `Auth: ${process.env.MCP_USER_API_KEY ? "MCP_USER_API_KEY env" : "_meta.apiKey per call"}`,
   );

--- a/src/__tests__/utils/urlUtils.test.ts
+++ b/src/__tests__/utils/urlUtils.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for `getSelfBaseUrl` — guards the resolution order that prevents
+ * server-side self-fetches from hitting Vercel's Deployment Protection
+ * gate on the deployment URL.
+ */
+import { getSelfBaseUrl } from "@/utils/urlUtils";
+
+describe("getSelfBaseUrl", () => {
+  const ENV_KEYS = [
+    "NEXT_PUBLIC_SITE_URL",
+    "SITE_URL",
+    "VERCEL_PROJECT_PRODUCTION_URL",
+    "VERCEL_URL",
+    "PORT",
+  ] as const;
+
+  let saved: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>>;
+
+  beforeEach(() => {
+    saved = {};
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      const v = saved[k];
+      if (v === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = v;
+      }
+    }
+  });
+
+  it("prefers NEXT_PUBLIC_SITE_URL when set", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "https://alchm.kitchen";
+    process.env.VERCEL_PROJECT_PRODUCTION_URL = "alchm.kitchen";
+    process.env.VERCEL_URL = "deploy-abc.vercel.app";
+    expect(getSelfBaseUrl()).toBe("https://alchm.kitchen");
+  });
+
+  it("prefers SITE_URL if NEXT_PUBLIC_SITE_URL is absent", () => {
+    process.env.SITE_URL = "https://example.com/";
+    process.env.VERCEL_URL = "deploy-abc.vercel.app";
+    expect(getSelfBaseUrl()).toBe("https://example.com");
+  });
+
+  it("uses VERCEL_PROJECT_PRODUCTION_URL when no explicit override", () => {
+    process.env.VERCEL_PROJECT_PRODUCTION_URL = "alchm.kitchen";
+    process.env.VERCEL_URL = "alchm-kitchen-abc.vercel.app";
+    expect(getSelfBaseUrl()).toBe("https://alchm.kitchen");
+  });
+
+  it("strips an accidental scheme from VERCEL_PROJECT_PRODUCTION_URL", () => {
+    process.env.VERCEL_PROJECT_PRODUCTION_URL = "https://alchm.kitchen";
+    expect(getSelfBaseUrl()).toBe("https://alchm.kitchen");
+  });
+
+  it("falls back to VERCEL_URL only as last resort on Vercel", () => {
+    process.env.VERCEL_URL = "alchm-kitchen-abc.vercel.app";
+    expect(getSelfBaseUrl()).toBe("https://alchm-kitchen-abc.vercel.app");
+  });
+
+  it("falls back to localhost when nothing is set", () => {
+    expect(getSelfBaseUrl()).toBe("http://localhost:3000");
+  });
+
+  it("honors PORT in localhost fallback", () => {
+    process.env.PORT = "4001";
+    expect(getSelfBaseUrl()).toBe("http://localhost:4001");
+  });
+});

--- a/src/app/(alchm)/account/billing/mcp/page.tsx
+++ b/src/app/(alchm)/account/billing/mcp/page.tsx
@@ -1,0 +1,32 @@
+/**
+ * /account/billing/mcp — buy-button page for the MCP top-up SKUs.
+ *
+ * Server component shell mounts the client panel; auth and DB I/O all
+ * happen inside the panel's fetch calls so this segment stays fast.
+ *
+ * Wrapped in <Suspense> because the panel uses useSearchParams to
+ * surface ?status=success / ?status=canceled after the Stripe return —
+ * Next.js requires Suspense around any client component that reads
+ * search params in app router.
+ *
+ * @file src/app/(alchm)/account/billing/mcp/page.tsx
+ */
+
+import { Suspense } from "react";
+import { McpTopUpPanel } from "@/components/account/McpTopUpPanel";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "MCP top-up — alchm.kitchen",
+  description:
+    "Buy ESMS bundles to use against the alchm.kitchen MCP tools.",
+};
+
+export default function McpBillingPage() {
+  return (
+    <Suspense fallback={null}>
+      <McpTopUpPanel />
+    </Suspense>
+  );
+}

--- a/src/app/(alchm)/profile/api-keys/page.tsx
+++ b/src/app/(alchm)/profile/api-keys/page.tsx
@@ -1,0 +1,24 @@
+/**
+ * /profile/api-keys — mint, list, and revoke API keys for the MCP
+ * server and other external integrations.
+ *
+ * Mirrors the /profile/security shape: server-component page that mounts
+ * a single client panel; auth check and DB I/O happen inside the panel's
+ * fetch calls so the cold-start budget on this segment stays small.
+ *
+ * @file src/app/(alchm)/profile/api-keys/page.tsx
+ */
+
+import { ApiKeysPanel } from "@/components/account/ApiKeysPanel";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "API Keys — alchm.kitchen",
+  description:
+    "Mint and manage API keys for Claude Desktop, Cursor, and other MCP clients.",
+};
+
+export default function ProfileApiKeysPage() {
+  return <ApiKeysPanel />;
+}

--- a/src/app/api/account/api-keys/[keyId]/route.ts
+++ b/src/app/api/account/api-keys/[keyId]/route.ts
@@ -1,0 +1,86 @@
+/**
+ * DELETE /api/account/api-keys/[keyId] — soft-revoke a key.
+ *
+ * Sets `api_keys.is_active = false` rather than hard-deleting, so the
+ * `mcp_invocations.api_key_id` FK chain (ON DELETE SET NULL) keeps
+ * historical telemetry attributable.
+ *
+ * @file src/app/api/account/api-keys/[keyId]/route.ts
+ */
+
+import { NextResponse } from "next/server";
+import { revokeApiKey } from "@/lib/api-keys/queries";
+import { auth } from "@/lib/auth/auth";
+import { rateLimit } from "@/lib/rateLimit";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const REVOKE_LIMIT = {
+  window: 60_000,
+  max: 30,
+  bucket: "api-keys:revoke",
+};
+
+interface Params {
+  params: Promise<{ keyId: string }>;
+}
+
+async function resolveUserId(request: Request): Promise<string | null> {
+  const session = await auth();
+  const user = session?.user as { id?: string } | undefined;
+  if (user?.id) return user.id;
+
+  const authHeader = request.headers.get("authorization") ?? "";
+  if (authHeader.startsWith("Bearer ")) {
+    try {
+      const { validateToken } = await import("@/lib/auth/validateRequest");
+      const result = await validateToken(authHeader.slice(7));
+      if (result.valid && result.user) return result.user.userId;
+    } catch {
+      /* fall through */
+    }
+  }
+  return null;
+}
+
+export async function DELETE(request: Request, { params }: Params) {
+  const rl = await rateLimit(request, REVOKE_LIMIT);
+  if (!rl.allowed) return rl.response!;
+
+  const userId = await resolveUserId(request);
+  if (!userId) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 },
+    );
+  }
+
+  const { keyId } = await params;
+  if (!keyId) {
+    return NextResponse.json(
+      { success: false, error: "Missing keyId" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const revokedId = await revokeApiKey(userId, keyId);
+    if (!revokedId) {
+      return NextResponse.json(
+        { success: false, error: "Key not found or already revoked" },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({ success: true, revoked: revokedId });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Failed to revoke api key",
+        detail: process.env.NODE_ENV === "development" ? String(err) : undefined,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/account/api-keys/__tests__/route.test.ts
+++ b/src/app/api/account/api-keys/__tests__/route.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Route handler tests for /api/account/api-keys (GET, POST) and
+ * /api/account/api-keys/[keyId] (DELETE).
+ *
+ * DB + auth are mocked at module boundaries — this is a unit test on
+ * the handlers themselves: validation, status codes, one-time plaintext
+ * reveal contract, ownership checks via revokeApiKey delegation.
+ */
+
+jest.mock("@/lib/auth/auth", () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock("@/lib/rateLimit", () => ({
+  rateLimit: jest
+    .fn()
+    .mockResolvedValue({ allowed: true, remaining: 100, resetMs: 60_000 }),
+}));
+
+jest.mock("@/lib/api-keys/queries", () => ({
+  mintApiKey: jest.fn(),
+  listUserApiKeys: jest.fn(),
+  revokeApiKey: jest.fn(),
+}));
+
+import { auth } from "@/lib/auth/auth";
+import {
+  listUserApiKeys,
+  mintApiKey,
+  revokeApiKey,
+} from "@/lib/api-keys/queries";
+import { GET, POST } from "@/app/api/account/api-keys/route";
+import { DELETE } from "@/app/api/account/api-keys/[keyId]/route";
+
+const mockedAuth = auth as unknown as jest.MockedFunction<
+  () => Promise<unknown>
+>;
+const mockedMint = mintApiKey as jest.MockedFunction<typeof mintApiKey>;
+const mockedList = listUserApiKeys as jest.MockedFunction<
+  typeof listUserApiKeys
+>;
+const mockedRevoke = revokeApiKey as jest.MockedFunction<typeof revokeApiKey>;
+
+const USER_ID = "11111111-1111-1111-1111-111111111111";
+
+function makeRequest(
+  url: string,
+  init: RequestInit & { json?: unknown } = {},
+): Request {
+  const { json, ...rest } = init;
+  return new Request(url, {
+    ...rest,
+    headers: {
+      "content-type": "application/json",
+      ...(rest.headers as Record<string, string> | undefined),
+    },
+    body: json !== undefined ? JSON.stringify(json) : (rest.body as BodyInit),
+  });
+}
+
+beforeEach(() => {
+  mockedAuth.mockReset();
+  mockedMint.mockReset();
+  mockedList.mockReset();
+  mockedRevoke.mockReset();
+});
+
+describe("GET /api/account/api-keys", () => {
+  it("401s when no session", async () => {
+    mockedAuth.mockResolvedValueOnce(null);
+    const res = await GET(makeRequest("http://x/api/account/api-keys"));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns the user's keys (no plaintext) when authed", async () => {
+    mockedAuth.mockResolvedValueOnce({ user: { id: USER_ID } });
+    mockedList.mockResolvedValueOnce([
+      {
+        id: "k1",
+        name: "Claude Desktop",
+        scopes: ["mcp:invoke"],
+        rate_limit_tier: "authenticated",
+        is_active: true,
+        expires_at: null,
+        last_used_at: null,
+        usage_count: 0,
+        created_at: "2026-05-26T05:00:00.000Z",
+      },
+    ]);
+    const res = await GET(makeRequest("http://x/api/account/api-keys"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.keys).toHaveLength(1);
+    expect(body.keys[0].id).toBe("k1");
+    // Hard contract: GET response NEVER carries a plaintext field.
+    expect(JSON.stringify(body)).not.toMatch(/plaintext|sk_alchm_live_/);
+    expect(mockedList).toHaveBeenCalledWith(USER_ID);
+  });
+});
+
+describe("POST /api/account/api-keys", () => {
+  it("401s when no session", async () => {
+    mockedAuth.mockResolvedValueOnce(null);
+    const res = await POST(
+      makeRequest("http://x/api/account/api-keys", {
+        method: "POST",
+        json: { name: "test" },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("400s on empty name", async () => {
+    mockedAuth.mockResolvedValueOnce({ user: { id: USER_ID } });
+    const res = await POST(
+      makeRequest("http://x/api/account/api-keys", {
+        method: "POST",
+        json: { name: "   " },
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/name/);
+  });
+
+  it("400s on invalid JSON body", async () => {
+    mockedAuth.mockResolvedValueOnce({ user: { id: USER_ID } });
+    const res = await POST(
+      new Request("http://x/api/account/api-keys", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not json",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns the plaintext exactly once on a successful mint", async () => {
+    mockedAuth.mockResolvedValueOnce({ user: { id: USER_ID } });
+    mockedMint.mockResolvedValueOnce({
+      row: {
+        id: "k1",
+        name: "Cursor",
+        scopes: ["mcp:invoke"],
+        rate_limit_tier: "authenticated",
+        is_active: true,
+        expires_at: null,
+        last_used_at: null,
+        usage_count: 0,
+        created_at: "2026-05-26T05:00:00.000Z",
+      },
+      plaintext:
+        "sk_alchm_live_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq",
+    });
+    const res = await POST(
+      makeRequest("http://x/api/account/api-keys", {
+        method: "POST",
+        json: { name: "Cursor", scopes: ["mcp:invoke"] },
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.plaintext).toMatch(/^sk_alchm_live_[A-Za-z0-9_-]{43}$/);
+    expect(body.key.id).toBe("k1");
+    expect(mockedMint).toHaveBeenCalledWith({
+      userId: USER_ID,
+      name: "Cursor",
+      scopes: ["mcp:invoke"],
+      expiresAt: undefined,
+    });
+  });
+
+  it("500s when the DB layer throws", async () => {
+    mockedAuth.mockResolvedValueOnce({ user: { id: USER_ID } });
+    mockedMint.mockRejectedValueOnce(new Error("db went away"));
+    const res = await POST(
+      makeRequest("http://x/api/account/api-keys", {
+        method: "POST",
+        json: { name: "key" },
+      }),
+    );
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("DELETE /api/account/api-keys/[keyId]", () => {
+  const params = (keyId: string) => ({
+    params: Promise.resolve({ keyId }),
+  });
+
+  it("401s when no session", async () => {
+    mockedAuth.mockResolvedValueOnce(null);
+    const res = await DELETE(
+      makeRequest("http://x/api/account/api-keys/k1", {
+        method: "DELETE",
+      }),
+      params("k1"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("404s when the key is not owned by this user or already revoked", async () => {
+    mockedAuth.mockResolvedValueOnce({ user: { id: USER_ID } });
+    mockedRevoke.mockResolvedValueOnce(null);
+    const res = await DELETE(
+      makeRequest("http://x/api/account/api-keys/k1", { method: "DELETE" }),
+      params("k1"),
+    );
+    expect(res.status).toBe(404);
+    expect(mockedRevoke).toHaveBeenCalledWith(USER_ID, "k1");
+  });
+
+  it("returns the revoked id on success", async () => {
+    mockedAuth.mockResolvedValueOnce({ user: { id: USER_ID } });
+    mockedRevoke.mockResolvedValueOnce("k1");
+    const res = await DELETE(
+      makeRequest("http://x/api/account/api-keys/k1", { method: "DELETE" }),
+      params("k1"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.revoked).toBe("k1");
+  });
+});

--- a/src/app/api/account/api-keys/route.ts
+++ b/src/app/api/account/api-keys/route.ts
@@ -1,0 +1,128 @@
+/**
+ * GET  /api/account/api-keys — list the caller's keys (never the plaintext)
+ * POST /api/account/api-keys — mint a new key, returning the plaintext ONCE
+ *
+ * Plaintext appears only in the POST response body. Lookups (in
+ * `src/lib/mcp/auth.ts`) re-hash inbound keys and look them up by
+ * `key_hash`, so the plaintext is never recoverable after this call.
+ *
+ * Rate-limited per IP under bucket `api-keys` to throttle scripted abuse;
+ * the bucket is separate from per-key MCP-invoke limits.
+ *
+ * @file src/app/api/account/api-keys/route.ts
+ */
+
+import { NextResponse } from "next/server";
+import { listUserApiKeys, mintApiKey } from "@/lib/api-keys/queries";
+import { auth } from "@/lib/auth/auth";
+import { rateLimit } from "@/lib/rateLimit";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const LIST_LIMIT = { window: 60_000, max: 60, bucket: "api-keys:list" };
+const MINT_LIMIT = { window: 60_000, max: 10, bucket: "api-keys:mint" };
+
+async function resolveUserId(request: Request): Promise<string | null> {
+  const session = await auth();
+  const user = session?.user as { id?: string } | undefined;
+  if (user?.id) return user.id;
+
+  // Bearer JWT fallback so headless API clients (and tests) can hit the
+  // route without a NextAuth cookie. Cookie path stays primary for real users.
+  const authHeader = request.headers.get("authorization") ?? "";
+  if (authHeader.startsWith("Bearer ")) {
+    try {
+      const { validateToken } = await import("@/lib/auth/validateRequest");
+      const result = await validateToken(authHeader.slice(7));
+      if (result.valid && result.user) return result.user.userId;
+    } catch {
+      /* fall through */
+    }
+  }
+  return null;
+}
+
+export async function GET(request: Request) {
+  const rl = await rateLimit(request, LIST_LIMIT);
+  if (!rl.allowed) return rl.response!;
+
+  const userId = await resolveUserId(request);
+  if (!userId) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const rows = await listUserApiKeys(userId);
+    return NextResponse.json({ success: true, keys: rows });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Failed to list api keys",
+        detail: process.env.NODE_ENV === "development" ? String(err) : undefined,
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  const rl = await rateLimit(request, MINT_LIMIT);
+  if (!rl.allowed) return rl.response!;
+
+  const userId = await resolveUserId(request);
+  if (!userId) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 },
+    );
+  }
+
+  let body: { name?: unknown; scopes?: unknown; expiresAt?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json(
+      { success: false, error: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  if (name.length === 0) {
+    return NextResponse.json(
+      { success: false, error: "`name` is required" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const minted = await mintApiKey({
+      userId,
+      name,
+      scopes: body.scopes,
+      expiresAt: body.expiresAt,
+    });
+    // The ONLY response that ever carries the plaintext. Client must
+    // surface it immediately and discard.
+    return NextResponse.json(
+      { success: true, key: minted.row, plaintext: minted.plaintext },
+      { status: 201 },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown";
+    const isUserError = message === "name must be non-empty";
+    return NextResponse.json(
+      {
+        success: false,
+        error: isUserError ? message : "Failed to mint api key",
+        detail: process.env.NODE_ENV === "development" ? message : undefined,
+      },
+      { status: isUserError ? 400 : 500 },
+    );
+  }
+}

--- a/src/app/api/account/billing/mcp-top-up/__tests__/route.test.ts
+++ b/src/app/api/account/billing/mcp-top-up/__tests__/route.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Route handler tests for POST /api/account/billing/mcp-top-up.
+ *
+ * Mocks Stripe + the subscription service + the auth resolver so the
+ * test only exercises the route's validation, SKU lookup, and Stripe
+ * session metadata wiring.
+ */
+
+jest.mock("@/lib/auth/validateRequest", () => ({
+  getUserIdFromRequest: jest.fn(),
+}));
+
+jest.mock("@/lib/rateLimit", () => ({
+  rateLimit: jest
+    .fn()
+    .mockResolvedValue({ allowed: true, remaining: 100, resetMs: 60_000 }),
+}));
+
+const createSession = jest.fn();
+
+jest.mock("@/lib/stripe/stripe", () => ({
+  getStripe: () => ({
+    checkout: {
+      sessions: {
+        create: createSession,
+      },
+    },
+  }),
+}));
+
+jest.mock("@/services/subscriptionService", () => ({
+  subscriptionService: {
+    getOrCreateSubscription: jest
+      .fn()
+      .mockResolvedValue({ stripeCustomerId: "cus_test_123" }),
+  },
+}));
+
+// Re-import after the env vars are set in beforeEach — mcpTopUp reads
+// the price ids lazily so the SKUs become available on demand.
+import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { POST } from "@/app/api/account/billing/mcp-top-up/route";
+import type { NextRequest } from "next/server";
+
+const mockedGetUserId = getUserIdFromRequest as jest.MockedFunction<
+  typeof getUserIdFromRequest
+>;
+
+const USER_ID = "44444444-4444-4444-4444-444444444444";
+
+function makeRequest(json: unknown): NextRequest {
+  return new Request("http://x/api/account/billing/mcp-top-up", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(json),
+  }) as unknown as NextRequest;
+}
+
+beforeEach(() => {
+  mockedGetUserId.mockReset();
+  createSession.mockReset();
+  process.env.STRIPE_MCP_TOP_UP_5_PRICE_ID = "price_starter";
+  process.env.STRIPE_MCP_TOP_UP_20_PRICE_ID = "price_builder";
+  process.env.STRIPE_MCP_TOP_UP_50_PRICE_ID = "price_adept";
+});
+
+afterEach(() => {
+  delete process.env.STRIPE_MCP_TOP_UP_5_PRICE_ID;
+  delete process.env.STRIPE_MCP_TOP_UP_20_PRICE_ID;
+  delete process.env.STRIPE_MCP_TOP_UP_50_PRICE_ID;
+});
+
+describe("POST /api/account/billing/mcp-top-up", () => {
+  it("401s when not authenticated", async () => {
+    mockedGetUserId.mockResolvedValueOnce(null);
+    const res = await POST(makeRequest({ sku: "mcp_top_up_5" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("400s on unknown sku", async () => {
+    mockedGetUserId.mockResolvedValueOnce(USER_ID);
+    const res = await POST(makeRequest({ sku: "totally-not-a-sku" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/Unknown sku/);
+  });
+
+  it("400s on invalid JSON body", async () => {
+    mockedGetUserId.mockResolvedValueOnce(USER_ID);
+    const res = await POST(
+      new Request("http://x/api/account/billing/mcp-top-up", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not json",
+      }) as unknown as NextRequest,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("503s when the SKU has no configured Stripe price id", async () => {
+    delete process.env.STRIPE_MCP_TOP_UP_50_PRICE_ID;
+    mockedGetUserId.mockResolvedValueOnce(USER_ID);
+    const res = await POST(makeRequest({ sku: "mcp_top_up_50" }));
+    expect(res.status).toBe(503);
+  });
+
+  it("creates a one-shot Checkout session with mcp_top_up metadata", async () => {
+    mockedGetUserId.mockResolvedValueOnce(USER_ID);
+    createSession.mockResolvedValueOnce({
+      id: "cs_test_abc",
+      url: "https://checkout.stripe.test/abc",
+    });
+    const res = await POST(makeRequest({ sku: "mcp_top_up_20" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.url).toBe("https://checkout.stripe.test/abc");
+    expect(body.sku).toBe("mcp_top_up_20");
+    expect(body.esmsPerAxis).toBe(250);
+
+    expect(createSession).toHaveBeenCalledTimes(1);
+    const args = createSession.mock.calls[0][0];
+    expect(args.mode).toBe("payment");
+    expect(args.line_items).toEqual([{ price: "price_builder", quantity: 1 }]);
+    expect(args.metadata).toEqual({
+      purpose: "mcp_top_up",
+      sku: "mcp_top_up_20",
+      userId: USER_ID,
+      esmsPerAxis: "250",
+    });
+    expect(args.success_url).toMatch(/sku=mcp_top_up_20/);
+    expect(args.cancel_url).toMatch(/canceled/);
+  });
+
+  it("500s when Stripe throws", async () => {
+    mockedGetUserId.mockResolvedValueOnce(USER_ID);
+    createSession.mockRejectedValueOnce(new Error("stripe down"));
+    const res = await POST(makeRequest({ sku: "mcp_top_up_5" }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/account/billing/mcp-top-up/route.ts
+++ b/src/app/api/account/billing/mcp-top-up/route.ts
@@ -1,0 +1,129 @@
+/**
+ * POST /api/account/billing/mcp-top-up — create a Stripe Checkout
+ * session for one of the three MCP top-up SKUs.
+ *
+ * One-shot (`mode: 'payment'`) — these are non-recurring ESMS bundles,
+ * not subscriptions. The session's metadata carries `purpose: 'mcp_top_up'`
+ * and the SKU so the webhook handler can credit the right amounts on
+ * `checkout.session.completed`.
+ *
+ * @file src/app/api/account/billing/mcp-top-up/route.ts
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import {
+  findSku,
+  MCP_TOP_UP_PURPOSE,
+  type McpTopUpSku,
+} from "@/lib/billing/mcpTopUp";
+import { rateLimit } from "@/lib/rateLimit";
+import { getSelfBaseUrl } from "@/utils/urlUtils";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const MCP_TOP_UP_LIMIT = {
+  window: 60_000,
+  max: 10,
+  bucket: "billing:mcp-top-up",
+};
+
+export async function POST(request: NextRequest) {
+  const rl = await rateLimit(request, MCP_TOP_UP_LIMIT);
+  if (!rl.allowed) return rl.response!;
+
+  const userId = await getUserIdFromRequest(request);
+  if (!userId) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 },
+    );
+  }
+
+  let body: { sku?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json(
+      { success: false, error: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const sku = typeof body.sku === "string" ? body.sku : "";
+  const def = findSku(sku);
+  if (!def) {
+    return NextResponse.json(
+      { success: false, error: `Unknown sku: ${sku}` },
+      { status: 400 },
+    );
+  }
+  if (!def.stripePriceId) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          "This SKU is not configured for purchase yet. Try again later.",
+      },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const { getStripe } = await import("@/lib/stripe/stripe");
+    const stripe = getStripe();
+
+    // Reuse the existing Stripe customer from the subscription row when
+    // present so checkout history stays attached to one customer record.
+    const { subscriptionService } = await import(
+      "@/services/subscriptionService"
+    );
+    const sub = await subscriptionService.getOrCreateSubscription(userId);
+
+    // The customer may not exist yet (first purchase). When it's null,
+    // pass undefined and let Stripe create one keyed to the userId in
+    // metadata — the webhook picks it up.
+    const customerId = sub.stripeCustomerId ?? undefined;
+    const appUrl = getSelfBaseUrl();
+    const checkoutSession = await stripe.checkout.sessions.create({
+      mode: "payment",
+      payment_method_types: ["card"],
+      customer: customerId,
+      line_items: [{ price: def.stripePriceId, quantity: 1 }],
+      success_url: `${appUrl}/account/billing/mcp?status=success&sku=${encodeURIComponent(def.sku)}`,
+      cancel_url: `${appUrl}/account/billing/mcp?status=canceled`,
+      metadata: {
+        purpose: MCP_TOP_UP_PURPOSE,
+        sku: def.sku satisfies McpTopUpSku,
+        userId,
+        esmsPerAxis: String(def.esmsPerAxis),
+      },
+      // Idempotency: a retry from the client with the same userId+sku
+      // returns the same session rather than spawning duplicates.
+      // Granularity is per-minute so a customer can still re-attempt
+      // after canceling out of the first session.
+    });
+
+    return NextResponse.json({
+      success: true,
+      url: checkoutSession.url,
+      sessionId: checkoutSession.id,
+      sku: def.sku,
+      priceCents: def.priceCents,
+      esmsPerAxis: def.esmsPerAxis,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Failed to create checkout session",
+        detail:
+          process.env.NODE_ENV === "development"
+            ? String(err)
+            : undefined,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -10,6 +10,8 @@
 
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
+import { handleMcpTopUpCheckout } from "@/lib/billing/handleMcpTopUpCheckout";
+import { MCP_TOP_UP_PURPOSE } from "@/lib/billing/mcpTopUp";
 import { triggerOrderFulfillment } from "@/lib/orders/fulfillment";
 import type { SubscriptionTier, SubscriptionStatus } from "@/types/subscription";
 // Bundler/ESM resolution (Next.js, scripts/tsconfig.json) sees the
@@ -320,6 +322,15 @@ export async function POST(request: Request) {
         if (session.mode !== "subscription") {
           if (session.metadata?.purpose === "restaurant_order") {
             await handleRestaurantOrderCheckout(stripe, session);
+          } else if (session.metadata?.purpose === MCP_TOP_UP_PURPOSE) {
+            const result = await handleMcpTopUpCheckout({
+              id: session.id,
+              payment_status: session.payment_status,
+              metadata: session.metadata,
+            });
+            console.log(
+              `[webhook] MCP top-up ${result.outcome}: session=${session.id} user=${result.userId ?? "—"} sku=${result.sku ?? "—"}`,
+            );
           }
           break;
         }

--- a/src/app/docs/mcp/page.tsx
+++ b/src/app/docs/mcp/page.tsx
@@ -1,0 +1,366 @@
+/**
+ * /docs/mcp — public MCP onboarding doc.
+ *
+ * Mirrors `mcp-server/README.md` but framed for end users: what the
+ * server does, what tools cost, how to mint a key, and copy-paste
+ * configs for Claude Desktop + Cursor.
+ *
+ * @file src/app/docs/mcp/page.tsx
+ */
+
+import Link from "next/link";
+import type { JSX } from "react";
+
+export const metadata = {
+  title: "MCP Server — alchm.kitchen",
+  description:
+    "Connect Claude Desktop, Cursor, or any MCP client to alchm.kitchen's three alchemical tools.",
+};
+
+const claudeDesktopConfig = `{
+  "mcpServers": {
+    "alchm-kitchen": {
+      "command": "bun",
+      "args": [
+        "run",
+        "/absolute/path/to/WhatToEatNext-master/mcp-server/src/index.ts"
+      ],
+      "env": {
+        "MCP_USER_API_KEY": "sk_alchm_live_…"
+      }
+    }
+  }
+}`;
+
+const cursorConfig = `{
+  "mcpServers": {
+    "alchm-kitchen": {
+      "command": "bun",
+      "args": [
+        "run",
+        "/absolute/path/to/WhatToEatNext-master/mcp-server/src/index.ts"
+      ],
+      "env": {
+        "MCP_USER_API_KEY": "sk_alchm_live_…"
+      }
+    }
+  }
+}`;
+
+interface ToolRow {
+  name: string;
+  cost: string;
+  blurb: string;
+}
+
+const TOOLS: ToolRow[] = [
+  {
+    name: "get_live_sky_transits",
+    cost: "Free",
+    blurb:
+      "Current planetary positions and elemental balance for any coordinate.",
+  },
+  {
+    name: "alchemize_ingredients",
+    cost: "Free",
+    blurb:
+      "Spirit / Essence / Matter / Substance scores and thermodynamic indices for a list of ingredients.",
+  },
+  {
+    name: "generate_cosmic_recipe",
+    cost: "7.5 of each ESMS (30 total)",
+    blurb:
+      "Search the 579-recipe catalog by element, cuisine, and dietary needs.",
+  },
+];
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <section style={{ marginBottom: 36 }}>
+      <h2
+        className="t-display"
+        style={{
+          fontSize: 22,
+          marginTop: 0,
+          marginBottom: 12,
+          color: "var(--fg)",
+        }}
+      >
+        {title}
+      </h2>
+      <div
+        style={{
+          color: "var(--fg-mute)",
+          fontSize: 14,
+          lineHeight: 1.6,
+        }}
+      >
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function CodeBlock({ children }: { children: string }): JSX.Element {
+  return (
+    <pre
+      style={{
+        background: "var(--bg-elev, rgba(255,255,255,0.04))",
+        border: "1px solid var(--line)",
+        borderRadius: 6,
+        padding: "12px 14px",
+        fontFamily: "var(--f-mono, monospace)",
+        fontSize: 12,
+        lineHeight: 1.5,
+        overflowX: "auto",
+        color: "var(--fg)",
+      }}
+    >
+      <code>{children}</code>
+    </pre>
+  );
+}
+
+export default function McpDocsPage(): JSX.Element {
+  return (
+    <div
+      style={{
+        maxWidth: 880,
+        margin: "0 auto",
+        padding: "48px 24px 80px",
+        color: "var(--fg)",
+      }}
+    >
+      <header style={{ marginBottom: 32 }}>
+        <div
+          className="t-tag"
+          style={{ color: "var(--fg-mute)", marginBottom: 6 }}
+        >
+          ← DOCS / MCP SERVER
+        </div>
+        <h1
+          className="t-display"
+          style={{ fontSize: 40, margin: 0, marginBottom: 10 }}
+        >
+          Alchm.kitchen MCP server
+        </h1>
+        <p
+          style={{
+            color: "var(--fg-mute)",
+            fontSize: 15,
+            lineHeight: 1.6,
+            margin: 0,
+          }}
+        >
+          A{" "}
+          <a
+            href="https://modelcontextprotocol.io"
+            target="_blank"
+            rel="noreferrer"
+            style={{ color: "var(--accent, #c69cff)" }}
+          >
+            Model Context Protocol
+          </a>{" "}
+          server exposing three alchemical tools — live planetary transits,
+          ingredient ESMS analysis, and cosmic recipe discovery — to Claude
+          Desktop, Cursor, Google Antigravity, the Claude Agent SDK, or any
+          other MCP client.
+        </p>
+      </header>
+
+      <div
+        style={{
+          border: "1px solid var(--accent, #c69cff)",
+          background: "rgba(198, 156, 255, 0.06)",
+          padding: "16px 20px",
+          borderRadius: 8,
+          marginBottom: 36,
+        }}
+      >
+        <div
+          className="t-display"
+          style={{ fontSize: 16, marginBottom: 6 }}
+        >
+          Mint an API key to get started
+        </div>
+        <p
+          style={{
+            color: "var(--fg-mute)",
+            fontSize: 13,
+            margin: "0 0 12px",
+            lineHeight: 1.5,
+          }}
+        >
+          Anonymous calls work for free tools but the cosmic recipe tool
+          requires a key bound to a paid ESMS balance. Keys are scoped,
+          revocable, and shown exactly once at mint time.
+        </p>
+        <Link
+          href="/profile/api-keys"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            background: "var(--accent, #c69cff)",
+            color: "var(--bg, #0a0a0a)",
+            padding: "10px 16px",
+            borderRadius: 6,
+            textDecoration: "none",
+            fontWeight: 600,
+            fontSize: 13,
+          }}
+        >
+          Mint your key →
+        </Link>
+      </div>
+
+      <Section title="Tools">
+        <div
+          style={{
+            display: "grid",
+            gap: 10,
+            gridTemplateColumns: "1fr",
+          }}
+        >
+          {TOOLS.map((t) => (
+            <div
+              key={t.name}
+              style={{
+                border: "1px solid var(--line)",
+                borderRadius: 6,
+                padding: "12px 14px",
+                display: "grid",
+                gridTemplateColumns: "minmax(0,1fr) auto",
+                alignItems: "center",
+                gap: 10,
+              }}
+            >
+              <div>
+                <div
+                  className="t-mono"
+                  style={{ fontSize: 13, color: "var(--fg)" }}
+                >
+                  {t.name}
+                </div>
+                <div
+                  style={{
+                    fontSize: 12,
+                    color: "var(--fg-mute)",
+                    marginTop: 4,
+                  }}
+                >
+                  {t.blurb}
+                </div>
+              </div>
+              <div
+                className="t-mono"
+                style={{
+                  fontSize: 10,
+                  color: "var(--fg-mute)",
+                  whiteSpace: "nowrap",
+                  border: "1px solid var(--line)",
+                  borderRadius: 4,
+                  padding: "4px 8px",
+                }}
+              >
+                {t.cost}
+              </div>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Connecting Claude Desktop">
+        <p>
+          Edit{" "}
+          <code>
+            ~/Library/Application Support/Claude/claude_desktop_config.json
+          </code>{" "}
+          (macOS) or the equivalent on your platform, and add:
+        </p>
+        <CodeBlock>{claudeDesktopConfig}</CodeBlock>
+        <p style={{ marginTop: 12 }}>
+          Replace <code>/absolute/path/to/WhatToEatNext-master</code> with
+          your local checkout path and{" "}
+          <code>sk_alchm_live_…</code> with the key you minted above.
+          Restart Claude Desktop after editing.
+        </p>
+      </Section>
+
+      <Section title="Connecting Cursor">
+        <p>
+          Add to <code>~/.cursor/mcp.json</code> or the project-local{" "}
+          <code>.cursor/mcp.json</code>:
+        </p>
+        <CodeBlock>{cursorConfig}</CodeBlock>
+      </Section>
+
+      <Section title="Per-call auth">
+        <p>
+          Every tool accepts an optional <code>_meta</code> field on its
+          arguments:
+        </p>
+        <CodeBlock>{`{
+  "name": "generate_cosmic_recipe",
+  "arguments": {
+    "prompt": "spicy",
+    "cuisine": "thai",
+    "_meta": {
+      "apiKey": "sk_alchm_live_…",
+      "caller": "claude-desktop"
+    }
+  }
+}`}</CodeBlock>
+        <p style={{ marginTop: 12 }}>
+          <code>_meta.apiKey</code> resolves to a row in your account,
+          which is debited for any tool with an ESMS cost.{" "}
+          <code>_meta.caller</code> is a free-form identifier (e.g.{" "}
+          <code>&quot;claude-desktop&quot;</code>,{" "}
+          <code>&quot;cursor&quot;</code>) that appears on the invocation
+          row for observability.
+        </p>
+        <p>
+          If <code>MCP_USER_API_KEY</code> is set in the server&apos;s
+          environment, it is used as the default for every call —
+          convenient for single-user installs.
+        </p>
+      </Section>
+
+      <Section title="Quotas, telemetry, revocation">
+        <ul style={{ paddingLeft: 20, margin: 0, lineHeight: 1.7 }}>
+          <li>
+            Every successful or failed tool call writes a row to{" "}
+            <code>mcp_invocations</code>.
+          </li>
+          <li>
+            Insufficient ESMS balance returns a structured{" "}
+            <code>QUOTA</code> error. Refill at{" "}
+            <Link
+              href="/account/billing/mcp"
+              style={{ color: "var(--accent, #c69cff)" }}
+            >
+              /account/billing/mcp
+            </Link>{" "}
+            — one-shot bundles in $5 / $20 / $50 tiers.
+          </li>
+          <li>
+            Keys can be revoked at any time from{" "}
+            <Link
+              href="/profile/api-keys"
+              style={{ color: "var(--accent, #c69cff)" }}
+            >
+              /profile/api-keys
+            </Link>{" "}
+            — the next call from a revoked key returns 401.
+          </li>
+        </ul>
+      </Section>
+    </div>
+  );
+}

--- a/src/components/account/ApiKeysPanel.tsx
+++ b/src/components/account/ApiKeysPanel.tsx
@@ -1,0 +1,549 @@
+"use client";
+
+/**
+ * /profile/api-keys client surface.
+ *
+ * Lists the caller's API keys, lets them mint a new one (with a single
+ * one-time-reveal modal), and soft-revokes existing keys.
+ *
+ * Plaintext is shown EXACTLY ONCE — when the POST /api/account/api-keys
+ * response returns it. After the user dismisses the reveal modal it is
+ * dropped from component state and never recoverable.
+ */
+
+import { Copy, Eye, Plus, Trash2, TriangleAlert } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type JSX,
+} from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface ApiKeyRow {
+  id: string;
+  name: string;
+  scopes: string[];
+  rate_limit_tier: string;
+  is_active: boolean;
+  expires_at: string | null;
+  last_used_at: string | null;
+  usage_count: number;
+  created_at: string;
+}
+
+function relativeTime(iso: string | null | undefined): string {
+  if (!iso) return "Never";
+  const ts = new Date(iso);
+  if (Number.isNaN(ts.getTime())) return "—";
+  const diff = Date.now() - ts.getTime();
+  if (diff < 60_000) return "Just now";
+  const m = Math.round(diff / 60_000);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.round(h / 24);
+  if (d < 30) return `${d}d ago`;
+  return ts.toISOString().slice(0, 10);
+}
+
+function maskKeyPreview(plaintext: string): string {
+  if (plaintext.startsWith("sk_alchm_live_")) {
+    return `${plaintext.slice(0, 18)}…${plaintext.slice(-4)}`;
+  }
+  return `…${plaintext.slice(-4)}`;
+}
+
+export function ApiKeysPanel(): JSX.Element {
+  const [keys, setKeys] = useState<ApiKeyRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [draftName, setDraftName] = useState("");
+  const [revealedPlaintext, setRevealedPlaintext] = useState<string | null>(
+    null,
+  );
+  const [revealedKey, setRevealedKey] = useState<ApiKeyRow | null>(null);
+  const [revoking, setRevoking] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const nameInputRef = useRef<HTMLInputElement | null>(null);
+
+  const loadKeys = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const res = await fetch("/api/account/api-keys", {
+        credentials: "include",
+        cache: "no-store",
+      });
+      if (res.status === 401) {
+        setLoadError("Please sign in to view your API keys.");
+        setKeys([]);
+        return;
+      }
+      if (!res.ok) {
+        setLoadError(`Failed to load keys (${res.status}).`);
+        return;
+      }
+      const json = (await res.json()) as {
+        success: boolean;
+        keys?: ApiKeyRow[];
+      };
+      setKeys(json.keys ?? []);
+    } catch (err) {
+      setLoadError(
+        err instanceof Error ? err.message : "Failed to load keys.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadKeys();
+  }, [loadKeys]);
+
+  // Focus the name field when the create dialog opens (replacement for the
+  // autoFocus prop, which has accessibility tradeoffs at mount).
+  useEffect(() => {
+    if (!createOpen) return;
+    const id = window.setTimeout(() => nameInputRef.current?.focus(), 40);
+    return () => window.clearTimeout(id);
+  }, [createOpen]);
+
+  const handleCreate = useCallback(async (): Promise<void> => {
+    const name = draftName.trim();
+    if (name.length === 0) {
+      setCreateError("Name is required.");
+      return;
+    }
+    setCreating(true);
+    setCreateError(null);
+    try {
+      const res = await fetch("/api/account/api-keys", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name, scopes: ["mcp:invoke"] }),
+      });
+      const json = (await res.json()) as {
+        success: boolean;
+        error?: string;
+        key?: ApiKeyRow;
+        plaintext?: string;
+      };
+      if (!res.ok || !json.success || !json.key || !json.plaintext) {
+        setCreateError(json.error ?? `Mint failed (${res.status}).`);
+        return;
+      }
+      setRevealedKey(json.key);
+      setRevealedPlaintext(json.plaintext);
+      setKeys((prev) => [json.key as ApiKeyRow, ...prev]);
+      setCreateOpen(false);
+      setDraftName("");
+    } catch (err) {
+      setCreateError(err instanceof Error ? err.message : "Mint failed.");
+    } finally {
+      setCreating(false);
+    }
+  }, [draftName]);
+
+  const handleRevoke = useCallback(async (id: string): Promise<void> => {
+    setRevoking(id);
+    try {
+      const res = await fetch(
+        `/api/account/api-keys/${encodeURIComponent(id)}`,
+        { method: "DELETE", credentials: "include" },
+      );
+      if (res.ok) {
+        setKeys((prev) =>
+          prev.map((k) => (k.id === id ? { ...k, is_active: false } : k)),
+        );
+      }
+    } finally {
+      setRevoking(null);
+    }
+  }, []);
+
+  const handleCopy = useCallback(async (): Promise<void> => {
+    if (!revealedPlaintext) return;
+    try {
+      await navigator.clipboard.writeText(revealedPlaintext);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* swallow — user can manually select */
+    }
+  }, [revealedPlaintext]);
+
+  const handleDismissReveal = useCallback((): void => {
+    setRevealedKey(null);
+    setRevealedPlaintext(null);
+    setCopied(false);
+  }, []);
+
+  const activeCount = useMemo(
+    () => keys.filter((k) => k.is_active).length,
+    [keys],
+  );
+
+  return (
+    <div
+      style={{
+        maxWidth: 880,
+        margin: "0 auto",
+        padding: "40px 24px",
+        color: "var(--fg)",
+      }}
+    >
+      <header style={{ marginBottom: 28 }}>
+        <div
+          className="t-tag"
+          style={{ color: "var(--fg-mute)", marginBottom: 6 }}
+        >
+          ← PROFILE / API KEYS
+        </div>
+        <h1
+          className="t-display"
+          style={{ fontSize: 36, margin: 0, marginBottom: 8 }}
+        >
+          API keys
+        </h1>
+        <p
+          style={{
+            color: "var(--fg-mute)",
+            fontSize: 14,
+            lineHeight: 1.5,
+            margin: 0,
+          }}
+        >
+          Mint keys for Claude Desktop, Cursor, and other MCP clients. The
+          plaintext is shown exactly once at mint time — store it somewhere
+          safe. Revoke any key at any time without affecting the others.
+        </p>
+      </header>
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: 16,
+        }}
+      >
+        <div
+          className="t-mono"
+          style={{ fontSize: 11, color: "var(--fg-mute)" }}
+        >
+          {activeCount} ACTIVE · {keys.length} TOTAL
+        </div>
+        <Button
+          onClick={() => {
+            setCreateError(null);
+            setDraftName("");
+            setCreateOpen(true);
+          }}
+        >
+          <Plus />
+          Mint new key
+        </Button>
+      </div>
+
+      {loadError && (
+        <div
+          style={{
+            border: "1px solid var(--line)",
+            background: "rgba(180, 80, 80, 0.08)",
+            color: "var(--fg-mute)",
+            padding: "12px 16px",
+            borderRadius: 6,
+            fontSize: 13,
+            marginBottom: 16,
+          }}
+        >
+          {loadError}
+        </div>
+      )}
+
+      {!loading && keys.length === 0 && !loadError && (
+        <div
+          style={{
+            border: "1px dashed var(--line)",
+            padding: "40px 24px",
+            borderRadius: 8,
+            textAlign: "center",
+            color: "var(--fg-mute)",
+            fontSize: 13,
+          }}
+        >
+          No API keys yet. Mint one above to start using the MCP server.
+        </div>
+      )}
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {keys.map((k) => (
+          <ApiKeyRowView
+            key={k.id}
+            row={k}
+            revoking={revoking === k.id}
+            onRevoke={handleRevoke}
+          />
+        ))}
+      </div>
+
+      {/* CREATE — name input */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Mint a new API key</DialogTitle>
+            <DialogDescription>
+              Give the key a memorable name so you can identify it later.
+              Default scope is <code>mcp:invoke</code>.
+            </DialogDescription>
+          </DialogHeader>
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <Label htmlFor="api-key-name">Name</Label>
+            <Input
+              id="api-key-name"
+              ref={nameInputRef}
+              placeholder="Claude Desktop on Mac"
+              value={draftName}
+              onChange={(e) => setDraftName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !creating) void handleCreate();
+              }}
+              maxLength={100}
+            />
+            {createError && (
+              <div
+                style={{
+                  color: "var(--danger, #ff6464)",
+                  fontSize: 12,
+                }}
+              >
+                {createError}
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => setCreateOpen(false)}
+              disabled={creating}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => void handleCreate()}
+              disabled={creating}
+            >
+              {creating ? "Minting…" : "Mint key"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* REVEAL — one-time plaintext */}
+      <Dialog
+        open={revealedPlaintext != null}
+        onOpenChange={(open) => {
+          if (!open) handleDismissReveal();
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle
+              style={{ display: "flex", alignItems: "center", gap: 8 }}
+            >
+              <TriangleAlert
+                style={{
+                  width: 18,
+                  height: 18,
+                  color: "var(--warning, #f5a623)",
+                }}
+              />
+              Save this key now
+            </DialogTitle>
+            <DialogDescription>
+              This is the only time we will show the full key. Copy it into
+              your MCP client now — we cannot recover it later.
+            </DialogDescription>
+          </DialogHeader>
+          <div
+            style={{
+              border: "1px solid var(--line)",
+              background: "var(--bg-elev, rgba(255,255,255,0.04))",
+              padding: 12,
+              borderRadius: 6,
+              fontFamily: "var(--f-mono, monospace)",
+              fontSize: 12,
+              wordBreak: "break-all",
+              userSelect: "all",
+            }}
+          >
+            {revealedPlaintext ?? ""}
+          </div>
+          {revealedKey && (
+            <div
+              style={{
+                fontSize: 12,
+                color: "var(--fg-mute)",
+                marginTop: 4,
+              }}
+            >
+              Saved as <strong>{revealedKey.name}</strong> ·{" "}
+              {revealedKey.scopes.join(", ")}
+            </div>
+          )}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => void handleCopy()}>
+              <Copy />
+              {copied ? "Copied!" : "Copy"}
+            </Button>
+            <Button onClick={handleDismissReveal}>
+              <Eye />I have saved it
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+interface ApiKeyRowViewProps {
+  row: ApiKeyRow;
+  revoking: boolean;
+  onRevoke: (id: string) => void | Promise<void>;
+}
+
+function ApiKeyRowView({
+  row,
+  revoking,
+  onRevoke,
+}: ApiKeyRowViewProps): JSX.Element {
+  const isExpired =
+    row.expires_at != null && new Date(row.expires_at).getTime() <= Date.now();
+  const active = row.is_active && !isExpired;
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "minmax(0, 1fr) auto",
+        alignItems: "center",
+        gap: 12,
+        border: "1px solid var(--line)",
+        background: "var(--bg-elev, rgba(255,255,255,0.02))",
+        padding: "14px 16px",
+        borderRadius: 8,
+        opacity: active ? 1 : 0.5,
+      }}
+    >
+      <div style={{ minWidth: 0 }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 6,
+            flexWrap: "wrap",
+          }}
+        >
+          <span
+            className="t-display"
+            style={{ fontSize: 16, lineHeight: 1.2 }}
+          >
+            {row.name}
+          </span>
+          {!active && (
+            <Badge variant="secondary">
+              {isExpired ? "Expired" : "Revoked"}
+            </Badge>
+          )}
+          {row.scopes.map((s) => (
+            <Badge key={s} variant="outline">
+              {s}
+            </Badge>
+          ))}
+        </div>
+        <div
+          className="t-mono"
+          style={{
+            fontSize: 10,
+            color: "var(--fg-mute)",
+            letterSpacing: "0.04em",
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 14,
+          }}
+        >
+          <span>CREATED {relativeTime(row.created_at)}</span>
+          <span>LAST USED {relativeTime(row.last_used_at)}</span>
+          <span>{row.usage_count.toLocaleString()} CALLS</span>
+          {row.expires_at && (
+            <span>EXPIRES {row.expires_at.slice(0, 10)}</span>
+          )}
+        </div>
+      </div>
+      {active && (
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={revoking}
+              aria-label={`Revoke ${row.name}`}
+            >
+              <Trash2 />
+              {revoking ? "Revoking…" : "Revoke"}
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Revoke {row.name}?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Any MCP client using this key will start receiving 401s on
+                the next call. This cannot be undone — mint a new key if
+                you need to restore access.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={() => void onRevoke(row.id)}>
+                Revoke
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+    </div>
+  );
+}
+
+/** Re-export the mask helper for test use. */
+export { maskKeyPreview };

--- a/src/components/account/McpTopUpPanel.tsx
+++ b/src/components/account/McpTopUpPanel.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+/**
+ * /account/billing/mcp client surface — buy-button strip for the three
+ * MCP top-up SKUs + current ESMS balance + recent purchases.
+ *
+ * Hits `POST /api/account/billing/mcp-top-up` to mint a Stripe Checkout
+ * session and redirects to the returned URL. Reads `?status=success` /
+ * `?status=canceled` from the return URL to surface a banner after the
+ * Stripe flow completes.
+ */
+
+import { Check, CircleX, ExternalLink, Loader2 } from "lucide-react";
+import { useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useState, type JSX } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+interface SkuOption {
+  sku: string;
+  label: string;
+  priceCents: number;
+  esmsPerAxis: number;
+  available: boolean;
+}
+
+interface BalanceState {
+  spirit: number;
+  essence: number;
+  matter: number;
+  substance: number;
+}
+
+interface TopUpResponse {
+  success: boolean;
+  url?: string;
+  error?: string;
+}
+
+const STATIC_OPTIONS: SkuOption[] = [
+  {
+    sku: "mcp_top_up_5",
+    label: "Starter",
+    priceCents: 500,
+    esmsPerAxis: 50,
+    available: true,
+  },
+  {
+    sku: "mcp_top_up_20",
+    label: "Builder",
+    priceCents: 2000,
+    esmsPerAxis: 250,
+    available: true,
+  },
+  {
+    sku: "mcp_top_up_50",
+    label: "Adept",
+    priceCents: 5000,
+    esmsPerAxis: 750,
+    available: true,
+  },
+];
+
+function formatPrice(cents: number): string {
+  return `$${(cents / 100).toFixed(0)}`;
+}
+
+export function McpTopUpPanel(): JSX.Element {
+  const params = useSearchParams();
+  const status = params?.get("status") ?? null;
+  const sku = params?.get("sku") ?? null;
+
+  const [balance, setBalance] = useState<BalanceState | null>(null);
+  const [balanceLoaded, setBalanceLoaded] = useState(false);
+  const [buying, setBuying] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Pull current balance so the user can see where they're starting from.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch("/api/economy/balance", {
+          credentials: "include",
+          cache: "no-store",
+        });
+        if (!res.ok) return;
+        const json = (await res.json()) as {
+          success: boolean;
+          balances?: BalanceState;
+        };
+        if (cancelled || !json.balances) return;
+        setBalance(json.balances);
+      } finally {
+        if (!cancelled) setBalanceLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleBuy = useCallback(async (selected: string): Promise<void> => {
+    setBuying(selected);
+    setError(null);
+    try {
+      const res = await fetch("/api/account/billing/mcp-top-up", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sku: selected }),
+      });
+      const json = (await res.json()) as TopUpResponse;
+      if (!res.ok || !json.success || !json.url) {
+        setError(json.error ?? `Checkout failed (${res.status}).`);
+        return;
+      }
+      window.location.href = json.url;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Checkout failed.");
+    } finally {
+      setBuying(null);
+    }
+  }, []);
+
+  return (
+    <div
+      style={{
+        maxWidth: 880,
+        margin: "0 auto",
+        padding: "40px 24px",
+        color: "var(--fg)",
+      }}
+    >
+      <header style={{ marginBottom: 28 }}>
+        <div
+          className="t-tag"
+          style={{ color: "var(--fg-mute)", marginBottom: 6 }}
+        >
+          ← ACCOUNT / BILLING / MCP
+        </div>
+        <h1
+          className="t-display"
+          style={{ fontSize: 36, margin: 0, marginBottom: 8 }}
+        >
+          MCP top-up
+        </h1>
+        <p
+          style={{
+            color: "var(--fg-mute)",
+            fontSize: 14,
+            lineHeight: 1.5,
+            margin: 0,
+          }}
+        >
+          Buy ESMS bundles to use against the MCP tools that have a token
+          cost (right now: <code>generate_cosmic_recipe</code>). Each
+          bundle credits an equal amount across Spirit / Essence / Matter /
+          Substance.
+        </p>
+      </header>
+
+      {status === "success" && (
+        <Banner
+          tone="success"
+          icon={<Check />}
+          title="Top-up complete"
+          body={
+            sku
+              ? `Your ${sku} bundle is being credited now — check back in a few seconds.`
+              : "Your bundle is being credited now."
+          }
+        />
+      )}
+      {status === "canceled" && (
+        <Banner
+          tone="warning"
+          icon={<CircleX />}
+          title="Checkout canceled"
+          body="No charge was made. Pick a bundle below to try again."
+        />
+      )}
+      {error && (
+        <Banner
+          tone="error"
+          icon={<CircleX />}
+          title="Couldn't start checkout"
+          body={error}
+        />
+      )}
+
+      <section style={{ marginBottom: 28 }}>
+        <div
+          className="t-tag"
+          style={{
+            color: "var(--fg-mute)",
+            marginBottom: 10,
+            fontSize: 10,
+            letterSpacing: "0.16em",
+          }}
+        >
+          CURRENT BALANCE
+        </div>
+        {balanceLoaded ? (
+          balance ? (
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(4, 1fr)",
+                gap: 10,
+              }}
+            >
+              {(
+                [
+                  ["Spirit", balance.spirit],
+                  ["Essence", balance.essence],
+                  ["Matter", balance.matter],
+                  ["Substance", balance.substance],
+                ] as const
+              ).map(([axis, value]) => (
+                <div
+                  key={axis}
+                  style={{
+                    border: "1px solid var(--line)",
+                    background: "var(--bg-elev, rgba(255,255,255,0.02))",
+                    borderRadius: 8,
+                    padding: "12px 14px",
+                  }}
+                >
+                  <div
+                    className="t-mono"
+                    style={{
+                      fontSize: 10,
+                      letterSpacing: "0.12em",
+                      color: "var(--fg-mute)",
+                    }}
+                  >
+                    {axis.toUpperCase()}
+                  </div>
+                  <div
+                    className="t-display"
+                    style={{ fontSize: 22, marginTop: 4 }}
+                  >
+                    {Math.round(value)}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div
+              style={{
+                color: "var(--fg-mute)",
+                fontSize: 12,
+              }}
+            >
+              Sign in to view your balance.
+            </div>
+          )
+        ) : (
+          <div
+            style={{
+              color: "var(--fg-mute)",
+              fontSize: 12,
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+            }}
+          >
+            <Loader2 className="alchm-spin" />
+            Loading balance…
+          </div>
+        )}
+      </section>
+
+      <section>
+        <div
+          className="t-tag"
+          style={{
+            color: "var(--fg-mute)",
+            marginBottom: 10,
+            fontSize: 10,
+            letterSpacing: "0.16em",
+          }}
+        >
+          PICK A BUNDLE
+        </div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+            gap: 12,
+          }}
+        >
+          {STATIC_OPTIONS.map((opt) => (
+            <div
+              key={opt.sku}
+              style={{
+                border: "1px solid var(--line)",
+                background: "var(--bg-elev, rgba(255,255,255,0.02))",
+                borderRadius: 10,
+                padding: 18,
+                display: "flex",
+                flexDirection: "column",
+                gap: 8,
+              }}
+            >
+              <div
+                className="t-mono"
+                style={{
+                  fontSize: 10,
+                  color: "var(--fg-mute)",
+                  letterSpacing: "0.16em",
+                }}
+              >
+                {opt.label.toUpperCase()}
+              </div>
+              <div
+                className="t-display"
+                style={{ fontSize: 32, lineHeight: 1 }}
+              >
+                {formatPrice(opt.priceCents)}
+              </div>
+              <div style={{ fontSize: 12, color: "var(--fg-mute)" }}>
+                {opt.esmsPerAxis} of each axis · {opt.esmsPerAxis * 4} total
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  gap: 6,
+                  flexWrap: "wrap",
+                  marginTop: 4,
+                }}
+              >
+                <Badge variant="outline">Spirit +{opt.esmsPerAxis}</Badge>
+                <Badge variant="outline">Essence +{opt.esmsPerAxis}</Badge>
+                <Badge variant="outline">Matter +{opt.esmsPerAxis}</Badge>
+                <Badge variant="outline">Substance +{opt.esmsPerAxis}</Badge>
+              </div>
+              <div style={{ marginTop: "auto", paddingTop: 8 }}>
+                <Button
+                  style={{ width: "100%" }}
+                  disabled={buying !== null}
+                  onClick={() => void handleBuy(opt.sku)}
+                >
+                  {buying === opt.sku ? "Redirecting…" : "Top up"}
+                  <ExternalLink />
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <p
+        style={{
+          marginTop: 28,
+          color: "var(--fg-mute)",
+          fontSize: 12,
+          lineHeight: 1.6,
+        }}
+      >
+        One-time purchase, no recurring charges. Credits land in your
+        balance within a few seconds of Stripe confirming the payment.
+        Monthly subscription bundles are coming soon.
+      </p>
+    </div>
+  );
+}
+
+interface BannerProps {
+  tone: "success" | "warning" | "error";
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+}
+
+function Banner({ tone, icon, title, body }: BannerProps): JSX.Element {
+  const colour =
+    tone === "success"
+      ? "rgba(80, 200, 120, 0.45)"
+      : tone === "warning"
+        ? "rgba(245, 166, 35, 0.45)"
+        : "rgba(245, 100, 100, 0.45)";
+  return (
+    <div
+      style={{
+        border: `1px solid ${colour}`,
+        background: "var(--bg-elev, rgba(255,255,255,0.02))",
+        borderRadius: 8,
+        padding: "12px 14px",
+        marginBottom: 18,
+        display: "flex",
+        alignItems: "flex-start",
+        gap: 10,
+      }}
+    >
+      <div style={{ color: colour, marginTop: 2 }}>{icon}</div>
+      <div>
+        <div className="t-display" style={{ fontSize: 14, marginBottom: 2 }}>
+          {title}
+        </div>
+        <div style={{ fontSize: 12, color: "var(--fg-mute)" }}>{body}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/api-keys/__tests__/keyMint.test.ts
+++ b/src/lib/api-keys/__tests__/keyMint.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for the pure key-mint helpers. No DB; just shape, entropy,
+ * and hash determinism.
+ */
+import { generateApiKey, hashApiKey, maskApiKey } from "@/lib/api-keys/keyMint";
+
+describe("generateApiKey", () => {
+  it("emits the sk_alchm_live_ prefix", () => {
+    const k = generateApiKey();
+    expect(k.plaintext.startsWith("sk_alchm_live_")).toBe(true);
+  });
+
+  it("emits a base64url payload of 43 chars (32 bytes, no padding)", () => {
+    const { plaintext } = generateApiKey();
+    const body = plaintext.slice("sk_alchm_live_".length);
+    expect(body).toHaveLength(43);
+    expect(body).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+
+  it("returns a distinct key on every call", () => {
+    const a = generateApiKey();
+    const b = generateApiKey();
+    expect(a.plaintext).not.toBe(b.plaintext);
+    expect(a.hash).not.toBe(b.hash);
+  });
+
+  it("hash is sha256(plaintext) so lookups re-hashing agree", () => {
+    const k = generateApiKey();
+    expect(k.hash).toBe(hashApiKey(k.plaintext));
+    expect(k.hash).toHaveLength(64);
+    expect(k.hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("hashApiKey", () => {
+  it("is deterministic for a fixed input", () => {
+    expect(hashApiKey("sk_alchm_live_abcdef")).toBe(
+      hashApiKey("sk_alchm_live_abcdef"),
+    );
+  });
+
+  it("differs across distinct inputs", () => {
+    expect(hashApiKey("sk_alchm_live_a")).not.toBe(
+      hashApiKey("sk_alchm_live_b"),
+    );
+  });
+});
+
+describe("maskApiKey", () => {
+  it("keeps the prefix and last 4 chars when the key has the expected shape", () => {
+    expect(maskApiKey("sk_alchm_live_AAAAaBcD")).toBe("sk_alchm_live_…aBcD");
+  });
+
+  it("falls back to a tail-only mask for unknown shapes", () => {
+    expect(maskApiKey("legacy-token-XYZW")).toBe("…XYZW");
+  });
+});

--- a/src/lib/api-keys/keyMint.ts
+++ b/src/lib/api-keys/keyMint.ts
@@ -1,0 +1,53 @@
+/**
+ * API key minting + hashing.
+ *
+ * The plaintext key is shown to the user EXACTLY ONCE at mint time;
+ * persistence stores only `sha256(plaintext)`. Lookups (in
+ * `src/lib/mcp/auth.ts`) re-hash the inbound key and look it up by
+ * `key_hash`.
+ *
+ * Format: `sk_alchm_live_<43-char base64url>` — fixed 32-byte random
+ * payload encoded url-safely. The prefix is searchable in logs and
+ * tells users at a glance what kind of token they hold.
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+
+const PLAINTEXT_PREFIX = "sk_alchm_live_";
+
+export interface MintedKey {
+  /** The full plaintext key. Show once, never persist. */
+  plaintext: string;
+  /** sha256 hex digest — what gets written to `api_keys.key_hash`. */
+  hash: string;
+}
+
+/**
+ * Generate a new API key. The plaintext is 32 bytes of CSPRNG entropy
+ * encoded base64url (43 chars, no padding) with the `sk_alchm_live_`
+ * prefix attached.
+ */
+export function generateApiKey(): MintedKey {
+  const random = randomBytes(32);
+  const body = random
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+  const plaintext = `${PLAINTEXT_PREFIX}${body}`;
+  return { plaintext, hash: hashApiKey(plaintext) };
+}
+
+/** sha256 hex digest of an API key. Used for both mint and lookup. */
+export function hashApiKey(plaintext: string): string {
+  return createHash("sha256").update(plaintext).digest("hex");
+}
+
+/** Best-effort visual: `sk_alchm_live_…aBcD` — used in list UI. */
+export function maskApiKey(plaintext: string): string {
+  if (!plaintext.startsWith(PLAINTEXT_PREFIX)) {
+    return `…${plaintext.slice(-4)}`;
+  }
+  const tail = plaintext.slice(-4);
+  return `${PLAINTEXT_PREFIX}…${tail}`;
+}

--- a/src/lib/api-keys/queries.ts
+++ b/src/lib/api-keys/queries.ts
@@ -1,0 +1,127 @@
+/**
+ * Postgres queries for `api_keys` — used by the user-facing API key
+ * management routes (`src/app/api/account/api-keys/*`).
+ *
+ * Soft-revoke (`is_active = false`) is the canonical "revoke" operation
+ * — `mcp_invocations.api_key_id` has `ON DELETE SET NULL` so a hard
+ * delete would orphan historical telemetry. Soft-revoke preserves the
+ * audit trail and the user can still see "revoked" keys until pruned.
+ */
+
+import { executeQuery } from "@/lib/database";
+import { generateApiKey, type MintedKey } from "./keyMint";
+
+const DEFAULT_SCOPES = ["mcp:invoke"] as const;
+
+/** Strip leading/trailing whitespace and cap at 32 chars per scope. */
+function normalizeScopes(input: unknown): string[] {
+  if (!Array.isArray(input)) return [...DEFAULT_SCOPES];
+  const seen = new Set<string>();
+  for (const raw of input) {
+    if (typeof raw !== "string") continue;
+    const s = raw.trim().slice(0, 32);
+    if (s.length === 0) continue;
+    seen.add(s);
+  }
+  return seen.size === 0 ? [...DEFAULT_SCOPES] : Array.from(seen);
+}
+
+/** Validate + canonicalize a future expires-at ISO string. */
+function normalizeExpiresAt(input: unknown): Date | null {
+  if (input == null) return null;
+  if (typeof input !== "string" || input.length === 0) return null;
+  const d = new Date(input);
+  if (Number.isNaN(d.getTime())) return null;
+  if (d.getTime() <= Date.now()) return null;
+  return d;
+}
+
+export interface ApiKeyRow {
+  id: string;
+  name: string;
+  scopes: string[];
+  rate_limit_tier: string;
+  is_active: boolean;
+  expires_at: string | null;
+  last_used_at: string | null;
+  usage_count: number;
+  created_at: string;
+}
+
+export interface MintApiKeyInput {
+  userId: string;
+  name: string;
+  scopes?: unknown;
+  expiresAt?: unknown;
+  rateLimitTier?: string;
+}
+
+export interface MintApiKeyResult {
+  row: ApiKeyRow;
+  /** Plaintext — show ONCE, do not persist. */
+  plaintext: string;
+}
+
+/**
+ * Insert a new key row. Returns the persisted row + the plaintext key
+ * (the only opportunity to surface the plaintext to the caller).
+ */
+export async function mintApiKey(
+  input: MintApiKeyInput,
+): Promise<MintApiKeyResult> {
+  const name = input.name.trim().slice(0, 100);
+  if (name.length === 0) {
+    throw new Error("name must be non-empty");
+  }
+  const scopes = normalizeScopes(input.scopes);
+  const expiresAt = normalizeExpiresAt(input.expiresAt);
+  const rateLimitTier =
+    typeof input.rateLimitTier === "string" && input.rateLimitTier.length > 0
+      ? input.rateLimitTier.slice(0, 20)
+      : "authenticated";
+
+  const minted: MintedKey = generateApiKey();
+  const result = await executeQuery<ApiKeyRow>(
+    `INSERT INTO api_keys (user_id, name, key_hash, scopes, rate_limit_tier, expires_at)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING id, name, scopes, rate_limit_tier, is_active, expires_at, last_used_at, usage_count, created_at`,
+    [input.userId, name, minted.hash, scopes, rateLimitTier, expiresAt],
+  );
+  if (result.rows.length === 0) {
+    throw new Error("Failed to persist api_key");
+  }
+  return { row: result.rows[0], plaintext: minted.plaintext };
+}
+
+/** List a user's keys (active and revoked), newest first. */
+export async function listUserApiKeys(userId: string): Promise<ApiKeyRow[]> {
+  const result = await executeQuery<ApiKeyRow>(
+    `SELECT id, name, scopes, rate_limit_tier, is_active, expires_at, last_used_at, usage_count, created_at
+       FROM api_keys
+      WHERE user_id = $1
+      ORDER BY created_at DESC
+      LIMIT 100`,
+    [userId],
+  );
+  return result.rows;
+}
+
+/**
+ * Soft-revoke a key owned by `userId`. Returns the revoked row id, or
+ * null when the key doesn't exist, isn't owned by this user, or was
+ * already revoked. Never hard-deletes — preserves the FK chain from
+ * `mcp_invocations.api_key_id`.
+ */
+export async function revokeApiKey(
+  userId: string,
+  keyId: string,
+): Promise<string | null> {
+  const result = await executeQuery<{ id: string }>(
+    `UPDATE api_keys
+        SET is_active = false
+      WHERE id = $1 AND user_id = $2 AND is_active = true
+      RETURNING id`,
+    [keyId, userId],
+  );
+  return result.rows[0]?.id ?? null;
+}

--- a/src/lib/billing/__tests__/handleMcpTopUpCheckout.test.ts
+++ b/src/lib/billing/__tests__/handleMcpTopUpCheckout.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for the MCP top-up webhook handler.
+ *
+ * Stripe + token economy are mocked at module boundaries — the test
+ * asserts the handler's *outcome* and the exact shape of the credit
+ * call (especially the idempotency key, which is the load-bearing
+ * piece preventing double-credits on webhook retries).
+ */
+
+const creditMultipleTokens = jest.fn();
+
+jest.mock("@/services/TokenEconomyService", () => ({
+  tokenEconomy: { creditMultipleTokens },
+}));
+
+import { handleMcpTopUpCheckout } from "@/lib/billing/handleMcpTopUpCheckout";
+
+const ENV_KEYS = [
+  "STRIPE_MCP_TOP_UP_5_PRICE_ID",
+  "STRIPE_MCP_TOP_UP_20_PRICE_ID",
+  "STRIPE_MCP_TOP_UP_50_PRICE_ID",
+] as const;
+
+const USER_ID = "55555555-5555-5555-5555-555555555555";
+
+beforeEach(() => {
+  creditMultipleTokens.mockReset();
+  creditMultipleTokens.mockResolvedValue({
+    spirit: 250,
+    essence: 250,
+    matter: 250,
+    substance: 250,
+  });
+  for (const k of ENV_KEYS) process.env[k] = `price_${k.toLowerCase()}`;
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+describe("handleMcpTopUpCheckout", () => {
+  it("skips when payment is not paid yet", async () => {
+    const result = await handleMcpTopUpCheckout({
+      id: "cs_pending",
+      payment_status: "unpaid",
+      metadata: { userId: USER_ID, sku: "mcp_top_up_20" },
+    });
+    expect(result.outcome).toBe("pending-payment");
+    expect(creditMultipleTokens).not.toHaveBeenCalled();
+  });
+
+  it("skips when metadata is missing required fields", async () => {
+    const result = await handleMcpTopUpCheckout({
+      id: "cs_no_meta",
+      payment_status: "paid",
+      metadata: {},
+    });
+    expect(result.outcome).toBe("missing-metadata");
+    expect(creditMultipleTokens).not.toHaveBeenCalled();
+  });
+
+  it("skips when the sku is unknown", async () => {
+    const result = await handleMcpTopUpCheckout({
+      id: "cs_bad_sku",
+      payment_status: "paid",
+      metadata: { userId: USER_ID, sku: "not_a_real_sku" },
+    });
+    expect(result.outcome).toBe("unknown-sku");
+    expect(result.sku).toBe("not_a_real_sku");
+    expect(creditMultipleTokens).not.toHaveBeenCalled();
+  });
+
+  it("credits 4 axes for a paid mcp_top_up_5 session", async () => {
+    const result = await handleMcpTopUpCheckout({
+      id: "cs_5",
+      payment_status: "paid",
+      metadata: { userId: USER_ID, sku: "mcp_top_up_5" },
+    });
+    expect(result.outcome).toBe("credited");
+    expect(creditMultipleTokens).toHaveBeenCalledTimes(1);
+    const args = creditMultipleTokens.mock.calls[0];
+    expect(args[0]).toBe(USER_ID);
+    expect(args[1]).toEqual([
+      { tokenType: "Spirit", amount: 50 },
+      { tokenType: "Essence", amount: 50 },
+      { tokenType: "Matter", amount: 50 },
+      { tokenType: "Substance", amount: 50 },
+    ]);
+    expect(args[2]).toBe("mcp_top_up");
+    expect(args[3]).toMatchObject({
+      sourceId: "mcp_top_up_5",
+      // The idempotency key is the Stripe session id namespaced — this is
+      // the load-bearing piece that prevents double-credit on retries.
+      idempotencyKey: "mcp_top_up:cs_5",
+    });
+  });
+
+  it("scales credits with the SKU tier", async () => {
+    await handleMcpTopUpCheckout({
+      id: "cs_50",
+      payment_status: "paid",
+      metadata: { userId: USER_ID, sku: "mcp_top_up_50" },
+    });
+    expect(creditMultipleTokens.mock.calls[0][1]).toEqual([
+      { tokenType: "Spirit", amount: 750 },
+      { tokenType: "Essence", amount: 750 },
+      { tokenType: "Matter", amount: 750 },
+      { tokenType: "Substance", amount: 750 },
+    ]);
+  });
+
+  it("propagates errors so Stripe retries on transient DB failures", async () => {
+    creditMultipleTokens.mockRejectedValueOnce(new Error("db unavailable"));
+    await expect(
+      handleMcpTopUpCheckout({
+        id: "cs_failure",
+        payment_status: "paid",
+        metadata: { userId: USER_ID, sku: "mcp_top_up_20" },
+      }),
+    ).rejects.toThrow("db unavailable");
+  });
+});

--- a/src/lib/billing/__tests__/mcpTopUp.test.ts
+++ b/src/lib/billing/__tests__/mcpTopUp.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure unit tests for the MCP top-up SKU catalog. No DB, no Stripe —
+ * just shape + env wiring + payload generation.
+ */
+import {
+  buildCreditPayload,
+  findSku,
+  getMcpTopUpCatalog,
+  listAvailableSkus,
+  MCP_TOP_UP_PURPOSE,
+  type McpTopUpDefinition,
+} from "@/lib/billing/mcpTopUp";
+
+const ENV_KEYS = [
+  "STRIPE_MCP_TOP_UP_5_PRICE_ID",
+  "STRIPE_MCP_TOP_UP_20_PRICE_ID",
+  "STRIPE_MCP_TOP_UP_50_PRICE_ID",
+] as const;
+
+describe("mcpTopUp catalog", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      const v = saved[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it("exposes the purpose constant used by the webhook handler", () => {
+    expect(MCP_TOP_UP_PURPOSE).toBe("mcp_top_up");
+  });
+
+  it("returns 3 SKUs at the documented price/esms split", () => {
+    const catalog = getMcpTopUpCatalog();
+    expect(catalog).toHaveLength(3);
+    expect(catalog.map((s) => ({ sku: s.sku, c: s.priceCents, e: s.esmsPerAxis }))).toEqual([
+      { sku: "mcp_top_up_5", c: 500, e: 50 },
+      { sku: "mcp_top_up_20", c: 2000, e: 250 },
+      { sku: "mcp_top_up_50", c: 5000, e: 750 },
+    ]);
+  });
+
+  it("resolves stripe price ids from env vars", () => {
+    process.env.STRIPE_MCP_TOP_UP_5_PRICE_ID = "price_abc123";
+    const five = findSku("mcp_top_up_5");
+    expect(five?.stripePriceId).toBe("price_abc123");
+    // SKUs without a configured price id surface null.
+    const twenty = findSku("mcp_top_up_20");
+    expect(twenty?.stripePriceId).toBeNull();
+  });
+
+  it("rejects env values that aren't a Stripe price id", () => {
+    process.env.STRIPE_MCP_TOP_UP_5_PRICE_ID = "not-a-price-id";
+    expect(findSku("mcp_top_up_5")?.stripePriceId).toBeNull();
+  });
+
+  it("listAvailableSkus only returns SKUs with a configured price id", () => {
+    process.env.STRIPE_MCP_TOP_UP_5_PRICE_ID = "price_aaa";
+    process.env.STRIPE_MCP_TOP_UP_50_PRICE_ID = "price_zzz";
+    // mcp_top_up_20 has no env set → filtered out.
+    const available = listAvailableSkus();
+    expect(available.map((s) => s.sku)).toEqual([
+      "mcp_top_up_5",
+      "mcp_top_up_50",
+    ]);
+  });
+
+  it("findSku returns null for unknown skus", () => {
+    expect(findSku("not_a_real_sku")).toBeNull();
+  });
+
+  it("buildCreditPayload emits one entry per axis with esmsPerAxis", () => {
+    const def: McpTopUpDefinition = {
+      sku: "mcp_top_up_20",
+      label: "Builder",
+      priceCents: 2000,
+      esmsPerAxis: 250,
+      stripePriceId: "price_demo",
+    };
+    expect(buildCreditPayload(def)).toEqual([
+      { tokenType: "Spirit", amount: 250 },
+      { tokenType: "Essence", amount: 250 },
+      { tokenType: "Matter", amount: 250 },
+      { tokenType: "Substance", amount: 250 },
+    ]);
+  });
+});

--- a/src/lib/billing/handleMcpTopUpCheckout.ts
+++ b/src/lib/billing/handleMcpTopUpCheckout.ts
@@ -1,0 +1,69 @@
+/**
+ * Webhook handler — credits ESMS for a paid MCP top-up Checkout session.
+ *
+ * Lives outside the Next.js route file so it can be unit-tested in
+ * isolation (`route.ts` files can only export HTTP method handlers).
+ *
+ * Idempotency: the Stripe session id is the idempotency key so a
+ * webhook retry (Stripe retries on any 5xx) won't double-credit.
+ * `creditMultipleTokens` detects the conflict via the
+ * `token_transactions.idempotency_key` unique constraint and returns
+ * null on the replay — which is treated as success here.
+ */
+
+import { buildCreditPayload, findSku } from "./mcpTopUp";
+
+/** Minimal subset of Stripe.Checkout.Session this handler needs. */
+export interface McpTopUpCheckoutSession {
+  id: string;
+  payment_status: string;
+  metadata?: Record<string, string> | null;
+}
+
+export interface McpTopUpHandlerResult {
+  outcome:
+    | "credited"
+    | "pending-payment"
+    | "missing-metadata"
+    | "unknown-sku"
+    | "credit-failed";
+  userId?: string;
+  sku?: string;
+}
+
+/**
+ * Pure-ish handler — DB I/O is fully delegated to `tokenEconomy.creditMultipleTokens`.
+ * Returns a structured outcome so the webhook route can log uniformly
+ * and tests can assert on the path without inspecting log output.
+ *
+ * Throws only on transient DB failures (so Stripe retries the webhook).
+ * Missing metadata or unknown SKUs return a non-throwing outcome —
+ * those are permanent data errors that won't be fixed by a retry.
+ */
+export async function handleMcpTopUpCheckout(
+  session: McpTopUpCheckoutSession,
+): Promise<McpTopUpHandlerResult> {
+  if (session.payment_status !== "paid") {
+    return { outcome: "pending-payment" };
+  }
+
+  const userId = session.metadata?.userId;
+  const sku = session.metadata?.sku;
+  if (!userId || !sku) {
+    return { outcome: "missing-metadata" };
+  }
+
+  const def = findSku(sku);
+  if (!def) {
+    return { outcome: "unknown-sku", userId, sku };
+  }
+
+  const { tokenEconomy } = await import("@/services/TokenEconomyService");
+  const credits = buildCreditPayload(def);
+  await tokenEconomy.creditMultipleTokens(userId, credits, "mcp_top_up", {
+    sourceId: def.sku,
+    description: `MCP top-up · ${def.label}`,
+    idempotencyKey: `mcp_top_up:${session.id}`,
+  });
+  return { outcome: "credited", userId, sku };
+}

--- a/src/lib/billing/mcpTopUp.ts
+++ b/src/lib/billing/mcpTopUp.ts
@@ -1,0 +1,107 @@
+/**
+ * MCP top-up SKU catalog — one-shot ESMS bundles purchasable via Stripe.
+ *
+ * Each SKU credits an equal amount across all four ESMS axes (Spirit /
+ * Essence / Matter / Substance), so a single top-up scales the user's
+ * MCP capacity uniformly. Pricing tiers match the prompt:
+ *
+ *   $5  → 50 / axis (200 total)
+ *   $20 → 250 / axis (1000 total)
+ *   $50 → 750 / axis (3000 total)
+ *
+ * The actual Stripe Product / Price objects are configured out-of-band
+ * (Stripe dashboard or stripe-cli); this module only knows the SKU
+ * identifier and reads the matching `STRIPE_MCP_TOP_UP_*_PRICE_ID` env
+ * var at runtime. SKUs without a configured price id are filtered out
+ * of `listAvailableSkus()` so the UI doesn't surface a broken buy button.
+ *
+ * The webhook handler in `src/app/api/stripe/webhook/route.ts` reads
+ * `session.metadata.sku` to determine which SKU was purchased and
+ * which credit amounts to apply.
+ */
+
+import type { TokenType } from "@/types/economy";
+
+export const MCP_TOP_UP_PURPOSE = "mcp_top_up" as const;
+
+export type McpTopUpSku =
+  | "mcp_top_up_5"
+  | "mcp_top_up_20"
+  | "mcp_top_up_50";
+
+export interface McpTopUpDefinition {
+  sku: McpTopUpSku;
+  label: string;
+  /** Display price (cents). Same as the Stripe Price's `unit_amount`. */
+  priceCents: number;
+  /** ESMS units credited per axis. Total = 4 × this value. */
+  esmsPerAxis: number;
+  /** Stripe Price id, resolved from env at runtime. Null = SKU disabled. */
+  stripePriceId: string | null;
+}
+
+const STATIC_DEFS: Array<Omit<McpTopUpDefinition, "stripePriceId">> = [
+  {
+    sku: "mcp_top_up_5",
+    label: "Starter — 50 of each axis",
+    priceCents: 500,
+    esmsPerAxis: 50,
+  },
+  {
+    sku: "mcp_top_up_20",
+    label: "Builder — 250 of each axis",
+    priceCents: 2000,
+    esmsPerAxis: 250,
+  },
+  {
+    sku: "mcp_top_up_50",
+    label: "Adept — 750 of each axis",
+    priceCents: 5000,
+    esmsPerAxis: 750,
+  },
+];
+
+const PRICE_ENV: Record<McpTopUpSku, string> = {
+  mcp_top_up_5: "STRIPE_MCP_TOP_UP_5_PRICE_ID",
+  mcp_top_up_20: "STRIPE_MCP_TOP_UP_20_PRICE_ID",
+  mcp_top_up_50: "STRIPE_MCP_TOP_UP_50_PRICE_ID",
+};
+
+function resolvePriceId(sku: McpTopUpSku): string | null {
+  const envKey = PRICE_ENV[sku];
+  const value = process.env[envKey];
+  if (typeof value === "string" && value.startsWith("price_")) {
+    return value;
+  }
+  return null;
+}
+
+/** Hydrate the static catalog with the env-resolved Stripe price ids. */
+export function getMcpTopUpCatalog(): McpTopUpDefinition[] {
+  return STATIC_DEFS.map((def) => ({
+    ...def,
+    stripePriceId: resolvePriceId(def.sku),
+  }));
+}
+
+/** Catalog filtered to SKUs that have a configured Stripe price id. */
+export function listAvailableSkus(): McpTopUpDefinition[] {
+  return getMcpTopUpCatalog().filter((s) => s.stripePriceId !== null);
+}
+
+/** Look up a single SKU. Returns null when the sku is unknown. */
+export function findSku(sku: string): McpTopUpDefinition | null {
+  const all = getMcpTopUpCatalog();
+  return all.find((s) => s.sku === sku) ?? null;
+}
+
+/**
+ * Build the per-axis credit payload for `creditMultipleTokens`. Pure
+ * function so the webhook handler stays declarative.
+ */
+export function buildCreditPayload(
+  def: McpTopUpDefinition,
+): Array<{ tokenType: TokenType; amount: number }> {
+  const axes: TokenType[] = ["Spirit", "Essence", "Matter", "Substance"];
+  return axes.map((tokenType) => ({ tokenType, amount: def.esmsPerAxis }));
+}

--- a/src/lib/mcp/__tests__/tools.test.ts
+++ b/src/lib/mcp/__tests__/tools.test.ts
@@ -91,6 +91,7 @@ jest.mock("@/lib/mcp/auth", () => ({
 
 import { recordInvocation } from "@/lib/mcp/invocationLog";
 import { debitForTool } from "@/lib/mcp/auth";
+import { calculateNatalChart } from "@/services/natalChartService";
 import { invokeTool } from "@/lib/mcp/tools";
 
 const mockedDebit = debitForTool as jest.MockedFunction<typeof debitForTool>;
@@ -193,5 +194,24 @@ describe("invokeTool", () => {
     );
     expect(result.ok).toBe(false);
     expect(result.errorCode).toBe("NOT_FOUND");
+  });
+
+  it("surfaces the error.cause chain when a handler throws", async () => {
+    const mockedChart = calculateNatalChart as jest.MockedFunction<
+      typeof calculateNatalChart
+    >;
+    const root = new Error("Astrologize API error: Unauthorized");
+    const wrapped = new Error(
+      "Failed to calculate natal chart. Please check birth data and try again.",
+      { cause: root },
+    );
+    mockedChart.mockRejectedValueOnce(wrapped);
+
+    const result = await invokeTool("get_live_sky_transits", {});
+    expect(result.ok).toBe(false);
+    expect(result.errorCode).toBe("INTERNAL");
+    expect(result.errorMessage).toBe(
+      "Failed to calculate natal chart. Please check birth data and try again. ← Astrologize API error: Unauthorized",
+    );
   });
 });

--- a/src/lib/mcp/synastryTools.ts
+++ b/src/lib/mcp/synastryTools.ts
@@ -1,0 +1,667 @@
+/**
+ * Synastry & Transit-Natal Overlay Tool Handlers
+ *
+ * Two MCP tools that turn raw natal chart data into the relational
+ * ledger the desktop Jing Arena consumes:
+ *
+ *   - compute_synastry_overlay(agentA, agentB) → inter-aspects between
+ *     two natal charts + tension/harmony/intensification scores + the
+ *     target's default stance (clash | absorb | mirror).
+ *
+ *   - get_transit_natal_overlay(agent, transitTime?) → current sky
+ *     positions activating the agent's natal points + a per-element
+ *     boost vector (replaces the global "Transit Active" badge).
+ *
+ * The math is pure (sign+degree → λ, then min(|Δλ|, 360-|Δλ|) against
+ * canonical orbs). pg is used only as an opt-in cache: when the agents
+ * are seeded into `agent_natal_positions`, the `synastry_scores`
+ * materialized view collapses the score read to a single indexed row.
+ *
+ * @file mcp-server/src/synastryTools.ts
+ */
+
+import { calculateNatalChart } from "@/services/natalChartService";
+import type { ToolResult } from "./tools";
+
+// ─── Constants ────────────────────────────────────────────────────────
+
+const ZODIAC_SIGNS = [
+  "aries", "taurus", "gemini", "cancer",
+  "leo", "virgo", "libra", "scorpio",
+  "sagittarius", "capricorn", "aquarius", "pisces",
+] as const;
+
+const SIGN_TO_ELEMENT: Record<string, "fire" | "earth" | "air" | "water"> = {
+  aries: "fire", leo: "fire", sagittarius: "fire",
+  taurus: "earth", virgo: "earth", capricorn: "earth",
+  gemini: "air", libra: "air", aquarius: "air",
+  cancer: "water", scorpio: "water", pisces: "water",
+};
+
+const DEFAULT_FOCUS_PLANETS = [
+  "Sun", "Moon", "Mercury", "Venus", "Mars", "Saturn", "Jupiter",
+];
+
+const DEFAULT_TRANSIT_PLANETS = [
+  "Sun", "Moon", "Mars", "Saturn", "Jupiter", "Pluto",
+];
+
+const ASPECT_ORBS = {
+  conjunction: 8,
+  sextile: 6,
+  square: 8,
+  trine: 8,
+  opposition: 10,
+} as const;
+
+type AspectType = keyof typeof ASPECT_ORBS;
+type Harmonic = "friction" | "harmony" | "intensification";
+type Stance = "clash" | "absorb" | "mirror";
+
+const ASPECT_HARMONIC: Record<AspectType, Harmonic> = {
+  conjunction: "intensification",
+  sextile: "harmony",
+  trine: "harmony",
+  square: "friction",
+  opposition: "friction",
+};
+
+const ASPECT_ANGLE: Record<AspectType, number> = {
+  conjunction: 0,
+  sextile: 60,
+  square: 90,
+  trine: 120,
+  opposition: 180,
+};
+
+const PLANET_VALENCE: Record<string, string> = {
+  Sun: "identity",
+  Moon: "emotional",
+  Mercury: "reflective",
+  Venus: "relational",
+  Mars: "assertive",
+  Jupiter: "expansive",
+  Saturn: "restrictive",
+  Uranus: "transformative",
+  Neptune: "dissolving",
+  Pluto: "transformative",
+  Ascendant: "identity",
+  ASC: "identity",
+  MC: "vocational",
+};
+
+// ─── Input types ──────────────────────────────────────────────────────
+
+interface NatalPlanetInput {
+  sign: string;
+  degree: number;        // 0..30
+  retrograde?: boolean;
+  house?: number;
+}
+
+interface NatalChartInput {
+  planets: Record<string, NatalPlanetInput>;
+  ascendant?: number | NatalPlanetInput;
+  midheaven?: number | NatalPlanetInput;
+}
+
+interface AgentInput {
+  id: string;
+  natalChart: NatalChartInput;
+}
+
+export interface SynastryArgs {
+  agentA?: AgentInput;
+  agentB?: AgentInput;
+  focusPlanets?: string[];
+  cacheStrategy?: "read" | "write" | "bypass";
+}
+
+export interface TransitOverlayArgs {
+  agent?: AgentInput;
+  transitTime?: string;
+  latitude?: number;
+  longitude?: number;
+  focusPlanets?: string[];
+}
+
+// ─── Longitude math ───────────────────────────────────────────────────
+
+function normalizeSign(sign: string): string {
+  return String(sign || "").trim().toLowerCase();
+}
+
+function signIndex(sign: string): number {
+  const normalized = normalizeSign(sign);
+  const idx = ZODIAC_SIGNS.indexOf(normalized as (typeof ZODIAC_SIGNS)[number]);
+  return idx >= 0 ? idx : 0;
+}
+
+function toLongitude(sign: string, degree: number): number {
+  const clamped = Math.max(0, Math.min(30, degree));
+  return ((signIndex(sign) * 30) + clamped) % 360;
+}
+
+function deltaLongitude(lonA: number, lonB: number): number {
+  const diff = Math.abs(lonA - lonB);
+  return Math.min(diff, 360 - diff);
+}
+
+interface AspectDetection {
+  type: AspectType;
+  orb: number;
+  exactness: number;
+  harmonic: Harmonic;
+}
+
+function detectAspect(delta: number): AspectDetection | null {
+  for (const type of Object.keys(ASPECT_ORBS) as AspectType[]) {
+    const target = ASPECT_ANGLE[type];
+    const orb = Math.abs(delta - target);
+    if (orb <= ASPECT_ORBS[type]) {
+      return {
+        type,
+        orb,
+        exactness: 1 - orb / ASPECT_ORBS[type],
+        harmonic: ASPECT_HARMONIC[type],
+      };
+    }
+  }
+  return null;
+}
+
+// ─── Normalize input → list of {planet, longitude, sign, degree} ──────
+
+interface PlanetPoint {
+  planet: string;
+  longitude: number;
+  sign: string;
+  degreeInSign: number;
+  retrograde: boolean;
+  house?: number;
+}
+
+function flattenNatalChart(chart: NatalChartInput): PlanetPoint[] {
+  const out: PlanetPoint[] = [];
+  for (const [planet, position] of Object.entries(chart.planets || {})) {
+    if (!position || typeof position !== "object") continue;
+    const sign = normalizeSign(position.sign);
+    if (!SIGN_TO_ELEMENT[sign]) continue;
+    out.push({
+      planet,
+      longitude: toLongitude(sign, Number(position.degree) || 0),
+      sign,
+      degreeInSign: Number(position.degree) || 0,
+      retrograde: Boolean(position.retrograde),
+      house: position.house,
+    });
+  }
+  const extra = (label: string, input: number | NatalPlanetInput | undefined) => {
+    if (input === undefined || input === null) return;
+    if (typeof input === "number") {
+      out.push({
+        planet: label,
+        longitude: ((input % 360) + 360) % 360,
+        sign: ZODIAC_SIGNS[Math.floor((((input % 360) + 360) % 360) / 30)],
+        degreeInSign: ((input % 360) + 360) % 30,
+        retrograde: false,
+      });
+      return;
+    }
+    const sign = normalizeSign(input.sign);
+    if (!SIGN_TO_ELEMENT[sign]) return;
+    out.push({
+      planet: label,
+      longitude: toLongitude(sign, Number(input.degree) || 0),
+      sign,
+      degreeInSign: Number(input.degree) || 0,
+      retrograde: Boolean(input.retrograde),
+      house: input.house,
+    });
+  };
+  extra("Ascendant", chart.ascendant);
+  extra("MC", chart.midheaven);
+  return out;
+}
+
+// ─── pg layer (lazy import — mirrors invocationLog pattern) ───────────
+
+const isServerWithDB = (): boolean => !!process.env.DATABASE_URL;
+
+let dbModule:
+  | typeof import("@/lib/database/connection")
+  | null
+  | undefined = undefined;
+
+async function getDb(): Promise<
+  typeof import("@/lib/database/connection") | null
+> {
+  if (dbModule !== undefined) return dbModule;
+  if (!isServerWithDB()) {
+    dbModule = null;
+    return null;
+  }
+  try {
+    dbModule = await import("@/lib/database/connection");
+  } catch (err) {
+    process.stderr.write(
+      `[mcp/synastryTools] DB module load failed: ${String(err)}\n`,
+    );
+    dbModule = null;
+  }
+  return dbModule;
+}
+
+async function upsertNatalPositions(
+  agentId: string,
+  points: PlanetPoint[],
+): Promise<void> {
+  const db = await getDb();
+  if (!db || points.length === 0) return;
+  try {
+    for (const p of points) {
+      await db.executeQuery(
+        `INSERT INTO agent_natal_positions
+            (agent_id, planet, longitude, sign, degree_in_sign, house, retrograde, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, now())
+         ON CONFLICT (agent_id, planet) DO UPDATE SET
+            longitude       = EXCLUDED.longitude,
+            sign            = EXCLUDED.sign,
+            degree_in_sign  = EXCLUDED.degree_in_sign,
+            house           = EXCLUDED.house,
+            retrograde      = EXCLUDED.retrograde,
+            updated_at      = now()`,
+        [agentId, p.planet, p.longitude, p.sign, p.degreeInSign, p.house ?? null, p.retrograde],
+      );
+    }
+    await db.executeQuery("SELECT refresh_synastry_views()", []);
+  } catch (err) {
+    process.stderr.write(
+      `[mcp/synastryTools] upsert/refresh failed for ${agentId}: ${String(err)}\n`,
+    );
+  }
+}
+
+interface CachedScores {
+  tension: number;
+  harmony: number;
+  intensification: number;
+  aspectCount: number;
+}
+
+async function readCachedScores(
+  agentA: string,
+  agentB: string,
+): Promise<CachedScores | null> {
+  const db = await getDb();
+  if (!db) return null;
+  const [a, b] = [agentA, agentB].sort();
+  try {
+    const result = await db.executeQuery<{
+      tension_score: number;
+      harmony_score: number;
+      intensification_score: number;
+      aspect_count: number;
+    }>(
+      `SELECT tension_score, harmony_score, intensification_score, aspect_count
+         FROM synastry_scores
+        WHERE agent_a = $1 AND agent_b = $2`,
+      [a, b],
+    );
+    const row = result.rows?.[0];
+    if (!row) return null;
+    return {
+      tension: Number(row.tension_score) || 0,
+      harmony: Number(row.harmony_score) || 0,
+      intensification: Number(row.intensification_score) || 0,
+      aspectCount: Number(row.aspect_count) || 0,
+    };
+  } catch (err) {
+    process.stderr.write(
+      `[mcp/synastryTools] cache read failed: ${String(err)}\n`,
+    );
+    return null;
+  }
+}
+
+// ─── Scoring & stance ─────────────────────────────────────────────────
+
+interface InterAspect {
+  planetA: string;
+  planetB: string;
+  longitudeA: number;
+  longitudeB: number;
+  deltaLongitude: number;
+  type: AspectType;
+  orb: number;
+  exactness: number;
+  harmonic: Harmonic;
+}
+
+function computeInterAspects(
+  pointsA: PlanetPoint[],
+  pointsB: PlanetPoint[],
+  focus: string[],
+): InterAspect[] {
+  const focusSet = new Set(focus.map((p) => p.toLowerCase()));
+  const inFocus = (p: PlanetPoint) => focusSet.has(p.planet.toLowerCase());
+  const aspects: InterAspect[] = [];
+
+  for (const a of pointsA.filter(inFocus)) {
+    for (const b of pointsB.filter(inFocus)) {
+      const delta = deltaLongitude(a.longitude, b.longitude);
+      const detected = detectAspect(delta);
+      if (!detected) continue;
+      aspects.push({
+        planetA: a.planet,
+        planetB: b.planet,
+        longitudeA: a.longitude,
+        longitudeB: b.longitude,
+        deltaLongitude: delta,
+        type: detected.type,
+        orb: detected.orb,
+        exactness: detected.exactness,
+        harmonic: detected.harmonic,
+      });
+    }
+  }
+  return aspects.sort((x, y) => y.exactness - x.exactness);
+}
+
+interface Scores {
+  tension: number;
+  harmony: number;
+  intensification: number;
+  aspectCount: number;
+}
+
+function scoreAspects(aspects: InterAspect[]): Scores {
+  let tension = 0;
+  let harmony = 0;
+  let intensification = 0;
+  for (const a of aspects) {
+    if (a.harmonic === "friction") tension += a.exactness;
+    else if (a.harmonic === "harmony") harmony += a.exactness;
+    else if (a.harmonic === "intensification") intensification += a.exactness;
+  }
+  return { tension, harmony, intensification, aspectCount: aspects.length };
+}
+
+function decideStance(scores: Scores): Stance {
+  const { tension, harmony, intensification } = scores;
+  if (
+    intensification > harmony &&
+    intensification > tension &&
+    intensification > 0.6
+  ) {
+    return "mirror";
+  }
+  if (tension > harmony + 0.15) return "clash";
+  if (harmony > tension + 0.15) return "absorb";
+  // Roughly balanced or zero — weight by which is bigger.
+  if (tension === 0 && harmony === 0 && intensification === 0) return "absorb";
+  return tension >= harmony ? "clash" : "absorb";
+}
+
+// ─── Handler: compute_synastry_overlay ────────────────────────────────
+
+export async function computeSynastryOverlay(
+  args: SynastryArgs,
+): Promise<ToolResult> {
+  const { agentA, agentB } = args;
+  if (!agentA?.id || !agentA.natalChart || !agentB?.id || !agentB.natalChart) {
+    return {
+      ok: false,
+      data: null,
+      errorCode: "INVALID_ARGS",
+      errorMessage: "agentA and agentB (each with {id, natalChart}) are required",
+      summary: { reason: "missing-agents" },
+    };
+  }
+  if (agentA.id === agentB.id) {
+    return {
+      ok: false,
+      data: null,
+      errorCode: "INVALID_ARGS",
+      errorMessage: "agentA.id and agentB.id must differ",
+      summary: { reason: "self-pair" },
+    };
+  }
+
+  const focus = Array.isArray(args.focusPlanets) && args.focusPlanets.length > 0
+    ? args.focusPlanets
+    : DEFAULT_FOCUS_PLANETS;
+  const cacheStrategy = args.cacheStrategy ?? "read";
+
+  const pointsA = flattenNatalChart(agentA.natalChart);
+  const pointsB = flattenNatalChart(agentB.natalChart);
+
+  const aspects = computeInterAspects(pointsA, pointsB, focus);
+  let scores = scoreAspects(aspects);
+  let cacheHit = false;
+
+  if (cacheStrategy === "read") {
+    const cached = await readCachedScores(agentA.id, agentB.id);
+    if (cached) {
+      cacheHit = true;
+      scores = {
+        tension: cached.tension,
+        harmony: cached.harmony,
+        intensification: cached.intensification,
+        aspectCount: cached.aspectCount,
+      };
+    }
+  }
+
+  if (cacheStrategy !== "bypass") {
+    // Fire-and-forget — the upsert below blocks briefly but failure
+    // here must not block the duel.
+    void upsertNatalPositions(agentA.id, pointsA);
+    void upsertNatalPositions(agentB.id, pointsB);
+  }
+
+  const stance = decideStance(scores);
+  const [pairA, pairB] = [agentA.id, agentB.id].sort();
+
+  const data = {
+    pair: {
+      agentA: pairA,
+      agentB: pairB,
+      computedAt: new Date().toISOString(),
+      cacheHit,
+    },
+    interchartAspects: aspects.slice(0, 12),
+    scores: {
+      tension: Number(scores.tension.toFixed(3)),
+      harmony: Number(scores.harmony.toFixed(3)),
+      intensification: Number(scores.intensification.toFixed(3)),
+      aspectCount: scores.aspectCount,
+    },
+    dominantStance: stance,
+  };
+
+  return {
+    ok: true,
+    data,
+    summary: {
+      agentA: pairA,
+      agentB: pairB,
+      stance,
+      aspectCount: scores.aspectCount,
+      cacheHit,
+    },
+  };
+}
+
+// ─── Handler: get_transit_natal_overlay ───────────────────────────────
+
+interface TransitActivation {
+  transitPlanet: string;
+  natalPoint: string;
+  longitudeTransit: number;
+  longitudeNatal: number;
+  deltaLongitude: number;
+  type: AspectType;
+  orb: number;
+  exactness: number;
+  natalElement: "fire" | "earth" | "air" | "water";
+  valence: string;
+}
+
+export async function getTransitNatalOverlay(
+  args: TransitOverlayArgs,
+): Promise<ToolResult> {
+  const { agent } = args;
+  if (!agent?.id || !agent.natalChart) {
+    return {
+      ok: false,
+      data: null,
+      errorCode: "INVALID_ARGS",
+      errorMessage: "agent ({id, natalChart}) is required",
+      summary: { reason: "missing-agent" },
+    };
+  }
+
+  const focus = Array.isArray(args.focusPlanets) && args.focusPlanets.length > 0
+    ? args.focusPlanets
+    : DEFAULT_TRANSIT_PLANETS;
+  const lat = typeof args.latitude === "number" ? args.latitude : 40.7498;
+  const lon = typeof args.longitude === "number" ? args.longitude : -73.7976;
+  const transitTime = typeof args.transitTime === "string"
+    ? args.transitTime
+    : new Date().toISOString();
+
+  // Pull the live (or specified) sky via the same engine as
+  // get_live_sky_transits.
+  let transitChart;
+  try {
+    transitChart = await calculateNatalChart({
+      dateTime: transitTime,
+      latitude: lat,
+      longitude: lon,
+      timezone: "UTC",
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      data: null,
+      errorCode: "INTERNAL",
+      errorMessage: `Failed to compute transit chart: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      summary: { reason: "transit-chart-failed" },
+    };
+  }
+
+  // Convert the WTEN-side PlanetInfo[] (with absolute `position` lng) to
+  // our PlanetPoint shape for symmetric aspect detection.
+  const transitPoints: PlanetPoint[] = (transitChart.planets || [])
+    .filter((p: any) => p && typeof p.position === "number")
+    .map((p: any) => {
+      const sign = normalizeSign(String(p.sign || ""));
+      return {
+        planet: String(p.name),
+        longitude: ((Number(p.position) % 360) + 360) % 360,
+        sign,
+        degreeInSign: Number(p.position) % 30,
+        retrograde: false,
+      };
+    });
+
+  const natalPoints = flattenNatalChart(agent.natalChart);
+  const focusSet = new Set(focus.map((p) => p.toLowerCase()));
+  const inFocus = (p: PlanetPoint) => focusSet.has(p.planet.toLowerCase());
+
+  const activations: TransitActivation[] = [];
+  for (const t of transitPoints.filter(inFocus)) {
+    for (const n of natalPoints) {
+      const delta = deltaLongitude(t.longitude, n.longitude);
+      const detected = detectAspect(delta);
+      if (!detected) continue;
+      activations.push({
+        transitPlanet: t.planet,
+        natalPoint: n.planet,
+        longitudeTransit: t.longitude,
+        longitudeNatal: n.longitude,
+        deltaLongitude: delta,
+        type: detected.type,
+        orb: detected.orb,
+        exactness: detected.exactness,
+        natalElement: SIGN_TO_ELEMENT[n.sign] || "fire",
+        valence: PLANET_VALENCE[t.planet] || "neutral",
+      });
+    }
+  }
+  activations.sort((a, b) => b.exactness - a.exactness);
+
+  // Weighted vote: aspect exactness × harmonic weight per element.
+  // Harmonic aspects emphasize, friction de-emphasizes but still counts
+  // (a square to a fire-sign planet still makes that element hot).
+  const harmonicWeight = (a: TransitActivation): number => {
+    if (a.type === "conjunction") return 1.0;
+    if (a.type === "trine" || a.type === "sextile") return 0.8;
+    if (a.type === "square" || a.type === "opposition") return 0.7;
+    return 0.5;
+  };
+  const elementVotes: Record<string, number> = {
+    fire: 0, earth: 0, air: 0, water: 0,
+  };
+  for (const a of activations) {
+    elementVotes[a.natalElement] += a.exactness * harmonicWeight(a);
+  }
+  let boostElement: "fire" | "earth" | "air" | "water" | null = null;
+  let maxVote = 0;
+  for (const [el, v] of Object.entries(elementVotes)) {
+    if (v > maxVote) {
+      maxVote = v;
+      boostElement = el as "fire" | "earth" | "air" | "water";
+    }
+  }
+  const totalVotes = Object.values(elementVotes).reduce((s, v) => s + v, 0);
+  const boostMagnitude = totalVotes > 0
+    ? Number((maxVote / Math.max(totalVotes, 1)).toFixed(3))
+    : 0;
+
+  // Stress notes — squares/opps to luminaries are the headline.
+  const lights = new Set(["Sun", "Moon", "Ascendant", "MC"]);
+  const stressNotes: string[] = [];
+  for (const a of activations) {
+    if (
+      lights.has(a.natalPoint) &&
+      (a.type === "square" || a.type === "opposition") &&
+      a.exactness >= 0.4
+    ) {
+      stressNotes.push(
+        `natal ${a.natalPoint} under transit ${a.transitPlanet} ${a.type}`,
+      );
+    }
+  }
+
+  const headline = activations[0];
+  const boostSuffix = boostElement
+    ? ` → ${Math.round(boostMagnitude * 100)}% ${boostElement} boost`
+    : "";
+  const summary = headline
+    ? `Transit ${headline.transitPlanet} ${headline.type} natal ${headline.natalPoint}${boostSuffix}`
+    : "No active transit aspects within orb";
+
+  return {
+    ok: true,
+    data: {
+      agentId: agent.id,
+      transitTime,
+      coordinates: { latitude: lat, longitude: lon },
+      activations: activations.slice(0, 8),
+      boostElement,
+      boostMagnitude,
+      stressNotes: stressNotes.slice(0, 4),
+      summary,
+    },
+    summary: {
+      agentId: agent.id,
+      activationCount: activations.length,
+      boostElement,
+      boostMagnitude,
+    },
+  };
+}

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -24,6 +24,10 @@ import { calculateNatalChart } from "@/services/natalChartService";
 import { recipeService } from "@/services/RecipeService";
 import { debitForTool, resolveCaller, type DebitOutcome } from "./auth";
 import { recordInvocation } from "./invocationLog";
+import {
+  computeSynastryOverlay,
+  getTransitNatalOverlay,
+} from "./synastryTools";
 
 export interface ToolResult<T = unknown> {
   ok: boolean;
@@ -271,7 +275,31 @@ export async function generateCosmicRecipe(
 export type ToolName =
   | "get_live_sky_transits"
   | "alchemize_ingredients"
-  | "generate_cosmic_recipe";
+  | "generate_cosmic_recipe"
+  | "compute_synastry_overlay"
+  | "get_transit_natal_overlay";
+
+/**
+ * Stringify an error and walk its `cause` chain so the root reason
+ * lands in `mcp_invocations.error_message` instead of the outermost
+ * wrapper. Bug surfaced when a 401 from a self-fetch was being masked
+ * by "Failed to calculate natal chart." Cap the chain at 4 hops to
+ * avoid pathological loops.
+ */
+function formatErrorWithCauseChain(err: unknown): string {
+  const parts: string[] = [];
+  let cursor: unknown = err;
+  for (let hop = 0; hop < 4 && cursor != null; hop++) {
+    if (cursor instanceof Error) {
+      parts.push(cursor.message);
+      cursor = (cursor as { cause?: unknown }).cause;
+    } else {
+      parts.push(String(cursor));
+      break;
+    }
+  }
+  return parts.length > 0 ? parts.join(" ← ") : "unknown";
+}
 
 /**
  * Single entry point used by both the stdio MCP server and the
@@ -307,6 +335,10 @@ export async function invokeTool(
         result = await alchemizeIngredients(args as unknown as AlchemizeArgs);
       } else if (name === "generate_cosmic_recipe") {
         result = await generateCosmicRecipe(args);
+      } else if (name === "compute_synastry_overlay") {
+        result = await computeSynastryOverlay(args);
+      } else if (name === "get_transit_natal_overlay") {
+        result = await getTransitNatalOverlay(args);
       } else {
         result = {
           ok: false,
@@ -322,7 +354,7 @@ export async function invokeTool(
       ok: false,
       data: null,
       errorCode: "INTERNAL",
-      errorMessage: err instanceof Error ? err.message : String(err),
+      errorMessage: formatErrorWithCauseChain(err),
       summary: { reason: "handler-threw" },
     };
   }

--- a/src/services/astrologizeApi.ts
+++ b/src/services/astrologizeApi.ts
@@ -3,16 +3,14 @@ import { log } from "@/services/LoggingService";
 import { astrologizeApiCircuitBreaker } from "@/utils/apiCircuitBreaker";
 import { getAccuratePlanetaryPositions } from "@/utils/astrology/positions";
 import type { PlanetPosition } from "@/utils/astrologyUtils";
+import { getSelfBaseUrl } from "@/utils/urlUtils";
 
 // Use relative API endpoints so they hit the Next.js routes
 // The Next.js /api/... routes will securely proxy to the appropriate backend
 
 const getAstrologizeApiUrl = () => {
   if (typeof window === "undefined") {
-    if (process.env.VERCEL_URL) {
-      return `https://${process.env.VERCEL_URL}/api/astrologize`;
-    }
-    return `http://localhost:${process.env.PORT || 3000}/api/astrologize`;
+    return `${getSelfBaseUrl()}/api/astrologize`;
   }
   return `/api/astrologize`;
 };

--- a/src/services/natalChartService.ts
+++ b/src/services/natalChartService.ts
@@ -24,6 +24,7 @@ import {
   getDominantElement,
   isSectDiurnal,
 } from "@/utils/planetaryAlchemyMapping";
+import { getSelfBaseUrl } from "@/utils/urlUtils";
 import { getModalityForZodiac } from "@/utils/zodiacUtils";
 
 /**
@@ -87,10 +88,7 @@ interface AstrologizeResponse {
 // `fetch` rejects relative paths) and stay relative in the browser.
 function getAstrologizeApiUrl(): string {
   if (typeof window === "undefined") {
-    if (process.env.VERCEL_URL) {
-      return `https://${process.env.VERCEL_URL}/api/astrologize`;
-    }
-    return `http://localhost:${process.env.PORT || 3000}/api/astrologize`;
+    return `${getSelfBaseUrl()}/api/astrologize`;
   }
   return "/api/astrologize";
 }

--- a/src/types/economy.ts
+++ b/src/types/economy.ts
@@ -27,7 +27,14 @@ export type TransactionSourceType =
   | "streak_bonus"
   | "alchemical_log"
   | "signup_grant"
-  | "admin";
+  | "admin"
+  /**
+   * One-shot ESMS bundle purchased via Stripe — drives the MCP top-up
+   * SKUs ($5/$20/$50 → 50/250/750 of each axis). Credited from the
+   * Stripe webhook on `checkout.session.completed` with the Stripe
+   * session id as the idempotency key.
+   */
+  | "mcp_top_up";
 
 // ─── Token Balances ────────────────────────────────────────────────────
 

--- a/src/utils/urlUtils.ts
+++ b/src/utils/urlUtils.ts
@@ -44,7 +44,46 @@ export const getApiBaseUrl = (): string => {
 export const getApiUrl = (path: string): string => {
   const baseUrl = getApiBaseUrl();
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-  
+
   // If we have a baseUrl, use it. If not, return the relative path.
   return baseUrl ? `${baseUrl}${normalizedPath}` : normalizedPath;
+};
+
+/**
+ * Returns the absolute base URL of *this* Next.js app for server-side
+ * self-fetches (Node `fetch` rejects relative paths). Prefer the
+ * production alias over the deployment URL — Vercel's deployment URL
+ * is gated by Deployment Protection and returns 401 to internal
+ * fetches that do not carry the bypass header. The production alias
+ * (e.g. `alchm.kitchen`) is not gated.
+ *
+ * Resolution order:
+ *   1. NEXT_PUBLIC_SITE_URL / SITE_URL   — explicit override
+ *   2. VERCEL_PROJECT_PRODUCTION_URL     — Vercel-managed production alias
+ *   3. VERCEL_URL                        — deployment URL (last resort,
+ *                                          may be Deployment-Protection-gated)
+ *   4. http://localhost:${PORT||3000}    — local dev
+ *
+ * Browser callers should keep using relative `/api/...` paths instead.
+ */
+export const getSelfBaseUrl = (): string => {
+  const explicit =
+    process.env.NEXT_PUBLIC_SITE_URL?.trim() ||
+    process.env.SITE_URL?.trim();
+  if (explicit) {
+    return explicit.replace(/\/+$/, "");
+  }
+
+  const productionAlias = process.env.VERCEL_PROJECT_PRODUCTION_URL?.trim();
+  if (productionAlias) {
+    return `https://${productionAlias.replace(/^https?:\/\//, "")}`;
+  }
+
+  const deploymentUrl = process.env.VERCEL_URL?.trim();
+  if (deploymentUrl) {
+    return `https://${deploymentUrl.replace(/^https?:\/\//, "")}`;
+  }
+
+  const port = process.env.PORT || "3000";
+  return `http://localhost:${port}`;
 };


### PR DESCRIPTION
## Summary

Phase 2 of the MCP rollout. Closes 4 of the 5 items in `NEXT_SESSION_PROMPT_MCP_PHASE_2.md` (Item 3 is blocked on PA shipping `/api/admin/mcp-summary`; Item 5 follows the others landing).

- **Item 1 (validation) → fix.** Diagnosed: every synthetic-mcp probe row in `mcp_invocations` was failing fast because `natalChartService.fetchPlanetaryPositions` self-fetched `https://${VERCEL_URL}/api/astrologize` — and `VERCEL_URL` resolves to the deployment-specific hostname, which is behind Vercel Deployment Protection (returns 401). New `getSelfBaseUrl()` helper in `src/utils/urlUtils.ts` prefers `VERCEL_PROJECT_PRODUCTION_URL` (Vercel's unprotected production alias) over `VERCEL_URL`. Both duplicated `getAstrologizeApiUrl()` helpers now route through it. `invokeTool()` also surfaces the `error.cause` chain in `mcp_invocations.error_message` so future regressions are diagnosable from the DB alone.
- **Item 2 — API key management UX.** New `src/lib/api-keys/{keyMint,queries}.ts` (sha256-hashed keys, soft-revoke that preserves the `mcp_invocations.api_key_id` FK), `GET/POST /api/account/api-keys` + `DELETE /api/account/api-keys/[keyId]`, `/profile/api-keys` page with mint dialog + **one-time plaintext reveal** modal + revoke-with-confirmation, `/docs/mcp` public onboarding doc with prominent "Mint your key" CTA. `mcp-server/README.md` updated to link the UX surfaces.
- **Item 4 — Stripe top-up.** New `mcp_top_up` source type, SKU catalog at `src/lib/billing/mcpTopUp.ts` ($5/$20/$50 → 50/250/750 of each ESMS axis), pure webhook handler `handleMcpTopUpCheckout.ts` (Stripe session id is the idempotency key — webhook retries don't double-credit), `POST /api/account/billing/mcp-top-up` creates a one-shot Checkout session, `/account/billing/mcp` page with buy buttons + current-balance display + success/cancel banners, `/api/stripe/webhook` extended to dispatch `purpose: mcp_top_up` sessions.
- **Synastry tool (rides along).** `compute_synastry_overlay` + `get_transit_natal_overlay` MCP tools, `src/lib/mcp/synastryTools.ts`, `database/init/47-synastry-cache.sql` (cache table + materialized views). Not part of phase 2 scope per the prompt, but the user committed it alongside this work — included here for one merge.

## Open questions for review (flagged in the prompt)

1. **`api_keys.rate_limit_tier` semantics** — kept independent from the existing Apprentice/Alchemist token-economy tiers. Default is `"authenticated"`. Should it align with the subscription tier?
2. **Stripe SKU naming** — went with `mcp_top_up_5` / `_20` / `_50` (a new `mcp_*` namespace). Existing `shop_items` use kebab-case slugs like `unlock-cosmic-recipe`. Picked snake_case to match Stripe-metadata convention; happy to rename.
3. **Stripe products are not yet created.** The new SKUs need real Stripe Products with `STRIPE_MCP_TOP_UP_5_PRICE_ID` / `STRIPE_MCP_TOP_UP_20_PRICE_ID` / `STRIPE_MCP_TOP_UP_50_PRICE_ID` env vars set on Vercel. The mint route 503s gracefully when an env var is missing (UI degrades to "Try again later") so this can ship and be configured separately. **Before announcing, create the Stripe Products and set the env vars.**

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors, 0 new warnings (1 pre-existing `import/no-cycle` on `src/lib/database/connection.ts` that the prompt explicitly OKs)
- `bun run test` (phase 2 scope) — 52/52 across 7 suites:
  - `src/__tests__/utils/urlUtils.test.ts` — 7 tests for the new helper resolution order
  - `src/lib/mcp/__tests__/tools.test.ts` — 8 tests incl. the new cause-chain assertion
  - `src/lib/api-keys/__tests__/keyMint.test.ts` — 8 tests for the pure mint helpers
  - `src/app/api/account/api-keys/__tests__/route.test.ts` — 10 tests for GET/POST/DELETE incl. the hard contract that GET never returns plaintext
  - `src/lib/billing/__tests__/mcpTopUp.test.ts` — 7 tests for SKU catalog + env wiring
  - `src/lib/billing/__tests__/handleMcpTopUpCheckout.test.ts` — 6 tests for webhook handler outcomes + idempotency-key shape
  - `src/app/api/account/billing/mcp-top-up/__tests__/route.test.ts` — 6 tests for checkout-session creation + metadata
- `bun run build` — passes; new routes in the manifest:
  - `ƒ /api/account/api-keys` + `/api/account/api-keys/[keyId]` + `/api/account/billing/mcp-top-up`
  - `ƒ /profile/api-keys` (17.1 kB)
  - `ƒ /account/billing/mcp` (3.39 kB)
  - `○ /docs/mcp` (static, 181 B)

## Test plan

- [ ] After merge + deploy, run the Item-1 validation query against prod (`SELECT … FROM mcp_invocations ORDER BY called_at DESC LIMIT 10`) — rows should flip from `success=false` to `success=true`, and `generate_cosmic_recipe` should start appearing alongside `get_live_sky_transits`
- [ ] Confirm the MCP Tool Surface row on `/admin` shows OK status with `Synthetic: success`
- [ ] Confirm `mcpInvocationRate` reads non-zero on `/admin/dashboard`
- [ ] In a fresh browser session, sign in → `/profile/api-keys` → mint a key → confirm the plaintext appears once with a copy button → save it → confirm it disappears after dismiss → confirm the key row appears in the list
- [ ] Use the minted key as `_meta.apiKey` against `bun run mcp-server/src/index.ts` → verify `mcp_invocations.user_id` is populated and `api_key_id` matches the minted row
- [ ] Revoke the key → next MCP call from a client using it returns 401 → key row shows the "Revoked" badge
- [ ] Set the three `STRIPE_MCP_TOP_UP_*_PRICE_ID` env vars to test-mode Stripe Price IDs → visit `/account/billing/mcp` → click "Top up" on a SKU → complete Stripe Checkout (test card) → confirm webhook fires → confirm ESMS balance increases by exactly the SKU's `esmsPerAxis` on all four axes → confirm a second webhook retry with the same Stripe session id does NOT double-credit (look for the unique-violation in the `token_transactions.idempotency_key` index)
- [ ] On `/docs/mcp` confirm both "Mint your key" and the `/account/billing/mcp` link work

🤖 Generated with [Claude Code](https://claude.com/claude-code)