### PR TITLE
fix: replace stale PLANETARY_KINETICS_URL fallbacks with PLANETARY_AGENTS_API_URL

### DIFF
--- a/src/app/api/admin/agent-sync/route.ts
+++ b/src/app/api/admin/agent-sync/route.ts
@@ -49,8 +49,8 @@ function getPaConfig(): { url: string; secret: string } | { error: string } {
   // agents.alchm.kitchen domain is the Next.js UI and does NOT serve
   // /api/internal/agent-sync (would silently 404).
   const base = (
+    process.env.PLANETARY_AGENTS_API_URL ||
     process.env.NEXT_PUBLIC_PLANETARY_AGENTS_URL ||
-    process.env.NEXT_PUBLIC_PLANETARY_KINETICS_URL ||
     "https://api.agents.alchm.kitchen"
   ).replace(/\/+$/, "");
   if (!secret) return { error: "INTERNAL_API_SECRET not configured" };

--- a/src/app/api/admin/agents/monica/route.ts
+++ b/src/app/api/admin/agents/monica/route.ts
@@ -55,9 +55,8 @@ export interface MonicaTelemetryPayload {
 
 function paBaseUrl(): string {
   return (
+    process.env.PLANETARY_AGENTS_API_URL ||
     process.env.NEXT_PUBLIC_PLANETARY_AGENTS_URL ||
-    process.env.NEXT_PUBLIC_PLANETARY_KINETICS_URL ||
-    process.env.NEXT_PUBLIC_AGENTS_UI_URL ||
     "https://api.agents.alchm.kitchen"
   ).replace(/\/+$/, "");
 }

--- a/src/app/api/agent-forge/ignite/route.ts
+++ b/src/app/api/agent-forge/ignite/route.ts
@@ -179,7 +179,7 @@ export async function POST(req: Request) {
       console.log(`[ignite] Initiating direct fallback fetch to planetary agents API...`);
       const agentBaseUrl =
         process.env.PLANETARY_AGENTS_API_URL ||
-        process.env.NEXT_PUBLIC_PLANETARY_KINETICS_URL ||
+        process.env.NEXT_PUBLIC_PLANETARY_AGENTS_URL ||
         "https://api.agents.alchm.kitchen";
 
       const raw = getAccuratePlanetaryPositions(new Date());

--- a/src/app/api/generate-cosmic-recipe/route.ts
+++ b/src/app/api/generate-cosmic-recipe/route.ts
@@ -271,7 +271,7 @@ async function handlePost(request: NextRequest) {
   // back a validated CosmicRecipeResponse.
   const agentBaseUrl =
     process.env.PLANETARY_AGENTS_API_URL ||
-    process.env.NEXT_PUBLIC_PLANETARY_KINETICS_URL ||
+    process.env.NEXT_PUBLIC_PLANETARY_AGENTS_URL ||
     "https://api.agents.alchm.kitchen";
 
   let recipe: z.infer<typeof cosmicRecipeSchema>;

--- a/src/app/api/nanobanana/generate/route.ts
+++ b/src/app/api/nanobanana/generate/route.ts
@@ -43,11 +43,13 @@ export async function POST(req: NextRequest) {
       console.warn("[NanoBanana] Redis read failed:", err);
     }
 
-    // PA's image-gen route lives on the Next.js UI host (agents.alchm.kitchen),
-    // not the Python backend (api.agents.*) — it proxies to Cloudflare Workers
-    // AI from the UI app. Don't "fix" this to api.agents.alchm.kitchen.
+    // PA's image-gen route is served by the Python backend at
+    // api.agents.alchm.kitchen — the bare agents.alchm.kitchen host is the
+    // Next.js UI and does not serve /api/generate-image (would 404 silently).
     const agentBaseUrl =
-      process.env.NEXT_PUBLIC_PLANETARY_KINETICS_URL || "https://agents.alchm.kitchen";
+      process.env.PLANETARY_AGENTS_API_URL ||
+      process.env.NEXT_PUBLIC_PLANETARY_AGENTS_URL ||
+      "https://api.agents.alchm.kitchen";
 
     // /api/generate-image expects { prompt }, not { title, description }.
     const promptParts = [

--- a/src/app/api/planetary-agents/diet/route.ts
+++ b/src/app/api/planetary-agents/diet/route.ts
@@ -13,7 +13,9 @@ export const runtime = "nodejs";
 
 export async function GET() {
   try {
-    const backendUrl = process.env.NEXT_PUBLIC_PLANETARY_KINETICS_URL;
+    const backendUrl =
+      process.env.PLANETARY_AGENTS_API_URL ||
+      process.env.NEXT_PUBLIC_PLANETARY_AGENTS_URL;
     if (!backendUrl) {
       return NextResponse.json(
         { success: false, error: "Planetary agents backend is not configured." },

--- a/src/lib/agents/fetchAgentProfile.ts
+++ b/src/lib/agents/fetchAgentProfile.ts
@@ -1,7 +1,7 @@
 import type { CraftedAgentProfile } from "./craftedAgentTypes";
 
 const AGENTS_BASE_URL =
-  process.env.NEXT_PUBLIC_PLANETARY_KINETICS_URL || "https://agents.alchm.kitchen";
+  process.env.NEXT_PUBLIC_PLANETARY_AGENTS_URL || "https://api.agents.alchm.kitchen";
 
 export interface AgentInteraction {
   id: string;

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -385,8 +385,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
               // PA Python backend is at api.agents.alchm.kitchen — the bare
               // agents.alchm.kitchen domain is the Next.js UI and would 404.
               const paBase = (
+                process.env.PLANETARY_AGENTS_API_URL ||
                 process.env.NEXT_PUBLIC_PLANETARY_AGENTS_URL ||
-                process.env.NEXT_PUBLIC_PLANETARY_KINETICS_URL ||
                 "https://api.agents.alchm.kitchen"
               ).replace(/\/$/, "");
 

--- a/src/lib/kinetics-integration.ts
+++ b/src/lib/kinetics-integration.ts
@@ -20,7 +20,6 @@ export interface EnhancedKineticData {
 // /api/agents/{id}/kinetics — would 404 silently if used here.
 const PA_URL = (
   process.env.NEXT_PUBLIC_PLANETARY_AGENTS_URL ||
-  process.env.NEXT_PUBLIC_PLANETARY_KINETICS_URL ||
   'https://api.agents.alchm.kitchen'
 ).replace(/\/+$/, '')
 

--- a/src/lib/planetaryAgentsClient.ts
+++ b/src/lib/planetaryAgentsClient.ts
@@ -1,6 +1,6 @@
 // src/lib/planetaryAgentsClient.ts
 
-export const PLANETARY_AGENTS_URL = process.env.NEXT_PUBLIC_PLANETARY_AGENTS_URL || 'https://agents.alchm.kitchen';
+export const PLANETARY_AGENTS_URL = process.env.NEXT_PUBLIC_PLANETARY_AGENTS_URL || 'https://api.agents.alchm.kitchen';
 
 export async function fetchAgentForDegree(degree: number) {
   try {

--- a/src/services/PlanetaryAgentsAdapter.ts
+++ b/src/services/PlanetaryAgentsAdapter.ts
@@ -457,5 +457,5 @@ export class PlanetaryAgentsAdapter {
 
 // Export singleton instance
 export const planetaryAgentsAdapter = new PlanetaryAgentsAdapter(
-  process.env.NEXT_PUBLIC_PLANETARY_KINETICS_URL || "http://localhost:8000",
+  process.env.NEXT_PUBLIC_PLANETARY_AGENTS_URL || "https://api.agents.alchm.kitchen",
 );


### PR DESCRIPTION
## Summary

- The `NEXT_PUBLIC_PLANETARY_KINETICS_URL` env var on Vercel points to the PA Next.js UI host (`agents.alchm.kitchen`), NOT the PA Python API (`api.agents.alchm.kitchen`). Routes that fell back to it hit the UI host and 404'd — exactly how `/api/generate-cosmic-recipe` produced 502s every hour for 24h until `PLANETARY_AGENTS_API_URL` was set on Vercel (phase 2 of #457/#458).
- Sweeps the remaining 10 server-side + library sites onto the canonical chain per CLAUDE.md (`PLANETARY_AGENTS_API_URL` → `NEXT_PUBLIC_PLANETARY_AGENTS_URL` → `https://api.agents.alchm.kitchen`), and replaces the lingering `https://agents.alchm.kitchen` and `http://localhost:8000` fallbacks with the API host so a missing env var no longer routes API calls to the wrong place.
- Vercel env var `NEXT_PUBLIC_PLANETARY_KINETICS_URL` is left in place — the operator scripts in `scripts/` still consume it under that name.

## Files touched

| File | Notes |
| --- | --- |
| `src/app/api/planetary-agents/diet/route.ts` | Was the ONLY route with no fallback chain at all — diet profiles 503'd on any env hiccup. Now reads `PLANETARY_AGENTS_API_URL` then `NEXT_PUBLIC_PLANETARY_AGENTS_URL`. |
| `src/app/api/admin/agent-sync/route.ts` | Dropped stale `KINETICS_URL`, promoted `PLANETARY_AGENTS_API_URL` to first in chain. |
| `src/app/api/nanobanana/generate/route.ts` | Sole fallback was `KINETICS_URL || "https://agents.alchm.kitchen"` — both wrong host. The inline "don't fix this" comment was inaccurate (the UI host serves no `/api/generate-image`); updated to match other PA routes. |
| `src/app/api/admin/agents/monica/route.ts` | Dropped `KINETICS_URL` + `NEXT_PUBLIC_AGENTS_UI_URL` (UI host is wrong for this API call), promoted `PLANETARY_AGENTS_API_URL` to first. |
| `src/app/api/agent-forge/ignite/route.ts` | Replaced `KINETICS_URL` middle-of-chain with `NEXT_PUBLIC_PLANETARY_AGENTS_URL`. |
| `src/app/api/generate-cosmic-recipe/route.ts` | The route that triggered the original incident — same stale `KINETICS_URL` rung in the chain, swapped for `NEXT_PUBLIC_PLANETARY_AGENTS_URL`. (Not in the original 9, but identical pattern in the same chain as the bug.) |
| `src/lib/kinetics-integration.ts` | Removed the dead `KINETICS_URL` rung. |
| `src/lib/auth/auth.ts` | Agent-sync POST during signIn — promoted `PLANETARY_AGENTS_API_URL` first, dropped `KINETICS_URL`. |
| `src/lib/agents/fetchAgentProfile.ts` | `KINETICS_URL || "https://agents.alchm.kitchen"` → `NEXT_PUBLIC_PLANETARY_AGENTS_URL || "https://api.agents.alchm.kitchen"`. |
| `src/lib/planetaryAgentsClient.ts` | Same wrong-host fallback pattern (no `KINETICS_URL` ref but `agents.alchm.kitchen` fallback) — swept onto `api.agents.alchm.kitchen`. |
| `src/services/PlanetaryAgentsAdapter.ts` | Singleton instantiated with `KINETICS_URL || "http://localhost:8000"` — production-broken default replaced. |

## Test plan

- [x] `bun run verify` (typecheck + lint) — 0 errors. The 1 lint warning (`src/lib/database/connection.ts` dependency cycle) is pre-existing and unrelated.
- [x] `bun run build` — full production build clean.
- [ ] Post-merge: confirm next `/api/generate-cosmic-recipe` cron run returns 200 (its env-var setting on Vercel still wins, so no behavior change expected for that route, but the rest of the surface is now safe even if someone unsets `PLANETARY_AGENTS_API_URL`).
- [ ] Post-merge: confirm the new `nanobanana` chain works on next image generation — the inline comment that warned against this change was incorrect, but worth eyeballing once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)