### PR TITLE
fix(mcp): correct stale launch artifacts (tool count 3→5)

### DIFF
--- a/content/blog/announcing-alchm-mcp.md
+++ b/content/blog/announcing-alchm-mcp.md
@@ -20,8 +20,8 @@ summary: >
 
 > **DRAFT — not yet published.** Marketing pass + final pricing
 > language before going live. The technical details and config snippets
-> are sourced from `mcp-server/README.md` and `docs/mcp-launch-checklist.md`
-> and have been verified end-to-end against the live MCP server.
+> are sourced from `mcp-server/README.md` and have been verified
+> end-to-end against the live MCP server.
 
 The chat assistants people are running today — Claude Desktop, Cursor,
 Cline, Antigravity, anything built on the [Claude Agent

--- a/docs/mcp-registry-submission.md
+++ b/docs/mcp-registry-submission.md
@@ -128,8 +128,8 @@ gh pr create --repo modelcontextprotocol/servers \
 
 - Add a "Listed on the MCP server registry" line to
   `mcp-server/README.md`.
-- Link from `docs/mcp-launch-checklist.md` Item 9 to the merged PR.
-- Update this file's status header to ✅.
+- Record the merged registry PR link in this file's **Submission status**
+  header, and flip it to ✅.
 
 ---
 

--- a/docs/mcp-registry-submission.md
+++ b/docs/mcp-registry-submission.md
@@ -1,137 +1,128 @@
 # MCP Server Registry submission — alchm.kitchen
 
-Submission prep for [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers).
-This file is the canonical local copy of what we plan to submit upstream
-— operator can lift content verbatim into the GitHub PR.
+How to list the alchm.kitchen MCP server in the official MCP registry.
 
-**Submission status:** ⏸ not yet submitted. File the PR once Item 6's
-load test passes and the blog post is live.
+**Submission status:** ⏸ not yet submitted. Gated on (a) the announcement
+blog being live and (b) the packaging prerequisite below.
 
----
-
-## Step 1 — Decide which list we're submitting to
-
-The MCP servers repo has three lists in `README.md`:
-
-| List | Criteria | Our fit |
-| --- | --- | --- |
-| 🔌 **Reference servers** | Anthropic-maintained examples. | ❌ Not us. |
-| 🌎 **Third-party servers** | Anyone, official or community. | ✅ This is the slot. |
-| 🚀 **Community servers** | Unofficial / experimental. | ⏸ Fallback if third-party reviewers push back. |
-
-We target the **third-party servers** list. The README sorts that list
-alphabetically by company/project name — we land under `A` (alchm).
+> ⚠️ **Approach corrected 2026-05-29.** The old plan here — open a PR adding an
+> entry to a "third-party servers" list in `modelcontextprotocol/servers/README.md`
+> — is **obsolete**. That repo is now *reference-servers only*; its README states:
+> *"If you are looking for a list of MCP servers, you can browse published servers
+> on [the MCP Registry](https://registry.modelcontextprotocol.io/). The repository
+> served by this README is dedicated to housing just the small number of reference
+> servers maintained by the MCP steering group."* A README PR there would be closed.
+> Servers are now published to **registry.modelcontextprotocol.io** via the
+> `mcp-publisher` CLI + a `server.json`.
 
 ---
 
-## Step 2 — Entry to add
+## ⛔ Prerequisite — package the server first (blocker)
 
-Append to the third-party servers section of
-`README.md` (alphabetical insertion under `A`):
+The registry catalogs **installable** servers — an npm/PyPI/Docker package or a
+remote (HTTP) endpoint. Our server today runs via `bun run /abs/path/.../mcp-server/src/index.ts`
+(a local stdio process), which the registry **cannot** reference. Before we can
+publish, pick one:
 
-```markdown
-- **[alchm.kitchen](https://alchm.kitchen)** — Live planetary transits,
-  ingredient ESMS analysis, cosmic recipe search, synastry overlays,
-  and transit×natal overlays. Powers alchemy-aware food + ritual
-  recommendations.
-  [Source](https://github.com/gregcastro23/WhatToEatNext/tree/master/mcp-server)
-  · [Docs](https://alchm.kitchen/docs/mcp)
-```
+- **Option A (recommended): publish `mcp-server/` to npm** as e.g.
+  `@alchm/mcp-server` with a `bin` so `npx -y @alchm/mcp-server` (or `bunx`)
+  launches it. Then `server.json` references the npm package. Requires: an npm
+  `package.json` with `bin` + `files`, an npm org/account, `npm publish`. The
+  server imports from `../../src/lib/mcp/*`, so packaging must bundle those (or
+  the npm build must vendor them) — non-trivial; scope this as its own task.
+- **Option B: host a remote MCP endpoint** (HTTP/SSE) and register it as a
+  `remotes` entry. The server is stdio-only today, so this is also new work.
 
----
-
-## Step 3 — PR template
-
-```markdown
-## Add alchm.kitchen MCP server
-
-Adds the alchm.kitchen MCP server (5 tools) to the third-party servers
-list.
-
-### Tools exposed
-
-| Tool | Function |
-| --- | --- |
-| `get_live_sky_transits` | Current planetary positions + elemental balance for any coordinate. |
-| `alchemize_ingredients` | Spirit / Essence / Matter / Substance scores + thermodynamic indices for an ingredient list. |
-| `generate_cosmic_recipe` | Search the 579-recipe catalog by element, cuisine, or dietary need. |
-| `compute_synastry_overlay` | Inter-aspect ledger between two natal charts (tension / harmony / intensification). |
-| `get_transit_natal_overlay` | Live sky × one agent's natal chart, with continuous boost magnitude per planet. |
-
-### Where it lives
-
-- **Source:** https://github.com/gregcastro23/WhatToEatNext/tree/master/mcp-server
-- **Docs:** https://alchm.kitchen/docs/mcp
-- **Connector config examples (Claude Desktop, Cursor, Cline):** in the
-  source `README.md`.
-
-### Auth model
-
-Public users mint per-key API keys at `/profile/api-keys`. Keys are
-sha256-hashed at rest. Tool-call telemetry is attributed via
-`_meta.apiKey` on the JSON-RPC argument envelope. Anonymous calls are
-allowed but receive degraded responses for paid tools.
-
-### Operational health
-
-- Synthetic-probe heartbeat every 30 min (`mcp_invocations` table)
-- Per-tool latency + error rate visible on
-  `https://alchm.kitchen/admin` (operator-only)
-- Public status checks via the standard `tools/list` handshake.
-
-### Checklist
-
-- [x] Source link works and points at the actual server entrypoint.
-- [x] Docs link works and resolves to a public connector guide.
-- [x] Tools listed are the actual `tools/list` output (verified
-      `MCP_E2E=1 bun test mcp-server/src/__tests__/stdio.test.ts`).
-- [x] No credentials required to install — users mint their own.
-- [x] License: MIT (matches the repo).
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-```
+Until one of these exists, the steps below cannot complete the `publish`.
 
 ---
 
-## Step 4 — Verification before filing
+## Step 1 — Namespace + auth
 
-1. `MCP_E2E=1 bun test mcp-server/src/__tests__/stdio.test.ts` — the
-   five tool names returned by `tools/list` must match the table above
-   exactly.
-2. `curl -I https://alchm.kitchen/docs/mcp` returns 200.
-3. `curl -I https://github.com/gregcastro23/WhatToEatNext/tree/master/mcp-server`
-   returns 200.
-4. Blog post `content/blog/announcing-alchm-mcp.md` has been published
-   to a public URL (or has a no-link variant ready — reviewers
-   sometimes ask for a hosted overview).
-
----
-
-## Step 5 — Filing the PR
+The registry validates namespace ownership against a GitHub identity. Publish
+under **`io.github.gregcastro23/alchm-kitchen`** (the `io.github.<user>/<name>`
+namespace), authenticated as `gregcastro23`:
 
 ```bash
-gh repo fork modelcontextprotocol/servers --clone --remote
-cd servers
-git checkout -b add-alchm-kitchen
-# edit README.md per Step 2 above
-git add README.md
-git commit -m "Add alchm.kitchen MCP server to third-party servers"
-git push -u origin add-alchm-kitchen
-gh pr create --repo modelcontextprotocol/servers \
-  --title "Add alchm.kitchen MCP server" \
-  --body-file <path-to-rendered-step-3>
+mcp-publisher login github          # opens browser; auth as gregcastro23
 ```
 
----
+(For CI publishing, a GitHub Action running on a gregcastro23-owned repo can
+authenticate instead.)
 
-## Step 6 — After merge
+## Step 2 — Generate + fill `server.json`
 
-- Add a "Listed on the MCP server registry" line to
+`mcp-publisher init` writes a schema-valid `server.json` template — start from
+it (don't hand-author the schema; it drifts). Fill in our values:
+
+```jsonc
+// DRAFT — reconcile field names/shape with `mcp-publisher init` output + the
+// live $schema before publishing. Assumes Option A (npm package) above.
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.gregcastro23/alchm-kitchen",
+  "description": "Live planetary transits, ingredient ESMS analysis, cosmic recipe search, synastry + transit×natal overlays — alchemy-aware food & ritual recommendations.",
+  "version": "1.1.0",
+  "repository": {
+    "url": "https://github.com/gregcastro23/WhatToEatNext",
+    "source": "github",
+    "subfolder": "mcp-server"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@alchm/mcp-server",
+      "version": "1.1.0",
+      "transport": { "type": "stdio" },
+      "environmentVariables": [
+        { "name": "MCP_USER_API_KEY", "description": "alchm.kitchen API key minted at /profile/api-keys (optional; unlocks per-user quotas)", "isSecret": true, "isRequired": false },
+        { "name": "DATABASE_URL", "description": "Optional; enables the token gate + invocation telemetry. Omit for anonymous mode.", "isSecret": true, "isRequired": false }
+      ]
+    }
+  ]
+}
+```
+
+Notes:
+- `version` (1.1.0) matches `mcp-server/package.json` + the server's `serverInfo`.
+- No credentials are required to install — users mint their own API key; both
+  env vars are optional (anonymous mode works).
+
+## Step 3 — Verify before publishing
+
+1. `MCP_E2E=1 bun test mcp-server/src/__tests__/stdio.test.ts` — `tools/list`
+   must return exactly these **5** tools:
+
+   | Tool | Function |
+   | --- | --- |
+   | `get_live_sky_transits` | Current planetary positions + elemental balance for any coordinate. |
+   | `alchemize_ingredients` | Spirit / Essence / Matter / Substance scores + thermodynamic indices for an ingredient list. |
+   | `generate_cosmic_recipe` | Search the 579-recipe catalog by element, cuisine, or dietary need. |
+   | `compute_synastry_overlay` | Inter-aspect ledger between two natal charts (tension / harmony / intensification). |
+   | `get_transit_natal_overlay` | Live sky × one agent's natal chart, with continuous boost magnitude per planet. |
+
+2. `npx -y @alchm/mcp-server` (the published package) starts and answers a
+   `tools/list` handshake — i.e. the npm package, not just the local checkout.
+3. `curl -I https://alchm.kitchen/docs/mcp` → 200 (the public connector guide).
+4. The announcement blog (`content/blog/announcing-alchm-mcp.md`) is published.
+
+## Step 4 — Publish
+
+```bash
+mcp-publisher publish        # validates server.json against the live schema + pushes
+```
+
+Then verify the listing resolves on https://registry.modelcontextprotocol.io/.
+
+## Step 5 — After publish
+
+- Add a "Listed on the MCP registry" line + the registry URL to
   `mcp-server/README.md`.
-- Record the merged registry PR link in this file's **Submission status**
-  header, and flip it to ✅.
+- Record the published namespace/version in this file's **Submission status**
+  header and flip it to ✅.
 
 ---
 
-_Drafted 2026-05-27. Re-verify all URLs the morning of submission — the
-registry reviewers will reject any PR with a broken link._
+_Rewritten 2026-05-29 to target registry.modelcontextprotocol.io (the README-PR
+path is obsolete). The `server.json` above is a DRAFT — validate against
+`mcp-publisher init` + the live `$schema` at publish time._

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,6 +1,6 @@
 # Alchm.kitchen MCP Server
 
-An [MCP server](https://modelcontextprotocol.io) exposing three alchemical tools — live sky transits, ingredient ESMS analysis, and cosmic recipe discovery — to any LLM client that speaks MCP (Claude Desktop, Cursor, Google Antigravity, Claude Agent SDK, etc.).
+An [MCP server](https://modelcontextprotocol.io) exposing five alchemical tools — live sky transits, ingredient ESMS analysis, cosmic recipe discovery, synastry overlays, and transit×natal overlays — to any LLM client that speaks MCP (Claude Desktop, Cursor, Google Antigravity, Claude Agent SDK, etc.).
 
 ## Tools
 
@@ -9,8 +9,10 @@ An [MCP server](https://modelcontextprotocol.io) exposing three alchemical tools
 | `get_live_sky_transits` | Free | Current planetary positions + elemental balance for any coordinate. |
 | `alchemize_ingredients` | Free | Spirit / Essence / Matter / Substance scores + thermodynamic indices for a list of ingredients. |
 | `generate_cosmic_recipe` | 7.5 of each ESMS (30 total) | Search the 579-recipe catalog by element, cuisine, dietary needs. |
+| `compute_synastry_overlay` | Free | Inter-aspect ledger between two natal charts — tension / harmony / intensification scores + a recommended stance. |
+| `get_transit_natal_overlay` | Free | Live sky × one agent's natal chart — which transiting planets activate which natal points, with continuous boost magnitude. |
 
-`generate_cosmic_recipe` debits tokens only when called with a valid `_meta.apiKey`. Anonymous callers receive a `QUOTA` error rather than a free recipe.
+`generate_cosmic_recipe` debits tokens only when called with a valid `_meta.apiKey`. Anonymous callers receive a `QUOTA` error rather than a free recipe. The other four tools are free.
 
 ## Mint an API key
 

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alchm-mcp-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/mcp-server/src/__tests__/stdio.test.ts
+++ b/mcp-server/src/__tests__/stdio.test.ts
@@ -112,14 +112,16 @@ describeIf("MCP stdio transport", () => {
     client?.close();
   });
 
-  it("lists the three expected tools", async () => {
+  it("lists the five expected tools", async () => {
     const res = await client.request("tools/list");
     const tools = (res.result as { tools: Array<{ name: string }> }).tools;
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
       "alchemize_ingredients",
+      "compute_synastry_overlay",
       "generate_cosmic_recipe",
       "get_live_sky_transits",
+      "get_transit_natal_overlay",
     ]);
   });
 


### PR DESCRIPTION
## What

Corrects stale MCP launch artifacts found while prepping the registry submission.

### 1. Tool count 3 → 5
The standalone server registers **5** tools, but the artifacts claimed **3** (`compute_synastry_overlay` + `get_transit_natal_overlay` were missing):
- **`mcp-server/src/__tests__/stdio.test.ts`** — asserted exactly 3 tools via `toEqual`, so `tools/list` returning 5 made it **fail**. Since the submission doc tells the operator to run this exact test to verify the surface before publishing, the submission was effectively blocked. Now asserts all 5; **passes** under `MCP_E2E=1`.
- **`mcp-server/README.md`** — intro + tools table 3 → 5.
- **`mcp-server/package.json`** — version `1.0.0` → `1.1.0` (server already self-reports `1.1.0`).

### 2. Registry submission process was obsolete
`docs/mcp-registry-submission.md` planned a PR adding an entry to a "third-party servers" list in `modelcontextprotocol/servers/README.md`. That repo is now **reference-servers only** — its README points third-party servers to **registry.modelcontextprotocol.io**. Rewrote the doc to the correct `mcp-publisher` + `server.json` process (namespace `io.github.gregcastro23/alchm-kitchen`, draft server.json), and flagged the real blocker: **the registry catalogs installable packages, but our stdio server runs via `bun run <local path>` and isn't published — it needs npm packaging (or a remote endpoint) first.**

### 3. Dangling refs
Removed blog + submission-doc references to a non-existent `docs/mcp-launch-checklist.md`.

The announcement blog stays `draft: true` — marketing/pricing pass is comms-owned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)