### PR TITLE
docs(tech-week): day-by-day checklist

### DIFF
--- a/TECH_WEEK_ROADMAP.md
+++ b/TECH_WEEK_ROADMAP.md
@@ -8,14 +8,14 @@ _Rev 2 · 2026-06-01 · prod = `master` (Vercel auto-deploy) + Railway Postgres_
 - **Prod:** v**3.1.0**, `/api/health` healthy, DB `OK`. Latest `master` deploy `READY`.
 - **Shipped this session:** Neon-failover revert · leaked-credential removal · HSCA corpus cleanup · **Lab Book** recipe ingestion · **ESMS milestone quests**.
 - **⛔ Blockers (P0):** rotate the leaked DB password · confirm Vercel `DATABASE_URL` → Railway.
-- **🟡 Pending landing:** **[PR #487](https://github.com/gregcastro23/WhatToEatNext/pull/487)** (quests) — merging deploys + runs **migration 50**.
+- **✅ Landed:** [#487](https://github.com/gregcastro23/WhatToEatNext/pull/487) (Lab Book quests) + [#488](https://github.com/gregcastro23/WhatToEatNext/pull/488) (this checklist) merged to `master`. ⚠️ Confirm **migration 50** applied on the Railway backend (quests appear once it has).
 
 ---
 
 ## 🔴 P0 — clear before tech-week
 - [ ] 👤 **Rotate the Railway Postgres password.** ⏱5 min. Leaked to `master` history (#443) + chat — rotation is the only real fix. Then set the new `DATABASE_URL` in **Vercel** *and* local `.env*` (backfill scripts now require it). Triggers a redeploy.
 - [ ] 👤 **Confirm Vercel `DATABASE_URL` → Railway (not Neon).** ⏱2 min. Vercel → Settings → Environment Variables; check the host. *(🤖 I can surface just the host via a temp `vercel env pull` — never the password — if you want.)*
-- [ ] 👤 **Merge [PR #487](https://github.com/gregcastro23/WhatToEatNext/pull/487)** when ready. ⏱1 min. ⚠️ Merge = Vercel deploy **+ Railway migration 50** (idempotent quest INSERTs, transaction-safe).
+- [x] **Merged [PR #487](https://github.com/gregcastro23/WhatToEatNext/pull/487)** (quests) → `master`. ⚠️ **Confirm migration 50 ran on the Railway backend deploy** — it applies there, *not* in the Vercel build, so the quests show in `/admin`/Quests only once that deploy has run.
 
 ## 🟡 P1 — confirm
 - [x] **`ALCHM_KITCHEN_SYNC_SECRET` set in Vercel prod** (verified ~19d ago) — PA↔WTEN credit sync auth.
@@ -39,6 +39,65 @@ _Rev 2 · 2026-06-01 · prod = `master` (Vercel auto-deploy) + Railway Postgres_
 - [ ] **Rollback path:** Vercel → Deployments → a previous `READY` prod deploy → **Instant Rollback** (recent rollback targets: `17f04acd`, `70409445`). Reverts code in seconds.
   - ⚠️ **Migrations are forward-only** — a code rollback does **not** undo DB migrations. Recent ones (quest INSERTs, column-default restores) are additive/harmless; a *bad* migration needs a manual DB fix, not a rollback.
 - [ ] **Watch during the event:** `/admin` System Status + `/api/health`. Status-transition alerts fire to Slack/email when `ALERT_SLACK_WEBHOOK_URL` / `ADMIN_EMAILS` are set.
+
+---
+
+## 📅 Day-by-day plan
+
+> Assumes a **5-day (Mon–Fri) tech week** + a prep day before and a wrap day after — relabel to real dates. The repeatable **Daily ritual** is defined once; each day lists it plus that day's focus.
+
+### 🔁 Daily ritual
+**Morning pre-flight (~15 min before doors):**
+- [ ] `curl https://alchm.kitchen/api/health` → `"version":"3.1.0"`, `"database":"healthy"`
+- [ ] `/admin` System Status — all flows `OK` (no DEGRADED / INCIDENT)
+- [ ] Demo account: signed in + ESMS balance comfortably above demo needs (Lab Book & cosmic recipe are token-gated)
+- [ ] One live dry-run of the headline flow (e.g. Lab Book: paste → **Save** → milestone)
+- [ ] Skim overnight alerts (Slack/email) + `/admin` error & slow-query rings
+
+**End of day:**
+- [ ] Review System Status + error logs for the day; jot anything flaky
+- [ ] Triage: hotfix tonight vs park for the post-week list
+- [ ] Top up demo-account ESMS if it ran low
+
+### Day −1 · Prep & freeze
+- [ ] 🔴 Rotate Railway password → set new `DATABASE_URL` (Vercel + local `.env*`) — also settles the "is it Railway?" check
+- [ ] Confirm **migration 50** applied → quests show in the Quests panel
+- [ ] Fund the demo account with ESMS (or use Premium); finish onboarding / natal chart
+- [ ] Confirm OpenAI quota (GPT-4o powers Lab Book + cosmic recipe)
+- [ ] Full smoke test (Kitchen recs · Discover · Lab Book · Quests · Cosmic Recipe · Commensal)
+- [ ] Record the current-good prod deploy SHA + confirm the Vercel **Instant Rollback** path
+- [ ] **Soft-freeze `master`** — docs / hotfixes only from here
+
+### Day 1 · Go-live
+- [ ] AM ritual → final go/no-go (prod healthy, account ready)
+- [ ] _Suggested focus:_ Onboarding + **Kitchen** (tonight's personalized recommendations) — the core hook
+- [ ] EOD ritual
+
+### Day 2
+- [ ] AM ritual
+- [ ] _Suggested focus:_ **Discover** — cuisines, ingredients, cooking methods (catalog breadth)
+- [ ] EOD ritual
+
+### Day 3
+- [ ] AM ritual
+- [ ] _Suggested focus:_ **Lab Book** — ingest a recipe by text *and* by photo → Save → **ESMS milestone quest** (the new feature)
+- [ ] EOD ritual
+
+### Day 4
+- [ ] AM ritual
+- [ ] _Suggested focus:_ **Cosmic Recipe** generation + **Commensal** dinner-party harmonization (AI + social)
+- [ ] EOD ritual
+
+### Day 5 · Wind-down
+- [ ] AM ritual
+- [ ] _Suggested focus:_ **Lab / Quantities** — the alchemy internals ("how it works") + recap of the week's highlights
+- [ ] Capture standout feedback + metrics before close
+- [ ] EOD ritual
+
+### Day +1 · Post-week
+- [ ] Quick retro: what broke, what to harden
+- [ ] Lift the `master` freeze; resume normal dev
+- [ ] Clear deferred items: git-history scrub (now safe post-rotation) · `.claude/worktrees/*` sweep · Lab Book follow-ups (scope quests to `source=scan`, persist photos, PDF import)
 
 ---
 


### PR DESCRIPTION
## Summary
Extends the tech-week plan with a **day-by-day checklist**.

## Changes (doc only)
- New **📅 Day-by-day plan**: a reusable **Daily ritual** (AM pre-flight + EOD wrap), a **Day −1 prep & freeze** list, **Day 1–5** with suggested demo focuses (Day 3 = the new Lab Book + quests), and a **Day +1 post-week** wrap.
- Marked PR #487 (quests) as merged in the status line + P0 (those lines were stale).

Docs-only — no code or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)