### PR TITLE
fix(db): PgBouncer transaction-mode compat + connection hardening

### DIFF
--- a/docs/adr/007-database-connection-pooling.md
+++ b/docs/adr/007-database-connection-pooling.md
@@ -1,0 +1,134 @@
+# ADR-007: Serverless Database Connection Pooling (PgBouncer Transaction Mode)
+
+**Status**: Accepted
+**Date**: 2026-05-28
+**Deciders**: Greg Castro
+
+---
+
+## Context
+
+The Next.js app runs on Vercel serverless functions. Each function instance
+owns its own `pg` pool (`src/lib/database/config.ts`, `max: 5`). Under cold
+starts and cron storms, many instances each tried to open up to 5 connections
+directly against Railway Postgres. Postgres ran out of backend connection
+slots, so `pool.connect()` blocked — surfacing as multi-minute "queries" on
+trivial SELECTs (the SQL never started; the instance was stuck waiting for a
+connection).
+
+Mitigations already in place were band-aids over this root cause:
+
+- a per-statement `statement_timeout` (Postgres cancels at 5s, code 57014);
+- a client-side `query_timeout` (aborts the client read);
+- a throttle on the per-slow-query `system_metrics` write so bursts can't
+  self-amplify pool pressure.
+
+A **PgBouncer** service already existed in the Railway project, but it was
+configured with `PGBOUNCER_POOL_MODE=session`. Session pooling pins one backend
+Postgres connection for a client's entire session — so fronting short-lived
+serverless connections with it gives **almost no fan-in benefit**: a serverless
+instance still effectively holds a backend connection for its lifetime.
+
+The pooling mode that actually solves serverless connection storms is
+**transaction pooling**: many short client connections are multiplexed onto a
+small set of server connections, each borrowed only for the duration of a
+transaction.
+
+### The statement_timeout / transaction-pooling interaction
+
+`node-postgres` sends `statement_timeout` as a **connection startup
+parameter** (`client.js` `getStartupConf`). PgBouncer in transaction mode
+**rejects** startup parameters that aren't allow-listed, and even when they are
+ignored they have no effect, because server connections are shared across
+clients. `query_timeout`, by contrast, is purely client-side — it aborts the
+client's read but does **not** cancel the backend query, so it cannot be the
+only cap (a runaway query keeps consuming a server connection after the client
+gives up).
+
+So under transaction pooling we must deliver the server-side statement cap by a
+different route than the startup packet.
+
+## Decision
+
+1. **Front the serverless app with PgBouncer in `transaction` mode**, and point
+   the app's `DATABASE_URL` at PgBouncer (not directly at Postgres).
+   - Vercel (external): the PgBouncer public TCP proxy.
+   - Railway-internal services: `pgbouncer.railway.internal:6432`.
+
+2. **Make the connection layer pooler-aware** via a new `DB_POOLER_MODE`
+   env var (`direct` | `session` | `transaction`, default `direct`). The flag
+   is read in `src/lib/database/config.ts` and applied in
+   `getDatabaseConfig()`/`withTransaction()` in `connection.ts`. With the
+   default (`direct`), **behavior is unchanged** — this is a safe no-op until
+   the env is flipped.
+
+3. **Deliver the server-side statement cap without the startup param** when
+   `DB_POOLER_MODE=transaction`:
+   - **Omit** `statement_timeout` from the `pg` config (so PgBouncer won't
+     reject the connection).
+   - Keep the client-side `query_timeout` as the request-level bound.
+   - Inside `withTransaction`, issue `SET LOCAL statement_timeout` — scoped to
+     the transaction, safe on shared server connections — so transactional
+     writes keep a real server-side cap.
+   - For single (non-transactional) `pool.query` calls, the server-side cap
+     comes from a **PgBouncer `connect_query`** that runs once per server
+     connection: `connect_query = 'SET statement_timeout = 5000'`. Because every
+     query through PgBouncer wants the same cap, applying it per server
+     connection is correct and consistent.
+
+4. **Keep the per-instance `pg` pool small** (`max: 5`). With transaction
+   pooling, per-instance sizing barely matters — PgBouncer's `default_pool_size`
+   (currently 20) governs real backend concurrency, and `max_client_conn`
+   (currently 120) bounds total client connections.
+
+## Consequences
+
+- Many short serverless connections now fan into ~20 backend Postgres
+  connections; cold-start / cron storms no longer exhaust Postgres.
+- **Session-level features are unavailable** through the pooler: no
+  `SET` that must persist across statements (use `SET LOCAL` in a transaction),
+  no session advisory locks, no `LISTEN/NOTIFY`, no server-side prepared
+  statements by name. The app uses `pg` parameterized queries (unnamed extended
+  protocol), which are transaction-mode safe.
+- The server-side statement cap now has three delivery points instead of one
+  (PgBouncer `connect_query`, `SET LOCAL` in `withTransaction`, client-side
+  `query_timeout`). Documented here so the redundancy is intentional, not
+  accidental.
+- A future dedicated low-privilege application role (instead of connecting as
+  `postgres`) would let us set `statement_timeout` at the role level and drop
+  the `connect_query`; deferred (requires a new credential + repoint).
+
+## Rollout / runbook
+
+Order matters — keep a statement cap in force at every step.
+
+1. **Land the code** (this ADR's change). With `DB_POOLER_MODE` unset, nothing
+   changes in production yet.
+2. **Configure PgBouncer** (Railway → PgBouncer service):
+   - `PGBOUNCER_POOL_MODE=transaction`
+   - add a `connect_query = 'SET statement_timeout = 5000'`
+     (via the image's config/env; if `connect_query` isn't exposed, set
+     `ignore_startup_parameters = statement_timeout` so the client param is
+     tolerated, and rely on `SET LOCAL` + `query_timeout` until a role-level
+     default is added).
+   - confirm `default_pool_size` (20) and `max_client_conn` (120) suit expected
+     Vercel concurrency; raise `max_client_conn` if instances spike.
+3. **Repoint `DATABASE_URL`** at PgBouncer and set `DB_POOLER_MODE=transaction`:
+   - Vercel env (Next.js app): PgBouncer **public** proxy host/port.
+   - Railway-internal services: `pgbouncer.railway.internal:6432`.
+   - Redeploy so the new env takes effect.
+4. **Verify**:
+   - app boots, `checkDatabaseHealth()` is green;
+   - a write path that uses `withTransaction` succeeds (the `SET LOCAL` runs);
+   - induce a slow query and confirm it's cancelled around 5s (57014);
+   - watch Postgres backend connection count stays near `default_pool_size`,
+     not spiking with Vercel instance count.
+5. **Rollback**: set `DB_POOLER_MODE=direct` and point `DATABASE_URL` back at
+   Postgres directly; redeploy. The code's default path returns automatically.
+
+### Migrations / DDL note
+
+Schema migrations and `CREATE INDEX CONCURRENTLY` must **bypass PgBouncer** and
+run **directly against Postgres** (CONCURRENTLY cannot run inside a transaction,
+which transaction pooling would impose). Use the Postgres direct connection
+(public TCP proxy or `postgres.railway.internal:5432`) for `database/init/*.sql`.

--- a/src/app/api/food-lab/route.ts
+++ b/src/app/api/food-lab/route.ts
@@ -64,12 +64,22 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ success: false, message: "Authentication required" }, { status: 401 });
   }
 
+  // Bound the read. The default is a generous safety ceiling (not a small page)
+  // so clients expecting "all entries" aren't silently truncated; callers can
+  // request a smaller window via ?limit / ?offset.
+  const { searchParams } = new URL(request.url);
+  const limit = Math.min(
+    Math.max(parseInt(searchParams.get("limit") || "500", 10) || 500, 1),
+    1000,
+  );
+  const offset = Math.max(parseInt(searchParams.get("offset") || "0", 10) || 0, 0);
+
   const db = await getDbModule();
   if (db) {
     try {
       const result = await db.executeQuery(
-        `SELECT * FROM food_lab_entries WHERE user_id = $1 ORDER BY cooked_at DESC`,
-        [userId],
+        `SELECT * FROM food_lab_entries WHERE user_id = $1 ORDER BY cooked_at DESC LIMIT $2 OFFSET $3`,
+        [userId, limit, offset],
       );
       const entries = result.rows.map(rowToEntry);
       return NextResponse.json({ success: true, entries, count: entries.length });
@@ -84,7 +94,7 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  const entries = getUserEntries(userId);
+  const entries = getUserEntries(userId).slice(offset, offset + limit);
   return NextResponse.json({ success: true, entries, count: entries.length });
 }
 

--- a/src/lib/database/config.ts
+++ b/src/lib/database/config.ts
@@ -37,6 +37,20 @@ export const databaseConfig = {
   // the floor that should always be on.
   statementTimeoutMs: parseInt(process.env.DB_STATEMENT_TIMEOUT_MS || "5000", 10),
 
+  // Pooler topology in front of Postgres. Governs how the per-statement cap is
+  // delivered (see getDatabaseConfig in connection.ts):
+  //   "direct"      — app talks straight to Postgres (or a session-mode pooler).
+  //                   `statement_timeout` is sent as a connection startup param.
+  //   "session"     — session-mode PgBouncer; same startup-param path as direct.
+  //   "transaction" — transaction-mode PgBouncer. Startup params other than the
+  //                   allow-listed few are REJECTED, and `SET`s don't persist
+  //                   across the shared server connections, so we must NOT send
+  //                   `statement_timeout` at startup. Server-side capping then
+  //                   comes from a PgBouncer `connect_query` (recommended) and
+  //                   `SET LOCAL` inside withTransaction; client-side bounding
+  //                   stays on `query_timeout`. See docs/adr/007.
+  poolerMode: (process.env.DB_POOLER_MODE || "direct").toLowerCase(),
+
   // Application settings
   environment: process.env.NODE_ENV || "development",
   logQueries: process.env.DB_LOG_QUERIES === "true",
@@ -95,6 +109,11 @@ export function validateDatabaseConfig(): { valid: boolean; errors: string[] } {
   ) {
     errors.push(
       "DB_STATEMENT_TIMEOUT_MS must be between 100ms and 60000ms",
+    );
+  }
+  if (!["direct", "session", "transaction"].includes(databaseConfig.poolerMode)) {
+    errors.push(
+      'DB_POOLER_MODE must be one of "direct", "session", or "transaction"',
     );
   }
 

--- a/src/lib/database/connection.ts
+++ b/src/lib/database/connection.ts
@@ -56,9 +56,14 @@ export interface DatabaseConfig {
   // Server-side per-statement cap (ms). Postgres cancels with code 57014 when
   // a query runs longer than this. Floors pool-storm outliers at the cap
   // instead of letting them block a function instance for many minutes.
-  statement_timeout: number;
-  // Client-side query timeout (ms). Belt-and-suspenders against the rare case
-  // where the server doesn't honor statement_timeout for the connection.
+  // Omitted under transaction-mode PgBouncer (it can't be sent as a startup
+  // param there) — see getDatabaseConfig and docs/adr/007.
+  statement_timeout?: number;
+  // Client-side query timeout (ms). The primary request-level bound through a
+  // transaction-mode pooler (statement_timeout is unavailable there). Note this
+  // only aborts the client read — it does NOT cancel the backend query — so it
+  // is paired with a server-side cap (statement_timeout direct, or a PgBouncer
+  // connect_query when pooled).
   query_timeout: number;
 }
 // Configuration import
@@ -76,7 +81,26 @@ function getDatabaseConfig(): DatabaseConfig {
     idleTimeout,
     connectionTimeout,
     statementTimeoutMs,
+    poolerMode,
   } = databaseConfig;
+
+  // Under transaction-mode PgBouncer, `statement_timeout` cannot ride the
+  // connection startup packet: PgBouncer rejects non-allow-listed startup
+  // params, and even when ignored it has no effect because server connections
+  // are shared across clients. Omit it there and deliver the server-side cap
+  // via a PgBouncer `connect_query` (+ `SET LOCAL` in withTransaction) instead.
+  // In direct/session mode the per-connection startup param is the right floor.
+  const serverStatementCap =
+    poolerMode === "transaction"
+      ? {}
+      : { statement_timeout: statementTimeoutMs };
+
+  // SSL: Railway fronts Postgres/PgBouncer with a self-signed cert, and the
+  // internal `*.railway.internal` traffic never leaves Railway's private
+  // network. We can't pin a CA we don't control (Railway rotates it), so we
+  // accept the cert for any remote host — the confidentiality guarantee is
+  // Railway's network + proxy TLS, not certificate pinning.
+  const remoteSsl = { rejectUnauthorized: false };
 
   if (databaseUrl) {
     // Parse connection URL for cloud deployments
@@ -89,13 +113,12 @@ function getDatabaseConfig(): DatabaseConfig {
       password: url.password,
       // Enable SSL for any remote connection (non-localhost)
       ssl: url.hostname !== "localhost" && url.hostname !== "127.0.0.1"
-        ? { rejectUnauthorized: false }
+        ? remoteSsl
         : false,
       max: maxConnections,
-
       idleTimeoutMillis: idleTimeout,
       connectionTimeoutMillis: connectionTimeout,
-      statement_timeout: statementTimeoutMs,
+      ...serverStatementCap,
       query_timeout: statementTimeoutMs,
     };
   }
@@ -106,11 +129,11 @@ function getDatabaseConfig(): DatabaseConfig {
     database,
     user,
     password,
-    ssl: ssl ? { rejectUnauthorized: false } : false,
+    ssl: ssl ? remoteSsl : false,
     max: maxConnections,
     idleTimeoutMillis: idleTimeout,
     connectionTimeoutMillis: connectionTimeout,
-    statement_timeout: statementTimeoutMs,
+    ...serverStatementCap,
     query_timeout: statementTimeoutMs,
   };
 }
@@ -196,10 +219,13 @@ export async function checkDatabaseHealth(): Promise<{
   error?: string;
 }> {
   const startTime = Date.now();
+  // Release in finally: if the health query throws, the client must still be
+  // returned to the pool — otherwise a failing health check (the exact moment
+  // the DB is under stress) leaks a pooled connection on every poll.
+  let client: PoolClient | null = null;
   try {
-    const client = await getDatabasePool().connect();
+    client = await getDatabasePool().connect();
     const result = await client.query("SELECT 1 as health_check");
-    client.release();
     const latency = Date.now() - startTime;
     const healthy = result.rows.length > 0;
     return { healthy, latency };
@@ -210,6 +236,10 @@ export async function checkDatabaseHealth(): Promise<{
       latency,
       error: error instanceof Error ? error.message : "Unknown database error",
     };
+  } finally {
+    if (client) {
+      client.release();
+    }
   }
 }
 // Transaction wrapper for database operations
@@ -219,6 +249,16 @@ export async function withTransaction<T>(
   const client = await getDatabasePool().connect();
   try {
     await client.query("BEGIN");
+    // Under transaction-mode PgBouncer the startup-level statement_timeout is
+    // absent (see getDatabaseConfig). SET LOCAL is scoped to this transaction —
+    // safe on shared pooled server connections — and restores a real
+    // server-side cap for the duration of the transaction. statementTimeoutMs
+    // is a parsed integer; Number() keeps the interpolation injection-proof.
+    if (databaseConfig.poolerMode === "transaction") {
+      await client.query(
+        `SET LOCAL statement_timeout = ${Number(databaseConfig.statementTimeoutMs)}`,
+      );
+    }
     const result = await operation(client);
     await client.query("COMMIT");
     return result;
@@ -316,13 +356,31 @@ export async function executeQuery<_T extends any = any>(
     throw error;
   }
 }
-// Utility function to safely execute queries with retry logic
+// Utility function to safely execute queries with retry logic.
+//
+// IMPORTANT — retries are only safe for read/idempotent queries. A mutating
+// statement that timed out (57014) or lost its connection mid-flight may have
+// already applied on the server, so replaying it risks a double-write. This
+// helper therefore executes any data-modifying statement exactly once,
+// regardless of `maxRetries`. Callers that need a retried write must guarantee
+// idempotency (e.g. an idempotency key) and call executeQuery directly.
 export async function executeQueryWithRetry<T extends any = any>(
   query: string,
   params: any[] = [],
   maxRetries = 3,
   retryDelay = 1000,
 ): Promise<QueryResult<any>> {
+  const head = query.replace(/^\s+/, "").slice(0, 12).toUpperCase();
+  const isMutating =
+    /^(INSERT|UPDATE|DELETE|MERGE|TRUNCATE|CREATE|ALTER|DROP|GRANT|REVOKE)\b/.test(
+      head,
+    ) ||
+    // Data-modifying CTE, e.g. `WITH x AS (INSERT ...) SELECT ...`.
+    (/^WITH\b/.test(head) && /\b(INSERT|UPDATE|DELETE|MERGE)\b/i.test(query));
+  if (isMutating) {
+    return executeQuery<T>(query, params);
+  }
+
   let lastError: Error;
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {

--- a/src/services/TokenEconomyService.ts
+++ b/src/services/TokenEconomyService.ts
@@ -73,6 +73,36 @@ function rowToTransaction(row: any): TokenTransaction {
   };
 }
 
+// Single-statement credit: ensure the balance row exists, insert an immutable
+// ledger entry (idempotency-guarded), and apply the delta to the typed column —
+// all atomically. `column` is a constrained union literal (never user input),
+// so interpolating it is injection-safe. Params, in order:
+//   $1 userId  $2 tokenType  $3 amount  $4 sourceType
+//   $5 sourceId  $6 description  $7 transactionGroupId  $8 idempotencyKey
+function creditTokensSql(
+  column: "spirit" | "essence" | "matter" | "substance",
+): string {
+  return `WITH ensure_balance AS (
+            INSERT INTO token_balances (user_id)
+            VALUES ($1)
+            ON CONFLICT (user_id) DO NOTHING
+          ),
+          inserted AS (
+            INSERT INTO token_transactions
+              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+            VALUES
+              (COALESCE($7::uuid, uuid_generate_v4()), $1, $2, $3, $4, $5, $6, $8)
+            ON CONFLICT (idempotency_key) DO NOTHING
+            RETURNING id
+          )
+          UPDATE token_balances
+          SET ${column} = ${column} + $3,
+              updated_at = now()
+          WHERE user_id = $1
+            AND EXISTS (SELECT 1 FROM inserted)
+          RETURNING *`;
+}
+
 // ─── Service Class ────────────────────────────────────────────────────
 
 class TokenEconomyService {
@@ -157,38 +187,17 @@ class TokenEconomyService {
 
     if (db) {
       try {
-        // Use a transaction for atomicity
-        const result = await db.executeQuery(
-          `WITH ensure_balance AS (
-            INSERT INTO token_balances (user_id)
-            VALUES ($1)
-            ON CONFLICT (user_id) DO NOTHING
-          ),
-          inserted AS (
-            INSERT INTO token_transactions
-              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
-            VALUES
-              (COALESCE($7::uuid, uuid_generate_v4()), $1, $2, $3, $4, $5, $6, $8)
-            ON CONFLICT (idempotency_key) DO NOTHING
-            RETURNING id
-          )
-          UPDATE token_balances
-          SET ${column} = ${column} + $3,
-              updated_at = now()
-          WHERE user_id = $1
-            AND EXISTS (SELECT 1 FROM inserted)
-          RETURNING *`,
-          [
-            userId,
-            tokenType,
-            amount,
-            sourceType,
-            opts?.sourceId || null,
-            opts?.description || null,
-            opts?.transactionGroupId || null,
-            opts?.idempotencyKey || null,
-          ],
-        );
+        // Single atomic statement (insert ledger row + apply delta).
+        const result = await db.executeQuery(creditTokensSql(column), [
+          userId,
+          tokenType,
+          amount,
+          sourceType,
+          opts?.sourceId || null,
+          opts?.description || null,
+          opts?.transactionGroupId || null,
+          opts?.idempotencyKey || null,
+        ]);
 
         if (result.rows.length > 0) {
           return rowToBalances(result.rows[0]);
@@ -321,28 +330,72 @@ class TokenEconomyService {
     },
   ): Promise<TokenBalances | null> {
     const groupId = crypto.randomUUID();
-    let lastBalances: TokenBalances | null = null;
+    const db = await getDbModule();
 
+    if (db) {
+      // All credits in ONE transaction so a multi-token grant is all-or-nothing:
+      // previously each credit auto-committed independently, so a failure on
+      // (say) the 3rd of 4 left a partially-applied grant. Per-type idempotency
+      // keys still make the whole grant safe to replay.
+      try {
+        const lastRow = await db.withTransaction(async (client) => {
+          let last: Record<string, unknown> | null = null;
+          for (const { tokenType, amount } of credits) {
+            if (amount <= 0) continue;
+            const column = tokenType.toLowerCase() as
+              | "spirit"
+              | "essence"
+              | "matter"
+              | "substance";
+            const idemKey = opts?.idempotencyKey
+              ? `${opts.idempotencyKey}:${tokenType}`
+              : null;
+            const res = await client.query(creditTokensSql(column), [
+              userId,
+              tokenType,
+              amount,
+              sourceType,
+              opts?.sourceId || null,
+              opts?.description || null,
+              groupId,
+              idemKey,
+            ]);
+            if (res.rows.length > 0) last = res.rows[0];
+          }
+          return last;
+        });
+
+        if (lastRow) return rowToBalances(lastRow);
+        // No row updated: every credit hit ON CONFLICT DO NOTHING (idempotency
+        // replay) or all amounts were non-positive. The balance already
+        // reflects any prior claim, so return the current balance.
+        return this.getBalances(userId);
+      } catch (error) {
+        _logger.error(
+          "[TokenEconomy] creditMultipleTokens failed, rolled back:",
+          error,
+        );
+        return null;
+      }
+    }
+
+    // In-memory fallback (no DB): apply sequentially via creditTokens.
+    let lastBalances: TokenBalances | null = null;
     for (const { tokenType, amount } of credits) {
       if (amount <= 0) continue;
-
       const idemKey = opts?.idempotencyKey
         ? `${opts.idempotencyKey}:${tokenType}`
         : undefined;
-
       lastBalances = await this.creditTokens(userId, tokenType, amount, sourceType, {
         sourceId: opts?.sourceId,
         description: opts?.description,
         idempotencyKey: idemKey,
         transactionGroupId: groupId,
       });
-
       if (lastBalances === null && idemKey) {
-        // Idempotency blocked — already claimed
         return null;
       }
     }
-
     return lastBalances || this.getBalances(userId);
   }
 

--- a/src/services/commensalDatabaseService.ts
+++ b/src/services/commensalDatabaseService.ts
@@ -381,8 +381,10 @@ class CommensalDatabaseService {
     const db = await getDbModule();
     if (db) {
       try {
+        // LIMIT is a safety ceiling, not pagination — a user's saved charts are
+        // inherently few; the cap just bounds a pathological/abuse-driven read.
         const result = await db.executeQuery(
-          `SELECT * FROM saved_charts WHERE owner_id = $1 ORDER BY is_primary DESC, created_at ASC`,
+          `SELECT * FROM saved_charts WHERE owner_id = $1 ORDER BY is_primary DESC, created_at ASC LIMIT 500`,
           [userId],
         );
         return result.rows.map((r: any) => this.rowToSavedChart(r));
@@ -445,8 +447,9 @@ class CommensalDatabaseService {
     const db = await getDbModule();
     if (db) {
       try {
+        // LIMIT is a safety ceiling, not pagination — bounds a pathological read.
         const result = await db.executeQuery(
-          `SELECT * FROM manual_companion_charts WHERE owner_id::text = $1 ORDER BY created_at DESC`,
+          `SELECT * FROM manual_companion_charts WHERE owner_id::text = $1 ORDER BY created_at DESC LIMIT 500`,
           [userId],
         );
         return result.rows.map((r: any) => ({


### PR DESCRIPTION
## Summary

Closes the loop on the `...allow-pgbouncer` branch: makes the DB connection layer ready to sit behind **PgBouncer transaction-mode pooling** (the real fix for the serverless pool-acquisition storms), plus a round of DB call-path hardening from the production-readiness audit. Follows #465.

`bun run verify` + `bun run build` + `bun run test` (521 passed / 9 skipped) all green.

## Item 2 — connection pooling (main thrust)
- **`DB_POOLER_MODE`** env flag (`direct` | `session` | `transaction`, default `direct`). Default path is a **no-op** — production behavior is unchanged until the env is flipped.
- In `transaction` mode: `statement_timeout` is **dropped from the startup packet** (node-pg sends it as a startup param, which PgBouncer transaction mode rejects / can't honor on shared server connections). Client-side `query_timeout` stays as the request bound, and `withTransaction` issues `SET LOCAL statement_timeout` to keep a real server-side cap.
- **`docs/adr/007`** records the decision + a full rollout/rollback runbook (PgBouncer `connect_query` for the per-server-connection cap, `DATABASE_URL` repoint, verification, rollback).
- Fixed a **connection leak** in `checkDatabaseHealth` — the client was released outside `try`, so a failing health query (i.e. when the DB is already stressed) leaked a pooled connection on every poll. Now released in `finally`.

## Item 3 — DB hardening
- **`creditMultipleTokens`** now runs all credits inside one `withTransaction` so a multi-token grant is all-or-nothing (previously each credit auto-committed independently → a mid-loop failure left a partial grant). In-memory fallback preserved; per-type idempotency keys keep replay safe.
- **`executeQueryWithRetry`** no longer replays mutating statements (a timed-out / connection-dropped INSERT/UPDATE may have already applied → double-write). Reads still retry.
- **Bounded unbounded per-user SELECTs**: `food-lab` GET (`?limit`/`?offset`, generous default so existing clients aren't truncated) and `saved_charts` / `manual_companion_charts` (`LIMIT 500` safety ceiling).
- Documented the Railway **SSL `rejectUnauthorized:false`** tradeoff in-code (self-signed cert we can't pin; confidentiality is Railway network/proxy TLS).

## Operator actions (cannot be done in code)
- **Migration 48** was already applied to prod + verified out-of-band this session (indexes matched to the dashboard COUNT queries; planner defaults to seq scan at current small row counts, will switch as tables grow).
- **Pooler flip** → see `docs/adr/007` rollout section.
- **Rotate `INTERNAL_API_SECRET`** (old literal leaked in history) across Vercel + Railway + PA.

## Test plan
- [x] `bun run verify` (0 type errors, 0 lint warnings)
- [x] `bun run build` (route-handler type-check)
- [x] `bun run test` (no regressions)
- [ ] After pooler flip: confirm health green, a `withTransaction` write succeeds, a slow query is cancelled ~5s (57014), and Postgres backend connection count stays near `default_pool_size`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)