### PR TITLE
fix(mcp): reach a real backend for standalone sky-transit/chart tools

### DIFF
--- a/mcp-server/.gitignore
+++ b/mcp-server/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+bin/
 .npmrc
 
 .DS_Store

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -49,11 +49,31 @@ bun run mcp-server/src/index.ts
 Optional env:
 
 ```bash
+ALCHM_MCP_BACKEND_URL=https://alchm.kitchen  # alchm.kitchen host the chart/transit tools fetch /api/astrologize from
 DATABASE_URL=postgres://...           # enables token gate + invocation telemetry
 MCP_USER_API_KEY=sk_alchm_...         # single-user setups (Claude Desktop)
 INTERNAL_API_SECRET=...               # synthetic-probe exempt path (set by Vercel cron)
 SYNTHETIC_PROBE_USER_ID=<uuid>        # attribute synthetic-probe invocations to this user
 ```
+
+### `ALCHM_MCP_BACKEND_URL` — where chart/transit tools fetch from
+
+`get_live_sky_transits` and `get_transit_natal_overlay` build a natal chart by
+POSTing to `<base>/api/astrologize`, a route served by the alchm.kitchen
+Next.js app. This server runs standalone (no co-located backend), so `<base>`
+is resolved as:
+
+1. **`ALCHM_MCP_BACKEND_URL`** (or `SITE_URL` / Vercel envs) — explicit, always wins.
+2. **Bundled artifacts** — the npm `dist/index.js` and the `bun build --compile`
+   binary (`bin/alchm-mcp`) default to **`https://alchm.kitchen`**, since an
+   end-user machine has no local backend.
+3. **From-source dev** (`bun run mcp-server/src/index.ts`) defaults to
+   **`http://localhost:3000`** — run `bun run dev` alongside, or set
+   `ALCHM_MCP_BACKEND_URL`, to point it elsewhere.
+
+When the backend is unreachable the tools fail loud with the attempted URL and
+this env var name, rather than a bare "fetch failed". Build the desktop sidecar
+binary with `bun run --cwd mcp-server build:binary` → `mcp-server/bin/alchm-mcp`.
 
 When `DATABASE_URL` is absent the server still runs — all calls become anonymous, the token gate skips, and invocations are not logged.
 

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -13,7 +13,8 @@
     "README.md"
   ],
   "scripts": {
-    "build": "bun build src/index.ts --outfile dist/index.js --bundle --target node --external pg",
+    "build": "bun build src/index.ts --outfile dist/index.js --bundle --target node --external pg --define 'process.env.ALCHM_MCP_BUNDLED=\"1\"'",
+    "build:binary": "bun build src/index.ts --compile --outfile bin/alchm-mcp --define 'process.env.ALCHM_MCP_BUNDLED=\"1\"'",
     "start": "bun run src/index.ts",
     "prepublishOnly": "bun run build"
   },

--- a/mcp-server/src/__tests__/stdio.test.ts
+++ b/mcp-server/src/__tests__/stdio.test.ts
@@ -89,7 +89,13 @@ describeIf("MCP stdio transport", () => {
     const serverPath = resolve(__dirname, "..", "index.ts");
     const proc = spawn("bun", ["run", serverPath], {
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env },
+      // A from-source run defaults the chart/transit backend to localhost:3000,
+      // which isn't up in CI — point it at prod so get_live_sky_transits does a
+      // real round-trip. An externally-set ALCHM_MCP_BACKEND_URL still wins.
+      env: {
+        ALCHM_MCP_BACKEND_URL: "https://alchm.kitchen",
+        ...process.env,
+      },
     });
     // Surface server stderr so failures are debuggable.
     proc.stderr.setEncoding("utf8");

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -23,6 +23,53 @@ import {
 
 import { invokeTool, type ToolName } from "../../src/lib/mcp/tools.js";
 
+// ─── Backend URL for chart/transit self-fetches ───────────────────────
+//
+// The chart-dependent tools (get_live_sky_transits, get_transit_natal_overlay)
+// build a natal chart by POSTing to `${base}/api/astrologize`, a route served
+// by the alchm.kitchen Next.js app. Inside that app `base` resolves to the
+// Vercel alias — but this server runs STANDALONE (Claude Desktop, the npm
+// package, or the Bun-compiled desktop sidecar) with no co-located Next
+// backend, so the inherited `http://localhost:3000` default is unreachable on
+// an end-user machine → "fetch failed".
+//
+// Mirror the PA sidecar fix (planetary_agents `_resolve_url`): an explicit env
+// always wins; a bundled/compiled artifact (no local backend) falls back to
+// PROD; a from-source dev run falls back to localhost. The chart fetch reads
+// `ALCHM_MCP_BACKEND_URL` first (see natalChartService.getAstrologizeApiUrl()).
+const PROD_BACKEND_URL = "https://alchm.kitchen";
+const DEV_BACKEND_URL = "http://localhost:3000";
+
+/**
+ * True when this process is a distributable artifact — the npm `dist/index.js`
+ * bundle or the `bun build --compile` binary — rather than a raw
+ * `bun run src/index.ts`. The build scripts bake `ALCHM_MCP_BUNDLED=1` via
+ * `--define`; the `$bunfs` check is a runtime fallback for a compiled binary
+ * built without that flag (Bun executables resolve their entry inside the
+ * embedded "$bunfs" virtual filesystem; a from-source run resolves a real path).
+ */
+function isBundledSidecar(): boolean {
+  if (process.env.ALCHM_MCP_BUNDLED === "1") return true;
+  const bunMain = (globalThis as { Bun?: { main?: string } }).Bun?.main ?? "";
+  return bunMain.includes("/$bunfs/");
+}
+
+// Explicit backend env (any of these) wins and is left untouched. Only when
+// none is set do we choose a default: prod for bundled artifacts, localhost for
+// from-source dev runs.
+const hasExplicitBackend = Boolean(
+  process.env.ALCHM_MCP_BACKEND_URL?.trim() ||
+    process.env.NEXT_PUBLIC_SITE_URL?.trim() ||
+    process.env.SITE_URL?.trim() ||
+    process.env.VERCEL_PROJECT_PRODUCTION_URL?.trim() ||
+    process.env.VERCEL_URL?.trim(),
+);
+if (!hasExplicitBackend) {
+  process.env.ALCHM_MCP_BACKEND_URL = isBundledSidecar()
+    ? PROD_BACKEND_URL
+    : DEV_BACKEND_URL;
+}
+
 const server = new Server(
   {
     name: "alchm-mcp-server",
@@ -224,6 +271,9 @@ async function main() {
   );
   console.error(
     `DB:   ${process.env.DATABASE_URL ? "live" : "local-fallback (no telemetry, no token gate)"}`,
+  );
+  console.error(
+    `Backend (chart/transit /api/astrologize): ${process.env.ALCHM_MCP_BACKEND_URL ?? "app self-URL (SITE_URL / VERCEL_URL)"}${isBundledSidecar() ? " [bundled]" : ""}`,
   );
   console.error("==================================================================\n");
 }

--- a/src/services/natalChartService.ts
+++ b/src/services/natalChartService.ts
@@ -86,11 +86,20 @@ interface AstrologizeResponse {
 
 // Resolve an absolute astrologize URL when running on the server (where
 // `fetch` rejects relative paths) and stay relative in the browser.
+//
+// Server-side base resolution: an explicit `ALCHM_MCP_BACKEND_URL` wins — the
+// stdio MCP server / desktop sidecar injects it so this self-fetch reaches a
+// real alchm.kitchen instead of a non-existent localhost backend. Otherwise we
+// fall back to the app's own self base URL (Vercel alias in prod, localhost in
+// dev), which is correct when this runs inside the Next.js app itself. See
+// `mcp-server/src/index.ts` for how the sidecar defaults this env var.
 function getAstrologizeApiUrl(): string {
-  if (typeof window === "undefined") {
-    return `${getSelfBaseUrl()}/api/astrologize`;
+  if (typeof window !== "undefined") {
+    return "/api/astrologize";
   }
-  return "/api/astrologize";
+  const explicit = process.env.ALCHM_MCP_BACKEND_URL?.trim();
+  const base = explicit ? explicit.replace(/\/+$/, "") : getSelfBaseUrl();
+  return `${base}/api/astrologize`;
 }
 
 /**
@@ -197,11 +206,25 @@ async function fetchPlanetaryPositions(
       zodiacSystem: "tropical" as const,
     };
 
-    const response = await fetch(getAstrologizeApiUrl(), {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
+    const astrologizeUrl = getAstrologizeApiUrl();
+    let response: Response;
+    try {
+      response = await fetch(astrologizeUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+    } catch (cause) {
+      // Fail loud with the unreachable URL + the knob to fix it, instead of a
+      // bare "fetch failed". This is the path hit when the standalone MCP
+      // sidecar self-fetches a backend that isn't there (e.g. localhost with no
+      // local app running).
+      throw new Error(
+        `Could not reach the astrologize backend at ${astrologizeUrl}. ` +
+          "Set ALCHM_MCP_BACKEND_URL to a reachable alchm.kitchen host.",
+        { cause },
+      );
+    }
 
     if (!response.ok) {
       throw new Error(`Astrologize API error: ${response.statusText}`);


### PR DESCRIPTION
## Problem

The `alchm-mcp` server (run standalone by Claude Desktop, the npm package, and the PA Tauri desktop sidecar) failed `get_live_sky_transits` / `get_transit_natal_overlay`:

```
Failed to calculate natal chart … ← fetch failed
```

Root cause: the chart tools build a natal chart by POSTing to `${getSelfBaseUrl()}/api/astrologize` (a route on the alchm.kitchen Next.js app). Standalone, that base falls back to `http://localhost:3000` — unreachable on an end-user machine with no co-located backend → `fetch failed`.

## Fix (transport/config only — no alchemy/astrology formula logic changed)

- **`natalChartService.getAstrologizeApiUrl()`** — an explicit `ALCHM_MCP_BACKEND_URL` now wins for the server-side base; otherwise falls back to `getSelfBaseUrl()` unchanged (the Next.js app path is untouched).
- **`fetchPlanetaryPositions()`** — wraps the fetch to fail **loud** with the attempted URL + the env var to set, instead of a bare `fetch failed`.
- **`mcp-server/src/index.ts`** — mirrors the PA sidecar fix (`_resolve_url`): explicit env wins; a **bundled/compiled artifact defaults to `https://alchm.kitchen`**; a **from-source dev run keeps `http://localhost:3000`**. Boot banner prints the resolved backend.
- **`package.json`** — bakes `ALCHM_MCP_BUNDLED=1` into the dist bundle via `--define`, and adds **`build:binary`** (`bun build --compile` → `bin/alchm-mcp`) for the desktop sidecar.
- **`stdio.test.ts`** — the `MCP_E2E` suite now injects the prod backend so `get_live_sky_transits` does a real round-trip.

## Env var (for the PA desktop app to inject into the sidecar)

```
ALCHM_MCP_BACKEND_URL=https://alchm.kitchen
```

⚠️ Dedicated name — **not** PA's generic `ALCHM_BACKEND_URL` (that points at `alchm-backend.onrender.com`, which does not serve `/api/astrologize`). The rebuilt binary also self-defaults to prod, so injection is belt-and-suspenders.

## Verification

- `bun run verify` (typecheck + lint) → exit 0
- `bun test src/lib/mcp/__tests__/tools.test.ts` → 9 pass
- `MCP_E2E=1 bun test mcp-server/src/__tests__/stdio.test.ts` → 2 pass (real prod round-trip)
- Compiled `bin/alchm-mcp`, **zero env** → banner `https://alchm.kitchen [bundled]`, returns real positions (Sun gemini, Moon aquarius, …), `isError: false`
- Compiled binary with explicit `ALCHM_MCP_BACKEND_URL` override → honored; unreachable host → loud, actionable error

🤖 Generated with [Claude Code](https://claude.com/claude-code)