### PR TITLE
fix(economy): premium-journey readiness ($5 price, +starter grant, swap 402)

### DIFF
--- a/src/app/api/economy/swap/route.ts
+++ b/src/app/api/economy/swap/route.ts
@@ -108,7 +108,7 @@ export async function POST(request: NextRequest) {
           message: `Insufficient ${fromToken}. Need ${costAmount}.`,
           rate: rateEntry,
         },
-        { status: 400 },
+        { status: 402 },
       );
     }
 

--- a/src/components/auth/AuthFollowups.tsx
+++ b/src/components/auth/AuthFollowups.tsx
@@ -687,8 +687,8 @@ const TIERS: readonly UpgradeTier[] = [
   {
     id: "alchemist",
     label: "Alchemist",
-    price: "$14",
-    period: "per month · $140/yr",
+    price: "$5",
+    period: "per month",
     features: [
       "Everything in Apprentice",
       "Unlimited saves & natal-chart compute",

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -456,10 +456,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
               await tokenEconomy.creditMultipleTokens(
                 dbUser.id,
                 [
-                  { tokenType: "Spirit", amount: 5 },
-                  { tokenType: "Essence", amount: 5 },
-                  { tokenType: "Matter", amount: 5 },
-                  { tokenType: "Substance", amount: 5 },
+                  { tokenType: "Spirit", amount: 15 },
+                  { tokenType: "Essence", amount: 15 },
+                  { tokenType: "Matter", amount: 15 },
+                  { tokenType: "Substance", amount: 15 },
                 ],
                 "signup_grant",
                 {


### PR DESCRIPTION
## Summary
Readiness fixes for the **onboard → upgrade → spend** journey (from the tech-week audit).

## Changes
- **Premium price display:** the upgrade gate now shows **$5/mo** (was $14 / $140yr) to match `TIER_LIMITS` and the Stripe price object — $5/mo confirmed canonical.
- **Starter grant:** new users get **15 of each ESMS (60 total)**, up from 5 (20), so booth sign-ups can try the token-gated features (cosmic recipe / ingest / refine) before claiming daily yield. Idempotent per user — existing users unaffected.
- **`/api/economy/swap`** returns **402** (not 400) on insufficient balance, consistent with the other token-gated routes.

## Verified
`bun run verify` (0 errors / 0 warnings) + `bun run build` clean.

## ⚠️ Operator follow-ups (NOT in this PR — Stripe, your side)
- Confirm the Stripe **premium price object = $5/mo** (the live price ID is set; just verify the amount).
- Create **3 MCP top-up Stripe prices** ($5/$20/$50) + set `STRIPE_MCP_TOP_UP_{5,20,50}_PRICE_ID` in Vercel — the existing `/account/billing/mcp` top-up panel renders **empty** without them, so users can't self-serve refill ESMS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)