### PR TITLE
fix(health): stop idle dependency-UNKNOWN from pinning the admin banner amber

### DIFF
--- a/src/services/__tests__/systemStatusService.test.ts
+++ b/src/services/__tests__/systemStatusService.test.ts
@@ -1,5 +1,6 @@
 import {
   worst,
+  rollUpOverall,
   statusFromPathHealth,
   type FlowStatus,
 } from "@/services/systemStatusService";
@@ -47,6 +48,40 @@ describe("systemStatusService.worst", () => {
 
   it("INCIDENT beats UNKNOWN", () => {
     expect(worst(["UNKNOWN", "INCIDENT"])).toBe<FlowStatus>("INCIDENT");
+  });
+});
+
+describe("systemStatusService.rollUpOverall", () => {
+  it("stays OK when all flows are OK and dependencies are idle-UNKNOWN", () => {
+    // The regression: Stripe + Google OAuth sit at UNKNOWN on a low-traffic day
+    // (no synthetic ping), which previously pinned the banner at DEGRADED even
+    // though every flow was green. Idle dependency-UNKNOWN must NOT escalate.
+    expect(
+      rollUpOverall(["OK", "OK", "OK"], ["UNKNOWN", "UNKNOWN"]),
+    ).toBe<FlowStatus>("OK");
+  });
+
+  it("still surfaces an unmeasurable FLOW as DEGRADED (real blind spot)", () => {
+    // Flows are softened by nothing — an UNKNOWN flow is a genuine blind spot.
+    expect(rollUpOverall(["OK", "UNKNOWN"], ["UNKNOWN"])).toBe<FlowStatus>(
+      "DEGRADED",
+    );
+  });
+
+  it("escalates when a dependency reports a CONCRETE DEGRADED", () => {
+    expect(rollUpOverall(["OK", "OK"], ["DEGRADED"])).toBe<FlowStatus>(
+      "DEGRADED",
+    );
+  });
+
+  it("escalates to INCIDENT when a dependency is in INCIDENT", () => {
+    expect(rollUpOverall(["OK"], ["UNKNOWN", "INCIDENT"])).toBe<FlowStatus>(
+      "INCIDENT",
+    );
+  });
+
+  it("is OK when flows are OK and there are no dependencies", () => {
+    expect(rollUpOverall(["OK", "OK"], [])).toBe<FlowStatus>("OK");
   });
 });
 

--- a/src/services/systemStatusService.ts
+++ b/src/services/systemStatusService.ts
@@ -107,6 +107,31 @@ export function worst(statuses: FlowStatus[]): FlowStatus {
 }
 
 /**
+ * Roll per-flow and per-dependency statuses up into the single banner status.
+ *
+ * Flows contribute directly: an unmeasurable flow (UNKNOWN) is a genuine blind
+ * spot worth surfacing as amber, so `worst()` maps it to DEGRADED.
+ *
+ * Dependencies are different — they're only PASSIVELY observed. Stripe and
+ * Google OAuth get no synthetic ping, so on a low-traffic day they sit at
+ * UNKNOWN as their NORMAL idle state. Letting that idle-UNKNOWN map to DEGRADED
+ * pinned the banner permanently amber even when every flow was green. So a
+ * dependency only escalates the banner when it reports a CONCRETE
+ * DEGRADED/INCIDENT (real webhook/callback 5xx); idle-UNKNOWN is treated as OK.
+ *
+ * Exported for unit tests.
+ */
+export function rollUpOverall(
+  flowStatuses: FlowStatus[],
+  dependencyStatuses: FlowStatus[],
+): FlowStatus {
+  return worst([
+    ...flowStatuses,
+    ...dependencyStatuses.map((s) => (s === "UNKNOWN" ? "OK" : s)),
+  ]);
+}
+
+/**
  * Derive a single FlowStatus from a PathHealth observation. Exported for
  * unit tests.
  */
@@ -1257,10 +1282,10 @@ export async function getSystemStatus(): Promise<SystemStatusPayload> {
     probeGoogleOAuthDependency(),
   ];
 
-  const overall = worst([
-    ...flows.map((f) => f.status),
-    ...dependencies.map((d) => d.status),
-  ]);
+  const overall = rollUpOverall(
+    flows.map((f) => f.status),
+    dependencies.map((d) => d.status),
+  );
 
   return {
     generatedAt: new Date().toISOString(),


### PR DESCRIPTION
## Problem

The admin status banner could **never go green**. All nine flow probes read OK, but the overall roll-up folded the **Stripe** and **Google OAuth** *dependency* statuses through the same `worst()` that maps `UNKNOWN → DEGRADED`.

Those two deps are only **passively observed** — they get no synthetic ping, so liveness is inferred from organic webhook/callback traffic. On a low-traffic day there is no such traffic, so they sit at `UNKNOWN` as their **normal idle state** — permanently dragging the banner to DEGRADED even when everything is healthy.

## Fix

Extract the roll-up into a pure, unit-tested `rollUpOverall(flowStatuses, dependencyStatuses)`:

- **Flows** still contribute directly — an unmeasurable flow (`UNKNOWN`) is a genuine blind spot worth surfacing as amber, so `worst()`'s `UNKNOWN → DEGRADED` behavior is preserved for them.
- **Dependencies** only escalate the banner when they report a **concrete** `DEGRADED`/`INCIDENT` (real webhook/callback 5xx). Idle dependency-`UNKNOWN` now maps to `OK` in the roll-up, so the banner can reach green.

`worst()` itself is unchanged — this is a roll-up-level fix, the same class of bug as the earlier MCP dependency fix but at the overall level.

## Verification

- ✅ 5 new `rollUpOverall` unit tests (idle deps → OK; flow-UNKNOWN still amber; concrete dep DEGRADED/INCIDENT still escalate). **18/18 suite pass.**
- ✅ `typecheck` + `lint` clean (pre-commit hook).