### PR TITLE
fix(spacetime): planner sync guards + regmarks click-through + local-dev CSP

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -76,6 +76,20 @@ const getSecurityHeaders = () => {
     "https:",
   ];
 
+  // Local SpacetimeDB (ws://) needs both the WebSocket origin and its http://
+  // counterpart in connect-src: the SDK exchanges a stored identity token via
+  // an HTTP POST to /v1/identity/websocket-token before every reconnect.
+  // Production (wss:// + https://) is already covered by the https: source.
+  const spacetimeUri = process.env.NEXT_PUBLIC_SPACETIME_URI;
+  if (spacetimeUri && spacetimeUri.startsWith("ws://")) {
+    try {
+      const origin = new URL(spacetimeUri).origin.replace(/^http:/, "ws:");
+      connectSrcParts.push(origin, origin.replace(/^ws:/, "http:"));
+    } catch {
+      // Malformed URI — the client will surface the connection error.
+    }
+  }
+
   const cspHeader = [
     "default-src 'self'",
     `script-src ${scriptSrcParts.join(" ")}`,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -497,6 +497,11 @@ a {
 
 /* Registration marks (NASA panel corners) */
 .regmarks { position: absolute; inset: 0; pointer-events: none; }
+/* Applied directly to a content panel (alchm-panel regmarks), the marks come
+   from the pseudo-elements alone — the panel must stay in normal flow and
+   interactive, or every real-pointer click inside it falls through to
+   whatever is stacked beneath (planner strip, calendar, modals). */
+.alchm-panel.regmarks { position: relative; inset: auto; pointer-events: auto; }
 .regmarks::before, .regmarks::after,
 .regmarks > i::before, .regmarks > i::after {
   content: "";

--- a/src/hooks/useSpacetimePlannerSync.ts
+++ b/src/hooks/useSpacetimePlannerSync.ts
@@ -125,6 +125,16 @@ export function useSpacetimePlannerSync(
   /** Bumped on every remote row event so the apply effect re-runs. */
   const [remoteVersion, setRemoteVersion] = useState(0);
   const pushedRef = useRef<Map<string, PushedEntry>>(new Map());
+  /**
+   * Keys whose slot existed in the local plan at some point THIS session.
+   * Remote deletes are scoped to this set, not the durable map: the local
+   * plan does not persist across reloads (in-memory for guests), so a fresh
+   * page load starts with an empty plan while the durable map still lists
+   * past pushes — issuing deletes from the durable map would wipe the user's
+   * remote plan on every reload. The durable map only serves remote-deletion
+   * recognition and the local-echo guard.
+   */
+  const sessionKeysRef = useRef<Set<string>>(new Set());
   const storageKeyRef = useRef<string | null>(null);
   const trackedRef = useRef(false);
   const actionsRef = useRef(actions);
@@ -249,14 +259,18 @@ export function useSpacetimePlannerSync(
           });
         }
         const sig = slotSignature(slot);
+        sessionKeysRef.current.add(key);
         if (pushedRef.current.get(key)?.s !== sig) {
           pushedRef.current.set(key, { s: sig, t: Date.now() });
           dirty = true;
         }
       }
 
-      // Scoped deletes: only retract slots this device previously pushed.
+      // Scoped deletes: only retract slots that were present in the local
+      // plan during THIS session — a reload's empty plan must never wipe
+      // remote rows recorded in the durable map.
       for (const [key] of pushedRef.current) {
+        if (!sessionKeysRef.current.has(key)) continue;
         if (!desired.has(key) && remote.has(key)) {
           const [week, day, meal] = key.split("|").map(Number);
           void connection.reducers.clearMealPlanSlot({
@@ -265,9 +279,11 @@ export function useSpacetimePlannerSync(
             mealType: meal,
           });
           pushedRef.current.delete(key);
+          sessionKeysRef.current.delete(key);
           dirty = true;
         } else if (!desired.has(key) && !remote.has(key)) {
           pushedRef.current.delete(key);
+          sessionKeysRef.current.delete(key);
           dirty = true;
         }
       }
@@ -322,6 +338,13 @@ export function useSpacetimePlannerSync(
         // Replaced with a different dish elsewhere — needs catalog
         // rehydration to materialize; surface instead of guessing.
         unapplied += 1;
+        continue;
+      }
+      if (pushed !== undefined && pushed.s !== slotSignature(slot)) {
+        // The local slot is ahead of what this device last pushed — a local
+        // edit is still waiting on the debounced write-mirror. Applying the
+        // (stale) remote values now would revert the edit before it ever
+        // reaches the module. Skip; the push will converge remote to local.
         continue;
       }
       if (Math.abs(remoteSlot.servings - slot.servings) > 1e-6) {


### PR DESCRIPTION
## Context

Full local verification of the v4.0 SpacetimeDB live layer (post #514/#515) against an isolated local instance, prompted by a prod smoke test reporting zero live badges. The prod report turned out to be a sandboxed-browser artifact (prod config is fully correct: URI + all 5 flags baked into the deployed bundle, Maincloud module published and seeded with 1030 recipes, wss reachable from real Chrome) — but the verification surfaced three real bugs, all fixed and re-verified here.

## Fixes

**1. Planner remote→local echo race (`useSpacetimePlannerSync`)** — the v1.1 read-path applied stale remote servings/locks the moment a local edit happened, before the 600ms-debounced write-mirror pushed it. Net effect: local servings/lock changes reverted instantly and never reached the module (`Updated servings … to 2` / `… to 1` pairs in the console). Now guarded the same way the cart sync is: remote values are only adopted when the local slot matches what this device last pushed.

**2. Reload wiped the remote plan** — the v1.1 durable pushed-map (tombstone-equivalent) combined with non-persistent guest planner state meant a page reload (empty in-memory plan + hydrated durable map) issued `clearMealPlanSlot` for every slot the device ever pushed. Verified live: 2 of 3 module rows destroyed on reload. Remote deletes are now scoped to keys seen in the local plan **this session**; the durable map continues to serve remote-deletion recognition and the echo guard. After the fix, remote rows survive reload and surface as the honest "N elsewhere" badge count.

**3. `.regmarks` click-through (globals.css)** — the decorative corner-marks class sets `position:absolute; inset:0; pointer-events:none` and is applied directly to interactive `alchm-panel` containers (planner command strip, weekly calendar, 4 planner modals, admin shell, today's-meals widget). The later cascade position made those panels click-dead for real pointers: clicks fell through to elements stacked beneath — e.g. the slot "✨ Generate" area triggering Save-as-Template, as seen in the prod smoke report. `.alchm-panel.regmarks` now stays in normal flow and interactive; corner marks render unchanged via the pseudo-elements. Verified by `elementFromPoint` hit-tests before/after.

**4. Local-dev CSP for SpacetimeDB (next.config.js)** — `connect-src` lacked the local instance origins, blocking the SDK's `POST /v1/identity/websocket-token` exchange (fires on every reconnect with a stored token), so local sessions went permanently `degraded` after the first load. The ws:// origin + its http:// counterpart are appended only when `NEXT_PUBLIC_SPACETIME_URI` is a `ws://` URI; production (wss/https, covered by the existing `https:` source) is untouched.

## Verification

Full 9-point matrix against an isolated local SpacetimeDB 2.4.1 (module published + seeded, two identities via minted tokens + a reducer-driver script): fallback mode, culinary read-path chip (⚡ 40 LIVE), planner write-mirror (SQL-verified servings/lock), remote→local apply (servings/clear/lock + "1 elsewhere" for additions), cart two-way + durable tombstone (no resurrection after offline delete), feed live publish (instant event + chip increment), commensal lobby (create/join presence/lock rejection/host-leave-closes, both directions), degraded mode + ~35s reconnect, and the Stitch visual checks. `bun run verify` clean (0 errors; 9 pre-existing warnings in untouched files), `bun run build` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)