### PR TITLE
docs: refresh CHANGELOG / README / API_REFERENCE to 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,52 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### In Progress
-- MenuPlannerContext refactor: 2182-line file split into focused hooks
-- All auth-gated pages migrated into `(alchm)` route group (dark chrome)
-- Onboarding skip flow with `?prompt=natal` soft-prompt banner
-- Vercel Analytics funnel events (CommandPalette, UpgradeGate, AuthHandshake)
+- WTEN migration sessions 7–11 — porting the remaining `planetary_agents-main` UI surface into `src/` (7 of 11 done; see `WTEN_MIGRATION_PLAN.md`)
+- Real planetary alchemy replacing mock fallbacks in the recommendation/cuisine services
+
+---
+
+## [3.1.0] — 2026-05-29 — Modern Alchemist · MCP release
+
+3.0 shipped the redesigned surface (`git tag v3.0.0`). 3.1 layers a published MCP server, an operational admin console, production-readiness hardening, and a tracked migration runner on top. (3.1 tag not yet cut.)
+
+### Added
+
+#### MCP server (PRs #454, #455, #457, #459, #464)
+- **Bun-powered MCP tool surface** exposing the alchemical/synastry tools to MCP clients (Claude Desktop, Cursor, Cline). Stdio transport.
+- **End-user API keys** — mint / list / revoke at `/profile/api-keys`, backed by `POST/GET /api/account/api-keys` and `DELETE /api/account/api-keys/[keyId]`. Plaintext is returned exactly once at mint time.
+- **Stripe ESMS top-ups** — `POST /api/account/billing/mcp-top-up` opens a Stripe checkout for a top-up SKU; the webhook credits all four token axes idempotently (keyed on the checkout session id).
+- **Tier-aware rate limiting** — `api_keys.rate_limit_tier` maps to a per-key RPM cap (`alchemist` 300, `apprentice`/`authenticated` 60) via `rpmForTier()`.
+- **Telemetry / probe / economy instrumentation** — `mcp_invocations` table, a 4th dashboard telemetry tile (`mcpInvocationRate`), a synthetic MCP heartbeat probe, and per-invocation token debiting. Precision latency via `performance.now()`.
+- **Cross-server admin panel** — `/admin/mcp` + `mcpNetworkService` aggregate WTEN's `mcp_invocations` with PA's `GET /api/admin/mcp-summary`; each source degrades independently to `live: false`.
+- Migrations 44–47 (`user-daily-limits`, `agent-forge`, `mcp-invocations`, `synastry-cache`).
+
+#### Operational admin console (PRs #445, #446)
+- **`/admin` operational dashboard** — `TodaysHighlightsPanel` (24h vs prior-24h deltas), `LiveActivityPanel` (6-source merged feed), `SystemStatusPanel` (8 flow probes + dependency strip), `OnboardingFunnelPanel`, `ApiRouteHealthPanel`. Visibility-aware hardened polling (`useHardenedPolling`).
+- **Operational health services** — `systemStatusService`, `onboardingHealthService`, `liveActivityService`, `todaysHighlightsService`, `userTimelineService`. All compute from existing signals; each degrades independently.
+- **Hourly health snapshots + transition-based alerting** — `healthSnapshotService` + `alertService` (DB + Slack + email sinks, each independent; per-component cooldown).
+- **5 synthetic probes** — onboarding-skip, cosmic-recipe gen, recommendations, Stripe-webhook reachability, auth-handshake. Cron-driven; results in `synthetic_probe_results`.
+- **Observability persistence** — request-log, slow-query-log, and alert-log rings mirrored to DB so cold starts don't lose history. Daily prune cron.
+
+#### Schema-drift cleanup + migration runner (PR #448)
+- **Tracked, auto-applied migrations** — `_migrations` table + `scripts/migrate.ts` (TS, local) and `backend/scripts/run_init_migrations.py` (runs in the Railway backend container before uvicorn). `railway.json` watches `database/init/**`.
+- Applied previously-skipped migrations (incl. 31 agent-profile columns) and restored lost column defaults (migrations 42–43) — same class of bug as the #447 signup outage.
+
+#### Calc observability (PR #470)
+- **`degraded` flag** (`src/types/degraded.ts`) — threaded from the positions layer (`astronomy-engine-fallback` / `stale-positions`) and `alchemize` (`monica-degenerate`) through `/api/alchm-quantities` to a badge on `/quantities`. Additive/optional — existing consumers unaffected.
+
+### Changed
+
+- **Database: PgBouncer transaction-mode compatibility** (PR #466, **ADR-007**) — `DB_POOLER_MODE`, `SET LOCAL statement_timeout` in transactions, connection-leak fix in `checkDatabaseHealth`, write-replay guard in `executeQueryWithRetry`.
+- **Internal-URL centralization** (PR #467) — `src/lib/serviceUrls.ts` (`getServiceUrl` / `getServiceUrlSafe`, fail-loud) replaces scattered env reads.
+- **DB module hygiene** (PR #470) — raw pool extracted to `src/lib/database/rawPool.ts`, breaking the `connection.ts ↔ slowQueryLog` import cycle.
+- **Toolchain** — Docker dev image bumped to `node:26-alpine` (#389); GitHub Actions group bumped (#390).
+
+### Fixed
+
+- **Production-readiness hardening** (PR #465) — security, DB resilience, calc guards (kalchm base-clamp + finite guard, Sun-absent guard in `alchemize`, cross-backend rectification limited to finite/>0 values, NY-pinned signup/insight dedupe).
+- **cosmic-recipe error contract** (PR #468) — `/api/generate-cosmic-recipe` returns `503` when the token debit throws server-side (`purchase_failed`) instead of masking it as a billing `402`; genuine balance failures keep the `402`.
+- **Signup outage** (PR #447) — restored `NOT NULL DEFAULT`s on `users.email_verified` / `users.login_count` that had been lost from the migration history.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Alchm.kitchen — v3.0.0
+# Alchm.kitchen — v3.1.0
 
 [![Bun](https://img.shields.io/badge/Bun-v1.3.13-black?logo=bun&logoColor=white)](https://bun.sh)
 [![Next.js](https://img.shields.io/badge/Next.js-v15-black?logo=next.js)](https://nextjs.org)
@@ -10,6 +10,18 @@
 **The world's first astrological meal-planning system.** Alchm.kitchen bridges ancient alchemical wisdom with modern AI to deliver personalized food recommendations based on natal charts, live planetary positions, elemental harmony, and thermodynamic resonance.
 
 Production: **[alchm.kitchen](https://alchm.kitchen)**
+
+---
+
+## What's new in 3.1 — MCP release
+
+- **MCP server**: a Bun-powered Model Context Protocol tool surface — connect Claude Desktop / Cursor / Cline, mint a per-user API key at `/profile/api-keys`, and buy ESMS top-ups via Stripe. Tier-aware per-key rate limiting + full telemetry.
+- **Operational admin console** at `/admin`: per-flow system status, live activity stream, onboarding funnel watch, today's highlights, and API-route health — all from existing signals, each panel degrading independently. Hourly health snapshots + Slack/email/DB alerting, plus 5 synthetic probes.
+- **Tracked, auto-applied migrations**: a `_migrations` table + `scripts/migrate.ts` run on every Railway deploy, closing the schema-drift gap that caused prior signup/dashboard outages.
+- **Production-readiness hardening**: PgBouncer transaction-mode compatibility ([ADR-007](docs/adr/007-database-connection-pooling.md)), internal-URL centralization (`src/lib/serviceUrls.ts`), and DB/calc/security guards.
+- **Calc observability**: a `degraded` flag surfaces silent astronomy fallbacks and degenerate calculations on `/quantities` instead of letting them masquerade as live data.
+
+See [CHANGELOG.md](CHANGELOG.md) for the full 3.1 detail.
 
 ---
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -84,9 +84,10 @@ Generate a structured cosmic recipe aligned to the current planetary moment.
 ```
 
 **Errors**:
-- `402` — Insufficient tokens (free users)
+- `402` — Insufficient tokens: the user's balance can't cover the personalized live cost (free users, after the free daily generation)
 - `429` — Demo quota exceeded (anonymous users)
-- `500` — Shop item unavailable (ops alert)
+- `500` — Shop item unavailable / misconfigured (ops alert)
+- `503` — `generation_unavailable`: the token debit threw server-side (distinct from a balance failure — surfaces as an incident, not a billing response). Added in #468.
 
 ---
 
@@ -353,6 +354,20 @@ Personalized astrological recommendations for the authenticated user.
 
 ---
 
+### `GET` / `POST /api/alchm-quantities`
+
+Live ESMS (Spirit/Essence/Matter/Substance) quantities, thermodynamics, kinetics, and the reactive P=IV circuit computed from the current sky. Backs the `/quantities` surface. POST is an alias for GET.
+
+**Auth**: None (rate-limited, 30/min/IP).
+
+**Response** (validated by `AlchmQuantitiesApiResponseSchema`): `quantities`, `heat`, `entropy`, `reactivity`, `energy`, `kalchm`, `monica`, `kinetics`, `circuit`, `vectorCircuit`, `planetaryMomentum`, plus an **optional `degraded`** block:
+```json
+{ "degraded": { "reasons": ["astronomy-engine-fallback" | "stale-positions" | "monica-degenerate"] } }
+```
+`degraded` is present only when the result is not fully live (silent astronomy fallback or a degenerate monica); absent on healthy payloads. See `src/types/degraded.ts`.
+
+---
+
 ## Content Routes
 
 ### `GET /api/recipes`
@@ -464,6 +479,42 @@ Get the authenticated user's token wallet balance.
 Claim the daily token allotment.
 
 **Auth**: Auth required.
+
+---
+
+## MCP & API Keys
+
+End-user API keys authenticate MCP tool calls (the keys' `rate_limit_tier` drives the per-key RPM cap). UI lives at `/profile/api-keys`.
+
+### `GET /api/account/api-keys`
+
+List the caller's API keys (metadata only — never the plaintext).
+
+**Auth**: Session. **Response**: `{ success: true, keys: [...] }`.
+
+### `POST /api/account/api-keys`
+
+Mint a new API key. **The only response that ever carries the plaintext** — the client must surface it once and discard.
+
+**Auth**: Session. **Request**: `{ name: string, scopes?: string[], expiresAt?: string }`. **Response** (`201`): `{ success: true, key: {...}, plaintext: "sk_..." }`. `400` on empty `name`.
+
+### `DELETE /api/account/api-keys/[keyId]`
+
+Revoke a key. Subsequent MCP calls with it return `401`.
+
+**Auth**: Session.
+
+### `POST /api/account/billing/mcp-top-up`
+
+Open a Stripe checkout session for an ESMS token top-up. The webhook credits all four axes idempotently (keyed on the checkout session id).
+
+**Auth**: Session. **Request**: `{ sku: string }`. **Errors**: `400` unknown sku · `503` sku not configured for purchase.
+
+### `GET /api/admin/mcp-summary`
+
+Cross-server MCP telemetry (this server's `mcp_invocations` + PA's summary) for the `/admin/mcp` panel.
+
+**Auth**: `validateAdminRequest` (admin only).
 
 ---
 


### PR DESCRIPTION
## Summary

The three top-level reference docs were stale at 3.0 (dated May 22) — they predate the entire MCP server, operational admin console, production-readiness hardening, and migration runner. This brings them current to 3.1. **Docs only; no code touched**, and disjoint from #470's CLAUDE.md refresh so the two don't conflict.

- **CHANGELOG.md** — adds a `[3.1.0]` section grouped Added/Changed/Fixed (MCP server #454/#455/#457/#459/#464, operational admin console #445/#446, schema-drift + migration runner #448, prod-readiness #465/#466/#467, calc observability #470, cosmic-recipe 503 #468, signup fix #447). Clears the stale `[Unreleased]` "In Progress" list (all shipped in 3.0) and replaces it with the real in-flight items (WTEN 7–11, real recommendations).
- **README.md** — bumps the title to `v3.1.0` and adds a "What's new in 3.1" section.
- **docs/API_REFERENCE.md** — documents the **MCP & API Keys** routes (`/api/account/api-keys` GET/POST, `[keyId]` DELETE, `mcp-top-up` POST, `admin/mcp-summary` GET) and **`GET/POST /api/alchm-quantities`** including the optional `degraded` block; adds the new `503` to `/api/generate-cosmic-recipe`.

All route contracts were verified against the actual handler source (methods, auth, request/response shapes) rather than assumed.

## Test plan

Markdown only — not covered by typecheck/lint/build. Reviewed for accuracy against the route handlers and the shipped PR set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)