### PR TITLE
fix(commensal): make group recommendations resilient

### DIFF
--- a/src/app/(alchm)/commensal/page.tsx
+++ b/src/app/(alchm)/commensal/page.tsx
@@ -1,31 +1,33 @@
-'use client';
+"use client";
 
-import { useSession } from 'next-auth/react';
-import React, { useState } from 'react';
-import { CompanionSuggestions } from '@/components/commensal/CompanionSuggestions';
-import { CompositeEnergyVisualizer } from '@/components/commensal/CompositeEnergyVisualizer';
-import { CookingMethodsList } from '@/components/commensal/CookingMethodsList';
-import LiveCommensalLobby from '@/components/commensal/LiveCommensalLobby';
-import { RecommendedRecipeCard } from '@/components/commensal/RecommendedRecipeCard';
-import { RestaurantList } from '@/components/commensal/RestaurantList';
-import { SaveGroupButton } from '@/components/commensal/SaveGroupButton';
-import { SignInPrompt } from '@/components/commensal/SignInPrompt';
+import { useSession } from "next-auth/react";
+import React, { useEffect, useState } from "react";
+import { CompanionSuggestions } from "@/components/commensal/CompanionSuggestions";
+import { CompositeEnergyVisualizer } from "@/components/commensal/CompositeEnergyVisualizer";
+import { CookingMethodsList } from "@/components/commensal/CookingMethodsList";
+import LiveCommensalLobby from "@/components/commensal/LiveCommensalLobby";
+import { RecommendedRecipeCard } from "@/components/commensal/RecommendedRecipeCard";
+import { RestaurantList } from "@/components/commensal/RestaurantList";
+import { SaveGroupButton } from "@/components/commensal/SaveGroupButton";
+import { SignInPrompt } from "@/components/commensal/SignInPrompt";
 import {
   CompositeEnergySkeleton,
   MethodsSkeleton,
   RecipeSkeleton,
   RestaurantSkeleton,
-} from '@/components/commensal/skeletons';
-import { LocationSearch } from '@/components/onboarding/LocationSearch';
+} from "@/components/commensal/skeletons";
+import { LocationSearch } from "@/components/onboarding/LocationSearch";
 import {
   useGuestRecommendations,
   type SearchLocation,
-} from '@/hooks/useCommensalRecommendations';
-import type { BirthData } from '@/types/natalChart';
+} from "@/hooks/useCommensalRecommendations";
+import type { BirthData, NatalChart } from "@/types/natalChart";
 
 interface GuestEntry {
+  id?: string;
   name: string;
   birthData: BirthData;
+  natalChart?: NatalChart | null;
 }
 
 interface GuestFormProps {
@@ -35,11 +37,11 @@ interface GuestFormProps {
 
 function GuestForm({ onAdd, onCompanionSaved }: GuestFormProps) {
   const { status: authStatus } = useSession();
-  const [name, setName] = useState('');
-  const [dateTime, setDateTime] = useState('');
-  const [latitude, setLatitude] = useState('');
-  const [longitude, setLongitude] = useState('');
-  const [timezone, setTimezone] = useState('');
+  const [name, setName] = useState("");
+  const [dateTime, setDateTime] = useState("");
+  const [latitude, setLatitude] = useState("");
+  const [longitude, setLongitude] = useState("");
+  const [timezone, setTimezone] = useState("");
   const [loading, setLoading] = useState(false);
   const [successMsg, setSuccessMsg] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -57,54 +59,61 @@ function GuestForm({ onAdd, onCompanionSaved }: GuestFormProps) {
       setErrorMsg(null);
       setSuccessMsg(null);
 
-      if (authStatus === 'authenticated') {
+      if (authStatus === "authenticated") {
         setLoading(true);
         void (async () => {
           try {
-            const res = await fetch('/api/user/commensals', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
+            const res = await fetch("/api/user/commensals", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
                 name,
-                relationship: 'friend',
+                relationship: "friend",
                 birthData: data,
               }),
             });
             const result = await res.json();
             if (!res.ok || !result.success) {
-              throw new Error(result.message || 'Failed to save companion chart');
+              throw new Error(
+                result.message || "Failed to save companion chart",
+              );
             }
 
             // Companion saved successfully!
-            setSuccessMsg(`✓ Saved ${name}! Quest complete: Earned 20 Matter tokens.`);
-            
+            setSuccessMsg(
+              `✓ Saved ${name}! Quest complete: Earned 20 Matter tokens.`,
+            );
+
             // Trigger global token widget update
-            if (typeof window !== 'undefined') {
-              window.dispatchEvent(new Event('tokenEconomy:updated'));
+            if (typeof window !== "undefined") {
+              window.dispatchEvent(new Event("tokenEconomy:updated"));
             }
 
             // Call parent to add guest to the local recommendation list
             onAdd(name, data);
-            
+
             // Trigger companion suggestions tab reload
             if (onCompanionSaved) onCompanionSaved();
 
             // Reset fields
-            setName('');
-            setDateTime('');
-            setLatitude('');
-            setLongitude('');
-            setTimezone('');
+            setName("");
+            setDateTime("");
+            setLatitude("");
+            setLongitude("");
+            setTimezone("");
           } catch (err: any) {
             console.error(err);
-            setErrorMsg(err.message || 'Saved companion locally instead due to a temporary error.');
+            setErrorMsg(
+              err.message ||
+                "Saved companion locally instead due to a temporary error.",
+            );
             // Fallback to local-only guest addition so user can still compute recommendations
             onAdd(name, data);
-            setName('');
-            setDateTime('');
-            setLatitude('');
-            setLongitude('');
-            setTimezone('');
+            setName("");
+            setDateTime("");
+            setLatitude("");
+            setLongitude("");
+            setTimezone("");
           } finally {
             setLoading(false);
           }
@@ -112,12 +121,14 @@ function GuestForm({ onAdd, onCompanionSaved }: GuestFormProps) {
       } else {
         // Fallback for anonymous users: add locally
         onAdd(name, data);
-        setSuccessMsg(`Added locally. Sign in to save permanently & earn 20 Matter tokens!`);
-        setName('');
-        setDateTime('');
-        setLatitude('');
-        setLongitude('');
-        setTimezone('');
+        setSuccessMsg(
+          `Added locally. Sign in to save permanently & earn 20 Matter tokens!`,
+        );
+        setName("");
+        setDateTime("");
+        setLatitude("");
+        setLongitude("");
+        setTimezone("");
       }
     }
   };
@@ -132,13 +143,19 @@ function GuestForm({ onAdd, onCompanionSaved }: GuestFormProps) {
           Add Commensal
         </h3>
         <p className="text-[11px] text-purple-300/60 leading-relaxed">
-          Input your dining guest or any moment of alignment to compute alchemical compatibility.
+          Input your dining guest or any moment of alignment to compute
+          alchemical compatibility.
         </p>
       </div>
 
       <div className="space-y-3">
         <div>
-          <label htmlFor="commensal-name" className="block text-xs text-white/50 mb-1">Name / Moment Identifier</label>
+          <label
+            htmlFor="commensal-name"
+            className="block text-xs text-white/50 mb-1"
+          >
+            Name / Moment Identifier
+          </label>
           <input
             id="commensal-name"
             type="text"
@@ -151,7 +168,12 @@ function GuestForm({ onAdd, onCompanionSaved }: GuestFormProps) {
           />
         </div>
         <div>
-          <label htmlFor="commensal-datetime" className="block text-xs text-white/50 mb-1">Birth date &amp; time *</label>
+          <label
+            htmlFor="commensal-datetime"
+            className="block text-xs text-white/50 mb-1"
+          >
+            Birth date &amp; time *
+          </label>
           <input
             id="commensal-datetime"
             type="datetime-local"
@@ -163,7 +185,9 @@ function GuestForm({ onAdd, onCompanionSaved }: GuestFormProps) {
           />
         </div>
         <div>
-          <div className="block text-xs text-white/50 mb-1">Birth location *</div>
+          <div className="block text-xs text-white/50 mb-1">
+            Birth location *
+          </div>
           <LocationSearch
             onLocationSelect={(loc) => {
               setLatitude(loc.latitude.toString());
@@ -181,7 +205,7 @@ function GuestForm({ onAdd, onCompanionSaved }: GuestFormProps) {
         disabled={loading || !name || !dateTime || !latitude || !longitude}
         className="w-full py-2.5 bg-gradient-to-r from-alchm-copper to-alchm-violet text-white text-sm font-bold rounded-lg hover:opacity-90 disabled:opacity-50 transition-all flex items-center justify-center gap-2"
       >
-        {loading ? 'Calculating heavens & saving...' : 'Add guest & Save Chart'}
+        {loading ? "Calculating heavens & saving..." : "Add guest & Save Chart"}
       </button>
 
       {successMsg && (
@@ -201,7 +225,9 @@ function GuestForm({ onAdd, onCompanionSaved }: GuestFormProps) {
 
 export default function CommensalPage() {
   const [guests, setGuests] = useState<GuestEntry[]>([]);
-  const [searchLocation, setSearchLocation] = useState<SearchLocation | null>(null);
+  const [searchLocation, setSearchLocation] = useState<SearchLocation | null>(
+    null,
+  );
   const [refreshTrigger, setRefreshTrigger] = useState(0);
 
   const {
@@ -213,6 +239,7 @@ export default function CommensalPage() {
     savableGuests,
     error: errorMessage,
     run,
+    reset,
   } = useGuestRecommendations();
 
   const generateRecommendations = () => {
@@ -220,25 +247,52 @@ export default function CommensalPage() {
     void run({ guests, location: searchLocation });
   };
 
-  const handleInviteCompanion = (name: string, birthData: BirthData) => {
-    if (guests.some((g) => g.name.toLowerCase() === name.toLowerCase())) return;
-    setGuests((prev) => [...prev, { name, birthData }]);
+  const handleInviteCompanion = (
+    id: string,
+    name: string,
+    birthData: BirthData,
+    natalChart: NatalChart | null,
+  ) => {
+    if (
+      guests.some(
+        (guest) =>
+          guest.id === id || guest.name.toLowerCase() === name.toLowerCase(),
+      )
+    ) {
+      return;
+    }
+    setGuests((prev) => [...prev, { id, name, birthData, natalChart }]);
   };
 
   const removeGuest = (idx: number) => {
     setGuests((prev) => prev.filter((_, i) => i !== idx));
   };
 
-  const showSkeletons = phase === 'composing' || phase === 'scoring';
-  const showRestaurantSkeleton = phase === 'searching';
+  // Keep the composite and recommendations synchronized with the actual
+  // dinner party. The hook ignores stale responses when members change again.
+  useEffect(() => {
+    if (guests.length === 0) {
+      reset();
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      void run({ guests, location: searchLocation });
+    }, 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [guests, reset, run, searchLocation]);
+
+  const showSkeletons = phase === "composing" || phase === "scoring";
+  const showRestaurantSkeleton = phase === "searching";
   const buttonLabel =
-    phase === 'composing'
-      ? 'Synthesizing cosmos…'
-      : phase === 'scoring'
-        ? 'Scoring recipes…'
-        : phase === 'searching'
-          ? 'Finding restaurants…'
-          : 'Generate real-time recommendations';
+    phase === "composing"
+      ? "Synthesizing cosmos…"
+      : phase === "scoring"
+        ? "Scoring recipes…"
+        : phase === "searching"
+          ? "Finding restaurants…"
+          : "Generate real-time recommendations";
 
   return (
     <div className="min-h-screen bg-transparent text-white p-4 md:p-8">
@@ -283,7 +337,7 @@ export default function CommensalPage() {
                 <ul className="space-y-2">
                   {guests.map((g, idx) => (
                     <li
-                      key={`${g.name}-${idx}`}
+                      key={g.id || `${g.name}-${idx}`}
                       className="flex justify-between items-center bg-white/5 border border-white/5 px-3 py-2 rounded-lg"
                     >
                       <span className="font-medium text-sm text-white/90">
@@ -325,7 +379,12 @@ export default function CommensalPage() {
 
             <button
               onClick={() => void generateRecommendations()}
-              disabled={guests.length === 0 || phase === 'composing' || phase === 'scoring' || phase === 'searching'}
+              disabled={
+                guests.length === 0 ||
+                phase === "composing" ||
+                phase === "scoring" ||
+                phase === "searching"
+              }
               className="w-full py-4 bg-gradient-to-r from-alchm-copper to-alchm-violet text-white font-bold rounded-lg hover:opacity-90 disabled:opacity-50 transition-all shadow-lg shadow-alchm-violet/20"
             >
               {buttonLabel}
@@ -337,14 +396,14 @@ export default function CommensalPage() {
               </div>
             )}
 
-            {phase === 'done' && composite && savableGuests.length > 0 && (
+            {phase === "done" && composite && savableGuests.length > 0 && (
               <>
                 <SaveGroupButton
                   guests={savableGuests.map((g) => ({
                     name: g.name,
                     birthData: g.birthData,
                     natalChart: g.natalChart,
-                    relationship: 'friend',
+                    relationship: "friend",
                   }))}
                   defaultGroupName={`${composite.dominantElement} group · ${new Date().toLocaleDateString()}`}
                 />
@@ -362,22 +421,24 @@ export default function CommensalPage() {
               </>
             )}
 
-            {composite && phase !== 'composing' && phase !== 'scoring' && (
+            {composite && phase !== "composing" && phase !== "scoring" && (
               <CompositeEnergyVisualizer composite={composite} />
             )}
 
-            {composite && cookingMethods.length > 0 && phase !== 'composing' && (
-              <CookingMethodsList methods={cookingMethods} />
-            )}
+            {composite &&
+              cookingMethods.length > 0 &&
+              phase !== "composing" && (
+                <CookingMethodsList methods={cookingMethods} />
+              )}
 
-            {recipes.length > 0 && phase !== 'composing' && (
+            {recipes.length > 0 && phase !== "composing" && (
               <div className="space-y-4">
                 <RecommendedRecipeCard scored={recipes[0]} />
                 {recipes.length > 1 && (
                   <details className="glass-card-premium rounded-2xl p-5 border border-white/10">
                     <summary className="cursor-pointer text-sm font-semibold text-white/90">
                       {recipes.length - 1} more recipe match
-                      {recipes.length - 1 === 1 ? '' : 'es'}
+                      {recipes.length - 1 === 1 ? "" : "es"}
                     </summary>
                     <div className="mt-4 space-y-3">
                       {recipes.slice(1).map((r) => (
@@ -395,14 +456,14 @@ export default function CommensalPage() {
 
             {showRestaurantSkeleton && <RestaurantSkeleton />}
 
-            {phase === 'done' && restaurants.length > 0 && searchLocation && (
+            {phase === "done" && restaurants.length > 0 && searchLocation && (
               <RestaurantList
                 restaurants={restaurants}
                 locationLabel={searchLocation.displayName}
               />
             )}
 
-            {phase === 'idle' && !composite && (
+            {phase === "idle" && !composite && (
               <div className="glass-card-premium rounded-3xl p-8 border border-white/10 text-center">
                 <p className="text-white/70">
                   Add at least one guest, then generate recommendations to see

--- a/src/app/api/commensal/companions/__tests__/route.test.ts
+++ b/src/app/api/commensal/companions/__tests__/route.test.ts
@@ -23,9 +23,17 @@ jest.mock("@/lib/auth/validateRequest", () => ({
   getDatabaseUserFromRequest: jest.fn(() => Promise.resolve(null)),
 }));
 
+jest.mock("@/services/commensalDatabaseService", () => ({
+  commensalDatabase: {
+    getManualCompanionsForUser: jest.fn(() => Promise.resolve([])),
+    getLinkedCommensalsForUser: jest.fn(() => Promise.resolve([])),
+  },
+}));
+
 import { executeQuery } from "@/lib/database";
 import { fetchAgentsForDate } from "@/lib/planetaryAgentsClient";
 import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
+import { commensalDatabase } from "@/services/commensalDatabaseService";
 import { GET } from "../route";
 
 function makeRequest(url = "http://localhost/api/commensal/companions"): any {
@@ -41,45 +49,57 @@ const mockLocalAgents = {
       user_id: "agent_monica_id",
       email: "monica@agents.alchm.kitchen",
       profile: {
-        birthData: { dateTime: "2026-01-01T12:00:00Z", latitude: 40, longitude: -74 }
+        birthData: {
+          dateTime: "2026-01-01T12:00:00Z",
+          latitude: 40,
+          longitude: -74,
+        },
       },
       name: "Monica Constant",
       bio: "High Alchemist Monica",
       dominant_element: "Fire",
       monica_constant: "1.618033",
       birth_data: null,
-      natal_chart: null
+      natal_chart: null,
     },
     {
       user_id: "agent_hermes_id",
       email: "hermes@agents.alchm.kitchen",
       profile: {
-        birthData: { dateTime: "2026-02-02T12:00:00Z", latitude: 35, longitude: 25 }
+        birthData: {
+          dateTime: "2026-02-02T12:00:00Z",
+          latitude: 35,
+          longitude: 25,
+        },
       },
       name: "Hermes Trismegistus",
       bio: "Thoth scribe and master alchemist",
       dominant_element: "Air",
       monica_constant: null,
       birth_data: null,
-      natal_chart: null
-    }
-  ]
+      natal_chart: null,
+    },
+  ],
 };
 
 const mockFeedEvents = {
   rows: [
-    { actor_id: "agent_monica_id", last_action_at: "2026-06-01T15:00:00Z" }
-  ]
+    { actor_id: "agent_monica_id", last_action_at: "2026-06-01T15:00:00Z" },
+  ],
 };
 
 const mockActivations = [
   {
-    agent: { id: "monica", name: "Monica Constant", description: "Active Monica" },
+    agent: {
+      id: "monica",
+      name: "Monica Constant",
+      description: "Active Monica",
+    },
     strength: 0.95,
     dignity: "domicile",
     element: "Fire",
-    planetaryRuler: "Mars"
-  }
+    planetaryRuler: "Mars",
+  },
 ];
 
 describe("GET /api/commensal/companions", () => {
@@ -92,6 +112,12 @@ describe("GET /api/commensal/companions", () => {
       return Promise.resolve(mockLocalAgents);
     });
     (fetchAgentsForDate as jest.Mock).mockResolvedValue(mockActivations);
+    (
+      commensalDatabase.getManualCompanionsForUser as jest.Mock
+    ).mockResolvedValue([]);
+    (
+      commensalDatabase.getLinkedCommensalsForUser as jest.Mock
+    ).mockResolvedValue([]);
   });
 
   it("successfully returns active agents, historical agents, and the cosmic roster", async () => {
@@ -119,7 +145,9 @@ describe("GET /api/commensal/companions", () => {
   });
 
   it("degrades gracefully when Planetary Agents activations API fails", async () => {
-    (fetchAgentsForDate as jest.Mock).mockRejectedValue(new Error("PA API Timeout"));
+    (fetchAgentsForDate as jest.Mock).mockRejectedValue(
+      new Error("PA API Timeout"),
+    );
 
     const res = await GET(makeRequest());
     const data = await res.json();
@@ -128,30 +156,50 @@ describe("GET /api/commensal/companions", () => {
     expect(data.success).toBe(true);
     expect(data.activeAgents).toHaveLength(0); // active is empty but the endpoint doesn't fail
     expect(data.cosmicRoster).toHaveLength(2); // still loads roster
+    expect(data.degraded).toBe(true);
+    expect(data.unavailableSources).toContain("planetary-activations");
+  });
+
+  it("returns usable empty categories when the database is unavailable", async () => {
+    (executeQuery as jest.Mock).mockRejectedValue(
+      Object.assign(new Error("connection refused"), { code: "ECONNREFUSED" }),
+    );
+
+    const res = await GET(makeRequest());
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.activeAgents).toEqual([]);
+    expect(data.historicalAgents).toEqual([]);
+    expect(data.cosmicRoster).toEqual([]);
+    expect(data.savedCompanions).toEqual([]);
+    expect(data.degraded).toBe(true);
+    expect(data.unavailableSources).toEqual(
+      expect.arrayContaining(["cosmic-roster", "historical-feed"]),
+    );
   });
 
   it("returns savedCompanions when user is authenticated", async () => {
-    (getDatabaseUserFromRequest as jest.Mock).mockResolvedValue({ id: "user-123" });
-
-    (executeQuery as jest.Mock).mockImplementation((query: string) => {
-      if (query.includes("manual_companion_charts")) {
-        return Promise.resolve({
-          rows: [
-            {
-              id: "manual-001",
-              name: "Saved Friend",
-              relationship: "friend",
-              birth_data: { dateTime: "2026-03-03T12:00:00Z", latitude: 12, longitude: 34 },
-              natal_chart: { dominantElement: "Water" }
-            }
-          ]
-        });
-      }
-      if (query.includes("feed_events")) {
-        return Promise.resolve(mockFeedEvents);
-      }
-      return Promise.resolve(mockLocalAgents);
+    (getDatabaseUserFromRequest as jest.Mock).mockResolvedValue({
+      id: "user-123",
     });
+
+    (
+      commensalDatabase.getManualCompanionsForUser as jest.Mock
+    ).mockResolvedValue([
+      {
+        id: "manual-001",
+        name: "Saved Friend",
+        relationship: "friend",
+        birthData: {
+          dateTime: "2026-03-03T12:00:00Z",
+          latitude: 12,
+          longitude: 34,
+        },
+        natalChart: { dominantElement: "Water" },
+      },
+    ]);
 
     const res = await GET(makeRequest());
     const data = await res.json();
@@ -161,5 +209,8 @@ describe("GET /api/commensal/companions", () => {
     expect(data.savedCompanions).toHaveLength(1);
     expect(data.savedCompanions[0].name).toBe("Saved Friend");
     expect(data.savedCompanions[0].dominantElement).toBe("Water");
+    expect(data.savedCompanions[0].natalChart).toEqual(
+      expect.objectContaining({ dominantElement: "Water" }),
+    );
   });
 });

--- a/src/app/api/commensal/companions/route.ts
+++ b/src/app/api/commensal/companions/route.ts
@@ -11,6 +11,8 @@ import { NextResponse, type NextRequest } from "next/server";
 import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
 import { executeQuery } from "@/lib/database";
 import { fetchAgentsForDate } from "@/lib/planetaryAgentsClient";
+import { commensalDatabase } from "@/services/commensalDatabaseService";
+import type { BirthData, NatalChart } from "@/types/natalChart";
 import { safeJsonParse } from "@/utils/typeGuards";
 
 export const dynamic = "force-dynamic";
@@ -28,18 +30,55 @@ interface LocalAgentRow {
   natal_chart: any;
 }
 
-export async function GET(_req: NextRequest) {
-  try {
-    // 1. Fetch active agents for the current date from Planetary Agents API
-    let activations: any[] = [];
-    try {
-      activations = await fetchAgentsForDate(new Date());
-    } catch (err) {
-      console.warn("[companions] Failed to fetch active transits from PA, degrading gracefully:", err);
-    }
+interface CompanionView {
+  userId: string;
+  email: string;
+  name: string;
+  bio: string;
+  dominantElement: string;
+  monicaConstant: number | null;
+  birthData: BirthData;
+  natalChart: NatalChart | null;
+}
 
-    // 2. Fetch all local synchronized agents
-    const agentsResult = await executeQuery<LocalAgentRow>(
+function parseObject(value: unknown): Record<string, any> | null {
+  const parsed =
+    typeof value === "string"
+      ? safeJsonParse<Record<string, any>>(value)
+      : value;
+  return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+    ? (parsed as Record<string, any>)
+    : null;
+}
+
+function errorSummary(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    typeof error.code === "string"
+  ) {
+    return error.code;
+  }
+  return "unavailable";
+}
+
+export async function GET(_req: NextRequest) {
+  const warnings: string[] = [];
+
+  // Planetary activations and the local roster are independent sources. A
+  // failure in either one should not prevent saved companions from loading.
+  const [activations, localAgents] = await Promise.all([
+    fetchAgentsForDate(new Date()).catch((error) => {
+      warnings.push("planetary-activations");
+      console.warn(
+        "[companions] Planetary activations unavailable:",
+        errorSummary(error),
+      );
+      return [] as any[];
+    }),
+    executeQuery<LocalAgentRow>(
       `SELECT u.id AS user_id,
               u.email,
               u.profile,
@@ -53,55 +92,96 @@ export async function GET(_req: NextRequest) {
          LEFT JOIN user_profiles up ON up.user_id = u.id
         WHERE COALESCE(u.is_agent, false) = true
           AND u.is_active = true`,
-      []
-    );
+      [],
+    )
+      .then((result) => result.rows || [])
+      .catch((error) => {
+        warnings.push("cosmic-roster");
+        console.warn(
+          "[companions] Local agent roster unavailable:",
+          errorSummary(error),
+        );
+        return [] as LocalAgentRow[];
+      }),
+  ]);
 
-    const localAgents = agentsResult.rows || [];
+  // Parse and normalize birth data + charts with defensive fallback structures.
+  const hydratedAgents = localAgents
+    .map((row): CompanionView | null => {
+      const profile = parseObject(row.profile) || {};
+      const birthData =
+        parseObject(row.birth_data) ||
+        parseObject(profile.birthData) ||
+        parseObject(profile.birth_data) ||
+        parseObject(profile.natalChart)?.birthData ||
+        parseObject(profile.natal_chart)?.birthData;
+      const natalChart =
+        parseObject(row.natal_chart) ||
+        parseObject(profile.natalChart) ||
+        parseObject(profile.natal_chart);
+      const email = typeof row.email === "string" ? row.email : "";
 
-    // Parse and normalize birth data + charts with bulletproof fallback structures
-    const hydratedAgents = localAgents.map((row) => {
-      const profile = typeof row.profile === "string" ? safeJsonParse(row.profile) : row.profile || {};
-      const birthData = row.birth_data 
-        ? (typeof row.birth_data === "string" ? safeJsonParse(row.birth_data) : row.birth_data)
-        : (profile.birthData || profile.birth_data || profile.natalChart?.birthData || profile.natal_chart?.birthData);
-      
-      const natalChart = row.natal_chart
-        ? (typeof row.natal_chart === "string" ? safeJsonParse(row.natal_chart) : row.natal_chart)
-        : (profile.natalChart || profile.natal_chart);
+      if (!email || !birthData) return null;
 
       return {
         userId: row.user_id,
-        email: row.email,
-        slug: row.email.split("@")[0].toLowerCase(),
-        name: row.name || row.email.split("@")[0],
-        bio: row.bio || profile.bio || "Planetary sage guiding alchemical balance.",
-        dominantElement: row.dominant_element || natalChart?.dominantElement || "Fire",
-        monicaConstant: row.monica_constant ? parseFloat(row.monica_constant) : null,
-        birthData: birthData && Object.keys(birthData).length > 0 ? birthData : null,
-        natalChart: natalChart && Object.keys(natalChart).length > 0 ? natalChart : null,
+        email,
+        name: row.name || email.split("@")[0],
+        bio:
+          row.bio ||
+          profile.bio ||
+          "Planetary sage guiding alchemical balance.",
+        dominantElement:
+          row.dominant_element || natalChart?.dominantElement || "Fire",
+        monicaConstant: row.monica_constant
+          ? parseFloat(row.monica_constant)
+          : null,
+        birthData: birthData as BirthData,
+        natalChart: (natalChart as NatalChart | null) || null,
       };
-    }).filter(a => a.birthData !== null); // Filter out agents that do not have valid birth data
+    })
+    .filter((agent): agent is CompanionView => agent !== null);
 
-    // 3. Fetch historical feed activity for agents
-    const feedResult = await executeQuery<{ actor_id: string; last_action_at: string }>(
-      `SELECT actor_id, MAX(created_at) AS last_action_at
+  // Historical activity is optional. If it is unavailable, the roster and
+  // saved companions remain fully usable.
+  const feedActors: Array<{
+    actor_id: string;
+    last_action_at: string;
+  }> = await executeQuery<{
+    actor_id: string;
+    last_action_at: string;
+  }>(
+    `SELECT actor_id, MAX(created_at) AS last_action_at
          FROM feed_events
         GROUP BY actor_id
         ORDER BY last_action_at DESC
         LIMIT 30`,
-      []
-    );
-    const feedActors = feedResult.rows || [];
-    const actorTimestamps = new Map(feedActors.map(f => [f.actor_id, f.last_action_at]));
+    [],
+  )
+    .then((result) => result.rows || [])
+    .catch((error) => {
+      warnings.push("historical-feed");
+      console.warn(
+        "[companions] Historical feed unavailable:",
+        errorSummary(error),
+      );
+      return [] as Array<{ actor_id: string; last_action_at: string }>;
+    });
+  const actorTimestamps = new Map<string, string>(
+    feedActors.map((feed) => [feed.actor_id, feed.last_action_at] as const),
+  );
 
-    // --- Build Companion Categories ---
+  // --- Build Companion Categories ---
 
-    // Category 1: Present Moment Agents (aligned with active transits)
-    const activeAgents = activations.map((act: any) => {
+  // Category 1: Present Moment Agents (aligned with active transits)
+  const activeAgents = activations
+    .map((act: any) => {
       const actAgentId = String(act.agent?.id || "").toLowerCase();
       // Match by email slug (prefix before @)
-      const matchedLocal = hydratedAgents.find(a => a.slug === actAgentId);
-      
+      const matchedLocal = hydratedAgents.find(
+        (agent) => agent.email.split("@")[0].toLowerCase() === actAgentId,
+      );
+
       if (!matchedLocal) return null;
 
       return {
@@ -111,72 +191,78 @@ export async function GET(_req: NextRequest) {
           dignity: act.dignity || "peregrine",
           element: act.element || matchedLocal.dominantElement,
           planetaryRuler: act.planetaryRuler || "Sun",
-          description: act.agent?.description || matchedLocal.bio
-        }
+          description: act.agent?.description || matchedLocal.bio,
+        },
       };
-    }).filter((a): a is NonNullable<typeof a> => a !== null);
+    })
+    .filter((a): a is NonNullable<typeof a> => a !== null);
 
-    // Category 2: Historical Feed Companions (who recently posted in the feed)
-    const historicalAgents = hydratedAgents
-      .filter(a => actorTimestamps.has(a.userId))
-      .map(a => ({
-        ...a,
-        lastActionAt: actorTimestamps.get(a.userId) || null
-      }))
-      .sort((a, b) => {
-        const timeA = new Date(a.lastActionAt || 0).getTime();
-        const timeB = new Date(b.lastActionAt || 0).getTime();
-        return timeB - timeA;
-      });
+  // Category 2: Historical Feed Companions (who recently posted in the feed)
+  const historicalAgents = hydratedAgents
+    .filter((a) => actorTimestamps.has(a.userId))
+    .map((a) => ({
+      ...a,
+      lastActionAt: actorTimestamps.get(a.userId) || null,
+    }))
+    .sort((a, b) => {
+      const timeA = new Date(a.lastActionAt || 0).getTime();
+      const timeB = new Date(b.lastActionAt || 0).getTime();
+      return timeB - timeA;
+    });
 
-    // Category 3: Cosmic Agent Roster (All synchronized charts)
-    const cosmicRoster = [...hydratedAgents].sort((a, b) => a.name.localeCompare(b.name));
+  // Category 3: Cosmic Agent Roster (All synchronized charts)
+  const cosmicRoster = [...hydratedAgents].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
 
-    // Category 4: Custom Manual Companions (for authenticated users)
-    let savedCompanions: any[] = [];
+  // Custom and linked companions are also optional. Auth or persistence issues
+  // should never hide the manual Add Commensal workflow.
+  let savedCompanions: CompanionView[] = [];
+  try {
     const user = await getDatabaseUserFromRequest(_req);
     if (user) {
-      const savedResult = await executeQuery<{
-        id: string;
-        name: string;
-        relationship: string;
-        birth_data: any;
-        natal_chart: any;
-      }>(
-        `SELECT id, name, relationship, birth_data, natal_chart
-           FROM manual_companion_charts
-          WHERE owner_id = $1
-          ORDER BY name ASC`,
-        [user.id]
-      );
-      savedCompanions = (savedResult.rows || []).map(row => {
-        const birthData = typeof row.birth_data === "string" ? safeJsonParse(row.birth_data) : row.birth_data;
-        const natalChart = typeof row.natal_chart === "string" ? safeJsonParse(row.natal_chart) : row.natal_chart;
-        return {
-          userId: row.id,
+      const [manual, linked] = await Promise.all([
+        commensalDatabase.getManualCompanionsForUser(user.id),
+        commensalDatabase.getLinkedCommensalsForUser(user.id),
+      ]);
+      savedCompanions = [
+        ...manual.map((companion) => ({
+          userId: companion.id,
           email: "",
-          name: row.name,
-          bio: `Custom companion chart (${row.relationship})`,
-          dominantElement: row.natal_chart?.dominantElement || natalChart?.dominantElement || "Fire",
+          name: companion.name,
+          bio: `Saved companion chart (${companion.relationship || "friend"})`,
+          dominantElement: companion.natalChart.dominantElement || "Fire",
           monicaConstant: null,
-          birthData,
-          natalChart,
-        };
-      });
+          birthData: companion.birthData,
+          natalChart: companion.natalChart,
+        })),
+        ...linked.map((companion) => ({
+          userId: companion.userId,
+          email: companion.email,
+          name: companion.name || companion.email.split("@")[0],
+          bio: "Linked dining companion",
+          dominantElement: companion.natalChart.dominantElement || "Fire",
+          monicaConstant: null,
+          birthData: companion.birthData,
+          natalChart: companion.natalChart,
+        })),
+      ].sort((a, b) => a.name.localeCompare(b.name));
     }
-
-    return NextResponse.json({
-      success: true,
-      activeAgents,
-      historicalAgents,
-      cosmicRoster,
-      savedCompanions,
-    });
   } catch (error) {
-    console.error("[GET /api/commensal/companions] Failed to resolve dining companions:", error);
-    return NextResponse.json(
-      { success: false, message: "Failed to resolve dining companions" },
-      { status: 500 }
+    warnings.push("saved-companions");
+    console.warn(
+      "[companions] Saved companions unavailable:",
+      errorSummary(error),
     );
   }
+
+  return NextResponse.json({
+    success: true,
+    activeAgents,
+    historicalAgents,
+    cosmicRoster,
+    savedCompanions,
+    degraded: warnings.length > 0,
+    unavailableSources: [...new Set(warnings)],
+  });
 }

--- a/src/app/api/commensal/guest-recommendations/__tests__/route.test.ts
+++ b/src/app/api/commensal/guest-recommendations/__tests__/route.test.ts
@@ -82,7 +82,12 @@ const stubComposite = {
 const stubRecipeResult = {
   recommendations: [
     {
-      recipe: { id: "r1", name: "Spicy Test Dish", ingredients: [], instructions: [] },
+      recipe: {
+        id: "r1",
+        name: "Spicy Test Dish",
+        ingredients: [],
+        instructions: [],
+      },
       score: 0.85,
       scoreBreakdown: {
         nutritionalGap: 0.5,
@@ -141,11 +146,7 @@ beforeEach(() => {
 
 describe("POST /api/commensal/guest-recommendations", () => {
   it("returns composite, recipes, methods, and cuisine recs for a 3-guest group", async () => {
-    const guests = [
-      makeGuest("Alice"),
-      makeGuest("Bob"),
-      makeGuest("Carol"),
-    ];
+    const guests = [makeGuest("Alice"), makeGuest("Bob"), makeGuest("Carol")];
     const res = await POST(makeRequest({ guests }));
     const data = await res.json();
 
@@ -185,6 +186,51 @@ describe("POST /api/commensal/guest-recommendations", () => {
     );
   });
 
+  it("uses a supplied companion chart in the composite without recalculating it", async () => {
+    const savedChart = {
+      ...stubNatalChart,
+      dominantElement: "Water",
+      elementalBalance: { Fire: 0.1, Water: 0.6, Earth: 0.2, Air: 0.1 },
+    };
+    const guest = {
+      ...makeGuest("Saved Friend"),
+      id: "manual-001",
+      natalChart: savedChart,
+    };
+
+    const res = await POST(makeRequest({ guests: [guest] }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(calculateNatalChart).not.toHaveBeenCalled();
+    expect(calculateCompositeNatalChart).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          id: "manual-001",
+          name: "Saved Friend",
+          natalChart: expect.objectContaining({
+            dominantElement: "Water",
+            elementalBalance: expect.objectContaining({ Water: 0.6 }),
+          }),
+        }),
+      ],
+      "guest-session",
+    );
+  });
+
+  it("recalculates when a supplied chart is incomplete", async () => {
+    const guest = {
+      ...makeGuest("Legacy Friend"),
+      natalChart: { dominantElement: "Earth" },
+    };
+
+    const res = await POST(makeRequest({ guests: [guest] }));
+
+    expect(res.status).toBe(200);
+    expect(calculateNatalChart).toHaveBeenCalledTimes(1);
+  });
+
   it("returns 400 when birthData is missing latitude", async () => {
     const guest = {
       name: "Alice",
@@ -219,9 +265,7 @@ describe("POST /api/commensal/guest-recommendations", () => {
     expect(data.success).toBe(true);
     expect(data.compositeChart.memberCount).toBe(1);
     expect(calculateCompositeNatalChart).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ name: "Solo" }),
-      ]),
+      expect.arrayContaining([expect.objectContaining({ name: "Solo" })]),
       "guest-session",
     );
   });

--- a/src/app/api/commensal/guest-recommendations/route.ts
+++ b/src/app/api/commensal/guest-recommendations/route.ts
@@ -23,8 +23,10 @@ const birthDataSchema = z
   .passthrough();
 
 const guestSchema = z.object({
+  id: z.string().trim().min(1).max(200).optional(),
   name: z.string().trim().min(1, "name is required").max(120),
   birthData: birthDataSchema,
+  natalChart: z.unknown().optional(),
 });
 
 const bodySchema = z.object({
@@ -38,7 +40,9 @@ export async function POST(req: Request) {
     if (!parsed.success) {
       const first = parsed.error.issues[0];
       const path = first?.path.join(".") || "request";
-      const message = first ? `${path}: ${first.message}` : "Invalid request payload";
+      const message = first
+        ? `${path}: ${first.message}`
+        : "Invalid request payload";
       return NextResponse.json(
         {
           success: false,
@@ -60,11 +64,20 @@ export async function POST(req: Request) {
     // the guest chart computations so we don't pay for them in serial.
     const [selfMember, natalCharts] = await Promise.all([
       loadAuthenticatedSelfMember(),
-      Promise.all(guests.map((g) => calculateNatalChart(g.birthData))),
+      Promise.all(
+        guests.map((guest) =>
+          isUsableNatalChart(guest.natalChart)
+            ? Promise.resolve({
+                ...guest.natalChart,
+                birthData: guest.birthData,
+              })
+            : calculateNatalChart(guest.birthData),
+        ),
+      ),
     ]);
 
     const commensalMembers: GroupMember[] = guests.map((guest, i) => ({
-      id: `commensal_${i}`,
+      id: guest.id || `commensal_${i}`,
       name: guest.name,
       relationship: "friend",
       birthData: guest.birthData,
@@ -145,10 +158,21 @@ function isCompleteBirthData(value: unknown): value is BirthData {
 function isUsableNatalChart(value: unknown): value is NatalChart {
   if (!value || typeof value !== "object") return false;
   const c = value as Partial<NatalChart>;
+  const elements = ["Fire", "Water", "Earth", "Air"] as const;
+  const alchemical = ["Spirit", "Essence", "Matter", "Substance"] as const;
   return (
     !!c.planetaryPositions &&
+    typeof c.planetaryPositions === "object" &&
+    Array.isArray(c.planets) &&
+    typeof c.ascendant === "string" &&
+    typeof c.dominantElement === "string" &&
+    elements.includes(c.dominantElement) &&
+    typeof c.dominantModality === "string" &&
+    ["Cardinal", "Fixed", "Mutable"].includes(c.dominantModality) &&
     !!c.elementalBalance &&
-    !!c.alchemicalProperties
+    elements.every((key) => Number.isFinite(c.elementalBalance?.[key])) &&
+    !!c.alchemicalProperties &&
+    alchemical.every((key) => Number.isFinite(c.alchemicalProperties?.[key]))
   );
 }
 

--- a/src/components/commensal/CompanionSuggestions.tsx
+++ b/src/components/commensal/CompanionSuggestions.tsx
@@ -1,8 +1,17 @@
 "use client";
 
-import { Users, Sparkles, Flame, Droplets, Wind, Mountain, Compass, Loader2 } from "lucide-react";
+import {
+  Users,
+  Sparkles,
+  Flame,
+  Droplets,
+  Wind,
+  Mountain,
+  Compass,
+  Loader2,
+} from "lucide-react";
 import React, { useState, useEffect } from "react";
-import type { BirthData } from "@/types/natalChart";
+import type { BirthData, NatalChart } from "@/types/natalChart";
 
 interface Companion {
   userId: string;
@@ -12,7 +21,7 @@ interface Companion {
   dominantElement: "Fire" | "Water" | "Air" | "Earth" | string;
   monicaConstant: number | null;
   birthData: BirthData;
-  natalChart: any;
+  natalChart: NatalChart | null;
   activation?: {
     strength: number;
     dignity: string;
@@ -24,8 +33,13 @@ interface Companion {
 }
 
 interface CompanionSuggestionsProps {
-  onInvite: (name: string, birthData: BirthData) => void;
-  activeGuests: Array<{ name: string }>;
+  onInvite: (
+    id: string,
+    name: string,
+    birthData: BirthData,
+    natalChart: NatalChart | null,
+  ) => void;
+  activeGuests: Array<{ id?: string; name: string }>;
   refreshTrigger?: number;
 }
 
@@ -40,7 +54,8 @@ const ELEMENT_BORDER: Record<string, string> = {
   Fire: "border-orange-500/20 hover:border-orange-500/40 focus:ring-orange-500/30",
   Water: "border-blue-500/20 hover:border-blue-500/40 focus:ring-blue-500/30",
   Air: "border-purple-500/20 hover:border-purple-500/40 focus:ring-purple-500/30",
-  Earth: "border-green-500/20 hover:border-green-500/40 focus:ring-green-500/30",
+  Earth:
+    "border-green-500/20 hover:border-green-500/40 focus:ring-green-500/30",
 };
 
 const ELEMENT_GLOW: Record<string, string> = {
@@ -50,30 +65,45 @@ const ELEMENT_GLOW: Record<string, string> = {
   Earth: "shadow-[0_0_15px_-3px_rgba(34,197,94,0.15)]",
 };
 
-export function CompanionSuggestions({ onInvite, activeGuests, refreshTrigger = 0 }: CompanionSuggestionsProps) {
+export function CompanionSuggestions({
+  onInvite,
+  activeGuests,
+  refreshTrigger = 0,
+}: CompanionSuggestionsProps) {
   const [activeAgents, setActiveAgents] = useState<Companion[]>([]);
   const [historicalAgents, setHistoricalAgents] = useState<Companion[]>([]);
   const [cosmicRoster, setCosmicRoster] = useState<Companion[]>([]);
   const [savedCompanions, setSavedCompanions] = useState<Companion[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<"moment" | "feed" | "roster" | "saved">("moment");
+  const [degraded, setDegraded] = useState(false);
+  const [activeTab, setActiveTab] = useState<
+    "moment" | "feed" | "roster" | "saved"
+  >("moment");
 
   useEffect(() => {
+    const controller = new AbortController();
+
     async function loadCompanions() {
       try {
         setLoading(true);
         setError(null);
-        const res = await fetch("/api/commensal/companions");
-        if (!res.ok) throw new Error("Failed to load dining companions");
-        const data = await res.json();
-        
+        setDegraded(false);
+        const res = await fetch("/api/commensal/companions", {
+          signal: controller.signal,
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          throw new Error(data.message || "Failed to load dining companions");
+        }
+
         if (data.success) {
           setActiveAgents(data.activeAgents || []);
           setHistoricalAgents(data.historicalAgents || []);
           setCosmicRoster(data.cosmicRoster || []);
           setSavedCompanions(data.savedCompanions || []);
-          
+          setDegraded(data.degraded === true);
+
           if (data.savedCompanions && data.savedCompanions.length > 0) {
             setActiveTab("saved");
           }
@@ -81,14 +111,18 @@ export function CompanionSuggestions({ onInvite, activeGuests, refreshTrigger = 
           throw new Error(data.message || "Failed to load dining companions");
         }
       } catch (err) {
+        if (controller.signal.aborted) return;
         console.error("Error loading companions:", err);
-        setError("Unable to retrieve planetary companions. Check back shortly.");
+        setError(
+          "Unable to retrieve planetary companions. Check back shortly.",
+        );
       } finally {
-        setLoading(false);
+        if (!controller.signal.aborted) setLoading(false);
       }
     }
 
     void loadCompanions();
+    return () => controller.abort();
   }, [refreshTrigger]);
 
   const getActiveList = () => {
@@ -108,9 +142,17 @@ export function CompanionSuggestions({ onInvite, activeGuests, refreshTrigger = 
           Cosmic Dining Companions
         </h3>
         <p className="text-xs text-purple-300/70 mt-1">
-          Bridge the cosmos by inviting historical sages or active planetary agents to your dining table.
+          Bridge the cosmos by inviting historical sages or active planetary
+          agents to your dining table.
         </p>
       </div>
+
+      {degraded && !error && (
+        <div className="px-3 py-2 rounded-lg bg-amber-500/10 border border-amber-400/20 text-[11px] text-amber-100">
+          Some companion sources are temporarily unavailable. You can still add
+          saved or manual charts and build the dinner party.
+        </div>
+      )}
 
       {/* Tabs */}
       <div className="flex bg-black/40 rounded-lg p-1 border border-white/5 flex-wrap gap-1">
@@ -163,7 +205,9 @@ export function CompanionSuggestions({ onInvite, activeGuests, refreshTrigger = 
         {loading ? (
           <div className="flex flex-col items-center justify-center py-16 space-y-2">
             <Loader2 className="w-8 h-8 text-alchm-copper animate-spin" />
-            <span className="text-xs text-purple-300/60">Interrogating the heavens...</span>
+            <span className="text-xs text-purple-300/60">
+              Interrogating the heavens...
+            </span>
           </div>
         ) : error ? (
           <div className="text-center py-12 px-3 border border-red-500/10 rounded-xl bg-red-500/5">
@@ -172,23 +216,29 @@ export function CompanionSuggestions({ onInvite, activeGuests, refreshTrigger = 
         ) : currentList.length === 0 ? (
           <div className="flex flex-col items-center justify-center text-center py-16 px-4">
             <Compass className="w-10 h-10 text-purple-500/20 mb-3" />
-            <h4 className="text-sm font-semibold text-purple-200">No Companions Aligned</h4>
+            <h4 className="text-sm font-semibold text-purple-200">
+              No Companions Aligned
+            </h4>
             <p className="text-xs text-purple-300/50 mt-1 max-w-xs leading-relaxed">
               {activeTab === "moment"
                 ? "No planetary agents are strongly activated at this exact degree under today's sky."
                 : activeTab === "feed"
-                ? "No recent feed broadcasts found. Sync agentic updates from Planetary Agents."
-                : activeTab === "saved"
-                ? "You haven't saved any custom companion charts yet. Add charts using the form to persist them here and earn ESMS tokens!"
-                : "The cosmic roster is currently empty."}
+                  ? "No recent feed broadcasts found. Sync agentic updates from Planetary Agents."
+                  : activeTab === "saved"
+                    ? "You haven't saved any custom companion charts yet. Add charts using the form to persist them here and earn ESMS tokens!"
+                    : "The cosmic roster is currently empty."}
             </p>
           </div>
         ) : (
           currentList.map((agent) => {
             const isAlreadyInvited = activeGuests.some(
-              (g) => g.name.toLowerCase() === agent.name.toLowerCase()
+              (g) =>
+                g.id === agent.userId ||
+                g.name.toLowerCase() === agent.name.toLowerCase(),
             );
-            const borderClass = ELEMENT_BORDER[agent.dominantElement] || "border-white/10 hover:border-white/20";
+            const borderClass =
+              ELEMENT_BORDER[agent.dominantElement] ||
+              "border-white/10 hover:border-white/20";
             const glowClass = ELEMENT_GLOW[agent.dominantElement] || "";
 
             return (
@@ -199,7 +249,9 @@ export function CompanionSuggestions({ onInvite, activeGuests, refreshTrigger = 
                 <div>
                   <div className="flex items-start justify-between">
                     <div>
-                      <h4 className="text-sm font-bold text-purple-100">{agent.name}</h4>
+                      <h4 className="text-sm font-bold text-purple-100">
+                        {agent.name}
+                      </h4>
                       {agent.activation?.planetaryRuler && (
                         <span className="text-[10px] uppercase font-mono tracking-wider text-purple-400">
                           Ruler: {agent.activation.planetaryRuler}
@@ -207,8 +259,12 @@ export function CompanionSuggestions({ onInvite, activeGuests, refreshTrigger = 
                       )}
                     </div>
                     <div className="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-white/5 border border-white/5">
-                      {ELEMENT_ICON[agent.dominantElement] || <Sparkles className="w-3 h-3 text-purple-300" />}
-                      <span className="text-[10px] font-semibold text-purple-200">{agent.dominantElement}</span>
+                      {ELEMENT_ICON[agent.dominantElement] || (
+                        <Sparkles className="w-3 h-3 text-purple-300" />
+                      )}
+                      <span className="text-[10px] font-semibold text-purple-200">
+                        {agent.dominantElement}
+                      </span>
                     </div>
                   </div>
                   <p className="text-xs text-purple-300/70 mt-1.5 leading-relaxed line-clamp-2">
@@ -220,12 +276,16 @@ export function CompanionSuggestions({ onInvite, activeGuests, refreshTrigger = 
                     <div className="mt-2.5 space-y-1">
                       <div className="flex items-center justify-between text-[10px] text-purple-400 font-mono">
                         <span>Alignment: {agent.activation.dignity}</span>
-                        <span>{Math.round(agent.activation.strength * 100)}%</span>
+                        <span>
+                          {Math.round(agent.activation.strength * 100)}%
+                        </span>
                       </div>
                       <div className="w-full bg-white/5 rounded-full h-1 overflow-hidden">
                         <div
                           className="h-full bg-gradient-to-r from-alchm-copper to-alchm-violet rounded-full"
-                          style={{ width: `${agent.activation.strength * 100}%` }}
+                          style={{
+                            width: `${agent.activation.strength * 100}%`,
+                          }}
                         />
                       </div>
                     </div>
@@ -234,13 +294,21 @@ export function CompanionSuggestions({ onInvite, activeGuests, refreshTrigger = 
                   {/* Feed Action Indicator */}
                   {agent.lastActionAt && !agent.activation && (
                     <div className="mt-2 text-[10px] text-purple-400 font-mono">
-                      Last Active: {new Date(agent.lastActionAt).toLocaleDateString()}
+                      Last Active:{" "}
+                      {new Date(agent.lastActionAt).toLocaleDateString()}
                     </div>
                   )}
                 </div>
 
                 <button
-                  onClick={() => onInvite(agent.name, agent.birthData)}
+                  onClick={() =>
+                    onInvite(
+                      agent.userId,
+                      agent.name,
+                      agent.birthData,
+                      agent.natalChart,
+                    )
+                  }
                   disabled={isAlreadyInvited}
                   className={`w-full py-1.5 rounded-lg text-xs font-bold transition-all ${
                     isAlreadyInvited

--- a/src/services/commensalRecommendationService.ts
+++ b/src/services/commensalRecommendationService.ts
@@ -15,14 +15,17 @@ import type {
   BirthData,
   CompositeNatalChart,
   GroupMember,
+  NatalChart,
 } from "@/types/natalChart";
 import type { FoursquarePlace } from "@/types/restaurant";
 
 // ─── Shared request/response types ──────────────────────────
 
 export interface GuestInput {
+  id?: string;
   name: string;
   birthData: BirthData;
+  natalChart?: NatalChart | null;
 }
 
 export interface GuestRecommendationResponse {
@@ -153,7 +156,10 @@ export async function searchNearbyRestaurants(
   try {
     const res = await fetch(`/api/restaurants/search?${qs.toString()}`);
     if (!res.ok) return [];
-    const data = (await res.json()) as { success?: boolean; results?: FoursquarePlace[] };
+    const data = (await res.json()) as {
+      success?: boolean;
+      results?: FoursquarePlace[];
+    };
     if (data?.success !== true) return [];
     return data.results ?? [];
   } catch {


### PR DESCRIPTION
## Summary
- degrade companion discovery sources independently instead of returning a total 500
- preserve saved natal charts through party selection and composite recommendation scoring
- automatically recompute recommendations when dinner-party membership changes
- add regression coverage for database outages and supplied/legacy chart handling

## Verification
- bun run typecheck
- focused ESLint on changed source files
- 13 focused API tests
- live companion endpoint returned 200 in degraded database mode
- live supplied-chart request produced chart-adjusted recommendations