### PR TITLE
feat(agents): clickable transits open a planetary-degree group chat

### DIFF
--- a/src/app/api/agents/group-chat/route.ts
+++ b/src/app/api/agents/group-chat/route.ts
@@ -1,0 +1,147 @@
+/**
+ * Transit → group-chat session creator (server proxy to Planetary Agents).
+ *
+ * POST /api/agents/group-chat
+ *
+ * Body:
+ *   {
+ *     agents: Array<{ id: string; planet?; sign?; degree?; name? }>,  // ≥1, capped at 6
+ *     transit?: { aspect?: string; key?: string; label?: string },
+ *     source?: string                                                  // e.g. "aspects-display"
+ *   }
+ *
+ * Behaviour (matches the "create-then-redirect" decision):
+ *   - 1 agent  → return the existing single-agent deep link (works today; no PA call).
+ *   - ≥2 agents → POST to PA `${agentsUi}/api/internal/group-chat` with
+ *                 `X-Sync-Secret: INTERNAL_API_SECRET` (mirrors the admin agent-sync
+ *                 proxy), expecting `{ sessionId, url }` back, and return that url.
+ *   - Any failure (PA route not yet shipped, unreachable, unconfigured) degrades
+ *     gracefully to the primary agent's single chat so the click never dead-ends.
+ *
+ * The browser always just navigates to the returned `url` — all fallback logic
+ * lives here, server-side. `userId` is best-effort attribution only (the call is
+ * secret-gated server-to-server, so it is not a trust boundary).
+ *
+ * @file src/app/api/agents/group-chat/route.ts
+ */
+
+import { NextResponse } from "next/server";
+import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { rateLimit } from "@/lib/rateLimit";
+import { getServiceUrlSafe } from "@/lib/serviceUrls";
+import { createLogger } from "@/utils/logger";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const logger = createLogger("TransitGroupChatProxy");
+
+const RATE_LIMIT = { window: 60_000, max: 20, bucket: "agents-group-chat" };
+const PA_TIMEOUT_MS = 6000;
+const MAX_AGENTS = 6;
+
+interface Participant {
+  id: string;
+  planet?: string;
+  sign?: string;
+  degree?: number;
+  name?: string;
+}
+
+interface RequestBody {
+  agents?: Participant[];
+  transit?: { aspect?: string; key?: string; label?: string } | null;
+  source?: string;
+}
+
+/** Deep link a single agent's chat — used for solo councils and as the failure fallback. */
+function singleChatUrl(agentId: string): string {
+  return `${getServiceUrlSafe("agentsUi")}/gallery/chat/${encodeURIComponent(agentId)}`;
+}
+
+export async function POST(request: NextRequest) {
+  const rl = await rateLimit(request, RATE_LIMIT);
+  if (!rl.allowed) return rl.response!;
+
+  let body: RequestBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  // Validate + de-dupe + cap.
+  const seen = new Set<string>();
+  const agents = (Array.isArray(body.agents) ? body.agents : [])
+    .filter((a): a is Participant => !!a && typeof a.id === "string" && a.id.length > 0)
+    .filter((a) => (seen.has(a.id) ? false : (seen.add(a.id), true)))
+    .slice(0, MAX_AGENTS);
+
+  if (agents.length === 0) {
+    return NextResponse.json({ error: "No valid agents provided" }, { status: 400 });
+  }
+
+  // Solo council → the existing single-agent chat (resolves today against the
+  // seeded planetary-degree agents; no PA group endpoint needed).
+  if (agents.length === 1) {
+    return NextResponse.json({ url: singleChatUrl(agents[0].id), sessionId: null, degraded: false, solo: true });
+  }
+
+  const secret = process.env.INTERNAL_API_SECRET;
+  const paBase = getServiceUrlSafe("agentsUi");
+  const fallback = singleChatUrl(agents[0].id);
+
+  if (!secret) {
+    logger.warn("INTERNAL_API_SECRET unset — degrading to single-agent fallback");
+    return NextResponse.json({ url: fallback, degraded: true, reason: "secret-unconfigured" });
+  }
+
+  // Best-effort attribution; never blocks the request.
+  let userId: string | null = null;
+  try {
+    userId = await getUserIdFromRequest(request);
+  } catch {
+    userId = null;
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PA_TIMEOUT_MS);
+  try {
+    const resp = await fetch(`${paBase}/api/internal/group-chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-Sync-Secret": secret },
+      body: JSON.stringify({
+        agentIds: agents.map((a) => a.id),
+        agents,
+        transit: body.transit ?? null,
+        origin: "alchm.kitchen",
+        source: body.source ?? "transit-click",
+        userId,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => "");
+      logger.warn("PA group-chat create failed; using fallback", {
+        status: resp.status,
+        body: text.slice(0, 200),
+      });
+      return NextResponse.json({ url: fallback, degraded: true, reason: `pa-${resp.status}` });
+    }
+
+    const data = (await resp.json().catch(() => ({}))) as { sessionId?: string; url?: string };
+    const url =
+      data.url ??
+      (data.sessionId ? `${paBase}/gallery/group/${encodeURIComponent(data.sessionId)}` : fallback);
+
+    return NextResponse.json({ url, sessionId: data.sessionId ?? null, degraded: false });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn("PA group-chat create errored; using fallback", { error: msg });
+    return NextResponse.json({ url: fallback, degraded: true, reason: "pa-unreachable" });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/app/api/alchm-quantities/aspects/route.ts
+++ b/src/app/api/alchm-quantities/aspects/route.ts
@@ -54,6 +54,16 @@ export interface AspectEntry {
   state: "applying" | "separating" | "stationary";
   /** Source of velocity data, for downstream confidence weighting. */
   velocitySource: "ephemeris" | "average-fallback";
+  // Per-planet placement — lets clients build the canonical planetary-degree
+  // agent ids (`planetary-{planet}-{sign}-{degree}`) for the transit group chat.
+  /** Lowercase sign of planet1 (e.g. "aries"). */
+  sign1: string;
+  /** Integer degree of planet1 within its sign (0–29). */
+  degree1: number;
+  /** Lowercase sign of planet2. */
+  sign2: string;
+  /** Integer degree of planet2 within its sign (0–29). */
+  degree2: number;
 }
 
 const RATE_LIMIT = { window: 60_000, max: 30, bucket: "alchm-quantities-aspects" };
@@ -188,12 +198,19 @@ export async function GET(request: Request) {
         influence = "neutral";
       }
 
+      const pos1 = positions[aspect.planet1] as { sign?: string; degree?: number } | undefined;
+      const pos2 = positions[aspect.planet2] as { sign?: string; degree?: number } | undefined;
+
       result.push({
         planet1: aspect.planet1,
         planet2: aspect.planet2,
         type: aspect.type,
         aspectAngle,
         orbDegrees: parseFloat(currentOrb.toFixed(3)),
+        sign1: String(pos1?.sign ?? "").toLowerCase(),
+        degree1: Math.floor(pos1?.degree ?? 0),
+        sign2: String(pos2?.sign ?? "").toLowerCase(),
+        degree2: Math.floor(pos2?.degree ?? 0),
         strength: parseFloat(strength.toFixed(4)),
         applying,
         daysToExact: parseFloat(daysToExact.toFixed(2)),

--- a/src/components/PlanetaryAspectsDisplay.tsx
+++ b/src/components/PlanetaryAspectsDisplay.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import React, { useState, useEffect, useRef } from "react";
-import { FaArrowRight, FaArrowLeft, FaSyncAlt } from "react-icons/fa";
+import { FaArrowRight, FaArrowLeft, FaSyncAlt, FaComments } from "react-icons/fa";
+import { useTransitGroupChat } from "@/hooks/useTransitGroupChat";
+import { groupForAspect } from "@/lib/agents/transitAgents";
 import { reportQuestEvent } from "@/lib/questReporter";
 
 interface AspectEntry {
@@ -14,6 +16,11 @@ interface AspectEntry {
   applying: boolean;
   daysToExact: number;
   influence: "harmonious" | "challenging" | "neutral";
+  // Per-planet placement (from the aspects API) for building degree-agent ids.
+  sign1?: string;
+  degree1?: number;
+  sign2?: string;
+  degree2?: number;
 }
 
 interface AspectsData {
@@ -83,7 +90,15 @@ function StrengthBar({ strength, applying, type }: { strength: number; applying:
 
 // ── Single aspect card ────────────────────────────────────────────────────────
 
-function AspectCard({ aspect }: { aspect: AspectEntry }) {
+function AspectCard({
+  aspect,
+  onOpen,
+  pending,
+}: {
+  aspect: AspectEntry;
+  onOpen: (a: AspectEntry) => void;
+  pending: boolean;
+}) {
   const style = aspectStyle(aspect.type);
   const glyph1 = PLANET_GLYPHS[aspect.planet1] ?? "🪐";
   const glyph2 = PLANET_GLYPHS[aspect.planet2] ?? "🪐";
@@ -91,7 +106,13 @@ function AspectCard({ aspect }: { aspect: AspectEntry }) {
   const name = ASPECT_NAMES[aspect.type] ?? aspect.type;
 
   return (
-    <div className={`p-3 rounded-lg border ${style.border} ${style.bg}`}>
+    <button
+      type="button"
+      onClick={() => onOpen(aspect)}
+      disabled={pending}
+      aria-label={`Convene a planetary council chat for ${aspect.planet1} ${name} ${aspect.planet2}`}
+      className={`group block w-full text-left p-3 rounded-lg border ${style.border} ${style.bg} cursor-pointer transition-all hover:border-indigo-400/60 hover:ring-1 hover:ring-indigo-400/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/60 disabled:opacity-60 disabled:cursor-wait`}
+    >
       {/* Header: planets + aspect */}
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-1.5 text-sm font-semibold text-indigo-200 min-w-0">
@@ -138,7 +159,13 @@ function AspectCard({ aspect }: { aspect: AspectEntry }) {
           )}
         </div>
       </div>
-    </div>
+
+      {/* Council affordance */}
+      <div className="mt-2 flex items-center justify-center gap-1.5 border-t border-white/5 pt-1.5 text-[10px] font-semibold uppercase tracking-wide text-indigo-300/70 group-hover:text-indigo-200">
+        <FaComments className="h-3 w-3" />
+        <span>{pending ? "Opening council…" : "Convene council"}</span>
+      </div>
+    </button>
   );
 }
 
@@ -150,6 +177,16 @@ export default function PlanetaryAspectsDisplay() {
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<"all" | "applying" | "separating">("all");
   const questFired = useRef(false);
+  const { open, pending } = useTransitGroupChat();
+
+  const openCouncil = (a: AspectEntry) => {
+    const g = groupForAspect(
+      { planet: a.planet1, sign: a.sign1 ?? "", degree: a.degree1 ?? 0 },
+      { planet: a.planet2, sign: a.sign2 ?? "", degree: a.degree2 ?? 0 },
+      a.type,
+    );
+    if (g) void open(g.participants, g.descriptor, "aspects-display");
+  };
 
   const fetchData = async () => {
     try {
@@ -247,9 +284,18 @@ export default function PlanetaryAspectsDisplay() {
       {/* Aspect cards */}
       <div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
         {visible.map((a, i) => (
-          <AspectCard key={`${a.planet1}-${a.planet2}-${i}`} aspect={a} />
+          <AspectCard
+            key={`${a.planet1}-${a.planet2}-${i}`}
+            aspect={a}
+            onOpen={openCouncil}
+            pending={pending}
+          />
         ))}
       </div>
+
+      <p className="text-xs text-indigo-300/70 flex items-center gap-1.5">
+        <FaComments className="h-3 w-3 shrink-0" /> Tap any aspect to convene a council chat between its two planetary-degree agents.
+      </p>
 
       <p className="text-xs text-gray-500">
         Updated: {new Date(data.timestamp).toLocaleTimeString()} ·

--- a/src/components/dashboard/CurrentTransitAnalysis.tsx
+++ b/src/components/dashboard/CurrentTransitAnalysis.tsx
@@ -2,6 +2,8 @@
 
 import React, { useEffect, useState, useMemo } from 'react';
 import { useAlchemical } from '@/contexts/AlchemicalContext/hooks';
+import { useActiveTransits } from '@/hooks/useActiveTransits';
+import { useTransitGroupChat } from '@/hooks/useTransitGroupChat';
 import type { NatalChart } from '@/types/natalChart';
 import { extractPlanetaryPositions } from '@/utils/astrology/chartDataUtils';
 
@@ -126,6 +128,13 @@ function generateTransitMessage(planet: string, natalSign: string, transitSign: 
 export const CurrentTransitAnalysis: React.FC<CurrentTransitAnalysisProps> = ({ natalChart }) => {
   const { planetaryPositions: currentPositionsRaw, state } = useAlchemical();
   const [transitPositions, setTransitPositions] = useState<Record<string, TransitPosition>>({});
+  const { groupForPlanet } = useActiveTransits();
+  const { open, pending } = useTransitGroupChat();
+
+  const openPlanetCouncil = (planet: string, pos: TransitPosition) => {
+    const g = groupForPlanet(planet, { planet, sign: pos.sign, degree: pos.degree });
+    if (g) void open(g.participants, g.descriptor, 'current-transit-analysis');
+  };
 
   useEffect(() => {
     if (!currentPositionsRaw || Object.keys(currentPositionsRaw).length === 0) return;
@@ -309,6 +318,7 @@ export const CurrentTransitAnalysis: React.FC<CurrentTransitAnalysisProps> = ({ 
           </div>
 
           {/* Planet positions grid */}
+          <p className="text-[10px] text-indigo-300/60 mb-1.5">Tap a planet to convene its current transit as a council</p>
           <div className="grid grid-cols-5 sm:grid-cols-10 gap-1.5">
             {PLANETS.map((planet) => {
               const pos = transitPositions[planet];
@@ -316,18 +326,22 @@ export const CurrentTransitAnalysis: React.FC<CurrentTransitAnalysisProps> = ({ 
               const el = SIGN_ELEMENTS[pos.sign] || 'Fire';
               const color = ELEMENT_COLORS[el] || '#a78bfa';
               return (
-                <div
+                <button
+                  type="button"
                   key={planet}
-                  className="bg-white/[0.03] rounded-xl p-2 border border-white/5 text-center"
+                  onClick={() => openPlanetCouncil(planet, pos)}
+                  disabled={pending}
+                  aria-label={`Convene a planetary council chat for transiting ${planet}`}
+                  className="group bg-white/[0.03] rounded-xl p-2 border border-white/5 text-center cursor-pointer transition-all hover:border-indigo-400/40 hover:bg-indigo-500/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/50 disabled:opacity-60 disabled:cursor-wait"
                 >
                   <div className="text-sm" style={{ color }} title={planet}>{PLANET_SYMBOLS[planet]}</div>
                   <div className="text-[9px] text-white/30 font-medium uppercase mt-0.5">{planet.slice(0, 3)}</div>
                   <div className="text-[10px] text-white/60 font-semibold capitalize mt-0.5 whitespace-nowrap">
-                    <span className="mr-0.5" style={{ color }}>{SIGN_SYMBOLS[pos.sign]}</span> 
+                    <span className="mr-0.5" style={{ color }}>{SIGN_SYMBOLS[pos.sign]}</span>
                     {pos.degree}&deg;{pos.minute ? `${pos.minute}'` : ''}
                   </div>
                   {pos.isRetrograde && <div className="text-[8px] text-red-400 font-bold mt-0.5">Rx</div>}
-                </div>
+                </button>
               );
             })}
           </div>

--- a/src/components/dashboard/NatalTransitChart.tsx
+++ b/src/components/dashboard/NatalTransitChart.tsx
@@ -2,6 +2,8 @@
 
 import React, { useEffect, useState } from 'react';
 import { useAlchemical } from '@/contexts/AlchemicalContext/hooks';
+import { useActiveTransits } from '@/hooks/useActiveTransits';
+import { useTransitGroupChat } from '@/hooks/useTransitGroupChat';
 import type { NatalChart, Planet, ZodiacSignType } from '@/types/natalChart';
 import { extractPlanetaryPositions } from '@/utils/astrology/chartDataUtils';
 
@@ -50,6 +52,13 @@ interface TransitData {
 export const NatalTransitChart: React.FC<NatalTransitChartProps> = ({ natalChart }) => {
   const { planetaryPositions: currentPositionsRaw } = useAlchemical();
   const [transitData, setTransitData] = useState<Record<string, TransitData>>({});
+  const { groupForPlanet } = useActiveTransits();
+  const { open } = useTransitGroupChat();
+
+  const openTransitPlanetCouncil = (pos: { planet: string; sign: string; degree: number }) => {
+    const g = groupForPlanet(pos.planet, { planet: pos.planet, sign: pos.sign, degree: pos.degree });
+    if (g) void open(g.participants, g.descriptor, 'natal-transit-chart');
+  };
 
   useEffect(() => {
     if (!currentPositionsRaw || Object.keys(currentPositionsRaw).length === 0) return;
@@ -217,12 +226,27 @@ export const NatalTransitChart: React.FC<NatalTransitChartProps> = ({ natalChart
             );
           })}
 
-          {/* Transit planet markers (inner ring) */}
+          {/* Transit planet markers (inner ring) — click to convene that planet's council */}
           {spreadTransit.map((pos) => {
             const angle = toSvgAngle(pos.absAngle);
             const pt = polarToXY(angle, transitR);
             return (
-              <g key={`transit-${pos.planet}`}>
+              <g
+                key={`transit-${pos.planet}`}
+                role="button"
+                tabIndex={0}
+                aria-label={`Convene a planetary council chat for transiting ${pos.planet}`}
+                style={{ cursor: 'pointer' }}
+                className="transition-opacity hover:opacity-80"
+                onClick={() => openTransitPlanetCouncil({ planet: pos.planet, sign: pos.sign, degree: pos.degree })}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    openTransitPlanetCouncil({ planet: pos.planet, sign: pos.sign, degree: pos.degree });
+                  }
+                }}
+              >
+                <title>{`Convene ${pos.planet}'s transit council`}</title>
                 <circle cx={pt.x} cy={pt.y} r="13" fill="rgba(249,115,22,0.08)" />
                 <circle cx={pt.x} cy={pt.y} r="11" fill="rgba(249,115,22,0.15)" stroke="rgba(249,115,22,0.5)" strokeWidth="1" />
                 <text

--- a/src/components/dashboard/UserDashboard.tsx
+++ b/src/components/dashboard/UserDashboard.tsx
@@ -13,6 +13,8 @@ import { ElementalWheel } from '@/components/profile/ElementalWheel';
 import { ProfileHeroCard } from '@/components/profile/ProfileHeroCard';
 import { TierUpgradePrompt } from '@/components/profile/TierUpgradePrompt';
 import { useAlchemical } from '@/contexts/AlchemicalContext/hooks';
+import { useActiveTransits } from '@/hooks/useActiveTransits';
+import { useTransitGroupChat } from '@/hooks/useTransitGroupChat';
 import { reportQuestEvent } from '@/lib/questReporter';
 import type { UserTier } from '@/lib/tiers';
 import type { NatalChart } from '@/types/natalChart';
@@ -71,6 +73,8 @@ interface UserDashboardProps {
 
 function LiveTransitBar({ natalChart }: { natalChart: NatalChart }) {
   const { planetaryPositions: currentPositionsRaw } = useAlchemical();
+  const { groupForPlanet } = useActiveTransits();
+  const { open, pending } = useTransitGroupChat();
   const [now, setNow] = useState(new Date());
 
   useEffect(() => {
@@ -86,6 +90,12 @@ function LiveTransitBar({ natalChart }: { natalChart: NatalChart }) {
 
   const sunDeg = sunData?.degree != null ? `${Math.floor(sunData.degree % 30)}\u00B0` : '';
   const moonDeg = moonData?.degree != null ? `${Math.floor(moonData.degree % 30)}\u00B0` : '';
+
+  const openLuminaryCouncil = (planet: 'Sun' | 'Moon', sign: string, degree: number) => {
+    if (!sign) return;
+    const g = groupForPlanet(planet, { planet, sign, degree });
+    if (g) void open(g.participants, g.descriptor, 'live-transit-bar');
+  };
 
   return (
     <div className="glass-card-premium rounded-full px-8 py-4 border-white/10 shadow-3xl relative overflow-hidden group">
@@ -105,7 +115,13 @@ function LiveTransitBar({ natalChart }: { natalChart: NatalChart }) {
         </div>
         <div className="flex items-center gap-8 text-[11px] font-bold uppercase">
           {transitSunSign && (
-            <div className="flex items-center gap-2 group/sun">
+            <button
+              type="button"
+              onClick={() => openLuminaryCouncil('Sun', transitSunSign, sunData?.degree ?? 0)}
+              disabled={pending}
+              aria-label={`Convene a planetary council chat for the Sun in ${transitSunSign}`}
+              className="flex items-center gap-2 group/sun text-left cursor-pointer rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/50 disabled:cursor-wait"
+            >
               <span className="text-amber-400 text-xl group-hover/sun:scale-125 transition-transform duration-500 drop-shadow-[0_0_10px_rgba(251,191,36,0.5)]">
                 {SIGN_SYMBOLS[transitSunSign.toLowerCase()] || '\u2609'}
               </span>
@@ -113,11 +129,17 @@ function LiveTransitBar({ natalChart }: { natalChart: NatalChart }) {
                 <span className="text-white/70 group-hover/sun:text-white transition-colors tracking-[0.15em]">{transitSunSign}</span>
                 {sunDeg && <span className="text-white/20 font-mono text-[9px] tracking-tighter">{sunDeg} Solar Transit</span>}
               </div>
-            </div>
+            </button>
           )}
           <div className="w-px h-6 bg-white/5" />
           {transitMoonSign && (
-            <div className="flex items-center gap-2 group/moon">
+            <button
+              type="button"
+              onClick={() => openLuminaryCouncil('Moon', transitMoonSign, moonData?.degree ?? 0)}
+              disabled={pending}
+              aria-label={`Convene a planetary council chat for the Moon in ${transitMoonSign}`}
+              className="flex items-center gap-2 group/moon text-left cursor-pointer rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/50 disabled:cursor-wait"
+            >
               <span className="text-blue-300 text-xl group-hover/moon:scale-125 transition-transform duration-500 drop-shadow-[0_0_10px_rgba(147,197,253,0.5)]">
                 {SIGN_SYMBOLS[transitMoonSign.toLowerCase()] || '\u263D'}
               </span>
@@ -125,7 +147,7 @@ function LiveTransitBar({ natalChart }: { natalChart: NatalChart }) {
                 <span className="text-white/70 group-hover/moon:text-white transition-colors tracking-[0.15em]">{transitMoonSign}</span>
                 {moonDeg && <span className="text-white/20 font-mono text-[9px] tracking-tighter">{moonDeg} Lunar Flow</span>}
               </div>
-            </div>
+            </button>
           )}
         </div>
       </div>

--- a/src/hooks/useActiveTransits.ts
+++ b/src/hooks/useActiveTransits.ts
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * Shared, page-cached view of the currently-active major aspects, used to turn a
+ * click anywhere a transit is shown into the set of degree agents "involved".
+ *
+ * - Aspect surfaces (the Active Aspects list) already hold full aspect records and
+ *   call `groupForAspect` directly; they don't need this hook.
+ * - Position-only surfaces (planet tiles, the natal/transit wheel, the Sun/Moon
+ *   bar) show a single transiting planet. `groupForPlanet` maps that planet to the
+ *   transit it is most tightly involved in (smallest orb → exactly the two
+ *   transiting planets), and degrades to a solo degree-agent council when the
+ *   planet has no aspect in orb.
+ *
+ * Backed by `/api/alchm-quantities/aspects` (now carrying each planet's sign +
+ * degree). A module-level cache + in-flight de-dupe means every surface on a page
+ * shares one fetch.
+ */
+
+import { useEffect, useState } from "react";
+import { groupForAspect, type TransitBody, type TransitGroup } from "@/lib/agents/transitAgents";
+
+interface RawAspect {
+  planet1: string;
+  planet2: string;
+  type: string;
+  orbDegrees: number;
+  sign1?: string;
+  degree1?: number;
+  sign2?: string;
+  degree2?: number;
+}
+
+const TTL_MS = 120_000;
+let cache: { at: number; aspects: RawAspect[] } | null = null;
+let inflight: Promise<RawAspect[]> | null = null;
+
+async function loadAspects(): Promise<RawAspect[]> {
+  if (cache && Date.now() - cache.at < TTL_MS) return cache.aspects;
+  if (inflight) return inflight;
+  inflight = fetch("/api/alchm-quantities/aspects")
+    .then((r) => (r.ok ? r.json() : { aspects: [] }))
+    .then((j) => {
+      const aspects: RawAspect[] = Array.isArray(j?.aspects) ? j.aspects : [];
+      cache = { at: Date.now(), aspects };
+      return aspects;
+    })
+    .catch(() => [] as RawAspect[])
+    .finally(() => {
+      inflight = null;
+    });
+  return inflight;
+}
+
+export function useActiveTransits() {
+  const [aspects, setAspects] = useState<RawAspect[]>(cache?.aspects ?? []);
+
+  useEffect(() => {
+    let alive = true;
+    void loadAspects().then((a) => {
+      if (alive) setAspects(a);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  /** Group for an explicit aspect record (both transiting planets). */
+  const groupForRecord = (a: RawAspect): TransitGroup | null =>
+    groupForAspect(
+      { planet: a.planet1, sign: a.sign1 ?? "", degree: a.degree1 ?? 0 },
+      { planet: a.planet2, sign: a.sign2 ?? "", degree: a.degree2 ?? 0 },
+      a.type,
+    );
+
+  /**
+   * Group for a single transiting planet: its tightest active aspect (→ two
+   * planets), falling back to a solo council from `body` when nothing is in orb.
+   */
+  const groupForPlanet = (planet: string, body?: TransitBody): TransitGroup | null => {
+    const pl = planet.toLowerCase();
+    const tightest = aspects
+      .filter((a) => a.planet1.toLowerCase() === pl || a.planet2.toLowerCase() === pl)
+      .sort((x, y) => x.orbDegrees - y.orbDegrees)[0];
+    if (tightest) return groupForRecord(tightest);
+    return body ? groupForAspect(body, body) : null;
+  };
+
+  return { aspects, groupForRecord, groupForPlanet };
+}

--- a/src/hooks/useTransitGroupChat.ts
+++ b/src/hooks/useTransitGroupChat.ts
@@ -1,0 +1,80 @@
+"use client";
+
+/**
+ * Opens a group chat between the planetary-degree agents involved in a transit.
+ *
+ * Flow (matches the "deep-link to PA, new tab" + "create-then-redirect" decision):
+ *   1. Open a blank tab SYNCHRONOUSLY inside the click handler — this preserves the
+ *      user-gesture so the browser does not treat the post-await navigation as a
+ *      blocked popup. We keep the window handle (no `noopener`) so we can point it
+ *      at the session URL once it resolves.
+ *   2. POST the participants to `/api/agents/group-chat`, which creates the PA
+ *      session and returns the chat `url` (or a graceful single-agent fallback).
+ *   3. Navigate the pre-opened tab to that url. If the popup was blocked we fall
+ *      back to same-tab navigation.
+ */
+
+import { track } from "@vercel/analytics";
+import { useCallback, useState } from "react";
+import type { TransitParticipant, TransitDescriptor } from "@/lib/agents/transitAgents";
+
+export function useTransitGroupChat() {
+  const [pending, setPending] = useState(false);
+
+  const open = useCallback(
+    async (
+      participants: TransitParticipant[],
+      descriptor: TransitDescriptor,
+      source = "transit-click",
+    ) => {
+      if (pending || !participants.length || typeof window === "undefined") return;
+
+      // 1. Synchronous tab — keeps the gesture alive for the async navigation.
+      const tab = window.open("about:blank", "_blank");
+      setPending(true);
+
+      try {
+        track("transit_group_chat_open", {
+          transit: descriptor.key,
+          aspect: descriptor.aspect ?? "none",
+          agents: participants.length,
+          source,
+        });
+      } catch {
+        /* analytics is best-effort */
+      }
+
+      try {
+        const res = await fetch("/api/agents/group-chat", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ agents: participants, transit: descriptor, source }),
+        });
+        const data = (await res.json().catch(() => ({}))) as { url?: string };
+
+        if (data.url) {
+          if (tab) {
+            try {
+              tab.opener = null;
+            } catch {
+              /* cross-origin opener clear may throw — non-fatal */
+            }
+            tab.location.href = data.url;
+          } else {
+            // Popup blocked → navigate the current tab instead.
+            window.location.href = data.url;
+          }
+        } else if (tab) {
+          tab.close();
+        }
+      } catch {
+        if (tab) tab.close();
+      } finally {
+        setPending(false);
+      }
+    },
+    [pending],
+  );
+
+  return { open, pending };
+}

--- a/src/lib/agents/transitAgents.ts
+++ b/src/lib/agents/transitAgents.ts
@@ -1,0 +1,142 @@
+/**
+ * Resolve the planetary-degree agents "involved in" a transit, and build the
+ * canonical Planetary-Agents (PA) agent IDs the planetary_agents project expects.
+ *
+ * A "transit" here is an aspect between two transiting planets. Per product
+ * decision the council = exactly those two planets' degree agents. A single
+ * transiting planet (clicked on a position-only surface) resolves to the transit
+ * it is most tightly involved in (see `useActiveTransits`), and degrades to a
+ * solo degree-agent chat when nothing is in orb.
+ *
+ * Canonical ID format — verified identical in BOTH repos:
+ *   - PA seed: `backend/seed_3600_planetary_agents.py`
+ *       agent_id = f"planetary-{planet.lower()}-{sign.lower()}-{degree}"
+ *   - WTEN:    `src/lib/unified-agent-factory.ts`
+ *       `planetary-${planet.toLowerCase()}-${sign.toLowerCase()}-${degree}`
+ *   →  planetary-{planet}-{sign}-{degree}   (all lowercase, degree 0-29 within sign)
+ *
+ * PA pre-seeds all 3600 (10 planets × 12 signs × 30°), so a canonical ID resolves
+ * to a real, addressable agent. The PA `/api/chat` parser also accepts the
+ * prefixless form, but we always emit the seeded canonical form.
+ *
+ * This module is pure (no server/client-only imports) so it can be shared by the
+ * proxy route, the hooks, and the surface components.
+ */
+
+/** The 10 planets that have seeded degree agents (Sun..Pluto), lowercase. */
+export const SEEDED_PLANETS = [
+  "sun", "moon", "mercury", "venus", "mars",
+  "jupiter", "saturn", "uranus", "neptune", "pluto",
+] as const;
+
+const SEEDED = new Set<string>(SEEDED_PLANETS);
+
+export interface TransitBody {
+  /** Planet name, any case (e.g. "Mars"). */
+  planet: string;
+  /** Zodiac sign, any case (e.g. "Aries"). */
+  sign: string;
+  /** Degree WITHIN the sign (0–29.99…); fractional is fine — it is floored. */
+  degree: number;
+}
+
+export interface TransitParticipant {
+  /** Canonical PA agent id: `planetary-{planet}-{sign}-{degree}`. */
+  id: string;
+  /** Title-cased display planet (e.g. "Mars"). */
+  planet: string;
+  /** Lowercase sign (e.g. "aries"). */
+  sign: string;
+  /** Integer degree within the sign (0–29). */
+  degree: number;
+  /** Display name, mirrors the PA seed: "Mars in Aries 15 Degree". */
+  name: string;
+}
+
+export interface TransitDescriptor {
+  /** Aspect type — "square" | "trine" | … . Omitted for solo clicks. */
+  aspect?: string;
+  /** Stable key for analytics + PA idempotency, e.g. "mars-aries-15--square--saturn-capricorn-15". */
+  key: string;
+  /** Human label, e.g. "Mars square Saturn" (or just "Mars" for a solo council). */
+  label: string;
+}
+
+export interface TransitGroup {
+  participants: TransitParticipant[];
+  descriptor: TransitDescriptor;
+}
+
+function titleCase(s: string): string {
+  const t = String(s ?? "").trim();
+  return t ? t.charAt(0).toUpperCase() + t.slice(1).toLowerCase() : t;
+}
+
+/** Normalize a within-sign degree into an integer 0–29. */
+export function normalizeDegree(degree: number): number {
+  const d = Math.floor(Number.isFinite(degree) ? degree : 0);
+  return ((d % 30) + 30) % 30;
+}
+
+/**
+ * Build the canonical PA degree-agent id for a transiting body.
+ * Returns null for bodies without a seeded degree agent (Nodes, Asc/MC, …) or
+ * when the sign is missing.
+ */
+export function degreeAgentId(planet: string, sign: string, degree: number): string | null {
+  const p = String(planet ?? "").trim().toLowerCase();
+  const s = String(sign ?? "").trim().toLowerCase();
+  if (!SEEDED.has(p) || !s) return null;
+  return `planetary-${p}-${s}-${normalizeDegree(degree)}`;
+}
+
+/** Turn a transiting body into a participant, or null if it has no seeded agent. */
+export function toParticipant(body: TransitBody): TransitParticipant | null {
+  const id = degreeAgentId(body.planet, body.sign, body.degree);
+  if (!id) return null;
+  const planet = titleCase(body.planet);
+  const sign = String(body.sign).trim().toLowerCase();
+  const degree = normalizeDegree(body.degree);
+  return { id, planet, sign, degree, name: `${planet} in ${titleCase(sign)} ${degree} Degree` };
+}
+
+/**
+ * Resolve the participants + descriptor for an aspect between two transiting
+ * bodies. Pass the same body twice for a solo council (it de-dupes to one).
+ * Returns null when neither body has a seeded degree agent.
+ */
+export function groupForAspect(a: TransitBody, b: TransitBody, aspect?: string): TransitGroup | null {
+  const participants: TransitParticipant[] = [];
+  const seen = new Set<string>();
+  for (const body of [a, b]) {
+    const p = toParticipant(body);
+    if (p && !seen.has(p.id)) {
+      seen.add(p.id);
+      participants.push(p);
+    }
+  }
+  if (participants.length === 0) return null;
+
+  const idPart = participants.map((p) => `${p.planet.toLowerCase()}-${p.sign}-${p.degree}`);
+  const asp = aspect ? String(aspect).toLowerCase() : undefined;
+
+  if (participants.length === 1 || !asp) {
+    return {
+      participants,
+      descriptor: {
+        aspect: asp,
+        key: idPart.join("--"),
+        label: participants.map((p) => p.planet).join(" · "),
+      },
+    };
+  }
+
+  return {
+    participants,
+    descriptor: {
+      aspect: asp,
+      key: `${idPart[0]}--${asp}--${idPart[1]}`,
+      label: `${participants[0].planet} ${asp} ${participants[1].planet}`,
+    },
+  };
+}


### PR DESCRIPTION
## What & why
Clicking any displayed transit on alchm.kitchen now opens a **group chat between the two planetary-degree agents** involved in that transit — deep-linked to the Planetary Agents UI in a new tab.

## Decisions (confirmed)
- Surfaces: **all four** transit surfaces clickable
- Participants: **the two transiting planets** only
- Open mode: **deep-link to PA, new tab**
- Session: **create-then-redirect** (POST agents → sessionId/url → open)
- Access: **public** (matches existing single-agent chat links in /feed, /profile)

## alchm.kitchen changes
- `src/lib/agents/transitAgents.ts` — canonical ids `planetary-{planet}-{sign}-{degree}` (matches PA seed + `unified-agent-factory.ts`) + participant resolver
- `src/app/api/agents/group-chat/route.ts` — server proxy → PA `POST /api/internal/group-chat` (`X-Sync-Secret`). **solo → single chat, group → PA, any failure → graceful single-agent fallback**
- `src/hooks/useTransitGroupChat.ts` (popup-safe new-tab open) + `src/hooks/useActiveTransits.ts` (single planet → tightest active aspect; solo fallback)
- extended `/api/alchm-quantities/aspects` with per-planet sign+degree
- wired surfaces: PlanetaryAspectsDisplay, dashboard/CurrentTransitAnalysis (planet tiles), dashboard/NatalTransitChart (transit markers), dashboard/UserDashboard LiveTransitBar (Sun/Moon)

## ⚠️ Depends on PA (degrades gracefully until then)
PA must ship `POST /api/internal/group-chat` (returns `{sessionId, url}`) + a `/gallery/group/[id]` page. **Until then, group clicks fall back to single-agent chat — no breakage.** Full contract + acceptance criteria live in `NEXT_SESSION_PROMPT_PA_TRANSIT_GROUP_CHAT.md` (also copied into the PA repo).

Contract this PR calls:
```
POST {agentsUi}/api/internal/group-chat   header: X-Sync-Secret: INTERNAL_API_SECRET
body  { agentIds[], agents[], transit, origin, source, userId }  →  { sessionId, url }
```

## Verification
- `bun run verify` (typecheck + lint): **0 errors / 0 warnings**
- `bun run build`: **passes** (new route compiles)
- Browser `/quantities?tab=aspects`: aspect cards render a "💬 Convene council" action; proxy returns correct group(fallback)/solo/empty(400) responses; **0 console errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)