### PR TITLE
fix(health): re-land auth-signin probe + digest retry dropped by #546 squash

### DIFF
--- a/src/app/api/admin/digest/route.ts
+++ b/src/app/api/admin/digest/route.ts
@@ -164,12 +164,45 @@ export async function POST(request: NextRequest) {
     const subject = `Alchm Kitchen — ${period === "weekly" ? "Weekly" : "Daily"} digest`;
     const html = renderHtml(payload);
     const text = JSON.stringify(payload, null, 2);
-    const sent = await emailService.sendEmail({ to: recipient, subject, html, text });
+
+    // Retry transient email-provider failures (a Resend/SMTP blip or a brief
+    // network error mid-deploy) before giving up. sendEmail() returns false on
+    // failure and never throws, so loop on the boolean. A single flake was
+    // enough to fail-send the digest; layered with the cron's own --retry this
+    // makes a one-off blip a non-event while a real outage still surfaces.
+    const MAX_ATTEMPTS = 3;
+    let sent = false;
+    let attempts = 0;
+    for (; attempts < MAX_ATTEMPTS; attempts++) {
+      if (attempts > 0) {
+        await new Promise((resolve) => setTimeout(resolve, 1000 * attempts));
+      }
+      sent = await emailService.sendEmail({ to: recipient, subject, html, text });
+      if (sent) break;
+    }
+
+    if (!sent) {
+      // Surface persistent failure (502) so the scheduled caller registers it
+      // instead of silently reporting success when no digest was delivered.
+      console.error(
+        `[admin/digest] email delivery failed after ${MAX_ATTEMPTS} attempts to ${recipient}`,
+      );
+      return NextResponse.json(
+        {
+          success: false,
+          delivered: false,
+          message: "Email delivery failed after retries",
+          recipient,
+        },
+        { status: 502 },
+      );
+    }
 
     return NextResponse.json({
-      success: sent !== false,
-      delivered: sent !== false,
+      success: true,
+      delivered: true,
       recipient,
+      attempts: attempts + 1,
       payload,
     });
   } catch (error) {

--- a/src/app/api/cron/synthetic-auth-signin/route.ts
+++ b/src/app/api/cron/synthetic-auth-signin/route.ts
@@ -1,0 +1,52 @@
+/**
+ * Synthetic Auth Sign-in Probe — cron endpoint
+ *
+ * Triggered every 15 min by Vercel cron. Drives the real Google OAuth
+ * sign-in entry path (CSRF → POST /api/auth/signin/google → expect a 302
+ * to accounts.google.com) and checks the OAuth client secret against
+ * Google's token endpoint. Unlike `auth-handshake` (which uses a
+ * long-lived bearer and so skips the OAuth + secret path entirely), this
+ * catches a broken sign-in or a rotated AUTH_GOOGLE_SECRET while existing
+ * JWT-cookie sessions keep the rest of the site looking healthy.
+ *
+ * @file src/app/api/cron/synthetic-auth-signin/route.ts
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import {
+  getCronBaseUrl,
+  isAuthorizedCron,
+} from "@/app/api/cron/_lib/cronAuth";
+import { _logger } from "@/lib/logger";
+import { runAuthSigninProbe } from "@/services/syntheticProbeService";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+export async function GET(request: NextRequest) {
+  if (!isAuthorizedCron(request)) {
+    return NextResponse.json(
+      { success: false, message: "Unauthorized" },
+      { status: 401 },
+    );
+  }
+  try {
+    const result = await runAuthSigninProbe({
+      baseUrl: getCronBaseUrl(),
+    });
+    return NextResponse.json({
+      success: result.status === "success",
+      result,
+    });
+  } catch (err) {
+    _logger.error("[cron/synthetic-auth-signin] probe failed:", err);
+    return NextResponse.json(
+      {
+        success: false,
+        message: err instanceof Error ? err.message : "unknown",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/services/__tests__/syntheticProbeService.test.ts
+++ b/src/services/__tests__/syntheticProbeService.test.ts
@@ -10,6 +10,7 @@ jest.mock("@/lib/database/connection", () => ({
 }));
 
 import {
+  runAuthSigninProbe,
   runCosmicRecipeProbe,
   runOnboardingSkipProbe,
 } from "@/services/syntheticProbeService";
@@ -192,5 +193,119 @@ describe("runCosmicRecipeProbe", () => {
 
     expect(result.status).toBe("failure");
     expect(result.httpStatus).toBe(200);
+  });
+});
+
+describe("runAuthSigninProbe", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    // Default: no Google creds in env → the secret-validity check is skipped,
+    // so these tests exercise the initiation path in isolation.
+    delete process.env.AUTH_GOOGLE_ID;
+    delete process.env.AUTH_GOOGLE_SECRET;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  // Route each fetch by URL so the multi-step flow (csrf → signin → token)
+  // can be stubbed independently.
+  function mockFlow(opts: { location: string; tokenError?: string }) {
+    return jest
+      .spyOn(globalThis, "fetch" as any)
+      .mockImplementation(async (input: any) => {
+        const url = String(input);
+        if (url.includes("/api/auth/csrf")) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ csrfToken: "test-csrf" }),
+            headers: {
+              get: () => null,
+              getSetCookie: () => [
+                "authjs.csrf-token=test-csrf%7Cabc; Path=/; HttpOnly",
+              ],
+            },
+          } as unknown as Response;
+        }
+        if (url.includes("/api/auth/signin/google")) {
+          return {
+            status: 302,
+            json: async () => ({}),
+            headers: {
+              get: (k: string) =>
+                k.toLowerCase() === "location" ? opts.location : null,
+              getSetCookie: () => [],
+            },
+          } as unknown as Response;
+        }
+        if (url.includes("oauth2.googleapis.com/token")) {
+          return {
+            ok: false,
+            status: 400,
+            json: async () => ({ error: opts.tokenError ?? "invalid_grant" }),
+            headers: { get: () => null },
+          } as unknown as Response;
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      });
+  }
+
+  it("succeeds when sign-in initiation 302s to Google with a client_id", async () => {
+    mockFlow({
+      location:
+        "https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=test.apps.googleusercontent.com&code_challenge=abc",
+    });
+
+    const result = await runAuthSigninProbe({ baseUrl: "https://app.test" });
+
+    expect(result.status).toBe("success");
+    expect(result.httpStatus).toBe(302);
+    expect(result.responsePayload).toMatchObject({ initiationOk: true });
+  });
+
+  it("fails when initiation redirects to the auth error page (broken config)", async () => {
+    mockFlow({
+      location: "https://app.test/auth/error?error=Configuration",
+    });
+
+    const result = await runAuthSigninProbe({ baseUrl: "https://app.test" });
+
+    expect(result.status).toBe("failure");
+    expect(result.errorMessage).toMatch(/did not redirect to Google/);
+  });
+
+  it("fails when Google rejects the client secret (invalid_client → rotated secret)", async () => {
+    process.env.AUTH_GOOGLE_ID = "test.apps.googleusercontent.com";
+    process.env.AUTH_GOOGLE_SECRET = "stale-secret";
+    mockFlow({
+      location:
+        "https://accounts.google.com/o/oauth2/v2/auth?client_id=test.apps.googleusercontent.com&code_challenge=abc",
+      tokenError: "invalid_client",
+    });
+
+    const result = await runAuthSigninProbe({ baseUrl: "https://app.test" });
+
+    expect(result.status).toBe("failure");
+    expect(result.errorMessage).toMatch(/invalid_client/);
+    expect(result.responsePayload).toMatchObject({ secretCheck: "invalid" });
+  });
+
+  it("succeeds when the secret check returns invalid_grant (credentials accepted, bogus code)", async () => {
+    process.env.AUTH_GOOGLE_ID = "test.apps.googleusercontent.com";
+    process.env.AUTH_GOOGLE_SECRET = "good-secret";
+    mockFlow({
+      location:
+        "https://accounts.google.com/o/oauth2/v2/auth?client_id=test.apps.googleusercontent.com&code_challenge=abc",
+      tokenError: "invalid_grant",
+    });
+
+    const result = await runAuthSigninProbe({ baseUrl: "https://app.test" });
+
+    expect(result.status).toBe("success");
+    expect(result.responsePayload).toMatchObject({ secretCheck: "valid" });
   });
 });

--- a/src/services/syntheticProbeService.ts
+++ b/src/services/syntheticProbeService.ts
@@ -20,6 +20,12 @@
  *   - `auth-handshake` — GET /api/auth/sessions as the synthetic user;
  *     expects 200 with the device-session list. Catches NextAuth /
  *     session-machinery regressions.
+ *   - `auth-signin` — drives the real Google OAuth entry path: CSRF +
+ *     POST /api/auth/signin/google expecting a 302 to accounts.google.com,
+ *     plus a client-secret validity check against Google's token endpoint.
+ *     Catches a broken sign-in (Configuration error) or a rotated
+ *     AUTH_GOOGLE_SECRET — which the bearer-token handshake probe can't,
+ *     and which leaves existing JWT sessions looking healthy.
  *
  * Each run inserts into `synthetic_probe_results`. The latest row per
  * `probe_name` feeds `systemStatusService` so a synthetic failure
@@ -371,6 +377,173 @@ export async function runAuthHandshakeProbe(options: {
     } else {
       status = "failure";
       errorMessage = `HTTP ${res.status}`;
+    }
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      status = "timeout";
+      errorMessage = `Probe timed out after ${PROBE_TIMEOUT_MS}ms`;
+    } else {
+      status = "failure";
+      errorMessage = err instanceof Error ? err.message : "Unknown error";
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const result: ProbeResult = {
+    probeName,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    status,
+    latencyMs: Date.now() - t0,
+    httpStatus,
+    errorMessage,
+    responsePayload,
+  };
+  await recordProbeResult(result);
+  return result;
+}
+
+/**
+ * Run the auth sign-in probe: exercise the REAL Google OAuth sign-in
+ * entry path end-to-end (minus the human consent step), which the
+ * `auth-handshake` probe deliberately skips by using a long-lived bearer.
+ *
+ * Two independent checks, both of which a broken sign-in would trip while
+ * existing JWT-cookie sessions keep the site looking alive:
+ *
+ *   1. Initiation: GET /api/auth/csrf, then POST /api/auth/signin/google
+ *      with the CSRF token+cookie. A healthy stack 302s to
+ *      accounts.google.com with a client_id + PKCE challenge. A broken
+ *      provider/secret/route 302s to /auth/error?error=Configuration.
+ *      Catches: missing/empty AUTH_GOOGLE_ID, NextAuth route/CSRF
+ *      breakage, provider misconfig.
+ *
+ *   2. Secret validity: POST the client_id+client_secret to Google's
+ *      token endpoint with a throwaway code. `invalid_grant` ("bad code")
+ *      means Google ACCEPTED the credentials → secret is valid;
+ *      `invalid_client` means the secret was rotated/revoked and every
+ *      real callback's token exchange will fail. This is the one check
+ *      that catches a silent secret rotation — initiation alone can't,
+ *      because it never needs the secret. Best-effort: a network/Google
+ *      hiccup is inconclusive, never a failure.
+ *
+ * No tokens spent, no rows written, no real account involved.
+ */
+export async function runAuthSigninProbe(options: {
+  baseUrl: string;
+}): Promise<ProbeResult> {
+  const probeName = "auth-signin";
+  const startedAt = new Date().toISOString();
+  const t0 = Date.now();
+
+  let httpStatus: number | null = null;
+  let errorMessage: string | null = null;
+  let status: ProbeStatus = "failure";
+  let responsePayload: Record<string, unknown> = {};
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+
+  try {
+    // ── 1. Initiation: CSRF handshake → provider sign-in POST ──────────
+    const csrfRes = await fetch(`${options.baseUrl}/api/auth/csrf`, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
+    const csrfBody = (await csrfRes.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
+    const csrfToken =
+      typeof csrfBody.csrfToken === "string" ? csrfBody.csrfToken : "";
+    // Auth.js sets the CSRF cookie via Set-Cookie; forward the name=value
+    // pairs back on the POST (double-submit cookie). getSetCookie() is the
+    // spec API for multiple cookies; fall back to the single-header form.
+    const setCookies =
+      typeof csrfRes.headers.getSetCookie === "function"
+        ? csrfRes.headers.getSetCookie()
+        : csrfRes.headers.get("set-cookie")
+          ? [csrfRes.headers.get("set-cookie") as string]
+          : [];
+    const cookieHeader = setCookies
+      .map((c) => c.split(";")[0])
+      .filter(Boolean)
+      .join("; ");
+
+    const signinRes = await fetch(
+      `${options.baseUrl}/api/auth/signin/google`,
+      {
+        method: "POST",
+        redirect: "manual",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          ...(cookieHeader ? { Cookie: cookieHeader } : {}),
+        },
+        body: new URLSearchParams({
+          csrfToken,
+          callbackUrl: options.baseUrl,
+        }).toString(),
+        signal: controller.signal,
+      },
+    );
+    httpStatus = signinRes.status;
+    const location = signinRes.headers.get("location") ?? "";
+    const initiationOk =
+      /^https:\/\/accounts\.google\.com\//.test(location) &&
+      location.includes("client_id=");
+
+    // Store a compact, secret-free view of where initiation landed.
+    let locationSummary = location;
+    try {
+      const u = new URL(location);
+      locationSummary = `${u.origin}${u.pathname}`;
+    } catch {
+      /* keep raw (e.g. relative /auth/error) */
+    }
+
+    // ── 2. Secret validity against Google's token endpoint ─────────────
+    const clientId = process.env.AUTH_GOOGLE_ID;
+    const clientSecret = process.env.AUTH_GOOGLE_SECRET;
+    let secretCheck: "valid" | "invalid" | "skipped" = "skipped";
+    if (clientId && clientSecret) {
+      try {
+        const tokenRes = await fetch("https://oauth2.googleapis.com/token", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({
+            client_id: clientId,
+            client_secret: clientSecret,
+            code: "synthetic-probe-invalid-code",
+            grant_type: "authorization_code",
+            redirect_uri: `${options.baseUrl}/api/auth/callback/google`,
+          }).toString(),
+          signal: controller.signal,
+        });
+        const tokenBody = (await tokenRes.json().catch(() => ({}))) as Record<
+          string,
+          unknown
+        >;
+        // Only an explicit invalid_client condemns the secret. invalid_grant
+        // (our bogus code) means the credentials were accepted.
+        secretCheck = tokenBody.error === "invalid_client" ? "invalid" : "valid";
+      } catch {
+        secretCheck = "skipped";
+      }
+    }
+
+    responsePayload = { initiationOk, location: locationSummary, secretCheck };
+
+    if (!initiationOk) {
+      status = "failure";
+      errorMessage = `Sign-in initiation did not redirect to Google (landed: ${locationSummary || "no Location header"})`;
+    } else if (secretCheck === "invalid") {
+      status = "failure";
+      errorMessage =
+        "Google rejected the OAuth client credentials (invalid_client) — AUTH_GOOGLE_SECRET likely rotated/revoked; real callbacks will fail token exchange";
+    } else {
+      status = "success";
     }
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {

--- a/src/services/systemStatusService.ts
+++ b/src/services/systemStatusService.ts
@@ -262,11 +262,16 @@ async function probeAuth(latest: LatestProbeRow[]): Promise<FlowHealth> {
     latest,
     STALE_15MIN,
   );
+  // Real OAuth entry path + client-secret validity. This is what catches a
+  // genuinely broken sign-in: organic sign-in counts can read 0 simply
+  // because everyone's on long-lived JWT cookies, so without this probe the
+  // auth panel is vacuously "OK" and can't tell idle from broken.
+  const signin = evaluateSyntheticProbe("auth-signin", latest, STALE_15MIN);
 
   let status: FlowStatus;
   if (!session.observed && !authEventsLive) status = "UNKNOWN";
   else if (failureRate24h >= 0.5) status = "INCIDENT";
-  else if (handshake.freshFailure) status = "INCIDENT";
+  else if (handshake.freshFailure || signin.freshFailure) status = "INCIDENT";
   else if (
     failureRate24h >= 0.2 ||
     statusFromPathHealth(session, {
@@ -276,13 +281,15 @@ async function probeAuth(latest: LatestProbeRow[]): Promise<FlowHealth> {
     }) === "INCIDENT"
   ) {
     status = "DEGRADED";
-  } else if (handshake.stale) {
+  } else if (handshake.stale || signin.stale) {
     status = "DEGRADED";
   } else {
     status = "OK";
   }
 
   const issues: FlowIssue[] = [];
+  // Sign-in breakage is the most actionable auth issue — surface it first.
+  if (signin.issue) issues.push(signin.issue);
   if (handshake.issue) issues.push(handshake.issue);
   const sessionIssue = issueFromFailure(session, "auth");
   if (sessionIssue) issues.push(sessionIssue);
@@ -295,15 +302,19 @@ async function probeAuth(latest: LatestProbeRow[]): Promise<FlowHealth> {
     status,
     summary:
       status === "OK"
-        ? `${signins24h} successful sign-ins in 24h`
+        ? `${signins24h} sign-ins in 24h · sign-in path verified`
         : status === "DEGRADED"
-          ? handshake.stale
-            ? "Synthetic auth-handshake probe stale"
-            : `${failures24h} sign-in failures in 24h (${formatPct(failureRate24h)})`
+          ? signin.stale
+            ? "Synthetic auth-signin probe stale"
+            : handshake.stale
+              ? "Synthetic auth-handshake probe stale"
+              : `${failures24h} sign-in failures in 24h (${formatPct(failureRate24h)})`
           : status === "INCIDENT"
-            ? handshake.freshFailure
-              ? "Synthetic auth-handshake probe failing"
-              : `Sign-ins failing — ${formatPct(failureRate24h)} failure rate 24h`
+            ? signin.freshFailure
+              ? "Synthetic auth-signin probe failing — sign-in likely broken"
+              : handshake.freshFailure
+                ? "Synthetic auth-handshake probe failing"
+                : `Sign-ins failing — ${formatPct(failureRate24h)} failure rate 24h`
             : "No auth signal in window",
     metrics: [
       { label: "Sign-ins · 24h", value: `${signins24h}`, raw: signins24h },
@@ -318,9 +329,9 @@ async function probeAuth(latest: LatestProbeRow[]): Promise<FlowHealth> {
         raw: session.p95LatencyMs,
       },
       {
-        label: "Synthetic",
-        value: handshake.metricValue,
-        raw: handshake.metricRaw,
+        label: "Sign-in probe",
+        value: signin.metricValue,
+        raw: signin.metricRaw,
       },
     ],
     issues,

--- a/vercel.json
+++ b/vercel.json
@@ -32,6 +32,10 @@
       "schedule": "*/15 * * * *"
     },
     {
+      "path": "/api/cron/synthetic-auth-signin",
+      "schedule": "*/15 * * * *"
+    },
+    {
       "path": "/api/cron/synthetic-mcp",
       "schedule": "*/30 * * * *"
     },


### PR DESCRIPTION
## What happened

PR #546 squash-merged using the **stale PR head \`df077b8a\`** — the head never caught up to the two commits pushed afterward. Result: the cosmic-recipe 402 + MCP fixes landed, but **two commits were silently dropped from master**:

- the end-to-end **auth sign-in probe** (`/api/cron/synthetic-auth-signin`), and
- the **daily-digest transient-email retry**.

The auth-signin cron currently **404s in production** — the route file is absent from the deployed build. This is broken shipped work, so it goes first.

## What this PR does

Clean re-land via cherry-pick onto current \`origin/master\` (zero conflicts; byte-identical to the dropped commits per \`git range-diff\`):

- `81221aa0` — `feat(health): add end-to-end auth sign-in probe to close the dashboard blind spot`
- `a17a8ce5` — `fix(health): retry transient email failures in the daily digest`

No recipe/unrelated commits bundled in — kept isolated precisely because mixing is what caused the drop.

## Verification

- ✅ `synthetic-auth-signin` route present **and registered** in `vercel.json` (cron will actually fire).
- ✅ `bun run jest syntheticProbeService.test.ts` — **14/14 pass** (incl. all auth-signin cases).
- ✅ `bun run typecheck` — clean.

## Merge note

Squash-merge **only after** confirming the PR head SHA matches the pushed tip — the head/tip mismatch is exactly what dropped these commits the first time.