### PR TITLE
Production-readiness hardening: security, DB resilience, calc guards

### DIFF
--- a/database/init/48-dashboard-count-indexes.sql
+++ b/database/init/48-dashboard-count-indexes.sql
@@ -1,0 +1,51 @@
+-- 48-dashboard-count-indexes.sql
+--
+-- Indexes backing the admin dashboard "practitioner cohorts" and user-insights
+-- panels, which run full-table COUNT(*) / COUNT(DISTINCT ...) over users,
+-- user_interactions, and user_subscriptions (see src/services/dashboardPanelsService.ts
+-- and src/services/userInsightsService.ts). At the project's million-user goal
+-- these were sequential scans on every dashboard load; the 5s memoize bounds
+-- frequency but not per-query cost.
+--
+-- IMPORTANT — CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+-- Run this file OUTSIDE a transaction (e.g. psql \i, or a migration runner set to
+-- skip the implicit BEGIN/COMMIT for this file). If your runner wraps every file
+-- in a transaction, either remove CONCURRENTLY (accepting a brief write lock) or
+-- apply these statements manually during a low-traffic window. All are IF NOT
+-- EXISTS so re-running is safe.
+
+-- Completed-profile count:
+--   SELECT COUNT(*) FROM users WHERE (profile->>'birthData') IS NOT NULL
+--     AND (profile->>'natalChart') IS NOT NULL
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_profile_complete
+  ON users ((profile->>'birthData'))
+  WHERE (profile->>'birthData') IS NOT NULL
+    AND (profile->>'natalChart') IS NOT NULL;
+
+-- Active-user count: SELECT COUNT(*) FROM users WHERE is_active = true
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_is_active
+  ON users (is_active)
+  WHERE is_active = true;
+
+-- Signup-window counts (24h / 7d / 30d) and the 14-day signup trend.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_created_at
+  ON users (created_at);
+
+-- Active-window counts: last_login_at >= NOW() - INTERVAL ...
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_last_login_at
+  ON users (last_login_at);
+
+-- Dominant-element histogram:
+--   GROUP BY profile->'natalChart'->>'dominantElement'
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_dominant_element
+  ON users ((profile->'natalChart'->>'dominantElement'))
+  WHERE profile->'natalChart' IS NOT NULL;
+
+-- Recipe-cook reach:
+--   SELECT COUNT(DISTINCT user_id) FROM user_interactions WHERE interaction_type = 'recipe_cook'
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_interactions_type_user
+  ON user_interactions (interaction_type, user_id);
+
+-- Active subscriptions: SELECT COUNT(*) FROM user_subscriptions WHERE status = 'active'
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_subscriptions_status
+  ON user_subscriptions (status);

--- a/src/app/api/admin/send-test-email/route.ts
+++ b/src/app/api/admin/send-test-email/route.ts
@@ -9,16 +9,21 @@
  */
 
 import { NextResponse } from "next/server";
+import { validateAdminRequest } from "@/lib/auth/validateRequest";
 import emailService from "@/services/emailService";
 import type { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-const ADMIN_EMAILS = ["xalchm@gmail.com", "cookingwithcastrollc@gmail.com"];
-
 export async function POST(request: NextRequest) {
   try {
+    // Admin gate — require a valid session with admin role + allowlisted email.
+    const auth = await validateAdminRequest(request);
+    if ("error" in auth) {
+      return auth.error;
+    }
+
     const body = await request.json().catch(() => ({}));
 
     const {
@@ -32,20 +37,6 @@ export async function POST(request: NextRequest) {
       dominantElement?: string;
       type?: "welcome" | "admin" | "login";
     };
-
-    // Simple admin gate: request must come from an admin email or include the admin secret
-    const adminSecret = process.env.ADMIN_SECRET || process.env.AUTH_SECRET;
-    const providedSecret = request.headers.get("x-admin-secret");
-    const isAuthorized =
-      ADMIN_EMAILS.includes(to) ||
-      (adminSecret && providedSecret === adminSecret);
-
-    if (!isAuthorized && process.env.NODE_ENV === "production") {
-      return NextResponse.json(
-        { success: false, error: "Unauthorized" },
-        { status: 401 },
-      );
-    }
 
     // Re-check env vars in case they weren't available at module load
     emailService.ensureInitialized();

--- a/src/app/api/admin/users/insights/route.ts
+++ b/src/app/api/admin/users/insights/route.ts
@@ -11,11 +11,14 @@
 
 import { NextResponse } from "next/server";
 import { validateAdminRequest } from "@/lib/auth/validateRequest";
+import { memoize } from "@/lib/cache/memoryCache";
 import { getUserInsights } from "@/services/userInsightsService";
 import type { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+const CACHE_TTL_MS = 5_000;
 
 export async function GET(request: NextRequest) {
   try {
@@ -24,7 +27,9 @@ export async function GET(request: NextRequest) {
       return authResult.error;
     }
 
-    const payload = await getUserInsights();
+    const payload = await memoize("admin:user-insights", CACHE_TTL_MS, () =>
+      getUserInsights(),
+    );
     return NextResponse.json({ success: true, ...payload });
   } catch (error) {
     console.error("[admin/users/insights] Failed:", error);

--- a/src/app/api/alchm-quantities/planetary/route.ts
+++ b/src/app/api/alchm-quantities/planetary/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { rateLimit } from "@/lib/rateLimit";
+import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
 import type { PlanetPosition } from "@/utils/astrologyUtils";
 import { createLogger } from "@/utils/logger";
 import {
@@ -8,7 +9,6 @@ import {
   getPlanetarySectElement,
   getZodiacQuality,
 } from "@/utils/planetaryAlchemyMapping";
-import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
 import { calculateNextSignTransition } from "@/utils/planetaryTransitions";
 import {
   calculatePlanetaryPositions,

--- a/src/app/api/alchm-quantities/route.ts
+++ b/src/app/api/alchm-quantities/route.ts
@@ -497,7 +497,15 @@ export async function GET(request: Request) {
       process.env.CROSS_BACKEND_SYNC_ENABLED === "true" ||
       process.env.CROSS_BACKEND_RECTIFICATION_ENABLED === "true";
 
-    if (isVerificationEnabled) {
+    const internalSecret = process.env.INTERNAL_API_SECRET;
+    if (isVerificationEnabled && !internalSecret) {
+      // Fail closed: never call the internal backend with a hardcoded fallback
+      // secret. If INTERNAL_API_SECRET is unset, skip cross-verification entirely.
+      logger.warn(
+        "Cross-backend verification enabled but INTERNAL_API_SECRET is unset; skipping verification.",
+      );
+    }
+    if (isVerificationEnabled && internalSecret) {
       const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || "https://whattoeatnext-production.up.railway.app";
       try {
         const controller = new AbortController();
@@ -509,7 +517,7 @@ export async function GET(request: Request) {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
-              "Authorization": `Bearer ${process.env.INTERNAL_API_SECRET || "882133EA-3D06-4DF2-A63C-F4114AB4EFBC"}`
+              "Authorization": `Bearer ${internalSecret}`
             },
             body: JSON.stringify({
               recipe: {
@@ -543,16 +551,30 @@ export async function GET(request: Request) {
           };
 
           const maxDiscrepancy = Math.max(discrepancy.Spirit, discrepancy.Essence, discrepancy.Matter, discrepancy.Substance);
-          const status = maxDiscrepancy < 0.05 ? ("verified" as const) : ("rectified" as const);
+
+          // A backend value is only authoritative when it's finite and > 0. An
+          // all-zero or partial payload means the backend couldn't compute it —
+          // treat that as a failure rather than rectifying healthy local values
+          // down to 0.
+          const usableAxes = ESMS_KEYS.filter(
+            (k) => Number.isFinite(backendQuantities[k]) && backendQuantities[k] > 0,
+          );
+          const backendUsable = usableAxes.length > 0;
+
+          const status = !backendUsable
+            ? ("failed" as const)
+            : maxDiscrepancy < 0.05
+              ? ("verified" as const)
+              : ("rectified" as const);
 
           const originalLocalQuantities = { ...quantities };
 
-          // Rectify local quantities to match backend authoritative values if discrepancy is detected
+          // Rectify ONLY the axes where the backend returned a usable (finite, >0)
+          // value; never overwrite a healthy local quantity with a 0/NaN.
           if (status === "rectified") {
-            quantities.Spirit = backendQuantities.Spirit;
-            quantities.Essence = backendQuantities.Essence;
-            quantities.Matter = backendQuantities.Matter;
-            quantities.Substance = backendQuantities.Substance;
+            for (const k of usableAxes) {
+              quantities[k] = backendQuantities[k];
+            }
           }
 
           crossVerification = {

--- a/src/app/api/alchm-quantities/route.ts
+++ b/src/app/api/alchm-quantities/route.ts
@@ -5,14 +5,14 @@
  * - alchm-kinetics
  */
 import { NextResponse } from "next/server";
+import { PLANET_WEIGHTS, normalizePlanetWeight } from "@/data/planets";
 import { rateLimit } from "@/lib/rateLimit";
 import { AlchmQuantitiesApiResponseSchema } from "@/lib/validation/apiSchemas";
 import { getCachedHistoricalStats } from "@/services/HistoricalStatsService";
 import { alchemize, type PlanetaryPosition } from "@/services/RealAlchemizeService";
+import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
 import { createLogger } from "@/utils/logger";
 import { PLANETARY_ALCHEMY } from "@/utils/planetaryAlchemyMapping";
-import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
-import { PLANET_WEIGHTS, normalizePlanetWeight } from "@/data/planets";
 import {
   calculatePlanetaryPositions,
   getFallbackPlanetaryPositions,

--- a/src/app/api/alchm-quantities/trends/route.ts
+++ b/src/app/api/alchm-quantities/trends/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { rateLimit } from "@/lib/rateLimit";
 import { alchemize } from "@/services/RealAlchemizeService";
-import { createLogger } from "@/utils/logger";
 import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
+import { createLogger } from "@/utils/logger";
 import {
   calculatePlanetaryPositions,
   getFallbackPlanetaryPositions,

--- a/src/app/api/nanobanana/cuisine/route.ts
+++ b/src/app/api/nanobanana/cuisine/route.ts
@@ -1,11 +1,11 @@
 import { createHash } from "crypto";
 import { NextResponse } from "next/server";
+import { getCuisineData, CUISINES_METADATA } from "@/data/cuisines/index";
 import { auth } from "@/lib/auth/auth";
 import { rateLimit } from "@/lib/rateLimit";
 import { redisGet, redisSet } from "@/lib/redis";
-import { getCuisineData, CUISINES_METADATA } from "@/data/cuisines/index";
-import type { NextRequest } from "next/server";
 import type { Cuisine } from "@/types/cuisine";
+import type { NextRequest } from "next/server";
 
 const RATE_LIMIT = { window: 60_000, max: 10, bucket: "nanobanana-generate" };
 const CACHE_TTL = 60 * 60 * 24 * 7; // 7 days
@@ -64,19 +64,6 @@ export async function POST(req: NextRequest) {
     const metadata = CUISINES_METADATA[cuisineKey];
     const cuisineName = metadata.name ?? cuisineKey;
 
-    const cacheKey = `gen_image_cuisine:${cuisineKey.toLowerCase()}`;
-
-    // Try to get cached result
-    try {
-      const cached = await redisGet<{ url: string }>(cacheKey);
-      if (cached) {
-        console.debug(`[NanoBanana-Cuisine] Serving cached image result for ${cuisineName}`);
-        return NextResponse.json(cached);
-      }
-    } catch (err) {
-      console.warn("[NanoBanana-Cuisine] Redis read failed:", err);
-    }
-
     // Load full cuisine data dynamically (contains dishes list)
     const cuisineData = await getCuisineData(cuisineKey);
     if (!cuisineData) {
@@ -97,8 +84,10 @@ export async function POST(req: NextRequest) {
       elementalLighting = "The setting has a cool, refreshing, and serene atmosphere, with soft morning light reflecting off elegant glass carafes and fresh, dew-kissed seafood platters.";
     } else if (earth > 0.35) {
       elementalLighting = "The dining scene is grounded and rustic, using textured hand-thrown ceramic tableware on a solid dark oak banquet table. Hearty whole grains, roasted root vegetables, and deep forest-green accents enrich the presentation.";
-    } else {
+    } else if (air > 0.35) {
       elementalLighting = "The composition is light, airy, and expansive, featuring delicate fresh herb garnishes and high-key, natural diffused sunlight casting soft, bright highlights across the feast.";
+    } else {
+      elementalLighting = "The table is balanced and harmonious, lit with even, naturalistic daylight that gives equal weight to every dish — neither dramatic nor stark, a poised culinary still life.";
     }
 
     const dishesSection = dishesList.length > 0 
@@ -113,6 +102,23 @@ export async function POST(req: NextRequest) {
       elementalLighting,
       "Beautifully plated, restaurant-quality, professional food styling, natural lighting, macro details, shallow depth of field, sharp focus, 8k resolution. No text, labels, or watermarks."
     ].filter(Boolean).join(" ");
+
+    // Content-address the cache by the generated prompt: when the dishes, elemental
+    // lighting, or description change, the hash changes and the image regenerates
+    // instead of serving a stale 7-day entry keyed only by cuisine name.
+    const promptHash = createHash("sha256").update(imagePrompt).digest("hex").slice(0, 16);
+    const cacheKey = `gen_image_cuisine:${cuisineKey.toLowerCase()}:${promptHash}`;
+
+    // Try to get cached result
+    try {
+      const cached = await redisGet<{ url: string }>(cacheKey);
+      if (cached) {
+        console.debug(`[NanoBanana-Cuisine] Serving cached image result for ${cuisineName}`);
+        return NextResponse.json(cached);
+      }
+    } catch (err) {
+      console.warn("[NanoBanana-Cuisine] Redis read failed:", err);
+    }
 
     const agentBaseUrl =
       process.env.PLANETARY_AGENTS_API_URL ||

--- a/src/data/cuisines/index.ts
+++ b/src/data/cuisines/index.ts
@@ -148,7 +148,7 @@ export function processCuisineRecipes(cuisine: any): Cuisine {
   }
 
   const normalizedKey = name === "Middle Eastern" ? "MiddleEastern" : name;
-  const imageUrl = (cuisineImages as Record<string, string>)[normalizedKey] || undefined;
+  const imageUrl = cuisineImages[normalizedKey] || undefined;
 
   return {
     ...cuisine,

--- a/src/lib/database/config.ts
+++ b/src/lib/database/config.ts
@@ -104,6 +104,23 @@ export function validateDatabaseConfig(): { valid: boolean; errors: string[] } {
   };
 }
 
+/**
+ * Runtime guard for the dangerous "missing DATABASE_URL in production" case.
+ *
+ * `databaseUrl` above always has a localhost default, so a missing env var passes
+ * validateDatabaseConfig()'s format check yet silently points the app at a
+ * non-existent local database. Call this at pool-creation time (NOT at import —
+ * module-level work hangs the Next build) to fail fast instead of limping along.
+ */
+export function assertRuntimeDatabaseConfig(): void {
+  if (process.env.NODE_ENV === "production" && !process.env.DATABASE_URL) {
+    throw new Error(
+      "DATABASE_URL is not set in production — refusing to start against the " +
+        "localhost default. Set DATABASE_URL (or DB_HOST/DB_NAME/DB_USER/DB_PASSWORD).",
+    );
+  }
+}
+
 // Initialize configuration and log warnings
 // DISABLED: Module-level logging causes Next.js build to hang during module scanning
 // These validations and logs should be called at runtime, not during import

--- a/src/lib/database/connection.ts
+++ b/src/lib/database/connection.ts
@@ -1,7 +1,12 @@
 import pkg from 'pg';
 import { logger } from "../logger";
+// Intentional, benign cycle: slowQueryLog lazily `import()`s this module's raw
+// pool at call time to avoid runtime recursion (see its own disable at the
+// import site). This static edge is the hot-path recordSlowQuery, called on
+// every query, so it stays static for perf.
+// eslint-disable-next-line import/no-cycle
 import { recordSlowQuery } from "../observability/slowQueryLog";
-import { databaseConfig } from "./config";
+import { databaseConfig, assertRuntimeDatabaseConfig } from "./config";
 import type { Pool, PoolClient, QueryResult } from "pg";
 
 // Robustly extract Pool and types from the pg package (handles various bundling scenarios)
@@ -11,6 +16,15 @@ const types = (pkg as any).types || (pkg as any).default?.types || (pkg as unkno
 if (!PoolValue) {
   console.error("FATAL: pg.Pool is undefined. Environment might be incompatible with the current pg import strategy.");
 }
+
+// Throttle the per-query system_metrics persistence (in executeQuery below) so a
+// burst of slow queries — e.g. during pool contention — can't self-amplify by
+// each firing an extra pooled INSERT against the very pool that's already
+// saturated. The in-memory ring (recordSlowQuery) keeps full fidelity at zero
+// pool cost; this durable sink is sampled to at most one write per interval per
+// instance.
+let _lastSlowQueryMetricAt = 0;
+const SLOW_QUERY_METRIC_MIN_INTERVAL_MS = 2000;
 
 // Note: neonConfig is no longer used as we are using standard pg
 
@@ -107,7 +121,11 @@ export function initializeDatabase(): Pool {
   if (pool) {
     return pool;
   }
-  
+
+  // Fail fast in production if DATABASE_URL is unset (would silently fall back
+  // to the localhost default and "succeed" until the first query times out).
+  assertRuntimeDatabaseConfig();
+
   const config = getDatabaseConfig();
 
   pool = new PoolValue(config);
@@ -239,8 +257,14 @@ export async function executeQuery<_T extends any = any>(
     // surface gradual regressions here long before they trip the >1s warn.
     recordSlowQuery(executionTime, query, result.rowCount);
     
-    // Persist slow queries to system_metrics table (excluding self-telemetry)
-    if (executionTime >= 200 && !query.toLowerCase().includes("system_metrics")) {
+    // Persist slow queries to system_metrics (sampled — see throttle note at top).
+    const nowMs = Date.now();
+    if (
+      executionTime >= 200 &&
+      !query.toLowerCase().includes("system_metrics") &&
+      nowMs - _lastSlowQueryMetricAt >= SLOW_QUERY_METRIC_MIN_INTERVAL_MS
+    ) {
+      _lastSlowQueryMetricAt = nowMs;
       getDatabasePool().query(
         `INSERT INTO system_metrics (metric_name, metric_value, metric_unit, tags)
          VALUES ($1, $2, $3, $4)`,

--- a/src/lib/economy/livePricing.ts
+++ b/src/lib/economy/livePricing.ts
@@ -1,7 +1,7 @@
 import { alchemize, type PlanetaryPosition } from "@/services/RealAlchemizeService";
 import type { AlchemicalProperties } from "@/types/celestial";
-import { calculateAlchemicalFromPlanets } from "@/utils/planetaryAlchemyMapping";
 import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
+import { calculateAlchemicalFromPlanets } from "@/utils/planetaryAlchemyMapping";
 import {
   calculatePlanetaryPositions,
   getFallbackPlanetaryPositions,

--- a/src/services/AstrologicalService.ts
+++ b/src/services/AstrologicalService.ts
@@ -27,11 +27,11 @@ import type {
   LunarPhase,
 } from "@/types/celestial";
 import { AstrologicalState as _CentralizedAstrologicalState } from "@/types/celestial";
+import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
 import {
   aggregateEnhancedZodiacElementals,
   calculateAlchemicalFromPlanets,
 } from "@/utils/planetaryAlchemyMapping";
-import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
 import { createLogger } from "../utils/logger";
 import astrologizeApiCache from "./AstrologizeApiCache";
 

--- a/src/services/DailyYieldService.ts
+++ b/src/services/DailyYieldService.ts
@@ -22,8 +22,8 @@ import {
   TRANSIT_BONUS_SCALE,
   getStreakMultiplier,
 } from "@/types/economy";
-import { calculateAlchemicalFromPlanets } from "@/utils/planetaryAlchemyMapping";
 import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
+import { calculateAlchemicalFromPlanets } from "@/utils/planetaryAlchemyMapping";
 import { reportQuestEventBestEffort } from "./questEventReporter";
 import { streakService } from "./StreakService";
 import { tokenEconomy } from "./TokenEconomyService";

--- a/src/services/RealAlchemizeService.ts
+++ b/src/services/RealAlchemizeService.ts
@@ -381,10 +381,18 @@ export function alchemize(
   const reactivity = (reactivityNum / (Matter || 1)) + Math.pow(Earth, 2);
   // Greg's Energy;
   const gregsEnergy = heat - entropy * reactivity;
-  // Kalchm (K_alchm)
-  const kalchm =
-    (Math.pow(Spirit, Spirit) * Math.pow(Essence, Essence)) /
-    (Math.pow(Matter, Matter) * Math.pow(Substance, Substance));
+  // Kalchm (K_alchm). Clamp ESMS bases to a tiny positive epsilon first: a
+  // negative base (possible after aspect modifications subtract below 0) makes
+  // Math.pow return NaN, which would otherwise propagate into monica, pricing,
+  // and the API payload. x^x → 1 as x → 0, so valid inputs are unaffected.
+  const kSpirit = Math.max(Spirit, 1e-9);
+  const kEssence = Math.max(Essence, 1e-9);
+  const kMatter = Math.max(Matter, 1e-9);
+  const kSubstance = Math.max(Substance, 1e-9);
+  const kalchmRaw =
+    (Math.pow(kSpirit, kSpirit) * Math.pow(kEssence, kEssence)) /
+    (Math.pow(kMatter, kMatter) * Math.pow(kSubstance, kSubstance));
+  const kalchm = Number.isFinite(kalchmRaw) ? kalchmRaw : 1;
   // Monica constant: −GregsEnergy / (Reactivity × ln(Kalchm))
   // Guards: kalchm must be > 0; lnK must be non-zero; reactivity must be non-zero
   let monica = 1.0; // Default value
@@ -431,8 +439,8 @@ export function alchemize(
       source: "alchemize",
       dominantElement,
       dominantModality: "Cardinal", // Simplified for now,
-      sunSign: planetaryPositions["Sun"].sign || "",
-      chartRuler: getZodiacElement(planetaryPositions["Sun"].sign || "aries"),
+      sunSign: planetaryPositions["Sun"]?.sign || "",
+      chartRuler: getZodiacElement(planetaryPositions["Sun"]?.sign || "aries"),
       isDiurnal: diurnal,
     },
   };
@@ -640,9 +648,16 @@ export function alchemizeDetailed(
     Math.pow(Water, 2);
   const reactivity = reactivityNum / (Matter || 1) + Math.pow(Earth, 2);
   const gregsEnergy = heat - entropy * reactivity;
-  const kalchm =
-    (Math.pow(Spirit, Spirit) * Math.pow(Essence, Essence)) /
-    (Math.pow(Matter, Matter) * Math.pow(Substance, Substance));
+  // Clamp ESMS bases to epsilon before pow/ratio so a negative base can't make
+  // kalchm NaN (mirrors alchemize()); x^x → 1 as x → 0 so valid inputs are unaffected.
+  const kSpirit = Math.max(Spirit, 1e-9);
+  const kEssence = Math.max(Essence, 1e-9);
+  const kMatter = Math.max(Matter, 1e-9);
+  const kSubstance = Math.max(Substance, 1e-9);
+  const kalchmRaw =
+    (Math.pow(kSpirit, kSpirit) * Math.pow(kEssence, kEssence)) /
+    (Math.pow(kMatter, kMatter) * Math.pow(kSubstance, kSubstance));
+  const kalchm = Number.isFinite(kalchmRaw) ? kalchmRaw : 1;
   let monica = 1.0;
   if (kalchm > 0 && isFinite(kalchm)) {
     const lnK = Math.log(kalchm);

--- a/src/services/RealAlchemizeService.ts
+++ b/src/services/RealAlchemizeService.ts
@@ -1,12 +1,12 @@
 import fs from "fs";
 import { _logger } from "@/lib/logger";
 import type { ElementalProperties } from "@/types/celestial";
-import {
-    getPlanetarySectElement, calculateEnhancedAlchemicalFromPlanets, PLANETARY_SECTARIAN_ESMS
-} from "@/utils/planetaryAlchemyMapping";
 import { calculateComprehensiveAspects } from "@/utils/aspectCalculator";
 import type { AspectWithStrength } from "@/utils/aspectESMSEffects";
 import { getAccuratePlanetaryPositions, isCurrentSkyDiurnal } from "@/utils/astrology/positions";
+import {
+    getPlanetarySectElement, calculateEnhancedAlchemicalFromPlanets, PLANETARY_SECTARIAN_ESMS
+} from "@/utils/planetaryAlchemyMapping";
 
 const PLANET_ALCHM_PERIODS: Record<string, number> = {
   Pluto: 247.94,

--- a/src/services/RecommendationService.ts
+++ b/src/services/RecommendationService.ts
@@ -2,11 +2,11 @@ import type { ThermodynamicMetrics } from "@/types/alchemical";
 import type { ElementalProperties } from "@/types/alchemy";
 import type { Ingredient } from "@/types/ingredient";
 import type { Recipe } from "@/types/recipe";
+import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
 import { logger } from "@/utils/logger";
 import {
   aggregateEnhancedZodiacElementals,
 } from "@/utils/planetaryAlchemyMapping";
-import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
 import { RecipeService } from "./RecipeService";
 import type {
     CookingMethodRecommendationCriteria,

--- a/src/services/RecommendationService.ts
+++ b/src/services/RecommendationService.ts
@@ -393,12 +393,33 @@ export class RecommendationService implements RecommendationServiceInterface {
       ];
       let filteredMethods = [...defaultMethods];
       const scores: { [key: string]: number } = {};
-      // Apply elemental filtering (simplified)
+      // Score each method by how well its elemental nature aligns with the
+      // requested elemental profile — deterministic, not random.
+      const METHOD_ELEMENTAL_AFFINITY: Record<string, Partial<ElementalProperties>> = {
+        Grilling: { Fire: 1 },
+        "Stir-frying": { Fire: 0.6, Air: 0.4 },
+        Steaming: { Water: 0.7, Air: 0.3 },
+        Roasting: { Fire: 0.6, Earth: 0.4 },
+        Braising: { Water: 0.5, Earth: 0.5 },
+        Sautéing: { Fire: 0.6, Air: 0.4 },
+        Boiling: { Water: 1 },
+        Frying: { Fire: 0.8, Air: 0.2 },
+        "Slow-cooking": { Earth: 0.6, Water: 0.4 },
+      };
       if (criteria.elementalProperties) {
+        const el = criteria.elementalProperties;
         filteredMethods.forEach((method) => {
-          scores[method] = Math.random() * 0.5 + 0.5;
+          const affinity = METHOD_ELEMENTAL_AFFINITY[method] ?? {};
+          const dot =
+            (affinity.Fire ?? 0) * (el.Fire ?? 0) +
+            (affinity.Water ?? 0) * (el.Water ?? 0) +
+            (affinity.Earth ?? 0) * (el.Earth ?? 0) +
+            (affinity.Air ?? 0) * (el.Air ?? 0);
+          // Map the elemental dot-product into a stable 0.5–1.0 band so even a
+          // weak match remains a usable suggestion.
+          scores[method] = 0.5 + Math.min(0.5, Math.max(0, dot) * 0.5);
         });
-        // Sort by score
+        // Sort by score (highest elemental alignment first)
         filteredMethods.sort((a, b) => scores[b] - scores[a]);
       } else {
         // Default scores
@@ -568,13 +589,18 @@ export class RecommendationService implements RecommendationServiceInterface {
     const reactivity = Math.abs(Fire - Water) / 2;
     // Greg's Energy: Balance between heat and entropy
     const gregsEnergy = heat - entropy * reactivity;
+    // kalchm and monica are NOT derivable from elemental properties alone — they
+    // require the Spirit/Essence/Matter/Substance axes. This elemental-only path
+    // returns NaN sentinels rather than a fake 0 that masquerades as real; callers
+    // needing real values must use the canonical engine (RealAlchemizeService).
+    // Detect the not-computed case with Number.isFinite().
     return {
       heat,
       entropy,
       reactivity,
       gregsEnergy,
-      kalchm: 0, // Placeholder
-      monica: 0, // Placeholder
+      kalchm: NaN,
+      monica: NaN,
     };
   }
   /**

--- a/src/services/commensalDatabaseService.ts
+++ b/src/services/commensalDatabaseService.ts
@@ -19,6 +19,7 @@ import {
   aggregateEnhancedZodiacElementals,
   isSectDiurnal,
 } from "@/utils/planetaryAlchemyMapping";
+import { safeJsonParse } from "@/utils/typeGuards";
 
 const isServerWithDB = (): boolean => {
   return typeof window === "undefined" && !!process.env.DATABASE_URL;
@@ -289,11 +290,11 @@ class CommensalDatabaseService {
       return result.rows
         .filter((r: any) => {
           // Only include commensals who have completed onboarding (have natal chart)
-          const profile = typeof r.profile === "string" ? JSON.parse(r.profile) : r.profile;
+          const profile = typeof r.profile === "string" ? safeJsonParse(r.profile) : r.profile;
           return profile?.natalChart && Object.keys(profile.natalChart).length > 0;
         })
         .map((r: any) => {
-          const profile = typeof r.profile === "string" ? JSON.parse(r.profile) : r.profile;
+          const profile = typeof r.profile === "string" ? safeJsonParse(r.profile) : r.profile;
           const birthData = profile.birthData || profile.birth_data;
           const natalChart = profile.natalChart || profile.natal_chart;
           
@@ -430,8 +431,8 @@ class CommensalDatabaseService {
   private rowToSavedChart(row: any): SavedChart {
     return {
       id: row.id, ownerId: row.owner_id, label: row.label, chartType: row.chart_type,
-      birthData: typeof row.birth_data === "string" ? JSON.parse(row.birth_data) : row.birth_data,
-      natalChart: typeof row.natal_chart === "string" ? JSON.parse(row.natal_chart) : row.natal_chart,
+      birthData: typeof row.birth_data === "string" ? safeJsonParse(row.birth_data) : row.birth_data,
+      natalChart: typeof row.natal_chart === "string" ? safeJsonParse(row.natal_chart) : row.natal_chart,
       isPrimary: row.is_primary,
       createdAt: row.created_at?.toISOString?.() ?? row.created_at,
       updatedAt: row.updated_at?.toISOString?.() ?? row.updated_at,
@@ -452,8 +453,8 @@ class CommensalDatabaseService {
           id: r.id,
           name: r.name,
           relationship: r.relationship,
-          birthData: typeof r.birth_data === "string" ? JSON.parse(r.birth_data) : r.birth_data,
-          natalChart: typeof r.natal_chart === "string" ? JSON.parse(r.natal_chart) : r.natal_chart,
+          birthData: typeof r.birth_data === "string" ? safeJsonParse(r.birth_data) : r.birth_data,
+          natalChart: typeof r.natal_chart === "string" ? safeJsonParse(r.natal_chart) : r.natal_chart,
           createdAt: r.created_at?.toISOString?.() ?? r.created_at,
         }));
       } catch (error) {
@@ -623,7 +624,7 @@ class CommensalDatabaseService {
 
       if (profileResult.rows.length > 0) {
         const profile = typeof profileResult.rows[0].profile === "string"
-          ? JSON.parse(profileResult.rows[0].profile)
+          ? safeJsonParse(profileResult.rows[0].profile)
           : profileResult.rows[0].profile;
         const natalChart = profile?.natalChart || profile?.natal_chart;
         const birthData = profile?.birthData || profile?.birth_data;
@@ -647,7 +648,7 @@ class CommensalDatabaseService {
     birth_data: unknown;
   }): ElementalProperties | null {
     const natalChart = (typeof row.natal_chart === "string"
-      ? JSON.parse(row.natal_chart)
+      ? safeJsonParse(row.natal_chart)
       : row.natal_chart) as Partial<NatalChart> | null;
     if (!natalChart) return null;
 
@@ -667,7 +668,7 @@ class CommensalDatabaseService {
       if (Object.keys(positions).length === 0) return null;
 
       const birthData = (typeof row.birth_data === "string"
-        ? JSON.parse(row.birth_data)
+        ? safeJsonParse(row.birth_data)
         : row.birth_data) as Partial<BirthData> | null;
       const birthDate = birthData?.dateTime
         ? new Date(birthData.dateTime)

--- a/src/services/notificationDatabaseService.ts
+++ b/src/services/notificationDatabaseService.ts
@@ -246,9 +246,12 @@ class NotificationDatabaseService {
     if (db) {
       try {
         const result = await db.executeQuery(
+          // "Today" = the current New York calendar day (domain timezone), not the
+          // DB session's CURRENT_DATE (UTC), so the once-per-day dedupe rolls over
+          // at ET midnight rather than UTC midnight.
           `SELECT id FROM notifications
            WHERE user_id = $1 AND type = 'daily_insight'
-             AND created_at >= CURRENT_DATE
+             AND created_at >= date_trunc('day', now() AT TIME ZONE 'America/New_York') AT TIME ZONE 'America/New_York'
            LIMIT 1`,
           [userId],
         );

--- a/src/services/userDatabaseService.ts
+++ b/src/services/userDatabaseService.ts
@@ -8,6 +8,7 @@ import { randomUUID } from "crypto";
 import type { UserProfile } from "@/contexts/UserContext";
 import type { User, UserRole } from "@/lib/auth/jwt-auth";
 import { _logger } from "@/lib/logger";
+import { safeJsonParse } from "@/utils/typeGuards";
 
 // Extended User type with profile data
 export interface UserWithProfile extends User {
@@ -742,24 +743,27 @@ class UserDatabaseService {
    * Convert database row to UserWithProfile object
    */
   private rowToUserWithProfile(row: any): UserWithProfile {
+    // Guarded JSON parsing: these are JSONB columns (node-postgres usually returns
+    // them pre-parsed), but a text-typed or double-encoded value would otherwise
+    // throw here and turn one corrupt row into a silent auth/profile-load outage.
     const birthData =
       typeof row.birth_data === "string"
-        ? JSON.parse(row.birth_data)
+        ? safeJsonParse(row.birth_data)
         : row.birth_data;
     const natalChart =
       typeof row.natal_chart === "string"
-        ? JSON.parse(row.natal_chart)
+        ? safeJsonParse(row.natal_chart)
         : row.natal_chart;
     const dietaryPreferences =
       typeof row.dietary_preferences === "string"
-        ? JSON.parse(row.dietary_preferences)
+        ? safeJsonParse(row.dietary_preferences, {})
         : row.dietary_preferences || {};
     // users.preferences is the canonical store for general preferences.
     // For legacy rows where general prefs were written to dietary_preferences,
     // fall back to that column if users.preferences is empty.
     const rawUserPrefs =
       typeof row.preferences === "string"
-        ? JSON.parse(row.preferences)
+        ? safeJsonParse(row.preferences, {})
         : row.preferences || {};
     const preferences =
       Object.keys(rawUserPrefs || {}).length > 0
@@ -767,11 +771,11 @@ class UserDatabaseService {
         : dietaryPreferences;
     const groupMembers =
       typeof row.group_members === "string"
-        ? JSON.parse(row.group_members)
+        ? safeJsonParse(row.group_members, [])
         : row.group_members || [];
     const diningGroups =
       typeof row.dining_groups === "string"
-        ? JSON.parse(row.dining_groups)
+        ? safeJsonParse(row.dining_groups, [])
         : row.dining_groups || [];
 
     // Map single 'role' ENUM column back to roles array

--- a/src/services/userInsightsService.ts
+++ b/src/services/userInsightsService.ts
@@ -129,7 +129,8 @@ export async function getUserInsights(): Promise<UserInsightsPayload> {
     sunSignsRes,
     medianRes,
     sessionsRes,
-  ] = await Promise.all([
+  ] = (await Promise.all(
+    [
     executeQuery<RollupRow>(
       `SELECT
          COUNT(*)::int AS total,
@@ -163,13 +164,16 @@ export async function getUserInsights(): Promise<UserInsightsPayload> {
     ),
 
     executeQuery<{ day: string; count: number }>(
+      // Bucket by New York calendar day (the app's domain timezone), not the DB
+      // session zone — a 9pm-ET signup must count toward that ET day, and the JS
+      // axis in fillSignupTrend() builds the same NY day keys.
       `SELECT
-         to_char(date_trunc('day', u.created_at), 'YYYY-MM-DD') AS day,
+         to_char(date_trunc('day', u.created_at AT TIME ZONE 'America/New_York'), 'YYYY-MM-DD') AS day,
          COUNT(*)::int AS count
        FROM users u
        WHERE u.created_at >= NOW() - INTERVAL '14 days'
          AND COALESCE(u.is_agent, false) = false
-       GROUP BY date_trunc('day', u.created_at)
+       GROUP BY date_trunc('day', u.created_at AT TIME ZONE 'America/New_York')
        ORDER BY day ASC`,
     ),
 
@@ -224,7 +228,27 @@ export async function getUserInsights(): Promise<UserInsightsPayload> {
        FROM device_sessions
        WHERE revoked_at IS NULL`,
     ),
-  ]);
+    ].map((p) =>
+      // Each sub-query degrades independently: a single failed aggregate returns
+      // empty rows (logged) instead of rejecting the whole insights payload.
+      // Consumers below already handle empty rows (e.g. `?? emptyRollup()`).
+      p.catch((e) => {
+        console.warn(
+          "[userInsights] sub-query failed, degrading to empty rows:",
+          e,
+        );
+        return { rows: [] as never[] };
+      }),
+    ),
+  )) as unknown as [
+    { rows: RollupRow[] },
+    { rows: Array<{ day: string; count: number }> },
+    { rows: Array<CountRow<string>> },
+    { rows: Array<CountRow<string>> },
+    { rows: Array<CountRow<string>> },
+    { rows: MedianRow[] },
+    { rows: ActiveSessionsRow[] },
+  ];
 
   const rollup = rollupRes.rows[0] ?? emptyRollup();
   const activeSessions = sessionsRes.rows[0]?.active_sessions ?? 0;
@@ -335,12 +359,22 @@ function fillSignupTrend(
   const byDay = new Map<string, number>();
   for (const row of rows) byDay.set(row.day, row.count);
 
+  // Build the 14-day axis in New York calendar days so the keys match the SQL's
+  // `AT TIME ZONE 'America/New_York'` buckets. Anchor on NY's current date at
+  // noon UTC (avoids any midnight/DST rollover when stepping back by day).
+  const nyToday = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/New_York",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date());
+  const [y, m, dd] = nyToday.split("-").map(Number);
+  const anchor = new Date(Date.UTC(y, m - 1, dd, 12, 0, 0));
+
   const out: SignupTrendPoint[] = [];
-  const today = new Date();
-  today.setUTCHours(0, 0, 0, 0);
   for (let i = 13; i >= 0; i--) {
-    const d = new Date(today);
-    d.setUTCDate(today.getUTCDate() - i);
+    const d = new Date(anchor);
+    d.setUTCDate(anchor.getUTCDate() - i);
     const day = d.toISOString().slice(0, 10);
     out.push({ day, count: byDay.get(day) ?? 0 });
   }

--- a/tests/alchm-quantities-verification.test.ts
+++ b/tests/alchm-quantities-verification.test.ts
@@ -29,6 +29,9 @@ describe("Cross-Backend Alchemical Quantities Verification Tests", () => {
       ...originalEnv,
       CROSS_BACKEND_SYNC_ENABLED: "true",
       NEXT_PUBLIC_BACKEND_URL: "https://whattoeatnext-production.up.railway.app",
+      // The route now fails closed and skips cross-verification when
+      // INTERNAL_API_SECRET is unset (the hardcoded fallback was removed).
+      INTERNAL_API_SECRET: "test-internal-secret",
     };
   });
 


### PR DESCRIPTION
## Summary

Audit-driven hardening pass for the v3 release, covering the four areas surfaced in a multi-agent review: secrets/auth, database calls, calculation pipelines, and user-metrics. `bun run verify` is fully green (0 type errors, 0 lint warnings); the alchm-quantities test suite passes 4/4.

## Security
- **Removed the hardcoded `INTERNAL_API_SECRET` fallback** in `/api/alchm-quantities` — cross-backend verification now **fails closed** when the secret is unset (no guessable literal in source/history).
- **Fixed `/api/admin/send-test-email` auth** — replaced the recipient-based gate (authorizable via request body, and fully open when `NODE_ENV !== production`) with `validateAdminRequest`.

## Database resilience & scale
- **Throttled** the per-slow-query `system_metrics` write so query bursts can't self-amplify pool exhaustion (the in-memory ring keeps full fidelity).
- **`assertRuntimeDatabaseConfig`** — fail fast in production when `DATABASE_URL` is unset instead of silently using the localhost default.
- **Guarded `JSON.parse`** of user/commensal JSONB columns with `safeJsonParse` so one corrupt row can't crash auth/profile loads.
- **`/api/admin/users/insights`** is now memoized (5s) and each sub-query degrades independently — one failed aggregate no longer rejects the whole panel.
- **New migration `database/init/48-dashboard-count-indexes.sql`** — partial/expression indexes for the dashboard `COUNT` scans.

## Calculation pipelines
- **`kalchm` NaN guard** — clamp ESMS bases before the `pow`/ratio and guard the result finite (no NaN into pricing/persistence); guard Sun-absent in `alchemize()`.
- **Timezone** — signup-trend buckets and the daily-insight dedupe now pin to `America/New_York` (were UTC), fixing day-boundary drift.
- **RecommendationService** — deterministic elemental cooking-method scoring (no `Math.random`); honest `NaN` sentinels for the elemental-only `kalchm`/`monica` instead of fake `0`s.
- **Cross-backend rectification** — only rectifies axes where the backend value is finite & > 0 (never overwrites healthy local values with 0).

## Lint cleanup
- Reintegrated (not deleted) the cuisine route's `createHash` (now content-addresses the image cache key) and `air` (explicit elemental-lighting branch); removed a redundant type assertion; documented the intentional `connection`↔`slowQueryLog` import cycle.

## Reviewer notes
- The PR also carries the trailing `5464cd40` import-order fixup (leftover from the alchemy work in #464, not yet in master).
- **Operator action items (cannot be done in code):** rotate `INTERNAL_API_SECRET` (treat the old literal as leaked), apply migration `48` **outside a transaction** (`CREATE INDEX CONCURRENTLY`), and confirm Railway-side connection pooling.
- **Deliberately deferred:** threading a `degraded: true` flag from the planetary-positions layer through the API schema (cross-cutting; better as its own change).
- Credential/migration helper scripts in the working tree were intentionally left out of this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)