### PR TITLE
feat: live agent activity feed on profile pages (+ lint clean)

### DIFF
--- a/src/app/(alchm)/profile/[userId]/page.tsx
+++ b/src/app/(alchm)/profile/[userId]/page.tsx
@@ -7,11 +7,10 @@ import { useSession } from "next-auth/react";
 import React, { useEffect, useState } from "react";
 import Header from "@/components/Header";
 import { CustomizeDrawer } from "@/components/profile/CustomizeDrawer";
+import { LiveAgentFeed } from "@/components/profile/LiveAgentFeed";
 import { PROFILE_BLOCKS, type ProfileTab } from "@/components/profile/ProfileBlockRegistry";
 import type { CraftedAgentProfile } from "@/lib/agents/craftedAgentTypes";
-import { narrateFeedEvent } from "@/lib/feed/eventNarration";
 import AgentProfile from "./AgentProfile";
-import { LiveAgentFeed } from "@/components/profile/LiveAgentFeed";
 
 interface NatalPosition {
   planet?: string;
@@ -62,15 +61,6 @@ const TOKEN_VISUAL: Record<string, { symbol: string; color: string }> = {
   matter: { symbol: "🝙", color: "text-emerald-400" },
   substance: { symbol: "🝉", color: "text-purple-400" },
 };
-
-function formatRelativeTime(iso: string): string {
-  const then = new Date(iso).getTime();
-  const diffSec = Math.max(0, Math.floor((Date.now() - then) / 1000));
-  if (diffSec < 60) return "just now";
-  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
-  if (diffSec < 86_400) return `${Math.floor(diffSec / 3600)}h ago`;
-  return `${Math.floor(diffSec / 86_400)}d ago`;
-}
 
 function formatPlacement(placement: NatalPosition): string | null {
   if (!placement.planet) return null;

--- a/src/app/(alchm)/profile/[userId]/page.tsx
+++ b/src/app/(alchm)/profile/[userId]/page.tsx
@@ -11,6 +11,7 @@ import { PROFILE_BLOCKS, type ProfileTab } from "@/components/profile/ProfileBlo
 import type { CraftedAgentProfile } from "@/lib/agents/craftedAgentTypes";
 import { narrateFeedEvent } from "@/lib/feed/eventNarration";
 import AgentProfile from "./AgentProfile";
+import { LiveAgentFeed } from "@/components/profile/LiveAgentFeed";
 
 interface NatalPosition {
   planet?: string;
@@ -298,45 +299,12 @@ export default function PublicProfilePage() {
         {!loading && !error && profile && (
           <section className="glass-card-premium rounded-3xl p-6 md:p-8 border-white/8">
             <h2 className="text-[10px] font-black text-white/30 uppercase tracking-[0.4em] mb-4">
-              Recent Activity
+              Live Feed
             </h2>
-            {profile.recentActivity.length === 0 ? (
-              <p className="text-sm text-white/40">No recorded actions yet.</p>
-            ) : (
-              <ul className="space-y-3">
-                {profile.recentActivity.map((event) => {
-                  const narration = narrateFeedEvent(
-                    event.eventType,
-                    event.metadataPayload,
-                  );
-                  return (
-                    <li
-                      key={event.id}
-                      className="flex items-start gap-3 p-3 rounded-2xl border border-white/5 bg-white/[0.02]"
-                    >
-                      <span className="text-lg">{narration.icon}</span>
-                      <div className="flex-1">
-                        {narration.href ? (
-                          <Link
-                            href={narration.href}
-                            className="text-sm text-white/85 hover:text-white underline decoration-purple-500/30 underline-offset-2"
-                          >
-                            {narration.label}
-                          </Link>
-                        ) : (
-                          <p className="text-sm text-white/85">
-                            {narration.label}
-                          </p>
-                        )}
-                        <p className="text-[10px] uppercase tracking-widest text-white/30 mt-1">
-                          {formatRelativeTime(event.createdAt)}
-                        </p>
-                      </div>
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
+            <LiveAgentFeed 
+              userId={profile.userId} 
+              initialEvents={profile.recentActivity} 
+            />
           </section>
         )}
       </div>

--- a/src/app/api/users/[userId]/feed/route.ts
+++ b/src/app/api/users/[userId]/feed/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { feedDatabase } from "@/services/feedDatabaseService";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  try {
+    const { userId } = await params;
+    const { searchParams } = new URL(request.url);
+    const limit = Math.min(parseInt(searchParams.get("limit") ?? "20", 10), 100);
+    const offset = parseInt(searchParams.get("offset") || "0", 10);
+
+    const events = await feedDatabase.getEventsByActor(userId, limit, offset);
+
+    return NextResponse.json({
+      success: true,
+      events,
+    });
+  } catch (error) {
+    console.error("[GET /api/users/:userId/feed] error:", error);
+    return NextResponse.json(
+      { success: false, message: "Failed to fetch user feed events." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -23,6 +23,9 @@ export default function Navigation() {
             <Link href="/alchm-kitchen" className="text-purple-600 hover:text-purple-900 font-medium">
               Alchm Kitchen
             </Link>
+            <Link href="/feed" className="text-amber-600 hover:text-amber-900 font-medium">
+              Activity Feed
+            </Link>
             <Link href="/profile" className="text-emerald-600 hover:text-emerald-900 font-medium">
               Profile
             </Link>

--- a/src/components/profile/LiveAgentFeed.tsx
+++ b/src/components/profile/LiveAgentFeed.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { motion, AnimatePresence } from "framer-motion";
+import Link from "next/link";
+import React, { useCallback, useEffect, useState } from "react";
+import { narrateFeedEvent } from "@/lib/feed/eventNarration";
+import { agentChatUrl } from "@/lib/agents/agentChatUrl";
+import { ELEMENT_COLORS } from "@/lib/elementColors";
+
+function formatRelativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  const diffSec = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (diffSec < 60) return `${diffSec}s ago`;
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
+  if (diffSec < 86_400) return `${Math.floor(diffSec / 3600)}h ago`;
+  return `${Math.floor(diffSec / 86_400)}d ago`;
+}
+
+interface SignaturePlacement {
+  planet?: string;
+  sign?: string;
+  degree?: number;
+}
+
+interface PlanetarySignature {
+  planetaryHour?: string;
+  planetaryDay?: string;
+  dominantPlanet?: string;
+  dominantSign?: string;
+  dominantElement?: string;
+  sacredStat?: string;
+  natalPositions?: SignaturePlacement[];
+}
+
+function getPlanetarySignature(metadata: any): PlanetarySignature | null {
+  const signature = metadata?.planetarySignature;
+  return signature && typeof signature === "object" ? signature : null;
+}
+
+function formatPlacement(placement: SignaturePlacement): string | null {
+  if (!placement.planet) return null;
+  const degree = typeof placement.degree === "number" ? `${placement.degree.toFixed(1)}°` : "";
+  const sign = placement.sign ? ` ${placement.sign}` : "";
+  return `${placement.planet} ${degree}${sign}`.trim();
+}
+
+interface FeedEvent {
+  id: string;
+  eventType: string;
+  metadataPayload: any;
+  createdAt: string;
+  actorIsAgent?: boolean;
+  actorName?: string;
+  actorSlug?: string;
+  actorImage?: string;
+}
+
+export function LiveAgentFeed({
+  userId,
+  initialEvents,
+}: {
+  userId: string;
+  initialEvents: FeedEvent[];
+}) {
+  const [events, setEvents] = useState<FeedEvent[]>(initialEvents);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(initialEvents.length >= 20); // rough heuristic
+
+  const refreshEvents = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/users/${userId}/feed?limit=20`);
+      if (res.ok) {
+        const data = await res.json();
+        if (data.success) {
+          setEvents(data.events || []);
+          setHasMore(data.events.length >= 20);
+        }
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  }, [userId]);
+
+  const loadMore = async () => {
+    if (loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const res = await fetch(`/api/users/${userId}/feed?limit=20&offset=${events.length}`);
+      if (res.ok) {
+        const data = await res.json();
+        if (data.success && data.events.length > 0) {
+          setEvents((prev) => [...prev, ...data.events]);
+          setHasMore(data.events.length >= 20);
+        } else {
+          setHasMore(false);
+        }
+      }
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  useEffect(() => {
+    // Poll every 30 seconds for live updates
+    const id = window.setInterval(() => {
+      void refreshEvents();
+    }, 30_000);
+    return () => window.clearInterval(id);
+  }, [refreshEvents]);
+
+  if (events.length === 0) {
+    return (
+      <div className="glass-card-premium rounded-3xl p-10 text-center border-white/8">
+        <p className="text-white/40">No recorded actions yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <AnimatePresence>
+        {events.map((event, index) => {
+          const signature = event.actorIsAgent ? getPlanetarySignature(event.metadataPayload) : null;
+          const natalPlacements =
+            signature?.natalPositions?.map(formatPlacement).filter(Boolean).slice(0, 4) || [];
+          const narration = narrateFeedEvent(event.eventType, event.metadataPayload);
+          
+          // Use event-level actorName if available (from API), fallback to static "This user" context
+          const displayName = event.actorName || "They";
+          
+          return (
+            <motion.div
+              key={event.id}
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              className={`glass-card-premium rounded-2xl p-5 transition-all flex items-start gap-4 ${
+                event.actorIsAgent
+                  ? "border-amber-500/20 hover:border-amber-400/35"
+                  : "border-white/8 hover:border-purple-500/20"
+              }`}
+            >
+              <div className="w-10 h-10 rounded-full glass-base flex items-center justify-center text-xl shrink-0 border border-white/5 overflow-hidden">
+                {event.actorImage ? (
+                  /* eslint-disable-next-line @next/next/no-img-element */
+                  <img
+                    src={event.actorImage}
+                    alt="Avatar"
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  narration.icon
+                )}
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm text-white/80">
+                  <span className="font-bold mr-1">{displayName}</span>
+                  {narration.href ? (
+                    <Link
+                      href={narration.href}
+                      className="text-white/80 hover:text-white underline decoration-purple-400/30 underline-offset-2"
+                    >
+                      {narration.action}
+                    </Link>
+                  ) : (
+                    <span className="text-white/60">{narration.action}</span>
+                  )}
+                </p>
+                <div className="flex items-center gap-3 mt-2">
+                  <span className="text-[10px] text-white/30 font-mono">
+                    {formatRelativeTime(event.createdAt)}
+                  </span>
+                  {event.actorIsAgent && event.actorSlug && (
+                    <a
+                      href={agentChatUrl(event.actorSlug)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[10px] text-amber-300/70 hover:text-amber-200 uppercase tracking-wider font-bold"
+                    >
+                      Chat with Agent ✦
+                    </a>
+                  )}
+                </div>
+                {signature && (
+                  <div
+                    className={`mt-3 rounded-xl border px-3 py-2 ${
+                      ELEMENT_COLORS[signature.dominantElement ?? ""] ??
+                      "border-amber-400/15 bg-amber-500/10 text-amber-100/75"
+                    }`}
+                  >
+                    <div className="flex flex-wrap gap-x-3 gap-y-1 text-[10px] font-bold uppercase tracking-wider">
+                      {(signature.planetaryHour || signature.dominantPlanet) && (
+                        <span>Hour {signature.planetaryHour || signature.dominantPlanet}</span>
+                      )}
+                      {signature.planetaryDay && <span>Day {signature.planetaryDay}</span>}
+                      {signature.sacredStat && <span>{signature.sacredStat}</span>}
+                      {signature.dominantElement && <span>{signature.dominantElement}</span>}
+                    </div>
+                    {natalPlacements.length > 0 && (
+                      <p className="mt-1.5 text-xs leading-relaxed opacity-80">
+                        Natal signature: {natalPlacements.join(" · ")}
+                      </p>
+                    )}
+                  </div>
+                )}
+              </div>
+            </motion.div>
+          );
+        })}
+      </AnimatePresence>
+      {hasMore && (
+        <div className="pt-4 flex justify-center">
+          <button
+            onClick={loadMore}
+            disabled={loadingMore}
+            className="px-6 py-2 rounded-full border border-white/10 bg-white/5 hover:bg-white/10 text-white/60 text-xs font-bold uppercase tracking-widest transition-colors disabled:opacity-50"
+          >
+            {loadingMore ? "Loading..." : "Load More Actions"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/profile/LiveAgentFeed.tsx
+++ b/src/components/profile/LiveAgentFeed.tsx
@@ -3,9 +3,9 @@
 import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
 import React, { useCallback, useEffect, useState } from "react";
-import { narrateFeedEvent } from "@/lib/feed/eventNarration";
 import { agentChatUrl } from "@/lib/agents/agentChatUrl";
 import { ELEMENT_COLORS } from "@/lib/elementColors";
+import { narrateFeedEvent } from "@/lib/feed/eventNarration";
 
 function formatRelativeTime(iso: string): string {
   const then = new Date(iso).getTime();
@@ -121,7 +121,7 @@ export function LiveAgentFeed({
   return (
     <div className="space-y-4">
       <AnimatePresence>
-        {events.map((event, index) => {
+        {events.map((event) => {
           const signature = event.actorIsAgent ? getPlanetarySignature(event.metadataPayload) : null;
           const natalPlacements =
             signature?.natalPositions?.map(formatPlacement).filter(Boolean).slice(0, 4) || [];
@@ -212,7 +212,7 @@ export function LiveAgentFeed({
       {hasMore && (
         <div className="pt-4 flex justify-center">
           <button
-            onClick={loadMore}
+            onClick={() => void loadMore()}
             disabled={loadingMore}
             className="px-6 py-2 rounded-full border border-white/10 bg-white/5 hover:bg-white/10 text-white/60 text-xs font-bold uppercase tracking-widest transition-colors disabled:opacity-50"
           >

--- a/src/services/feedDatabaseService.ts
+++ b/src/services/feedDatabaseService.ts
@@ -140,6 +140,46 @@ class FeedDatabaseService {
       return [];
     }
   }
+
+  /**
+   * Fetch paginated feed events for a specific actor
+   */
+  async getEventsByActor(actorId: string, limit: number = 20, offset: number = 0): Promise<FeedEvent[]> {
+    try {
+      const result = await executeQuery(
+        `SELECT f.*, u.is_agent, u.email as actor_email, u.image as actor_image, up.name as actor_name
+         FROM feed_events f
+         JOIN users u ON f.actor_id = u.id
+         LEFT JOIN user_profiles up ON u.id = up.user_id
+         WHERE f.actor_id = $1
+         ORDER BY f.created_at DESC
+         LIMIT $2 OFFSET $3`,
+        [actorId, limit, offset]
+      );
+
+      return result.rows.map(row => {
+        const isAgent = row.is_agent === true;
+        const actorSlug =
+          isAgent && typeof row.actor_email === "string" && row.actor_email.includes("@")
+            ? row.actor_email.split("@")[0]
+            : undefined;
+        return {
+          id: row.id,
+          actorId: row.actor_id,
+          eventType: row.event_type,
+          metadataPayload: row.metadata_payload,
+          createdAt: new Date(row.created_at),
+          actorName: row.actor_name || 'Alchemist',
+          actorImage: row.actor_image,
+          actorIsAgent: isAgent,
+          actorSlug,
+        };
+      });
+    } catch (error) {
+      _logger.error("Failed to fetch actor feed events:", error);
+      return [];
+    }
+  }
 }
 
 export const feedDatabase = new FeedDatabaseService();


### PR DESCRIPTION
Brings the **LiveAgentFeed** feature (originally committed to `main` as `be05aad0`, never merged to master) onto master, lint-clean.

## What
- LiveAgentFeed on profile pages: paginated per-actor feed (`/api/users/[userId]/feed` + `feedDatabaseService.getEventsByActor`), the `LiveAgentFeed` component, profile-page integration, and a nav link.
- **Lint-clean:** removed an unused `narrateFeedEvent` import + dead `formatRelativeTime`, fixed `@/lib/*` import order, dropped an unused `index` map arg, and void-wrapped an async `onClick` — the 6 warnings that were the only thing keeping it off master.

## Why now
`main` carried this feature unmerged (1 ahead) while master moved 14 commits ahead. Landing it makes master complete and lets `main` be re-synced to master (ending the stale divergence).

## Verified
typecheck ✓ · lint ✓ (0 warnings) · build ✓. `be05aad0`'s original CI was green on Verify/Build/Test — its only red was the redundant Vercel deploy job, since removed in #484. `feedDatabaseService.ts` auto-merged cleanly with #480's `transit_attunement` edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
