### PR TITLE
fix(db): drop CONCURRENTLY from migration 48 (unblocks prod deploy)

### DIFF
--- a/database/init/48-dashboard-count-indexes.sql
+++ b/database/init/48-dashboard-count-indexes.sql
@@ -7,45 +7,47 @@
 -- these were sequential scans on every dashboard load; the 5s memoize bounds
 -- frequency but not per-query cost.
 --
--- IMPORTANT — CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
--- Run this file OUTSIDE a transaction (e.g. psql \i, or a migration runner set to
--- skip the implicit BEGIN/COMMIT for this file). If your runner wraps every file
--- in a transaction, either remove CONCURRENTLY (accepting a brief write lock) or
--- apply these statements manually during a low-traffic window. All are IF NOT
--- EXISTS so re-running is safe.
+-- NOTE — these were originally CREATE INDEX CONCURRENTLY, but the deploy-time
+-- migration runners (backend/scripts/run_init_migrations.py and scripts/migrate.ts)
+-- execute each file inside an implicit transaction, and CONCURRENTLY cannot run in
+-- a transaction block — which crash-looped the Railway deploy on startup. Dropped
+-- to plain CREATE INDEX IF NOT EXISTS: it builds inside the txn with a brief write
+-- lock, acceptable at current table sizes. If a zero-lock rebuild is ever needed,
+-- run these CONCURRENTLY by hand in a low-traffic window (or teach the runner a
+-- no-transaction path). All are IF NOT EXISTS, so re-running is safe.
 
 -- Completed-profile count:
 --   SELECT COUNT(*) FROM users WHERE (profile->>'birthData') IS NOT NULL
 --     AND (profile->>'natalChart') IS NOT NULL
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_profile_complete
+CREATE INDEX IF NOT EXISTS idx_users_profile_complete
   ON users ((profile->>'birthData'))
   WHERE (profile->>'birthData') IS NOT NULL
     AND (profile->>'natalChart') IS NOT NULL;
 
 -- Active-user count: SELECT COUNT(*) FROM users WHERE is_active = true
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_is_active
+CREATE INDEX IF NOT EXISTS idx_users_is_active
   ON users (is_active)
   WHERE is_active = true;
 
 -- Signup-window counts (24h / 7d / 30d) and the 14-day signup trend.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_created_at
+CREATE INDEX IF NOT EXISTS idx_users_created_at
   ON users (created_at);
 
 -- Active-window counts: last_login_at >= NOW() - INTERVAL ...
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_last_login_at
+CREATE INDEX IF NOT EXISTS idx_users_last_login_at
   ON users (last_login_at);
 
 -- Dominant-element histogram:
 --   GROUP BY profile->'natalChart'->>'dominantElement'
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_dominant_element
+CREATE INDEX IF NOT EXISTS idx_users_dominant_element
   ON users ((profile->'natalChart'->>'dominantElement'))
   WHERE profile->'natalChart' IS NOT NULL;
 
 -- Recipe-cook reach:
 --   SELECT COUNT(DISTINCT user_id) FROM user_interactions WHERE interaction_type = 'recipe_cook'
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_interactions_type_user
+CREATE INDEX IF NOT EXISTS idx_user_interactions_type_user
   ON user_interactions (interaction_type, user_id);
 
 -- Active subscriptions: SELECT COUNT(*) FROM user_subscriptions WHERE status = 'active'
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_subscriptions_status
+CREATE INDEX IF NOT EXISTS idx_user_subscriptions_status
   ON user_subscriptions (status);


### PR DESCRIPTION
The prod Railway deploy of `WhatToEatNext` crash-looped on startup: the migration runner applies each file in a transaction, but migration 48 used `CREATE INDEX CONCURRENTLY`, which can't run in a transaction block — so it failed on every retry, uvicorn never started, and the healthcheck failed (`1/1 replicas never became healthy`). This also blocked migration 49 + the just-merged #480 airdrop feature from reaching prod (prod is still on the pre-#480 image).

**Fix:** drop `CONCURRENTLY` from the 7 indexes → plain `CREATE INDEX IF NOT EXISTS`. Brief write lock during build, negligible at current table sizes; 48 had never applied, so editing it in place is clean. Fixes both runners (`run_init_migrations.py` + `migrate.ts`) at once.

**Follow-up (not blocking):** teach the runner a no-transaction path (autocommit + per-statement) so `CONCURRENTLY` can be used for zero-lock index builds later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
