### PR TITLE
fix(admin): render mcpInvocationRate as 4th telemetry tile

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -34,6 +34,7 @@ interface AgentTelemetry {
   agentHarmony: TelemetryMetric;
   transmutationRate: TelemetryMetric;
   spiritualEntropy: TelemetryMetric;
+  mcpInvocationRate: TelemetryMetric;
   generatedAt: string;
   allLive: boolean;
 }
@@ -596,10 +597,11 @@ function TelemetryPanel({ telemetry }: { telemetry: AgentTelemetry | null }) {
           {hasTelemetry ? "db · ephemeris" : "—"}
         </span>
       </div>
-      <div className="grid grid-cols-3 gap-3 text-center">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-center">
         <TelemetryMetricTile label="Agent Harmony" metric={telemetry?.agentHarmony} />
         <TelemetryMetricTile label="Transmutation" metric={telemetry?.transmutationRate} />
         <TelemetryMetricTile label="Spiritual Entropy" metric={telemetry?.spiritualEntropy} />
+        <TelemetryMetricTile label="MCP Invocations" metric={telemetry?.mcpInvocationRate} />
       </div>
       {telemetry && (
         <p className="mt-2 text-center text-[9px] font-mono text-gray-400">


### PR DESCRIPTION
## Summary
Closes the doc-vs-reality gap surfaced while verifying [PR #458](https://github.com/gregcastro23/WhatToEatNext/pull/458)'s phase 2 rollout. `src/services/agentTelemetryService.ts:182` exports `mcpInvocationRate` as part of the network-telemetry payload (originally added in [PR #455](https://github.com/gregcastro23/WhatToEatNext/pull/455)), and both `mcp-server/README.md:108` and `mcp-server/ARCHITECTURE.md:121` document it as live on the High Alchemist dashboard alongside `agentHarmony` / `transmutationRate` / `spiritualEntropy`. The `AgentTelemetry` interface in `src/app/admin/page.tsx` was never updated to pick it up though, so the tile grid still only rendered three metrics.

## Changes
- Add `mcpInvocationRate: TelemetryMetric` to the local `AgentTelemetry` interface ([src/app/admin/page.tsx:33-40](src/app/admin/page.tsx#L33-L40))
- Render the 4th `<TelemetryMetricTile label="MCP Invocations">` in the grid
- Expand the grid from `grid-cols-3` → `grid-cols-2 md:grid-cols-4` so four tiles stay readable on mobile

## Verification
- `bun run typecheck` — clean
- `bun run lint` — clean (the pre-existing `import/no-cycle` warning on `src/lib/database/connection.ts` is the known one CLAUDE.md OKs)
- `bun run build` — clean

Visual verification of the new tile on the live admin page requires admin auth, which can be checked after merge + deploy.

## Test plan
- [ ] CI typecheck + lint + build pass on this branch
- [ ] After merge, sign in to `/admin` as the admin user and confirm the Agent Telemetry panel renders four tiles (Agent Harmony / Transmutation / Spiritual Entropy / **MCP Invocations**) and the new tile shows a live rate (≥ 4 calls/hr based on the synthetic probe cadence)
- [ ] Confirm `live: true` indicator under the new tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)