### PR TITLE
chore(db): migration-runner no-transaction path (enables CONCURRENTLY safely)

### DIFF
--- a/backend/scripts/run_init_migrations.py
+++ b/backend/scripts/run_init_migrations.py
@@ -17,6 +17,7 @@ on the first migration that errors, leaving prior commits intact.
 from __future__ import annotations
 
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -29,6 +30,123 @@ def list_migration_files() -> list[str]:
     return sorted(
         p.name for p in INIT_DIR.glob("*.sql") if " 2." not in p.name
     )
+
+
+# ── No-transaction migrations ─────────────────────────────────────────────
+# Most migrations run inside a transaction (the file + its _migrations row commit
+# atomically). But some statements are illegal inside a transaction block —
+# notably CREATE/DROP INDEX CONCURRENTLY. A migration opts out by declaring
+# `-- migrate:no-transaction`, or is auto-detected when it contains CONCURRENTLY.
+# Such migrations run statement-by-statement in autocommit and MUST be idempotent
+# (IF NOT EXISTS), since a mid-file failure is not rolled back.
+_NO_TXN_DIRECTIVE = "migrate:no-transaction"
+
+
+def _strip_sql_comments(sql: str) -> str:
+    sql = re.sub(r"/\*.*?\*/", "", sql, flags=re.DOTALL)
+    sql = re.sub(r"--[^\n]*", "", sql)
+    return sql
+
+
+def _needs_no_transaction(sql: str) -> bool:
+    if _NO_TXN_DIRECTIVE in sql.lower():
+        return True
+    # Detect CONCURRENTLY only in executable SQL, not in comments (so a migration
+    # that merely mentions it in a comment isn't misclassified).
+    return bool(re.search(r"\bconcurrently\b", _strip_sql_comments(sql), re.IGNORECASE))
+
+
+def _split_sql_statements(sql: str) -> list[str]:
+    """Split into statements on top-level `;`, respecting '...' string literals,
+    $tag$...$tag$ dollar-quotes, and -- / /* */ comments."""
+    statements: list[str] = []
+    buf: list[str] = []
+    i, n = 0, len(sql)
+    in_squote = in_line_comment = in_block_comment = False
+    dollar_tag: str | None = None
+    while i < n:
+        ch = sql[i]
+        pair = sql[i : i + 2]
+        if in_line_comment:
+            buf.append(ch)
+            if ch == "\n":
+                in_line_comment = False
+            i += 1
+        elif in_block_comment:
+            buf.append(ch)
+            if pair == "*/":
+                buf.append("/")
+                in_block_comment = False
+                i += 2
+            else:
+                i += 1
+        elif dollar_tag is not None:
+            if sql.startswith(dollar_tag, i):
+                buf.append(dollar_tag)
+                i += len(dollar_tag)
+                dollar_tag = None
+            else:
+                buf.append(ch)
+                i += 1
+        elif in_squote:
+            buf.append(ch)
+            if ch == "'":
+                if sql[i + 1 : i + 2] == "'":
+                    buf.append("'")
+                    i += 2
+                    continue
+                in_squote = False
+            i += 1
+        elif pair == "--":
+            in_line_comment = True
+            buf.append(pair)
+            i += 2
+        elif pair == "/*":
+            in_block_comment = True
+            buf.append(pair)
+            i += 2
+        elif ch == "'":
+            in_squote = True
+            buf.append(ch)
+            i += 1
+        elif ch == "$" and (m := re.match(r"\$[A-Za-z0-9_]*\$", sql[i:])):
+            dollar_tag = m.group(0)
+            buf.append(dollar_tag)
+            i += len(dollar_tag)
+        elif ch == ";":
+            stmt = "".join(buf).strip()
+            if stmt:
+                statements.append(stmt)
+            buf = []
+            i += 1
+        else:
+            buf.append(ch)
+            i += 1
+    tail = "".join(buf).strip()
+    if tail:
+        statements.append(tail)
+    return statements
+
+
+def _apply_no_transaction(conn, filename: str, sql: str) -> None:
+    """Apply a migration outside a transaction: each statement autocommits on its
+    own, then the file is marked applied. For CONCURRENTLY and friends. Requires
+    no open transaction on entry (the caller commits after every file)."""
+    prev_autocommit = conn.autocommit
+    conn.autocommit = True
+    try:
+        for stmt in _split_sql_statements(sql):
+            if not _strip_sql_comments(stmt).strip():
+                continue
+            with conn.cursor() as cur:
+                cur.execute(stmt)
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO _migrations (filename) VALUES (%s) ON CONFLICT DO NOTHING",
+                (filename,),
+            )
+    finally:
+        conn.autocommit = prev_autocommit
 
 
 def main() -> int:
@@ -84,18 +202,23 @@ def main() -> int:
         print(f"[migrate] {len(pending)} pending: {', '.join(pending)}")
         for f in pending:
             sql = (INIT_DIR / f).read_text(encoding="utf-8")
+            no_txn = _needs_no_transaction(sql)
             if dry_run:
-                print(f"[migrate] DRY-RUN would apply {f} ({len(sql)} bytes)")
+                mode = "no-txn" if no_txn else "txn"
+                print(f"[migrate] DRY-RUN would apply {f} ({len(sql)} bytes, {mode})")
                 continue
-            print(f"[migrate] applying {f}...")
+            print(f"[migrate] applying {f}{' [no-txn]' if no_txn else ''}...")
             try:
-                with conn.cursor() as cur:
-                    cur.execute(sql)
-                    cur.execute(
-                        "INSERT INTO _migrations (filename) VALUES (%s) ON CONFLICT DO NOTHING",
-                        (f,),
-                    )
-                conn.commit()
+                if no_txn:
+                    _apply_no_transaction(conn, f, sql)
+                else:
+                    with conn.cursor() as cur:
+                        cur.execute(sql)
+                        cur.execute(
+                            "INSERT INTO _migrations (filename) VALUES (%s) ON CONFLICT DO NOTHING",
+                            (f,),
+                        )
+                    conn.commit()
                 print(f"[migrate]   ok {f}")
             except Exception as err:  # noqa: BLE001
                 conn.rollback()

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -43,6 +43,109 @@ function listMigrationFiles(): string[] {
     .sort();
 }
 
+// ── No-transaction migrations ─────────────────────────────────────────────
+// Most migrations run inside a transaction (the file + its _migrations row commit
+// atomically). Some statements are illegal inside a transaction block — notably
+// CREATE/DROP INDEX CONCURRENTLY. A migration opts out by declaring
+// `-- migrate:no-transaction`, or is auto-detected when it contains CONCURRENTLY,
+// and then runs statement-by-statement in autocommit. Such migrations MUST be
+// idempotent (IF NOT EXISTS) — a mid-file failure is not rolled back.
+const NO_TXN_DIRECTIVE = "migrate:no-transaction";
+
+function stripSqlComments(sql: string): string {
+  return sql.replace(/\/\*[\s\S]*?\*\//g, "").replace(/--[^\n]*/g, "");
+}
+
+function needsNoTransaction(sql: string): boolean {
+  if (sql.toLowerCase().includes(NO_TXN_DIRECTIVE)) return true;
+  // Detect CONCURRENTLY only in executable SQL, not comments.
+  return /\bconcurrently\b/i.test(stripSqlComments(sql));
+}
+
+// Split SQL on top-level `;`, respecting '...' strings, $tag$...$tag$
+// dollar-quotes, and line/block comments.
+function splitSqlStatements(sql: string): string[] {
+  const statements: string[] = [];
+  let buf = "";
+  let i = 0;
+  const n = sql.length;
+  let inSquote = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+  let dollarTag: string | null = null;
+  while (i < n) {
+    const ch = sql[i];
+    const pair = sql.slice(i, i + 2);
+    if (inLineComment) {
+      buf += ch;
+      if (ch === "\n") inLineComment = false;
+      i += 1;
+    } else if (inBlockComment) {
+      buf += ch;
+      if (pair === "*/") {
+        buf += "/";
+        inBlockComment = false;
+        i += 2;
+      } else {
+        i += 1;
+      }
+    } else if (dollarTag !== null) {
+      if (sql.startsWith(dollarTag, i)) {
+        buf += dollarTag;
+        i += dollarTag.length;
+        dollarTag = null;
+      } else {
+        buf += ch;
+        i += 1;
+      }
+    } else if (inSquote) {
+      buf += ch;
+      if (ch === "'") {
+        if (sql[i + 1] === "'") {
+          buf += "'";
+          i += 2;
+          continue;
+        }
+        inSquote = false;
+      }
+      i += 1;
+    } else if (pair === "--") {
+      inLineComment = true;
+      buf += pair;
+      i += 2;
+    } else if (pair === "/*") {
+      inBlockComment = true;
+      buf += pair;
+      i += 2;
+    } else if (ch === "'") {
+      inSquote = true;
+      buf += ch;
+      i += 1;
+    } else if (ch === "$") {
+      const m = /^\$[A-Za-z0-9_]*\$/.exec(sql.slice(i));
+      if (m) {
+        dollarTag = m[0];
+        buf += dollarTag;
+        i += dollarTag.length;
+      } else {
+        buf += ch;
+        i += 1;
+      }
+    } else if (ch === ";") {
+      const stmt = buf.trim();
+      if (stmt) statements.push(stmt);
+      buf = "";
+      i += 1;
+    } else {
+      buf += ch;
+      i += 1;
+    }
+  }
+  const tail = buf.trim();
+  if (tail) statements.push(tail);
+  return statements;
+}
+
 async function main() {
   const dbUrl = process.env.DATABASE_URL;
   if (!dbUrl) {
@@ -90,22 +193,37 @@ async function main() {
 
     for (const f of pending) {
       const sql = readFileSync(join(INIT_DIR, f), "utf8");
+      const noTxn = needsNoTransaction(sql);
       if (dryRun) {
-        console.log(`[migrate] DRY-RUN would apply ${f} (${sql.length} bytes)`);
+        console.log(`[migrate] DRY-RUN would apply ${f} (${sql.length} bytes, ${noTxn ? "no-txn" : "txn"})`);
         continue;
       }
-      console.log(`[migrate] applying ${f}...`);
+      console.log(`[migrate] applying ${f}${noTxn ? " [no-txn]" : ""}...`);
       try {
-        await client.query("BEGIN");
-        await client.query(sql);
-        await client.query(
-          `INSERT INTO _migrations (filename) VALUES ($1) ON CONFLICT DO NOTHING`,
-          [f],
-        );
-        await client.query("COMMIT");
+        if (noTxn) {
+          // Outside a transaction: pg auto-commits each query when no BEGIN is
+          // open, so run statements one at a time (CREATE INDEX CONCURRENTLY etc.).
+          // Idempotent only — a mid-file failure is not rolled back.
+          for (const stmt of splitSqlStatements(sql)) {
+            if (!stripSqlComments(stmt).trim()) continue;
+            await client.query(stmt);
+          }
+          await client.query(
+            `INSERT INTO _migrations (filename) VALUES ($1) ON CONFLICT DO NOTHING`,
+            [f],
+          );
+        } else {
+          await client.query("BEGIN");
+          await client.query(sql);
+          await client.query(
+            `INSERT INTO _migrations (filename) VALUES ($1) ON CONFLICT DO NOTHING`,
+            [f],
+          );
+          await client.query("COMMIT");
+        }
         console.log(`[migrate]   ok ${f}`);
       } catch (err) {
-        await client.query("ROLLBACK");
+        await client.query("ROLLBACK").catch(() => {});
         console.error(`[migrate]   FAILED ${f}:`, err instanceof Error ? err.message : err);
         process.exit(1);
       }
@@ -116,7 +234,13 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+// Only run when invoked directly (the prod Dockerfile does `bun scripts/migrate.ts`);
+// guarded so the no-transaction helpers can be imported in tests without connecting.
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+export { splitSqlStatements, needsNoTransaction, stripSqlComments };


### PR DESCRIPTION
## Why
The deploy-time migration runners (`backend/scripts/run_init_migrations.py`, `scripts/migrate.ts`) execute each `database/init/*.sql` file **inside a transaction**. `CREATE INDEX CONCURRENTLY` can't run in a transaction block, so migration 48 crash-looped the prod backend deploy (fixed reactively in #481 by dropping `CONCURRENTLY`). This closes the footgun so the next person who needs a no-transaction statement doesn't take prod down.

## What
- A migration runs **outside a transaction** (statement-by-statement, autocommit) when it either declares `-- migrate:no-transaction` **or** contains `CONCURRENTLY` (detected in executable SQL, not comments — so merely mentioning it in a comment doesn't misclassify).
- Everything else keeps the existing **atomic** path (file + `_migrations` row commit together). **Dormant until opted into — no behavior change for current migrations.**
- Adds a comment/string/`$$`-dollar-quote-aware statement splitter so a `;` inside a string or function body doesn't mis-split.
- Kept the two runners in sync (their docstrings require it). TS `main()` is now guarded with `import.meta.main` and the helpers exported, so the splitter is unit-testable.

## Caveat
No-transaction migrations **must be idempotent** (`IF NOT EXISTS`): a mid-file failure isn't rolled back. (Same constraint Postgres imposes on `CONCURRENTLY` anyway.)

## Verified
`py_compile` + `tsc --noEmit` green; detection + splitter unit-tested in both Python and TS (strings, dollar-quotes, comment-only `CONCURRENTLY`, `ALTER TYPE ADD VALUE` stays transactional). Dormant path, so the redeploy has no pending migrations to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
