### PR TITLE
test: fix date-flaky Providers season test (red CI since June 1)

### DIFF
--- a/src/__tests__/providers/Providers.test.tsx
+++ b/src/__tests__/providers/Providers.test.tsx
@@ -42,12 +42,20 @@ describe("AlchemicalProvider", () => {
       </AlchemicalProvider>
     );
 
+    // currentSeason + dominant element are derived from the live date/sky (the
+    // provider overrides the static "spring"/"Fire" defaults on mount), so assert
+    // they're VALID values rather than hard-coding them — otherwise this test
+    // breaks every time the real-world season rolls over (it was red from June 1
+    // when spring → summer).
+    const SEASON = /^(spring|summer|autumn|fall|winter)$/i;
+    const ELEMENT = /^(Fire|Water|Earth|Air)$/;
+
     await waitFor(() => {
-      expect(screen.getByTestId("season")).toHaveTextContent("spring");
+      expect(screen.getByTestId("season")).toHaveTextContent(SEASON);
     });
 
-    expect(screen.getByTestId("season")).toHaveTextContent("spring");
-    expect(screen.getByTestId("dominant")).toHaveTextContent("Fire");
+    expect(screen.getByTestId("season")).toHaveTextContent(SEASON);
+    expect(screen.getByTestId("dominant")).toHaveTextContent(ELEMENT);
   });
 });
 


### PR DESCRIPTION
The CI `Test` job has been failing since June 1 — `Providers.test.tsx` hard-codes `currentSeason === 'spring'` / `dominant === 'Fire'`, but `AlchemicalProvider` derives both from the live date/sky and overrides the static defaults on mount. Once the real-world season rolled spring → summer, the assertion broke (1 failed / 539 passed). Unrelated to recent feature work; just a brittle test.

Fix: assert the values are *valid* (season ∈ spring/summer/autumn/winter, element ∈ Fire/Water/Earth/Air) instead of hard-coding, so it's stable year-round. Verified locally: 6/6 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)