### PR TITLE
fix(alchemy): correct live-sky ESMS grounding and New York sect

### DIFF
--- a/src/app/api/alchm-quantities/planetary/route.ts
+++ b/src/app/api/alchm-quantities/planetary/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { rateLimit } from "@/lib/rateLimit";
+import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
 import type { PlanetPosition } from "@/utils/astrologyUtils";
 import { createLogger } from "@/utils/logger";
 import {
@@ -8,7 +9,6 @@ import {
   getPlanetarySectElement,
   getZodiacQuality,
 } from "@/utils/planetaryAlchemyMapping";
-import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
 import { calculateNextSignTransition } from "@/utils/planetaryTransitions";
 import {
   calculatePlanetaryPositions,

--- a/src/app/api/alchm-quantities/route.ts
+++ b/src/app/api/alchm-quantities/route.ts
@@ -5,14 +5,14 @@
  * - alchm-kinetics
  */
 import { NextResponse } from "next/server";
+import { PLANET_WEIGHTS, normalizePlanetWeight } from "@/data/planets";
 import { rateLimit } from "@/lib/rateLimit";
 import { AlchmQuantitiesApiResponseSchema } from "@/lib/validation/apiSchemas";
 import { getCachedHistoricalStats } from "@/services/HistoricalStatsService";
 import { alchemize, type PlanetaryPosition } from "@/services/RealAlchemizeService";
+import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
 import { createLogger } from "@/utils/logger";
 import { PLANETARY_ALCHEMY } from "@/utils/planetaryAlchemyMapping";
-import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
-import { PLANET_WEIGHTS, normalizePlanetWeight } from "@/data/planets";
 import {
   calculatePlanetaryPositions,
   getFallbackPlanetaryPositions,

--- a/src/app/api/alchm-quantities/trends/route.ts
+++ b/src/app/api/alchm-quantities/trends/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { rateLimit } from "@/lib/rateLimit";
 import { alchemize } from "@/services/RealAlchemizeService";
-import { createLogger } from "@/utils/logger";
 import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
+import { createLogger } from "@/utils/logger";
 import {
   calculatePlanetaryPositions,
   getFallbackPlanetaryPositions,

--- a/src/lib/economy/livePricing.ts
+++ b/src/lib/economy/livePricing.ts
@@ -1,7 +1,7 @@
 import { alchemize, type PlanetaryPosition } from "@/services/RealAlchemizeService";
 import type { AlchemicalProperties } from "@/types/celestial";
-import { calculateAlchemicalFromPlanets } from "@/utils/planetaryAlchemyMapping";
 import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
+import { calculateAlchemicalFromPlanets } from "@/utils/planetaryAlchemyMapping";
 import {
   calculatePlanetaryPositions,
   getFallbackPlanetaryPositions,

--- a/src/services/AstrologicalService.ts
+++ b/src/services/AstrologicalService.ts
@@ -27,11 +27,11 @@ import type {
   LunarPhase,
 } from "@/types/celestial";
 import { AstrologicalState as _CentralizedAstrologicalState } from "@/types/celestial";
+import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
 import {
   aggregateEnhancedZodiacElementals,
   calculateAlchemicalFromPlanets,
 } from "@/utils/planetaryAlchemyMapping";
-import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
 import { createLogger } from "../utils/logger";
 import astrologizeApiCache from "./AstrologizeApiCache";
 

--- a/src/services/DailyYieldService.ts
+++ b/src/services/DailyYieldService.ts
@@ -22,8 +22,8 @@ import {
   TRANSIT_BONUS_SCALE,
   getStreakMultiplier,
 } from "@/types/economy";
-import { calculateAlchemicalFromPlanets } from "@/utils/planetaryAlchemyMapping";
 import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
+import { calculateAlchemicalFromPlanets } from "@/utils/planetaryAlchemyMapping";
 import { reportQuestEventBestEffort } from "./questEventReporter";
 import { streakService } from "./StreakService";
 import { tokenEconomy } from "./TokenEconomyService";

--- a/src/services/RealAlchemizeService.ts
+++ b/src/services/RealAlchemizeService.ts
@@ -1,12 +1,12 @@
 import fs from "fs";
 import { _logger } from "@/lib/logger";
 import type { ElementalProperties } from "@/types/celestial";
-import {
-    getPlanetarySectElement, calculateEnhancedAlchemicalFromPlanets, PLANETARY_SECTARIAN_ESMS
-} from "@/utils/planetaryAlchemyMapping";
 import { calculateComprehensiveAspects } from "@/utils/aspectCalculator";
 import type { AspectWithStrength } from "@/utils/aspectESMSEffects";
 import { getAccuratePlanetaryPositions, isCurrentSkyDiurnal } from "@/utils/astrology/positions";
+import {
+    getPlanetarySectElement, calculateEnhancedAlchemicalFromPlanets, PLANETARY_SECTARIAN_ESMS
+} from "@/utils/planetaryAlchemyMapping";
 
 const PLANET_ALCHM_PERIODS: Record<string, number> = {
   Pluto: 247.94,

--- a/src/services/RecommendationService.ts
+++ b/src/services/RecommendationService.ts
@@ -2,11 +2,11 @@ import type { ThermodynamicMetrics } from "@/types/alchemical";
 import type { ElementalProperties } from "@/types/alchemy";
 import type { Ingredient } from "@/types/ingredient";
 import type { Recipe } from "@/types/recipe";
+import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
 import { logger } from "@/utils/logger";
 import {
   aggregateEnhancedZodiacElementals,
 } from "@/utils/planetaryAlchemyMapping";
-import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
 import { RecipeService } from "./RecipeService";
 import type {
     CookingMethodRecommendationCriteria,


### PR DESCRIPTION
## Summary

Two correctness fixes for location-less "current sky" alchemical calculations, both rooted in the same gap — a live sky carries no observer location.

**1. Centralized Physical-Vessel grounding** (`calculateEnhancedAlchemicalFromPlanets`)
- Injects a synthetic, sign-independent (Neutral-dignity) Ascendant when none is present, so the diurnal sect no longer collapses **Matter & Substance to 0** in location-less day charts.
- Removes the asymmetry where only natal charts (which carry a real Ascendant) were grounded, which had been distorting the natal-vs-current `alchemicalAlignment` cosine score in `personalized-recommendations`.
- Natal inputs are untouched (injection fires only when the Ascendant is absent), and the caller's object is never mutated (operates on a copy).

**2. New York "live sky" sect** (`isCurrentSkyDiurnal`, new in `astrology/positions.ts`)
- Computes the real diurnal/nocturnal sect from the Sun's actual altitude at New York via astronomy-engine (UTC-hour fallback on error), replacing a raw UTC-hour heuristic that was wrong for NY by ~5h (US afternoons read as "night").
- Sect flips the entire day/night ESMS split (day → Spirit/Essence, night → Matter/Substance), so this **materially changes current-moment numbers**.
- All ~20 current-moment callers switched; **natal sect (birth date) intentionally stays on `isSectDiurnal`** so existing charts' day/night isn't silently altered.

## Reviewer notes
- **This intentionally changes outputs** on current-moment surfaces (recommendations, alchm-quantities, live pricing, daily yield, etc.).
- Scope rule applied: *what instant does the sect represent?* → "now" uses NY; a birth date stays unchanged.
- This branch also carries the prior `feat(physics)` commit (`fe2c46ea` — aspect-aware ESMS, classical moieties, cosine-bell orbs) that isn't yet in `master`, so it rides along in this PR's diff.
- **Known gaps left for follow-up:** natal sect still uses the UTC-hour approximation (correct fix = birthplace + birth time); the basic `calculateAlchemicalFromPlanets` has the same day-sect collapse and isn't grounded.

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] `eslint` — 0 warnings on changed files
- [x] `planetaryAlchemyMapping` suite 32/32, `HooksCompliance` 3/3
- [x] new `positions.test.ts` (NY sect boundary) 3/3
- [x] verified sect flips for the hours the old UTC rule got backwards (18:00 UTC → day, 06:00 UTC → night) and that 23:00 UTC reads day via real late-May sunset math

🤖 Generated with [Claude Code](https://claude.com/claude-code)