### PR TITLE
feat(payments): pre-launch ESMS food-redemption controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -283,7 +283,16 @@ NEXT_PUBLIC_STRIPE_RESTAURANT_CRYPTO_ENABLED=false
 NEXT_PUBLIC_ESMS_RESTAURANT_PAYMENTS_ENABLED=false
 # Published redemption value in whole cents per ESMS token. Keep this below the
 # cheapest acquisition cost and account for all outstanding reward liability.
+# This rate is also published to users at /rewards (read from the same value).
 NEXT_PUBLIC_ESMS_RESTAURANT_CENTS_PER_TOKEN=1
+# Daily ESMS food-redemption caps (server-enforced, UTC day). Tokens summed
+# across all four axes. 0 = unlimited; unset falls back to the defaults below.
+# Per-user default 5000 (=$50 at 1c); aggregate default 200000 (=$2000 at 1c).
+ESMS_RESTAURANT_PER_USER_DAILY_CAP=5000
+ESMS_RESTAURANT_AGGREGATE_DAILY_CAP=200000
+# /api/cron/esms-reconciliation runs hourly and reuses CRON_SECRET (above) to
+# cross-check token debits against Stripe transfers; operators resolve stuck
+# orders at POST /api/admin/restaurants/settlement.
 
 # POS / logistics integrations
 DELIVERECT_API_URL=https://api.deliverect.com

--- a/src/app/api/admin/restaurants/settlement/route.ts
+++ b/src/app/api/admin/restaurants/settlement/route.ts
@@ -1,0 +1,365 @@
+/**
+ * Admin Restaurant ESMS Settlement Operations
+ *
+ * GET  /api/admin/restaurants/settlement — list orders stuck in
+ *      settlement_pending (token already debited, restaurant transfer not
+ *      confirmed).
+ * POST /api/admin/restaurants/settlement — resolve one such order:
+ *      { orderId, action: "retry" | "refund" }
+ *
+ *   - "retry": re-issue the Stripe transfer using the SAME deterministic
+ *     idempotency key the original attempt used
+ *     (`restaurant_order_esms_transfer_<orderId>`). If a transfer was in fact
+ *     created the first time, Stripe returns that same transfer rather than
+ *     double-paying. On success the order is marked paid and fulfillment is
+ *     (re)triggered.
+ *   - "refund": only after confirming via Stripe that NO transfer exists for
+ *     this order's transfer_group, re-credit the exact ESMS the order debited
+ *     (idempotency-guarded) and mark the order refunded.
+ *
+ * This is the authenticated operator workflow required by
+ * docs/payments/CRYPTO_FOOD_PAYMENTS.md before a public launch.
+ *
+ * @file src/app/api/admin/restaurants/settlement/route.ts
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+import { validateAdminRequest } from "@/lib/auth/validateRequest";
+import { executeQuery } from "@/lib/database/connection";
+import { _logger } from "@/lib/logger";
+import { getStripe } from "@/lib/stripe/stripe";
+import { tokenEconomy } from "@/services/TokenEconomyService";
+import { TOKEN_TYPES, type TokenType } from "@/types/economy";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+interface OrderRow {
+  id: string;
+  user_id: string | null;
+  restaurant_name: string;
+  currency: string;
+  transfer_amount_cents: number;
+  stripe_connected_account_id: string | null;
+  stripe_transfer_id: string | null;
+  status: string;
+  payment_status: string | null;
+  transfer_status: string | null;
+}
+
+const bodySchema = z.object({
+  orderId: z.string().min(8).max(120),
+  action: z.enum(["retry", "refund"]),
+});
+
+async function loadOrder(orderId: string): Promise<OrderRow | null> {
+  const result = await executeQuery<OrderRow>(
+    `SELECT id, user_id, restaurant_name, currency, transfer_amount_cents,
+            stripe_connected_account_id, stripe_transfer_id,
+            status, payment_status, transfer_status
+     FROM restaurant_order_intents
+     WHERE id = $1`,
+    [orderId],
+  );
+  return result.rows[0] ?? null;
+}
+
+async function updateOrder(input: {
+  orderId: string;
+  status: string;
+  transferId?: string | null;
+  transferStatus: string;
+  paymentStatus: string;
+  completed: boolean;
+  metadata: Record<string, unknown>;
+}): Promise<void> {
+  await executeQuery(
+    `UPDATE restaurant_order_intents
+     SET status = $2,
+         stripe_transfer_id = COALESCE($3, stripe_transfer_id),
+         transfer_status = $4,
+         payment_status = $5,
+         metadata = metadata || $6::jsonb,
+         completed_at = CASE WHEN $7 THEN NOW() ELSE completed_at END,
+         updated_at = NOW()
+     WHERE id = $1`,
+    [
+      input.orderId,
+      input.status,
+      input.transferId ?? null,
+      input.transferStatus,
+      input.paymentStatus,
+      JSON.stringify(input.metadata),
+      input.completed,
+    ],
+  );
+}
+
+/** Sum the exact ESMS this order debited (source_type='restaurant_order'). */
+async function debitedBasket(
+  orderId: string,
+): Promise<Array<{ tokenType: TokenType; amount: number }>> {
+  const result = await executeQuery<{ token_type: string; total: string }>(
+    `SELECT token_type, SUM(amount) AS total
+     FROM token_transactions
+     WHERE source_type = 'restaurant_order'
+       AND source_id = $1
+       AND amount < 0
+     GROUP BY token_type`,
+    [orderId],
+  );
+  const credits: Array<{ tokenType: TokenType; amount: number }> = [];
+  for (const row of result.rows) {
+    const tokenType = TOKEN_TYPES.find((t) => t === row.token_type);
+    if (!tokenType) continue;
+    const debited = Number(row.total); // negative
+    const refundAmount = Math.abs(debited);
+    if (refundAmount > 0) credits.push({ tokenType, amount: refundAmount });
+  }
+  return credits;
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await validateAdminRequest(request);
+  if ("error" in authResult) return authResult.error;
+
+  try {
+    const result = await executeQuery<OrderRow & { created_at: string }>(
+      `SELECT id, user_id, restaurant_name, currency, transfer_amount_cents,
+              stripe_connected_account_id, stripe_transfer_id,
+              status, payment_status, transfer_status, created_at
+       FROM restaurant_order_intents
+       WHERE status = 'settlement_pending'
+          OR transfer_status = 'retry_required'
+       ORDER BY created_at DESC
+       LIMIT 100`,
+    );
+    return NextResponse.json({ success: true, pending: result.rows });
+  } catch (error) {
+    _logger.error("[admin/restaurants/settlement] list failed:", error);
+    return NextResponse.json(
+      { success: false, message: "Could not list pending settlements." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = await validateAdminRequest(request);
+  if ("error" in authResult) return authResult.error;
+
+  let body: z.infer<typeof bodySchema>;
+  try {
+    body = bodySchema.parse(await request.json());
+  } catch (err) {
+    const message =
+      err instanceof z.ZodError
+        ? err.issues[0]?.message ?? "Invalid body"
+        : "Invalid JSON";
+    return NextResponse.json({ success: false, message }, { status: 400 });
+  }
+
+  const { orderId, action } = body;
+  const operator = authResult.user.email;
+
+  const order = await loadOrder(orderId);
+  if (!order) {
+    return NextResponse.json(
+      { success: false, message: "Order not found." },
+      { status: 404 },
+    );
+  }
+
+  // Only ESMS orders left in a pending/retry state are eligible.
+  const isPending =
+    order.status === "settlement_pending" ||
+    order.transfer_status === "retry_required";
+  if (!isPending) {
+    return NextResponse.json(
+      {
+        success: false,
+        message: `Order is not awaiting settlement (status=${order.status}, transfer_status=${order.transfer_status}).`,
+      },
+      { status: 409 },
+    );
+  }
+
+  const transferGroup = `restaurant_order_${orderId}`;
+  const stripe = getStripe();
+
+  if (action === "retry") {
+    if (!order.stripe_connected_account_id || order.transfer_amount_cents <= 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          message:
+            "Order is missing a connected account or transfer amount; cannot retry.",
+        },
+        { status: 409 },
+      );
+    }
+    try {
+      const transfer = await stripe.transfers.create(
+        {
+          amount: order.transfer_amount_cents,
+          currency: order.currency,
+          destination: order.stripe_connected_account_id,
+          transfer_group: transferGroup,
+          metadata: {
+            purpose: "restaurant_order_esms_settlement_retry",
+            orderId,
+            operator,
+          },
+        },
+        { idempotencyKey: `restaurant_order_esms_transfer_${orderId}` },
+      );
+
+      await updateOrder({
+        orderId,
+        status: "paid",
+        transferId: transfer.id,
+        transferStatus: "created",
+        paymentStatus: "paid_with_esms",
+        completed: true,
+        metadata: {
+          settlementRetry: {
+            at: new Date().toISOString(),
+            operator,
+            transferId: transfer.id,
+          },
+        },
+      });
+
+      try {
+        const { triggerOrderFulfillment } = await import(
+          "@/lib/orders/fulfillment"
+        );
+        await triggerOrderFulfillment(orderId);
+      } catch (error) {
+        _logger.error(
+          `[admin/restaurants/settlement] retry fulfillment failed: ${orderId}`,
+          error,
+        );
+      }
+
+      return NextResponse.json({
+        success: true,
+        action,
+        orderId,
+        transferId: transfer.id,
+        status: "paid",
+      });
+    } catch (error) {
+      _logger.error(
+        `[admin/restaurants/settlement] retry transfer failed: ${orderId}`,
+        error,
+      );
+      return NextResponse.json(
+        {
+          success: false,
+          message:
+            error instanceof Error
+              ? error.message
+              : "Stripe transfer retry failed.",
+        },
+        { status: 502 },
+      );
+    }
+  }
+
+  // action === "refund"
+  try {
+    // Refund is only safe if NO transfer was actually created for this order.
+    const existing = await stripe.transfers.list({
+      transfer_group: transferGroup,
+      limit: 1,
+    });
+    if (existing.data.length > 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          message:
+            "A Stripe transfer already exists for this order — the restaurant was paid. Use retry to mark it paid instead of refunding ESMS.",
+          transferId: existing.data[0]?.id,
+        },
+        { status: 409 },
+      );
+    }
+
+    if (!order.user_id) {
+      return NextResponse.json(
+        { success: false, message: "Order has no user to refund." },
+        { status: 409 },
+      );
+    }
+
+    const credits = await debitedBasket(orderId);
+    if (credits.length === 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: "No ESMS debit found for this order; nothing to refund.",
+        },
+        { status: 409 },
+      );
+    }
+
+    // Idempotency-guarded re-credit of the exact debited basket. Repeating the
+    // refund returns the existing balance without double-crediting.
+    const balances = await tokenEconomy.creditMultipleTokens(
+      order.user_id,
+      credits,
+      "restaurant_refund",
+      {
+        sourceId: orderId,
+        idempotencyKey: `restaurant_refund:${orderId}`,
+        description: `Refund for ${order.restaurant_name} (settlement failed) by ${operator}`,
+      },
+    );
+
+    if (balances === null) {
+      return NextResponse.json(
+        { success: false, message: "Refund credit failed." },
+        { status: 500 },
+      );
+    }
+
+    await updateOrder({
+      orderId,
+      status: "refunded",
+      transferStatus: "refunded",
+      paymentStatus: "esms_refunded",
+      completed: false,
+      metadata: {
+        settlementRefund: {
+          at: new Date().toISOString(),
+          operator,
+          credited: credits,
+        },
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      action,
+      orderId,
+      credited: credits,
+      balances,
+      status: "refunded",
+    });
+  } catch (error) {
+    _logger.error(
+      `[admin/restaurants/settlement] refund failed: ${orderId}`,
+      error,
+    );
+    return NextResponse.json(
+      {
+        success: false,
+        message:
+          error instanceof Error ? error.message : "ESMS refund failed.",
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/api/cron/esms-reconciliation/route.ts
+++ b/src/app/api/cron/esms-reconciliation/route.ts
@@ -1,0 +1,162 @@
+/**
+ * ESMS Restaurant Settlement Reconciliation — cron endpoint
+ *
+ * Cross-checks the off-chain ESMS ledger against Stripe transfers so token
+ * debits and restaurant payouts can't silently drift. It surfaces:
+ *
+ *   - stuck: orders whose ESMS was debited but the Stripe transfer was never
+ *     confirmed (status=settlement_pending / transfer_status=retry_required).
+ *     Each is probed against Stripe to classify it as `retryable` (a transfer
+ *     actually exists — mark paid via the admin retry action) or `refundable`
+ *     (no transfer — safe to refund the ESMS).
+ *   - paidWithoutTransfer: orders marked paid_with_esms but missing a
+ *     stripe_transfer_id (record drift).
+ *   - orphanDebits: restaurant_order token debits with no order-intent row.
+ *   - daily token totals redeemed vs refunded (sanity signal).
+ *
+ * Findings are logged for operators; the JSON summary is returned for the
+ * caller / admin dashboards. Resolution happens via the authenticated
+ * operator endpoint at /api/admin/restaurants/settlement.
+ *
+ * Auth: `Authorization: Bearer <CRON_SECRET>` (shared cron auth).
+ *
+ * @file src/app/api/cron/esms-reconciliation/route.ts
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import { isAuthorizedCron } from "@/app/api/cron/_lib/cronAuth";
+import { executeQuery } from "@/lib/database/connection";
+import { _logger } from "@/lib/logger";
+import { getStripe } from "@/lib/stripe/stripe";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+// Cap the per-run Stripe probes so a backlog can't blow the function budget.
+const MAX_STRIPE_PROBES = 50;
+
+interface StuckOrder {
+  id: string;
+  status: string;
+  payment_status: string | null;
+  transfer_status: string | null;
+  stripe_transfer_id: string | null;
+  created_at: string;
+}
+
+export async function GET(request: NextRequest) {
+  if (!isAuthorizedCron(request)) {
+    return NextResponse.json(
+      { success: false, message: "Unauthorized" },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const [stuckRes, paidNoTransferRes, orphanRes, redeemedRes, refundedRes] =
+      await Promise.all([
+        executeQuery<StuckOrder>(
+          `SELECT id, status, payment_status, transfer_status,
+                  stripe_transfer_id, created_at
+           FROM restaurant_order_intents
+           WHERE status = 'settlement_pending'
+              OR transfer_status = 'retry_required'
+           ORDER BY created_at DESC
+           LIMIT 200`,
+        ),
+        executeQuery<{ id: string }>(
+          `SELECT id FROM restaurant_order_intents
+           WHERE payment_status = 'paid_with_esms'
+             AND stripe_transfer_id IS NULL
+           LIMIT 200`,
+        ),
+        executeQuery<{ source_id: string }>(
+          `SELECT DISTINCT tt.source_id
+           FROM token_transactions tt
+           LEFT JOIN restaurant_order_intents r ON r.id = tt.source_id
+           WHERE tt.source_type = 'restaurant_order'
+             AND tt.amount < 0
+             AND tt.created_at >= now() - interval '7 days'
+             AND r.id IS NULL
+           LIMIT 200`,
+        ),
+        executeQuery<{ total: string }>(
+          `SELECT COALESCE(SUM(-amount), 0) AS total
+           FROM token_transactions
+           WHERE source_type = 'restaurant_order'
+             AND amount < 0
+             AND created_at >= date_trunc('day', now())`,
+        ),
+        executeQuery<{ total: string }>(
+          `SELECT COALESCE(SUM(amount), 0) AS total
+           FROM token_transactions
+           WHERE source_type = 'restaurant_refund'
+             AND amount > 0
+             AND created_at >= date_trunc('day', now())`,
+        ),
+      ]);
+
+    const stuck = stuckRes.rows;
+    const stripe = getStripe();
+
+    // Probe Stripe (bounded) to classify each stuck order.
+    const probeTargets = stuck.slice(0, MAX_STRIPE_PROBES);
+    const retryable: string[] = [];
+    const refundable: string[] = [];
+    let probeErrors = 0;
+
+    for (const order of probeTargets) {
+      try {
+        const transfers = await stripe.transfers.list({
+          transfer_group: `restaurant_order_${order.id}`,
+          limit: 1,
+        });
+        if (transfers.data.length > 0) {
+          retryable.push(order.id);
+        } else {
+          refundable.push(order.id);
+        }
+      } catch (error) {
+        probeErrors += 1;
+        _logger.warn(
+          `[cron/esms-reconciliation] Stripe probe failed for ${order.id}:`,
+          error instanceof Error ? error.message : error,
+        );
+      }
+    }
+
+    const summary = {
+      stuckCount: stuck.length,
+      probed: probeTargets.length,
+      unprobed: Math.max(stuck.length - probeTargets.length, 0),
+      retryable,
+      refundable,
+      probeErrors,
+      paidWithoutTransfer: paidNoTransferRes.rows.map((r) => r.id),
+      orphanDebits: orphanRes.rows.map((r) => r.source_id),
+      tokensRedeemedToday: Number(redeemedRes.rows[0]?.total) || 0,
+      tokensRefundedToday: Number(refundedRes.rows[0]?.total) || 0,
+    };
+
+    const driftDetected =
+      summary.stuckCount > 0 ||
+      summary.paidWithoutTransfer.length > 0 ||
+      summary.orphanDebits.length > 0;
+
+    if (driftDetected) {
+      _logger.warn(
+        "[cron/esms-reconciliation] settlement drift detected",
+        summary,
+      );
+    }
+
+    return NextResponse.json({ success: true, driftDetected, ...summary });
+  } catch (err) {
+    _logger.error("[cron/esms-reconciliation] failed:", err);
+    return NextResponse.json(
+      { success: false, message: err instanceof Error ? err.message : "unknown" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/stripe/restaurant-order/__tests__/route.test.ts
+++ b/src/app/api/stripe/restaurant-order/__tests__/route.test.ts
@@ -152,3 +152,39 @@ it("debits an ESMS basket and settles the connected restaurant", async () => {
   expect(triggerOrderFulfillment).toHaveBeenCalledTimes(1);
 });
 
+it("returns 429 when a daily redemption cap is exceeded", async () => {
+  process.env.NEXT_PUBLIC_ESMS_RESTAURANT_PAYMENTS_ENABLED = "true";
+  process.env.NEXT_PUBLIC_ESMS_RESTAURANT_CENTS_PER_TOKEN = "1";
+  process.env.DATABASE_URL = "postgresql://test";
+  executeQuery.mockImplementation(async (sql: string) => {
+    if (sql.includes("SELECT id, stripe_connect_account_id")) {
+      return {
+        rows: [
+          { id: "rest_123", stripe_connect_account_id: "acct_restaurant" },
+        ],
+      };
+    }
+    return { rows: [] };
+  });
+  reserveEsmsForRestaurantOrder.mockResolvedValue({
+    reserved: false,
+    alreadyReserved: false,
+    balances: null,
+    capExceeded: {
+      scope: "per_user",
+      limit: 5000,
+      used: 4800,
+      requested: 2000,
+    },
+  });
+
+  const response = await POST(request("esms"));
+  expect(response.status).toBe(429);
+  const body = await response.json();
+  expect(body.code).toBe("redemption_cap_exceeded");
+  expect(body.scope).toBe("per_user");
+  expect(body.cap).toEqual({ limit: 5000, remaining: 200, requested: 2000 });
+  expect(createTransfer).not.toHaveBeenCalled();
+  expect(triggerOrderFulfillment).not.toHaveBeenCalled();
+});
+

--- a/src/app/api/stripe/restaurant-order/route.ts
+++ b/src/app/api/stripe/restaurant-order/route.ts
@@ -621,6 +621,32 @@ export async function POST(request: Request) {
     });
 
     if (!reservation.reserved) {
+      if (reservation.capExceeded) {
+        const cap = reservation.capExceeded;
+        await updateEsmsOrderSettlement({
+          orderId,
+          status: "payment_failed",
+          transferStatus: "not_started",
+          paymentStatus: "redemption_cap_exceeded",
+          metadata: { esmsCost, redemptionCap: cap },
+        });
+        const remaining = Math.max(cap.limit - cap.used, 0);
+        return NextResponse.json(
+          {
+            error:
+              cap.scope === "per_user"
+                ? "You've reached today's ESMS food-redemption limit. Try again tomorrow or pay with card or USDC."
+                : "ESMS food redemption is temporarily at its daily limit. Please pay with card or USDC, or try again tomorrow.",
+            code: "redemption_cap_exceeded",
+            scope: cap.scope,
+            orderId,
+            esmsCost,
+            cap: { limit: cap.limit, remaining, requested: cap.requested },
+          },
+          { status: 429 },
+        );
+      }
+
       await updateEsmsOrderSettlement({
         orderId,
         status: "payment_failed",

--- a/src/app/restaurants/[id]/menu/MenuOrderClient.tsx
+++ b/src/app/restaurants/[id]/menu/MenuOrderClient.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { DeliverectMenu } from "@/lib/integrations/deliverect";
 import {
   canAffordEsmsBasket,
+  esmsRestaurantCentsPerToken,
   esmsRestaurantPaymentsEnabled,
   quoteEsmsBasket,
 } from "@/lib/payments/restaurantEsms";
@@ -375,6 +376,14 @@ export default function MenuOrderClient({
               {esmsBalanceStatus === "ready" && !canAffordEsms && (
                 <p className="mt-1 text-amber-200">One or more axes are below the required balance.</p>
               )}
+              <p className="mt-2 border-t border-violet-300/15 pt-2 text-violet-100/55">
+                {esmsRestaurantCentsPerToken() > 0
+                  ? `1 ESMS = ${esmsRestaurantCentsPerToken()}¢ of food value (closed-loop, not withdrawable cash). `
+                  : "ESMS is closed-loop food value, not withdrawable cash. "}
+                <a href="/rewards" className="text-violet-200 underline hover:text-violet-100">
+                  How ESMS redemption works
+                </a>
+              </p>
             </div>
           )}
           {error && <p className="mt-3 text-xs text-rose-300">{error}</p>}

--- a/src/app/rewards/page.tsx
+++ b/src/app/rewards/page.tsx
@@ -1,0 +1,125 @@
+import Link from "next/link";
+import { esmsRestaurantCentsPerToken } from "@/lib/payments/restaurantEsms";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "ESMS Rewards & Redemption | Alchm Kitchen",
+  description:
+    "How ESMS tokens work, the food redemption rate, and our redemption-rate change policy.",
+};
+
+// Render the published rate from the same config the checkout uses, so the
+// disclosure can never drift from what is actually charged. When the rate is
+// not configured (the feature is off), we say so plainly rather than implying
+// a value.
+function formatRate(centsPerToken: number): string | null {
+  if (!Number.isInteger(centsPerToken) || centsPerToken <= 0) return null;
+  const dollars = centsPerToken / 100;
+  // 1¢ → "$0.01"; keep it exact for small integer-cent rates.
+  return `$${dollars.toFixed(2)}`;
+}
+
+export default function RewardsPage() {
+  const centsPerToken = esmsRestaurantCentsPerToken();
+  const rate = formatRate(centsPerToken);
+
+  return (
+    <main className="min-h-screen bg-[#08080e] text-white">
+      <section className="mx-auto max-w-4xl px-4 py-12 md:py-16">
+        <Link href="/" className="text-sm text-white/60 hover:text-amber-300">
+          &larr; Back to Alchm Kitchen
+        </Link>
+
+        <div className="mt-6 rounded-3xl border border-white/10 bg-white/[0.04] p-6 md:p-10 shadow-2xl shadow-purple-950/30">
+          <p className="text-xs font-bold uppercase tracking-[0.3em] text-amber-300">
+            Rewards
+          </p>
+          <h1 className="mt-3 text-4xl font-black tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-purple-300 via-amber-200 to-orange-300">
+            ESMS Rewards &amp; Redemption
+          </h1>
+          <p className="mt-3 text-sm text-white/50">Last updated: June 14, 2026</p>
+
+          <div className="mt-8 space-y-7 text-sm leading-7 text-white/75">
+            <section>
+              <h2 className="text-xl font-bold text-white">
+                What ESMS tokens are
+              </h2>
+              <p className="mt-2">
+                ESMS (Spirit, Essence, Matter, Substance) are loyalty tokens you
+                earn for using Alchm Kitchen — daily rituals, quests, streaks,
+                and onboarding. They are <strong>closed-loop rewards</strong>:
+                they unlock features and can be redeemed toward the cost of food
+                orders with participating restaurant partners.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-white">
+                Food redemption rate
+              </h2>
+              {rate ? (
+                <p className="mt-2">
+                  The current redemption rate is{" "}
+                  <strong className="text-amber-200">
+                    1 ESMS token = {rate}
+                  </strong>{" "}
+                  of food value ({centsPerToken}
+                  ¢ per token). At checkout we convert your order total into an
+                  equal four-axis basket (Spirit / Essence / Matter / Substance)
+                  rounded up to whole tokens, and debit that basket from your
+                  balance. The restaurant is paid the order total in USD.
+                </p>
+              ) : (
+                <p className="mt-2">
+                  ESMS food redemption is not currently enabled. When it is, the
+                  exact redemption rate will be published here before you can
+                  rely on it.
+                </p>
+              )}
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-white">
+                Not a cash equivalent
+              </h2>
+              <p className="mt-2">
+                ESMS is food value within Alchm Kitchen only. ESMS is{" "}
+                <strong>not withdrawable cash or USDC</strong>, is not redeemable
+                for money, has no cash surrender value, and cannot be transferred
+                or sold. Daily and overall redemption limits may apply. If you
+                want to pay with cryptocurrency, use the USDC checkout option,
+                which is separate from ESMS rewards.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-white">
+                Changes to this program
+              </h2>
+              <p className="mt-2">
+                We will publish the current redemption rate on this page and give
+                reasonable advance notice here before reducing the value of ESMS
+                you have already earned, consistent with consumer-rewards
+                guidance. We may end or change the program, or adjust earning and
+                redemption rules, including for fraud prevention or to keep the
+                program sustainable.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-bold text-white">Related</h2>
+              <p className="mt-2">
+                See our{" "}
+                <Link href="/terms" className="text-amber-300 hover:underline">
+                  Terms of Service
+                </Link>
+                . For questions, contact the Alchm Kitchen operator through the
+                contact method listed on the site or your account channels.
+              </p>
+            </section>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -54,6 +54,22 @@ export default function TermsPage() {
             </section>
 
             <section>
+              <h2 className="text-xl font-bold text-white">Rewards and ESMS tokens</h2>
+              <p className="mt-2">
+                ESMS (Spirit, Essence, Matter, Substance) are closed-loop loyalty
+                rewards. They are not cash, not withdrawable, and have no cash
+                value. You may redeem ESMS toward food orders with participating
+                partners at the published rate, subject to daily and overall
+                limits. The current redemption rate and our change policy are on
+                the{" "}
+                <Link href="/rewards" className="text-amber-300 hover:underline">
+                  ESMS Rewards &amp; Redemption
+                </Link>{" "}
+                page.
+              </p>
+            </section>
+
+            <section>
               <h2 className="text-xl font-bold text-white">Third-party services</h2>
               <p className="mt-2">
                 The site may link to services such as Amazon, payment processors,

--- a/src/lib/payments/__tests__/restaurantEsms.test.ts
+++ b/src/lib/payments/__tests__/restaurantEsms.test.ts
@@ -1,12 +1,17 @@
 import {
   canAffordEsmsBasket,
+  esmsBasketTotal,
+  esmsRestaurantAggregateDailyCap,
   esmsRestaurantCentsPerToken,
+  esmsRestaurantPerUserDailyCap,
   quoteEsmsBasket,
 } from "@/lib/payments/restaurantEsms";
 
 describe("restaurant ESMS redemption", () => {
   afterEach(() => {
     delete process.env.NEXT_PUBLIC_ESMS_RESTAURANT_CENTS_PER_TOKEN;
+    delete process.env.ESMS_RESTAURANT_PER_USER_DAILY_CAP;
+    delete process.env.ESMS_RESTAURANT_AGGREGATE_DAILY_CAP;
   });
 
   it("quotes an even four-axis basket", () => {
@@ -36,6 +41,38 @@ describe("restaurant ESMS redemption", () => {
     const cost = { spirit: 10, essence: 10, matter: 10, substance: 10 };
     expect(canAffordEsmsBasket(cost, cost)).toBe(true);
     expect(canAffordEsmsBasket({ ...cost, matter: 9 }, cost)).toBe(false);
+  });
+
+  it("sums a basket across all four axes", () => {
+    expect(esmsBasketTotal({ spirit: 501, essence: 500, matter: 500, substance: 500 })).toBe(
+      2001,
+    );
+  });
+
+  describe("daily redemption caps", () => {
+    it("falls back to defaults when unset", () => {
+      expect(esmsRestaurantPerUserDailyCap()).toBe(5000);
+      expect(esmsRestaurantAggregateDailyCap()).toBe(200000);
+    });
+
+    it("honors explicit overrides", () => {
+      process.env.ESMS_RESTAURANT_PER_USER_DAILY_CAP = "1200";
+      process.env.ESMS_RESTAURANT_AGGREGATE_DAILY_CAP = "50000";
+      expect(esmsRestaurantPerUserDailyCap()).toBe(1200);
+      expect(esmsRestaurantAggregateDailyCap()).toBe(50000);
+    });
+
+    it("treats explicit 0 as unlimited", () => {
+      process.env.ESMS_RESTAURANT_PER_USER_DAILY_CAP = "0";
+      expect(esmsRestaurantPerUserDailyCap()).toBe(0);
+    });
+
+    it("falls back to the default on an invalid value rather than disabling the cap", () => {
+      process.env.ESMS_RESTAURANT_PER_USER_DAILY_CAP = "-5";
+      expect(esmsRestaurantPerUserDailyCap()).toBe(5000);
+      process.env.ESMS_RESTAURANT_PER_USER_DAILY_CAP = "abc";
+      expect(esmsRestaurantPerUserDailyCap()).toBe(5000);
+    });
   });
 });
 

--- a/src/lib/payments/esmsRestaurantLedger.ts
+++ b/src/lib/payments/esmsRestaurantLedger.ts
@@ -2,14 +2,39 @@ import "server-only";
 
 import { randomUUID } from "node:crypto";
 import { withTransaction } from "@/lib/database";
-import type { EsmsBasketCost } from "@/lib/payments/restaurantEsms";
+import {
+  esmsBasketTotal,
+  esmsRestaurantAggregateDailyCap,
+  esmsRestaurantPerUserDailyCap,
+  type EsmsBasketCost,
+} from "@/lib/payments/restaurantEsms";
 import type { TokenBalances, TokenType } from "@/types/economy";
+
+export type RedemptionCapScope = "per_user" | "aggregate";
+
+export interface RedemptionCapInfo {
+  scope: RedemptionCapScope;
+  /** Cap ceiling in tokens for the UTC day. */
+  limit: number;
+  /** Tokens already redeemed for food in the window before this order. */
+  used: number;
+  /** Tokens this order would redeem. */
+  requested: number;
+}
 
 interface ReservationResult {
   reserved: boolean;
   alreadyReserved: boolean;
   balances: TokenBalances | null;
+  /** Set when the reservation was refused because a daily cap would be exceeded. */
+  capExceeded: RedemptionCapInfo | null;
 }
+
+// Stable 64-bit key so every restaurant-redemption reservation that needs a
+// cap check serializes on the same advisory lock — without it, two concurrent
+// orders could each read the pre-debit total and both slip past an aggregate
+// (or same-user) ceiling. Held only for the transaction; pilot volume is low.
+const CAP_LOCK_KEY = "esms_restaurant_redemption_cap";
 
 function rowToBalances(row: Record<string, unknown>): TokenBalances {
   return {
@@ -59,7 +84,73 @@ export async function reserveEsmsForRestaurantOrder(input: {
         reserved: true,
         alreadyReserved: true,
         balances: current.rows[0] ? rowToBalances(current.rows[0]) : null,
+        capExceeded: null,
       };
+    }
+
+    // Enforce per-user and aggregate daily redemption caps before any debit.
+    // Counts gross restaurant_order debits in the current UTC day; refunds use
+    // a different source_type so a refunded order still counts toward the day's
+    // cap (conservative — resets at the next UTC day).
+    const perUserCap = esmsRestaurantPerUserDailyCap();
+    const aggregateCap = esmsRestaurantAggregateDailyCap();
+    const requested = esmsBasketTotal(input.cost);
+
+    if ((perUserCap > 0 || aggregateCap > 0) && requested > 0) {
+      // Serialize concurrent cap checks so two orders can't both pass.
+      await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [
+        CAP_LOCK_KEY,
+      ]);
+
+      if (perUserCap > 0) {
+        const perUser = await client.query<{ used: string }>(
+          `SELECT COALESCE(SUM(-amount), 0) AS used
+           FROM token_transactions
+           WHERE source_type = 'restaurant_order'
+             AND amount < 0
+             AND user_id = $1
+             AND created_at >= date_trunc('day', now())`,
+          [input.userId],
+        );
+        const used = Number(perUser.rows[0]?.used) || 0;
+        if (used + requested > perUserCap) {
+          return {
+            reserved: false,
+            alreadyReserved: false,
+            balances: null,
+            capExceeded: {
+              scope: "per_user",
+              limit: perUserCap,
+              used,
+              requested,
+            },
+          };
+        }
+      }
+
+      if (aggregateCap > 0) {
+        const aggregate = await client.query<{ used: string }>(
+          `SELECT COALESCE(SUM(-amount), 0) AS used
+           FROM token_transactions
+           WHERE source_type = 'restaurant_order'
+             AND amount < 0
+             AND created_at >= date_trunc('day', now())`,
+        );
+        const used = Number(aggregate.rows[0]?.used) || 0;
+        if (used + requested > aggregateCap) {
+          return {
+            reserved: false,
+            alreadyReserved: false,
+            balances: null,
+            capExceeded: {
+              scope: "aggregate",
+              limit: aggregateCap,
+              used,
+              requested,
+            },
+          };
+        }
+      }
     }
 
     await client.query(
@@ -92,7 +183,12 @@ export async function reserveEsmsForRestaurantOrder(input: {
     );
 
     if (updated.rows.length === 0) {
-      return { reserved: false, alreadyReserved: false, balances: null };
+      return {
+        reserved: false,
+        alreadyReserved: false,
+        balances: null,
+        capExceeded: null,
+      };
     }
 
     const transactionGroupId = randomUUID();
@@ -126,6 +222,7 @@ export async function reserveEsmsForRestaurantOrder(input: {
       reserved: true,
       alreadyReserved: false,
       balances: rowToBalances(updated.rows[0]),
+      capExceeded: null,
     };
   });
 }

--- a/src/lib/payments/restaurantEsms.ts
+++ b/src/lib/payments/restaurantEsms.ts
@@ -25,6 +25,50 @@ export function esmsRestaurantCentsPerToken(): number {
   return Number.isInteger(value) && value > 0 ? value : 0;
 }
 
+// ─── Redemption caps (server-enforced pre-launch guardrails) ───────────
+//
+// Per CRYPTO_FOOD_PAYMENTS.md the pilot must "Cap per-user and aggregate
+// daily redemption" before enabling ESMS food payments in production.
+// These read NON-public env vars and are only ever evaluated server-side
+// (in the reservation transaction) — never call them from a client bundle.
+// A value of 0 (or unset/invalid) means "no cap" — an explicit opt-out.
+// The window is a UTC calendar day (date_trunc('day', now())), matching
+// the rest of the daily-yield accounting.
+
+const DEFAULT_PER_USER_DAILY_CAP = 5000; // tokens/day ($50 at 1¢/token)
+const DEFAULT_AGGREGATE_DAILY_CAP = 200_000; // tokens/day ($2,000 at 1¢/token)
+
+function capFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  const value = Number(raw);
+  // Explicit 0 disables the cap; negative/NaN falls back to the default so a
+  // typo can never silently remove the guardrail.
+  if (!Number.isFinite(value) || value < 0) return fallback;
+  return Math.floor(value);
+}
+
+/** Max ESMS tokens a single user may redeem for food per UTC day (0 = unlimited). */
+export function esmsRestaurantPerUserDailyCap(): number {
+  return capFromEnv(
+    "ESMS_RESTAURANT_PER_USER_DAILY_CAP",
+    DEFAULT_PER_USER_DAILY_CAP,
+  );
+}
+
+/** Max ESMS tokens redeemed for food platform-wide per UTC day (0 = unlimited). */
+export function esmsRestaurantAggregateDailyCap(): number {
+  return capFromEnv(
+    "ESMS_RESTAURANT_AGGREGATE_DAILY_CAP",
+    DEFAULT_AGGREGATE_DAILY_CAP,
+  );
+}
+
+/** Total tokens across all four axes for a basket. */
+export function esmsBasketTotal(cost: EsmsBasketCost): number {
+  return cost.spirit + cost.essence + cost.matter + cost.substance;
+}
+
 export function quoteEsmsBasket(
   totalCents: number,
   centsPerToken = esmsRestaurantCentsPerToken(),

--- a/src/types/economy.ts
+++ b/src/types/economy.ts
@@ -54,7 +54,14 @@ export type TransactionSourceType =
    * Live-priced per extraction like refine_oracle; refunded if extraction fails.
    */
   | "recipe_ingestion"
-  | "restaurant_order";
+  | "restaurant_order"
+  /**
+   * Re-credit of a restaurant_order debit when the restaurant settlement
+   * (Stripe transfer) could not be confirmed and an operator refunds the
+   * exact ESMS basket. Idempotency key shape: `restaurant_refund:<orderId>`.
+   * See src/app/api/admin/restaurants/settlement/route.ts.
+   */
+  | "restaurant_refund";
 
 // ─── Token Balances ────────────────────────────────────────────────────
 

--- a/vercel.json
+++ b/vercel.json
@@ -50,6 +50,10 @@
     {
       "path": "/api/cron/prewarm-agent-recipes",
       "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/cron/esms-reconciliation",
+      "schedule": "15 * * * *"
     }
   ],
   "env": {


### PR DESCRIPTION
## What

Adds the four pre-launch guardrails called for in [docs/payments/CRYPTO_FOOD_PAYMENTS.md](docs/payments/CRYPTO_FOOD_PAYMENTS.md) (lines 87–92, 182–192) before the ESMS restaurant-payment rails shipped in #521 can be turned on in production. An audit found all four **missing**; this implements them. **No schema migration** — `token_transactions.source_type` is unconstrained and already indexed.

### 1. Per-user **and** aggregate daily redemption caps
- `restaurantEsms.ts`: server-enforced caps (UTC day, tokens summed across all four axes). Env `ESMS_RESTAURANT_PER_USER_DAILY_CAP` (default 5000 = $50 @ 1¢), `ESMS_RESTAURANT_AGGREGATE_DAILY_CAP` (default 200000 = $2000 @ 1¢); `0` = unlimited; invalid → default (a typo can't silently remove the guardrail).
- `esmsRestaurantLedger.ts`: enforced **inside the reservation transaction**, serialized on a shared advisory lock so concurrent orders can't both slip past a ceiling. Returns a typed `capExceeded`.
- Route returns **429 `redemption_cap_exceeded`** (distinct from the existing 402 insufficient-balance path).

### 2. Reconciliation of token debits vs Stripe transfers/refunds
- New cron **`/api/cron/esms-reconciliation`** (hourly, `CRON_SECRET`). Surfaces `stuck` / `paidWithoutTransfer` / `orphanDebits` drift, probes Stripe (bounded to 50/run) to classify stuck orders as **retryable** (transfer exists) vs **refundable** (none), reports daily redeemed-vs-refunded token totals, and logs drift for operators.

### 3. Operator retry/refund workflow for `settlement_pending`
- New admin **`/api/admin/restaurants/settlement`**. `GET` lists pending orders; `POST {orderId, action}`:
  - `retry`: re-issues the Stripe transfer with the **original** idempotency key (`restaurant_order_esms_transfer_<id>`) — never double-pays — then marks paid + (re)triggers fulfillment.
  - `refund`: only after confirming via Stripe that **no** transfer exists for the order's `transfer_group`, re-credits the **exact** debited basket (idempotency-guarded, `source_type='restaurant_refund'`) and marks the order refunded.

### 4. Published redemption-rate disclosure (CFPB rewards guidance)
- New public **`/rewards`** page stating the cents-per-token rate (read from the same config the checkout uses, so it can't drift), that ESMS is closed-loop / not withdrawable cash, and a change-notice policy. Linked from the ESMS checkout panel and Terms.

## Testing
- New unit tests: cap config (defaults / override / 0=unlimited / invalid→default) and the route 429 cap path.
- `bun run typecheck` + `eslint` clean (pre-commit hook passed).

## Notes
- These are guardrails only; the rails stay **flag-gated OFF** (`NEXT_PUBLIC_ESMS_RESTAURANT_PAYMENTS_ENABLED` unset). The caps activate with the feature.
- The reconciliation cron is registered in `vercel.json` and reuses the existing `CRON_SECRET`.
- Cap counts gross `restaurant_order` debits per UTC day; refunds use a separate source type and don't offset same-day (conservative; resets next UTC day).

🤖 Generated with [Claude Code](https://claude.com/claude-code)