### PR TITLE
fix(cosmic-recipe): return 503 (not 402) when the token debit throws server-side

### DIFF
--- a/src/app/api/generate-cosmic-recipe/route.ts
+++ b/src/app/api/generate-cosmic-recipe/route.ts
@@ -147,6 +147,21 @@ async function handlePost(request: NextRequest) {
         });
 
         if (!purchase.success && purchase.reason !== "already_owned") {
+          // `purchase_failed` means the debit threw server-side (e.g. a DB error
+          // inside purchaseShopItem) — NOT that the user is out of tokens. Return
+          // 5xx so it surfaces as an incident on the synthetic probe / dashboards
+          // instead of masquerading as a billing 402. (Masking a server throw as
+          // "insufficient tokens" is exactly what hid the 42702 CTE bug fixed in
+          // #446.) Only genuine balance failures get the 402 + upsell copy.
+          if (purchase.reason === "purchase_failed") {
+            return new Response(JSON.stringify({
+              error: "generation_unavailable",
+              message: "Recipe generation is temporarily unavailable. Please try again shortly.",
+            }), {
+              status: 503,
+              headers: { "Content-Type": "application/json" },
+            });
+          }
           return new Response(JSON.stringify({
             error: "Insufficient tokens",
             message: `You have generated your free recipe for today. Generating another requires ${liveCost.spirit.toFixed(2)} Spirit and ${liveCost.essence.toFixed(2)} Essence. Earn more via the daily Cosmic Yield, complete quests, or upgrade to Premium for unlimited generations!`,


### PR DESCRIPTION
## Summary

While investigating the `[TokenEconomy] purchase...` 402s flagged in prod logs, I confirmed the underlying token-charging bug (the 42702 ambiguous-column CTE throw) was already fixed in #446, and the `createNotification` FK-violation noise was reclassified to `warn` in #448. `unlock-cosmic-recipe` is correctly `is_one_time=false` (repeatable), so there is no under-charge bug.

This PR closes the **one residual**: the route's error-contract masked server-side failures as billing failures.

`purchaseShopItem` distinguishes `insufficient_funds` (user is out of tokens) from `purchase_failed` (the debit threw server-side — e.g. a DB error). The route previously mapped **both** to `402 "Insufficient tokens"`. A genuine server error therefore looked like normal "you're broke" traffic — invisible to the synthetic cosmic-recipe probe and the dashboards. That masking is exactly what let the 42702 CTE bug sit silent until it was noticed in logs.

## Change

- `purchase_failed` → `503 generation_unavailable` ("temporarily unavailable, try again shortly"), so it surfaces as an incident.
- `insufficient_funds` (and any other non-`already_owned` reason) → unchanged `402` + upsell copy.

## Test plan

- `bun run typecheck` — clean
- `bun run lint` — 0 warnings on the route
- `bun run build` — clean
- The synthetic cosmic-recipe probe treats any non-OK as failure, so its pass/fail is unchanged; this only improves the recorded `http_status` fidelity (503 server-error vs misleading 402) in `synthetic_probe_results`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)