### PR TITLE
fix(audit): pass-2/2b restore + spacetime hardening, /upgrade CTA, ingredient browse filter

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -81,10 +81,13 @@ const getSecurityHeaders = () => {
   // an HTTP POST to /v1/identity/websocket-token before every reconnect.
   // Production (wss:// + https://) is already covered by the https: source.
   const spacetimeUri = process.env.NEXT_PUBLIC_SPACETIME_URI;
-  if (spacetimeUri && spacetimeUri.startsWith("ws://")) {
+  if (spacetimeUri && (spacetimeUri.startsWith("ws://") || spacetimeUri.startsWith("wss://"))) {
     try {
-      const origin = new URL(spacetimeUri).origin.replace(/^http:/, "ws:");
-      connectSrcParts.push(origin, origin.replace(/^ws:/, "http:"));
+      const httpUri = spacetimeUri.replace(/^ws/, "http");
+      const url = new URL(httpUri);
+      const httpOrigin = url.origin;
+      const wsOrigin = httpOrigin.replace(/^http/, "ws");
+      connectSrcParts.push(wsOrigin, httpOrigin);
     } catch {
       // Malformed URI — the client will surface the connection error.
     }

--- a/src/app/(alchm)/current-chart/page.tsx
+++ b/src/app/(alchm)/current-chart/page.tsx
@@ -30,9 +30,11 @@ export default async function CurrentChartPage() {
 
   const nowStr = new Date().toLocaleString('en-US', {
     weekday: 'long',
-    month: 'long', 
+    month: 'long',
     day: 'numeric',
     year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
     timeZoneName: 'short'
   });
 

--- a/src/app/pantry/page.tsx
+++ b/src/app/pantry/page.tsx
@@ -42,25 +42,25 @@ export default function PantryPage() {
   }, [filtered]);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-white to-emerald-50">
+    <div className="min-h-screen bg-[#08080e]">
       <div className="mx-auto max-w-6xl px-4 py-8">
         <div className="mb-6 flex items-start justify-between flex-wrap gap-4">
           <div>
-            <h1 className="text-3xl font-bold text-gray-900">
+            <h1 className="text-3xl font-bold text-white">
               🥫 Your Pantry
             </h1>
-            <p className="text-sm text-gray-600 mt-1">
+            <p className="text-sm text-white/60 mt-1">
               Ingredients you have on hand. Add from the{" "}
               <Link
                 href="/#ingredients"
-                className="text-emerald-700 underline hover:text-emerald-900"
+                className="text-emerald-400 underline hover:text-emerald-300"
               >
                 Ingredient Recommender
               </Link>{" "}
               on the home page, or jump over to the{" "}
               <Link
                 href="/menu-planner"
-                className="text-purple-700 underline hover:text-purple-900"
+                className="text-purple-400 underline hover:text-purple-300"
               >
                 Menu Planner
               </Link>{" "}
@@ -70,7 +70,7 @@ export default function PantryPage() {
           <div className="flex gap-2">
             <Link
               href="/#ingredients"
-              className="px-4 py-2 rounded-lg bg-emerald-600 text-white text-sm font-medium hover:bg-emerald-700"
+              className="px-4 py-2 rounded-lg bg-emerald-600 text-white text-sm font-medium hover:bg-emerald-500"
             >
               + Browse ingredients
             </Link>
@@ -82,7 +82,7 @@ export default function PantryPage() {
                     clear();
                   }
                 }}
-                className="px-4 py-2 rounded-lg bg-gray-100 text-gray-700 text-sm font-medium hover:bg-gray-200"
+                className="px-4 py-2 rounded-lg bg-white/10 text-white/80 text-sm font-medium hover:bg-white/15"
               >
                 Clear pantry
               </button>
@@ -92,35 +92,35 @@ export default function PantryPage() {
 
         {/* Stats */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
-          <div className="bg-white border border-gray-200 rounded-xl p-4">
-            <div className="text-xs uppercase tracking-wide text-gray-500">
+          <div className="bg-white/[0.03] border border-white/10 rounded-xl p-4">
+            <div className="text-xs uppercase tracking-wide text-white/40">
               Total items
             </div>
-            <div className="text-2xl font-bold text-gray-900 mt-1">
+            <div className="text-2xl font-bold text-white mt-1">
               {stats.totalItems}
             </div>
           </div>
-          <div className="bg-white border border-gray-200 rounded-xl p-4">
-            <div className="text-xs uppercase tracking-wide text-gray-500">
+          <div className="bg-white/[0.03] border border-white/10 rounded-xl p-4">
+            <div className="text-xs uppercase tracking-wide text-white/40">
               Categories
             </div>
-            <div className="text-2xl font-bold text-gray-900 mt-1">
+            <div className="text-2xl font-bold text-white mt-1">
               {Object.keys(stats.categoryCounts).length}
             </div>
           </div>
-          <div className="bg-white border border-amber-200 rounded-xl p-4">
-            <div className="text-xs uppercase tracking-wide text-amber-700">
+          <div className="bg-white/[0.03] border border-amber-500/30 rounded-xl p-4">
+            <div className="text-xs uppercase tracking-wide text-amber-400">
               Expiring ≤ 7 days
             </div>
-            <div className="text-2xl font-bold text-amber-900 mt-1">
+            <div className="text-2xl font-bold text-amber-300 mt-1">
               {stats.expiringIn7Days}
             </div>
           </div>
-          <div className="bg-white border border-red-200 rounded-xl p-4">
-            <div className="text-xs uppercase tracking-wide text-red-700">
+          <div className="bg-white/[0.03] border border-red-500/30 rounded-xl p-4">
+            <div className="text-xs uppercase tracking-wide text-red-400">
               Expired
             </div>
-            <div className="text-2xl font-bold text-red-900 mt-1">
+            <div className="text-2xl font-bold text-red-300 mt-1">
               {stats.expired}
             </div>
           </div>
@@ -134,12 +134,12 @@ export default function PantryPage() {
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search pantry..."
-              className="flex-1 min-w-[200px] px-4 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-400"
+              className="flex-1 min-w-[200px] px-4 py-2 border border-white/10 bg-white/[0.04] text-white placeholder:text-white/40 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
             />
             <select
               value={categoryFilter}
               onChange={(e) => setCategoryFilter(e.target.value)}
-              className="px-4 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-emerald-400"
+              className="px-4 py-2 border border-white/10 rounded-lg text-sm bg-white/[0.04] text-white focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
             >
               <option value="all">All categories ({items.length})</option>
               {categories.map((c) => (
@@ -153,16 +153,16 @@ export default function PantryPage() {
 
         {/* Items */}
         {!isLoaded ? (
-          <div className="text-center py-12 text-gray-500">Loading pantry...</div>
+          <div className="text-center py-12 text-white/40">Loading pantry...</div>
         ) : items.length === 0 ? (
-          <div className="bg-white border-2 border-dashed border-gray-300 rounded-xl p-12 text-center">
+          <div className="bg-white/[0.03] border-2 border-dashed border-white/15 rounded-xl p-12 text-center">
             <div className="text-5xl mb-3">🧺</div>
-            <h2 className="text-xl font-semibold text-gray-800 mb-2">
+            <h2 className="text-xl font-semibold text-white mb-2">
               Your pantry is empty
             </h2>
-            <p className="text-gray-600 mb-6 max-w-md mx-auto">
+            <p className="text-white/60 mb-6 max-w-md mx-auto">
               Tap the{" "}
-              <span className="inline-block bg-amber-100 text-amber-800 text-xs font-medium px-2 py-0.5 rounded">
+              <span className="inline-block bg-amber-500/15 text-amber-300 text-xs font-medium px-2 py-0.5 rounded">
                 + Pantry
               </span>{" "}
               button on any ingredient card on the home page to start tracking
@@ -170,22 +170,22 @@ export default function PantryPage() {
             </p>
             <Link
               href="/#ingredients"
-              className="inline-block px-6 py-3 rounded-lg bg-emerald-600 text-white font-medium hover:bg-emerald-700"
+              className="inline-block px-6 py-3 rounded-lg bg-emerald-600 text-white font-medium hover:bg-emerald-500"
             >
               Browse ingredients
             </Link>
           </div>
         ) : filtered.length === 0 ? (
-          <div className="bg-white border border-gray-200 rounded-xl p-8 text-center">
-            <p className="text-gray-600">No pantry items match those filters.</p>
+          <div className="bg-white/[0.03] border border-white/10 rounded-xl p-8 text-center">
+            <p className="text-white/60">No pantry items match those filters.</p>
           </div>
         ) : (
           <div className="space-y-6">
             {grouped.map(([category, catItems]) => (
               <section key={category}>
-                <h2 className="text-lg font-semibold text-gray-800 mb-3 capitalize">
+                <h2 className="text-lg font-semibold text-white mb-3 capitalize">
                   {formatName(category)}{" "}
-                  <span className="text-sm font-normal text-gray-500">
+                  <span className="text-sm font-normal text-white/40">
                     ({catItems.length})
                   </span>
                 </h2>
@@ -196,15 +196,15 @@ export default function PantryPage() {
                     return (
                       <div
                         key={item.id}
-                        className={`bg-white border rounded-xl p-4 flex items-start justify-between gap-3 ${
-                          isExpired ? "border-red-200 bg-red-50" : "border-gray-200"
+                        className={`bg-white/[0.03] border rounded-xl p-4 flex items-start justify-between gap-3 ${
+                          isExpired ? "border-red-500/30 bg-red-500/10" : "border-white/10"
                         }`}
                       >
                         <div className="flex-1 min-w-0">
-                          <div className="font-medium text-gray-900 truncate">
+                          <div className="font-medium text-white truncate">
                             {formatName(item.name)}
                           </div>
-                          <div className="text-xs text-gray-500 mt-0.5">
+                          <div className="text-xs text-white/40 mt-0.5">
                             Added{" "}
                             {new Date(item.addedDate).toLocaleDateString()}
                             {item.expirationDate &&
@@ -217,12 +217,12 @@ export default function PantryPage() {
                                   quantity: Math.max(0, item.quantity - 1),
                                 })
                               }
-                              className="w-6 h-6 rounded bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm flex items-center justify-center"
+                              className="w-6 h-6 rounded bg-white/10 hover:bg-white/15 text-white/80 text-sm flex items-center justify-center"
                               aria-label="Decrease quantity"
                             >
                               −
                             </button>
-                            <span className="text-sm font-medium text-gray-800 min-w-[60px] text-center">
+                            <span className="text-sm font-medium text-white/90 min-w-[60px] text-center">
                               {item.quantity} {item.unit}
                             </span>
                             <button
@@ -231,7 +231,7 @@ export default function PantryPage() {
                                   quantity: item.quantity + 1,
                                 })
                               }
-                              className="w-6 h-6 rounded bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm flex items-center justify-center"
+                              className="w-6 h-6 rounded bg-white/10 hover:bg-white/15 text-white/80 text-sm flex items-center justify-center"
                               aria-label="Increase quantity"
                             >
                               +
@@ -240,7 +240,7 @@ export default function PantryPage() {
                         </div>
                         <button
                           onClick={() => removeItem(item.id)}
-                          className="text-gray-400 hover:text-red-600 text-sm"
+                          className="text-white/40 hover:text-red-400 text-sm"
                           title="Remove from pantry"
                         >
                           ✕

--- a/src/app/rewards/page.tsx
+++ b/src/app/rewards/page.tsx
@@ -3,7 +3,7 @@ import { esmsRestaurantCentsPerToken } from "@/lib/payments/restaurantEsms";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "ESMS Rewards & Redemption | Alchm Kitchen",
+  title: "ESMS Rewards & Redemption",
   description:
     "How ESMS tokens work, the food redemption rate, and our redemption-rate change policy.",
 };

--- a/src/components/auth/AuthFollowups.tsx
+++ b/src/components/auth/AuthFollowups.tsx
@@ -733,6 +733,14 @@ export function UpgradeGate({
   );
 
   const handleClick = (t: UpgradeTier) => {
+    // The free card is only clickable for a premium viewer (for their own tier it
+    // renders a disabled "current plan" pill) — so a click here is a downgrade.
+    // Route to the subscription manager rather than a nonsensical free "trial".
+    if (t.id === "free") {
+      track("upgrade_gate_downgrade", { from: currentTier });
+      window.location.href = "/premium";
+      return;
+    }
     if (t.id === "alchemist") {
       track("upgrade_gate_converted", { plan: "alchemist" });
     }
@@ -1055,7 +1063,7 @@ export function UpgradeGate({
                         : "var(--line-hi)",
                     }}
                   >
-                    START 7-DAY TRIAL
+                    {tier.id === "free" ? "DOWNGRADE TO FREE" : "START 7-DAY TRIAL"}
                   </button>
                 )}
               </div>

--- a/src/components/home/Promotion.tsx
+++ b/src/components/home/Promotion.tsx
@@ -73,7 +73,7 @@ export function Promotion() {
               <p className="mt-2 text-xs md:text-sm text-white/50 leading-relaxed max-w-xl">
                 Alchm Kitchen balances four primary alchemical elements to match recipes with your birth chart and the live sky. During Tech Week, get a boosted welcome grant of{" "}
                 <strong className="text-white/80">60 ESMS tokens</strong> (15 of each: Spirit, Essence, Matter, Substance) to immediately begin your cosmic culinary journey. Your ESMS now lives{" "}
-                <strong className="text-white/80">on-chain</strong> — claim it to your Base wallet and check out real food with <strong className="text-white/80">USDC or ESMS</strong>.
+                <strong className="text-white/80">on-chain</strong> — claim it to your Base wallet and check out real food with <strong className="text-white/80">USDC</strong>.
               </p>
             </div>
 
@@ -109,7 +109,7 @@ export function Promotion() {
                 <div className="space-y-0.5">
                   <h4 className="text-xs font-bold text-white/90">Pay for Food with Crypto</h4>
                   <p className="text-[10px] text-white/40 leading-relaxed">
-                    Check out real restaurant orders with USDC or your soulbound ESMS — settled on-chain, with card always available as a fallback.
+                    Check out real restaurant orders with USDC — settled on-chain, with card always available as a fallback.
                   </p>
                 </div>
               </div>
@@ -179,7 +179,7 @@ export function Promotion() {
             className="inline-flex items-center gap-2 px-5 py-3 rounded-2xl bg-cyan-500/10 hover:bg-cyan-500/20 border border-cyan-500/25 hover:border-cyan-500/40 text-cyan-300 font-semibold text-sm transition-all duration-200 group"
           >
             <span>🪙</span>
-            Order Food — Pay with USDC or ESMS
+            Order Food — Pay with USDC
             <span className="group-hover:translate-x-1 transition-transform duration-200">&rarr;</span>
           </Link>
 

--- a/src/components/recommendations/EnhancedIngredientRecommender.tsx
+++ b/src/components/recommendations/EnhancedIngredientRecommender.tsx
@@ -17,6 +17,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { useAlchemical } from "@/contexts/AlchemicalContext/hooks";
 import type { UnifiedIngredient } from "@/data/unified/unifiedTypes";
 import { usePantry } from "@/hooks/usePantry";
+import { isBoilerplateCoverageIngredient } from "@/lib/ingredients/coverageQuality";
 import { IngredientService } from "@/services/IngredientService";
 import type { ElementalProperties } from "@/types/alchemy";
 import { normalizeForDisplay } from "@/utils/elemental/normalization";
@@ -719,7 +720,11 @@ export const EnhancedIngredientRecommender: React.FC<
   useEffect(() => {
     setLoading(true);
     try {
-      const allIngredients = ingredientService.getAllIngredientsFlat();
+      // Auto-generated recipe-coverage entries (boilerplate copy + placeholder
+      // nutrition) exist for recipe mapping only — keep them off this browse grid.
+      const allIngredients = ingredientService
+        .getAllIngredientsFlat()
+        .filter((ing) => !isBoilerplateCoverageIngredient(ing));
       setIngredients(allIngredients);
     } catch (error) {
       console.error("Error loading ingredients:", error);

--- a/src/contexts/SpacetimeContext.tsx
+++ b/src/contexts/SpacetimeContext.tsx
@@ -54,6 +54,7 @@ const SpacetimeContext = createContext<SpacetimeContextValue>({
 const DEGRADED_AFTER_FAILURES = 3;
 const BACKOFF_BASE_MS = 1_000;
 const BACKOFF_CAP_MS = 30_000;
+const MAX_RECONNECT_ATTEMPTS = 8;
 
 function readStoredToken(): string | undefined {
   if (typeof window === "undefined") return undefined;
@@ -95,6 +96,12 @@ export function SpacetimeProvider({ children }: { children: ReactNode }) {
       failuresRef.current += 1;
       if (failuresRef.current >= DEGRADED_AFTER_FAILURES) {
         setStatus("degraded");
+      }
+      // Give up after enough failures so a permanently-unreachable WS doesn't
+      // reconnect forever (the SDK logs a "Connecting…" line on every attempt).
+      // The 30s HTTP poll remains the fallback once we stop.
+      if (failuresRef.current >= MAX_RECONNECT_ATTEMPTS) {
+        return;
       }
       const delay = Math.min(
         BACKOFF_CAP_MS,
@@ -143,11 +150,31 @@ export function SpacetimeProvider({ children }: { children: ReactNode }) {
       }
     };
 
+    const handleRecovery = () => {
+      if (disposedRef.current) return;
+      // Only reconnect if we don't have a live connection
+      if (activeConnRef.current === null) {
+        console.info("[spacetime] triggering recovery reconnect (network/focus restored)");
+        failuresRef.current = 0;
+        if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+        connect();
+      }
+    };
+
+    if (typeof window !== "undefined") {
+      window.addEventListener("online", handleRecovery);
+      window.addEventListener("focus", handleRecovery);
+    }
+
     connect();
 
     return () => {
       disposedRef.current = true;
       if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+      if (typeof window !== "undefined") {
+        window.removeEventListener("online", handleRecovery);
+        window.removeEventListener("focus", handleRecovery);
+      }
       try {
         activeConnRef.current?.disconnect();
       } catch {

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -1,27 +1,45 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { calculateKinetics } from "@/calculations/kinetics";
 import { useUser } from "@/contexts/UserContext";
+import { AspectsService } from "@/services/AspectsService";
+import {
+  getCurrentPlanetaryPositions,
+  getPlanetaryPositionsForDateTime,
+} from "@/services/astrologizeApi";
 import type { PlanetaryAspect, PlanetaryPosition } from "@/types/celestial";
 import type { KineticMetrics } from "@/types/kinetics";
+import {
+  aggregateZodiacElementals,
+  calculateEnhancedAlchemicalFromPlanets,
+  isSectDiurnal,
+} from "@/utils/planetaryAlchemyMapping";
 
 /**
  * useChartData Hook
  *
- * Fetches and manages planetary chart data from the astrologize and alchemize APIs.
- * Calculates planetary aspects and provides alchemical properties.
+ * Fetches planetary positions from the astrologize API and computes aspects,
+ * alchemical (ESMS / elemental / thermodynamic) properties, and planetary
+ * kinetics (P=IV) client-side from the fetched positions. Mirrors the
+ * calculation pipeline used by /api/alchemize and usePlanetaryKinetics so the
+ * math stays consistent across the app.
  */
- // Import the useUser hook
 type PlanetPosition = PlanetaryPosition;
+
+// Default location (New York City) so the hook never hangs waiting on a
+// location the caller forgot to supply.
+const DEFAULT_LOCATION = { latitude: 40.7128, longitude: -74.006 };
+
 // Define the expected structure of AlchemicalResult
 export interface AlchemicalResult {
   // Properties expected by AlchemicalDisplay.tsx
-  elementalProperties: Record<string, number>; // Assuming a Record for elements
+  elementalProperties: Record<string, number>;
   thermodynamicProperties: {
     heat: number;
     entropy: number;
     reactivity: number;
-    gregsEnergy?: number; // Optional, as not directly destructured but could be part of it
+    gregsEnergy?: number;
   };
-  esms: Record<string, number>; // ESMS values
+  esms: Record<string, number>;
   kalchm: number;
   monica: number;
   score: number;
@@ -58,14 +76,42 @@ export interface ChartDataOptions {
   autoRefresh?: boolean;
   refreshInterval?: number; // milliseconds
 }
-// ... (interfaces remain the same)
+
+const ELEMENTS = ["Fire", "Water", "Earth", "Air"] as const;
+
+/** Capitalize a lowercase sign ("aries" -> "Aries") for ZODIAC_ELEMENTS lookups. */
+function capitalizeSign(sign: unknown): string {
+  const s = String(sign ?? "").toLowerCase();
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
+}
+
+/**
+ * Build planet -> sign maps from fetched positions.
+ * - lower:   lowercase signs (kinetics engine + alchemize ESMS expect these)
+ * - capital: Capitalized signs (aggregateZodiacElementals / ZODIAC_ELEMENTS expect these)
+ */
+function buildSignMaps(positions: Record<string, PlanetPosition>): {
+  lower: Record<string, string>;
+  capital: Record<string, string>;
+} {
+  const lower: Record<string, string> = {};
+  const capital: Record<string, string> = {};
+  for (const [planet, pos] of Object.entries(positions)) {
+    if (!pos || pos.sign == null) continue;
+    const lowerSign = String(pos.sign).toLowerCase();
+    lower[planet] = lowerSign;
+    capital[planet] = capitalizeSign(lowerSign);
+  }
+  return { lower, capital };
+}
+
 export function useChartData(options: ChartDataOptions = {}): ChartData {
   const {
-    dateTime: _dateTime,
-    location: optionLocation, // Rename to avoid conflict
+    dateTime,
+    location: optionLocation,
     zodiacSystem = "tropical",
-    autoRefresh: _autoRefresh = false,
-    refreshInterval: _refreshInterval = 60000, // 1 minute default
+    autoRefresh = false,
+    refreshInterval = 60000, // 1 minute default
   } = options;
   const { currentUser } = useUser();
   const userLocation = currentUser?.birthData
@@ -74,35 +120,168 @@ export function useChartData(options: ChartDataOptions = {}): ChartData {
         longitude: currentUser.birthData.longitude,
       }
     : undefined;
-  // Determine the location to use: option > user > null
-  const location = optionLocation || userLocation;
-  const [positions, _setPositions] = useState<Record<
+  // Determine the location to use: option > user > NYC default (never null,
+  // so the page can't hang on a missing location).
+  const location = optionLocation || userLocation || DEFAULT_LOCATION;
+
+  const [positions, setPositions] = useState<Record<
     string,
     PlanetPosition
   > | null>(null);
-  const [aspects, _setAspects] = useState<PlanetaryAspect[]>([]);
-  const [alchemical, _setAlchemical] = useState<AlchemicalResult | null>(null);
-  const [kinetics, _setKinetics] = useState<KineticMetrics | null>(null);
-  const [timestamp, _setTimestamp] = useState<string | null>(null);
+  const [aspects, setAspects] = useState<PlanetaryAspect[]>([]);
+  const [alchemical, setAlchemical] = useState<AlchemicalResult | null>(null);
+  const [kinetics, setKinetics] = useState<KineticMetrics | null>(null);
+  const [timestamp, setTimestamp] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // Stabilize fetch dependencies so the effect doesn't re-run on every render
+  // (the location object identity changes when the page passes a literal).
+  const latitude = location.latitude;
+  const longitude = location.longitude;
+  const dateTimeMs = dateTime ? dateTime.getTime() : null;
+
   const fetchChartData = useCallback(async () => {
-    // If no location is available, do not fetch data
-    if (!location) {
+    const loc = { latitude, longitude };
+    if (
+      !loc ||
+      typeof loc.latitude !== "number" ||
+      typeof loc.longitude !== "number" ||
+      Number.isNaN(loc.latitude) ||
+      Number.isNaN(loc.longitude)
+    ) {
       setError("Location data is required to fetch chart data.");
       setIsLoading(false);
       return;
     }
+
     setIsLoading(true);
     setError(null);
+
     try {
-      // Build query parameters
-      const _params = new URLSearchParams({
-        latitude: location.latitude.toString(),
-        longitude: location.longitude.toString(),
-        zodiacSystem,
+      const requestedDate =
+        dateTimeMs != null ? new Date(dateTimeMs) : new Date();
+
+      // 1. Fetch planetary positions (astrologize API, with built-in
+      //    circuit-breaker + astronomy-engine fallback so it never hangs).
+      const fetchedPositions =
+        dateTimeMs != null
+          ? await getPlanetaryPositionsForDateTime(
+              requestedDate,
+              loc,
+              zodiacSystem,
+            )
+          : await getCurrentPlanetaryPositions(loc, zodiacSystem);
+
+      if (!fetchedPositions || Object.keys(fetchedPositions).length === 0) {
+        throw new Error("No planetary positions returned");
+      }
+
+      // 2. Derive aspects from positions (reuses calculateAspects).
+      const { aspects: derivedAspects } =
+        AspectsService.calculateFromPositions(fetchedPositions);
+
+      // 3. Build planet -> sign maps (casing matters; see buildSignMaps).
+      const { lower, capital } = buildSignMaps(fetchedPositions);
+
+      // 4. Alchemical properties.
+      //    ESMS via the same path /api/alchemize uses (lowercase signs).
+      const diurnal = isSectDiurnal(requestedDate);
+      const esms = calculateEnhancedAlchemicalFromPlanets(lower, diurnal);
+      //    Elemental properties need Capitalized signs (ZODIAC_ELEMENTS).
+      const elementalProperties = aggregateZodiacElementals(capital);
+
+      // 5. Kinetics (P=IV). The engine expects lowercase signs. A single
+      //    snapshot (timeInterval=1, no previous frame) resolves velocities /
+      //    momenta to 0 and derives charge/V/I/P from current state — the same
+      //    first-frame behavior as usePlanetaryKinetics.
+      const kineticMetrics: KineticMetrics = calculateKinetics({
+        currentPlanetaryPositions: lower,
+        timeInterval: 1,
+        currentPlanet: "Sun",
       });
-      // ... (rest of the fetch logic remains the same)
+
+      // 6. Display-facing thermodynamics + kalchm/monica derived from the ESMS
+      //    totals (the engine's exact values are module-private). Same proxy
+      //    mapping /api/alchemize uses; all guarded against NaN/Infinity.
+      const spirit = esms.Spirit;
+      const essence = esms.Essence;
+      const matter = esms.Matter;
+      const substance = esms.Substance;
+      const total = spirit + essence + matter + substance || 1;
+
+      const safe = (n: number) => (Number.isFinite(n) ? n : 0);
+
+      const dominantElementalValue = Math.max(
+        ...ELEMENTS.map((e) => elementalProperties[e] ?? 0),
+      );
+      const heat = safe((spirit / total) * 10);
+      const entropy = safe(1 - dominantElementalValue);
+      const reactivity = safe(spirit / total);
+      const gregsEnergy = safe(heat - entropy * reactivity);
+
+      const kalchm = safe(
+        (Math.max(spirit, 0.0001) ** spirit *
+          Math.max(essence, 0.0001) ** essence) /
+          (Math.max(matter, 0.0001) ** matter *
+            Math.max(substance, 0.0001) ** substance),
+      );
+      const monica =
+        kalchm > 0 && reactivity !== 0 && Math.log(kalchm) !== 0
+          ? safe(-gregsEnergy / (reactivity * Math.log(kalchm)))
+          : 0;
+
+      const dominantElement =
+        ELEMENTS.slice().sort(
+          (a, b) =>
+            (elementalProperties[b] ?? 0) - (elementalProperties[a] ?? 0),
+        )[0] ?? "Earth";
+      const sunSign = lower.Sun;
+
+      const alchemicalResult: AlchemicalResult = {
+        elementalProperties: {
+          Fire: safe(elementalProperties.Fire),
+          Water: safe(elementalProperties.Water),
+          Earth: safe(elementalProperties.Earth),
+          Air: safe(elementalProperties.Air),
+        },
+        thermodynamicProperties: {
+          heat,
+          entropy,
+          reactivity,
+          gregsEnergy,
+        },
+        esms: {
+          Spirit: safe(spirit),
+          Essence: safe(essence),
+          Matter: safe(matter),
+          Substance: safe(substance),
+        },
+        kalchm,
+        monica,
+        score: safe(gregsEnergy),
+        metadata: {
+          dominantElement,
+          sunSign,
+          source: "astrologize + planetaryAlchemyMapping",
+        },
+        spirit: safe(spirit),
+        essence: safe(essence),
+        matter: safe(matter),
+        substance: safe(substance),
+      };
+
+      // 7. Commit all state.
+      setPositions(fetchedPositions);
+      // calculateAspects (via AspectsService) emits its own structurally-
+      // compatible PlanetaryAspect type; bridge it to the celestial type the
+      // page + PlanetaryChart consume. Runtime fields (planet1/planet2/type/orb)
+      // are identical.
+      setAspects(derivedAspects as unknown as PlanetaryAspect[]);
+      setAlchemical(alchemicalResult);
+      setKinetics(kineticMetrics);
+      setTimestamp(requestedDate.toISOString());
+      setError(null);
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : "Unknown error occurred";
@@ -111,12 +290,29 @@ export function useChartData(options: ChartDataOptions = {}): ChartData {
     } finally {
       setIsLoading(false);
     }
-  }, [location, zodiacSystem]);
+  }, [latitude, longitude, dateTimeMs, zodiacSystem]);
 
   const refetch = useCallback(() => {
     void fetchChartData();
   }, [fetchChartData]);
-  // ... (useEffect hooks remain the same)
+
+  // Fetch on mount and whenever location / dateTime / zodiacSystem change.
+  useEffect(() => {
+    void fetchChartData();
+  }, [fetchChartData]);
+
+  // Auto-refresh interval (only when enabled). Cleaned up on unmount / change.
+  const fetchRef = useRef(fetchChartData);
+  fetchRef.current = fetchChartData;
+  useEffect(() => {
+    if (!autoRefresh) return;
+    const interval = Math.max(5000, refreshInterval || 60000);
+    const id = setInterval(() => {
+      void fetchRef.current();
+    }, interval);
+    return () => clearInterval(id);
+  }, [autoRefresh, refreshInterval]);
+
   return {
     positions,
     aspects,

--- a/src/lib/ingredients/coverageQuality.ts
+++ b/src/lib/ingredients/coverageQuality.ts
@@ -1,0 +1,35 @@
+/**
+ * Quality gate for auto-generated "recipe coverage" ingredients.
+ *
+ * `scripts/generateRecipeCoverageIngredients.ts` emits ~427 entries (all flagged
+ * `provenance: "generated"`) so that every ingredient name referenced by a recipe
+ * resolves to a catalog entry for mapping/search. Most of those entries carry
+ * identical boilerplate copy and placeholder nutrition (100 cal / 1g / 10g / 1g) —
+ * fine for recipe-to-ingredient mapping, but they pollute user-facing *browse*
+ * surfaces (the home Ingredient Recommender and `/ingredients`) where they appear
+ * indistinguishable from curated entries.
+ *
+ * This predicate flags those boilerplate entries so the browse surfaces can hide
+ * them while the catalog keeps them for mapping. Coverage entries that were given
+ * a real description via `coverageCurationOverrides.ts` are NOT flagged.
+ *
+ * The marker phrase is the exact copy emitted by `generatedDescription()` in the
+ * generator script; keep the two in sync if that copy ever changes.
+ */
+const BOILERPLATE_DESCRIPTION_MARKER =
+  "recipe-linked ingredient captured from live cuisine data";
+
+/**
+ * True when `ingredient` is an auto-generated coverage entry that still carries
+ * the boilerplate description. Works on both the full `Ingredient` shape and the
+ * `UnifiedIngredient` shape (both surface `description` at the top level).
+ */
+export function isBoilerplateCoverageIngredient(
+  ingredient: { description?: unknown } | null | undefined,
+): boolean {
+  const description = ingredient?.description;
+  return (
+    typeof description === "string" &&
+    description.includes(BOILERPLATE_DESCRIPTION_MARKER)
+  );
+}

--- a/src/lib/ingredients/slimIngredients.ts
+++ b/src/lib/ingredients/slimIngredients.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { allIngredients } from "@/data/ingredients";
+import { isBoilerplateCoverageIngredient } from "@/lib/ingredients/coverageQuality";
 import type { Ingredient } from "@/types";
 
 /**
@@ -64,7 +65,12 @@ let cachedSlim: Ingredient[] | null = null;
  */
 export function getSlimIngredients(): Ingredient[] {
   if (cachedSlim) return cachedSlim;
-  cachedSlim = Object.values(allIngredients).map((ing) => {
+  cachedSlim = Object.values(allIngredients)
+    // Auto-generated recipe-coverage entries (boilerplate copy + placeholder
+    // nutrition) stay in the catalog for recipe mapping but are kept off the
+    // browse page; surfacing them next to curated entries reads as low quality.
+    .filter((ing) => !isBoilerplateCoverageIngredient(ing))
+    .map((ing) => {
     const src = ing as unknown as Record<string, unknown>;
     const slim: Record<string, unknown> = {};
     for (const field of SLIM_FIELDS) {

--- a/src/lib/spacetime/config.ts
+++ b/src/lib/spacetime/config.ts
@@ -23,9 +23,15 @@ export interface SpacetimeConfig {
 export function getSpacetimeConfig(): SpacetimeConfig | null {
   const uri = process.env.NEXT_PUBLIC_SPACETIME_URI;
   if (!uri) return null;
+  
+  let moduleName = process.env.NEXT_PUBLIC_SPACETIME_MODULE ?? "alchm-culinary";
+  if (moduleName.startsWith("@")) {
+    moduleName = moduleName.slice(1);
+  }
+
   return {
     uri,
-    moduleName: process.env.NEXT_PUBLIC_SPACETIME_MODULE ?? "alchm-culinary",
+    moduleName,
   };
 }
 


### PR DESCRIPTION
Follow-up to #526. Bundles four audit fixes — including **two that silently never reached production**.

## ⚠️ The important one: #526 squash-merged only Pass-1

#526 was squash-merged at 12:00 EDT capturing **only the pass-1 commit**. The **pass-2** (`600c7714`) and **pass-2b** (`1a4b6ff4`) commits were pushed to the branch *after* the merge closed it, so they never landed on `master`. These fixes are **still broken in production** right now:

| Page | Prod today | This PR |
|---|---|---|
| `/planetary-chart` | hangs forever on "Calculating planetary positions…" (130-line stub) | rebuilt `useChartData` that actually renders |
| `/pantry` | light cream page under the dark header | dark-themed |
| `/current-chart` | header reads "…AT UTC" | shows the real time |
| `/rewards` | doubled `<title>` suffix | single suffix |
| home promo | "USDC or ESMS" | "USDC" |

Commit `eb9ec3db` restores all five.

## New work (commit `3915429d`)

**SpaceTime WS hardening** — the env-var fix (Maincloud URI/module + 5 `LIVE_*` flags) is already deployed; this is defensive belt-and-suspenders left uncommitted by a concurrent session:
- `config.ts`: strip a stray leading `@` from `NEXT_PUBLIC_SPACETIME_MODULE`.
- `next.config.js`: extend the CSP `connect-src` token-fetch allowance to `wss://` (prod), not just `ws://` (local).
- `SpacetimeContext.tsx`: cap reconnects at 8 attempts (a dead WS stops spamming "Connecting…"; the 30s HTTP poll remains the fallback) + reconnect on `online`/`focus` recovery.

**`/upgrade` free-tier CTA** (P2) — the free "Apprentice" card showed "START 7-DAY TRIAL" to premium viewers (nonsensical + dead click). Now context-aware: free viewer → disabled "current plan" (unchanged); premium viewer → "Downgrade to Free", routed to `/premium`.

**Ingredient browse quality** (P1/P2) — ~354 auto-generated "recipe coverage" entries carry identical boilerplate copy + placeholder nutrition (100/1/10/1). They exist so recipes can map every ingredient name, but polluted the browse surfaces (Bitterleaves, Ndole, Molokhia, …). New `isBoilerplateCoverageIngredient()` predicate filters them out of the **home Ingredient Recommender** (`EnhancedIngredientRecommender`) and the **`/ingredients`** explorer (`getSlimIngredients`); the catalog keeps them for recipe mapping. Curated coverage entries (real descriptions) are unaffected.

## Verification

- `bunx tsc --noEmit`: **0 errors** project-wide.
- `bunx eslint` on all 12 changed files: clean (+ pre-commit hook).
- Local preview (port 3333):
  - `/api/astrologize` returns real positions (200) → `useChartData` data layer resolves; the rebuild **structurally cannot hang** (positions always resolve via astronomy-engine fallback; `isLoading` cleared in `finally`).
  - `/ingredients`: zero boilerplate names *and* zero occurrences of the marker phrase across 1.5 MB of HTML; Garlic/Ginger/Basil/Cinnamon remain.
  - home recommender: 21 cards render, marker + boilerplate names gone.
  - home promo "Pay with USDC" confirmed; `/rewards` title de-doubled.

## Follow-ups (out of scope here)

- `/planetary-chart` **premium UI render** needs a logged-in confirm on the deploy — the page is `PremiumGate`d, so my logged-out local preview verified the data layer, not the gated render. (Pass-3 Chrome audit covers this.)
- The 5 newly-live SpaceTime write-paths (planner/cart/feed/commensal/culinary) should be exercised on a **preview deploy** before prod-facing confidence.
- The non-Enhanced `IngredientRecommender` component is **dead code** (zero references) — candidate for removal.
- The thermo/kalchm/monica values in `useChartData` are derived proxies; exporting `alchemize`'s `ThermodynamicMetrics` from the engine is the clean upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)