### PR TITLE
feat(elemental): shared ElementalSignature model — adaptive co-dominant, one tie-break

### DIFF
--- a/src/__tests__/utils/elementalSignature.test.ts
+++ b/src/__tests__/utils/elementalSignature.test.ts
@@ -1,0 +1,210 @@
+import {
+  BALANCED_SPREAD,
+  CO_DOMINANT_DELTA,
+} from "@/constants/elementalSignature";
+// Also assert the helper is reachable through the elemental barrel.
+import { elementalSignature as fromBarrel } from "@/utils/elemental";
+import { elementalSignature } from "@/utils/elemental/signature";
+import type { ElementalProperties } from "@/types/alchemy";
+
+const props = (
+  Fire: number,
+  Water: number,
+  Earth: number,
+  Air: number,
+): ElementalProperties => ({ Fire, Water, Earth, Air });
+
+describe("elementalSignature", () => {
+  it("is exported through the elemental barrel", () => {
+    expect(typeof fromBarrel).toBe("function");
+    // Behaves identically to the direct import.
+    expect(fromBarrel(props(0.21, 0.29, 0.29, 0.21)).label).toBe(
+      elementalSignature(props(0.21, 0.29, 0.29, 0.21)).label,
+    );
+  });
+
+  describe("clear single lean", () => {
+    const sig = elementalSignature(props(0.5, 0.25, 0.15, 0.1));
+
+    it("names one dominant element", () => {
+      expect(sig.dominant).toBe("Fire");
+      expect(sig.tier).toBe("single");
+      expect(sig.coDominant).toEqual(["Fire"]);
+    });
+
+    it("uses a single-element label", () => {
+      expect(sig.label).toBe("leans fire");
+      expect(sig.shortLabel).toBe("Fire");
+    });
+  });
+
+  describe("exact two-way tie — the Water/Earth bug case", () => {
+    // The sky that read "leans water": Water 29% / Earth 29% (a tie).
+    const sig = elementalSignature(props(0.21, 0.29, 0.29, 0.21));
+
+    it("surfaces as co-dominant, not a silent single pick", () => {
+      expect(sig.tier).toBe("co-dominant");
+      expect(sig.coDominant).toEqual(["Water", "Earth"]);
+    });
+
+    it('reads "leans water & earth"', () => {
+      expect(sig.label).toBe("leans water & earth");
+      expect(sig.shortLabel).toBe("Water & Earth");
+    });
+
+    it("picks a deterministic dominant via canonical order (Water before Earth)", () => {
+      expect(sig.dominant).toBe("Water");
+    });
+
+    it("is identical regardless of the input object's key order", () => {
+      const reordered: ElementalProperties = {
+        Air: 0.21,
+        Earth: 0.29,
+        Water: 0.29,
+        Fire: 0.21,
+      };
+      const other = elementalSignature(reordered);
+      expect(other.dominant).toBe(sig.dominant);
+      expect(other.label).toBe(sig.label);
+      expect(other.coDominant).toEqual(sig.coDominant);
+    });
+  });
+
+  describe("near-tie within the co-dominant delta", () => {
+    const sig = elementalSignature(props(0.31, 0.29, 0.2, 0.2));
+
+    it("names the close runner-up but not the distant elements", () => {
+      expect(sig.tier).toBe("co-dominant");
+      expect(sig.coDominant).toEqual(["Fire", "Water"]);
+      expect(sig.label).toBe("leans fire & water");
+    });
+
+    it("excludes elements beyond the delta", () => {
+      // Earth/Air are 0.11 below the leader — well past CO_DOMINANT_DELTA.
+      expect(0.31 - 0.2).toBeGreaterThan(CO_DOMINANT_DELTA);
+      expect(sig.coDominant).not.toContain("Earth");
+    });
+  });
+
+  describe("three-way cluster", () => {
+    const sig = elementalSignature(props(0.3, 0.29, 0.28, 0.13));
+
+    it("names all three close elements", () => {
+      expect(sig.tier).toBe("co-dominant");
+      expect(sig.coDominant).toEqual(["Fire", "Water", "Earth"]);
+      expect(sig.label).toBe("leans fire, water & earth");
+      expect(sig.shortLabel).toBe("Fire, Water & Earth");
+    });
+  });
+
+  describe("balanced sky", () => {
+    it("reads balanced for a perfectly even vector", () => {
+      const sig = elementalSignature(props(0.25, 0.25, 0.25, 0.25));
+      expect(sig.tier).toBe("balanced");
+      expect(sig.label).toBe("is in balance");
+      expect(sig.shortLabel).toBe("Balanced");
+      expect(sig.balance).toBeCloseTo(1, 5);
+    });
+
+    it("reads balanced for a near-even vector under the spread threshold", () => {
+      const sig = elementalSignature(props(0.27, 0.26, 0.24, 0.23));
+      expect(0.27 - 0.23).toBeLessThan(BALANCED_SPREAD);
+      expect(sig.tier).toBe("balanced");
+    });
+  });
+
+  describe("deterministic tie-break (canonical Fire → Water → Earth → Air)", () => {
+    it("breaks a four-way exact tie toward Fire", () => {
+      expect(elementalSignature(props(0.25, 0.25, 0.25, 0.25)).dominant).toBe(
+        "Fire",
+      );
+    });
+
+    it("breaks an Earth/Air top tie toward Earth", () => {
+      const sig = elementalSignature(props(0.2, 0.2, 0.3, 0.3));
+      expect(sig.dominant).toBe("Earth");
+      expect(sig.coDominant).toEqual(["Earth", "Air"]);
+    });
+  });
+
+  describe("normalization", () => {
+    it("normalizes raw intensities (sum > 1) to shares summing to 1", () => {
+      const sig = elementalSignature(props(5, 3, 1, 1));
+      const sum =
+        sig.values.Fire + sig.values.Water + sig.values.Earth + sig.values.Air;
+      expect(sum).toBeCloseTo(1, 6);
+      expect(sig.values.Fire).toBeCloseTo(0.5, 6);
+      expect(sig.dominant).toBe("Fire");
+      expect(sig.tier).toBe("single");
+    });
+
+    it("preserves canonical Fire/Water/Earth/Air key order in values", () => {
+      const sig = elementalSignature(props(0.4, 0.3, 0.2, 0.1));
+      expect(Object.keys(sig.values)).toEqual(["Fire", "Water", "Earth", "Air"]);
+    });
+
+    it("ranks strongest → weakest across all four", () => {
+      const sig = elementalSignature(props(0.4, 0.3, 0.2, 0.1));
+      expect(sig.ranked.map((r) => r.element)).toEqual([
+        "Fire",
+        "Water",
+        "Earth",
+        "Air",
+      ]);
+    });
+  });
+
+  describe("degenerate input guards", () => {
+    it("falls back to an even balanced split for an all-zero vector", () => {
+      const sig = elementalSignature(props(0, 0, 0, 0));
+      expect(sig.tier).toBe("balanced");
+      expect(sig.dominant).toBe("Fire");
+      expect(sig.values.Fire).toBeCloseTo(0.25, 6);
+    });
+
+    it("treats NaN / non-finite channels as zero without throwing", () => {
+      const sig = elementalSignature(
+        props(0.5, Number.NaN, Number.POSITIVE_INFINITY, -2),
+      );
+      // Only Fire is a valid positive number → it dominates.
+      expect(sig.dominant).toBe("Fire");
+      expect(Number.isFinite(sig.values.Water)).toBe(true);
+      expect(sig.values.Water).toBeCloseTo(0, 6);
+    });
+
+    it("handles null / undefined input", () => {
+      expect(() => elementalSignature(null)).not.toThrow();
+      expect(elementalSignature(undefined).tier).toBe("balanced");
+    });
+  });
+
+  describe("invariants", () => {
+    const samples: ElementalProperties[] = [
+      props(0.5, 0.25, 0.15, 0.1),
+      props(0.21, 0.29, 0.29, 0.21),
+      props(0.25, 0.25, 0.25, 0.25),
+      props(0.3, 0.29, 0.28, 0.13),
+      props(5, 3, 1, 1),
+    ];
+
+    it("always includes the dominant in coDominant and ranks four elements", () => {
+      for (const sample of samples) {
+        const sig = elementalSignature(sample);
+        expect(sig.coDominant[0]).toBe(sig.dominant);
+        expect(sig.coDominant.length).toBeGreaterThanOrEqual(1);
+        expect(sig.ranked).toHaveLength(4);
+        expect(sig.balance).toBeGreaterThanOrEqual(0);
+        expect(sig.balance).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it("never uses opposition language (elements do not oppose)", () => {
+      for (const sample of samples) {
+        const sig = elementalSignature(sample);
+        for (const text of [sig.label, sig.shortLabel]) {
+          expect(text.toLowerCase()).not.toMatch(/\bvs\b|oppos|conflict|versus/);
+        }
+      }
+    });
+  });
+});

--- a/src/app/(alchm)/generated-recipe/[id]/page.tsx
+++ b/src/app/(alchm)/generated-recipe/[id]/page.tsx
@@ -17,6 +17,7 @@ import Link from "next/link";
 import { notFound, useParams, useRouter } from "next/navigation";
 import React, { useEffect, useState, useCallback } from "react";
 import type { MonicaOptimizedRecipe } from "@/data/unified/recipeBuilding";
+import { elementalSignature } from "@/utils/elemental/signature";
 import { getRecipeFromStore } from "@/utils/generatedRecipeStore";
 
 // ─── Element helpers ─────────────────────────────────────────────────────────
@@ -73,12 +74,16 @@ interface IngredientRowProps {
 
 function IngredientRow({ name, amount, unit, elementalProperties }: IngredientRowProps) {
   const [showProps, setShowProps] = useState(false);
-  const dominantElement =
-    elementalProperties
-      ? Object.entries(elementalProperties)
-          .filter(([k]) => ["Fire", "Water", "Earth", "Air"].includes(k))
-          .sort(([, a], [, b]) => b - a)[0]?.[0]
-      : undefined;
+  // Canonical dominant for the row icon — consistent tie-break with the rest
+  // of the app (this is a single-glyph affordance, so it stays single-element).
+  const dominantElement = elementalProperties
+    ? elementalSignature({
+        Fire: elementalProperties.Fire,
+        Water: elementalProperties.Water,
+        Earth: elementalProperties.Earth,
+        Air: elementalProperties.Air,
+      }).dominant
+    : undefined;
 
   return (
     <li className="flex items-center justify-between gap-2 py-2 px-3 rounded-lg hover:bg-gray-50 transition-colors group">

--- a/src/app/(alchm)/recipe-generator/page.tsx
+++ b/src/app/(alchm)/recipe-generator/page.tsx
@@ -31,6 +31,7 @@ import { useRecipeBuilder } from "@/contexts/RecipeBuilderContext";
 import { useUser } from "@/contexts/UserContext";
 import { useAstrologicalState } from "@/hooks/useAstrologicalState";
 import type { MealType, DayOfWeek } from "@/types/menuPlanner";
+import { elementalSignature } from "@/utils/elemental/signature";
 import { saveRecipeToStore } from "@/utils/generatedRecipeStore";
 import { createLogger } from "@/utils/logger";
 import {
@@ -162,9 +163,12 @@ function CosmicMomentBanner({
   isPersonalized,
   planetaryHour,
 }: CosmicMomentProps) {
-  const dominantElement = Object.entries(domElements).sort(
-    ([, a], [, b]) => b - a,
-  )[0];
+  const sig = elementalSignature({
+    Fire: domElements.Fire,
+    Water: domElements.Water,
+    Earth: domElements.Earth,
+    Air: domElements.Air,
+  });
 
   return (
     <div className="bg-gradient-to-r from-indigo-900 via-purple-900 to-violet-900 rounded-2xl p-5 text-white shadow-xl">
@@ -210,15 +214,17 @@ function CosmicMomentBanner({
           )}
         </div>
 
-        {/* Dominant Element */}
+        {/* Elemental Lean */}
         <div className="bg-white/10 rounded-xl p-3 backdrop-blur-sm">
-          <div className="text-xs opacity-70 mb-1">Dominant Element</div>
+          <div className="text-xs opacity-70 mb-1">Elemental Lean</div>
           <div className="flex items-center gap-1.5">
-            <span className="text-lg">{ELEMENT_ICONS[dominantElement?.[0]] || "⚡"}</span>
+            <span className="text-lg">{ELEMENT_ICONS[sig.dominant] || "⚡"}</span>
             <div>
-              <div className="font-bold text-sm">{dominantElement?.[0] || "Balanced"}</div>
+              <div className="font-bold text-sm">{sig.shortLabel}</div>
               <div className="text-xs opacity-70">
-                {dominantElement ? `${Math.round(dominantElement[1] * 100)}%` : ""}
+                {sig.tier === "balanced"
+                  ? "even"
+                  : `${Math.round(sig.values[sig.dominant] * 100)}%`}
               </div>
             </div>
           </div>

--- a/src/app/api/cuisines/recommend/route.ts
+++ b/src/app/api/cuisines/recommend/route.ts
@@ -18,6 +18,7 @@ import { withObservability } from "@/lib/observability/withObservability";
 import { rateLimit } from "@/lib/rateLimit";
 import { CuisinesQuerySchema, parseCuisinesResponse } from "@/lib/validation/railway";
 import { getAccuratePlanetaryPositions } from "@/utils/astrology/positions";
+import { elementalSignature } from "@/utils/elemental/signature";
 
 const CUISINES_LIMIT = { window: 60_000, max: 60, bucket: "cuisines-recommend" };
 
@@ -105,9 +106,17 @@ function computeLocalRecommendations() {
     if (el) elementCounts[el]++;
   }
 
-  const sorted = Object.entries(elementCounts).sort(([, a], [, b]) => b - a);
-  const dominant  = sorted[0][0];
-  const secondary = sorted[1][0];
+  // Canonical signature — one tie-break shared with every display surface, plus
+  // adaptive co-dominant framing for the UI. The 3+2 primary/secondary cuisine
+  // blend is preserved so the public marketing preview keeps its count.
+  const sig = elementalSignature({
+    Fire: elementCounts.Fire,
+    Water: elementCounts.Water,
+    Earth: elementCounts.Earth,
+    Air: elementCounts.Air,
+  });
+  const dominant = sig.dominant;
+  const secondary = sig.ranked[1].element;
 
   const primData = CUISINE_MAP[dominant];
   const secData  = CUISINE_MAP[secondary];
@@ -115,6 +124,12 @@ function computeLocalRecommendations() {
   return {
     dominantElement: dominant,
     secondaryElement: secondary,
+    signature: {
+      tier: sig.tier,
+      coDominant: sig.coDominant,
+      label: sig.label,
+      shortLabel: sig.shortLabel,
+    },
     recommendations: {
       cuisines:      [...primData.cuisines.slice(0, 3),      ...secData.cuisines.slice(0, 2)],
       cookingMethods:[...primData.cookingMethods.slice(0, 2), ...secData.cookingMethods.slice(0, 2)],

--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -2,9 +2,11 @@
 
 import Link from "next/link";
 import { useMemo, type JSX } from "react";
+import { ElementalSignature } from "@/components/ui/alchm/ElementalSignature";
 import { Glyph, type GlyphName } from "@/components/ui/alchm/Glyph";
 import { NAV_IA, type NavRoute } from "@/config/navigation";
 import { useElementalState } from "@/hooks/useElementalState";
+import { elementalSignature } from "@/utils/elemental/signature";
 
 /**
  * Discover — "Browse the cosmic pantry".
@@ -85,22 +87,20 @@ const ELEMENT_ROWS: readonly ElementRow[] = [
 function ElementalBrief(): JSX.Element {
   const el = useElementalState();
 
-  // Fire/Water/Earth/Air are genuine numeric fields; derive the dominant
-  // locally rather than trusting the hook's cast-on `dominant` field.
-  const { values, dominant } = useMemo(() => {
-    const v: Record<ElementRow["key"], number> = {
-      Fire: typeof el.Fire === "number" ? el.Fire : 0.25,
-      Water: typeof el.Water === "number" ? el.Water : 0.25,
-      Earth: typeof el.Earth === "number" ? el.Earth : 0.25,
-      Air: typeof el.Air === "number" ? el.Air : 0.25,
-    };
-    const dom = (Object.entries(v) as Array<[ElementRow["key"], number]>).reduce(
-      (a, b) => (b[1] > a[1] ? b : a),
-    )[0];
-    return { values: v, dominant: dom };
-  }, [el.Fire, el.Water, el.Earth, el.Air]);
-
-  const domRow = ELEMENT_ROWS.find((r) => r.key === dominant) ?? ELEMENT_ROWS[0];
+  // Fire/Water/Earth/Air are genuine numeric fields; route them through the
+  // canonical signature so the lean — and its tie-breaks — reads identically
+  // here and on every other surface (a tied sky now reads "leans water & earth"
+  // instead of silently picking one element).
+  const sig = useMemo(
+    () =>
+      elementalSignature({
+        Fire: typeof el.Fire === "number" ? el.Fire : 0.25,
+        Water: typeof el.Water === "number" ? el.Water : 0.25,
+        Earth: typeof el.Earth === "number" ? el.Earth : 0.25,
+        Air: typeof el.Air === "number" ? el.Air : 0.25,
+      }),
+    [el.Fire, el.Water, el.Earth, el.Air],
+  );
 
   return (
     <section
@@ -124,42 +124,22 @@ function ElementalBrief(): JSX.Element {
           TONIGHT&apos;S ELEMENTAL BRIEF · LIVE SKY
         </div>
 
-        <div className="discover-brief-head">
-          <div>
-            <div
-              className="t-display"
-              style={{ fontSize: 26, color: "var(--fg)", lineHeight: 1.15 }}
-            >
-              The sky leans{" "}
-              <span style={{ color: domRow.color }}>{domRow.label.toLowerCase()}</span>
-            </div>
-            <p
-              style={{
-                margin: "6px 0 0",
-                fontSize: 13,
-                color: "var(--fg-dim)",
-                lineHeight: 1.55,
-                maxWidth: 460,
-              }}
-            >
+        <ElementalSignature
+          variant="full"
+          signature={sig}
+          style={{ marginBottom: 22 }}
+          description={
+            <>
               Live elemental match across 2,901 ingredients and 184 cuisines. Everything
               below is filtered and ranked to this moment.
-            </p>
-          </div>
-          <div
-            className="discover-brief-dom"
-            style={{
-              background: `radial-gradient(circle at 32% 28%, ${domRow.color}, color-mix(in oklch, ${domRow.color}, black 55%))`,
-            }}
-            aria-hidden="true"
-          >
-            <Glyph name={domRow.glyph} size={26} stroke={1.3} style={{ color: "rgba(0,0,0,0.72)" }} />
-          </div>
-        </div>
+            </>
+          }
+        />
 
         <div className="discover-bars">
           {ELEMENT_ROWS.map((row) => {
-            const pct = Math.round((values[row.key] ?? 0) * 100);
+            const pct = Math.round((sig.values[row.key] ?? 0) * 100);
+            const named = sig.coDominant.includes(row.key);
             return (
               <div key={row.key} className="discover-bar">
                 <div className="discover-bar-top">
@@ -174,7 +154,7 @@ function ElementalBrief(): JSX.Element {
                   </span>
                   <span
                     className="t-num"
-                    style={{ fontSize: 12, color: row.key === dominant ? "var(--fg)" : "var(--fg-mute)" }}
+                    style={{ fontSize: 12, color: named ? "var(--fg)" : "var(--fg-mute)" }}
                   >
                     {pct}%
                   </span>
@@ -264,16 +244,6 @@ export default function DiscoverPage(): JSX.Element {
           position: relative;
           overflow: hidden;
         }
-        .discover-brief-head {
-          display: flex; align-items: flex-start; justify-content: space-between;
-          gap: 20px; margin-bottom: 22px;
-        }
-        .discover-brief-dom {
-          flex-shrink: 0;
-          width: 56px; height: 56px; border-radius: 14px;
-          display: flex; align-items: center; justify-content: center;
-          box-shadow: inset 0 1px 0 rgba(255,255,255,0.25);
-        }
         .discover-bars {
           display: grid;
           grid-template-columns: repeat(4, 1fr);
@@ -281,7 +251,6 @@ export default function DiscoverPage(): JSX.Element {
         }
         @media (max-width: 560px) {
           .discover-bars { grid-template-columns: repeat(2, 1fr); gap: 16px 18px; }
-          .discover-brief-dom { width: 48px; height: 48px; }
         }
         .discover-bar-top {
           display: flex; align-items: center; justify-content: space-between;

--- a/src/app/ingredients/IngredientsExplorer.tsx
+++ b/src/app/ingredients/IngredientsExplorer.tsx
@@ -53,6 +53,7 @@ import type {
   AmazonSearchResult,
 } from "@/types/amazon";
 import { normalizeForDisplay } from "@/utils/elemental/normalization";
+import { elementalSignature } from "@/utils/elemental/signature";
 import { looseIncludes } from "@/utils/searchNormalize";
 import { getAssetUrl } from "@/utils/urlUtils";
 
@@ -169,10 +170,13 @@ const SIGN_ELEMENT: Record<string, ElementKey> = {
 };
 
 function dominantElement(props: Ingredient["elementalProperties"]): ElementKey {
-  const entries = (Object.entries(props || {}) as Array<[ElementKey, number]>)
-    .filter(([k]) => k in ELEMENT_META)
-    .sort((a, b) => (Number(b[1]) || 0) - (Number(a[1]) || 0));
-  return (entries[0]?.[0]) || "Earth";
+  // Canonical dominant — consistent tie-break with every other surface.
+  return elementalSignature({
+    Fire: Number(props?.Fire) || 0,
+    Water: Number(props?.Water) || 0,
+    Earth: Number(props?.Earth) || 0,
+    Air: Number(props?.Air) || 0,
+  }).dominant;
 }
 
 function seasonsOf(ing: Ingredient): string[] {

--- a/src/components/CookingMethods.tsx
+++ b/src/components/CookingMethods.tsx
@@ -15,6 +15,7 @@ import type { ElementalProperties, ZodiacSign, BasicThermodynamicProperties } fr
 import { _COOKING_METHOD_THERMODYNAMICS as COOKING_METHOD_THERMODYNAMICS } from '@/types/alchemy';
 import { _staticAlchemize as staticAlchemize } from '@/utils/alchemyInitializer';
 import { getCulturalCookingMethods } from '@/utils/culturalMethodsAggregator';
+import { elementalSignature } from '@/utils/elemental/signature';
 import { _getLunarMultiplier as getLunarMultiplier } from '@/utils/lunarMultiplier';
 import { testCookingMethodRecommendations } from '../utils/testRecommendations';
 import styles from './CookingMethods.module.css';
@@ -1695,9 +1696,11 @@ export default function CookingMethods() {
                 const isExpanded = expandedMethods[methodId] || false;
                 const molecular = getMolecularDetails(method);
                 
-                // Get dominant element to display
-                const dominantElement = Object.entries(method.elementalProperties || {})
-                  .sort(([_a, a], [_b, b]) => b - a)[0]?.[0]?.toLowerCase() || 'fire';
+                // Canonical dominant for the method tag — consistent tie-break.
+                // Lowercased to match the CSS-module element classes.
+                const dominantElement = elementalSignature(
+                  method.elementalProperties ?? null,
+                ).dominant.toLowerCase();
                 
                 // Use the score from our state with a more reliable key (method.id or name)
                 // This ensures the score is consistent and doesn't change when clicked

--- a/src/components/ElementalVisualizer.tsx
+++ b/src/components/ElementalVisualizer.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useMemo, useState, useCallback, useRef } from 'react';
 import type { ElementalProperties } from '@/types/alchemy';
+import { elementalSignature } from '@/utils/elemental/signature';
 import { calculateElementalCompatibility } from '@/utils/elementalCompatibility';
 
 interface ElementalVisualizerProps {
@@ -112,7 +113,6 @@ const ElementalVisualizer: React.FC<ElementalVisualizerProps> = ({
   // Derived state calculations, memoized for performance
   const {
     normalizedValues,
-    dominantElement,
     compatibility,
     sortedElements,
     recommendations
@@ -575,7 +575,8 @@ const ElementalVisualizer: React.FC<ElementalVisualizerProps> = ({
           {showDetails && (
             <div className="details-content" style={{ marginTop: '8px' }}>
               <p style={{ fontSize: sizeConfig.fontSize - 2, margin: '4px 0' }}>
-                Dominant Element: <strong>{dominantElement}</strong>
+                Elemental Signature:{" "}
+                <strong>{elementalSignature(elementalProperties).shortLabel}</strong>
               </p>
               
               {sortedElements.map((element) => (
@@ -611,9 +612,9 @@ const ElementalVisualizer: React.FC<ElementalVisualizerProps> = ({
     );
   }, [
     className, 
-    compatibility, 
-    dominantElement, 
-    handleToggleDetails, 
+    compatibility,
+    elementalProperties,
+    handleToggleDetails,
     normalizedValues, 
     recommendations, 
     renderBarChart, 

--- a/src/components/IngredientCard.tsx
+++ b/src/components/IngredientCard.tsx
@@ -11,10 +11,8 @@ import Image from "next/image";
 import React, { useState } from "react";
 import { ingredientSummaries } from "@/data/ingredients/ingredientSummaries";
 import type { Ingredient, RecipeIngredient } from "@/types";
-import {
-  isRecipeIngredient,
-  getDominantElement,
-} from "@/utils/ingredientUtils";
+import { elementalSignature } from "@/utils/elemental/signature";
+import { isRecipeIngredient } from "@/utils/ingredientUtils";
 import { getAssetUrl } from "@/utils/urlUtils";
 import { AddToDiaryModal } from "./food-diary/AddToDiaryModal";
 
@@ -32,15 +30,11 @@ export const IngredientCard: React.FC<IngredientCardProps> = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [imgFailed, setImgFailed] = useState(false);
 
-  // Determine the dominant element to style the card
-  const dominantElement = getDominantElement(
-    ingredient.elementalProperties || {
-      Fire: 0.25,
-      Water: 0.25,
-      Earth: 0.25,
-      Air: 0.25,
-    },
-  );
+  // Route the card's lean through the canonical signature so its label is
+  // co-dominant-aware and ties read identically here and everywhere else. The
+  // single-hue card art keys off the dominant element.
+  const sig = elementalSignature(ingredient.elementalProperties ?? null);
+  const dominantElement = sig.dominant;
 
   const elementColors: Record<string, string> = {
     Fire: "from-orange-500/20 to-red-600/20 border-orange-500/30",
@@ -119,7 +113,9 @@ export const IngredientCard: React.FC<IngredientCardProps> = ({
               <span
                 className={`text-xs font-semibold uppercase tracking-wider ${textColorClass}`}
               >
-                {dominantElement} Dominant
+                {sig.tier === "single"
+                  ? `${sig.dominant} Dominant`
+                  : sig.shortLabel}
               </span>
             </div>
             <button

--- a/src/components/commensal/CompositeEnergyVisualizer.tsx
+++ b/src/components/commensal/CompositeEnergyVisualizer.tsx
@@ -3,6 +3,7 @@
 import dynamic from "next/dynamic";
 import React from "react";
 import type { CompositeNatalChart } from "@/types/natalChart";
+import { elementalSignature } from "@/utils/elemental/signature";
 
 const ElementalVisualizer = dynamic(
   () => import("@/components/ElementalVisualizer"),
@@ -66,6 +67,14 @@ export function CompositeEnergyVisualizer({
   theme = "dark",
 }: Props) {
   const t = THEME[theme];
+  // Canonical signature from the composite's elemental balance — co-dominant
+  // aware, with a tie-break consistent with every other surface.
+  const sig = elementalSignature({
+    Fire: composite.elementalBalance.Fire,
+    Water: composite.elementalBalance.Water,
+    Earth: composite.elementalBalance.Earth,
+    Air: composite.elementalBalance.Air,
+  });
   const elements: Array<keyof typeof composite.elementalBalance> = [
     "Fire",
     "Water",
@@ -85,16 +94,16 @@ export function CompositeEnergyVisualizer({
       <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
         <div className="flex items-center gap-3">
           <span className="text-3xl" aria-hidden>
-            {ELEMENT_ICON[composite.dominantElement] ?? "✨"}
+            {ELEMENT_ICON[sig.dominant] ?? "✨"}
           </span>
           <div>
             <h2 className={`text-xl md:text-2xl font-bold leading-tight ${t.title}`}>
               Composite Energy
             </h2>
             <p className={`text-sm ${t.subtitle}`}>
-              Dominant element:{" "}
+              Elemental signature:{" "}
               <span className={`font-semibold ${t.titleHighlight}`}>
-                {composite.dominantElement}
+                {sig.shortLabel}
               </span>{" "}
               · Modality:{" "}
               <span className={`font-semibold ${t.titleHighlight}`}>

--- a/src/components/ui/alchm/ElementalSignature.tsx
+++ b/src/components/ui/alchm/ElementalSignature.tsx
@@ -1,0 +1,230 @@
+import { Glyph, type GlyphName } from "@/components/ui/alchm/Glyph";
+import type { Element, ElementalProperties } from "@/types/alchemy";
+import {
+  elementalSignature,
+  type ElementalSignature as Signature,
+} from "@/utils/elemental/signature";
+import type { CSSProperties, JSX, ReactNode } from "react";
+
+/**
+ * Shared elemental-signature display.
+ *
+ * The one component every surface uses to *name* the current elemental lean,
+ * driven by the canonical {@link elementalSignature} model. It adapts: a clear
+ * sky reads as a single element, a close cluster reads co-dominant
+ * ("leans water & earth"), and an even sky reads "in balance" — identically
+ * everywhere, replacing a scatter of bespoke "{element} Dominant" labels.
+ *
+ * This is purely the *headline / label / orb*. Surfaces that show the full
+ * four-element breakdown keep their bars (ElementalMeter / the discover bars);
+ * this component supplies the wording above them.
+ *
+ * Elemental principle: co-dominant is additive blending, never opposition —
+ * there is no "vs" anywhere in the copy or visuals.
+ *
+ * @file src/components/ui/alchm/ElementalSignature.tsx
+ */
+
+interface ElementMeta {
+  label: string;
+  glyph: GlyphName;
+  colorVar: string;
+}
+
+/** Element → display label, alchemical-triangle glyph, and CSS color token. */
+export const ELEMENT_META: Record<Element, ElementMeta> = {
+  Fire: { label: "Fire", glyph: "triangle-up", colorVar: "var(--el-fire)" },
+  Water: { label: "Water", glyph: "triangle-down", colorVar: "var(--el-water)" },
+  Earth: { label: "Earth", glyph: "triangle-down-bar", colorVar: "var(--el-earth)" },
+  Air: { label: "Air", glyph: "triangle-up-bar", colorVar: "var(--el-air)" },
+};
+
+export type ElementalSignatureVariant = "full" | "compact" | "inline";
+
+export interface ElementalSignatureProps {
+  /** Raw or normalized four-element vector (normalized internally). */
+  values?: ElementalProperties | null;
+  /** A precomputed signature; overrides `values` when supplied. */
+  signature?: Signature;
+  /** `full` = hero headline + orb · `compact` = orb + chip · `inline` = colored label only. */
+  variant?: ElementalSignatureVariant;
+  /** Lead-in subject for the `full` headline (e.g. "The sky", "This dish"). */
+  subject?: string;
+  /** Optional sub-copy under the `full` headline. */
+  description?: ReactNode;
+  /** Headline font size for the `full` variant. */
+  headlineSize?: number;
+  className?: string;
+  style?: CSSProperties;
+}
+
+/** Colored, separator-joined element names ("water & earth", "fire, water & earth"). */
+function NamedElements({
+  elements,
+  lowercase,
+}: {
+  elements: Element[];
+  lowercase?: boolean;
+}): JSX.Element {
+  return (
+    <>
+      {elements.map((el, i) => {
+        const meta = ELEMENT_META[el];
+        const sep = i === 0 ? "" : i === elements.length - 1 ? " & " : ", ";
+        return (
+          <span key={el}>
+            {sep}
+            <span style={{ color: meta.colorVar }}>
+              {lowercase ? meta.label.toLowerCase() : meta.label}
+            </span>
+          </span>
+        );
+      })}
+    </>
+  );
+}
+
+/** The elements this signature actually *names* (dominant, or the co-dominant set). */
+function namedElements(sig: Signature): Element[] {
+  return sig.tier === "co-dominant" ? sig.coDominant : [sig.dominant];
+}
+
+/** Orb fill: a single radial for one element, an additive blend for co-dominant, a four-element wheel for balanced. */
+function orbBackground(sig: Signature): string {
+  if (sig.tier === "balanced") {
+    return "conic-gradient(from 90deg, var(--el-fire), var(--el-water), var(--el-earth), var(--el-air), var(--el-fire))";
+  }
+  const colors = namedElements(sig).map((el) => ELEMENT_META[el].colorVar);
+  if (colors.length === 1) {
+    return `radial-gradient(circle at 32% 28%, ${colors[0]}, color-mix(in oklch, ${colors[0]}, black 55%))`;
+  }
+  return `linear-gradient(135deg, ${colors.join(", ")})`;
+}
+
+function Orb({
+  sig,
+  size,
+  glyphSize,
+}: {
+  sig: Signature;
+  size: number;
+  glyphSize: number;
+}): JSX.Element {
+  const glyph: GlyphName =
+    sig.tier === "balanced" ? "atom" : ELEMENT_META[sig.dominant].glyph;
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        flexShrink: 0,
+        width: size,
+        height: size,
+        borderRadius: Math.round(size * 0.26),
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: orbBackground(sig),
+        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.25)",
+      }}
+    >
+      <Glyph
+        name={glyph}
+        size={glyphSize}
+        stroke={1.3}
+        style={{ color: "rgba(0,0,0,0.72)" }}
+      />
+    </span>
+  );
+}
+
+export function ElementalSignature({
+  values,
+  signature,
+  variant = "compact",
+  subject = "The sky",
+  description,
+  headlineSize = 26,
+  className,
+  style,
+}: ElementalSignatureProps): JSX.Element {
+  const sig = signature ?? elementalSignature(values ?? null);
+  const named = namedElements(sig);
+
+  if (variant === "inline") {
+    return (
+      <span className={className} style={style} aria-label={sig.shortLabel}>
+        {sig.tier === "balanced" ? (
+          "Balanced"
+        ) : (
+          <NamedElements elements={named} />
+        )}
+      </span>
+    );
+  }
+
+  if (variant === "compact") {
+    return (
+      <span
+        className={className}
+        aria-label={sig.shortLabel}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 8,
+          ...style,
+        }}
+      >
+        <Orb sig={sig} size={18} glyphSize={9} />
+        <span style={{ color: "var(--fg)", fontSize: 13 }}>{sig.shortLabel}</span>
+      </span>
+    );
+  }
+
+  // variant === "full"
+  return (
+    <div
+      className={className}
+      style={{
+        display: "flex",
+        alignItems: "flex-start",
+        justifyContent: "space-between",
+        gap: 20,
+        ...style,
+      }}
+    >
+      <div>
+        <div
+          className="t-display"
+          style={{ fontSize: headlineSize, color: "var(--fg)", lineHeight: 1.15 }}
+        >
+          {subject}{" "}
+          {sig.tier === "balanced" ? (
+            <>
+              is <span style={{ color: "var(--accent)" }}>in balance</span>
+            </>
+          ) : (
+            <>
+              leans <NamedElements elements={named} lowercase />
+            </>
+          )}
+        </div>
+        {description != null && (
+          <p
+            style={{
+              margin: "6px 0 0",
+              fontSize: 13,
+              color: "var(--fg-dim)",
+              lineHeight: 1.55,
+              maxWidth: 460,
+            }}
+          >
+            {description}
+          </p>
+        )}
+      </div>
+      <Orb sig={sig} size={56} glyphSize={26} />
+    </div>
+  );
+}
+
+export default ElementalSignature;

--- a/src/components/ui/alchm/index.ts
+++ b/src/components/ui/alchm/index.ts
@@ -1,6 +1,12 @@
 export { Glyph, type GlyphName, type GlyphProps } from "./Glyph";
 export { PlanetaryClock, type PlanetaryClockProps, type PlanetaryClockStyle, type PlanetaryPosition } from "./PlanetaryClock";
 export { ElementalMeter, type ElementalMeterProps, type ElementalValues } from "./ElementalMeter";
+export {
+  ElementalSignature,
+  ELEMENT_META,
+  type ElementalSignatureProps,
+  type ElementalSignatureVariant,
+} from "./ElementalSignature";
 export { CompatibilityRing, type CompatibilityRingProps } from "./CompatibilityRing";
 export { Sparkline, type SparklineProps } from "./Sparkline";
 export { LiveTimecode, type LiveTimecodeProps } from "./LiveTimecode";

--- a/src/constants/elementalSignature.ts
+++ b/src/constants/elementalSignature.ts
@@ -1,0 +1,47 @@
+import type { Element } from "@/types/alchemy";
+
+/**
+ * Tunable thresholds + canonical ordering for the shared elemental signature
+ * model (`src/utils/elemental/signature.ts`).
+ *
+ * These values frame how the four-element vector is *described* — they never
+ * change the underlying ranking math used by recommendations. They are the one
+ * place to retune the adaptive "single vs. co-dominant vs. balanced" framing
+ * against real sky data.
+ *
+ * Elemental principle: elements are individually valuable, self-reinforcing,
+ * and never opposed. A "co-dominant" reading is therefore richer description —
+ * an additive blend — never a conflict. There is no opposing-element logic here
+ * (or anywhere downstream of these constants).
+ */
+
+/**
+ * Last-resort, fully deterministic order used to break an *exact* numeric tie
+ * for `dominant`. With the co-dominant tier an exact tie almost always surfaces
+ * as co-dominant first, so this is only the final stabilizer that guarantees
+ * `dominant` is identical on every surface for the same sky.
+ */
+export const CANONICAL_ELEMENT_ORDER: readonly Element[] = [
+  "Fire",
+  "Water",
+  "Earth",
+  "Air",
+];
+
+/**
+ * An element joins the co-dominant set when its normalized share is within this
+ * delta of the leader. 0.03 ≈ "within 3 percentage points of the top element."
+ * Raise it to name secondaries more eagerly; lower it to insist on a clearer
+ * lead before a second element is named. Tunable against real sky data.
+ */
+export const CO_DOMINANT_DELTA = 0.03;
+
+/**
+ * When the full spread (strongest minus weakest share) is below this, the whole
+ * sky reads as "balanced" rather than leaning anywhere. 0.05 ≈ "all four
+ * elements sit within 5 points of each other." Kept deliberately tight so a
+ * genuine two-element lead (e.g. water & earth both ~8 points clear of the
+ * floor) still reads as co-dominant rather than collapsing to "balanced."
+ * Tunable against real sky data.
+ */
+export const BALANCED_SPREAD = 0.05;

--- a/src/hooks/useElementalState.ts
+++ b/src/hooks/useElementalState.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import type { ElementalProperties } from "@/types/alchemy";
+import { elementalSignature } from "@/utils/elemental/signature";
 import { useAlchemical } from "./useAlchemical";
 
 export interface ElementalState {
@@ -64,27 +65,20 @@ export function useElementalState() {
       Air: total > 0 ? elementCounts.Air / total : 0.25,
     };
 
-    // Find dominant element
-    const dominant = Object.entries(normalized).reduce((a, b) =>
-      normalized[a[0] as keyof ElementalState] >
-      normalized[b[0] as keyof ElementalState]
-        ? a
-        : b,
-    )[0] as keyof ElementalState;
-
-    // Calculate balance (how evenly distributed the elements are)
-    const values = Object.values(normalized);
-    const avg =
-      values.reduce((sum, val) => sum + val, 0) / (values || []).length;
-    const variance =
-      values.reduce((sum, val) => sum + Math.pow(val - avg, 2), 0) /
-      (values || []).length;
-    const balance = Math.max(0, 1 - variance * 4); // Scale to 0-1
+    // Route dominance + balance through the canonical signature so every
+    // surface agrees on ties (this previously used an Air-first reduce that
+    // disagreed with the Fire-first scan in ingredientUtils).
+    const sig = elementalSignature({
+      Fire: normalized.Fire,
+      Water: normalized.Water,
+      Earth: normalized.Earth,
+      Air: normalized.Air,
+    });
 
     return {
       ...normalized,
-      dominant,
-      balance,
+      dominant: sig.dominant,
+      balance: sig.balance,
     } as unknown as ElementalProperties;
   }, [planetaryPositions]);
 

--- a/src/utils/elemental.ts
+++ b/src/utils/elemental.ts
@@ -1,5 +1,16 @@
 import type { ElementalProperties } from "@/types/alchemy";
 
+// Canonical shared elemental signature model. Re-exported here because bare
+// `@/utils/elemental` resolves to this file (not the ./elemental/ directory
+// barrel), so this keeps the natural import path working alongside the direct
+// `@/utils/elemental/signature` path.
+export { elementalSignature } from "./elemental/signature";
+export type {
+  ElementalSignature,
+  ElementalTier,
+  RankedElement,
+} from "./elemental/signature";
+
 export interface ElementalColor {
   primary: string;
   secondary: string;

--- a/src/utils/elemental/index.ts
+++ b/src/utils/elemental/index.ts
@@ -19,6 +19,14 @@ export * from "./normalization";
 // Backwards compatibility utilities
 export * from "./compatibility";
 
+// Canonical shared elemental signature model (ranked + adaptive co-dominant)
+export { elementalSignature } from "./signature";
+export type {
+  ElementalSignature,
+  ElementalTier,
+  RankedElement,
+} from "./signature";
+
 // Re-export commonly used functions for backward compatibility
 export {
   ELEMENTAL_COLORS,

--- a/src/utils/elemental/signature.ts
+++ b/src/utils/elemental/signature.ts
@@ -1,0 +1,176 @@
+import {
+  BALANCED_SPREAD,
+  CANONICAL_ELEMENT_ORDER,
+  CO_DOMINANT_DELTA,
+} from "@/constants/elementalSignature";
+import type { Element, ElementalProperties } from "@/types/alchemy";
+
+/**
+ * The shared elemental signature model.
+ *
+ * One canonical, pure read of a four-element vector that every display surface
+ * (and the cuisine recommendation fallback) routes through, replacing a scatter
+ * of ad-hoc "dominant element" reductions that disagreed on ties. It always
+ * knows all four elements (ranked), but only *names* secondaries when they are
+ * genuinely close to the leader — a clear sky still reads as a single element.
+ *
+ * Elemental principle: elements are individually valuable, self-reinforcing,
+ * and never opposed. "Co-dominant" is additive blending — a richer description,
+ * never conflict. There is deliberately no opposing-element logic here.
+ *
+ * @file src/utils/elemental/signature.ts
+ */
+
+export type ElementalTier = "single" | "co-dominant" | "balanced";
+
+export interface RankedElement {
+  element: Element;
+  /** Normalized share, 0–1. */
+  value: number;
+}
+
+export interface ElementalSignature {
+  /** Normalized values (sum ≈ 1) in canonical Fire/Water/Earth/Air order. */
+  values: ElementalProperties;
+  /** All four elements, strongest → weakest, with exact ties broken deterministically. */
+  ranked: RankedElement[];
+  /** The single strongest element. Deterministic for any given input. */
+  dominant: Element;
+  /**
+   * Top-contiguous elements within {@link CO_DOMINANT_DELTA} of the leader.
+   * Always contains at least the dominant (length 1 = a clear single lean).
+   */
+  coDominant: Element[];
+  /** Adaptive framing: one clear lean, a close cluster, or an even sky. */
+  tier: ElementalTier;
+  /** 0–1 evenness (variance metric; identical formula to `useElementalState`). */
+  balance: number;
+  /**
+   * Verb-phrase predicate sized to follow "The sky ___":
+   * "leans water" · "leans water & earth" · "is in balance".
+   */
+  label: string;
+  /** Compact descriptor for chips/badges: "Water" · "Water & Earth" · "Balanced". */
+  shortLabel: string;
+}
+
+/** Coerce a single channel to a finite, non-negative number. */
+function channel(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(0, value)
+    : 0;
+}
+
+/** "a" · "a & b" · "a, b & c" — additive joins only, never "vs". */
+function joinNames(names: string[]): string {
+  if (names.length <= 1) return names[0] ?? "";
+  if (names.length === 2) return `${names[0]} & ${names[1]}`;
+  return `${names.slice(0, -1).join(", ")} & ${names[names.length - 1]}`;
+}
+
+function buildLabel(
+  tier: ElementalTier,
+  dominant: Element,
+  coDominant: Element[],
+): string {
+  if (tier === "balanced") return "is in balance";
+  const named = tier === "co-dominant" ? coDominant : [dominant];
+  return `leans ${joinNames(named.map((el) => el.toLowerCase()))}`;
+}
+
+function buildShortLabel(
+  tier: ElementalTier,
+  dominant: Element,
+  coDominant: Element[],
+): string {
+  if (tier === "balanced") return "Balanced";
+  return tier === "co-dominant" ? joinNames(coDominant) : dominant;
+}
+
+/**
+ * Derive the canonical {@link ElementalSignature} for a four-element vector.
+ *
+ * Accepts either raw intensities or already-normalized shares — the input is
+ * normalized to sum 1 internally (idempotent for normalized input). A degenerate
+ * all-zero / negative vector falls back to an even 0.25 split (→ "balanced"),
+ * which is also the SSR/first-paint state, keeping first render deterministic.
+ */
+export function elementalSignature(
+  props: ElementalProperties | null | undefined,
+): ElementalSignature {
+  const raw: Record<Element, number> = {
+    Fire: channel(props?.Fire),
+    Water: channel(props?.Water),
+    Earth: channel(props?.Earth),
+    Air: channel(props?.Air),
+  };
+
+  const sum = raw.Fire + raw.Water + raw.Earth + raw.Air;
+  const normalized: Record<Element, number> =
+    sum > 0
+      ? {
+          Fire: raw.Fire / sum,
+          Water: raw.Water / sum,
+          Earth: raw.Earth / sum,
+          Air: raw.Air / sum,
+        }
+      : { Fire: 0.25, Water: 0.25, Earth: 0.25, Air: 0.25 };
+
+  // Canonical Fire/Water/Earth/Air order for display bars.
+  const values: ElementalProperties = {
+    Fire: normalized.Fire,
+    Water: normalized.Water,
+    Earth: normalized.Earth,
+    Air: normalized.Air,
+  };
+
+  // Rank strongest → weakest; break exact ties by canonical order so `dominant`
+  // is identical everywhere regardless of the input object's key order.
+  const ranked: RankedElement[] = CANONICAL_ELEMENT_ORDER.map((element) => ({
+    element,
+    value: normalized[element],
+  })).sort((a, b) => {
+    if (b.value !== a.value) return b.value - a.value;
+    return (
+      CANONICAL_ELEMENT_ORDER.indexOf(a.element) -
+      CANONICAL_ELEMENT_ORDER.indexOf(b.element)
+    );
+  });
+
+  const dominant = ranked[0].element;
+  const leader = ranked[0].value;
+  const floor = ranked[ranked.length - 1].value;
+
+  // Co-dominant = the top-contiguous run within CO_DOMINANT_DELTA of the leader.
+  const coDominant = ranked
+    .filter((r) => leader - r.value <= CO_DOMINANT_DELTA)
+    .map((r) => r.element);
+
+  // Evenness — variance metric, identical to the existing useElementalState calc.
+  const avg = (normalized.Fire + normalized.Water + normalized.Earth + normalized.Air) / 4;
+  const variance =
+    (Math.pow(normalized.Fire - avg, 2) +
+      Math.pow(normalized.Water - avg, 2) +
+      Math.pow(normalized.Earth - avg, 2) +
+      Math.pow(normalized.Air - avg, 2)) /
+    4;
+  const balance = Math.max(0, 1 - variance * 4);
+
+  // A tight overall spread reads as balanced; otherwise a clustered top is
+  // co-dominant and a clear lead is a single element.
+  let tier: ElementalTier;
+  if (leader - floor < BALANCED_SPREAD) tier = "balanced";
+  else if (coDominant.length >= 2) tier = "co-dominant";
+  else tier = "single";
+
+  return {
+    values,
+    ranked,
+    dominant,
+    coDominant,
+    tier,
+    balance,
+    label: buildLabel(tier, dominant, coDominant),
+    shortLabel: buildShortLabel(tier, dominant, coDominant),
+  };
+}

--- a/src/utils/ingredientUtils.ts
+++ b/src/utils/ingredientUtils.ts
@@ -24,6 +24,7 @@ import type {
   RecipeIngredient,
   IngredientMappingType,
  ElementalProperties } from "@/types/alchemy";
+import { elementalSignature } from "@/utils/elemental/signature";
 
 /**
  * Determines the modality of an ingredient based on its qualities and elemental properties
@@ -309,19 +310,16 @@ export function mergeElementalProperties(
 }
 
 /**
- * Gets the dominant element from an ElementalProperties object
+ * Gets the dominant element from an ElementalProperties object.
+ *
+ * Delegates to the canonical {@link elementalSignature} model so the tie-break
+ * is identical across every surface (previously this used a Fire-first scan that
+ * disagreed with other "dominant element" implementations on ties).
  */
 export function getDominantElement(
   elementalProperties: ElementalProperties,
 ): string {
-  const { Fire, Water, Earth, Air } = elementalProperties;
-  const max = Math.max(Fire, Water, Earth, Air);
-
-  if (max === Fire) return "Fire";
-  if (max === Water) return "Water";
-  if (max === Earth) return "Earth";
-  if (max === Air) return "Air";
-  return "Balanced";
+  return elementalSignature(elementalProperties).dominant;
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces the scattered single-"dominant element" collapse with **one canonical, adaptive `ElementalSignature` model** consumed by every display surface and the cuisine recommendation fallback.

The `/discover` hero ([#504](https://github.com/gregcastro23/WhatToEatNext/pull/504)) exposed the bug: the sky was Water **29%** / Earth **29%** (a tie), but the brief silently rendered "leans water." Three different tie-break implementations disagreed about who wins a tie, so the same sky read differently on different screens. A tied sky now reads **"leans water & earth"** — identically everywhere.

## The model

`elementalSignature(props)` (`src/utils/elemental/signature.ts`) — a pure function that always knows all four elements (ranked) but only *names* secondaries when they're genuinely close to the leader:

- **values** — normalized (sum ≈ 1); accepts raw intensities or normalized shares (idempotent)
- **ranked / dominant** — deterministic tie-break via a single canonical order (Fire → Water → Earth → Air)
- **coDominant / tier** — adaptive: `single` (clear lean) · `co-dominant` (close cluster) · `balanced` (even sky)
- **balance** — reuses the existing variance-based evenness metric
- **label / shortLabel** — principle-respecting copy ("leans water & earth", "is in balance", "Balanced") — never "vs" / opposition

Thresholds are centralized and documented as tunable in `src/constants/elementalSignature.ts` (`CO_DOMINANT_DELTA = 0.03`, `BALANCED_SPREAD = 0.05`). **22 unit tests** cover clear-single, the exact Water/Earth tie → co-dominant, near-ties within delta, 3-way, balanced, the deterministic fallback order, normalization of raw intensities, and degenerate / NaN / null inputs.

## Shared component

`src/components/ui/alchm/ElementalSignature.tsx` — headline + dominant orb + label in `full | compact | inline` variants. Surfaces that already show the all-four bars keep them; this supplies the headline above them. Pure/presentational (no `"use client"`), so it renders in both server and client trees.

## Surfaces migrated (display)

discover brief · IngredientCard · CompositeEnergyVisualizer · recipe-generator · generated-recipe · CookingMethods · IngredientsExplorer · ElementalVisualizer.

(Surfaces with room — discover hero, IngredientCard, CompositeEnergyVisualizer, recipe-generator, ElementalVisualizer — show the co-dominant **label**; dense chips, e.g. the CookingMethods method tag and per-row ingredient glyphs, stay single-element but now use the **consistent canonical tie-break**.)

## Tie-break consolidation

The three conflicting display tie-breaks now route through the canonical helper:

- discover brief reduce (first-wins on tie) — replaced
- `useElementalState` reduce (last-wins on tie) — delegates (also sources `balance` from the helper)
- `ingredientUtils.getDominantElement` (Fire-first scan) — delegates; its `string` signature is preserved for non-display callers

## Cuisines recommendation

`computeLocalRecommendations` derives dominant/secondary from `elementalSignature` (consistent tie-break) and adds an additive `signature: { tier, coDominant, label, shortLabel }` object. The 3+2 primary/secondary **cuisine count is preserved**, so the public marketing preview doesn't regress. **Ranking math for ingredients / recipes / personalized recommendations is unchanged.**

## Verification

- ✅ 22/22 unit tests (`src/__tests__/utils/elementalSignature.test.ts`)
- ✅ `bun run typecheck` clean
- ✅ `eslint` clean on all changed files (0 warnings)
- ✅ `bun run build` passes
- ✅ Browser: `/discover` → 200, SSR renders the balanced 0.25 fallback ("The sky is in balance") which **matches the client's first render → no hydration mismatch by construction**; `/ingredients` → 200; `/api/cuisines/recommend` returns the new `signature` field with the cuisine count preserved (today's live sky: "leans air", single tier)

## Out of scope (intentional, flagged)

- **`IngredientDisplay.tsx`** — dead code (imported nowhere); left untouched.
- **admin-users badge** + **agent-profile badge** — render backend-precomputed single `dominantElement` *strings* with no elemental vector in the component; can't be made co-dominant without an API change. Not local tie-break bugs.
- **~20 calc-internal `getDominantElement` / `calculateDominantElement`** definitions (thermo / feed ranking) — left untouched to avoid score drift (the documented stretch goal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
