### PR TITLE
fix(spacetime): normalize module name to bare DB name (fixes WS reconnect loop)

### DIFF
--- a/src/lib/spacetime/config.ts
+++ b/src/lib/spacetime/config.ts
@@ -24,10 +24,18 @@ export function getSpacetimeConfig(): SpacetimeConfig | null {
   const uri = process.env.NEXT_PUBLIC_SPACETIME_URI;
   if (!uri) return null;
   
-  let moduleName = process.env.NEXT_PUBLIC_SPACETIME_MODULE ?? "alchm-culinary";
-  if (moduleName.startsWith("@")) {
-    moduleName = moduleName.slice(1);
-  }
+  // Normalize to the bare database name the SpacetimeDB HTTP/WS API expects.
+  // The CLI and dashboard display modules as "owner/name" (sometimes prefixed
+  // with "@"), but the connection URL is /v1/database/<name>/subscribe — a slash
+  // there is an invalid database name, so EVERY WS handshake 400s ("invalid
+  // characters in database name") and the client is trapped in a reconnect loop
+  // (the live badge never lights). Strip a leading "@" and any "owner/" prefix so
+  // whichever form the env var carries resolves to the publishable name.
+  const rawModule = (
+    process.env.NEXT_PUBLIC_SPACETIME_MODULE ?? "alchm-culinary"
+  ).trim();
+  const moduleName =
+    rawModule.replace(/^@/, "").split("/").pop()?.trim() || "alchm-culinary";
 
   return {
     uri,


### PR DESCRIPTION
## Root cause

The prod SpacetimeDB WebSocket has been stuck in a reconnect loop (the "⚡ live" badge never lights; connect errors every 1–2s), even though #529 made the CSP `connect-src` correctly allow `wss://maincloud.spacetimedb.com` and the env vars are inlined in the build.

The client builds the WS URL as `/v1/database/<moduleName>/subscribe`. `NEXT_PUBLIC_SPACETIME_MODULE` was set to the CLI/dashboard **`owner/name`** form (`cookingwithcastrollc/alchm-culinary`). The `/` makes an **invalid database name**, so Maincloud rejects the handshake before the upgrade.

### Evidence (probed against `maincloud.spacetimedb.com`)

| Request | Result |
|---|---|
| `GET /v1/database/alchm-culinary/subscribe` | **426** "requires websocket protocol" — valid name, ready to upgrade ✅ |
| `GET /v1/database/alchm-culinary/schema` | **200** with real types (spirit/essence/matter F32) — module is live & seeded ✅ |
| `GET /v1/database/cookingwithcastrollc/alchm-culinary/subscribe` | **400** "invalid characters in database name" ❌ |
| same, URL-encoded `%2F` | **400** — a DB name simply can't contain a slash ❌ |
| `POST /v1/identity` (anon token) | **200** — token fetch works ✅ |

So CSP ✅, env build ✅, connect code ✅ — the only broken link was the module **name format**.

## Fix

`config.ts` previously stripped only a leading `@`. Normalize to the bare publishable database name — strip `@` and any `owner/` prefix (and trim):

```ts
const rawModule = (process.env.NEXT_PUBLIC_SPACETIME_MODULE ?? "alchm-culinary").trim();
const moduleName = rawModule.replace(/^@/, "").split("/").pop()?.trim() || "alchm-culinary";
```

Now `alchm-culinary`, `cookingwithcastrollc/alchm-culinary`, and `@cookingwithcastrollc/alchm-culinary` all resolve to `alchm-culinary`.

## Deploy note

`NEXT_PUBLIC_*` is build-time inlined, so this takes effect on the **next redeploy**. After deploy, the badge should light and the connect-error spam should stop. (Operator may also set the Vercel env to the bare `alchm-culinary` — either works now.)

## Verification

- `bunx tsc --noEmit` → 0 errors; `bunx eslint` → clean.
- Runtime test: all four module-name forms (+ trimmed) resolve to `alchm-culinary`; unset URI still returns `null` (disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)