### PR TITLE
fix(audit): pass-3 follow-ups — food-tracking P1, title-doubling, WS CSP, profile polish

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -74,12 +74,18 @@ const getSecurityHeaders = () => {
     "https://*.vercel.live",
     "https://accounts.google.com",
     "https:",
+    // SpacetimeDB Maincloud WebSocket. The bare `https:` source above does NOT
+    // cover `wss:` (a distinct CSP scheme), so the prod WS origin must be listed
+    // explicitly — and statically, so the allowance never silently depends on
+    // whether NEXT_PUBLIC_SPACETIME_URI was present at *build* time. The token
+    // POST to https://maincloud.spacetimedb.com is already covered by `https:`.
+    "wss://maincloud.spacetimedb.com",
   ];
 
-  // Local SpacetimeDB (ws://) needs both the WebSocket origin and its http://
-  // counterpart in connect-src: the SDK exchanges a stored identity token via
-  // an HTTP POST to /v1/identity/websocket-token before every reconnect.
-  // Production (wss:// + https://) is already covered by the https: source.
+  // Local self-hosted SpacetimeDB (ws://) needs both the WebSocket origin and
+  // its http:// counterpart in connect-src: the SDK exchanges a stored identity
+  // token via an HTTP POST to /v1/identity/websocket-token before reconnect.
+  // (Prod wss://maincloud.spacetimedb.com is allowed statically above.)
   const spacetimeUri = process.env.NEXT_PUBLIC_SPACETIME_URI;
   if (spacetimeUri && (spacetimeUri.startsWith("ws://") || spacetimeUri.startsWith("wss://"))) {
     try {

--- a/src/app/(alchm)/account/billing/mcp/page.tsx
+++ b/src/app/(alchm)/account/billing/mcp/page.tsx
@@ -18,7 +18,7 @@ import { McpTopUpPanel } from "@/components/account/McpTopUpPanel";
 export const dynamic = "force-dynamic";
 
 export const metadata = {
-  title: "MCP top-up — alchm.kitchen",
+  title: "MCP top-up",
   description:
     "Buy ESMS bundles to use against the alchm.kitchen MCP tools.",
 };

--- a/src/app/(alchm)/profile/api-keys/page.tsx
+++ b/src/app/(alchm)/profile/api-keys/page.tsx
@@ -14,7 +14,7 @@ import { ApiKeysPanel } from "@/components/account/ApiKeysPanel";
 export const dynamic = "force-dynamic";
 
 export const metadata = {
-  title: "API Keys — alchm.kitchen",
+  title: "API Keys",
   description:
     "Mint and manage API keys for Claude Desktop, Cursor, and other MCP clients.",
 };

--- a/src/app/api/auth/sessions/route.ts
+++ b/src/app/api/auth/sessions/route.ts
@@ -98,6 +98,20 @@ export async function GET(request: Request) {
     /* ignore — fall back to JWT introspection below */
   }
 
+  // Best-effort signup date for the /profile/security "MEMBER SINCE" row.
+  let memberSince: string | null = null;
+  try {
+    const { executeQuery } = await import("@/lib/database");
+    const r = await executeQuery(
+      `SELECT created_at FROM users WHERE id = $1 LIMIT 1`,
+      [user.id],
+    );
+    const created = r.rows?.[0]?.created_at as string | Date | undefined;
+    if (created) memberSince = new Date(created).toISOString();
+  } catch {
+    /* best-effort — leave null */
+  }
+
   try {
     const { executeQuery } = await import("@/lib/database");
     const result = await executeQuery(
@@ -127,15 +141,17 @@ export async function GET(request: Request) {
       return NextResponse.json({
         sessions: jwtFallback(request, user.id, currentJti),
         source: "jwt-fallback",
+        memberSince,
       });
     }
 
-    return NextResponse.json({ sessions: rows, source: "db" });
+    return NextResponse.json({ sessions: rows, source: "db", memberSince });
   } catch (err) {
     // DB unavailable or table missing — degrade to JWT introspection.
     return NextResponse.json({
       sessions: jwtFallback(request, user.id, currentJti),
       source: "jwt-fallback",
+      memberSince,
       error: process.env.NODE_ENV === "development" ? String(err) : undefined,
     });
   }

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -19,7 +19,7 @@ import { userDatabase } from "@/services/userDatabaseService";
 import type { Planet, ZodiacSignType, Element, Modality } from "@/types/celestial";
 import type { NatalChart, PlanetInfo } from "@/types/natalChart";
 import { validatePlanetaryPositions, formatValidationResult } from "@/utils/astrology/planetaryValidation";
-import { calculateAlchemicalFromPlanets, isSectDiurnal } from "@/utils/planetaryAlchemyMapping";
+import { calculateEnhancedAlchemicalFromPlanets, isSectDiurnal } from "@/utils/planetaryAlchemyMapping";
 import type { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
@@ -221,7 +221,9 @@ export async function POST(request: NextRequest) {
       dominantElement: calcDominantElement(positions),
       dominantModality: calcDominantModality(positions),
       elementalBalance: calcElementalBalance(positions),
-      alchemicalProperties: calculateAlchemicalFromPlanets(positions, isSectDiurnal(birthDate)),
+      // Enhanced mapping injects the Ascendant so Matter/Substance don't collapse
+      // to 0 for day-born (diurnal) charts. Matches /api/user/charts.
+      alchemicalProperties: calculateEnhancedAlchemicalFromPlanets(positions, isSectDiurnal(birthDate)),
       calculatedAt: new Date().toISOString(),
     };
 

--- a/src/app/cuisines/[slug]/page.tsx
+++ b/src/app/cuisines/[slug]/page.tsx
@@ -38,11 +38,11 @@ export async function generateMetadata({
 }) {
   const { slug } = await params;
   const key = slugToCuisineKey(slug);
-  if (!key) return { title: "Cuisine — Alchm Kitchen" };
+  if (!key) return { title: "Cuisine" };
   const meta = CUISINES_METADATA[key];
   const name = meta?.name ?? key;
   return {
-    title: `${name} cuisine — Alchm Kitchen`,
+    title: `${name} cuisine`,
     description: meta?.description ?? `${name} culinary tradition.`,
   };
 }

--- a/src/app/docs/mcp/page.tsx
+++ b/src/app/docs/mcp/page.tsx
@@ -12,7 +12,7 @@ import Link from "next/link";
 import type { JSX } from "react";
 
 export const metadata = {
-  title: "MCP Server — alchm.kitchen",
+  title: "MCP Server",
   description:
     "Connect Claude Desktop, Cursor, or any MCP client to alchm.kitchen's three alchemical tools.",
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -138,7 +138,7 @@ export default function RootLayout({
             .alchm-main { min-height: calc(100vh - 80px); }
             @media (max-width: 899px) {
               .alchm-main {
-                padding-bottom: max(96px, env(safe-area-inset-bottom));
+                padding-bottom: calc(96px + env(safe-area-inset-bottom, 0px));
               }
             }
           `}</style>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Privacy Policy | Alchm Kitchen",
+  title: "Privacy Policy",
   description: "Privacy policy for Alchm Kitchen culinary planning tools.",
 };
 

--- a/src/app/restaurants/page.tsx
+++ b/src/app/restaurants/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import RestaurantsPageClient from "./RestaurantsPageClient";
 
 export const metadata = {
-  title: "Explore Local Restaurants — Alchm Kitchen",
+  title: "Explore Local Restaurants",
   description:
     "Discover restaurants near you, ranked by cosmic alignment with the current planetary moment.",
 };

--- a/src/app/sauces/page.tsx
+++ b/src/app/sauces/page.tsx
@@ -1,7 +1,7 @@
 import SaucesClient from "./SaucesClient";
 
 export const metadata = {
-  title: "Cosmic Sauce Recommender - Alchm Kitchen",
+  title: "Cosmic Sauce Recommender",
   description: "Discover alchemically balanced sauce pairings with nutritional data, batch scaling, and meal planner integration.",
 };
 

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Terms of Service | Alchm Kitchen",
+  title: "Terms of Service",
   description: "Terms for using Alchm Kitchen culinary planning tools.",
 };
 

--- a/src/components/auth/AuthFollowups.tsx
+++ b/src/components/auth/AuthFollowups.tsx
@@ -1136,6 +1136,7 @@ export function AccountSessions({
 }: AccountSessionsProps = {}): JSX.Element {
   const { data: session } = useSession();
   const [sessions, setSessions] = useState<SessionRow[]>(sessionsProp ?? FALLBACK_SESSIONS);
+  const [memberSince, setMemberSince] = useState<string | null>(null);
   const [agentSync, setAgentSync] = useState<{ active: boolean; lastSync: string | null }>({
     active: false,
     lastSync: null,
@@ -1149,9 +1150,13 @@ export function AccountSessions({
       try {
         const res = await fetch("/api/auth/sessions", { credentials: "include" });
         if (!res.ok) return;
-        const json = (await res.json()) as { sessions?: SessionRow[] };
-        if (cancelled || !json.sessions) return;
-        setSessions(json.sessions);
+        const json = (await res.json()) as {
+          sessions?: SessionRow[];
+          memberSince?: string;
+        };
+        if (cancelled) return;
+        if (json.sessions) setSessions(json.sessions);
+        if (json.memberSince) setMemberSince(json.memberSince);
       } catch {
         /* leave fallback */
       }
@@ -1281,9 +1286,11 @@ export function AccountSessions({
             <IdRow
               k="MEMBER SINCE"
               v={
+                memberSince?.slice(0, 10) ??
                 (user as { createdAt?: string } | undefined)?.createdAt
                   ?.toString()
-                  .slice(0, 10) ?? "—"
+                  .slice(0, 10) ??
+                "—"
               }
             />
             <IdRow

--- a/src/components/food-diary/NutritionDashboard.tsx
+++ b/src/components/food-diary/NutritionDashboard.tsx
@@ -100,7 +100,7 @@ export default function NutritionDashboard({
       {/* Today Tab */}
       {activeTab === "today" && (
         <div className="p-4">
-          {!dailySummary || dailySummary.entries.length === 0 ? (
+          {!dailySummary || (dailySummary.entries?.length ?? 0) === 0 ? (
             <div className="text-center py-8">
               <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
                 <svg
@@ -315,7 +315,7 @@ export default function NutritionDashboard({
                 <div className="space-y-2">
                   {(["breakfast", "lunch", "dinner", "snack"] as const).map(
                     (meal) => {
-                      const mealEntries = dailySummary.mealBreakdown[meal];
+                      const mealEntries = dailySummary.mealBreakdown?.[meal] ?? [];
                       const mealCalories = mealEntries.reduce(
                         (sum, e) => sum + (e.nutrition.calories || 0),
                         0,

--- a/src/components/profile/FoodPreferences.tsx
+++ b/src/components/profile/FoodPreferences.tsx
@@ -54,6 +54,7 @@ export const FoodPreferences: React.FC<FoodPreferencesProps> = ({
 }) => {
   const [localPrefs, setLocalPrefs] = useState<UserPreferences>({ ...preferences });
   const [dislikedInput, setDislikedInput] = useState('');
+  const [saved, setSaved] = useState(false);
   const [isSharing, setIsSharing] = useState(false);
   const [hasSharedFeed, setHasSharedFeed] = useState(false);
   const [hasSharedSocial, setHasSharedSocial] = useState(false);
@@ -387,10 +388,18 @@ export const FoodPreferences: React.FC<FoodPreferencesProps> = ({
         ) : <div />}
         <button
           type="button"
-          onClick={() => onSave(localPrefs)}
-          className="flex-none px-8 py-4 bg-emerald-500 text-white rounded-xl font-black hover:bg-emerald-600 transition-all duration-300 shadow-md shadow-emerald-500/20 active:scale-95 hover:shadow-lg hover:shadow-emerald-500/30"
+          onClick={() => {
+            onSave(localPrefs);
+            setSaved(true);
+            setTimeout(() => setSaved(false), 2000);
+          }}
+          className={`flex-none px-8 py-4 rounded-xl font-black transition-all duration-300 shadow-md active:scale-95 ${
+            saved
+              ? 'bg-emerald-100 text-emerald-700 border border-emerald-200'
+              : 'bg-emerald-500 text-white hover:bg-emerald-600 shadow-emerald-500/20 hover:shadow-lg hover:shadow-emerald-500/30'
+          }`}
         >
-          Save &amp; Optimize Algorithm
+          {saved ? '✓ Saved Successfully!' : 'Save & Optimize Algorithm'}
         </button>
       </div>
     </div>

--- a/src/hooks/useFoodDiary.ts
+++ b/src/hooks/useFoodDiary.ts
@@ -149,7 +149,13 @@ export function useFoodDiary(): UseFoodDiaryReturn {
       if (res.ok) {
         const data = await res.json();
         const entries = data.entries ?? [];
-        const summary = data.summary ?? null;
+        // The /api/food-diary GET returns a partial summary (totals only, no
+        // `entries`/`mealBreakdown`). Merge the entries the API did return so
+        // NutritionDashboard's `dailySummary.entries.length` check doesn't crash
+        // and users with logged food see their data rather than the empty state.
+        const summary = data.summary
+          ? { ...data.summary, entries: data.summary.entries ?? entries }
+          : null;
         const [stats, favorites] = await Promise.all([
           getServerStats(userId),
           getServerFavorites(userId),


### PR DESCRIPTION
Addresses the Pass-3 Chrome audit findings that weren't covered by #527. Five independent fixes, one PR.

## 1. `/food-tracking` P1 crash (production page was fully down)
`/api/food-diary` GET returns a **partial** summary (totals only — no `entries`/`mealBreakdown`). `NutritionDashboard` read `dailySummary.entries.length` on mount → `Cannot read properties of undefined (reading 'length')` → root error boundary, "Try Again" re-threw. Logged-in users only (guests' server-action path returns a full summary). **Fix:** guard the `entries`/`mealBreakdown` reads and merge the API's returned entries into the summary so users with logged food see their data.

## 2. Systemic doubled `<title>` suffix
The root layout sets `title.template: "%s | Alchm Kitchen"`. **Eight** pages hardcoded a brand suffix in their own title, so it got appended twice (`… | Alchm Kitchen | Alchm Kitchen` on /restaurants, /sauces, /profile/api-keys, /account/billing/mcp, /docs/mcp, /cuisines/[slug], /privacy, /terms). **Fix:** drop the hardcoded suffix so the template adds it once — matching #527's /rewards fix. ✅ Verified on a dev server: each now renders a single `<Title> | Alchm Kitchen`.

## 3. SpaceTime WS dead in prod — a real CSP code bug
`connect-src` only gained `wss://maincloud.spacetimedb.com` when `NEXT_PUBLIC_SPACETIME_URI` was present at **build** time, and the bare `https:` source does **not** cover the `wss:` scheme — so a build that didn't see the env var blocked every WS handshake (the prod symptom: 281 connect errors/session, no live badge). **Fix:** list the prod WS origin **statically** so the allowance no longer depends on build-time env. ✅ Verified the dev server's CSP header now contains `wss://maincloud.spacetimedb.com`.
> **Operator:** confirm the deployed CSP header's `connect-src` now contains `wss://maincloud.spacetimedb.com`. The env-var side (URI/module value + that they're in the build) is still yours to verify.

## 4 & 5. Profile / UX polish
- **`/profile/preferences` save toast** — "Save & Optimize Algorithm" now shows "✓ Saved Successfully!" (mirrors /profile/budget).
- **`/profile/security` "MEMBER SINCE —"** — surfaced via `/api/auth/sessions` (best-effort `users.created_at` lookup); the session never carried `createdAt`.
- **Birth-chart Matter/Substance = 0.0** — onboarding persisted natal charts with `calculateAlchemicalFromPlanets`, which ignores the Ascendant → day-born (diurnal) charts collapse Matter/Substance to 0. Switched to `calculateEnhancedAlchemicalFromPlanets` (injects the Ascendant), matching `/api/user/charts`. ⚠️ Only fixes **newly-onboarded** users; existing stored charts need a recompute/backfill (follow-up).
- **Mobile tab-bar overlap** — `padding-bottom: calc(96px + env(safe-area-inset-bottom))` instead of `max(96px, env(...))`, which clamped to 96px and never added the inset, so the fixed tab bar overlapped the last card on notched devices.

## Verification
- `bunx tsc --noEmit`: **0 errors** project-wide.
- `bunx eslint` on all changed files: clean (pre-existing warnings only).
- Dev server (worktree): title suffixes de-doubled ✓, CSP `connect-src` includes `wss://maincloud.spacetimedb.com` ✓.
- The auth-gated/data-layer fixes (food-tracking, preferences toast, member-since, onboarding) are code-reviewed against existing patterns + tsc; the Vercel preview on this PR is the place to confirm them logged-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)