### PR TITLE
feat(recommendations): real planetary alchemy via RealAlchemizeService

### DIFF
--- a/src/app/api/personalized-recommendations/route.ts
+++ b/src/app/api/personalized-recommendations/route.ts
@@ -10,6 +10,7 @@ import { NextResponse } from "next/server";
 import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
 import { withObservability } from "@/lib/observability/withObservability";
 import { rateLimit } from "@/lib/rateLimit";
+import { getCurrentAlchemicalState } from "@/services/RealAlchemizeService";
 import { extractPlanetaryPositions } from "@/utils/astrology/chartDataUtils";
 import { getAccuratePlanetaryPositions, isCurrentSkyDiurnal } from "@/utils/astrology/positions";
 import { calculateEnhancedAlchemicalFromPlanets, isSectDiurnal } from "@/utils/planetaryAlchemyMapping";
@@ -179,10 +180,36 @@ async function handlePost(request: NextRequest) {
       };
     }
 
+    // Today's real alchemical signature from the canonical engine: kalchm and
+    // monica are derived from the Spirit/Essence/Matter/Substance axes (the
+    // elemental-only path cannot produce them). Additive — the harmony meters
+    // above are unchanged. `degraded` is surfaced when the sky positions weren't
+    // fully live; null only if the engine itself throws.
+    let currentAlchemy: {
+      kalchm: number;
+      monica: number;
+      esms: { Spirit: number; Essence: number; Matter: number; Substance: number };
+      dominantElement: string;
+      degraded?: boolean;
+    } | null = null;
+    try {
+      const live = getCurrentAlchemicalState();
+      currentAlchemy = {
+        kalchm: live.kalchm,
+        monica: live.monica,
+        esms: live.esms,
+        dominantElement: live.metadata.dominantElement,
+        ...(live.degraded ? { degraded: true } : {}),
+      };
+    } catch (alchemyError) {
+      console.error("[personalized-recommendations] live alchemy unavailable:", alchemyError);
+    }
+
     return NextResponse.json({
       success: true,
       data: {
         chartComparison,
+        currentAlchemy,
         recommendations: {
           favorableElements,
           challengingElements,

--- a/src/components/dashboard/DashboardOverview.tsx
+++ b/src/components/dashboard/DashboardOverview.tsx
@@ -23,8 +23,17 @@ interface ChartComparisonData {
   };
 }
 
+interface CurrentAlchemyData {
+  kalchm: number;
+  monica: number;
+  esms: { Spirit: number; Essence: number; Matter: number; Substance: number };
+  dominantElement: string;
+  degraded?: boolean;
+}
+
 interface PersonalizedData {
   chartComparison: ChartComparisonData;
+  currentAlchemy?: CurrentAlchemyData | null;
   recommendations: {
     favorableElements: string[];
     challengingElements: string[];
@@ -122,6 +131,26 @@ export const DashboardOverview: React.FC<DashboardOverviewProps> = ({
               color="#4ade80"
             />
           </div>
+          {personalData.currentAlchemy && (
+            <div className="mt-6 pt-6 border-t border-white/5">
+              <div className="flex items-center justify-between mb-4">
+                <h4 className="text-[10px] font-bold text-white/40 uppercase tracking-[0.2em]">Today&apos;s Alchemy</h4>
+                {personalData.currentAlchemy.degraded && (
+                  <span className="text-[9px] text-amber-400/70 font-medium italic">estimated · sky degraded</span>
+                )}
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <p className="text-2xl font-bold text-white font-mono">{personalData.currentAlchemy.kalchm.toLocaleString(undefined, { maximumFractionDigits: 2 })}</p>
+                  <p className="text-[10px] text-white/40 uppercase tracking-wider mt-1">Kalchm</p>
+                </div>
+                <div>
+                  <p className="text-2xl font-bold text-white font-mono">{personalData.currentAlchemy.monica.toFixed(3)}</p>
+                  <p className="text-[10px] text-white/40 uppercase tracking-wider mt-1">Monica</p>
+                </div>
+              </div>
+            </div>
+          )}
         </div>
       ) : isLoading ? (
         <div className="alchm-card rounded-[2.5rem] shadow-2xl p-10 flex flex-col items-center justify-center border-white/5">

--- a/src/components/dashboard/RecommendationsPanel.tsx
+++ b/src/components/dashboard/RecommendationsPanel.tsx
@@ -52,6 +52,13 @@ interface PersonalizedData {
     alchemicalAlignment: number;
     planetaryResonance: number;
   };
+  currentAlchemy?: {
+    kalchm: number;
+    monica: number;
+    esms: { Spirit: number; Essence: number; Matter: number; Substance: number };
+    dominantElement: string;
+    degraded?: boolean;
+  } | null;
   recommendations: {
     favorableElements: string[];
     challengingElements: string[];
@@ -352,8 +359,16 @@ export const RecommendationsPanel: React.FC<RecommendationsPanelProps> = ({
               })}
             </div>
           </div>
-          <div className="flex items-center gap-2 text-[10px] font-bold text-white/20 uppercase tracking-widest">
+          <div className="flex items-center gap-4 text-[10px] font-bold text-white/20 uppercase tracking-widest flex-wrap">
             <span>ESMS Alignment: S{alchemical.Spirit} E{alchemical.Essence} M{alchemical.Matter} Su{alchemical.Substance}</span>
+            {personalData?.currentAlchemy && (
+              <span className="text-white/40">
+                Today · Kalchm {personalData.currentAlchemy.kalchm.toLocaleString(undefined, { maximumFractionDigits: 1 })} · Monica {personalData.currentAlchemy.monica.toFixed(2)}
+                {personalData.currentAlchemy.degraded && (
+                  <span className="ml-1 normal-case italic text-amber-400/70">(est.)</span>
+                )}
+              </span>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/profile/PersonalizedRecommendations.tsx
+++ b/src/components/profile/PersonalizedRecommendations.tsx
@@ -31,6 +31,13 @@ interface RecommendationData {
       recommendations: string[];
     };
   };
+  currentAlchemy?: {
+    kalchm: number;
+    monica: number;
+    esms: { Spirit: number; Essence: number; Matter: number; Substance: number };
+    dominantElement: string;
+    degraded?: boolean;
+  } | null;
   recommendations: {
     favorableElements: string[];
     challengingElements: string[];
@@ -192,6 +199,40 @@ export const PersonalizedRecommendations: React.FC<PersonalizedRecommendationsPr
               color="green"
             />
           </div>
+
+          {/* Today's real alchemical signature (ESMS-derived kalchm/monica) */}
+          {personalData.currentAlchemy && (
+            <div className="mb-6 rounded-lg border border-indigo-100 bg-indigo-50/50 p-4">
+              <p className="text-sm font-medium text-gray-700 mb-3">
+                Today&apos;s Alchemical Signature
+                {personalData.currentAlchemy.degraded && (
+                  <span className="ml-2 text-xs font-normal text-amber-600">
+                    (estimated — sky data degraded)
+                  </span>
+                )}
+              </p>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <p className="text-2xl font-bold text-indigo-600">
+                    {personalData.currentAlchemy.kalchm.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+                  </p>
+                  <p className="text-xs text-gray-500">Kalchm (Kₐ)</p>
+                </div>
+                <div>
+                  <p className="text-2xl font-bold text-indigo-600">
+                    {personalData.currentAlchemy.monica.toFixed(3)}
+                  </p>
+                  <p className="text-xs text-gray-500">Monica constant</p>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500">
+                <span>Spirit {personalData.currentAlchemy.esms.Spirit.toFixed(2)}</span>
+                <span>Essence {personalData.currentAlchemy.esms.Essence.toFixed(2)}</span>
+                <span>Matter {personalData.currentAlchemy.esms.Matter.toFixed(2)}</span>
+                <span>Substance {personalData.currentAlchemy.esms.Substance.toFixed(2)}</span>
+              </div>
+            </div>
+          )}
 
           {/* Favorable elements */}
           {personalData.recommendations.favorableElements.length > 0 && (

--- a/src/services/RealAlchemizeService.ts
+++ b/src/services/RealAlchemizeService.ts
@@ -839,6 +839,50 @@ export function calculateAlchemicalProperties(
 ): StandardizedAlchemicalResult {
   return alchemize(positions, historicalPositions);
 }
+
+/**
+ * Real alchemical signature for a planetary alignment, computed by the
+ * canonical {@link alchemize} engine.
+ *
+ * The recommendation layer historically carried positions as `{ sign, degree }`
+ * and could only map them to elemental properties — which cannot yield kalchm or
+ * monica, since those require the Spirit/Essence/Matter/Substance axes. This
+ * adapts those positions onto the canonical engine so callers get REAL ESMS,
+ * kalchm, monica, thermodynamics, and the engine's own sect-aware elemental
+ * profile from a single, internally-consistent computation.
+ *
+ * `degree`/`minute` are optional: they only feed inter-moment momentum, which is
+ * not computed here (no historical positions passed), so the sign alone drives
+ * the result. Inherits all of {@link alchemize}'s guards (epsilon-clamped kalchm,
+ * degenerate-monica detection, degraded flag).
+ */
+export interface PlanetaryAlignmentAlchemy {
+  elementalProperties: ElementalProperties;
+  esms: { Spirit: number; Essence: number; Matter: number; Substance: number };
+  kalchm: number;
+  monica: number;
+  thermodynamics: ThermodynamicProperties;
+  degraded?: DegradedInfo;
+}
+
+export function planetaryAlignmentAlchemy(
+  positions: Record<string, { sign: string; degree?: number; minute?: number }>,
+  date: Date = new Date(),
+): PlanetaryAlignmentAlchemy {
+  const full: Record<string, PlanetaryPosition> = {};
+  for (const [planet, p] of Object.entries(positions)) {
+    full[planet] = { sign: p.sign, degree: p.degree ?? 0, minute: p.minute ?? 0 };
+  }
+  const result = alchemize(full, null, date);
+  return {
+    elementalProperties: result.elementalProperties,
+    esms: result.esms,
+    kalchm: result.kalchm,
+    monica: result.monica,
+    thermodynamics: result.thermodynamicProperties,
+    ...(result.degraded ? { degraded: result.degraded } : {}),
+  };
+}
 // Export the service as default
 export default {
   alchemize,

--- a/src/services/UnifiedRecommendationService.ts
+++ b/src/services/UnifiedRecommendationService.ts
@@ -1,4 +1,5 @@
 import alchemicalEngine from "@/calculations/core/alchemicalEngine";
+import { planetaryAlignmentAlchemy } from "@/services/RealAlchemizeService";
 import { recipeDataService } from "@/services/recipeData";
 import type {
     // Element, // unused - removed for performance
@@ -592,40 +593,93 @@ export class UnifiedRecommendationService implements RecommendationServiceInterf
     }
   }
   /**
-   * Get recommendations based on planetary alignment
+   * Get recommendations based on planetary alignment.
+   *
+   * Maps the alignment onto the canonical alchemize engine
+   * (planetaryAlignmentAlchemy) for a real Spirit/Essence/Matter/Substance
+   * profile and the kalchm/monica derived from it, then drives the elemental
+   * recommendation path with the engine's sect-aware elemental profile. The real
+   * alchemical signature is attached to the result context, so callers get both
+   * the recommendations and the alchemy behind them. If the engine throws it
+   * degrades to a neutral elemental profile rather than fabricating alchemy.
    */
   async getRecommendationsForPlanetaryAlignment(
     planetaryPositions: Record<string, { sign: string; degree: number }>,
     type: "recipe" | "ingredient" | "cuisine" | "cookingMethod",
     limit?: number,
   ): Promise<RecommendationResult<unknown>> {
-    // Convert planetary positions to elemental properties
-    // This is a simplified implementation
-    const elementalProperties: ElementalProperties = {
-      Fire: 0.25,
-      Water: 0.25,
-      Earth: 0.25,
-      Air: 0.25,
+    let signature: ReturnType<typeof planetaryAlignmentAlchemy> | undefined;
+    try {
+      signature = planetaryAlignmentAlchemy(planetaryPositions);
+    } catch (error) {
+      console.error(
+        "[UnifiedRecommendationService] planetary alchemy computation failed:",
+        error,
+      );
+    }
+
+    // Fresh literal: the engine's ElementalProperties (@/types/celestial) has no
+    // index signature, so bridge to the @/types/alchemy shape this service uses.
+    const elementalProperties: ElementalProperties = signature
+      ? {
+          Fire: signature.elementalProperties.Fire,
+          Water: signature.elementalProperties.Water,
+          Earth: signature.elementalProperties.Earth,
+          Air: signature.elementalProperties.Air,
+        }
+      : { Fire: 0.25, Water: 0.25, Earth: 0.25, Air: 0.25 };
+
+    const result = await this.getRecommendationsForElements(
+      elementalProperties,
+      type,
+      limit,
+    );
+
+    return {
+      ...result,
+      context: {
+        ...(result.context ?? {}),
+        elementalProperties,
+        ...(signature
+          ? {
+              alchemy: {
+                esms: signature.esms,
+                kalchm: signature.kalchm,
+                monica: signature.monica,
+                thermodynamics: signature.thermodynamics,
+                ...(signature.degraded ? { degraded: signature.degraded } : {}),
+              },
+            }
+          : {}),
+      },
     };
-    // In a real implementation, we would use the AlchemicalEngine to calculate
-    // elemental properties based on planetary positions
-    // Get recommendations based on elemental properties
-    return this.getRecommendationsForElements(elementalProperties, type, limit);
   }
   /**
-   * Calculate thermodynamic metrics based on elemental properties
+   * Calculate thermodynamic metrics from elemental properties.
+   *
+   * heat / entropy / reactivity / gregsEnergy ARE derivable from the elemental
+   * balance and are computed here. kalchm and monica are NOT — they require the
+   * Spirit/Essence/Matter/Substance axes, which an elemental-only input does not
+   * carry. We return NaN sentinels (not a fake 1.0 that masquerades as real) so
+   * callers can detect the not-computed case with Number.isFinite(); for real
+   * values, route through getRecommendationsForPlanetaryAlignment or the
+   * canonical RealAlchemizeService, which derive them from ESMS.
    */
   calculateThermodynamics(
-    _elementalProperties: ElementalProperties,
+    elementalProperties: ElementalProperties,
   ): ThermodynamicMetrics {
-    // Use the AlchemicalEngine to calculate thermodynamic metrics
+    const { Fire = 0, Water = 0, Air = 0 } = elementalProperties;
+    const heat = (Fire + Air) / 2;
+    const entropy = (Air + Fire) / 2;
+    const reactivity = Math.abs(Fire - Water) / 2;
+    const gregsEnergy = heat - entropy * reactivity;
     return {
-      heat: 0.5,
-      entropy: 0.5,
-      reactivity: 0.5,
-      gregsEnergy: 0.5,
-      kalchm: 1.0,
-      monica: 1.0,
+      heat,
+      entropy,
+      reactivity,
+      gregsEnergy,
+      kalchm: NaN,
+      monica: NaN,
     };
   }
   /**

--- a/src/services/__tests__/realPlanetaryRecommendations.test.ts
+++ b/src/services/__tests__/realPlanetaryRecommendations.test.ts
@@ -1,0 +1,100 @@
+import { planetaryAlignmentAlchemy } from "@/services/RealAlchemizeService";
+import { unifiedRecommendationService } from "@/services/UnifiedRecommendationService";
+
+// A realistic, varied alignment spanning all four elements and both sects.
+const ALIGNMENT = {
+  Sun: { sign: "leo", degree: 15 },
+  Moon: { sign: "cancer", degree: 10 },
+  Mercury: { sign: "virgo", degree: 2 },
+  Venus: { sign: "libra", degree: 20 },
+  Mars: { sign: "aries", degree: 8 },
+  Jupiter: { sign: "sagittarius", degree: 25 },
+  Saturn: { sign: "capricorn", degree: 12 },
+};
+
+describe("planetaryAlignmentAlchemy (canonical engine adapter)", () => {
+  it("derives real, finite kalchm and monica from the ESMS axes", () => {
+    const sig = planetaryAlignmentAlchemy(ALIGNMENT);
+    expect(Number.isFinite(sig.kalchm)).toBe(true);
+    expect(Number.isFinite(sig.monica)).toBe(true);
+    const esmsSum =
+      sig.esms.Spirit + sig.esms.Essence + sig.esms.Matter + sig.esms.Substance;
+    expect(esmsSum).toBeGreaterThan(0);
+  });
+
+  it("returns a normalized elemental profile reflecting the alignment (not flat 0.25)", () => {
+    const { Fire, Water, Earth, Air } = planetaryAlignmentAlchemy(ALIGNMENT).elementalProperties;
+    expect(Fire + Water + Earth + Air).toBeCloseTo(1, 5);
+    const allQuarter = [Fire, Water, Earth, Air].every((v) => Math.abs(v - 0.25) < 1e-9);
+    expect(allQuarter).toBe(false);
+  });
+
+  it("tolerates positions without degree/minute (the sign alone drives the result)", () => {
+    const sig = planetaryAlignmentAlchemy({ Sun: { sign: "leo" }, Moon: { sign: "taurus" } });
+    expect(Number.isFinite(sig.kalchm)).toBe(true);
+    expect(Number.isFinite(sig.monica)).toBe(true);
+  });
+});
+
+describe("UnifiedRecommendationService.calculateThermodynamics (honest elemental-only path)", () => {
+  it("computes real heat/entropy/reactivity/gregsEnergy from the elemental balance", () => {
+    const t = unifiedRecommendationService.calculateThermodynamics({
+      Fire: 0.4,
+      Water: 0.2,
+      Earth: 0.1,
+      Air: 0.3,
+    });
+    expect(Number.isFinite(t.heat)).toBe(true);
+    expect(Number.isFinite(t.entropy)).toBe(true);
+    expect(Number.isFinite(t.reactivity)).toBe(true);
+    expect(Number.isFinite(t.gregsEnergy)).toBe(true);
+    expect(t.heat).toBeCloseTo((0.4 + 0.3) / 2, 10);
+  });
+
+  it("returns NaN for kalchm/monica — not derivable from elementals (no fabricated 1.0)", () => {
+    const t = unifiedRecommendationService.calculateThermodynamics({
+      Fire: 0.25,
+      Water: 0.25,
+      Earth: 0.25,
+      Air: 0.25,
+    });
+    expect(Number.isNaN(t.kalchm)).toBe(true);
+    expect(Number.isNaN(t.monica)).toBe(true);
+  });
+});
+
+describe("UnifiedRecommendationService.getRecommendationsForPlanetaryAlignment", () => {
+  type AlchemyCtx = {
+    base?: boolean;
+    elementalProperties: { Fire: number; Water: number; Earth: number; Air: number };
+    alchemy?: {
+      kalchm: number;
+      monica: number;
+      esms: { Spirit: number; Essence: number; Matter: number; Substance: number };
+    };
+  };
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it("drives recommendations with real elementals and attaches the real alchemy signature", async () => {
+    // Isolate from the recipe/ingredient/cuisine data path — we are asserting the
+    // alchemy wiring, not the downstream recommendation engine.
+    jest
+      .spyOn(unifiedRecommendationService, "getRecommendationsForElements")
+      .mockResolvedValue({ items: [], scores: {}, context: { base: true } });
+
+    const result = await unifiedRecommendationService.getRecommendationsForPlanetaryAlignment(
+      ALIGNMENT,
+      "cuisine",
+    );
+    const ctx = result.context as AlchemyCtx;
+
+    expect(ctx.base).toBe(true); // base context preserved
+    const ep = ctx.elementalProperties;
+    expect(ep.Fire + ep.Water + ep.Earth + ep.Air).toBeCloseTo(1, 5);
+    expect(ctx.alchemy).toBeDefined();
+    expect(Number.isFinite(ctx.alchemy!.kalchm)).toBe(true);
+    expect(Number.isFinite(ctx.alchemy!.monica)).toBe(true);
+    expect(ctx.alchemy!.esms.Spirit).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## What

Replaces mock alchemy in the wired recommendation service with real, ESMS-derived values from the canonical engine, and surfaces them on the live recommendations route.

### The mocks (before)
- `UnifiedRecommendationService.getRecommendationsForPlanetaryAlignment` ignored its positions and used flat `{0.25×4}` elementals.
- `UnifiedRecommendationService.calculateThermodynamics` returned a fabricated `kalchm: 1.0, monica: 1.0`.
- `/api/personalized-recommendations` (live; 3 dashboard/profile cards) computed real ESMS but never derived kalchm/monica.

### Changes
- **`RealAlchemizeService`** — new `planetaryAlignmentAlchemy()` helper maps `{sign, degree}` positions onto the canonical `alchemize` engine → real ESMS + kalchm + monica + thermodynamics (single source of truth; reusable).
- **`UnifiedRecommendationService`** — planetary path now uses real elementals and attaches the real alchemy signature to the result `context`; `calculateThermodynamics` is now **honest** (`NaN` kalchm/monica for the elemental-only path, which cannot derive them — matching the deleted `RecommendationService`'s documented stance).
- **`/api/personalized-recommendations`** — surfaces real `currentAlchemy` (kalchm / monica / ESMS) via `getCurrentAlchemicalState()`, **additively** — the existing harmony meters are untouched.
- **3 cards** (`DashboardOverview`, `RecommendationsPanel`, `profile/PersonalizedRecommendations`) display "Today's Alchemy".

## Verification
- 537 jest pass (incl. 6 new in `realPlanetaryRecommendations.test.ts`); `bun run verify` + `bun run build` green.
- Live route (guest) returns real values: `kalchm`, `monica: 0.029` (non-degenerate), ESMS, dominant element; `chartComparison: null` preserved for guests.
- The alchemy card itself renders only for a signed-in user with a natal chart, so the data path + compile + app-health were verified rather than the rendered card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)