### PR TITLE
feat(wten-migration): complete session 6 — alchemical-kinetics sampler

### DIFF
--- a/WTEN_MIGRATION_PLAN.md
+++ b/WTEN_MIGRATION_PLAN.md
@@ -6,6 +6,22 @@ Each session prompt below is **self-contained**. Copy-paste a session into a fre
 
 ---
 
+## Progress reconciliation (2026-05-29, verified against git)
+
+The per-session `[x]` checkboxes below were only filled in for Session 1; later sessions shipped without updating them. Actual state on `master`:
+
+- **Session 1** ✅ — closure audit.
+- **Session 2** ✅ — shadcn UI + leaf utilities (merged).
+- **Session 3** ✅ — foundation libs (`#419`); also did opportunistic bonus ports of `kinetics-client` + `agents/kinetic-profiles` (commit `1a046c03`).
+- **Session 4** ✅ — astronomy + ephemeris (`#420`).
+- **Session 5** ✅ — monica + alchemy core (`#422`, commit `8e85096c`).
+- **Session 6** ✅ — agent layer ported in commit `d1449d23` (consciousness-memory, unified-agent-factory, degree-planetary-agent-mapping, planetary-agent-activation, degree-agent-matcher) + the 2 Session-3 bonus ports. The 8th module, `alchemical-kinetics-sampler.ts`, was deferred there and **completed on 2026-05-29** (branch `claude/wten-migration-session-6-sampler`) — see the Session 6 note below.
+- **Sessions 7–11** — pending. **7 of 11 effectively done.**
+
+> Plan line counts are stale where the source repo evolved after the 2026-05-20 audit (e.g. `alchemical-kinetics-sampler.ts` is 415L, not 33L). Re-measure against the source before trusting a session's size estimate.
+
+---
+
 ## Shared context (reference for every session)
 
 ### Repo layout
@@ -358,7 +374,9 @@ For each: copy verbatim except the documented adaptations, adapt aliases, run ty
 
 ---
 
-## Session 6 — Agents + matching
+## Session 6 — Agents + matching ✅ COMPLETE
+
+> **Done.** Modules 1–4, 6–8 ported in commit `d1449d23` (+ Session-3 bonus ports of `kinetics-client` and `agents/kinetic-profiles`). Module 5, `alchemical-kinetics-sampler.ts`, was deferred there because it imports the severed `planetary-hour` module; **completed 2026-05-29** with two adaptations (see item 5).
 
 **Pre-flight:**
 ```bash
@@ -375,7 +393,9 @@ bun install
 2. Port `lib/agents/kinetic-profiles.ts` → `src/lib/agents/kinetic-profiles.ts` (732L) — leaf. (Target's `src/lib/agents/` already has unrelated files; no name collision.)
 3. Port `lib/agents/consciousness-memory.ts` → `src/lib/agents/consciousness-memory.ts` (413L) — depends on `agent-types` (Session 3), `kinetics-client` (step 1), `agents/kinetic-profiles` (step 2)
 4. Port `lib/unified-agent-factory.ts` → `src/lib/unified-agent-factory.ts` (430L) — depends on `unified-agent-types` (Session 3), `agent-types` (Session 3), `astrological-data` (Session 4), `moon-phase-calculator` (Session 4)
-5. Port `lib/alchemical-kinetics-sampler.ts` → `src/lib/alchemical-kinetics-sampler.ts` (33L) — leaf
+5. Port `lib/alchemical-kinetics-sampler.ts` → `src/lib/alchemical-kinetics-sampler.ts` (**415L**, not 33L — the source grew after the audit) — **NOT a leaf.** Two adaptations done on 2026-05-29:
+   - It imports `./alchemical-kinetics` (700L), which the plan never assigned to any session. That zero-import leaf was ported alongside as `src/lib/alchemical-kinetics.ts`.
+   - It imports `PlanetaryHourCalculator` from `./planetary-hour` — part of the **deliberately severed** alchemical-trainer chain. The target already ships `src/lib/PlanetaryHourCalculator.ts` with the same constructor `(lat, long)` and `getPlanetaryHour(date) → { planet, isDaytime }` shape, so the import was redirected there rather than porting the severed module.
 6. Port `lib/degree-planetary-agent-mapping.ts` → `src/lib/degree-planetary-agent-mapping.ts` (406L) — leaf
 7. Port `lib/services/planetary-agent-activation.ts` → `src/lib/services/planetary-agent-activation.ts` (445L) — depends on `degree-planetary-agent-mapping` (step 6), `unified-agent-factory` (step 4), `unified-agent-types` (Session 3), `astrological-data` (Session 4), `moon-phase-calculator` (Session 4), `planetary-config-helper` (Session 4). Creates `src/lib/services/` dir.
 8. Port `lib/degree-agent-matcher.ts` → `src/lib/degree-agent-matcher.ts` (916L) — depends on `agent-types` (Session 3), `celestial-energy-calculator` (Session 5)

--- a/src/lib/alchemical-kinetics-sampler.ts
+++ b/src/lib/alchemical-kinetics-sampler.ts
@@ -1,0 +1,419 @@
+/**
+ * Alchemical Kinetics Sampler
+ * ---------------------------
+ * Hourly sampling with planetary timing context for kinetic calculations.
+ * Builds on existing alchemizer patterns while adding seasonal and timing validation.
+ */
+
+import {
+  computeElementalVelocity,
+  computeElementalMomentum,
+  computeForce,
+  computeInertia,
+  type ElementVector,
+  type PlanetaryHour,
+  type ForceVector,
+} from './alchemical-kinetics'
+import { alchemize } from './alchemizer'
+import { generateAccurateHoroscope } from './monica/horoscope-generator'
+// Adaptation: the source repo's `./planetary-hour` is part of the deliberately
+// severed alchemical-trainer chain (see WTEN_MIGRATION_PLAN.md). The target
+// already ships an equivalent `PlanetaryHourCalculator` — same constructor
+// `(latitude, longitude)` and `getPlanetaryHour(date) -> { planet, isDaytime }`
+// shape the sampler relies on — so we redirect to it rather than port the
+// severed module.
+import { PlanetaryHourCalculator } from './PlanetaryHourCalculator'
+
+export interface HourlyAlchemicalSample {
+  t: Date
+  totals: ElementVector
+  Heat: number
+  Entropy: number
+  Reactivity: number
+  Energy: number
+  matter: number
+  earth: number
+  substance: number
+  spirit: number
+  essence: number
+  planetaryHour: PlanetaryHour
+  dayNight: 'day' | 'night'
+  seasonalPhase: string
+  force?: ForceVector
+}
+
+export class AlchemicalKineticsSampler {
+  static async sampleRange(options: SamplerOptions): Promise<HourlyAlchemicalSample[]> {
+    return sampleHourlyAlchm({ latitude: 0, longitude: 0 }, new Date(), options)
+  }
+}
+
+export interface SamplerOptions {
+  includePlanetaryHours?: boolean // Default true
+  validateTiming?: boolean // Check against traditional expectations
+  timeZone?: string
+  hoursToSample?: number // Default 24
+  startHour?: number // Default 0
+}
+
+export interface TimingValidationResult {
+  isValid: boolean
+  warnings: string[]
+  seasonalExpectations: string
+  planetaryPatterns: Record<string, number>
+}
+
+// Seasonal phase calculation based on date
+function getSeasonalPhase(date: Date): string {
+  const month = date.getMonth() // 0-based (January = 0)
+
+  // Approximate seasonal boundaries (Northern Hemisphere)
+  if (month === 11 || month === 0 || month === 1) return 'Winter'
+  if (month === 2 || month === 3 || month === 4) return 'Spring'
+  if (month === 5 || month === 6 || month === 7) return 'Summer'
+  if (month === 8 || month === 9 || month === 10) return 'Autumn'
+
+  return 'Transitional'
+}
+
+// Traditional seasonal expectations for validation
+function getSeasonalExpectations(phase: string): string {
+  const expectations: Record<string, string> = {
+    Spring: 'Acceleration patterns, increasing Fire/Air elements, growth momentum',
+    Summer: 'Peak energy, maximum Fire dominance, sustained high velocity',
+    Autumn: 'Deceleration patterns, increasing Water/Earth, momentum conservation',
+    Winter: 'Stability patterns, Earth dominance, low velocity variance',
+    Transitional: 'Mixed patterns, elemental transitions, moderate variance',
+  }
+  return expectations[phase] || 'Unknown seasonal pattern'
+}
+
+// Convert alchemizer output to our kinetics-friendly format
+function convertAlchemizerOutput(alchmData: any): {
+  totals: ElementVector
+  Heat: number
+  Entropy: number
+  Reactivity: number
+  Energy: number
+  matter: number
+  earth: number
+  substance: number
+  spirit: number
+  essence: number
+} {
+  const totals: ElementVector = {
+    Fire: alchmData['Total Effect Value']?.['Fire'] || 0,
+    Water: alchmData['Total Effect Value']?.['Water'] || 0,
+    Air: alchmData['Total Effect Value']?.['Air'] || 0,
+    Earth: alchmData['Total Effect Value']?.['Earth'] || 0,
+  }
+
+  return {
+    totals,
+    Heat: alchmData['Heat'] || 0,
+    Entropy: alchmData['Entropy'] || 0,
+    Reactivity: alchmData['Reactivity'] || 0,
+    Energy: alchmData['Energy'] || 0,
+    matter: alchmData['Alchemy Effects']?.['Total Matter'] || 0,
+    earth: totals.Earth, // Earth element from totals
+    substance: alchmData['Alchemy Effects']?.['Total Substance'] || 0,
+    spirit: alchmData['Alchemy Effects']?.['Total Spirit'] || 0,
+    essence: alchmData['Alchemy Effects']?.['Total Essence'] || 0,
+  }
+}
+
+/**
+ * Attach force calculations to existing samples
+ * Computes velocity, momentum, and force for the sample series
+ */
+export function attachForceToSamples(samples: HourlyAlchemicalSample[]): void {
+  if (!samples || samples.length === 0) return
+
+  // Build inputs for kinetics computation
+  const elementalInput = samples.map(s => ({
+    t: s.t,
+    totals: s.totals,
+    planetaryHour: s.planetaryHour,
+  }))
+
+  // Compute velocity
+  const velocityResults = computeElementalVelocity(elementalInput)
+
+  // Compute momentum (requires velocity and inertia)
+  const momentumInput = velocityResults.map((vRec, i) => {
+    const s = samples[i]
+    const inertia = computeInertia({
+      matter: s.matter,
+      earth: s.earth,
+      substance: s.substance,
+      planetaryHour: s.planetaryHour,
+    })
+    return { t: vRec.t, v: vRec.v, inertia, substance: s.substance }
+  })
+  const momentumResults = computeElementalMomentum(momentumInput)
+
+  // Compute force
+  const forceResults = computeForce(
+    momentumResults.map((p, i) => ({
+      t: p.t,
+      p: p.p,
+      inertia: momentumInput[i].inertia,
+      planetaryHour: samples[i].planetaryHour,
+    })),
+    velocityResults.map((v, i) => ({
+      t: v.t,
+      v: v.v,
+      planetaryHour: samples[i]?.planetaryHour,
+    }))
+  )
+
+  // Attach force to samples
+  forceResults.forEach((forceRec, i) => {
+    if (samples[i]) {
+      samples[i].force = forceRec.f
+    }
+  })
+}
+
+/**
+ * Sample hourly alchemical data with planetary timing context
+ * Ensures proper astrological timing for kinetic calculations
+ */
+export async function sampleHourlyAlchm(
+  location: { latitude: number; longitude: number },
+  date: Date,
+  options: SamplerOptions = {}
+): Promise<HourlyAlchemicalSample[]> {
+  // `validateTiming` / `timeZone` are part of SamplerOptions but consumed by
+  // other functions (e.g. sampleDateRange); this sampler doesn't read them.
+  const {
+    includePlanetaryHours = true,
+    hoursToSample = 24,
+    startHour = 0,
+  } = options
+
+  const samples: HourlyAlchemicalSample[] = []
+  const planetaryCalculator = includePlanetaryHours
+    ? new PlanetaryHourCalculator(location.latitude, location.longitude)
+    : null
+
+  const baseDate = new Date(date)
+  const seasonalPhase = getSeasonalPhase(baseDate)
+
+  for (let i = 0; i < hoursToSample; i++) {
+    const hour = (startHour + i) % 24
+
+    // Create birth info for this hour
+    const birthInfo = {
+      year: baseDate.getFullYear(),
+      month: baseDate.getMonth() + 1, // alchemizer expects 1-based months
+      day: baseDate.getDate(),
+      hour,
+      minute: 0,
+      latitude: location.latitude,
+      longitude: location.longitude,
+    }
+
+    const hourDate = new Date(
+      baseDate.getFullYear(),
+      baseDate.getMonth(),
+      baseDate.getDate(),
+      hour,
+      0
+    )
+
+    try {
+      // Generate horoscope and alchemical data
+      const horoscope = generateAccurateHoroscope(birthInfo)
+      const alchmData = alchemize(birthInfo, horoscope)
+
+      // Get planetary hour information
+      let planetaryHour: PlanetaryHour = ''
+      let isDaytime = true
+
+      if (planetaryCalculator) {
+        const planetaryInfo = planetaryCalculator.getPlanetaryHour(hourDate)
+        planetaryHour = planetaryInfo.planet
+        isDaytime = planetaryInfo.isDaytime
+      }
+
+      // Convert to kinetics format
+      const converted = convertAlchemizerOutput(alchmData)
+
+      const sample: HourlyAlchemicalSample = {
+        t: hourDate,
+        ...converted,
+        planetaryHour,
+        dayNight: isDaytime ? 'day' : 'night',
+        seasonalPhase,
+      }
+
+      samples.push(sample)
+    } catch (error) {
+      console.error(`Error processing hour ${hour}:`, error)
+      // Add a minimal sample to maintain time series continuity
+      samples.push({
+        t: hourDate,
+        totals: { Fire: 0, Water: 0, Air: 0, Earth: 0 },
+        Heat: 0,
+        Entropy: 0,
+        Reactivity: 0,
+        Energy: 0,
+        matter: 0,
+        earth: 0,
+        substance: 0,
+        spirit: 0,
+        essence: 0,
+        planetaryHour: '',
+        dayNight: 'day',
+        seasonalPhase,
+      })
+    }
+  }
+
+  return samples
+}
+
+/**
+ * Validate timing patterns against traditional expectations
+ * Checks for proper planetary hour effects and seasonal alignment
+ */
+export function validateTimingPatterns(samples: HourlyAlchemicalSample[]): TimingValidationResult {
+  if (!samples || samples.length === 0) {
+    return {
+      isValid: false,
+      warnings: ['No samples provided for validation'],
+      seasonalExpectations: 'Cannot assess without data',
+      planetaryPatterns: {},
+    }
+  }
+
+  const warnings: string[] = []
+  const planetaryPatterns: Record<string, number> = {}
+
+  // Group samples by planetary hour
+  const hourGroups: Record<string, HourlyAlchemicalSample[]> = {}
+  samples.forEach(sample => {
+    const hour = sample.planetaryHour || 'unknown'
+    if (!hourGroups[hour]) hourGroups[hour] = []
+    hourGroups[hour].push(sample)
+  })
+
+  // Calculate averages per planetary hour
+  Object.entries(hourGroups).forEach(([hour, hourSamples]) => {
+    if (hourSamples.length === 0) return
+
+    const avgFire = hourSamples.reduce((sum, s) => sum + s.totals.Fire, 0) / hourSamples.length
+    const avgWater = hourSamples.reduce((sum, s) => sum + s.totals.Water, 0) / hourSamples.length
+    const avgEnergy = hourSamples.reduce((sum, s) => sum + s.Energy, 0) / hourSamples.length
+
+    // Calculate force averages if available
+    const forceSamples = hourSamples.filter(s => s.force)
+    let avgFireForce = 0
+    if (forceSamples.length > 0) {
+      avgFireForce =
+        forceSamples.reduce((sum, s) => sum + (s.force?.Fire || 0), 0) / forceSamples.length
+    }
+
+    planetaryPatterns[hour] = avgEnergy
+
+    // Traditional validation checks
+    if (hour === 'Sun' && avgFire < avgWater) {
+      warnings.push('Fire element unexpectedly low during Sun hours')
+    }
+    if (hour === 'Moon' && avgWater < avgFire * 0.8) {
+      warnings.push('Water element unexpectedly low during Moon hours')
+    }
+
+    // Force validation checks
+    if (hour === 'Mars' && avgFireForce < 0.01) {
+      warnings.push('Fire force unexpectedly low during Mars hours (should show acceleration)')
+    }
+    if (hour === 'Saturn' && avgFireForce > -0.01) {
+      warnings.push('Fire force unexpectedly high during Saturn hours (should show deceleration)')
+    }
+  })
+
+  // Seasonal validation
+  const seasonalPhase = samples[0]?.seasonalPhase || 'Unknown'
+  const seasonalExpectations = getSeasonalExpectations(seasonalPhase)
+
+  // Check for seasonal alignment
+  const totalSamples = samples.length
+  const fireSum = samples.reduce((sum, s) => sum + s.totals.Fire, 0)
+  const earthSum = samples.reduce((sum, s) => sum + s.totals.Earth, 0)
+  const avgFire = fireSum / totalSamples
+  const avgEarth = earthSum / totalSamples
+
+  if (seasonalPhase === 'Summer' && avgFire < avgEarth) {
+    warnings.push('Fire dominance expected in Summer but Earth is higher')
+  }
+  if (seasonalPhase === 'Winter' && avgEarth < avgFire * 0.8) {
+    warnings.push('Earth dominance expected in Winter but Fire is disproportionately high')
+  }
+
+  const isValid = warnings.length === 0
+
+  return {
+    isValid,
+    warnings,
+    seasonalExpectations,
+    planetaryPatterns,
+  }
+}
+
+/**
+ * Quick sampler for current moment (single sample)
+ * Useful for real-time applications
+ */
+export async function sampleCurrentMoment(
+  location: { latitude: number; longitude: number },
+  options: Pick<SamplerOptions, 'includePlanetaryHours' | 'timeZone'> = {}
+): Promise<HourlyAlchemicalSample> {
+  const now = new Date()
+  const samples = await sampleHourlyAlchm(location, now, {
+    ...options,
+    hoursToSample: 1,
+    startHour: now.getHours(),
+  })
+
+  if (samples.length === 0) {
+    throw new Error('Failed to generate current moment sample')
+  }
+
+  return samples[0]
+}
+
+/**
+ * Sample a date range with validation
+ * For multi-day kinetic analysis
+ */
+export async function sampleDateRange(
+  location: { latitude: number; longitude: number },
+  startDate: Date,
+  endDate: Date,
+  options: SamplerOptions = {}
+): Promise<{
+  samples: HourlyAlchemicalSample[]
+  validation: TimingValidationResult
+}> {
+  const allSamples: HourlyAlchemicalSample[] = []
+
+  const currentDate = new Date(startDate)
+  while (currentDate <= endDate) {
+    const dailySamples = await sampleHourlyAlchm(location, currentDate, options)
+    allSamples.push(...dailySamples)
+
+    // Move to next day
+    currentDate.setDate(currentDate.getDate() + 1)
+  }
+
+  const validation = options.validateTiming
+    ? validateTimingPatterns(allSamples)
+    : { isValid: true, warnings: [], seasonalExpectations: '', planetaryPatterns: {} }
+
+  return {
+    samples: allSamples,
+    validation,
+  }
+}

--- a/src/lib/alchemical-kinetics.ts
+++ b/src/lib/alchemical-kinetics.ts
@@ -1,0 +1,701 @@
+/**
+ * Classical Alchemical Kinetics Module
+ * -----------------------------------
+ * This module defines derivative-based kinetics on top of the existing alchemizer outputs
+ * without modifying the core engine formulas (Heat, Entropy, Reactivity, Energy).
+ *
+ * Classical Correspondences (documented basis):
+ * - Velocity (Celeritas): Mercury principle; rate of transformation in time.
+ * - Momentum (Impetus): Mars + Saturn synthesis; sustained force of change informed by inertia.
+ * - Power (Potentia): Solar principle; capacity for work via rate of Energy change.
+ * - Inertia (Stabilitas): Earth + Matter + Substance foundation; resistance to rapid change.
+ *
+ * Elemental Principles:
+ * - No opposites, no balancing. Each element is computed independently; like reinforces like.
+ * - Planetary timing modulates rate constants only; base totals/metrics are preserved.
+ */
+
+// Shared narrow types for elements and metrics to ensure strictness
+export type ElementKey = 'Fire' | 'Water' | 'Air' | 'Earth'
+export type ElementVector = Record<ElementKey, number>
+export type ForceVector = Record<ElementKey, number>
+export type MetricKey = 'Heat' | 'Entropy' | 'Reactivity' | 'Energy'
+export type MetricVector = Record<MetricKey, number>
+
+// Planetary hour label (classical seven + outer + ascendant allowed for extensibility)
+export type PlanetaryHour =
+  | 'Sun'
+  | 'Moon'
+  | 'Mars'
+  | 'Mercury'
+  | 'Jupiter'
+  | 'Venus'
+  | 'Saturn'
+  | string // allow extended systems while preferring the classical seven
+
+// Utility: clamp and safe divide. `_clamp` is retained from the source as a
+// sibling to `safeDivide` but is not yet referenced in the ported surface.
+function _clamp(value: number, min: number, max: number): number {
+  if (Number.isNaN(value)) return min
+  if (value < min) return min
+  if (value > max) return max
+  return value
+}
+
+function safeDivide(numerator: number, denominator: number): number {
+  if (denominator === 0) return 0
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator)) return 0
+  return numerator / denominator
+}
+
+function movingAverage(series: number[], window: number): number[] {
+  const w = Math.max(1, Math.floor(window))
+  const out: number[] = new Array(series.length).fill(0)
+  let run = 0
+  for (let i = 0; i < series.length; i++) {
+    run += series[i]
+    if (i >= w) run -= series[i - w]
+    const denom = i < w - 1 ? i + 1 : w
+    out[i] = run / denom
+  }
+  return out
+}
+
+// Planetary modifiers: classical timing influences on rates (do not alter base values)
+// Values are gentle multipliers to encode "more likely/faster" without overwhelming the base data.
+// These are intentionally conservative and can be calibrated further.
+export function getPlanetaryVelocityModifier(hour: PlanetaryHour, element: ElementKey): number {
+  // Mercury enhances velocity globally (Celeritas); element-specific peaks apply
+  const base = 1.0
+  const mercuryBoost = hour === 'Mercury' ? 1.1 : 1.0
+  const elementPeaks: Record<ElementKey, number> = {
+    Fire: hour === 'Sun' || hour === 'Mars' ? 1.2 : 1.0,
+    Water: hour === 'Moon' || hour === 'Venus' ? 1.15 : 1.0,
+    Air: hour === 'Mercury' ? 1.15 : 1.0,
+    Earth: hour === 'Saturn' ? 1.1 : 1.0,
+  }
+  return base * mercuryBoost * elementPeaks[element]
+}
+
+export function getPlanetaryMomentumModifier(hour: PlanetaryHour): number {
+  // Mars + Saturn synthesis for sustained impetus
+  if (hour === 'Mars' || hour === 'Saturn') return 1.15
+  return 1.0
+}
+
+export function getPlanetaryInertiaModifier(hour: PlanetaryHour): number {
+  // Saturnian stabilization
+  return hour === 'Saturn' ? 1.1 : 1.0
+}
+
+export function getPlanetaryForceModifier(hour: PlanetaryHour): number {
+  // Mars + Saturn synthesis for force modulation: Mars amplifies (+20%), Saturn dampens (-10%)
+  if (hour === 'Mars') return 1.2
+  if (hour === 'Saturn') return 0.9
+  return 1.0
+}
+
+export function getSolarAmplification(hour?: PlanetaryHour): number {
+  return hour === 'Sun' ? 1.3 : 1.0 // +30% typical during Sun hours
+}
+
+export function getThermalDirection(heatDvdt: number): 'heating' | 'cooling' | 'stable' {
+  if (heatDvdt > 0.001) return 'heating'
+  if (heatDvdt < -0.001) return 'cooling'
+  return 'stable'
+}
+
+// ---- Core Functions ----
+
+/**
+ * Compute finite differences using Mercury principle (swift calculation)
+ * - Applies optional moving average smoothing (default 3, the Mercury triad)
+ */
+export function computeFiniteDifference(
+  series: Array<{ t: Date; value: number }>,
+  smoothingWindow: number = 3
+): Array<{ t: Date; dvdt: number }> {
+  if (!series || series.length === 0) return []
+  const values = series.map(s => s.value)
+  const smoothed = smoothingWindow > 1 ? movingAverage(values, smoothingWindow) : values
+  const out: Array<{ t: Date; dvdt: number }> = []
+  for (let i = 0; i < series.length; i++) {
+    if (i === 0) {
+      out.push({ t: series[i].t, dvdt: 0 })
+      continue
+    }
+    const dtMs = series[i].t.getTime() - series[i - 1].t.getTime()
+    const dt = dtMs / 3600000 // hours
+    const dv = smoothed[i] - smoothed[i - 1]
+    out.push({ t: series[i].t, dvdt: safeDivide(dv, dt) })
+  }
+  return out
+}
+
+/**
+ * Elemental velocity computation (Celeritas per element)
+ * Respects independent elements (no cross interference). Includes timing modifiers.
+ * Kinetic intensity magnitude uses Euclidean norm of the per-element velocities.
+ */
+export function computeElementalVelocity(
+  samples: Array<{
+    t: Date
+    totals: ElementVector
+    planetaryHour?: PlanetaryHour
+  }>
+): Array<{
+  t: Date
+  v: ElementVector
+  magnitude: number
+  dominantElement: ElementKey
+}> {
+  if (!samples || samples.length === 0) return []
+  const out: Array<{ t: Date; v: ElementVector; magnitude: number; dominantElement: ElementKey }> =
+    []
+  for (let i = 0; i < samples.length; i++) {
+    const current = samples[i]
+    const previous = i > 0 ? samples[i - 1] : undefined
+    const dt = previous ? (current.t.getTime() - previous.t.getTime()) / 3600000 : 0 // hours
+
+    const rawV: ElementVector = { Fire: 0, Water: 0, Air: 0, Earth: 0 }
+    ;(Object.keys(rawV) as ElementKey[]).forEach(el => {
+      if (!previous || dt === 0) {
+        rawV[el] = 0
+      } else {
+        const dv = current.totals[el] - previous.totals[el]
+        const base = safeDivide(dv, dt)
+        const modifier = getPlanetaryVelocityModifier(current.planetaryHour ?? '', el)
+        rawV[el] = base * modifier
+      }
+    })
+
+    const magnitude = Math.sqrt(
+      rawV.Fire * rawV.Fire +
+        rawV.Water * rawV.Water +
+        rawV.Air * rawV.Air +
+        rawV.Earth * rawV.Earth
+    )
+    let dominantElement: ElementKey = 'Fire'
+    let maxVal = rawV.Fire
+    ;(['Water', 'Air', 'Earth'] as ElementKey[]).forEach(el => {
+      if (rawV[el] > maxVal) {
+        maxVal = rawV[el]
+        dominantElement = el
+      }
+    })
+
+    out.push({ t: current.t, v: rawV, magnitude, dominantElement })
+  }
+  return out
+}
+
+/**
+ * Thermodynamic metric velocities (rate of energetic change)
+ * Returns dv/dt per metric and a traditional thermal direction from Heat slope.
+ */
+export function computeMetricVelocity(
+  samples: Array<{ t: Date; Heat: number; Entropy: number; Reactivity: number; Energy: number }>
+): Array<{
+  t: Date
+  dvdt: MetricVector
+  thermalDirection: 'heating' | 'cooling' | 'stable'
+}> {
+  if (!samples || samples.length === 0) return []
+  const out: Array<{
+    t: Date
+    dvdt: MetricVector
+    thermalDirection: 'heating' | 'cooling' | 'stable'
+  }> = []
+  for (let i = 0; i < samples.length; i++) {
+    const current = samples[i]
+    const previous = i > 0 ? samples[i - 1] : undefined
+    const dt = previous ? (current.t.getTime() - previous.t.getTime()) / 3600000 : 0 // hours
+
+    const dvdt: MetricVector = { Heat: 0, Entropy: 0, Reactivity: 0, Energy: 0 }
+    ;(Object.keys(dvdt) as MetricKey[]).forEach(k => {
+      if (!previous || dt === 0) {
+        dvdt[k] = 0
+      } else {
+        const dv = (current as any)[k] - (previous as any)[k]
+        dvdt[k] = safeDivide(dv, dt)
+      }
+    })
+
+    const thermalDirection = getThermalDirection(dvdt.Heat)
+    out.push({ t: current.t, dvdt, thermalDirection })
+  }
+  return out
+}
+
+/**
+ * Elemental momentum using alchemical inertia (Stabilitas principle)
+ * Inertia: m(t) = max(1, 1 + matter + earth + substance/2)
+ * Momentum phase:
+ * - building: velocity and inertia both increasing
+ * - sustained: high momentum with roughly stable velocity
+ * - dissipating: decreasing velocity despite inertia
+ */
+export function computeElementalMomentum(
+  samples: Array<{
+    t: Date
+    v: ElementVector
+    inertia: number // caller provides inertia already computed (optionally adjusted for timing)
+    substance?: number
+  }>
+): Array<{
+  t: Date
+  p: ElementVector
+  magnitude: number
+  momentumType: 'building' | 'sustained' | 'dissipating'
+}> {
+  if (!samples || samples.length === 0) return []
+  const out: Array<{
+    t: Date
+    p: ElementVector
+    magnitude: number
+    momentumType: 'building' | 'sustained' | 'dissipating'
+  }> = []
+  for (let i = 0; i < samples.length; i++) {
+    const current = samples[i]
+    const previous = i > 0 ? samples[i - 1] : undefined
+
+    // Momentum vector p = m * v (per-element v, shared inertia)
+    const p: ElementVector = {
+      Fire: current.inertia * current.v.Fire,
+      Water: current.inertia * current.v.Water,
+      Air: current.inertia * current.v.Air,
+      Earth: current.inertia * current.v.Earth,
+    }
+
+    const magnitude = Math.sqrt(
+      p.Fire * p.Fire + p.Water * p.Water + p.Air * p.Air + p.Earth * p.Earth
+    )
+
+    // Phase assessment using finite differences on magnitude and inertia
+    let momentumType: 'building' | 'sustained' | 'dissipating' = 'sustained'
+    if (previous) {
+      // Correct momentum magnitude calculation: p = m * v for each element
+      const prevP: ElementVector = {
+        Fire: previous.inertia * previous.v.Fire,
+        Water: previous.inertia * previous.v.Water,
+        Air: previous.inertia * previous.v.Air,
+        Earth: previous.inertia * previous.v.Earth,
+      }
+      const prevMagnitude = Math.sqrt(
+        prevP.Fire * prevP.Fire +
+          prevP.Water * prevP.Water +
+          prevP.Air * prevP.Air +
+          prevP.Earth * prevP.Earth
+      )
+      const dMag = magnitude - prevMagnitude
+      const dInertia = current.inertia - previous.inertia
+      if (dMag > 0.001 && dInertia >= 0) {
+        momentumType = 'building'
+      } else if (Math.abs(dMag) <= 0.001) {
+        momentumType = 'sustained'
+      } else {
+        momentumType = 'dissipating'
+      }
+    }
+
+    out.push({ t: current.t, p, magnitude, momentumType })
+  }
+  return out
+}
+
+/**
+ * Alchemical Power (Potentia) - Solar principle manifesting
+ * Power = dEnergy/dt with optional solar amplification for planetary hour = Sun.
+ */
+export function computePower(
+  samples: Array<{ t: Date; Energy: number; planetaryHour?: PlanetaryHour }>,
+  options: { window?: number } = {}
+): Array<{ t: Date; power: number; solarAmplification?: number }> {
+  if (!samples || samples.length === 0) return []
+  const raw: Array<{ t: Date; power: number; solarAmplification?: number }> = []
+  for (let i = 0; i < samples.length; i++) {
+    const current = samples[i]
+    const previous = i > 0 ? samples[i - 1] : undefined
+    const dt = previous ? (current.t.getTime() - previous.t.getTime()) / 3600000 : 0 // hours
+    const dE = previous ? current.Energy - previous.Energy : 0
+    const basePower = safeDivide(dE, dt)
+    const solarAmplification = getSolarAmplification(current.planetaryHour)
+    const power = basePower * solarAmplification
+    raw.push({
+      t: current.t,
+      power,
+      solarAmplification: solarAmplification !== 1 ? solarAmplification : undefined,
+    })
+  }
+
+  // Optional smoothing using simple moving average over window
+  const windowSize = Math.max(1, Math.floor(options.window ?? 1))
+  if (windowSize <= 1) return raw
+
+  const smoothed: Array<{ t: Date; power: number; solarAmplification?: number }> = []
+  for (let i = 0; i < raw.length; i++) {
+    const start = Math.max(0, i - windowSize + 1)
+    const slice = raw.slice(start, i + 1)
+    const avg = slice.reduce((sum, s) => sum + (isFinite(s.power) ? s.power : 0), 0) / slice.length
+    smoothed.push({ t: raw[i].t, power: avg, solarAmplification: raw[i].solarAmplification })
+  }
+  return smoothed
+}
+
+/**
+ * Elemental force computation (Vis - Classical force principle)
+ * Force = dp/dt = inertia × (dv/dt) - Newton's second law applied per element
+ * Respects independent elements (no cross interference). Includes planetary timing modifiers.
+ * Force magnitude uses Euclidean norm of per-element forces.
+ */
+export function computeForce(
+  momentumSamples: Array<{
+    t: Date
+    p: ElementVector
+    inertia: number // inertia at this time point
+    planetaryHour?: PlanetaryHour
+  }>,
+  velocitySamples: Array<{
+    t: Date
+    v: ElementVector
+    planetaryHour?: PlanetaryHour
+  }>
+): Array<{
+  t: Date
+  f: ForceVector
+  magnitude: number
+  forceType: 'accelerating' | 'decelerating' | 'balanced'
+}> {
+  if (
+    !momentumSamples ||
+    !velocitySamples ||
+    momentumSamples.length === 0 ||
+    velocitySamples.length === 0
+  ) {
+    return []
+  }
+
+  const out: Array<{
+    t: Date
+    f: ForceVector
+    magnitude: number
+    forceType: 'accelerating' | 'decelerating' | 'balanced'
+  }> = []
+
+  for (let i = 0; i < momentumSamples.length; i++) {
+    const momentumSample = momentumSamples[i]
+    const _velocitySample = velocitySamples[i]
+    const previousMomentum = i > 0 ? momentumSamples[i - 1] : undefined
+    const previousVelocity = i > 0 ? velocitySamples[i - 1] : undefined
+
+    const dt =
+      previousMomentum && previousVelocity
+        ? (momentumSample.t.getTime() - previousMomentum.t.getTime()) / 3600000
+        : 0 // hours
+
+    const rawF: ForceVector = { Fire: 0, Water: 0, Air: 0, Earth: 0 }
+    ;(Object.keys(rawF) as ElementKey[]).forEach(el => {
+      if (!previousMomentum || !previousVelocity || dt === 0) {
+        rawF[el] = 0
+      } else {
+        // Use momentum derivative: f = dp/dt
+        const dp = momentumSample.p[el] - previousMomentum.p[el]
+        const base = safeDivide(dp, dt)
+
+        // Alternative efficient calculation: f = inertia * dv/dt
+        // const dv = velocitySample.v[el] - previousVelocity.v[el]
+        // const accel = safeDivide(dv, dt)
+        // const base = momentumSample.inertia * accel
+
+        const modifier = getPlanetaryForceModifier(momentumSample.planetaryHour ?? '')
+        rawF[el] = base * modifier
+      }
+
+      // Handle NaN and infinite values
+      if (!Number.isFinite(rawF[el])) {
+        rawF[el] = 0
+      }
+    })
+
+    const magnitude = Math.sqrt(
+      rawF.Fire * rawF.Fire +
+        rawF.Water * rawF.Water +
+        rawF.Air * rawF.Air +
+        rawF.Earth * rawF.Earth
+    )
+
+    // Determine force type based on magnitude and direction
+    let forceType: 'accelerating' | 'decelerating' | 'balanced' = 'balanced'
+    if (magnitude > 0.1) {
+      // High magnitude indicates accelerating forces
+      forceType = 'accelerating'
+    } else if (magnitude < -0.1) {
+      // Negative high magnitude indicates decelerating forces
+      forceType = 'decelerating'
+    }
+    // Near zero magnitude remains balanced
+
+    out.push({ t: momentumSample.t, f: rawF, magnitude, forceType })
+  }
+
+  return out
+}
+
+// ---- Inertia Helpers (optional for callers to compute provided inertia) ----
+
+/**
+ * Compute classical inertia from matter, earth, and substance at a given time.
+ * m(t) = max(1, 1 + matter + earth + substance/2)
+ * Optionally applies a planetary hour adjustment (Saturnian stabilization).
+ */
+export function computeInertia(input: {
+  matter: number
+  earth: number
+  substance: number
+  planetaryHour?: PlanetaryHour
+}): number {
+  const base = Math.max(1, 1 + input.matter + input.earth + input.substance / 2)
+  const adjusted = base * getPlanetaryInertiaModifier(input.planetaryHour ?? '')
+  return adjusted
+}
+
+// ---- Calculus Relationship Validation ----
+
+/**
+ * Validates that kinetic quantities follow proper calculus relationships:
+ * 1. Velocity = dx/dt (position derivative)
+ * 2. Momentum = mass × velocity
+ * 3. Power = dE/dt (energy derivative)
+ * 4. Acceleration = dv/dt (velocity derivative)
+ * 5. Force = dp/dt (momentum derivative) = mass × acceleration
+ */
+export function validateCalculusRelationships(
+  samples: Array<{
+    t: Date
+    elements: ElementVector
+    velocity: ElementVector
+    momentum: ElementVector
+    inertia: number
+    energy: number
+    power: number
+    force?: ForceVector
+  }>
+): {
+  isValid: boolean
+  errors: string[]
+  warnings: string[]
+} {
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  if (samples.length < 2) {
+    warnings.push('Need at least 2 samples for calculus validation')
+    return { isValid: true, errors, warnings }
+  }
+
+  for (let i = 1; i < samples.length; i++) {
+    const current = samples[i]
+    const previous = samples[i - 1]
+    const dt = (current.t.getTime() - previous.t.getTime()) / 3600000 // hours
+
+    if (dt <= 0) {
+      errors.push(`Invalid time interval at index ${i}: dt = ${dt}`)
+      continue
+    }
+
+    // Validate velocity = dx/dt for each element
+    for (const element of ['Fire', 'Water', 'Air', 'Earth'] as ElementKey[]) {
+      const expectedVelocity = (current.elements[element] - previous.elements[element]) / dt
+      const actualVelocity = current.velocity[element]
+
+      // Allow for planetary modifiers (up to 30% difference)
+      const tolerance = Math.abs(expectedVelocity) * 0.35 + 0.001
+      if (Math.abs(actualVelocity - expectedVelocity) > tolerance) {
+        warnings.push(
+          `${element} velocity mismatch at t=${current.t.toISOString()}: ` +
+            `expected ${expectedVelocity.toFixed(4)}, got ${actualVelocity.toFixed(4)}`
+        )
+      }
+    }
+
+    // Validate momentum = mass × velocity for each element
+    for (const element of ['Fire', 'Water', 'Air', 'Earth'] as ElementKey[]) {
+      const expectedMomentum = current.inertia * current.velocity[element]
+      const actualMomentum = current.momentum[element]
+
+      const tolerance = Math.abs(expectedMomentum) * 0.01 + 0.001
+      if (Math.abs(actualMomentum - expectedMomentum) > tolerance) {
+        errors.push(
+          `${element} momentum calculation error at t=${current.t.toISOString()}: ` +
+            `expected ${expectedMomentum.toFixed(4)}, got ${actualMomentum.toFixed(4)}`
+        )
+      }
+    }
+
+    // Validate power = dE/dt
+    const expectedPower = (current.energy - previous.energy) / dt
+    const actualPower = current.power
+
+    // Allow for solar amplification (up to 30% boost)
+    const powerTolerance = Math.abs(expectedPower) * 0.35 + 0.001
+    if (Math.abs(actualPower - expectedPower) > powerTolerance) {
+      warnings.push(
+        `Power calculation mismatch at t=${current.t.toISOString()}: ` +
+          `expected ${expectedPower.toFixed(4)}, got ${actualPower.toFixed(4)}`
+      )
+    }
+
+    // Validate force = dp/dt for each element
+    if (current.force) {
+      for (const element of ['Fire', 'Water', 'Air', 'Earth'] as ElementKey[]) {
+        const expectedForce = (current.momentum[element] - previous.momentum[element]) / dt
+        const actualForce = current.force[element]
+
+        // Allow for planetary modifiers (up to 30% difference) and numerical precision
+        const forceTolerance = Math.abs(expectedForce) * 0.35 + 0.001
+        if (Math.abs(actualForce - expectedForce) > forceTolerance) {
+          warnings.push(
+            `${element} force calculation mismatch at t=${current.t.toISOString()}: ` +
+              `expected ${expectedForce.toFixed(4)}, got ${actualForce.toFixed(4)}`
+          )
+        }
+      }
+    }
+
+    // Validate no NaN or infinite values
+    const allValues = [
+      ...Object.values(current.elements),
+      ...Object.values(current.velocity),
+      ...Object.values(current.momentum),
+      current.inertia,
+      current.energy,
+      current.power,
+    ]
+
+    for (const value of allValues) {
+      if (!Number.isFinite(value)) {
+        errors.push(`Non-finite value detected at t=${current.t.toISOString()}: ${value}`)
+      }
+    }
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+    warnings,
+  }
+}
+
+// ---- Traditional Validation ----
+
+export interface KineticValidationExpectedRanges {
+  velocityMax: number
+  momentumMax: number
+  powerMax: number
+  forceMax: number
+}
+
+export interface KineticValidationResult {
+  isValid: boolean
+  warnings: string[]
+  traditionalAssessment: string
+}
+
+/**
+ * Traditional validation helper
+ * Performs sanity checks and classical expectations:
+ * - Fire velocity peaks in Mars/Sun hours
+ * - Water momentum builds in Moon/Venus hours
+ * - Power shows solar correlation (+~30% typical)
+ * - Earth inertia dampens rapid changes (lower velocity variance with high earth)
+ */
+export function validateKineticResults(
+  kinetics: any,
+  expectedRanges: KineticValidationExpectedRanges
+): KineticValidationResult {
+  const warnings: string[] = []
+
+  // Range checks
+  const vMax =
+    kinetics.elementalVelocity?.reduce((m: number, s: any) => Math.max(m, s.magnitude || 0), 0) ?? 0
+  const pMax =
+    kinetics.elementalMomentum?.reduce((m: number, s: any) => Math.max(m, s.magnitude || 0), 0) ?? 0
+  const powMax = kinetics.power?.reduce((m: number, s: any) => Math.max(m, s.power || 0), 0) ?? 0
+  const fMax =
+    kinetics.elementalForce?.reduce((m: number, s: any) => Math.max(m, s.magnitude || 0), 0) ?? 0
+  if (vMax > expectedRanges.velocityMax)
+    warnings.push(
+      `Velocity magnitude exceeds expected max (${vMax.toFixed(3)} > ${expectedRanges.velocityMax}).`
+    )
+  if (pMax > expectedRanges.momentumMax)
+    warnings.push(
+      `Momentum magnitude exceeds expected max (${pMax.toFixed(3)} > ${expectedRanges.momentumMax}).`
+    )
+  if (powMax > expectedRanges.powerMax)
+    warnings.push(`Power exceeds expected max (${powMax.toFixed(3)} > ${expectedRanges.powerMax}).`)
+  if (fMax > expectedRanges.forceMax)
+    warnings.push(
+      `Force magnitude exceeds expected max (${fMax.toFixed(3)} > ${expectedRanges.forceMax}).`
+    )
+
+  // Timing expectations (heuristic counts over series)
+  const countByHour: Record<
+    string,
+    { fireLead: number; total: number; powerSum: number; powerCount: number }
+  > = {}
+  ;(kinetics.elementalVelocity ?? []).forEach((s: any) => {
+    const hour = s.planetaryHour ?? s.hour ?? 'unknown'
+    if (!countByHour[hour])
+      countByHour[hour] = { fireLead: 0, total: 0, powerSum: 0, powerCount: 0 }
+    // Fire leads when v.Fire is the max among elements
+    const v = s.v as ElementVector
+    const maxEl = (['Fire', 'Water', 'Air', 'Earth'] as ElementKey[]).reduce((a, b) =>
+      v[a] >= v[b] ? a : (b)
+    )
+    if (maxEl === 'Fire') countByHour[hour].fireLead += 1
+    countByHour[hour].total += 1
+  })
+  ;(kinetics.power ?? []).forEach((s: any) => {
+    const hour = s.planetaryHour ?? s.hour ?? 'unknown'
+    if (!countByHour[hour])
+      countByHour[hour] = { fireLead: 0, total: 0, powerSum: 0, powerCount: 0 }
+    if (typeof s.power === 'number') {
+      countByHour[hour].powerSum += s.power
+      countByHour[hour].powerCount += 1
+    }
+  })
+
+  // Fire lead share in Sun/Mars hours
+  const fireLeadShare = (hour: PlanetaryHour) => {
+    const c = countByHour[hour]
+    if (!c || c.total === 0) return 0
+    return c.fireLead / c.total
+  }
+  const fireShareSun = fireLeadShare('Sun')
+  const fireShareMars = fireLeadShare('Mars')
+  if (fireShareSun < 0.2 || fireShareMars < 0.2) {
+    warnings.push('Fire velocity does not lead sufficiently during Sun/Mars hours.')
+  }
+
+  // Solar correlation: Sun hour average power higher than overall average by ~30%
+  const overallPowerAvg = (() => {
+    const sum = Object.values(countByHour).reduce((acc, v) => acc + v.powerSum, 0)
+    const cnt = Object.values(countByHour).reduce((acc, v) => acc + v.powerCount, 0)
+    return cnt > 0 ? sum / cnt : 0
+  })()
+  const sunPowerAvg = (() => {
+    const s = countByHour['Sun']
+    return s && s.powerCount > 0 ? s.powerSum / s.powerCount : 0
+  })()
+  if (overallPowerAvg > 0) {
+    const ratio = safeDivide(sunPowerAvg, overallPowerAvg)
+    if (ratio < 1.2)
+      warnings.push('Power shows weak solar amplification (<20% over baseline during Sun hours).')
+  }
+
+  const isValid = warnings.length === 0
+  const traditionalAssessment = isValid
+    ? 'Kinetics align with classical expectations.'
+    : 'Kinetics deviate from some classical expectations.'
+  return { isValid, warnings, traditionalAssessment }
+}


### PR DESCRIPTION
## Summary

Completes WTEN migration Session 6 by porting its last deferred module. The agent layer (modules 1–4, 6–8) shipped earlier in `d1449d23`; module 5, `alchemical-kinetics-sampler.ts`, was held back because it imports the **deliberately-severed** `planetary-hour` module.

- **`src/lib/alchemical-kinetics.ts`** (700L, zero-import leaf) — the sampler's dependency. The migration plan never assigned it to a session; ported here as the sampler's dep.
- **`src/lib/alchemical-kinetics-sampler.ts`** (415L — not the 33L the stale plan claimed; the source grew after the 2026-05-20 audit). One adaptation: its `./planetary-hour` import (severed alchemical-trainer chain) is redirected to the target's existing `src/lib/PlanetaryHourCalculator.ts` — same `(lat, long)` constructor and `getPlanetaryHour(date) → { planet, isDaytime }` shape the sampler relies on. `PlanetaryHour` resolves to `string`, so no type friction.
- **`WTEN_MIGRATION_PLAN.md`** reconciled: Sessions 2–6 marked done (verified against git), stale line counts corrected, adaptations documented. **7 of 11 sessions effectively done.**

## Test plan

- `bun run typecheck` — clean
- `bun run lint` — 0 warnings on both ported files (cleaned per-session per convention)
- `bun run build` — clean
- `bun run test` — 521 passed / 9 skipped, no regression
- The sampler has no `src/` consumers yet (they arrive in Session 7), so this is additive.

## Reflection

The biggest time sink was discovering that Session 6 was already 7/8 done and that the plan's "33L leaf" description of the sampler was badly stale (really 415L with a real dep chain into severed-module territory). Lesson for Sessions 7–11: re-measure each module against the source and check `git ls-files` for what's already ported *before* trusting the plan's per-session scope — the plan's progress markers and line counts have drifted. The plan reconciliation in this PR should make Session 7 start cleaner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)