### PR TITLE
fix(onboarding): correct stale grant/trial copy + harden ignite recipe fetches

### DIFF
--- a/src/app/api/agent-forge/ignite/route.ts
+++ b/src/app/api/agent-forge/ignite/route.ts
@@ -27,6 +27,15 @@ import { calculateAlchemicalFromPlanets } from "@/utils/planetaryAlchemyMapping"
 
 export const dynamic = "force-dynamic";
 
+/**
+ * Bound each recipe-generation fetch so a hung upstream can't consume the whole
+ * 60s function budget (vercel.json) and 504 the onboarding. Recipe generation is
+ * the last, non-critical step — the alchemical constitution is persisted and
+ * onboarding is marked complete *before* this runs — so on timeout/failure we
+ * degrade to `cosmicRecipe: null` rather than failing the whole request.
+ */
+const RECIPE_GEN_TIMEOUT_MS = 20_000;
+
 export async function POST(req: Request) {
   try {
     // 1. Authenticate user from active NextAuth session
@@ -159,6 +168,7 @@ export async function POST(req: Request) {
           },
           prompt: "A nourishing, restorative onboarding meal aligned with your alchemical constitution.",
         }),
+        signal: AbortSignal.timeout(RECIPE_GEN_TIMEOUT_MS),
       });
 
       if (generateRes.ok) {
@@ -175,66 +185,81 @@ export async function POST(req: Request) {
       fallbackUsed = true;
     }
 
-    // Direct Fallback if server-side fetch failed
+    // Direct Fallback if server-side fetch failed. The complimentary recipe is
+    // best-effort: the constitution is already persisted and onboarding is
+    // marked complete above, so a failure here must NOT 500 the onboarding (the
+    // client would bounce the user back to the form despite a successful
+    // ignition). On timeout/error we log and leave cosmicRecipe = null; the
+    // onboarding reveal renders a graceful "couldn't compile your recipe" state.
     if (fallbackUsed || !cosmicRecipe) {
-      console.log(`[ignite] Initiating direct fallback fetch to planetary agents API...`);
-      const agentBaseUrl = getServiceUrl("planetaryAgentsApi");
-
-      const raw = getAccuratePlanetaryPositions(new Date());
-      const dominantElement = getDominantElementFromPositions(raw);
-
-      const esms = calculateAlchemicalFromPlanets(
-        Object.entries(raw).reduce((acc, [planet, pos]) => {
-          acc[planet] = String((pos as any).sign ?? "");
-          return acc;
-        }, {} as Record<string, string>)
-      );
-
-      const alchemizedResult = alchemize(
-        Object.entries(raw).reduce((acc, [planet, pos]) => {
-          acc[planet] = {
-            sign: String((pos as any).sign ?? "").toLowerCase(),
-            degree: Number((pos as any).degree) || 0,
-            minute: Number((pos as any).minute) || 0,
-            isRetrograde: Boolean((pos as any).isRetrograde),
-          };
-          return acc;
-        }, {} as any)
-      );
-
-      const agentResponse = await fetch(`${agentBaseUrl}/api/generate-recipe`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          prompt: "A nourishing, restorative onboarding meal aligned with your alchemical constitution.",
-          dominantElement,
-          birthData,
-          dietPreference: "omnivore",
-          alchemicalState: esms,
-          thermodynamicProperties: alchemizedResult?.thermodynamicProperties,
-          userId,
-          tier: "free", // Strictly free-tier Groq/Gemini
-        }),
-      });
-
-      if (!agentResponse.ok) {
-        throw new Error(`Planetary agents direct fallback failed with status ${agentResponse.status}`);
-      }
-
-      const payload = await agentResponse.json();
-      cosmicRecipe = payload.recipe || payload;
-      
-      // Since we bypassed the endpoint proxy, record the limit directly in PostgreSQL for consistency
       try {
-        await executeQuery(`
-          INSERT INTO user_daily_limits (user_id, date, recipes_generated)
-          VALUES ($1, CURRENT_DATE, 1)
-          ON CONFLICT (user_id, date) 
-          DO UPDATE SET recipes_generated = user_daily_limits.recipes_generated + 1
-        `, [userId]);
-        console.log(`[ignite] Manually incremented user_daily_limits counter.`);
+        console.log(`[ignite] Initiating direct fallback fetch to planetary agents API...`);
+        const agentBaseUrl = getServiceUrl("planetaryAgentsApi");
+
+        const raw = getAccuratePlanetaryPositions(new Date());
+        const dominantElement = getDominantElementFromPositions(raw);
+
+        const esms = calculateAlchemicalFromPlanets(
+          Object.entries(raw).reduce((acc, [planet, pos]) => {
+            acc[planet] = String((pos as any).sign ?? "");
+            return acc;
+          }, {} as Record<string, string>)
+        );
+
+        const alchemizedResult = alchemize(
+          Object.entries(raw).reduce((acc, [planet, pos]) => {
+            acc[planet] = {
+              sign: String((pos as any).sign ?? "").toLowerCase(),
+              degree: Number((pos as any).degree) || 0,
+              minute: Number((pos as any).minute) || 0,
+              isRetrograde: Boolean((pos as any).isRetrograde),
+            };
+            return acc;
+          }, {} as any)
+        );
+
+        const agentResponse = await fetch(`${agentBaseUrl}/api/generate-recipe`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            prompt: "A nourishing, restorative onboarding meal aligned with your alchemical constitution.",
+            dominantElement,
+            birthData,
+            dietPreference: "omnivore",
+            alchemicalState: esms,
+            thermodynamicProperties: alchemizedResult?.thermodynamicProperties,
+            userId,
+            tier: "free", // Strictly free-tier Groq/Gemini
+          }),
+          signal: AbortSignal.timeout(RECIPE_GEN_TIMEOUT_MS),
+        });
+
+        if (!agentResponse.ok) {
+          throw new Error(`Planetary agents direct fallback failed with status ${agentResponse.status}`);
+        }
+
+        const payload = await agentResponse.json();
+        cosmicRecipe = payload.recipe || payload;
+
+        // Since we bypassed the endpoint proxy, record the limit directly in PostgreSQL for consistency
+        try {
+          await executeQuery(`
+            INSERT INTO user_daily_limits (user_id, date, recipes_generated)
+            VALUES ($1, CURRENT_DATE, 1)
+            ON CONFLICT (user_id, date)
+            DO UPDATE SET recipes_generated = user_daily_limits.recipes_generated + 1
+          `, [userId]);
+          console.log(`[ignite] Manually incremented user_daily_limits counter.`);
+        } catch (err) {
+          console.warn("[ignite] Failed to update user_daily_limits:", err);
+        }
       } catch (err) {
-        console.warn("[ignite] Failed to update user_daily_limits:", err);
+        // Non-fatal: onboarding already succeeded — return without a recipe.
+        console.warn(
+          "[ignite] Complimentary recipe generation failed; completing onboarding without it:",
+          err
+        );
+        cosmicRecipe = null;
       }
     }
 

--- a/src/components/auth/AuthFollowups.tsx
+++ b/src/components/auth/AuthFollowups.tsx
@@ -55,7 +55,7 @@ const HANDSHAKE_STEPS: readonly HandshakeStep[] = [
   { code: "IDENT",  label: "Identity verified",              hint: "iss · aud · exp · nonce" },
   { code: "RECORD", label: "User record",                    hint: "8000ms timeout · userCache 30s" },
   { code: "NATAL",  label: "Computing natal chart",          hint: "VSOP87 · DE440 · house cusps" },
-  { code: "GRANT",  label: "Granting starter Cosmic Yield",  hint: "250 tokens · 14-day trial" },
+  { code: "GRANT",  label: "Granting starter Cosmic Yield",  hint: "60 ESMS · 15 each" },
   { code: "MESH",   label: "Propagating session",            hint: "cookie · .alchm.kitchen · cross-subdomain" },
 ];
 
@@ -864,7 +864,7 @@ export function UpgradeGate({
 
         <section style={{ padding: 32, overflow: "auto" }}>
           <div className="t-tag" style={{ marginBottom: 10, color: "var(--accent)" }}>
-            UPGRADE · 14 DAYS FREE · CANCEL ANY TIME
+            UPGRADE · 7 DAYS FREE · CANCEL ANY TIME
           </div>
           <h2
             className="t-display"
@@ -1055,7 +1055,7 @@ export function UpgradeGate({
                         : "var(--line-hi)",
                     }}
                   >
-                    START 14-DAY TRIAL
+                    START 7-DAY TRIAL
                   </button>
                 )}
               </div>


### PR DESCRIPTION
Tech-week prep — two small fixes on the onboarding/auth path.

## 1. Auth handshake & upgrade copy (`AuthFollowups.tsx`)
The post-OAuth handshake's **GRANT** step advertised `250 tokens · 14-day trial`. Both halves were wrong:
- The real signup grant is **60 ESMS** — 15 each of Spirit/Essence/Matter/Substance (`src/lib/auth/auth.ts:459-467`, `signup_grant`).
- There is **no trial** attached to the signup grant.

→ Corrected the hint to `60 ESMS · 15 each`.

While in the file, two `UpgradeGate` labels still said **14-day** trial, but the actual Stripe trial is **7 days** (`stripe/checkout/route.ts` → `trial_period_days: 7`; `premium/page.tsx`, `PremiumGate.tsx`, and `CosmicVeilOverlay.tsx` all already say 7-day). Aligned both (`14 DAYS FREE` → `7 DAYS FREE`, `START 14-DAY TRIAL` → `START 7-DAY TRIAL`) so the upgrade screen no longer contradicts the rest of the app.

## 2. Ignite recipe-fetch hardening (`agent-forge/ignite/route.ts`)
The onboarding orchestrator self-calls the recipe API (and a PA fallback) with **no timeout**. Both routes inherit `maxDuration: 60` (vercel.json), so a hung upstream could burn the whole budget and **504 the onboarding**. Worse, the PA fallback `throw`ed on failure → outer catch → **500** — which the client (`onboarding/page.tsx:143`) treats as a hard failure and **bounces the user back to the input form**, even though their constitution was already persisted and onboarding already marked complete.

Changes:
- Bound **both** recipe fetches with `AbortSignal.timeout(20_000)`.
- Made the fallback **non-fatal**: on timeout/error we log and return `cosmicRecipe: null` instead of a 500. Recipe gen is the non-critical final flourish — the reveal already renders a graceful "couldn't compile your recipe" state when the recipe is null (`onboarding/page.tsx:607`).

The large line count in the route is mostly re-indentation from wrapping the fallback block in `try/catch`.

## Verification
- `bun run verify` (typecheck + lint): ✅
- `bun run build`: ✅ (route-handler change)
- Pre-commit hook (typecheck + lint): ✅

## Note (out of scope — flagging, not changing)
`AuthFollowups.tsx:1080` and `PremiumGate.tsx:193` claim "no credit card required" for the trial, but `stripe/checkout/route.ts` doesn't set `payment_method_collection: 'if_required'`, so Stripe Checkout (subscription mode) collects a card by default. That's a Stripe-config question consistent across multiple files — left untouched pending your call on whether to fix the copy or the checkout config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)