### PR TITLE
Tarot of the moment: surface cards on /current-chart + real scoring

### DIFF
--- a/src/app/(alchm)/current-chart/page.tsx
+++ b/src/app/(alchm)/current-chart/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
+import TarotCardDisplay from '@/components/TarotCardDisplay';
 import { auth } from '@/lib/auth/auth';
 import { withTimeout } from '@/lib/performance/withTimeout';
 import { userDatabase } from '@/services/userDatabaseService';
@@ -64,6 +65,19 @@ export default async function CurrentChartPage() {
         </div>
 
         <CurrentChartClient natalChart={natalChart} />
+
+        {/* Tarot of the Moment — the decan (minor) + planetary (major) cards ruling now */}
+        <section className="space-y-5">
+          <div className="text-center space-y-2">
+            <h2 className="text-2xl md:text-3xl font-black tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-fuchsia-300">
+              Tarot of the Moment
+            </h2>
+            <p className="text-white/40 font-mono text-xs uppercase tracking-widest">
+              The decan &amp; planetary cards ruling now
+            </p>
+          </div>
+          <TarotCardDisplay />
+        </section>
       </main>
     </div>
   );

--- a/src/components/TarotCardDisplay.module.css
+++ b/src/components/TarotCardDisplay.module.css
@@ -1,8 +1,6 @@
 .cardContainer {
-  padding: 1rem;
-  background: rgba(var(--background-rgb), 0.9);
-  border-radius: 12px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  padding: 0;
+  background: transparent;
 }
 
 .cardPair {
@@ -11,63 +9,80 @@
   gap: 1.5rem;
 }
 
+@media (max-width: 640px) {
+  .cardPair {
+    grid-template-columns: 1fr;
+  }
+}
+
 .card {
   padding: 1.5rem;
-  background: var(--card-background);
-  border-radius: 8px;
-  border: 1px solid rgba(var(--border-color-rgb), 0.2);
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 12px;
+  border: 1px solid rgba(168, 85, 247, 0.18);
+  box-shadow: inset 0 0 24px rgba(168, 85, 247, 0.05);
 }
 
 .card h3 {
-  font-size: 1.2rem;
-  color: #333;
-  margin-bottom: 5px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  color: rgba(255, 255, 255, 0.4);
+  margin: 0 0 8px;
 }
 
 .card h4 {
   font-size: 1.4rem;
-  color: #222;
-  margin-bottom: 10px;
+  font-weight: 800;
+  color: #fff;
+  margin: 0 0 6px;
 }
 
 .tokenComposition {
   margin: 1rem 0;
-  padding: 1rem;
-  background: rgba(var(--accent-color-rgb), 0.1);
-  border-radius: 6px;
-  font-size: 0.9rem;
+  padding: 0.9rem 1rem;
+  background: rgba(168, 85, 247, 0.08);
+  border-radius: 8px;
+  font-size: 0.8rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.3rem 1rem;
 }
 
 .tokenComposition div {
-  margin: 0.3rem 0;
-  color: var(--text-secondary);
+  color: rgba(255, 255, 255, 0.6);
 }
 
 .tokenValue {
-  font-weight: 500;
-  color: var(--accent-color);
-  margin-left: 0.5rem;
+  font-weight: 700;
+  color: #fbbf24;
+  margin-left: 0.4rem;
 }
 
 .keywords {
-  font-size: 0.85rem;
-  color: var(--text-secondary);
-  margin-top: 1rem;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.45);
+  margin-top: 0.75rem;
+  line-height: 1.5;
 }
 
 .arcanaName {
-  font-size: 0.9rem;
-  color: var(--accent-color);
-  margin: 0.5rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #c4b5fd;
+  margin: 0.4rem 0;
 }
 
 .element {
-  color: #1a73e8;
-  margin: 8px 0;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #a5b4fc;
+  margin: 6px 0;
 }
 
 .quantum {
-  color: #9c27b0;
-  margin: 8px 0;
+  color: #d8b4fe;
+  margin: 6px 0;
   font-weight: 500;
-} 
+}

--- a/src/components/TarotCardDisplay.tsx
+++ b/src/components/TarotCardDisplay.tsx
@@ -79,6 +79,9 @@ export default function TarotCardDisplay() {
                 <div className={styles.card}>
                     <h3>Decan Card</h3>
                     <h4>{tarotCards.minorCard.name}</h4>
+                    {tarotCards.minorCard.element && (
+                        <div className={styles.element}>{tarotCards.minorCard.element} · {tarotCards.minorCard.suit}</div>
+                    )}
                     <div className={styles.tokenComposition}>
                         {Object.entries(tokenValues).map(([token, value]) => (
                             <div key={token}>
@@ -94,6 +97,9 @@ export default function TarotCardDisplay() {
                     <h3>Ruling Planet</h3>
                     <h4>{tarotCards.majorCard.planet}</h4>
                     <div className={styles.arcanaName}>{tarotCards.majorCard.name}</div>
+                    {tarotCards.majorCard.element && (
+                        <div className={styles.element}>{tarotCards.majorCard.element}</div>
+                    )}
                     <div className={styles.keywords}>
                         Planetary Influence: {tarotCards.majorCard.keywords.join(', ')}
                     </div>

--- a/src/services/UnifiedScoringService.ts
+++ b/src/services/UnifiedScoringService.ts
@@ -10,6 +10,7 @@
  * - Tarot effects and other mystical influences
  */
 
+import { getTarotCardsForDate } from "@/lib/tarotCalculations";
 import { log } from "@/services/LoggingService";
 import {
   calculateThermodynamicCompatibility,
@@ -222,26 +223,61 @@ export function calculateDignityEffect(
   return Math.max(-0.3, Math.min(0.3, score)); // Clamp between -0.3 and 0.3
 }
 
+// Cache the moment's tarot card elements per calendar day so scoring a batch of
+// items computes them once (getTarotCardsForDate recomputes + logs per call).
+let _momentTarot: { key: string; elements: string[] } | null = null;
+function momentTarotElements(date: Date): string[] {
+  const key = date.toISOString().slice(0, 10);
+  if (_momentTarot?.key !== key) {
+    try {
+      const cards = getTarotCardsForDate(date);
+      _momentTarot = {
+        key,
+        elements: [
+          (cards.minorCard as { element?: string })?.element,
+          (cards.majorCard as { element?: string })?.element,
+        ].filter((e): e is string => Boolean(e)),
+      };
+    } catch {
+      _momentTarot = { key, elements: [] };
+    }
+  }
+  return _momentTarot.elements;
+}
+
+function dominantElementOf(props?: Record<string, number>): string | null {
+  if (!props) return null;
+  const entries = Object.entries(props);
+  if (!entries.length) return null;
+  const top = entries.sort((a, b) => b[1] - a[1])[0];
+  return top && top[1] > 0 ? top[0] : null;
+}
+
 /**
- * Calculate tarot effects (placeholder for future tarot integration)
+ * Tarot effect: resonance between the item's dominant element and the elements
+ * of the day's decan (minor) + planetary (major) tarot cards of the moment.
  */
 export function calculateTarotEffect(
   _astroData: AstrologicalData,
-  _context: ScoringContext,
+  context: ScoringContext,
 ): number {
-  // Future integration with tarot system
-  // For now, return neutral effect
-  const itemType = _context.item.type;
-
-  // Different item types have different tarot affinities
-  const tarotAffinities = {
-    ingredient: 0.05,
-    recipe: 0.1,
-    cuisine: 0.15,
-    cooking_method: 0.08,
-  };
-
-  return tarotAffinities[itemType] || 0;
+  const itemEl = dominantElementOf(context.item.elementalProperties);
+  if (!itemEl) {
+    // No elemental data — small per-type baseline (prior behavior).
+    const baseline: Record<string, number> = {
+      ingredient: 0.05,
+      recipe: 0.1,
+      cuisine: 0.15,
+      cooking_method: 0.08,
+    };
+    return baseline[context.item.type] || 0;
+  }
+  const cardElements = momentTarotElements(context.dateTime);
+  let score = 0;
+  for (const el of cardElements) {
+    if (el === itemEl) score += 0.15; // resonance with a card of the moment
+  }
+  return Math.max(-0.3, Math.min(0.3, score));
 }
 
 /**


### PR DESCRIPTION
Fixes (not removes) WTEN's underused tarot surface.

- **Render:** mount the previously-orphaned `TarotCardDisplay` (current **decan minor** + **planetary major** card of the moment, with element + ESMS tokens) under a "Tarot of the Moment" section on `/current-chart`; re-theme its CSS module light→dark so it reads on the page; surface each card's element.
- **Scoring:** `calculateTarotEffect` now scores an item's dominant element against the day's decan + planetary card elements (±0.15 per resonant card, clamped ±0.3, cached per-day) instead of a fixed per-type constant — falling back to the old baseline when an item has no elemental data.

Reference: PA renders the equivalent "cards of the moment" on `/tarot-dashboard` + `/chart-of-the-moment`. `bun run verify` 0/0 + `bun run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
