### PR TITLE
fix(recipes): /recipes/[id] 500 on recipes with missing ingredients/elementalProperties

### DIFF
--- a/src/app/recipes/[recipeId]/page.tsx
+++ b/src/app/recipes/[recipeId]/page.tsx
@@ -108,26 +108,41 @@ export default async function RecipePage({ params }: RecipePageProps) {
 
   const recipe = rawRecipe;
 
-  const proteins = (recipe.ingredients || [])
-    .filter((i) => i.category === "protein")
-    .map((i) => i.name);
-  const vegetables = (recipe.ingredients || [])
-    .filter((i) => i.category === "vegetable")
-    .map((i) => i.name);
-
   const cookingMethods = getCookingMethods(recipe);
 
-  const recommendedSauces = await sauceRecommender.recommendSauce(recipe.cuisine ?? "", {
-    protein: proteins[0],
-    vegetable: vegetables[0],
-    cookingMethod: cookingMethods[0],
-  });
+  // Non-essential enrichment. A recommender failure (e.g. a catalog recipe with
+  // missing fields) must never 500 the page — the recipe itself always renders.
+  let recommendedSauces: Awaited<
+    ReturnType<typeof sauceRecommender.recommendSauce>
+  > = [];
+  let recommendedRecipes: Awaited<
+    ReturnType<typeof _recipeRecommender.recommendSimilarRecipes>
+  > = [];
+  try {
+    const proteins = (recipe.ingredients || [])
+      .filter((i) => i.category === "protein")
+      .map((i) => i.name);
+    const vegetables = (recipe.ingredients || [])
+      .filter((i) => i.category === "vegetable")
+      .map((i) => i.name);
 
-  const allRecipes = await LocalRecipeService.getAllRecipes();
-  const recommendedRecipes = await _recipeRecommender.recommendSimilarRecipes(
-    rawRecipe,
-    allRecipes,
-  );
+    recommendedSauces = await sauceRecommender.recommendSauce(recipe.cuisine ?? "", {
+      protein: proteins[0],
+      vegetable: vegetables[0],
+      cookingMethod: cookingMethods[0],
+    });
+
+    const allRecipes = await LocalRecipeService.getAllRecipes();
+    recommendedRecipes = await _recipeRecommender.recommendSimilarRecipes(
+      rawRecipe,
+      allRecipes,
+    );
+  } catch (err) {
+    console.error(
+      `[recipes/${recipeId}] enrichment (sauces/similar recipes) failed; rendering recipe without recommendations:`,
+      err,
+    );
+  }
 
   const recipeRecord = recipe as Record<string, unknown>;
   // Build "3 cups all-purpose flour"-shaped strings for schema.org/Recipe.

--- a/src/services/recipeRecommendations.ts
+++ b/src/services/recipeRecommendations.ts
@@ -115,11 +115,25 @@ export class RecipeRecommender {
     ingredients1: Recipe["ingredients"],
     ingredients2: Recipe["ingredients"],
   ): number {
-    const names1 = new Set(ingredients1.map((i) => i.name));
-    const names2 = new Set(ingredients2.map((i) => i.name));
+    // Recipes in the catalog can be missing `ingredients` entirely (stocks,
+    // components, partial imports), so never assume an array.
+    const toNames = (ings: Recipe["ingredients"]): string[] =>
+      Array.isArray(ings)
+        ? ings
+            .map((i) =>
+              typeof i === "string"
+                ? i
+                : i && typeof i === "object" && "name" in i
+                  ? String((i as { name: unknown }).name)
+                  : "",
+            )
+            .filter(Boolean)
+        : [];
+    const names1 = new Set(toNames(ingredients1));
+    const names2 = new Set(toNames(ingredients2));
     const intersection = new Set([...names1].filter((x) => names2.has(x)));
     const union = new Set([...names1, ...names2]);
-    return intersection.size / union.size;
+    return union.size > 0 ? intersection.size / union.size : 0;
   }
 
   private calculateCookingMethodSimilarity(
@@ -353,14 +367,16 @@ export class RecipeRecommender {
     recipeElements: ElementalProperties,
     targetElements: ElementalProperties,
   ): number {
+    // Either recipe may have no elementalProperties — default to empty so we
+    // never call Object.keys/index on undefined.
+    const recipe = recipeElements ?? ({} as ElementalProperties);
+    const target = targetElements ?? ({} as ElementalProperties);
     let alignment = 0;
     let total = 0;
 
-    Object.keys(targetElements).forEach((element) => {
-      const key = element as any;
-      const diff = Math.abs(
-        (recipeElements[key] || 0) - (targetElements[key] || 0),
-      );
+    Object.keys(target).forEach((element) => {
+      const key = element as keyof ElementalProperties;
+      const diff = Math.abs((recipe[key] || 0) - (target[key] || 0));
       alignment += 1 - diff;
       total += 1;
     });


### PR DESCRIPTION
## Problem
`/recipes/[recipeId]` returns **HTTP 500** in production for valid recipe ids (e.g. `1366049e-…` "CURRY STOCK"), while `/api/recipes/[recipeId]` returns **200** with the same recipe. The data is fine — the **page component throws during render**.

## Root cause
The page (unlike the API route) calls `_recipeRecommender.recommendSimilarRecipes(recipe, allRecipes)`, which scores the recipe against the *entire* catalog. Two scoring helpers assumed fields that catalog recipes can lack:

- `calculateIngredientSimilarity` → `ingredients1.map(...)` / `ingredients2.map(...)` throws `TypeError` on any recipe with no `ingredients`.
- `calculateElementMatch` → `Object.keys(targetElements)` + `recipeElements[key]` throws when `elementalProperties` is undefined (true for "CURRY STOCK").

One throw anywhere in the `allRecipes` scan 500s the whole page.

## Fix
1. **Guard both helpers** — missing `ingredients`/`elementalProperties` are treated as empty; string ingredients handled; divide-by-zero guarded. Verified against the exact degenerate inputs that threw (6/6 now return sane scores, none throw).
2. **Defense-in-depth on the page** — wrap the non-essential enrichment (sauce + similar-recipe lookups) in try/catch so any future recommender failure degrades to empty arrays and the recipe still renders. A genuinely missing recipe still returns `notFound()` (404, not 500).

## Verification
- `bunx tsc --noEmit`: 0 errors (full project).
- Standalone repro of the fixed helpers against `undefined` ingredients / `undefined` elementalProperties: all return numbers, none throw.

Found while building Planetary Agents' agent-profile recipe cards — those consume the API proxy (worked), but the human-facing page 500'd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)