### PR TITLE
fix(audit): emergence-from-rubble live-site cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -350,6 +350,20 @@ PRIVY_APP_SECRET=
 # NEXT_PUBLIC_PLAUSIBLE_DOMAIN=alchm.kitchen
 
 # ============================================================================
+# PWA / SERVICE WORKER  (opt-in — off by default)
+# ============================================================================
+# The installable PWA + offline asset caching ship disabled. To turn them on,
+# set BOTH flags to "true" and redeploy:
+#   ENABLE_PWA             build-time: makes `next build` generate public/sw.js
+#   NEXT_PUBLIC_ENABLE_PWA runtime:    lets the browser register /sw.js
+# The service worker caches immutable /_next/static assets + images only — it
+# never caches HTML or /api responses, so deploys stay fresh and auth/economy
+# data always hits the network. Verify on a Vercel PREVIEW deploy before prod;
+# a service worker persists in users' browsers.
+# ENABLE_PWA=true
+# NEXT_PUBLIC_ENABLE_PWA=true
+
+# ============================================================================
 # DEVELOPMENT ONLY
 # ============================================================================
 

--- a/next.config.js
+++ b/next.config.js
@@ -201,7 +201,29 @@ const nextConfig = {
             cleanupOutdatedCaches: true,
             mode: process.env.NODE_ENV === "production" ? "production" : "development",
             exclude: [/\.map$/, /^build-manifest\.json$/, /^app-build-manifest\.json$/, /^react-loadable-manifest\.json$/],
-            runtimeCaching: [],
+            // Safe, additive runtime caching only. HTML navigations and /api/* are
+            // deliberately NOT cached, so every deploy serves fresh markup and
+            // auth/economy responses always hit the network. No navigateFallback —
+            // this is an SSR app, not an SPA, so serving a cached shell for every
+            // navigation would break it.
+            runtimeCaching: [
+              {
+                // Content-hashed build assets are immutable — serve from cache and
+                // revalidate in the background.
+                urlPattern: ({ url }) => url.pathname.startsWith("/_next/static/"),
+                handler: "StaleWhileRevalidate",
+                options: { cacheName: "alchm-static" },
+              },
+              {
+                // Images: cache-first with a bounded, expiring cache.
+                urlPattern: ({ request }) => request.destination === "image",
+                handler: "CacheFirst",
+                options: {
+                  cacheName: "alchm-images",
+                  expiration: { maxEntries: 96, maxAgeSeconds: 7 * 24 * 60 * 60 },
+                },
+              },
+            ],
           }),
           new CopyPwaAssetsPlugin(path.join(__dirname, "public")),
         );

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,8 +4,8 @@
   "description": "Culinary astrology and elemental recipe recommendations",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#0f172a",
-  "theme_color": "#6366f1",
+  "background_color": "#07060B",
+  "theme_color": "#07060B",
   "icons": [
     {
       "src": "/alchm-icon-64.png",

--- a/public/offline.html
+++ b/public/offline.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Offline - What to Eat Next</title>
+    <title>Offline · Alchm Kitchen</title>
     <style>
       * {
         margin: 0;
@@ -14,7 +14,7 @@
       body {
         font-family:
           -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        background: radial-gradient(circle at 30% 20%, #1a1430 0%, #07060b 60%);
         min-height: 100vh;
         display: flex;
         align-items: center;
@@ -110,7 +110,7 @@
       <div class="offline-icon">🌙</div>
       <h1>You're Offline</h1>
       <p>
-        Don't worry! What to Eat Next works offline too. While you're
+        Don't worry! Alchm Kitchen works offline too. While you're
         disconnected, you can still access your cached recipes and cooking
         methods.
       </p>

--- a/src/app/(alchm)/feed/page.tsx
+++ b/src/app/(alchm)/feed/page.tsx
@@ -2,6 +2,7 @@
 
 import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
+import { useSession } from "next-auth/react";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { HistoricalAgentFeedCard } from "@/components/feed/HistoricalAgentFeedItems";
 import Header from "@/components/Header";
@@ -551,6 +552,7 @@ function SwapTab({
   const [amount, setAmount] = useState<string>("1");
   const [submitting, setSubmitting] = useState(false);
   const [resultMessage, setResultMessage] = useState<{ kind: "ok" | "error"; text: string } | null>(null);
+  const { status: authStatus } = useSession();
 
   // Auto-fix invalid same-token selections
   useEffect(() => {
@@ -656,13 +658,22 @@ function SwapTab({
           </div>
         )}
 
-        <button
-          onClick={() => { void handleSwap(); }}
-          disabled={submitting || numericAmount <= 0}
-          className="mt-6 w-full px-6 py-3 rounded-2xl bg-purple-600 hover:bg-purple-500 disabled:bg-white/10 disabled:text-white/40 text-white font-black text-xs uppercase tracking-[0.3em] shadow-lg shadow-purple-900/40 transition-all"
-        >
-          {submitting ? "Performing rite..." : "Execute Swap"}
-        </button>
+        {authStatus === "authenticated" ? (
+          <button
+            onClick={() => { void handleSwap(); }}
+            disabled={submitting || numericAmount <= 0}
+            className="mt-6 w-full px-6 py-3 rounded-2xl bg-purple-600 hover:bg-purple-500 disabled:bg-white/10 disabled:text-white/40 text-white font-black text-xs uppercase tracking-[0.3em] shadow-lg shadow-purple-900/40 transition-all"
+          >
+            {submitting ? "Performing rite..." : "Execute Swap"}
+          </button>
+        ) : (
+          <Link
+            href="/login"
+            className="mt-6 block text-center w-full px-6 py-3 rounded-2xl bg-purple-600 hover:bg-purple-500 text-white font-black text-xs uppercase tracking-[0.3em] shadow-lg shadow-purple-900/40 transition-all"
+          >
+            Sign in to swap
+          </Link>
+        )}
 
         {resultMessage && (
           <div

--- a/src/app/(alchm)/ingredients/[ingredientId]/page.tsx
+++ b/src/app/(alchm)/ingredients/[ingredientId]/page.tsx
@@ -338,8 +338,8 @@ export default function IngredientHeroPage({
       {
         sym,
         n: `${ingredient.name}, market unit`,
-        src: "Whole Earth Mkt.",
-        px: "12.50",
+        src: "",
+        px: "",
         qty: 1,
         ingredientId: id,
       },

--- a/src/app/(alchm)/lab/page.tsx
+++ b/src/app/(alchm)/lab/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import Link from "next/link";
 import { useEffect, useState, type JSX } from "react";
 import {
   AstrologicalClockPanel,
@@ -586,16 +587,13 @@ export default function LaboratoryDashboardPage(): JSX.Element {
                 margin: "0 0 18px",
               }}
             >
-              Real-time positions are sourced from{" "}
-              <code style={{ fontSize: 12 }}>/api/astrologize</code>. The composed
-              recommendation copy and ranked ingredients are wired against the
-              backend contracts in{" "}
-              <code style={{ fontSize: 12 }}>src/lib/schemas/dashboard.ts</code>;
+              Real-time positions are sourced from live planetary data. Composed
+              recommendations and ranked ingredients are drawn from the backend;
               sections without live data are flagged below.
             </p>
             <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
-              <button
-                type="button"
+              <Link
+                href="/menu-planner"
                 className="alchm-btn"
                 style={{
                   background:
@@ -604,10 +602,10 @@ export default function LaboratoryDashboardPage(): JSX.Element {
                 }}
               >
                 Compose Tonight&apos;s Menu <Glyph name="arrow" size={14} />
-              </button>
-              <button type="button" className="alchm-btn alchm-btn-ghost">
+              </Link>
+              <Link href="/cosmic-recipe" className="alchm-btn alchm-btn-ghost">
                 Open Lab
-              </button>
+              </Link>
             </div>
           </div>
         </div>

--- a/src/app/(alchm)/profile/budget/page.tsx
+++ b/src/app/(alchm)/profile/budget/page.tsx
@@ -73,7 +73,7 @@ export default function BudgetPage() {
                   : 'bg-[#08080e] border border-white/10 text-white hover:bg-white/5 shadow-black/20 shadow-xl'
               }`}
             >
-              {saved ? '&#x2713; Saved Successfully!' : 'Save Budget Preference'}
+              {saved ? '✓ Saved Successfully!' : 'Save Budget Preference'}
             </button>
           </div>
         </div>

--- a/src/app/(alchm)/profile/page.tsx
+++ b/src/app/(alchm)/profile/page.tsx
@@ -111,14 +111,14 @@ function PremiumDashboard({
             <div className="flex items-center gap-3 mb-2">
               <span className="w-10 h-px bg-amber-500/40" />
               <span className="text-[9px] font-black text-amber-400/60 uppercase tracking-[0.5em]">
-                Premium — Premium Sanctum
+                Premium Sanctum
               </span>
             </div>
             <h1 className="text-4xl font-black text-white tracking-tighter alchm-gradient-text uppercase">
               {userName}
             </h1>
             <p className="text-white/20 text-xs mt-1 font-mono">
-              {email} · Alchemical Premium · Premium
+              {email} · Alchemical Premium
             </p>
           </div>
 
@@ -127,7 +127,7 @@ function PremiumDashboard({
             <div className="flex items-center gap-2 px-4 py-2 bg-amber-500/10 rounded-full border border-amber-500/30">
               <span className="text-amber-400 text-xs">✦</span>
               <span className="text-[10px] font-black text-amber-400 uppercase tracking-[0.3em]">
-                Premium Premium
+                Premium
               </span>
             </div>
             <button
@@ -352,7 +352,7 @@ function PremiumSettingsPanel({
   const rows = [
     { label: 'Name', value: session?.user?.name || '—' },
     { label: 'Email', value: session?.user?.email || '—' },
-    { label: 'Plan', value: 'Premium Premium' },
+    { label: 'Plan', value: 'Premium' },
     { label: 'Dominant Element', value: natalChart.dominantElement || '—' },
     { label: 'Dominant Modality', value: natalChart.dominantModality || '—' },
   ];

--- a/src/app/cuisines/page.tsx
+++ b/src/app/cuisines/page.tsx
@@ -63,9 +63,6 @@ export default function CuisinesPage() {
         variants={staggerContainer}
       >
         <motion.header variants={fadeInItem} className="mb-12 pt-4">
-          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-purple-900/40 border border-purple-500/30 text-purple-200 text-sm font-semibold mb-6 shadow-[0_0_15px_rgba(168,85,247,0.15)]">
-            <span className="text-xl">✨</span> Premium Alchemical Feature
-          </div>
           <h1 className="text-4xl md:text-6xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-purple-300 via-pink-300 to-rose-300 leading-tight pb-2">
             Cosmic Cuisines
           </h1>

--- a/src/app/menu-planner/page.tsx
+++ b/src/app/menu-planner/page.tsx
@@ -571,28 +571,9 @@ function MenuPlannerContent() {
           </div>
         </div>
 
-        {/* Sticky Nutrition Dashboard */}
-        <div className="sticky top-20 z-40 alchm-panel border-b border-muted bg-surface/90 backdrop-blur-md p-4 mb-8 flex flex-wrap gap-6 items-center rounded-xl">
-          <div className="flex items-center gap-2">
-            <span className="text-active-violet">⚡</span>
-            <span className="font-telemetry-md text-telemetry-md text-on-surface-variant">TGT: 2400 KCAL</span>
-          </div>
-          <div className="w-px h-6 bg-on-surface-variant/20 hidden md:block" />
-          <div className="flex items-center gap-2">
-            <span className="text-fire-spirit">💪</span>
-            <span className="font-telemetry-md text-telemetry-md text-on-surface-variant">PRO: 180G</span>
-          </div>
-          <div className="w-px h-6 bg-on-surface-variant/20 hidden md:block" />
-          <div className="flex items-center gap-2">
-            <span className="text-earth-matter">🌿</span>
-            <span className="font-telemetry-md text-telemetry-md text-on-surface-variant">FIB: 35G</span>
-          </div>
-          <div className="w-px h-6 bg-on-surface-variant/20 hidden md:block" />
-          <div className="flex items-center gap-2">
-            <span className="font-telemetry-md text-telemetry-md text-gold-accent">☉ 92%</span>
-            <span className="font-telemetry-md text-telemetry-md text-on-surface-variant">ORBITAL SYNC</span>
-          </div>
-        </div>
+        {/* Sticky nutrition bar removed — TGT/PRO/FIB and "ORBITAL SYNC" were
+            hardcoded placeholders, not computed from the planned meals. The real
+            nutrition totals live in the Nutrition Dashboard panel below. */}
         
         {/* Posso Widget Panel (collapsible) */}
         {showPosso && (
@@ -674,10 +655,8 @@ function MenuPlannerContent() {
                 &gt; NATAL RESONANCE: {natalResonance}%<br/>
                 &gt; OPTIMIZING MACROS...
               </div>
-              <div className="font-telemetry-md text-[10px] bg-surface-container-lowest p-2 border border-error/30 text-error h-12 overflow-y-auto leading-relaxed font-mono">
-                &gt; WARN: MERCURY RETROGRADE<br/>
-                &gt; ADJUSTING COGNITIVE LOAD...
-              </div>
+              {/* Fake "MERCURY RETROGRADE" warning terminal removed — it was a
+                  hardcoded decorative error, not a real transit alert. */}
             </div>
           </div>
 

--- a/src/app/premium-table/page.tsx
+++ b/src/app/premium-table/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useState, useEffect, Suspense } from "react";
 import { RecipeCard } from "@/components/recipes/RecipeCard";
@@ -17,6 +18,7 @@ function AdeptTableContent() {
   const [recipes, setRecipes] = useState<Recipe[]>([]);
   const [loading, setLoading] = useState(false);
   const [composite, setComposite] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
 
   // Friend's inputs
   const [friendFire, setFriendFire] = useState(25);
@@ -38,11 +40,16 @@ function AdeptTableContent() {
 
   const handleJoin = async () => {
     setLoading(true);
+    setError(null);
     try {
-      const hostFire = Number(searchParams?.get("host_fire")) || 25;
-      const hostWater = Number(searchParams?.get("host_water")) || 25;
-      const hostEarth = Number(searchParams?.get("host_earth")) || 25;
-      const hostAir = Number(searchParams?.get("host_air")) || 25;
+      // Host values arrive via URL query (invite link) — clamp to 0–100 so a
+      // crafted link can't skew the midpoint with out-of-range numbers.
+      const clampPct = (v: string | null | undefined) =>
+        Math.max(0, Math.min(100, Number(v) || 25));
+      const hostFire = clampPct(searchParams?.get("host_fire"));
+      const hostWater = clampPct(searchParams?.get("host_water"));
+      const hostEarth = clampPct(searchParams?.get("host_earth"));
+      const hostAir = clampPct(searchParams?.get("host_air"));
 
       const hostData = {
         elementalBalance: { Fire: hostFire, Water: hostWater, Earth: hostEarth, Air: hostAir },
@@ -64,12 +71,15 @@ function AdeptTableContent() {
         body: JSON.stringify({ hostData, friendData })
       });
       const data = await res.json();
-      if (data.success) {
+      if (res.ok && data.success) {
         setComposite(data.compositeChart);
         setRecipes(data.recipes);
+      } else {
+        setError(data.message || "Couldn't calculate the midpoint. Please try again.");
       }
     } catch (err) {
       console.error(err);
+      setError("Something went wrong reaching the Table. Please try again.");
     } finally {
       setLoading(false);
     }
@@ -81,9 +91,12 @@ function AdeptTableContent() {
         <div className="glass-card-premium rounded-3xl p-8 max-w-md text-center border-amber-500/30">
           <h1 className="text-2xl font-black text-amber-400 mb-4">Premium Status Required</h1>
           <p className="text-white/60 mb-6">Group Rituals and the Alchemical Midpoint table are exclusive to Premium users.</p>
-          <button className="px-6 py-2 rounded-full bg-amber-500 text-black font-bold uppercase tracking-widest hover:bg-amber-400 transition-colors">
+          <Link
+            href="/upgrade?from=/premium-table"
+            className="inline-block px-6 py-2 rounded-full bg-amber-500 text-black font-bold uppercase tracking-widest hover:bg-amber-400 transition-colors"
+          >
             Upgrade Now
-          </button>
+          </Link>
         </div>
       </main>
     );
@@ -143,6 +156,9 @@ function AdeptTableContent() {
                 >
                   {loading ? "Calculating Midpoint..." : "Calculate Harmony"}
                 </button>
+                {error && (
+                  <p className="mt-4 text-center text-sm text-red-400">{error}</p>
+                )}
               </motion.div>
             ) : (
               <motion.div initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} className="space-y-8">

--- a/src/app/restaurants/[id]/menu/page.tsx
+++ b/src/app/restaurants/[id]/menu/page.tsx
@@ -63,9 +63,16 @@ export default async function RestaurantMenuPage({
   }
 
   const deliverect = new DeliverectClient();
-  const menu = await deliverect.getMenu(
-    restaurant.deliverect_location_id || restaurant.id,
-  );
+  // A missing or failing POS integration must not 500 the whole page — fall back
+  // to a graceful "menu unavailable" state below if getMenu throws.
+  let menu: Awaited<ReturnType<typeof deliverect.getMenu>> | null = null;
+  try {
+    menu = await deliverect.getMenu(
+      restaurant.deliverect_location_id || restaurant.id,
+    );
+  } catch (err) {
+    console.error(`[restaurants/${id}/menu] getMenu failed:`, err);
+  }
   const fallbackMenuUrl = new URL(`/restaurants/${restaurant.id}/menu`, appUrl());
 
   return (
@@ -91,16 +98,31 @@ export default async function RestaurantMenuPage({
           </p>
         </header>
 
-        <MenuOrderClient
-          restaurant={{
-            id: restaurant.id,
-            name: restaurant.name,
-            url: restaurant.menu_url || fallbackMenuUrl.toString(),
-            stripeConnectAccountId:
-              restaurant.stripe_connect_account_id ?? undefined,
-          }}
-          menu={menu}
-        />
+        {menu ? (
+          <MenuOrderClient
+            restaurant={{
+              id: restaurant.id,
+              name: restaurant.name,
+              url: restaurant.menu_url || fallbackMenuUrl.toString(),
+              stripeConnectAccountId:
+                restaurant.stripe_connect_account_id ?? undefined,
+            }}
+            menu={menu}
+          />
+        ) : (
+          <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-8 text-center">
+            <p className="text-lg font-semibold text-white">Menu temporarily unavailable</p>
+            <p className="mx-auto mt-2 max-w-md text-sm text-white/55">
+              We couldn&apos;t load this restaurant&apos;s live menu right now. Please try again shortly.
+            </p>
+            <Link
+              href="/restaurants"
+              className="mt-6 inline-flex rounded-full bg-orange-500/90 px-5 py-2 text-sm font-bold text-black transition-colors hover:bg-orange-400"
+            >
+              Browse other restaurants
+            </Link>
+          </div>
+        )}
       </div>
     </main>
   );

--- a/src/components/nav/RedesignedFooter.tsx
+++ b/src/components/nav/RedesignedFooter.tsx
@@ -53,38 +53,7 @@ export function RedesignedFooter(): JSX.Element {
           >
             What you eat next, calibrated to your standing chart and the live sky.
           </p>
-          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-            <span
-              className="alchm-chip"
-              style={{ padding: "3px 8px", fontSize: 9, display: "inline-flex", alignItems: "center", gap: 6 }}
-            >
-              <span
-                className="el-dot"
-                style={{
-                  width: 6,
-                  height: 6,
-                  background: "oklch(0.74 0.11 130)",
-                  boxShadow: "0 0 6px oklch(0.74 0.11 130)",
-                }}
-              />
-              POSTGRES · OK
-            </span>
-            <span
-              className="alchm-chip"
-              style={{ padding: "3px 8px", fontSize: 9, display: "inline-flex", alignItems: "center", gap: 6 }}
-            >
-              <span
-                className="el-dot"
-                style={{
-                  width: 6,
-                  height: 6,
-                  background: "oklch(0.74 0.11 130)",
-                  boxShadow: "0 0 6px oklch(0.74 0.11 130)",
-                }}
-              />
-              EDGE · OK
-            </span>
-          </div>
+          {/* Live-status chips removed — they were hardcoded "OK" text, not real health probes. */}
         </div>
 
         {PRIMARY_KEYS.map((k) => {

--- a/src/components/ui/alchm/ProcurementKit.tsx
+++ b/src/components/ui/alchm/ProcurementKit.tsx
@@ -64,11 +64,14 @@ export function ProcurementKit({
     }
   };
 
+  const pricedItems = list.filter((it) => it.px);
   const computedTotal =
     total ??
-    list
-      .reduce((sum, it) => sum + parseFloat(it.px || "0") * it.qty, 0)
-      .toFixed(2);
+    (pricedItems.length
+      ? pricedItems
+          .reduce((sum, it) => sum + parseFloat(it.px || "0") * it.qty, 0)
+          .toFixed(2)
+      : null);
 
   const itemCount = list.length.toString().padStart(2, "0");
 
@@ -179,7 +182,7 @@ export function ProcurementKit({
                     letterSpacing: "0.08em",
                   }}
                 >
-                  SUPPLIER · {it.src}
+                  SUPPLIER · {it.src || "—"}
                 </div>
               </div>
               <div
@@ -243,7 +246,7 @@ export function ProcurementKit({
                   textAlign: "right",
                 }}
               >
-                ${it.px}
+                {it.px ? `$${it.px}` : "—"}
               </span>
               <Glyph name="check" size={12} stroke={1.6} style={{ color: "var(--accent-2)" }} />
             </div>
@@ -267,7 +270,7 @@ export function ProcurementKit({
           </div>
           <div style={{ display: "flex", alignItems: "baseline", gap: 6, marginTop: 2 }}>
             <span className="t-num" style={{ fontSize: 24, color: "var(--fg)" }}>
-              ${computedTotal}
+              {computedTotal != null ? `$${computedTotal}` : "—"}
             </span>
             <span className="t-mono" style={{ fontSize: 10, color: "var(--fg-mute)" }}>
               {currency}

--- a/src/contexts/SpacetimeContext.tsx
+++ b/src/contexts/SpacetimeContext.tsx
@@ -121,7 +121,11 @@ export function SpacetimeProvider({ children }: { children: ReactNode }) {
           })
           .onConnectError((_ctx, error) => {
             if (disposedRef.current) return;
-            console.warn("[spacetime] connect error:", error.message);
+            // Log only the first error of a disconnect episode; the reconnect
+            // loop retries on a backoff and would otherwise spam the console.
+            if (failuresRef.current === 0) {
+              console.warn("[spacetime] connect error:", error.message);
+            }
             setConnection(null);
             scheduleReconnect(connect);
           })


### PR DESCRIPTION
## Emergence from the rubble — live-site audit cleanup

Fixes surfaced by a full Claude-in-Chrome QA audit of the live site, **each verified against source** before changing (one reported "P0" — an exposed Execute Swap CTA — turned out to be server-gated already, so it was downgraded to a UX fix).

### Correctness / fake-data shown to users
- **`/profile/budget`** — render a real `✓` instead of the literal `&#x2713;` HTML entity
- **`/profile`** — de-dupe **four** doubled "Premium" labels (eyebrow, subtitle, badge, Plan row)
- **`/ingredients/[id]`** — drop the hardcoded `$12.50 / "Whole Earth Mkt."` price; `ProcurementKit` now shows `—` for missing price/supplier and total
- **`/menu-planner`** — remove the fake sticky telemetry (`2400 KCAL` / `92% ORBITAL SYNC`) and the permanent fake `WARN: MERCURY RETROGRADE` terminal
- **`/lab`** — scrub the leaked `src/lib/schemas/dashboard.ts` path from user-facing copy
- **Footer** — remove the hardcoded `POSTGRES · OK / EDGE · OK` chips (they read OK during an outage)

### Dead / half-wired UI
- **`/lab`** — wire "Compose Tonight's Menu" → `/menu-planner`, "Open Lab" → `/cosmic-recipe`
- **`/premium-table`** — wire the dead "Upgrade Now" button → `/upgrade`; surface API errors to the user; clamp `host_*` invite params to 0–100 (the `?invite=true` path is by design — middleware still blocks anonymous)
- **`/cuisines`** — drop the "Premium Alchemical Feature" badge (sauce is free)

### Robustness
- **`/feed`** — gate the ESMS "Execute Swap" CTA behind auth (sign-in prompt when logged out)
- **`/restaurants/[id]/menu`** — wrap `deliverect.getMenu` in try/catch so an unconfigured POS shows a graceful fallback instead of **500ing the route** (real P0)
- **`SpacetimeContext`** — log connect errors once per disconnect episode, not on every retry (was spamming the console every 2–4s)

### PWA (ready, still opt-in)
- Hardened the workbox `GenerateSW` config with **safe additive caching only** — immutable `/_next/static` + images; **no HTML/`/api` caching and no `navigateFallback`** (this is SSR, not an SPA)
- Reconciled `manifest.json` theme/background to `#07060B`; rebranded `offline.html` to dark/Alchm
- Documented `ENABLE_PWA` + `NEXT_PUBLIC_ENABLE_PWA` in `.env.example`

> ⚠️ **To activate the PWA**, set both env flags in Vercel and deploy — **verify on a preview deploy first** (a service worker persists in users' browsers). Not enabled by this PR.

### Verification
`eslint` clean and `tsc --noEmit` **0 errors** project-wide; `next.config.js` parses; `manifest.json` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
