### PR TITLE
feat(recipes): internal endpoint for agent-authored recipes

### DIFF
--- a/src/app/api/internal/agent-recipes/route.ts
+++ b/src/app/api/internal/agent-recipes/route.ts
@@ -1,0 +1,95 @@
+/**
+ * Internal Agent Recipe Authoring
+ * POST /api/internal/agent-recipes
+ *
+ * Lets the Planetary Agents service persist a recipe AUTHORED BY an agentic
+ * user into `user_custom_recipes` — the same store the human "save a custom
+ * recipe" flow uses — so an agent's recipe is real, durable, and attributed to
+ * its user row (it shows under that user the same way human custom recipes do).
+ *
+ * Secret-gated (INTERNAL_API_SECRET) because agentic users have no session
+ * cookie. The caller supplies the agent's WTEN user id, which Planetary Agents
+ * already stores as `alchmKitchenUserId` after agent-sync. Returns the new id
+ * so PA can reference it on the agent's profile feed event.
+ */
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { executeQuery } from "@/lib/database/connection";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const INTERNAL_API_SECRET = process.env.INTERNAL_API_SECRET || "";
+
+const AgentRecipeBodySchema = z.object({
+  // The authoring agent's WTEN user id (PA's alchmKitchenUserId).
+  userId: z.string().trim().min(1, "userId (agentic WTEN user id) is required"),
+  name: z.string().trim().min(1, "name is required").max(200),
+  cuisine: z.string().trim().max(120).optional(),
+  // Where the recipe came from; defaults to "agent" so these are filterable.
+  source: z.string().trim().max(60).optional(),
+  // Optional catalog recipe this was riffed from.
+  sourceRecipeId: z.string().trim().max(200).optional(),
+  payload: z.record(z.string(), z.unknown()),
+  notes: z.string().max(2000).optional(),
+});
+
+interface InsertedRow {
+  id: string;
+  created_at: string;
+}
+
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get("authorization") || "";
+  if (!INTERNAL_API_SECRET || authHeader !== `Bearer ${INTERNAL_API_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const parsed = AgentRecipeBodySchema.safeParse(rawBody);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request body", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+  const body = parsed.data;
+
+  try {
+    const result = await executeQuery<InsertedRow>(
+      `INSERT INTO user_custom_recipes
+         (user_id, name, cuisine, source, source_recipe_id, payload, notes)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)
+       RETURNING id, created_at`,
+      [
+        body.userId,
+        body.name,
+        body.cuisine ?? null,
+        body.source ?? "agent",
+        body.sourceRecipeId ?? null,
+        JSON.stringify(body.payload),
+        body.notes ?? null,
+      ],
+    );
+    const row = result.rows[0];
+    return NextResponse.json({
+      success: true,
+      id: row.id,
+      createdAt: new Date(row.created_at).getTime(),
+    });
+  } catch (error) {
+    console.error("[POST /api/internal/agent-recipes]", error);
+    return NextResponse.json(
+      { error: "Failed to author recipe" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## What
`POST /api/internal/agent-recipes` — a secret-gated (`INTERNAL_API_SECRET`) endpoint that persists a recipe **authored by an agentic user** into `user_custom_recipes`, attributed to the agent's WTEN user id. Returns the new recipe id.

## Why
Foundation for Planetary Agents **true recipe authorship**. Today agents only *feature* existing catalog recipes; this lets them author **real, durable, attributable** recipes that live under their user the same way human custom recipes do.

## How
- Reuses the exact INSERT + JSONB `payload` shape from `/api/users/me/recipes/custom` (so authored recipes share the human custom-recipe store + read path).
- Agents have no session cookie, so auth is the internal bearer secret (matching `api/group/compatibility`'s pattern) + an explicit `userId` (PA already stores each agent's `alchmKitchenUserId` after agent-sync).
- `source` defaults to `"agent"` so agent recipes are filterable.

## Verification
`bunx tsc --noEmit`: 0 errors (full project).

## Next (Planetary Agents side, separate PR)
PA's feed engine generates a voiced recipe → POSTs here → stores the returned id in the `recipe_generation` event; profile relabels authored recipes "Created by" and resolves their expand via the custom-recipe read path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)