### PR TITLE
fix(planetary-chart): correct alchemize Ascendant comment + harden sign lookup

### DIFF
--- a/src/calculations/core/alchemicalEngine.ts
+++ b/src/calculations/core/alchemicalEngine.ts
@@ -212,8 +212,10 @@ function alchemize(planetaryPositions: {
       totals[prop as keyof AlchemyTotals] += planetData.Alchemy[prop];
     }
 
-    // Sum elemental properties (use signInfo for sign's element)
-    const signElement = signInfo[sign].Element;
+    // Sum elemental properties (use signInfo for sign's element).
+    // Guard against an unrecognized sign string so a single bad position can't
+    // throw and take down the whole calculation.
+    const signElement = signInfo[sign]?.Element;
     if (signElement && totals[signElement] !== undefined) {
       totals[signElement] += 1;
     }

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -206,10 +206,11 @@ export function useChartData(options: ChartDataOptions = {}): ChartData {
       //    canonical alchemical engine (alchemize) for EXACT values — heat,
       //    entropy, reactivity, gregsEnergy, kalchm and monica via its precise
       //    thermodynamic formulas, replacing the prior proxy approximation. The
-      //    engine maps each planet through its own planetInfo/signInfo model
-      //    (it has no Ascendant entry, so it skips it). The ESMS shown below
-      //    stay on the richer enhanced (sect/dignity) mapping. All values are
-      //    guarded against NaN/Infinity via safe().
+      //    engine maps each planet through its own planetInfo/signInfo model,
+      //    including the Ascendant (it carries a planetInfo entry), so it grounds
+      //    day charts the same way the enhanced mapping does. The ESMS shown
+      //    below stay on the richer enhanced (sect/dignity) mapping. All values
+      //    are guarded against NaN/Infinity via safe().
       const spirit = esms.Spirit;
       const essence = esms.Essence;
       const matter = esms.Matter;


### PR DESCRIPTION
Small follow-up to #531.

## Two fixes

1. **Comment accuracy.** #531's comment claimed the engine "has no Ascendant entry, so it skips it." The opposite is true — `planetInfo` carries an `Ascendant` entry (`Matter: 1`, `Elements: ["Earth"]`), so `alchemize()` counts the Ascendant and grounds day charts. Corrected the comment to match the code.
2. **Crash hardening.** `alchemize()` did `signInfo[sign].Element`, which throws on an unrecognized sign string. #531 added a new call site (`alchemize(lower)`) on the premium chart page; guard the lookup with optional chaining (`signInfo[sign]?.Element`) so one bad position can't take down the whole calculation.

No behavior change for valid lowercase zodiac signs (the only thing the chart hook ever passes). `tsc --noEmit` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)