### PR TITLE
fix(home): gate crypto/on-chain promo behind real enabled flags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -285,6 +285,12 @@ NEXT_PUBLIC_ESMS_RESTAURANT_PAYMENTS_ENABLED=false
 # cheapest acquisition cost and account for all outstanding reward liability.
 # This rate is also published to users at /rewards (read from the same value).
 NEXT_PUBLIC_ESMS_RESTAURANT_CENTS_PER_TOKEN=1
+
+# On-chain ESMS promo gate. Controls whether the homepage advertises "On-Chain
+# ESMS" / "claim it to your Base wallet". MUST stay false until the EsmsToken
+# contract is actually deployed and verified on-chain (the agents app's
+# ESMS_CONTRACT_ADDRESS) — otherwise the site promises a flow that does not work.
+NEXT_PUBLIC_ESMS_ONCHAIN_ENABLED=false
 # Daily ESMS food-redemption caps (server-enforced, UTC day). Tokens summed
 # across all four axes. 0 = unlimited; unset falls back to the defaults below.
 # Per-user default 5000 (=$50 at 1c); aggregate default 200000 (=$2000 at 1c).

--- a/docs/payments/CRYPTO_FOOD_PAYMENTS.md
+++ b/docs/payments/CRYPTO_FOOD_PAYMENTS.md
@@ -177,7 +177,18 @@ merchant payout adapter. Stripe already supplies these controls for the pilot.
 NEXT_PUBLIC_STRIPE_RESTAURANT_CRYPTO_ENABLED=true
 NEXT_PUBLIC_ESMS_RESTAURANT_PAYMENTS_ENABLED=true
 NEXT_PUBLIC_ESMS_RESTAURANT_CENTS_PER_TOKEN=1
+# Only after the EsmsToken contract is deployed + verified on-chain:
+NEXT_PUBLIC_ESMS_ONCHAIN_ENABLED=true
 ```
+
+The homepage promo (`src/components/home/Promotion.tsx`) advertises each crypto
+rail **only** when its flag is on, via `src/lib/payments/cryptoPromo.ts`:
+`NEXT_PUBLIC_STRIPE_RESTAURANT_CRYPTO_ENABLED` gates the "Pay for Food with
+USDC" card + CTA, and `NEXT_PUBLIC_ESMS_ONCHAIN_ENABLED` gates the "On-Chain
+ESMS / claim to your Base wallet" copy. With every flag off (the default) the
+homepage shows only the off-chain ESMS welcome grant + token economy, which are
+live regardless. Never flip `NEXT_PUBLIC_ESMS_ONCHAIN_ENABLED` on until the
+contract address resolves to real bytecode on the target chain.
 
 ## Follow-up controls
 

--- a/src/components/home/Promotion.tsx
+++ b/src/components/home/Promotion.tsx
@@ -2,6 +2,10 @@
 
 import { motion } from "framer-motion";
 import Link from "next/link";
+import {
+  cryptoFoodCheckoutEnabled,
+  onchainEsmsEnabled,
+} from "@/lib/payments/cryptoPromo";
 
 const TOKENS = [
   {
@@ -35,6 +39,13 @@ const TOKENS = [
 ] as const;
 
 export function Promotion() {
+  // Only advertise crypto/on-chain rails that are actually live in this
+  // deployment. Off by default → the promo can never promise a flow that
+  // doesn't work. The off-chain ESMS welcome grant + token economy below are
+  // live regardless and are always shown.
+  const cryptoCheckout = cryptoFoodCheckoutEnabled();
+  const onchainEsms = onchainEsmsEnabled();
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 16 }}
@@ -63,17 +74,38 @@ export function Promotion() {
                 <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-amber-500/10 border border-amber-500/20 text-[9px] font-extrabold text-amber-400 uppercase tracking-wide">
                   +60 ESMS Welcome Grant
                 </span>
-                <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-cyan-500/10 border border-cyan-500/20 text-[9px] font-extrabold text-cyan-400 uppercase tracking-wide">
-                  New · On-Chain ESMS
-                </span>
+                {onchainEsms && (
+                  <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full bg-cyan-500/10 border border-cyan-500/20 text-[9px] font-extrabold text-cyan-400 uppercase tracking-wide">
+                    New · On-Chain ESMS
+                  </span>
+                )}
               </div>
               <h2 className="text-xl md:text-3xl font-black text-white/95 leading-tight tracking-tight">
                 Unleash Your Cosmic Culinary Yield
               </h2>
               <p className="mt-2 text-xs md:text-sm text-white/50 leading-relaxed max-w-xl">
                 Alchm Kitchen balances four primary alchemical elements to match recipes with your birth chart and the live sky. During Tech Week, get a boosted welcome grant of{" "}
-                <strong className="text-white/80">60 ESMS tokens</strong> (15 of each: Spirit, Essence, Matter, Substance) to immediately begin your cosmic culinary journey. Your ESMS now lives{" "}
-                <strong className="text-white/80">on-chain</strong> — claim it to your Base wallet and check out real food with <strong className="text-white/80">USDC</strong>.
+                <strong className="text-white/80">60 ESMS tokens</strong> (15 of each: Spirit, Essence, Matter, Substance) to immediately begin your cosmic culinary journey.
+                {onchainEsms && (
+                  <>
+                    {" "}Your ESMS now lives{" "}
+                    <strong className="text-white/80">on-chain</strong> — claim it to
+                    your Base wallet
+                    {cryptoCheckout && (
+                      <>
+                        {" "}and check out real food with{" "}
+                        <strong className="text-white/80">USDC</strong>
+                      </>
+                    )}
+                    .
+                  </>
+                )}
+                {!onchainEsms && cryptoCheckout && (
+                  <>
+                    {" "}Check out real restaurant food with{" "}
+                    <strong className="text-white/80">USDC</strong>, settled on-chain.
+                  </>
+                )}
               </p>
             </div>
 
@@ -104,15 +136,17 @@ export function Promotion() {
               </h3>
 
               {/* Feature: Web3 crypto food checkout */}
-              <div className="p-3.5 rounded-2xl bg-cyan-500/[0.04] border border-cyan-500/20 hover:border-cyan-500/35 transition-all duration-200 flex items-start gap-3">
-                <span className="text-xl p-1 bg-cyan-500/10 rounded-lg text-cyan-400">🪙</span>
-                <div className="space-y-0.5">
-                  <h4 className="text-xs font-bold text-white/90">Pay for Food with Crypto</h4>
-                  <p className="text-[10px] text-white/40 leading-relaxed">
-                    Check out real restaurant orders with USDC — settled on-chain, with card always available as a fallback.
-                  </p>
+              {cryptoCheckout && (
+                <div className="p-3.5 rounded-2xl bg-cyan-500/[0.04] border border-cyan-500/20 hover:border-cyan-500/35 transition-all duration-200 flex items-start gap-3">
+                  <span className="text-xl p-1 bg-cyan-500/10 rounded-lg text-cyan-400">🪙</span>
+                  <div className="space-y-0.5">
+                    <h4 className="text-xs font-bold text-white/90">Pay for Food with Crypto</h4>
+                    <p className="text-[10px] text-white/40 leading-relaxed">
+                      Check out real restaurant orders with USDC — settled on-chain, with card always available as a fallback.
+                    </p>
+                  </div>
                 </div>
-              </div>
+              )}
 
               {/* Feature 1 */}
               <div className="p-3.5 rounded-2xl bg-white/[0.02] border border-white/5 hover:border-purple-500/10 transition-all duration-200 flex items-start gap-3">
@@ -174,14 +208,16 @@ export function Promotion() {
           </Link>
 
           {/* Web3 crypto food checkout */}
-          <Link
-            href="/restaurants"
-            className="inline-flex items-center gap-2 px-5 py-3 rounded-2xl bg-cyan-500/10 hover:bg-cyan-500/20 border border-cyan-500/25 hover:border-cyan-500/40 text-cyan-300 font-semibold text-sm transition-all duration-200 group"
-          >
-            <span>🪙</span>
-            Order Food — Pay with USDC
-            <span className="group-hover:translate-x-1 transition-transform duration-200">&rarr;</span>
-          </Link>
+          {cryptoCheckout && (
+            <Link
+              href="/restaurants"
+              className="inline-flex items-center gap-2 px-5 py-3 rounded-2xl bg-cyan-500/10 hover:bg-cyan-500/20 border border-cyan-500/25 hover:border-cyan-500/40 text-cyan-300 font-semibold text-sm transition-all duration-200 group"
+            >
+              <span>🪙</span>
+              Order Food — Pay with USDC
+              <span className="group-hover:translate-x-1 transition-transform duration-200">&rarr;</span>
+            </Link>
+          )}
 
           {/* Amazon shopping — primary revenue source, exact original promotional link */}
           <Link

--- a/src/lib/payments/__tests__/cryptoPromo.test.ts
+++ b/src/lib/payments/__tests__/cryptoPromo.test.ts
@@ -1,0 +1,71 @@
+import {
+  anyCryptoFoodPromoEnabled,
+  cryptoFoodCheckoutEnabled,
+  esmsFoodRedemptionEnabled,
+  onchainEsmsEnabled,
+} from "@/lib/payments/cryptoPromo";
+
+// The homepage promo must never advertise a crypto/on-chain rail that isn't
+// live. These gates default OFF and only flip on an exact "true" string, so an
+// unset or typo'd flag can never accidentally promise a non-working flow.
+describe("crypto food promo gating", () => {
+  const FLAGS = [
+    "NEXT_PUBLIC_STRIPE_RESTAURANT_CRYPTO_ENABLED",
+    "NEXT_PUBLIC_ESMS_RESTAURANT_PAYMENTS_ENABLED",
+    "NEXT_PUBLIC_ESMS_ONCHAIN_ENABLED",
+  ] as const;
+  const original = new Map(FLAGS.map((f) => [f, process.env[f]] as const));
+
+  afterEach(() => {
+    for (const f of FLAGS) {
+      const v = original.get(f);
+      if (v === undefined) delete process.env[f];
+      else process.env[f] = v;
+    }
+  });
+
+  function clearAll() {
+    for (const f of FLAGS) delete process.env[f];
+  }
+
+  it("defaults every rail OFF when no flags are set", () => {
+    clearAll();
+    expect(cryptoFoodCheckoutEnabled()).toBe(false);
+    expect(esmsFoodRedemptionEnabled()).toBe(false);
+    expect(onchainEsmsEnabled()).toBe(false);
+    expect(anyCryptoFoodPromoEnabled()).toBe(false);
+  });
+
+  it("only enables a rail for the exact string 'true'", () => {
+    clearAll();
+    process.env.NEXT_PUBLIC_ESMS_ONCHAIN_ENABLED = "TRUE";
+    expect(onchainEsmsEnabled()).toBe(false);
+    process.env.NEXT_PUBLIC_ESMS_ONCHAIN_ENABLED = "1";
+    expect(onchainEsmsEnabled()).toBe(false);
+    process.env.NEXT_PUBLIC_ESMS_ONCHAIN_ENABLED = "true";
+    expect(onchainEsmsEnabled()).toBe(true);
+  });
+
+  it("maps each gate to its own flag", () => {
+    clearAll();
+    process.env.NEXT_PUBLIC_STRIPE_RESTAURANT_CRYPTO_ENABLED = "true";
+    expect(cryptoFoodCheckoutEnabled()).toBe(true);
+    expect(esmsFoodRedemptionEnabled()).toBe(false);
+    expect(onchainEsmsEnabled()).toBe(false);
+
+    clearAll();
+    process.env.NEXT_PUBLIC_ESMS_RESTAURANT_PAYMENTS_ENABLED = "true";
+    expect(esmsFoodRedemptionEnabled()).toBe(true);
+    expect(cryptoFoodCheckoutEnabled()).toBe(false);
+  });
+
+  it("anyCryptoFoodPromoEnabled is the OR of all three rails", () => {
+    for (const flag of FLAGS) {
+      clearAll();
+      process.env[flag] = "true";
+      expect(anyCryptoFoodPromoEnabled()).toBe(true);
+    }
+    clearAll();
+    expect(anyCryptoFoodPromoEnabled()).toBe(false);
+  });
+});

--- a/src/lib/payments/cryptoPromo.ts
+++ b/src/lib/payments/cryptoPromo.ts
@@ -1,0 +1,43 @@
+import { esmsRestaurantPaymentsEnabled } from "./restaurantEsms";
+import { restaurantCryptoPaymentsEnabled } from "./restaurantPayments";
+
+// ─── Homepage crypto/on-chain promo gating ─────────────────────────────
+//
+// The homepage promo must never advertise a crypto rail that isn't actually
+// live, or we promise users something that doesn't work (a consumer-protection
+// problem). Each advertised claim is gated on the SAME flag that gates the
+// underlying flow, so the copy can never drift ahead of the real feature.
+//
+// All of these read NEXT_PUBLIC_ vars only, so they are safe to evaluate in a
+// client bundle, and they are inlined identically on the server and client at
+// build time (no hydration mismatch).
+
+/** USDC restaurant checkout — same gate the order route + menu UI use. */
+export function cryptoFoodCheckoutEnabled(): boolean {
+  return restaurantCryptoPaymentsEnabled();
+}
+
+/** ESMS-for-food redemption — same gate the menu UI uses. */
+export function esmsFoodRedemptionEnabled(): boolean {
+  return esmsRestaurantPaymentsEnabled();
+}
+
+/**
+ * On-chain ESMS (claim to a Base wallet, on-chain burn in the Bazaar) is a
+ * distinct rail: it requires the ESMS token contract to be deployed on-chain
+ * and the agents app configured to settle against it. The kitchen app cannot
+ * introspect that state, so it is gated behind an explicit operator flag that
+ * MUST stay off until the contract is deployed and verified on-chain.
+ */
+export function onchainEsmsEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_ESMS_ONCHAIN_ENABLED === "true";
+}
+
+/** True when any crypto/on-chain food rail is live and may be advertised. */
+export function anyCryptoFoodPromoEnabled(): boolean {
+  return (
+    cryptoFoodCheckoutEnabled() ||
+    esmsFoodRedemptionEnabled() ||
+    onchainEsmsEnabled()
+  );
+}


### PR DESCRIPTION
## Why

The live homepage was advertising crypto features that **do not work in production**, a consumer-protection risk. A go-live audit this session established (with on-chain reads, not docs):

- **No on-chain ESMS contract exists on any chain.** `cast code` against the live Arc RPC (chainId `5042002`) returns empty `0x` for the ESMS proxy `0x124eCa1…`, StarVault `0x34eAC0…`, and the Constellation contracts; the system USDC at `0x3600…0000` returns real bytecode, so the chain/RPC are healthy and the read is valid. The Foundry deploy artifact has 17 txs but **0 receipts / null hashes** (never mined; "pre-wired" deterministic addresses). No Base/Base-Sepolia broadcast artifact exists at all.
- The Agents **Bazaar `/shop` returns HTTP 500** in prod (also `/account`, `/api/shop/catalog`) — not even read-only-browsable.
- WTEN `/rewards` reports ESMS food redemption "not currently enabled" (`NEXT_PUBLIC_ESMS_RESTAURANT_CENTS_PER_TOKEN` unset).

Despite all that, `src/components/home/Promotion.tsx` was **100% hardcoded** — it unconditionally rendered "On-Chain ESMS", "claim it to your Base wallet", "Pay for Food with Crypto", and an "Order Food — Pay with USDC" CTA. Copy had outrun the backend. (The restaurant **menu** options were already correctly flag-gated; only the homepage promo was dishonest.)

## What changed

Gate every crypto/on-chain claim behind the **real enabled flags**, defaulting **off**, so the site can never again promise a flow that doesn't work:

- **`src/lib/payments/cryptoPromo.ts`** (new) — single source of truth. Reuses the canonical `restaurantCryptoPaymentsEnabled()` gate (`NEXT_PUBLIC_STRIPE_RESTAURANT_CRYPTO_ENABLED`) for the USDC card + CTA, and adds one explicit operator flag **`NEXT_PUBLIC_ESMS_ONCHAIN_ENABLED`** (default `false`) for the on-chain-ESMS copy — because WTEN cannot introspect the Agents-app contract state.
- **`src/components/home/Promotion.tsx`** — the "On-Chain ESMS" badge, the "lives on-chain / claim to Base wallet / USDC" sentence, the "Pay for Food with Crypto" card, and the USDC CTA now each render only when their flag is on. The **off-chain +60 ESMS welcome grant + token economy stay shown** (they're live — `auth.ts` writes a real `signup_grant`).
- **`src/lib/payments/__tests__/cryptoPromo.test.ts`** (new) — 4 tests: default-off, exact-`"true"`-only, per-flag mapping, OR semantics.
- **`.env.example`** + **`docs/payments/CRYPTO_FOOD_PAYMENTS.md`** — documented the new flag and the gating contract.

## Verification

- Ran WTEN dev with flags off → homepage drops all five crypto strings (`Pay for Food with Crypto`, `Order Food`, `On-Chain ESMS`, `claim it to…`, `Pay with USDC`) while keeping `60 ESMS` / `Welcome Grant` / `Cosmic Token Economy` / `cosmic culinary journey`; no compile/runtime errors.
- `cryptoPromo.test.ts` — 4/4 pass. `eslint` clean on changed files.

## Reviewer notes

- **No behavior change in current prod** beyond removing the misleading copy: every gated flag is already off, so the crypto promo simply disappears until an operator turns it on.
- **To go live later**, the operator sets the flags (and `NEXT_PUBLIC_ESMS_ONCHAIN_ENABLED=true` only *after* the ESMS contract is deployed + verified on-chain) and redeploys — the promo + CTA return automatically.
- This is the code-side fix only. Remaining blockers are operator-owned: deploy EsmsToken to a real chain, set `ESMS_CONTRACT_ADDRESS` + a funded BURNER redeemer wallet, fix the Agents prod 500, and flip the WTEN flags + Stripe stablecoin approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
