### PR TITLE
feat(home): advertise on-chain ESMS + crypto food checkout on homepage

### DIFF
--- a/src/components/home/Promotion.tsx
+++ b/src/components/home/Promotion.tsx
@@ -63,13 +63,17 @@ export function Promotion() {
                 <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-amber-500/10 border border-amber-500/20 text-[9px] font-extrabold text-amber-400 uppercase tracking-wide">
                   +60 ESMS Welcome Grant
                 </span>
+                <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-cyan-500/10 border border-cyan-500/20 text-[9px] font-extrabold text-cyan-400 uppercase tracking-wide">
+                  New · On-Chain ESMS
+                </span>
               </div>
               <h2 className="text-xl md:text-3xl font-black text-white/95 leading-tight tracking-tight">
                 Unleash Your Cosmic Culinary Yield
               </h2>
               <p className="mt-2 text-xs md:text-sm text-white/50 leading-relaxed max-w-xl">
                 Alchm Kitchen balances four primary alchemical elements to match recipes with your birth chart and the live sky. During Tech Week, get a boosted welcome grant of{" "}
-                <strong className="text-white/80">60 ESMS tokens</strong> (15 of each: Spirit, Essence, Matter, Substance) to immediately begin your cosmic culinary journey.
+                <strong className="text-white/80">60 ESMS tokens</strong> (15 of each: Spirit, Essence, Matter, Substance) to immediately begin your cosmic culinary journey. Your ESMS now lives{" "}
+                <strong className="text-white/80">on-chain</strong> — claim it to your Base wallet and check out real food with <strong className="text-white/80">USDC or ESMS</strong>.
               </p>
             </div>
 
@@ -98,6 +102,17 @@ export function Promotion() {
               <h3 className="text-xs font-bold text-white/50 tracking-widest uppercase mb-1">
                 New Experiences & Enhancements
               </h3>
+
+              {/* Feature: Web3 crypto food checkout */}
+              <div className="p-3.5 rounded-2xl bg-cyan-500/[0.04] border border-cyan-500/20 hover:border-cyan-500/35 transition-all duration-200 flex items-start gap-3">
+                <span className="text-xl p-1 bg-cyan-500/10 rounded-lg text-cyan-400">🪙</span>
+                <div className="space-y-0.5">
+                  <h4 className="text-xs font-bold text-white/90">Pay for Food with Crypto</h4>
+                  <p className="text-[10px] text-white/40 leading-relaxed">
+                    Check out real restaurant orders with USDC or your soulbound ESMS — settled on-chain, with card always available as a fallback.
+                  </p>
+                </div>
+              </div>
 
               {/* Feature 1 */}
               <div className="p-3.5 rounded-2xl bg-white/[0.02] border border-white/5 hover:border-purple-500/10 transition-all duration-200 flex items-start gap-3">
@@ -155,6 +170,16 @@ export function Promotion() {
             className="inline-flex items-center gap-2 px-5 py-3 rounded-2xl bg-purple-500/5 hover:bg-purple-500/10 border border-purple-500/10 hover:border-purple-500/20 text-purple-400/90 font-semibold text-sm transition-all duration-200 group"
           >
             ✨ Open Lab Book
+            <span className="group-hover:translate-x-1 transition-transform duration-200">&rarr;</span>
+          </Link>
+
+          {/* Web3 crypto food checkout */}
+          <Link
+            href="/restaurants"
+            className="inline-flex items-center gap-2 px-5 py-3 rounded-2xl bg-cyan-500/10 hover:bg-cyan-500/20 border border-cyan-500/25 hover:border-cyan-500/40 text-cyan-300 font-semibold text-sm transition-all duration-200 group"
+          >
+            <span>🪙</span>
+            Order Food — Pay with USDC or ESMS
             <span className="group-hover:translate-x-1 transition-transform duration-200">&rarr;</span>
           </Link>
 


### PR DESCRIPTION
## What

Surfaces the crypto food-payment rails shipped in #521 on the homepage Promotion card.

- **"On-Chain ESMS" badge** on the welcome-grant block
- **Updated copy** — ESMS now lives on-chain; claim to a Base wallet and check out real food with USDC or ESMS
- **"Pay for Food with Crypto" feature card** in the enhancements list
- **Primary CTA** — *Order Food — Pay with USDC or ESMS* → `/restaurants`

Copy notes card checkout always remains as a fallback.

## Why

#521 (crypto food payments) is merged but the feature is invisible on the homepage. This is the marketing surface for it. Display-only — no logic, no new deps.

## Notes

- Branched fresh off `master` (#521's branch was already merged, can't reuse).
- Single file: `src/components/home/Promotion.tsx` (+26/-1).
- Pre-commit typecheck + lint clean (pre-existing warnings only).
- The underlying crypto rails remain **flag-gated OFF in prod** — this ad goes live with the copy regardless, but the `/restaurants` crypto checkout itself only activates when the go-live flags + Stripe/reserve are enabled. Worth confirming the desired sequencing before merge (ad-first vs. flags-first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)