### PR TITLE
ci: drop duplicate Vercel deploy job + fix tailwindcss override conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,18 +55,8 @@ jobs:
       - name: Run ${{ matrix.name }}
         run: ${{ matrix.command }}
 
-  deploy:
-    name: Deploy to Vercel
-    needs: [checks]
-    runs-on: ubuntu-latest
-    if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/backend-migration') && github.event_name == 'push'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v42
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.ORG_ID }}
-          vercel-project-id: ${{ secrets.PROJECT_ID }}
-          vercel-args: '--prod'
+  # NOTE: frontend prod deploys are handled by Vercel's native Git integration
+  # (auto-deploys on master merge — see CLAUDE.md + the "Vercel" status check).
+  # A second amondnet/vercel-action "Deploy to Vercel" job used to live here, but
+  # it duplicated that deploy and ran via npm (which tripped on the package.json
+  # tailwindcss override), so it was removed. Re-add only if native deploys stop.

--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,7 @@
         "stripe": "^22.1.1",
         "suncalc": "^1.9.0",
         "tailwind-merge": "^3.3.1",
-        "tailwindcss": "^4.3.0",
+        "tailwindcss": "3.4.19",
         "ws": "^8.20.0",
         "zod": "^4.4.3",
       },

--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
     "stripe": "^22.1.1",
     "suncalc": "^1.9.0",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss": "^4.3.0",
+    "tailwindcss": "3.4.19",
     "ws": "^8.20.0",
     "zod": "^4.4.3"
   },


### PR DESCRIPTION
## Why
After the flaky season test (#483) was fixed, the only remaining red CI check was the workflow's own **`Deploy to Vercel`** job (`amondnet/vercel-action`). It:
- **duplicates** Vercel's native Git integration (the separate green `Vercel` status check), which already auto-deploys prod on master merge (per CLAUDE.md), and
- runs via **npm** (`npx vercel`), which fails on `npm error EOVERRIDE: Override for tailwindcss@^4.3.0 conflicts with direct dependency`.

## What
- **Removed** the redundant `deploy` job from `.github/workflows/ci.yml` (left a comment explaining why). Native Vercel deploys are unchanged.
- **Fixed the real `package.json` inconsistency** behind the EOVERRIDE: direct dep `tailwindcss` was `^4.3.0` (v4) while `overrides` pinned `3.4.19` (v3). The app builds on v3 (the override wins under bun), so the direct spec is aligned to `3.4.19`. **Zero resolved-version change** — `bun install` reported "no changes"; `bun.lock` re-synced (2-line spec diff) so `bun install --frozen-lockfile` stays green.

## Verified
`bun install --frozen-lockfile` passes; `bun.lock` diff is the spec line only; ci.yml structure intact (`checks` matrix untouched). After merge, the master CI run is just the green `checks` matrix — no deploy job to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
