### PR TITLE
feat(lab-book): ESMS milestone quests for recipe ingestion

### DIFF
--- a/TECH_WEEK_ROADMAP.md
+++ b/TECH_WEEK_ROADMAP.md
@@ -1,0 +1,79 @@
+# Alchm.kitchen — Tech-Week Readiness Roadmap
+
+_Last updated: 2026-06-01_
+
+> Supersedes the earlier chat roadmap (which reprinted a live DB password and
+> restated unverified audit claims as fact) and corrects the source audit
+> `audit-reports/wten-architecture-audit-2026-06-01.md`. **Every item below was
+> checked against the codebase** — verification status is marked on each line.
+> No secrets appear in this file.
+
+## Legend
+- ✅ Done / verified in code
+- 🔴 **P0** — do before tech-week (action required)
+- 🟡 **P1** — should do
+- 🔵 **P2** — optional / cosmetic
+- ⚠️ Verify in an external console (Vercel / Railway) — cannot be confirmed from the repo
+- ❌ Audit claim that is **false or already resolved** — no action needed
+
+---
+
+## ✅ Done this session (on `master`)
+- **Reverted the Neon write-failover** — commit `70409445` reverts `8f1b2047`. It was a split-brain data-corruption hazard, not HA: Neon is the *pre-migration* database, not a synchronized Railway replica, so failing writes over to it forks the dataset. **Do not re-introduce.** Real resilience here is PgBouncer/Railway pooling + `statement_timeout` + fail-fast (ADR-007), already in place.
+- **Removed the hardcoded DB password** from `scripts/backfillHscaElementalProperties.ts` and `scripts/backfillRecipeAlchemicalQuantities.ts` — commit `17f04acd`. Both now require `DATABASE_URL` and throw if it is unset.
+- **Removed the ingested HSCA raw-source corpus** (`HSCArecipes/`, 512 files + `.venv_hsca`/PDF) — commit `f13f4f98`. Already in the DB read_model + `.vercelignore`'d; recoverable from git history.
+- **Shipped the Lab Book** — recipe ingestion: paste text **or** upload a photo → GPT-4o extraction → elemental + ESMS enrichment → saved to the personal cookbook (`user_custom_recipes`), token-gated on Essence. New `/lab-book` page + Lab nav entry, `POST /api/recipes/extract`, `src/lib/recipes/*`. typecheck/lint/build clean; page renders + auth-gated; `OPENAI_API_KEY` present in Vercel prod.
+- **ESMS milestone quests for the Lab Book** — `database/init/50-lab-book-quests.sql`: tiered achievements (add 1/5/25/100 recipes → 10/25/75/200 ESMS) + a weekly (3/week → 15 ESMS), via an `ingest_recipe` event reported on each cookbook save. Auto-applies on the next Railway deploy; surfaces in the existing Quests panel.
+
+---
+
+## 🔴 P0 — Critical
+
+1. **Rotate the Railway Postgres password.** It was committed to `master` (#443, 2026-05-24 — one day *after* the last rotation) and was exposed in chat. Removing it from the working tree does **not** undo the git-history exposure; rotation is the only real fix. _After rotating:_ set the new `DATABASE_URL` in the Vercel dashboard **and** your local `.env*` files (the backfill scripts now require it).
+
+2. ⚠️ **Reconcile `DATABASE_URL` in the Vercel dashboard.** Confirm production points at **Railway**, not a **Neon** host. The audit found a Neon reference in the Vercel-generated `.env.production`; this can only be checked in Vercel → Settings → Environment Variables. (With the failover reverted, a stray Neon URL no longer triggers silent failover — but it would still point the live app at the wrong cluster.)
+
+---
+
+## 🟡 P1 — Deploy & config
+
+3. ✅ **`ALCHM_KITCHEN_SYNC_SECRET` is set in Vercel production** — confirmed 2026-06-01 via `vercel env ls production` (present, `Encrypted`, added ~19d ago; `INTERNAL_API_SECRET` also present). The audit's "historically unset → 401 storms" risk does **not** apply to current prod. The endpoint authorizes via `X-Sync-Secret` (`src/app/api/economy/sync-credit/route.ts:51`).
+   - ⚠️ **Value-equality with the PA/FastAPI side was NOT verified here.** Confirming it means comparing the secret's *value* across two systems (the Railway MCP returns raw values, and was not authenticated in-session) — not worth exfiltrating a secret to check. Definitive, safe proof of a match = a real PA→WTEN sync landing a non-`401` at `/api/economy/sync-credit`. Confirm operator-side if a sync ever 401s.
+
+4. ✅ **Version 3.1.0 is already live — no new deploy needed.** Latest `master` commit `17f04acd` (sits on top of the failover revert `70409445`) is deployed to **production, state `READY`** (`dpl_4bo8CcsXYgpGrpzQaR7xmoLMYrSc`, target=production). `curl https://alchm.kitchen/api/health` →
+   ```json
+   {"status":"healthy","version":"3.1.0","environment":"production","services":{"database":"healthy","cache":"memory"}}
+   ```
+   The push already auto-deployed (`package.json` 3.1.0 → `next.config.js:122` `APP_VERSION` → `src/app/api/health/route.ts:26`). Forcing another deploy adds nothing.
+
+---
+
+## ❌ Audit "P0s" that are already resolved — **no action**
+
+- **`group_chat_quest` transaction whitelist** — already present in `src/types/economy.ts:50`. (Audit claimed it was missing.)
+- **`ALCHM_KITCHEN_SYNC_SECRET` documentation** — already present in **both** `AGENTS.md` and `GEMINI.md`. (Audit claimed it was omitted.)
+
+## ✅ Audit claims that ARE accurate (FYI, no action)
+
+- MCP server is `@alchm/mcp-server` **v1.1.2** (`mcp-server/package.json`).
+- `/api/cron/synthetic-mcp` exists in `vercel.json`.
+- `sync-credit` authorizes via `X-Sync-Secret`; `agent-recipes` via `Bearer INTERNAL_API_SECRET` (a real header-format mismatch — harmonizing them is a reasonable, non-blocking follow-up).
+
+---
+
+## 🔵 P2 — Optional / cosmetic
+
+- ✅ **Workspace clutter — done (2026-06-01).** Removed **744** redundant untracked Finder-copy files (`* 2.*` / `* 3.*`, incl. 717 under `HSCArecipes/`) + 3 `.eslintcache` dup copies (kept `.eslintcache` + `.eslintcache-fast`). All untracked → **0 tracked files changed, nothing to commit**. A canonical-exists guard preserved 7 legitimately-numbered files (`Brown Basmati Rice Variation 1–5.md`, 2 `Pizza Dough` files) that only *looked* like dupes. The specific root dupes the audit named (`apply_migration_45 2.cjs`, `recipes_database 3.json`, `HSCA_Recipes 3.pdf`) did not exist.
+- ℹ️ **Heavy route bundles — no action needed.** `/ingredients` (558→180 kB) and `/profile` (268→215 kB) already split (CLAUDE.md); `/menu-planner` already uses `next/dynamic` (`src/app/menu-planner/page.tsx`). Revisit only if it lags in a demo.
+- ℹ️ **Cron orchestration — verified, not changing.** 9 Vercel crons in `vercel.json`; no Railway cron config exists in the repo (any Railway crons are dashboard-defined, not editable from here). Consolidation is a nicety, not tech-week-blocking.
+- ⏸️ **Git-history scrub — deferred (do NOT run yet).** Requires the password rotation (P0) FIRST, then explicit go-ahead — it rewrites `master` history and invalidates every clone. Not performed.
+- ⏸️ **Stale agent worktrees** — ~37 `.claude/worktrees/*` (one is the live, locked `master` worktree). Not pruning unprompted: `git worktree remove` can destroy uncommitted work on those branches. Offer standing if you want a careful sweep.
+- ℹ️ **Lab Book follow-ups (optional)** — scope quests to `source === "scan"` if generator/riff saves shouldn't count toward "add a recipe"; persist the original photo (Vercel Blob vs base64); PDF / multi-page batch import; refactor `scripts/backfillRecipeAlchemicalQuantities.ts` to share `alchemizeExtractedRecipe` so script + feature use one path.
+
+---
+
+## Post-deploy smoke check (≈2 min)
+
+- `curl https://alchm.kitchen/api/health` → `"version":"3.1.0"`, healthy.
+- `/admin` → System Status panel shows the **database** flow `OK` (not `DEGRADED`).
+- A PA→WTEN sync (or the next real one) lands without a `401` at `/api/economy/sync-credit`.

--- a/database/init/50-lab-book-quests.sql
+++ b/database/init/50-lab-book-quests.sql
@@ -1,0 +1,17 @@
+-- Lab Book recipe-ingestion quests.
+-- Reward users with ESMS for building their personal recipe cookbook
+-- (user_custom_recipes) via the Lab Book. Each successful save to
+-- POST /api/users/me/recipes/custom reports the 'ingest_recipe' event;
+-- reportEvent() increments every matching quest, so these cumulative
+-- achievements (+ a recurring weekly) complete as the count climbs.
+-- Idempotent: ON CONFLICT (slug) DO NOTHING.
+
+INSERT INTO quest_definitions
+  (slug, title, description, quest_type, token_reward_type, token_reward_amount, trigger_event, trigger_threshold, sort_order)
+VALUES
+  ('achievement-lab-book-first',      'First Transcription', 'Add your first recipe to your Lab Book',     'achievement', 'all',  10, 'ingest_recipe',   1, 60),
+  ('achievement-lab-book-five',       'Stocked Shelf',       'Add 5 recipes to your Lab Book',             'achievement', 'all',  25, 'ingest_recipe',   5, 61),
+  ('achievement-lab-book-twentyfive', 'Cookbook Curator',    'Add 25 recipes to your Lab Book',            'achievement', 'all',  75, 'ingest_recipe',  25, 62),
+  ('achievement-lab-book-hundred',    'Grand Archivist',     'Add 100 recipes to your Lab Book',           'achievement', 'all', 200, 'ingest_recipe', 100, 63),
+  ('weekly-lab-book',                 'Weekly Archivist',    'Add 3 recipes to your Lab Book this week',    'weekly',      'all',  15, 'ingest_recipe',   3, 14)
+ON CONFLICT (slug) DO NOTHING;

--- a/src/app/api/users/me/recipes/custom/route.ts
+++ b/src/app/api/users/me/recipes/custom/route.ts
@@ -12,6 +12,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { auth } from "@/lib/auth/auth";
 import { executeQuery } from "@/lib/database/connection";
+import { questService } from "@/services/QuestService";
 import type { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
@@ -133,9 +134,27 @@ export async function POST(request: NextRequest) {
         body.notes ?? null,
       ],
     );
+    // Best-effort: reward building the Lab Book. reportEvent increments every
+    // quest listening on "ingest_recipe" (the tiered "add N recipes"
+    // achievements + the weekly) and returns any that just completed.
+    let completedQuests: Array<{
+      questSlug: string;
+      tokensAwarded: number;
+      tokenType: string;
+    }> = [];
+    try {
+      completedQuests = await questService.reportEvent(userId, "ingest_recipe");
+    } catch (questErr) {
+      console.error(
+        "[POST /api/users/me/recipes/custom] quest report failed",
+        questErr,
+      );
+    }
+
     return NextResponse.json({
       authenticated: true,
       recipe: rowToDTO(result.rows[0]),
+      completedQuests,
     });
   } catch (error) {
     console.error("[POST /api/users/me/recipes/custom]", error);

--- a/src/components/recipes/LabBookIngest.tsx
+++ b/src/components/recipes/LabBookIngest.tsx
@@ -174,8 +174,28 @@ export default function LabBookIngest() {
           setError("Failed to save recipe.");
           return;
         }
+        const data = (await res.json().catch(() => ({}))) as {
+          completedQuests?: Array<{
+            questSlug: string;
+            tokensAwarded: number;
+            tokenType: string;
+          }>;
+        };
         setPreviews((prev) => prev.filter((_, i) => i !== idx));
-        setNotice(`Saved "${recipe.name}" to your Lab Book.`);
+        const completed = data.completedQuests ?? [];
+        if (completed.length > 0) {
+          const totals = completed
+            .map(
+              (q) =>
+                `${q.tokensAwarded} ${q.tokenType === "all" ? "ESMS" : q.tokenType}`,
+            )
+            .join(" + ");
+          setNotice(
+            `Saved "${recipe.name}". 🏆 Milestone reached — claim ${totals} in Quests!`,
+          );
+        } else {
+          setNotice(`Saved "${recipe.name}" to your Lab Book.`);
+        }
         await loadSaved();
       } catch {
         setError("Failed to save recipe.");
@@ -256,6 +276,10 @@ export default function LabBookIngest() {
           {loading ? "Extracting…" : "Extract recipe"}
         </button>
         <span className="ml-3 text-xs text-white/40">Costs Essence (🜔)</span>
+        <p className="mt-3 text-xs text-white/40">
+          Building your Lab Book earns ESMS — milestones at 1, 5, 25 &amp; 100
+          recipes (track them in Quests).
+        </p>
 
         {error && <p className="mt-3 text-sm text-rose-300">{error}</p>}
         {notice && <p className="mt-3 text-sm text-emerald-300">{notice}</p>}


### PR DESCRIPTION
## Summary
Adds ESMS **milestone quests** that reward users for building their Lab Book (the recipe-ingestion feature already on `master`). Each save to the personal cookbook grants quest progress; tiered achievements + a weekly pay out ESMS through the existing Quests panel + claim flow.

## Changes
- **`database/init/50-lab-book-quests.sql`** — 5 quests on the `ingest_recipe` trigger (reward type `all`): First Transcription (add 1 → 10), Stocked Shelf (5 → 25), Cookbook Curator (25 → 75), Grand Archivist (100 → 200), Weekly Archivist (3/week → 15).
- **`POST /api/users/me/recipes/custom`** — reports `ingest_recipe` (best-effort) on each successful save and returns `completedQuests`.
- **`LabBookIngest.tsx`** — "🏆 Milestone reached" notice on completion + a standing earn hint.
- **`TECH_WEEK_ROADMAP.md`** — updated.

## ⚠️ Deploy notes
- Merging runs **DB migration 50** on Railway (idempotent `INSERT … ON CONFLICT DO NOTHING`, transaction-safe, no `CONCURRENTLY`) and auto-deploys via Vercel.
- No new env required — `OPENAI_API_KEY` (for the ingestion route) is already set in Vercel prod.

## Verification
- `bun run verify` (0 errors / 0 warnings) and `bun run build` clean.
- Uses the same quest mechanism as the existing shipped quests; the full complete→claim loop needs the migration applied + a signed-in session.

## Follow-ups (optional)
- Scope quests to `source === "scan"` if generator/riff saves shouldn't count.
- Persist original photo (Vercel Blob); PDF/multi-page batch; share `alchemizeExtractedRecipe` with the backfill script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)