### PR TITLE
feat(planetary-chart): exact alchemical-engine thermodynamics

### DIFF
--- a/src/calculations/core/alchemicalEngine.ts
+++ b/src/calculations/core/alchemicalEngine.ts
@@ -177,7 +177,7 @@ interface AlchemyTotals {
   Earth: number;
 }
 
-interface ThermodynamicMetrics {
+export interface ThermodynamicMetrics {
   heat: number;
   entropy: number;
   reactivity: number;

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { alchemize } from "@/calculations/core/alchemicalEngine";
 import { calculateKinetics } from "@/calculations/kinetics";
 import { useUser } from "@/contexts/UserContext";
 import { AspectsService } from "@/services/AspectsService";
@@ -201,35 +202,28 @@ export function useChartData(options: ChartDataOptions = {}): ChartData {
         currentPlanet: "Sun",
       });
 
-      // 6. Display-facing thermodynamics + kalchm/monica derived from the ESMS
-      //    totals (the engine's exact values are module-private). Same proxy
-      //    mapping /api/alchemize uses; all guarded against NaN/Infinity.
+      // 6. Display-facing thermodynamics + kalchm/monica come straight from the
+      //    canonical alchemical engine (alchemize) for EXACT values — heat,
+      //    entropy, reactivity, gregsEnergy, kalchm and monica via its precise
+      //    thermodynamic formulas, replacing the prior proxy approximation. The
+      //    engine maps each planet through its own planetInfo/signInfo model
+      //    (it has no Ascendant entry, so it skips it). The ESMS shown below
+      //    stay on the richer enhanced (sect/dignity) mapping. All values are
+      //    guarded against NaN/Infinity via safe().
       const spirit = esms.Spirit;
       const essence = esms.Essence;
       const matter = esms.Matter;
       const substance = esms.Substance;
-      const total = spirit + essence + matter + substance || 1;
 
       const safe = (n: number) => (Number.isFinite(n) ? n : 0);
 
-      const dominantElementalValue = Math.max(
-        ...ELEMENTS.map((e) => elementalProperties[e] ?? 0),
-      );
-      const heat = safe((spirit / total) * 10);
-      const entropy = safe(1 - dominantElementalValue);
-      const reactivity = safe(spirit / total);
-      const gregsEnergy = safe(heat - entropy * reactivity);
-
-      const kalchm = safe(
-        (Math.max(spirit, 0.0001) ** spirit *
-          Math.max(essence, 0.0001) ** essence) /
-          (Math.max(matter, 0.0001) ** matter *
-            Math.max(substance, 0.0001) ** substance),
-      );
-      const monica =
-        kalchm > 0 && reactivity !== 0 && Math.log(kalchm) !== 0
-          ? safe(-gregsEnergy / (reactivity * Math.log(kalchm)))
-          : 0;
+      const engineMetrics = alchemize(lower);
+      const heat = safe(engineMetrics.heat);
+      const entropy = safe(engineMetrics.entropy);
+      const reactivity = safe(engineMetrics.reactivity);
+      const gregsEnergy = safe(engineMetrics.gregsEnergy);
+      const kalchm = safe(engineMetrics.kalchm);
+      const monica = safe(engineMetrics.monica);
 
       const dominantElement =
         ELEMENTS.slice().sort(
@@ -263,7 +257,7 @@ export function useChartData(options: ChartDataOptions = {}): ChartData {
         metadata: {
           dominantElement,
           sunSign,
-          source: "astrologize + planetaryAlchemyMapping",
+          source: "astrologize + planetaryAlchemyMapping + alchemicalEngine",
         },
         spirit: safe(spirit),
         essence: safe(essence),


### PR DESCRIPTION
## What

`/planetary-chart` (via `useChartData`) previously derived its thermodynamics — heat, entropy, reactivity, gregsEnergy, kalchm, monica — from a **proxy approximation** built out of the displayed ESMS totals, because the engine's exact values were module-private. This wires it to the canonical engine for **exact** values.

## Changes

- `src/calculations/core/alchemicalEngine.ts`: export the `ThermodynamicMetrics` interface (the `alchemize()` function is already exported).
- `src/hooks/useChartData.ts`: replace the proxy thermo/kalchm/monica math with a single `alchemize(lower)` call using the engine's precise formulas.

## Notes

- The engine maps each planet through its own `planetInfo`/`signInfo` model. It has no Ascendant entry, so it skips the Ascendant (canonical engine behavior). The **displayed ESMS** stay on the richer enhanced (sect/dignity) mapping — only the thermodynamics move to the engine.
- All values remain guarded against NaN/Infinity via `safe()`.

## Verification

- Project-wide `bunx tsc --noEmit` → **0 errors**.
- `bunx eslint` on both files → clean.
- Runtime spot-check: `alchemize()` on a sample chart returns finite, nonzero metrics (e.g. kalchm 64, monica ≈ 0.0165).

🤖 Generated with [Claude Code](https://claude.com/claude-code)