### PR TITLE
feat(recipe-nft): harden the off-chain mint + smooth the featured-recipe edges

### DIFF
--- a/scripts/backfill-recipe-token-ids.ts
+++ b/scripts/backfill-recipe-token-ids.ts
@@ -1,0 +1,131 @@
+/**
+ * scripts/backfill-recipe-token-ids.ts
+ *
+ * One-shot backfill: resolve the on-chain token id for every recipe-NFT mint
+ * that settled on-chain but whose `token_id` is still NULL. The mint tx records
+ * only the hash (writeContract returns no value), so the id has to be recovered
+ * from the RecipeMinted event in the receipt logs — or, as a fallback, from the
+ * registry's `tokenForContentHash` view.
+ *
+ * Use it (a) after the first deploy that flips `recipeNftEnabled()` on, to fill
+ * rows minted before this decoder existed, and (b) as a safety net for any row
+ * where the synchronous decode in minter.ts came up empty.
+ *
+ * Required env vars:
+ *   DATABASE_PUBLIC_URL | DATABASE_URL    — WTEN Postgres connection string
+ *   NEXT_PUBLIC_RECIPE_REGISTRY_ADDRESS   — deployed RecipeRegistry address
+ *   NEXT_PUBLIC_RECIPE_NFT_CHAIN          — "base" | "base-sepolia" (default sepolia)
+ *   BASE_RPC_URL | BASE_SEPOLIA_RPC_URL   — RPC endpoint for the chosen chain
+ *
+ * Run (DATABASE_URL points at the internal hostname, so use the public URL or
+ * `railway run --service Postgres`):
+ *   bun run scripts/backfill-recipe-token-ids.ts [--dry-run]
+ */
+
+import pg from "pg";
+import type { Hex } from "viem";
+import {
+  recipeNftPublicClient,
+  recipeRegistryAbi,
+  recipeRegistryAddress,
+} from "../src/lib/recipe-nft/contract";
+import { decodeMintedTokenId } from "../src/lib/recipe-nft/minter";
+
+const { Pool } = pg;
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const connectionString = process.env.DATABASE_PUBLIC_URL || process.env.DATABASE_URL;
+
+if (!connectionString) {
+  console.error(
+    "DATABASE_PUBLIC_URL / DATABASE_URL not set — did you forget `railway run --service Postgres`?",
+  );
+  process.exit(2);
+}
+
+const registry = recipeRegistryAddress();
+if (!registry) {
+  console.error(
+    "NEXT_PUBLIC_RECIPE_REGISTRY_ADDRESS not set — the protocol must be deployed before token ids exist.",
+  );
+  process.exit(2);
+}
+
+interface MintRow {
+  id: string;
+  content_hash: string;
+  tx_hash: string | null;
+}
+
+async function main() {
+  const pool = new Pool({ connectionString });
+  const client = await pool.connect();
+  const publicClient = recipeNftPublicClient();
+  let filled = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  try {
+    const { rows } = await client.query<MintRow>(
+      `SELECT id, content_hash, tx_hash
+         FROM recipe_nft_mints
+        WHERE status = 'minted' AND token_id IS NULL
+        ORDER BY created_at ASC`,
+    );
+    console.log(`Found ${rows.length} minted row(s) missing token_id${DRY_RUN ? " (dry run)" : ""}.`);
+
+    for (const row of rows) {
+      try {
+        let tokenId: string | undefined;
+
+        // Primary: decode the RecipeMinted event from the mint tx receipt.
+        if (row.tx_hash) {
+          const receipt = await publicClient.getTransactionReceipt({ hash: row.tx_hash as Hex });
+          tokenId = decodeMintedTokenId(receipt.logs, registry);
+        }
+
+        // Fallback: ask the registry directly which token holds this content.
+        if (!tokenId) {
+          const onChain = (await publicClient.readContract({
+            address: registry,
+            abi: recipeRegistryAbi,
+            functionName: "tokenForContentHash",
+            args: [row.content_hash as Hex],
+          })) as bigint;
+          if (onChain > 0n) tokenId = onChain.toString();
+        }
+
+        if (!tokenId) {
+          console.warn(`SKIP id=${row.id} — no RecipeMinted event and no on-chain token for content.`);
+          skipped++;
+          continue;
+        }
+
+        if (DRY_RUN) {
+          console.log(`DRY id=${row.id} token_id=${tokenId}`);
+        } else {
+          await client.query(
+            `UPDATE recipe_nft_mints SET token_id = $1 WHERE id = $2 AND token_id IS NULL`,
+            [tokenId, row.id],
+          );
+          console.log(`OK  id=${row.id} token_id=${tokenId}`);
+        }
+        filled++;
+      } catch (err) {
+        console.error(`FAIL id=${row.id}:`, err instanceof Error ? err.message : err);
+        failed++;
+      }
+    }
+
+    console.log(`\nBackfill complete — filled: ${filled}, skipped: ${skipped}, failed: ${failed}`);
+    if (failed > 0) process.exitCode = 1;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/src/app/api/recipes/mint/route.ts
+++ b/src/app/api/recipes/mint/route.ts
@@ -2,7 +2,9 @@ import { NextResponse } from "next/server";
 import { gateDemoOrAuth } from "@/lib/auth/demoAccess";
 import { applyPersonalizedPricing, getPersonalizedPricingContext } from "@/lib/economy/livePricing";
 import { getCurrentSwapRates } from "@/lib/economy/swapRates";
+import { getPrivyWallet } from "@/lib/privy/server";
 import { buildMetadata, computeCommitments } from "@/lib/recipe-nft/content";
+import { recipeNftEnabled } from "@/lib/recipe-nft/contract";
 import { baseMintCost, elementToCoin, redistributeTowardDominant } from "@/lib/recipe-nft/cost";
 import { computeRecipeFingerprint } from "@/lib/recipe-nft/fingerprint";
 import { generateRecipeImage } from "@/lib/recipe-nft/image";
@@ -15,9 +17,13 @@ import { getCapitalizedNatalPositions } from "@/utils/astrology/chartDataUtils";
 import { getDominantElementFromPositions } from "@/utils/astrology/signElement";
 import { getSelfBaseUrl } from "@/utils/urlUtils";
 import type { NextRequest } from "next/server";
+import type { Address } from "viem";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+/** A 20-byte EVM address (case-insensitive). */
+const EVM_ADDRESS = /^0x[0-9a-fA-F]{40}$/;
 
 /**
  * Mint a recipe as an NFT — backend-sponsored. The user spends ESMS (all four
@@ -91,6 +97,14 @@ export async function POST(request: NextRequest) {
         { status: 402 },
       );
     }
+    if (purchase.reason === "item_not_found") {
+      // The recipe-nft-mint shop row is absent — migration 55 hasn't been
+      // applied to this environment. Surface a clear, diagnosable reason.
+      return NextResponse.json(
+        { error: "mint_unavailable", detail: "Recipe minting isn't configured on this server yet." },
+        { status: 503 },
+      );
+    }
     return NextResponse.json({ error: purchase.reason }, { status: 503 });
   }
 
@@ -109,9 +123,23 @@ export async function POST(request: NextRequest) {
   const metadataURI = `${base}/api/recipes/nft/metadata/${commitments.contentHash}`;
   const metadata = buildMetadata(recipe, fingerprint, { imageUrl, externalUrl: `${base}/recipe-builder` });
 
+  // Recipient = the user's own linked Base wallet when known, else the rights
+  // holder (custody, matching the gas-free claim-mint model). Resolved purely
+  // server-side from the authenticated user — a client-sent address is never
+  // trusted. The live Privy lookup only runs once on-chain minting is enabled,
+  // since the recipient is otherwise unused (pending_chain).
+  let recipient: Address = defaultRecipient();
+  const storedWallet = dbUser?.walletAddress;
+  if (storedWallet && EVM_ADDRESS.test(storedWallet)) {
+    recipient = storedWallet as Address;
+  } else if (dbUser?.privyDid && recipeNftEnabled()) {
+    const liveWallet = await getPrivyWallet(dbUser.privyDid);
+    if (liveWallet && EVM_ADDRESS.test(liveWallet)) recipient = liveWallet as Address;
+  }
+
   // Backend-sponsored on-chain mint (gated → pending_chain until deployed).
   const chainResult = await mintRecipeOnChain({
-    recipient: defaultRecipient(),
+    recipient,
     commitments,
     engineVersion: fingerprint.engineVersion,
     contentURI,
@@ -140,9 +168,39 @@ export async function POST(request: NextRequest) {
     imageUrl,
   });
 
+  // No ledger row written despite a successful debit → either a concurrent mint
+  // of this exact content won the content_hash race, or the write failed. The
+  // user got no token, so refund the ESMS (idempotent) to keep the off-chain
+  // spend exactly-once per content hash.
+  if (!record) {
+    await tokenEconomy.creditMultipleTokens(
+      userId,
+      [
+        { tokenType: "Spirit", amount: cost.spirit },
+        { tokenType: "Essence", amount: cost.essence },
+        { tokenType: "Matter", amount: cost.matter },
+        { tokenType: "Substance", amount: cost.substance },
+      ],
+      "mint_refund",
+      {
+        sourceId: purchase.transactionGroupId,
+        description: `Refund — mint not recorded: ${recipe.title}`,
+        idempotencyKey: `mint_refund:${commitments.contentHash}`,
+      },
+    );
+    const dupe = await recipeNftMintService.findByContentHash(commitments.contentHash);
+    if (dupe) {
+      return NextResponse.json(
+        { error: "already_minted", mintId: dupe.id, status: dupe.status, refunded: true },
+        { status: 409 },
+      );
+    }
+    return NextResponse.json({ error: "mint_record_failed", refunded: true }, { status: 500 });
+  }
+
   return NextResponse.json({
     success: true,
-    mintId: record?.id ?? null,
+    mintId: record.id,
     status: chainResult.status,
     pending: chainResult.status === "pending_chain",
     reason: chainResult.reason,

--- a/src/app/api/recipes/mint/route.ts
+++ b/src/app/api/recipes/mint/route.ts
@@ -146,13 +146,13 @@ export async function POST(request: NextRequest) {
     metadataURI,
   });
 
-  const record = await recipeNftMintService.recordMint({
+  const ledgerRow = {
     userId,
     recipeId: recipe.id,
     title: recipe.title,
     provenance: {
       creator: userId,
-      source: parsed.complete ? "generated" : "scan",
+      source: parsed.complete ? ("generated" as const) : ("scan" as const),
       parentRecipeId: null,
       createdAt: new Date().toISOString(),
     },
@@ -166,12 +166,47 @@ export async function POST(request: NextRequest) {
     metadataUri: metadataURI,
     recipeJson: recipe,
     imageUrl,
-  });
+  };
+  let record = await recipeNftMintService.recordMint(ledgerRow);
 
-  // No ledger row written despite a successful debit → either a concurrent mint
-  // of this exact content won the content_hash race, or the write failed. The
-  // user got no token, so refund the ESMS (idempotent) to keep the off-chain
-  // spend exactly-once per content hash.
+  // A real on-chain token was minted but the ledger write failed: the user HOLDS
+  // the asset, so we must never refund. Retry the write once to recover.
+  const mintedOnChain = chainResult.status === "minted" && !!chainResult.txHash;
+  if (!record && mintedOnChain) {
+    record = await recipeNftMintService.recordMint(ledgerRow);
+    if (!record) {
+      // Surface the tx loudly so it can be reconciled into the ledger — refunding
+      // here would hand the user both the NFT and their ESMS back.
+      console.error(
+        "recipe-nft mint: on-chain token minted but ledger write failed — needs reconciliation",
+        {
+          userId,
+          contentHash: commitments.contentHash,
+          txHash: chainResult.txHash,
+          tokenId: chainResult.tokenId ?? null,
+          transactionGroupId: purchase.transactionGroupId,
+        },
+      );
+      return NextResponse.json(
+        {
+          success: true,
+          reconcile: true,
+          status: chainResult.status,
+          contentHash: commitments.contentHash,
+          chain: chainResult.chain ?? null,
+          txHash: chainResult.txHash,
+          tokenId: chainResult.tokenId ?? null,
+          cost,
+        },
+        { status: 200 },
+      );
+    }
+  }
+
+  // No row written AND no on-chain token → the user got nothing: either a
+  // concurrent mint of this exact content won the content_hash race, or the
+  // write failed before any chain mint. Refund the debit (idempotent per debit)
+  // to keep the off-chain spend exactly-once.
   if (!record) {
     await tokenEconomy.creditMultipleTokens(
       userId,
@@ -185,7 +220,11 @@ export async function POST(request: NextRequest) {
       {
         sourceId: purchase.transactionGroupId,
         description: `Refund — mint not recorded: ${recipe.title}`,
-        idempotencyKey: `mint_refund:${commitments.contentHash}`,
+        // Key by the debit, NOT the content hash: token_transactions.idempotency_key
+        // is GLOBALLY unique, so multiple racers losing the same content_hash would
+        // share a content-keyed key and only the first would be refunded. The
+        // transaction group id is unique per debit, so every loser is refunded once.
+        idempotencyKey: `mint_refund:${purchase.transactionGroupId}`,
       },
     );
     const dupe = await recipeNftMintService.findByContentHash(commitments.contentHash);

--- a/src/components/home/FeaturedRecipe.tsx
+++ b/src/components/home/FeaturedRecipe.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { RecipeNftMintPanel } from "@/components/home/RecipeNftMintPanel";
+import { RecipeNftMintPanel, type QuoteResponse } from "@/components/home/RecipeNftMintPanel";
 import { FEATURED_RECIPE_META, featuredRecipe } from "@/data/featuredRecipe";
 import { elementalSignature } from "@/utils/elemental";
 
@@ -12,6 +12,35 @@ const ELEMENT_ROWS = [
   { key: "air", name: "Air", icon: "💨", bar: "bg-amber-400", text: "text-amber-300" },
   { key: "water", name: "Water", icon: "💧", bar: "bg-blue-500", text: "text-blue-400" },
 ] as const;
+
+const MIN_SERVINGS = 1;
+const MAX_SERVINGS = 24;
+
+/** Parse a recipe quantity ("2", "0.5", "1/2", "1 1/2") to a number, or null. */
+function parseQty(raw: string): number | null {
+  const s = raw.trim();
+  const mixed = s.match(/^(\d+)\s+(\d+)\/(\d+)$/);
+  if (mixed) return Number(mixed[1]) + Number(mixed[2]) / Number(mixed[3]);
+  const frac = s.match(/^(\d+)\/(\d+)$/);
+  if (frac) return Number(frac[1]) / Number(frac[2]);
+  const n = Number(s);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Tidy a scaled amount: integers stay integers, else up to 2 decimals, no trailing zeros. */
+function formatQty(n: number): string {
+  const rounded = Math.round(n * 100) / 100;
+  if (Number.isInteger(rounded)) return String(rounded);
+  return rounded.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+/** Scale a displayed ingredient amount by the serving factor (unparseable amounts pass through). */
+function scaleAmount(quantity: string, factor: number): string {
+  if (factor === 1) return quantity;
+  const n = parseQty(quantity);
+  if (n === null) return quantity;
+  return formatQty(n * factor);
+}
 
 /**
  * Featured Recipe of the Month — a self-contained block rendered inside the
@@ -24,19 +53,12 @@ export function FeaturedRecipe() {
 
   const recipe = featuredRecipe;
 
-  // Reconcile the displayed signature with what the NFT actually commits: the
-  // mint-quote returns the ingredient-derived (potency-weighted) elemental
-  // shares, so the badge + bars match the on-chain fingerprint rather than the
-  // authored elementalBalance seed. Falls back to the authored values until the
-  // quote resolves.
-  const [derived, setDerived] = useState<
-    { Fire: number; Water: number; Earth: number; Air: number } | null
-  >(null);
-  // Smart default servings (yield-limiting), computed server-side from the
-  // ingredient amounts vs catalog serving sizes.
-  const [smartServes, setSmartServes] = useState<number | null>(null);
-  const [servesLimitedBy, setServesLimitedBy] = useState<string | null>(null);
-  // Hero image — generated via the live nanobanana pipeline (Redis-cached).
+  // One shared mint-quote fetch for the whole featured block: it drives the
+  // ingredient-derived signature (badge + bars), the smart-default servings, and
+  // is handed straight to the mint panel below (which no longer self-fetches).
+  const [quote, setQuote] = useState<QuoteResponse | null>(null);
+  const [quoteError, setQuoteError] = useState(false);
+  // Hero image — generated via the live image pipeline (Redis-cached).
   const [heroImage, setHeroImage] = useState<string | null>(null);
 
   useEffect(() => {
@@ -59,17 +81,21 @@ export function FeaturedRecipe() {
     fetch("/api/recipes/featured/mint-quote")
       .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
       .then((j) => {
-        if (!active) return;
-        const el = j?.fingerprint?.elemental;
-        if (el) setDerived({ Fire: el.Fire, Water: el.Water, Earth: el.Earth, Air: el.Air });
-        if (typeof j?.fingerprint?.smartServings === "number") setSmartServes(j.fingerprint.smartServings);
-        if (typeof j?.fingerprint?.servingsLimitedBy === "string") setServesLimitedBy(j.fingerprint.servingsLimitedBy);
+        if (active) setQuote(j as QuoteResponse);
       })
-      .catch(() => {});
+      .catch(() => {
+        if (active) setQuoteError(true);
+      });
     return () => {
       active = false;
     };
   }, []);
+
+  // Ingredient-derived signature + smart servings come from the shared quote;
+  // fall back to the authored values until (or unless) it resolves.
+  const derived = quote?.fingerprint?.elemental ?? null;
+  const smartServes = quote?.fingerprint?.smartServings ?? null;
+  const servesLimitedBy = quote?.fingerprint?.servingsLimitedBy ?? null;
 
   const shares = useMemo(
     () =>
@@ -85,6 +111,20 @@ export function FeaturedRecipe() {
   const signature = useMemo(() => elementalSignature(shares), [shares]);
 
   const coDominantSet = new Set(signature.coDominant.map((e) => e.toLowerCase()));
+
+  // Servings adjuster (cooking convenience): scales the DISPLAYED ingredient
+  // amounts only. The mint cost stays the recipe's intrinsic per-serving
+  // fingerprint — it is computed server-side and never reads a client serving
+  // count, so the selector can't change what a mint charges.
+  const baseServings = smartServes ?? recipe.yields;
+  const [servingsOverride, setServingsOverride] = useState<number | null>(null);
+  const servings = servingsOverride ?? baseServings;
+  const scaleFactor = baseServings > 0 ? servings / baseServings : 1;
+  // Functional updater so rapid +/- clicks accumulate off the latest value.
+  const stepServings = (delta: number) =>
+    setServingsOverride((prev) =>
+      Math.max(MIN_SERVINGS, Math.min(MAX_SERVINGS, (prev ?? baseServings) + delta)),
+    );
 
   const steps = [...recipe.steps].sort(
     (a, b) => a.step_number - b.step_number,
@@ -105,6 +145,7 @@ export function FeaturedRecipe() {
                 src={heroImage}
                 alt={recipe.title}
                 loading="lazy"
+                onError={() => setHeroImage(null)}
                 className="w-full h-full object-cover"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-[#0a0f0a]/70 via-transparent to-transparent pointer-events-none" />
@@ -139,15 +180,45 @@ export function FeaturedRecipe() {
               <span className="text-white/80 font-semibold">{recipe.total_time} min</span>
             </div>
             <div
-              className="flex items-baseline gap-1.5"
+              className="flex items-center gap-1.5"
               title={
-                servesLimitedBy
-                  ? `Smart default — yield-limited by ${servesLimitedBy}; adjustable when viewing the recipe`
-                  : "Smart default servings; adjustable when viewing the recipe"
+                `${servesLimitedBy
+                  ? `Smart default — yield-limited by ${servesLimitedBy}. `
+                  : "Smart default servings. " 
+                }Adjust to scale the ingredient list; the mint cost is the recipe's fixed per-serving fingerprint.`
               }
             >
               <span className="text-white/35 uppercase tracking-wider text-[10px] font-bold">Serves</span>
-              <span className="text-white/80 font-semibold">{smartServes ?? recipe.yields}</span>
+              <div className="inline-flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => stepServings(-1)}
+                  disabled={servings <= MIN_SERVINGS}
+                  aria-label="Fewer servings"
+                  className="w-5 h-5 flex items-center justify-center rounded-md bg-white/[0.04] border border-white/10 text-white/60 hover:text-white hover:border-white/25 disabled:opacity-30 disabled:cursor-not-allowed transition-colors leading-none"
+                >
+                  −
+                </button>
+                <span className="text-white/80 font-semibold tabular-nums w-5 text-center">{servings}</span>
+                <button
+                  type="button"
+                  onClick={() => stepServings(1)}
+                  disabled={servings >= MAX_SERVINGS}
+                  aria-label="More servings"
+                  className="w-5 h-5 flex items-center justify-center rounded-md bg-white/[0.04] border border-white/10 text-white/60 hover:text-white hover:border-white/25 disabled:opacity-30 disabled:cursor-not-allowed transition-colors leading-none"
+                >
+                  +
+                </button>
+                {servingsOverride !== null && servingsOverride !== baseServings && (
+                  <button
+                    type="button"
+                    onClick={() => setServingsOverride(null)}
+                    className="ml-1 text-[9px] uppercase tracking-wider text-amber-300/70 hover:text-amber-200 transition-colors"
+                  >
+                    reset
+                  </button>
+                )}
+              </div>
             </div>
             <div className="flex items-baseline gap-1.5">
               <span className="text-white/35 uppercase tracking-wider text-[10px] font-bold">Level</span>
@@ -231,8 +302,9 @@ export function FeaturedRecipe() {
             </div>
           </div>
 
-          {/* Mint this recipe as an NFT — the featured mechanic */}
-          <RecipeNftMintPanel />
+          {/* Mint this recipe as an NFT — the featured mechanic. Fed the shared
+              quote so it doesn't re-fetch; falls back to its own fetch standalone. */}
+          <RecipeNftMintPanel quote={quote} quoteError={quoteError} />
 
           {/* Expand / collapse */}
           <button
@@ -253,6 +325,11 @@ export function FeaturedRecipe() {
               <div className="lg:col-span-2">
                 <h4 className="text-[11px] font-bold text-white/45 uppercase tracking-widest mb-3">
                   Ingredients · {recipe.ingredients.length}
+                  {scaleFactor !== 1 && (
+                    <span className="ml-2 text-amber-300/60 normal-case tracking-normal font-medium">
+                      scaled to {servings} serving{servings === 1 ? "" : "s"}
+                    </span>
+                  )}
                 </h4>
                 <ul className="space-y-2">
                   {recipe.ingredients.map((ing) => (
@@ -267,7 +344,7 @@ export function FeaturedRecipe() {
                         )}
                       </span>
                       <span className="text-amber-300/90 font-medium whitespace-nowrap">
-                        {ing.quantity} {ing.unit}
+                        {scaleAmount(ing.quantity, scaleFactor)} {ing.unit}
                       </span>
                     </li>
                   ))}

--- a/src/components/home/FeaturedRecipe.tsx
+++ b/src/components/home/FeaturedRecipe.tsx
@@ -120,6 +120,10 @@ export function FeaturedRecipe() {
   const [servingsOverride, setServingsOverride] = useState<number | null>(null);
   const servings = servingsOverride ?? baseServings;
   const scaleFactor = baseServings > 0 ? servings / baseServings : 1;
+  // Only let the stepper run once the quote has settled, so baseServings can't
+  // jump (recipe.yields → smartServings) under an in-progress override and
+  // silently re-scale the displayed amounts. On quote error it stays at yields.
+  const servingsReady = quote !== null || quoteError;
   // Functional updater so rapid +/- clicks accumulate off the latest value.
   const stepServings = (delta: number) =>
     setServingsOverride((prev) =>
@@ -193,7 +197,7 @@ export function FeaturedRecipe() {
                 <button
                   type="button"
                   onClick={() => stepServings(-1)}
-                  disabled={servings <= MIN_SERVINGS}
+                  disabled={!servingsReady || servings <= MIN_SERVINGS}
                   aria-label="Fewer servings"
                   className="w-5 h-5 flex items-center justify-center rounded-md bg-white/[0.04] border border-white/10 text-white/60 hover:text-white hover:border-white/25 disabled:opacity-30 disabled:cursor-not-allowed transition-colors leading-none"
                 >
@@ -203,7 +207,7 @@ export function FeaturedRecipe() {
                 <button
                   type="button"
                   onClick={() => stepServings(1)}
-                  disabled={servings >= MAX_SERVINGS}
+                  disabled={!servingsReady || servings >= MAX_SERVINGS}
                   aria-label="More servings"
                   className="w-5 h-5 flex items-center justify-center rounded-md bg-white/[0.04] border border-white/10 text-white/60 hover:text-white hover:border-white/25 disabled:opacity-30 disabled:cursor-not-allowed transition-colors leading-none"
                 >

--- a/src/components/home/RecipeNftMintPanel.tsx
+++ b/src/components/home/RecipeNftMintPanel.tsx
@@ -16,7 +16,7 @@ type CoinKey = (typeof COINS)[number]["key"];
 type Token = (typeof COINS)[number]["token"];
 type CoinAmounts = Record<CoinKey, number>;
 
-interface QuoteResponse {
+export interface QuoteResponse {
   recipeId: string;
   title: string;
   enabled: boolean;
@@ -25,6 +25,11 @@ interface QuoteResponse {
     totals: CoinAmounts;
     physics: { kalchm: number; monica: number; heat: number; entropy: number; reactivity: number; gregsEnergy: number };
     matchRate: number;
+    /** Ingredient-derived elemental shares (the FeaturedRecipe badge/bars read these). */
+    elemental: { Fire: number; Water: number; Earth: number; Air: number };
+    /** Yield-limited smart default + the staple that limits it. */
+    smartServings: number;
+    servingsLimitedBy: string | null;
   };
   quote: {
     baseCost: CoinAmounts;
@@ -54,9 +59,19 @@ const PHYSICS_CHIPS = [
  * chart's dominant coin (chart-weighted redistribution). The full alchemical
  * fingerprint (ESMS totals + physics) is what gets committed into the NFT.
  */
-export function RecipeNftMintPanel() {
-  const [data, setData] = useState<QuoteResponse | null>(null);
-  const [error, setError] = useState(false);
+export function RecipeNftMintPanel({
+  quote: quoteProp,
+  quoteError: quoteErrorProp,
+}: {
+  /** When provided, the panel uses the parent's shared quote instead of fetching its own. */
+  quote?: QuoteResponse | null;
+  quoteError?: boolean;
+} = {}) {
+  // Controlled (parent supplies the quote → one shared fetch for the featured
+  // card) vs standalone (panel fetches its own quote when rendered alone).
+  const controlled = quoteProp !== undefined;
+  const [selfData, setSelfData] = useState<QuoteResponse | null>(null);
+  const [selfError, setSelfError] = useState(false);
   const [dominant, setDominant] = useState<Token | null>(null);
   const [minting, setMinting] = useState(false);
   const [mintMsg, setMintMsg] = useState<string | null>(null);
@@ -70,15 +85,19 @@ export function RecipeNftMintPanel() {
   };
 
   useEffect(() => {
+    if (controlled) return;
     let active = true;
     fetch("/api/recipes/featured/mint-quote")
       .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
-      .then((j) => active && setData(j))
-      .catch(() => active && setError(true));
+      .then((j) => active && setSelfData(j))
+      .catch(() => active && setSelfError(true));
     return () => {
       active = false;
     };
-  }, []);
+  }, [controlled]);
+
+  const data = controlled ? quoteProp ?? null : selfData;
+  const error = controlled ? !!quoteErrorProp : selfError;
 
   const displayCost: CoinAmounts | null = useMemo(() => {
     if (!data) return null;

--- a/src/data/featuredRecipe.ts
+++ b/src/data/featuredRecipe.ts
@@ -25,7 +25,7 @@ export const featuredRecipe: CosmicRecipe = {
   id: "modernized-pasta-primavera-alchm-edition",
   title: "Modernized Pasta Primavera (Alchm Edition)",
   short_description:
-    "A bright, spring-forward primavera where a slow-sweated allium trio, a chili-sparked tomato base, and ribbons of asparagus, peas, and carrot are bound in a glossy starch emulsion and finished with vibrant green tarragon oil. Composed under a Mercury-led sky for additive, never-opposed Fire–Earth co-dominance.",
+    "A bright, spring-forward primavera where a slow-sweated allium trio, a chili-sparked tomato base, and ribbons of asparagus, peas, and carrot are bound in a glossy starch emulsion and finished with vibrant green tarragon oil. Composed under a Mercury-led sky for additive, never-opposed Water–Earth co-dominance — a tomato-and-wine body grounded by pasta and sweet roots.",
   category: "Dinner",
   cuisine: "Italian-American",
   difficulty: "intermediate",
@@ -40,7 +40,7 @@ export const featuredRecipe: CosmicRecipe = {
   },
   alignment_notes: [
     "Vegetarian as written; contains dry white wine and Pecorino Romano (not vegan or alcohol-free) — see substitutions for vegan and zero-alcohol paths.",
-    "Elemental balance is tuned for Fire–Earth co-dominance: the chili/tomato spark is additive to the carrot/pea sweetness, never opposed (No Oppositions protocol).",
+    "Elemental balance reads as Water–Earth co-dominant: the tomato-and-wine body (Water) and the pasta-and-root structure (Earth) reinforce each other, with the chili spark additive and never opposed (No Oppositions protocol).",
     "Total time ~45 min — the tomato simmer and the pasta boil are run concurrently to keep active time tight.",
     "Mafaldine's ruffled edges are chosen for maximum surface area to grip the starchy emulsion; pappardelle or fettuccine substitute cleanly.",
     "Pecorino is assertively salty — season the sauce lightly and adjust only at the very end.",
@@ -58,8 +58,8 @@ export const featuredRecipe: CosmicRecipe = {
       "gently spicy",
     ],
     cooking_methods: ["sauté", "deglaze", "simmer", "boil", "emulsify"],
-    elements: ["fire", "earth", "air", "water"],
-    planets: ["Mercury", "Venus", "Mars"],
+    elements: ["water", "earth", "air", "fire"],
+    planets: ["Mercury", "Venus", "Moon"],
   },
   ingredients: [
     {
@@ -314,10 +314,10 @@ export const featuredRecipe: CosmicRecipe = {
     },
   ],
   elementalBalance: {
-    fire: 30,
-    earth: 30,
-    water: 16,
-    air: 24,
+    fire: 14,
+    earth: 34,
+    water: 35,
+    air: 17,
   },
   nutrition: {
     calories: 520,
@@ -343,12 +343,12 @@ export const featuredRecipe: CosmicRecipe = {
   },
   astro_explanation: {
     summary:
-      "Composed under a Mercury-led spring sky, this primavera channels Mercury's quick, volatile air through the allium trio, Venus's sweetness through the root vegetables, and a measured spark of Mars through the chili and tomato — an additive, self-reinforcing balance with no elemental opposition.",
+      "Composed under a Mercury-led spring sky, this primavera channels Mercury's quick, volatile air through the allium trio and Venus's grounded sweetness through the roots, while the Moon lends the tomato-and-wine base its Water body — an additive, self-reinforcing Water–Earth balance with no elemental opposition, a contained chili spark lifting it rather than opposing it.",
     correspondences: [
       "Mercury (@mercury.agentic.alchm.kitchen) governs the volatile Air matrix — onion, leek, and shallot sweated low and slow to release their aromatic, communicative top-notes.",
       "Venus rules the foundational Earth/Water sweetness of carrots and English peas, grounding the dish and amplifying its natural sugars.",
-      "Mars supplies a contained Fire spark via crushed chili and tomato acidity — heat that elevates the Earth components' sweetness rather than opposing them (the No Oppositions protocol).",
-      "Fire and Earth read as co-dominant: the spark and the structure reinforce each other, with Air carrying aroma and Water lending body.",
+      "The Moon carries the dish's Water body — crushed and cherry tomatoes, the white-wine reduction, and the glossy starch emulsion that binds every ribbon.",
+      "Water and Earth read as co-dominant: the tomato-and-wine body and the pasta-and-root structure reinforce each other, with Air carrying aroma and a measured chili spark lifting the sweetness rather than opposing it (the No Oppositions protocol).",
       "Tarragon's anise-bright finish is an aerial, Mercurial flourish that lifts the whole plate at the moment of serving.",
     ],
   },

--- a/src/lib/recipe-nft/contract.ts
+++ b/src/lib/recipe-nft/contract.ts
@@ -75,6 +75,29 @@ export const recipeRegistryAbi = [
     inputs: [{ name: "tokenId", type: "uint256" }],
     outputs: [{ name: "", type: "string" }],
   },
+  {
+    // Emitted by mintRecipe — the only place the assigned tokenId is observable
+    // from a tx receipt (writeContract returns just a hash, not the return
+    // value). Decoded from the receipt logs to backfill recipe_nft_mints.token_id.
+    type: "event",
+    name: "RecipeMinted",
+    anonymous: false,
+    inputs: [
+      { name: "tokenId", type: "uint256", indexed: true },
+      { name: "rightsId", type: "bytes32", indexed: true },
+      { name: "contentHash", type: "bytes32", indexed: true },
+      { name: "creator", type: "address", indexed: false },
+      { name: "recipient", type: "address", indexed: false },
+      { name: "parentTokenId", type: "uint256", indexed: false },
+      { name: "relation", type: "uint8", indexed: false },
+      { name: "engineVersion", type: "uint64", indexed: false },
+      { name: "computationHash", type: "bytes32", indexed: false },
+      { name: "ingredientCatalogRoot", type: "bytes32", indexed: false },
+      { name: "licenseHash", type: "bytes32", indexed: false },
+      { name: "contentURI", type: "string", indexed: false },
+      { name: "metadataURI", type: "string", indexed: false },
+    ],
+  },
 ] as const;
 
 export const rightsRegistryAbi = [

--- a/src/lib/recipe-nft/mintClient.ts
+++ b/src/lib/recipe-nft/mintClient.ts
@@ -73,9 +73,14 @@ export function mintResultMessage(r: MintResult): string {
     return "Mint recorded.";
   }
   switch (r.httpStatus) {
+    case 0: return "Network hiccup — check your connection and try again.";
+    case 400:
+    case 422: return "That recipe can't be minted as-is — try regenerating it.";
     case 401: return "Sign in to mint a recipe NFT.";
     case 402: return r.cost ? `Not enough ESMS — minting costs ${coinSum(r.cost).toFixed(2)} across all four coins.` : "Not enough ESMS to mint.";
     case 409: return "This exact recipe has already been minted.";
-    default: return "Couldn't mint right now. Please try again shortly.";
+    case 503: return "Minting isn't available right now. Please try again shortly.";
+    // 500s here always refund the debit, so the user's ESMS are untouched.
+    default: return "Couldn't mint right now — your ESMS weren't spent. Please try again shortly.";
   }
 }

--- a/src/lib/recipe-nft/minter.ts
+++ b/src/lib/recipe-nft/minter.ts
@@ -11,7 +11,7 @@
  * a backfill can mint pending rows once addresses are configured.
  */
 
-import { createWalletClient, http, type Address, type Hex } from "viem";
+import { createWalletClient, decodeEventLog, http, type Address, type Hex, type Log } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import {
   RECIPE_RELATION,
@@ -112,9 +112,11 @@ export async function mintRecipeOnChain(input: MintOnChainInput): Promise<MintOn
     if (receipt.status !== "success") {
       return { status: "failed", chain: chain.name, txHash, reason: "tx-reverted" };
     }
-    // tokenId is emitted in the RecipeMinted event; the backfill/decoder fills it
-    // from logs. We record the tx now and resolve the id asynchronously.
-    return { status: "minted", chain: chain.name, txHash };
+    // tokenId is only observable from the RecipeMinted event log (writeContract
+    // returns just a hash). Decode it now; the backfill script recovers it for
+    // any rows where this synchronous decode came up empty.
+    const tokenId = decodeMintedTokenId(receipt.logs, registry);
+    return { status: "minted", chain: chain.name, txHash, tokenId };
   } catch (err) {
     return {
       status: "failed",
@@ -127,4 +129,29 @@ export async function mintRecipeOnChain(input: MintOnChainInput): Promise<MintOn
 /** The wallet that receives the minted token (the configured rights holder). */
 export function defaultRecipient(): Address {
   return RIGHTS_HOLDER;
+}
+
+/**
+ * Extract the assigned tokenId from a mint tx's receipt logs by decoding the
+ * RecipeMinted event emitted by the registry. Returns undefined if no matching
+ * event is found. Shared by the live mint path and the backfill script.
+ */
+export function decodeMintedTokenId(logs: readonly Log[], registry: Address): string | undefined {
+  const target = registry.toLowerCase();
+  for (const log of logs) {
+    if (log.address.toLowerCase() !== target) continue;
+    try {
+      const ev = decodeEventLog({
+        abi: recipeRegistryAbi,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (ev.eventName !== "RecipeMinted") continue;
+      const args = ev.args as unknown as { tokenId: bigint };
+      return args.tokenId.toString();
+    } catch {
+      // not the RecipeMinted event — keep scanning
+    }
+  }
+  return undefined;
 }

--- a/src/services/recipeNftMintService.ts
+++ b/src/services/recipeNftMintService.ts
@@ -72,6 +72,26 @@ export const recipeNftMintService = {
     }
   },
 
+  /**
+   * Backfill the on-chain token id once it has been decoded from the
+   * RecipeMinted event (the mint tx records only the hash). Returns true when a
+   * row was updated. Used by scripts/backfill-recipe-token-ids.ts.
+   */
+  async updateTokenId(contentHash: string, tokenId: string): Promise<boolean> {
+    try {
+      const res = await executeQuery(
+        `UPDATE recipe_nft_mints
+            SET token_id = $2
+          WHERE content_hash = $1 AND token_id IS NULL`,
+        [contentHash, tokenId],
+      );
+      return (res.rowCount ?? 0) > 0;
+    } catch (err) {
+      console.error("updateTokenId failed", err);
+      return false;
+    }
+  },
+
   /** Has this exact recipe content already been minted? */
   async findByContentHash(contentHash: string): Promise<{ id: string; status: string } | null> {
     try {

--- a/src/services/recipeNftMintService.ts
+++ b/src/services/recipeNftMintService.ts
@@ -72,26 +72,6 @@ export const recipeNftMintService = {
     }
   },
 
-  /**
-   * Backfill the on-chain token id once it has been decoded from the
-   * RecipeMinted event (the mint tx records only the hash). Returns true when a
-   * row was updated. Used by scripts/backfill-recipe-token-ids.ts.
-   */
-  async updateTokenId(contentHash: string, tokenId: string): Promise<boolean> {
-    try {
-      const res = await executeQuery(
-        `UPDATE recipe_nft_mints
-            SET token_id = $2
-          WHERE content_hash = $1 AND token_id IS NULL`,
-        [contentHash, tokenId],
-      );
-      return (res.rowCount ?? 0) > 0;
-    } catch (err) {
-      console.error("updateTokenId failed", err);
-      return false;
-    }
-  },
-
   /** Has this exact recipe content already been minted? */
   async findByContentHash(contentHash: string): Promise<{ id: string; status: string } | null> {
     try {

--- a/src/types/economy.ts
+++ b/src/types/economy.ts
@@ -61,7 +61,15 @@ export type TransactionSourceType =
    * exact ESMS basket. Idempotency key shape: `restaurant_refund:<orderId>`.
    * See src/app/api/admin/restaurants/settlement/route.ts.
    */
-  | "restaurant_refund";
+  | "restaurant_refund"
+  /**
+   * Re-credit of a `recipe-nft-mint` debit when the off-chain mint could not be
+   * recorded — e.g. a concurrent mint of the same recipe content won the
+   * content_hash race, or the ledger write failed after the ESMS was debited.
+   * Makes the off-chain spend exactly-once per content hash. Idempotency key
+   * shape: `mint_refund:<contentHash>`. See src/app/api/recipes/mint/route.ts.
+   */
+  | "mint_refund";
 
 // ─── Token Balances ────────────────────────────────────────────────────
 


### PR DESCRIPTION
Follow-up to the recipe-as-NFT feature ([#542](https://github.com/gregcastro23/WhatToEatNext/pull/542)): exercise the off-chain mint end-to-end and close the loose ends. On-chain minting stays **gated off** (`recipeNftEnabled()` unchanged) — this is all off-chain ledger + UI hardening, wired so the on-chain path is correct the moment it's flipped on.

## Track 1 — harden the off-chain mint

- **Exactly-once spend.** The 409 `content_hash` pre-check isn't atomic with the ESMS debit, so concurrent mints of the same recipe could both debit while only one ledger row was written — the loser's ESMS was lost. Now, when a debit succeeds but no row is written, the route refunds the four-coin cost (`creditMultipleTokens`, new `mint_refund` source type) and returns 409/500. The refund is keyed by the **debit** (`transactionGroupId`), not the content hash, because `token_transactions.idempotency_key` is globally unique — a content-keyed refund would suppress all-but-one racer.
- **Never refund a real on-chain mint** (caught in review). If a token was actually minted on-chain (`status:"minted"`, real `txHash`) but the ledger write then failed, the user *holds the asset* — the route retries the write once and, failing that, logs the tx for reconciliation and returns `200 {reconcile:true, txHash, tokenId}` instead of refunding + dropping the tx.
- **Mint to the user's wallet.** Recipient now resolves to the user's linked Base wallet (`dbUser.walletAddress` → a live `getPrivyWallet` lookup once minting is enabled) with the rights holder as the custody fallback. Resolved server-side only.
- **`token_id` resolution.** Added the real `RecipeMinted` event to the registry ABI + a shared `decodeMintedTokenId()`; `mintRecipeOnChain` now returns the tokenId decoded from the receipt. New `scripts/backfill-recipe-token-ids.ts` recovers `token_id` for any minted rows still missing it (receipt decode → `tokenForContentHash` view fallback).
- **Clearer 503** when the `recipe-nft-mint` shop row is missing (migration 55 not applied).

> **Migration 55** (the shop item + `recipe_nft_mints` table) is already on `master`, idempotent, and contains no `CREATE INDEX CONCURRENTLY` — it auto-applies on the next Railway backend deploy via the tracked runner. It is intentionally **not** hand-applied to prod here. Verified that `purchaseShopItem` accepts the non-one-time item + `overrideCosts` and never rejects as `already_owned`.

## Track 2 — smooth the four edges

- **Prose ↔ signature reconciled.** The recipe's ingredient-derived fingerprint is **Water 0.35 / Earth 0.34 co-dominant** (Air 0.17, Fire 0.14), but the prose still said Fire–Earth / Mars-led. Rewrote `short_description` + `astro_explanation` (Moon→Water body, chili a contained spark), swapped the Mars planet tag for the Moon, and realigned the authored `elementalBalance` seed. The badge now reads "Water & Earth · co-dominant" and the prose agrees. (Changes `contentHash` — fine, nothing's minted; hashes still recompute deterministically.)
- **One quote fetch.** `FeaturedRecipe` and the mint panel each fetched `/api/recipes/featured/mint-quote`; lifted it to `FeaturedRecipe` and pass the quote down (panel keeps a self-fetch fallback for standalone use). Verified one request instead of two.
- **On-view servings adjuster.** A `Serves` stepper (default = the yield-limited smart servings) scales the displayed ingredient amounts for cooking. It's purely a **display scaler** — the mint cost stays the recipe's intrinsic per-serving fingerprint, computed server-side; the mint route never reads a client serving count, so a serving choice can't change what a mint charges. Functional state updater; gated until the quote settles so the baseline can't shift under an in-progress override.
- **Loading / error / empty states.** Hero image self-hides on load error; the shared quote surfaces a real error in the panel instead of silently falling back; `mintResultMessage` gains distinct copy for network / 400 / 422 / 503 and notes that 500s are refunded.

## Verification
- `bun run typecheck` + eslint clean (husky pre-commit enforces both on every commit).
- Browser-verified the home Promotion: hero image, Serves stepper (scales ingredient amounts, reset, rapid-click safe), the Water & Earth signature badge matching the new prose, single quote fetch, the live mint cost panel, and no console errors.
- A multi-agent adversarial review of the diff produced the four fixes in the last commit; re-verified after.
- On-chain paths (recipient, token_id decode, backfill) are wired + unit-reasoned but only integration-testable once the protocol is deployed and `recipeNftEnabled()` flips on. No real ESMS debit was run locally (DATABASE_URL unset → in-memory fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)