### PR TITLE
ci(dependabot): ignore deferred majors + group minor/patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,14 @@ updates:
       all-npm-dependencies:
         patterns:
           - "*"
+        # Group only safe minor/patch bumps; any non-ignored major arrives as
+        # its own PR for individual review.
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
-      # Ignore major version updates for critical packages
+      # Major bumps for these are handled manually as dedicated migrations
+      # (see TECH_WEEK_ROADMAP backlog) — never auto-PR'd.
       - dependency-name: "next"
         update-types: ["version-update:semver-major"]
       - dependency-name: "react"
@@ -33,6 +39,20 @@ updates:
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
       - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "tailwindcss"        # v4 = engine/config rewrite; app pinned to v3 (overrides)
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"             # linter majors handled with the plugin chain
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@eslint/js"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "storybook"          # dev-only tooling; not in the prod/build path
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@storybook/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-devtools"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "date-fns"           # v4 coupled to the WTEN port (staging uses v2 API)
         update-types: ["version-update:semver-major"]
 
   # Enable version updates for GitHub Actions


### PR DESCRIPTION
## Summary
Stops dependabot from re-proposing the deferred breaking majors and cuts PR noise.

## Changes — `.github/dependabot.yml` (npm)
- The `all-npm-dependencies` group now batches **only minor/patch**; any non-ignored major arrives as its own reviewable PR.
- Added `ignore` (semver-major) for **tailwindcss, eslint, @eslint/js, storybook, @storybook/\*, react-devtools, date-fns** (joining the existing next/react/react-dom/typescript/@types/node). Each is a manual migration.

## eslint 10 — attempted, deferred (condition not met)
Tried adopting eslint 10 with the latest plugin chain. **`eslint-plugin-react@7.37.5` (latest) still calls `context.getFilename()`**, which eslint 10 removed → `TypeError` on lint. Not adoptable until `eslint-plugin-react` ships eslint-10 support; reverted. The ignore rule above keeps dependabot from re-proposing it meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)