### PR TITLE
fix(health): kill false-positive alerts + close the auth-monitoring blind spot

### DIFF
--- a/src/services/__tests__/syntheticProbeService.test.ts
+++ b/src/services/__tests__/syntheticProbeService.test.ts
@@ -9,7 +9,10 @@ jest.mock("@/lib/database/connection", () => ({
   executeQuery: jest.fn().mockResolvedValue({ rows: [] }),
 }));
 
-import { runOnboardingSkipProbe } from "@/services/syntheticProbeService";
+import {
+  runCosmicRecipeProbe,
+  runOnboardingSkipProbe,
+} from "@/services/syntheticProbeService";
 
 describe("runOnboardingSkipProbe", () => {
   beforeEach(() => {
@@ -113,5 +116,81 @@ describe("runOnboardingSkipProbe", () => {
 
     expect(result.status).toBe("timeout");
     expect(result.errorMessage).toMatch(/timed out/);
+  });
+});
+
+describe("runCosmicRecipeProbe", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns success when generation responds 200 + success:true", async () => {
+    jest.spyOn(globalThis, "fetch" as any).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, data: { recipe: {} } }),
+    } as Response);
+
+    const result = await runCosmicRecipeProbe({
+      baseUrl: "http://localhost:3000",
+      bearerToken: "test-token",
+    });
+
+    expect(result.status).toBe("success");
+    expect(result.httpStatus).toBe(200);
+    expect(result.errorMessage).toBeNull();
+  });
+
+  it("treats a 402 (daily free-generation quota spent) as success — the endpoint is healthy and token-gating is working", async () => {
+    jest.spyOn(globalThis, "fetch" as any).mockResolvedValue({
+      ok: false,
+      status: 402,
+      json: async () => ({
+        success: false,
+        message: "You have generated your free recipe for today.",
+      }),
+    } as Response);
+
+    const result = await runCosmicRecipeProbe({
+      baseUrl: "http://localhost:3000",
+      bearerToken: "test-token",
+    });
+
+    // The whole point of the fix: a 402 must NOT flap AI-generation to INCIDENT.
+    expect(result.status).toBe("success");
+    expect(result.httpStatus).toBe(402);
+  });
+
+  it("still fails on a 5xx (genuine generation breakage)", async () => {
+    jest.spyOn(globalThis, "fetch" as any).mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => ({ success: false, message: "backend down" }),
+    } as Response);
+
+    const result = await runCosmicRecipeProbe({
+      baseUrl: "http://localhost:3000",
+      bearerToken: "test-token",
+    });
+
+    expect(result.status).toBe("failure");
+    expect(result.httpStatus).toBe(502);
+    expect(result.errorMessage).toMatch(/502/);
+  });
+
+  it("still fails on 200 + success:false (endpoint reachable but generation failed)", async () => {
+    jest.spyOn(globalThis, "fetch" as any).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: false, message: "generation failed" }),
+    } as Response);
+
+    const result = await runCosmicRecipeProbe({
+      baseUrl: "http://localhost:3000",
+      bearerToken: "test-token",
+    });
+
+    expect(result.status).toBe("failure");
+    expect(result.httpStatus).toBe(200);
   });
 });

--- a/src/services/syntheticProbeService.ts
+++ b/src/services/syntheticProbeService.ts
@@ -203,7 +203,16 @@ export async function runCosmicRecipeProbe(options: {
       hasData: body.data != null,
       demo: body.demo ?? null,
     }),
-    isSuccess: (status, body) => status === 200 && body.success === true,
+    // A 402 means the synthetic user has already spent its one free daily
+    // generation — the endpoint is alive and token-gating is enforcing
+    // correctly, which is itself a healthy signal. Without this, every hourly
+    // run after the day's first (which actually generates) returned 402 and
+    // flapped AI-generation into a false INCIDENT ~23h/day. The once-daily
+    // real 200 still verifies generation end-to-end; genuine breakage (5xx,
+    // timeout, empty body) still fails. Mirrors the stripe-webhook probe,
+    // which treats an expected 4xx as success.
+    isSuccess: (status, body) =>
+      (status === 200 && body.success === true) || status === 402,
   });
 }
 

--- a/src/services/systemStatusService.ts
+++ b/src/services/systemStatusService.ts
@@ -922,8 +922,14 @@ async function probeMcp(latest: LatestProbeRow[]): Promise<FlowHealth> {
   const paStatus = await getMcpNetworkSummary().catch(() => null);
   const paVerdict = paStatus?.live ? paStatus.verdict : "UNKNOWN";
 
-  // Combine verdicts to represent the worst of both servers
-  const combinedVerdict = worst([wtenStatus, paVerdict]);
+  // Combine verdicts to represent the worst of both servers. PA telemetry
+  // being UNKNOWN (network summary unavailable) is an observability gap, not a
+  // tool-surface degradation — and worst() maps any UNKNOWN to DEGRADED, which
+  // was flapping this flow into a false DEGRADED (mislabelled "WTEN latency
+  // elevated") whenever PA telemetry was down. Only fold PA into the verdict
+  // when we actually have a live status for it.
+  const combinedVerdict =
+    paVerdict === "UNKNOWN" ? wtenStatus : worst([wtenStatus, paVerdict]);
 
   const issues: FlowIssue[] = [];
   if (synthetic.issue) issues.push(synthetic.issue);
@@ -955,9 +961,13 @@ async function probeMcp(latest: LatestProbeRow[]): Promise<FlowHealth> {
     status: combinedVerdict,
     summary:
       combinedVerdict === "OK"
-        ? calls1h > 0
-          ? `${calls1h} WTEN tool calls · WTEN & PA healthy`
-          : "Idle — WTEN & PA MCP healthy"
+        ? paVerdict === "UNKNOWN"
+          ? calls1h > 0
+            ? `${calls1h} WTEN tool calls · WTEN healthy · PA telemetry unavailable`
+            : "Idle — WTEN MCP healthy · PA telemetry unavailable"
+          : calls1h > 0
+            ? `${calls1h} WTEN tool calls · WTEN & PA healthy`
+            : "Idle — WTEN & PA MCP healthy"
         : combinedVerdict === "DEGRADED"
           ? paVerdict === "DEGRADED"
             ? `PA MCP degraded · p95 ${formatLatency(paStatus?.totals.p95LatencyMs ?? 0)}`
@@ -985,7 +995,10 @@ async function probeMcp(latest: LatestProbeRow[]): Promise<FlowHealth> {
     ],
     issues: issues.slice(0, 3),
     checkedAt,
-    live: live && (paStatus?.live ?? false),
+    // The verdict tracks WTEN's live signal; PA telemetry being unavailable is
+    // surfaced in the summary/metric, not by marking the whole flow non-live
+    // (which previously paired an OK verdict with a misleading "stale" hint).
+    live,
   };
 }
 


### PR DESCRIPTION
Operator dashboard hardening. The `/admin` pane had been pinned at **INCIDENT ~23h/day for over a week** and the MCP panel at a permanent **DEGRADED** — both monitoring bugs, not outages — while a real class of failure (sign-in breaking) couldn't be detected at all. This PR fixes the false positives and closes the blind spot.

## 1. `cosmic-recipe` probe no longer false-alarms on its own daily quota — *the INCIDENT driver*
The hourly probe signs in as the single free-tier `SYNTHETIC_PROBE_TOKEN` user. After the day's one free generation, every later run got **HTTP 402** (daily quota), scored as failure → `probeAIGeneration` → **INCIDENT**. It recovered at ~00:00 UTC (quota reset) and re-broke at ~01:00 UTC, daily. A 402 means the endpoint is alive and token-gating works, so it's now treated as success (the once-daily real `200` still verifies generation; 5xx/timeout/empty still fail). Mirrors the `stripe-webhook` probe.

## 2. MCP flow no longer falsely DEGRADED when PA telemetry is UNKNOWN
`worst([wtenStatus, "UNKNOWN"])` promoted the flow to DEGRADED and mislabeled it *"WTEN MCP tool latency elevated (p95 151ms)"*. PA telemetry being unavailable is an observability gap, not a degradation. Now PA folds into the verdict only when live; the summary says *"PA telemetry unavailable"* honestly. **`worst()` is unchanged.**

## 3. New end-to-end `auth-signin` probe — closes the dashboard blind spot
The auth panel couldn't tell *healthy-but-idle* from *sign-in-broken*: organic sign-in counts read 0 whenever everyone's on long-lived JWT cookies, and the `auth-handshake` probe uses a bearer token that skips OAuth + the signIn callback + the client secret. A real outage would show green.

New 15-min `auth-signin` probe exercises the real entry path:
- **Initiation** — CSRF → `POST /api/auth/signin/google` → expect a 302 to `accounts.google.com` with client_id + PKCE (a broken stack 302s to `/auth/error?error=Configuration`).
- **Secret validity** — POST client_id+secret to Google's token endpoint with a throwaway code: `invalid_grant` = credentials accepted; `invalid_client` = secret rotated/revoked and every real callback will fail. The only check that catches a silent secret rotation. Best-effort; a Google hiccup is never a failure.

Wired into `probeAuth` (fresh failure → INCIDENT, stale → DEGRADED); the OK summary now reads *"sign-ins in 24h · sign-in path verified"*. No tokens spent, no rows written, no real account.

## 4. Daily-digest email send hardened against transient failures
The Railway `daily-digest-cron` crashed on 2026-06-23; `sendEmail()` returns false (never throws) and the route previously returned **200 even on failure** (silent). Now retries the send 3× with backoff and returns **502** (not a silent 200) if all attempts fail, so a real outage surfaces.

> **Ops follow-up (not in this diff):** optionally harden the Railway `daily-digest-cron` start command to ride out deploy-window blips — add \`--retry-all-errors --connect-timeout 15 --max-time 90\` and bump \`--retry 5 --retry-delay 10\`. (Railway MCP write auth expired mid-session; this is a one-line paste in the service's Custom Start Command.)

## Verification
- 33/33 probe + systemStatus tests pass, incl. 8 new (`runCosmicRecipeProbe` ×4, `runAuthSigninProbe` ×4).
- \`tsc --noEmit\` clean tree-wide; eslint clean; pre-commit hook (typecheck+lint) passed on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)