### PR TITLE
chore(lint): fix import/order in serviceUrls consumers

### DIFF
--- a/src/app/api/admin/agent-sync/route.ts
+++ b/src/app/api/admin/agent-sync/route.ts
@@ -16,9 +16,9 @@
  */
 
 import { NextResponse } from "next/server";
-import { getServiceUrl } from "@/lib/serviceUrls";
 import { validateAdminRequest } from "@/lib/auth/validateRequest";
 import { executeQuery } from "@/lib/database";
+import { getServiceUrl } from "@/lib/serviceUrls";
 import { userDatabase } from "@/services/userDatabaseService";
 import { logger } from "@/utils/logger";
 import type { NextRequest } from "next/server";

--- a/src/app/api/admin/agents/monica/route.ts
+++ b/src/app/api/admin/agents/monica/route.ts
@@ -17,9 +17,9 @@
  */
 
 import { NextResponse, type NextRequest } from "next/server";
-import { getServiceUrl } from "@/lib/serviceUrls";
 import { validateAdminRequest } from "@/lib/auth/validateRequest";
 import { memoize } from "@/lib/cache/memoryCache";
+import { getServiceUrl } from "@/lib/serviceUrls";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";

--- a/src/app/api/admin/dashboard/route.ts
+++ b/src/app/api/admin/dashboard/route.ts
@@ -12,10 +12,10 @@
  */
 
 import { NextResponse, type NextRequest } from "next/server";
-import { getServiceUrlSafe } from "@/lib/serviceUrls";
 import type { AdminDashboardData } from "@/app/admin/_dashboard/data";
 import { validateAdminRequest } from "@/lib/auth/validateRequest";
 import { executeQuery } from "@/lib/database";
+import { getServiceUrlSafe } from "@/lib/serviceUrls";
 import { getAgentNetworkTelemetry } from "@/services/agentTelemetryService";
 import {
   getAuditEvents,

--- a/src/app/api/admin/mcp-summary/route.ts
+++ b/src/app/api/admin/mcp-summary/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { getServiceUrl } from "@/lib/serviceUrls";
 import { validateAdminRequest } from "@/lib/auth/validateRequest";
+import { getServiceUrl } from "@/lib/serviceUrls";
 import type { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";

--- a/src/app/api/admin/planetary-sync/route.ts
+++ b/src/app/api/admin/planetary-sync/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { getServiceUrl } from "@/lib/serviceUrls";
 import { validateAdminRequest } from "@/lib/auth/validateRequest";
+import { getServiceUrl } from "@/lib/serviceUrls";
 import { userDatabase } from "@/services/userDatabaseService";
 import type { UserWithProfile } from "@/services/userDatabaseService";
 import type { NextRequest } from "next/server";

--- a/src/app/api/agent-forge/ignite/route.ts
+++ b/src/app/api/agent-forge/ignite/route.ts
@@ -15,9 +15,9 @@
  */
 
 import { NextResponse } from "next/server";
-import { getServiceUrl } from "@/lib/serviceUrls";
 import { auth } from "@/lib/auth/auth";
 import { executeQuery } from "@/lib/database";
+import { getServiceUrl } from "@/lib/serviceUrls";
 import { geocodeLocationSingle } from "@/services/geocodingService";
 import { calculateNatalChart } from "@/services/natalChartService";
 import { alchemize } from "@/services/RealAlchemizeService";

--- a/src/app/api/generate-cosmic-recipe/route.ts
+++ b/src/app/api/generate-cosmic-recipe/route.ts
@@ -21,13 +21,13 @@
  * now in place, WTEN simplifies to a proxy.
  */
 import { z } from "zod";
-import { getServiceUrl } from "@/lib/serviceUrls";
 import { gateDemoOrAuth } from "@/lib/auth/demoAccess";
 import {
   applyPersonalizedPricing,
   getPersonalizedPricingContext,
 } from "@/lib/economy/livePricing";
 import { withObservability } from "@/lib/observability/withObservability";
+import { getServiceUrl } from "@/lib/serviceUrls";
 import { foodDiaryService } from "@/services/FoodDiaryService";
 import { reportQuestEventBestEffort } from "@/services/questEventReporter";
 import { alchemize } from "@/services/RealAlchemizeService";

--- a/src/app/api/group/compatibility/route.ts
+++ b/src/app/api/group/compatibility/route.ts
@@ -9,8 +9,8 @@
 
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth/auth";
-import { subscriptionService } from "@/services/subscriptionService";
 import { getServiceUrl } from "@/lib/serviceUrls";
+import { subscriptionService } from "@/services/subscriptionService";
 
 const INTERNAL_API_SECRET = process.env.INTERNAL_API_SECRET || "";
 

--- a/src/app/api/group/recommendations/route.ts
+++ b/src/app/api/group/recommendations/route.ts
@@ -9,8 +9,8 @@
 
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth/auth";
-import { subscriptionService } from "@/services/subscriptionService";
 import { getServiceUrl } from "@/lib/serviceUrls";
+import { subscriptionService } from "@/services/subscriptionService";
 
 const INTERNAL_API_SECRET = process.env.INTERNAL_API_SECRET || "";
 

--- a/src/app/api/nanobanana/cuisine/route.ts
+++ b/src/app/api/nanobanana/cuisine/route.ts
@@ -1,10 +1,10 @@
 import { createHash } from "crypto";
-import { getServiceUrl } from "@/lib/serviceUrls";
 import { NextResponse } from "next/server";
 import { getCuisineData, CUISINES_METADATA } from "@/data/cuisines/index";
 import { auth } from "@/lib/auth/auth";
 import { rateLimit } from "@/lib/rateLimit";
 import { redisGet, redisSet } from "@/lib/redis";
+import { getServiceUrl } from "@/lib/serviceUrls";
 import type { Cuisine } from "@/types/cuisine";
 import type { NextRequest } from "next/server";
 

--- a/src/app/api/nanobanana/generate/route.ts
+++ b/src/app/api/nanobanana/generate/route.ts
@@ -1,9 +1,9 @@
 import { createHash } from "crypto";
-import { getServiceUrl } from "@/lib/serviceUrls";
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth/auth";
 import { rateLimit } from "@/lib/rateLimit";
 import { redisGet, redisSet } from "@/lib/redis";
+import { getServiceUrl } from "@/lib/serviceUrls";
 import type { NextRequest } from "next/server";
 
 const RATE_LIMIT = { window: 60_000, max: 10, bucket: "nanobanana-generate" };

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -14,8 +14,8 @@
  */
 
 import NextAuth from "next-auth";
-import { getServiceUrlSafe } from "@/lib/serviceUrls";
 import { isAdminEmail, isPremiumEmail } from "@/lib/auth/adminEmails";
+import { getServiceUrlSafe } from "@/lib/serviceUrls";
 import { logAuthEvent } from "@/services/authEventsService";
 import { createLogger } from "@/utils/logger";
 import { authConfig } from "./auth.config";

--- a/src/lib/kinetics-integration.ts
+++ b/src/lib/kinetics-integration.ts
@@ -1,9 +1,9 @@
+import { getServiceUrlSafe } from '@/lib/serviceUrls'
 import {
   PlanetaryKineticsClient,
   type KineticsLocation,
   type KineticsOptions,
 } from '@/services/PlanetaryKineticsClient'
-import { getServiceUrlSafe } from '@/lib/serviceUrls'
 import { logger } from '@/utils/logger'
 
 export interface EnhancedKineticData {

--- a/src/services/PlanetaryAgentsAdapter.ts
+++ b/src/services/PlanetaryAgentsAdapter.ts
@@ -8,6 +8,7 @@
  */
 
 import { _logger } from "@/lib/logger";
+import { getServiceUrlSafe } from "@/lib/serviceUrls";
 import type {
   KineticsResponse,
   KineticsRequest as _KineticsRequest,
@@ -16,7 +17,6 @@ import type {
   GroupDynamicsResponse,
 } from "@/types/kinetics";
 import { computeGroupDynamics } from "@/utils/groupDynamics";
-import { getServiceUrlSafe } from "@/lib/serviceUrls";
 
 interface PlanetaryHourResponse {
   success: boolean;

--- a/src/services/systemStatusService.ts
+++ b/src/services/systemStatusService.ts
@@ -20,12 +20,12 @@
 
 import { checkDatabaseHealth, executeQuery } from "@/lib/database/connection";
 import { _logger } from "@/lib/logger";
-import { getServiceUrlSafe } from "@/lib/serviceUrls";
 import {
   summarizePath,
   type PathHealth,
 } from "@/lib/observability/requestLog";
 import { summarizeSlowQueries } from "@/lib/observability/slowQueryLog";
+import { getServiceUrlSafe } from "@/lib/serviceUrls";
 import { getEventCounts } from "@/services/authEventsService";
 import { feedEmitTracker } from "@/services/feedEmitTracker";
 import { getMcpNetworkSummary } from "@/services/mcpNetworkService";


### PR DESCRIPTION
## Summary

Commit `c3c21513` centralized the external service URLs behind `src/lib/serviceUrls.ts` (great change), but placed the new `@/lib/serviceUrls` import in a spot that trips eslint's `import/order` rule in 15 consumer files — leaving 15 lint warnings in `master`, which is below the repo's stated **0-lint-warnings** bar.

This PR reorders **only those import lines** (no logic change) to clear the warnings.

## Scope
- **15 files, import-order only.** Sanity-checked: every changed line is an `import` line — zero logic/behavior changes.
- No new files, no API changes.

## Verification
- [x] `bun run verify` — 0 errors, **0 warnings**
- [x] `bun run build` — passes
- [x] `bun run test` — 521 passed / 9 skipped

## Note
Discovered while independently implementing the same URL centralization in a parallel effort — `c3c21513` had already landed the substantive work (identical `serviceUrls.ts` + `getServiceUrl`/`getServiceUrlSafe` conversions), so this is purely the lint-hygiene tail of that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)