### PR TITLE
fix(health): report real Stripe MRR, not provisioned-account revenue

### DIFF
--- a/src/app/admin/_dashboard/data.ts
+++ b/src/app/admin/_dashboard/data.ts
@@ -262,6 +262,8 @@ export const FALLBACK_DATA: AdminDashboardData = {
   },
   commerce: {
     mrr: 0,
+    paidSubs: 0,
+    provisionedSubs: 0,
     recentOrders: [],
     live: false,
   },

--- a/src/app/admin/_dashboard/panels.tsx
+++ b/src/app/admin/_dashboard/panels.tsx
@@ -925,7 +925,7 @@ export function CatalogState({
 // COMMERCE PANEL — MRR + orders
 // ============================================================
 export function CommercePanel({ commerceSummary }: { commerceSummary: any }) {
-  const summary = commerceSummary || { mrr: 0, recentOrders: [], live: false };
+  const summary = commerceSummary || { mrr: 0, paidSubs: 0, provisionedSubs: 0, recentOrders: [], live: false };
   const live = summary.live ?? false;
   const stateColor: Record<string, string> = {
     fulfilled: "var(--el-earth)",
@@ -941,7 +941,7 @@ export function CommercePanel({ commerceSummary }: { commerceSummary: any }) {
       title="Commerce & Conversion"
       subtitle={
         live
-          ? `active Pro subscriptions · $${summary.mrr.toLocaleString()} MRR`
+          ? `${summary.paidSubs ?? 0} paying · $${summary.mrr.toLocaleString()} MRR${(summary.provisionedSubs ?? 0) > 0 ? ` · ${summary.provisionedSubs} provisioned` : ""}`
           : "billing telemetry offline"
       }
       right={

--- a/src/app/api/admin/dashboard/route.ts
+++ b/src/app/api/admin/dashboard/route.ts
@@ -39,6 +39,7 @@ import {
 import { feedEmitTracker } from "@/services/feedEmitTracker";
 import { getLiveActivity } from "@/services/liveActivityService";
 import { getSkyConditions } from "@/services/skyConditionsService";
+import { getSubscriptionRevenueBreakdown } from "@/services/subscriptionRevenueService";
 import { getSystemStatus } from "@/services/systemStatusService";
 import { userDatabase } from "@/services/userDatabaseService";
 
@@ -120,10 +121,12 @@ export async function GET(request: NextRequest) {
         "ingredients",
         "SELECT COUNT(*)::integer AS count FROM ingredients",
       ),
-      safeCount(
-        "active subscriptions",
-        "SELECT COUNT(*)::integer AS count FROM user_subscriptions WHERE status = 'active'",
-      ),
+      // Only Stripe-backed subs are paying customers; provisioned/agent
+      // accounts (no stripe_subscription_id) are not revenue. Falls back to 0
+      // on failure, matching the safeCount() graceful-degradation pattern.
+      getSubscriptionRevenueBreakdown()
+        .then((b) => b.paidSubs)
+        .catch(() => 0),
       safeCount(
         "token transactions",
         "SELECT COUNT(*)::integer AS count FROM token_transactions",

--- a/src/services/__tests__/subscriptionRevenueService.test.ts
+++ b/src/services/__tests__/subscriptionRevenueService.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for getSubscriptionRevenueBreakdown — the single source of truth for
+ * "what counts as real subscription revenue". The rule under test: MRR is
+ * derived ONLY from Stripe-backed subs; provisioned/agent accounts (premium
+ * tier, no stripe_subscription_id) are NOT revenue. This is what stops the
+ * admin dashboard from reporting a fabricated $22.6k MRR off 944 comp subs.
+ */
+
+jest.mock("@/lib/database", () => ({
+  executeQuery: jest.fn(),
+}));
+
+import { executeQuery } from "@/lib/database";
+import {
+  getSubscriptionRevenueBreakdown,
+  PREMIUM_MONTHLY_PRICE_USD,
+} from "@/services/subscriptionRevenueService";
+
+const mockExecuteQuery = executeQuery as jest.MockedFunction<
+  typeof executeQuery
+>;
+
+describe("getSubscriptionRevenueBreakdown", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("derives MRR from Stripe-backed subs only — provisioned subs are not revenue", async () => {
+    mockExecuteQuery.mockResolvedValueOnce({
+      rows: [{ paid: 3, provisioned: 941 }],
+    } as never);
+
+    const result = await getSubscriptionRevenueBreakdown();
+
+    expect(result.paidSubs).toBe(3);
+    expect(result.provisionedSubs).toBe(941);
+    expect(result.mrr).toBe(3 * PREMIUM_MONTHLY_PRICE_USD);
+  });
+
+  it("reports $0 MRR when nobody is paying, even with hundreds provisioned", async () => {
+    mockExecuteQuery.mockResolvedValueOnce({
+      rows: [{ paid: 0, provisioned: 944 }],
+    } as never);
+
+    const result = await getSubscriptionRevenueBreakdown();
+
+    expect(result.paidSubs).toBe(0);
+    expect(result.provisionedSubs).toBe(944);
+    expect(result.mrr).toBe(0);
+  });
+
+  it("defaults to zeros on an empty result set", async () => {
+    mockExecuteQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    await expect(getSubscriptionRevenueBreakdown()).resolves.toEqual({
+      paidSubs: 0,
+      provisionedSubs: 0,
+      mrr: 0,
+    });
+  });
+
+  it("propagates query failures so callers can mark the panel offline (not a false $0)", async () => {
+    mockExecuteQuery.mockRejectedValueOnce(new Error("connection refused"));
+
+    await expect(getSubscriptionRevenueBreakdown()).rejects.toThrow(
+      "connection refused",
+    );
+  });
+});

--- a/src/services/dashboardPanelsService.ts
+++ b/src/services/dashboardPanelsService.ts
@@ -15,6 +15,7 @@ import {
   getRecentSlowQueries,
   getSlowQueryThresholdMs,
 } from "@/lib/observability/slowQueryLog";
+import { getSubscriptionRevenueBreakdown } from "@/services/subscriptionRevenueService";
 
 // ─── Cosmic Yield · token economy ──────────────────────────────────────
 
@@ -493,6 +494,10 @@ export interface PractitionerCohortsData {
 
 export interface CommerceSummaryData {
   mrr: number;
+  /** Stripe-backed subs — actual paying customers. */
+  paidSubs: number;
+  /** Premium subs with no Stripe link — provisioned/agent accounts, $0 revenue. */
+  provisionedSubs: number;
   recentOrders: Array<{
     id: string;
     user: string;
@@ -627,8 +632,12 @@ export async function getPractitionerCohorts(): Promise<PractitionerCohortsData>
 
 export async function getCommerceTelemetry(): Promise<CommerceSummaryData> {
   try {
-    const [subCountRes, ordersRes] = await Promise.all([
-      executeQuery("SELECT COUNT(*)::integer AS count FROM user_subscriptions WHERE status = 'active'").catch(() => ({ rows: [{ count: 0 }] })),
+    const [revenue, ordersRes] = await Promise.all([
+      getSubscriptionRevenueBreakdown().catch(() => ({
+        paidSubs: 0,
+        provisionedSubs: 0,
+        mrr: 0,
+      })),
       executeQuery(`
         SELECT 
           c.id, 
@@ -654,8 +663,7 @@ export async function getCommerceTelemetry(): Promise<CommerceSummaryData> {
       `).catch(() => ({ rows: [] })),
     ]);
 
-    const activeSubs = Number(subCountRes.rows[0]?.count ?? 0);
-    const mrr = activeSubs * 24.00;
+    const { paidSubs, provisionedSubs, mrr } = revenue;
 
     const recentOrders = (ordersRes.rows as Array<{
       id: string;
@@ -673,10 +681,12 @@ export async function getCommerceTelemetry(): Promise<CommerceSummaryData> {
       status: String(r.status),
     }));
 
-    // Real MRR (active subs × price) and real cart/order intents — including
-    // empty — never a fabricated placeholder order.
+    // Real MRR (Stripe-backed subs × price) and real cart/order intents —
+    // including empty — never a fabricated placeholder order.
     return {
       mrr,
+      paidSubs,
+      provisionedSubs,
       recentOrders,
       live: true,
     };
@@ -684,6 +694,8 @@ export async function getCommerceTelemetry(): Promise<CommerceSummaryData> {
     _logger.error("[getCommerceTelemetry] failed:", error);
     return {
       mrr: 0,
+      paidSubs: 0,
+      provisionedSubs: 0,
       recentOrders: [],
       live: false,
     };

--- a/src/services/subscriptionRevenueService.ts
+++ b/src/services/subscriptionRevenueService.ts
@@ -1,0 +1,57 @@
+/**
+ * Subscription Revenue Service (server-only)
+ *
+ * The single source of truth for "what counts as real subscription revenue".
+ * Kept out of the isomorphic subscriptionService (whose lazy DB pattern exists
+ * to keep `pg` out of client bundles) — this statically imports executeQuery
+ * and is only ever pulled in by server-side admin telemetry.
+ *
+ * @file src/services/subscriptionRevenueService.ts
+ */
+
+import { executeQuery } from "@/lib/database";
+
+/** Monthly price of the single paid tier, in USD. Used to derive MRR. */
+export const PREMIUM_MONTHLY_PRICE_USD = 24;
+
+export interface SubscriptionRevenueBreakdown {
+  /** Active subs backed by a real Stripe subscription — actual paying customers. */
+  paidSubs: number;
+  /**
+   * Active premium subs with NO Stripe link — agent/comp/provisioned accounts.
+   * Real members, but they generate $0, so they are NOT counted as revenue.
+   */
+  provisionedSubs: number;
+  /** Monthly recurring revenue from paid subs only (paidSubs × price). */
+  mrr: number;
+}
+
+/**
+ * Split active subscriptions into REAL revenue (Stripe-backed) vs provisioned
+ * accounts (premium tier, no Stripe subscription).
+ *
+ * Counting provisioned subs as revenue fabricated the admin dashboard's MRR —
+ * 944 auto-provisioned "premium" rows with zero stripe_subscription_id read as
+ * $22.6k/mo when actual Stripe revenue is $0. MRR is derived ONLY from
+ * Stripe-linked subs so it reflects money that actually changes hands.
+ *
+ * Throws when the query fails, so telemetry callers can mark their panel
+ * offline instead of reporting a misleading $0.
+ */
+export async function getSubscriptionRevenueBreakdown(): Promise<SubscriptionRevenueBreakdown> {
+  const result = await executeQuery<{ paid: number; provisioned: number }>(
+    `SELECT
+        COUNT(*) FILTER (WHERE stripe_subscription_id IS NOT NULL)::int AS paid,
+        COUNT(*) FILTER (WHERE stripe_subscription_id IS NULL
+                           AND tier = 'premium')::int                  AS provisioned
+       FROM user_subscriptions
+      WHERE status = 'active'`,
+  );
+  const paidSubs = Number(result.rows[0]?.paid ?? 0);
+  const provisionedSubs = Number(result.rows[0]?.provisioned ?? 0);
+  return {
+    paidSubs,
+    provisionedSubs,
+    mrr: paidSubs * PREMIUM_MONTHLY_PRICE_USD,
+  };
+}

--- a/src/services/systemStatusService.ts
+++ b/src/services/systemStatusService.ts
@@ -29,6 +29,7 @@ import { getServiceUrlSafe } from "@/lib/serviceUrls";
 import { getEventCounts } from "@/services/authEventsService";
 import { feedEmitTracker } from "@/services/feedEmitTracker";
 import { getMcpNetworkSummary } from "@/services/mcpNetworkService";
+import { getSubscriptionRevenueBreakdown } from "@/services/subscriptionRevenueService";
 import {
   getLatestProbeResults,
   type LatestProbeRow,
@@ -697,14 +698,13 @@ async function probePayments(latest: LatestProbeRow[]): Promise<FlowHealth> {
   const combined = [checkout, webhook, portal];
 
   let mrr = 0;
-  let activeSubs = 0;
+  let paidSubs = 0;
+  let provisionedSubs = 0;
   let live = true;
   try {
-    const result = await executeQuery<{ active: number }>(
-      `SELECT COUNT(*)::int AS active FROM user_subscriptions WHERE status = 'active' AND tier = 'premium'`,
-    );
-    activeSubs = result.rows[0]?.active ?? 0;
-    mrr = activeSubs * 24;
+    // Only Stripe-backed subs are revenue; provisioned/agent accounts are not.
+    ({ paidSubs, provisionedSubs, mrr } =
+      await getSubscriptionRevenueBreakdown());
   } catch (err) {
     _logger.warn("[systemStatus] subscriptions query failed:", err);
     live = false;
@@ -749,7 +749,7 @@ async function probePayments(latest: LatestProbeRow[]): Promise<FlowHealth> {
     status,
     summary:
       status === "OK"
-        ? `${activeSubs} active subs · MRR $${mrr.toLocaleString()}`
+        ? `${paidSubs} paid · MRR $${mrr.toLocaleString()}${provisionedSubs > 0 ? ` · ${provisionedSubs} provisioned` : ""}`
         : status === "DEGRADED"
           ? synthetic.stale
             ? "Synthetic stripe-webhook probe stale"
@@ -760,8 +760,13 @@ async function probePayments(latest: LatestProbeRow[]): Promise<FlowHealth> {
               : `Stripe endpoints failing (${formatPct(errorRate)})`
             : "No payment traffic in window",
     metrics: [
-      { label: "Active subs", value: `${activeSubs}`, raw: activeSubs },
+      { label: "Paid subs", value: `${paidSubs}`, raw: paidSubs },
       { label: "MRR", value: `$${mrr.toLocaleString()}`, raw: mrr },
+      {
+        label: "Provisioned",
+        value: `${provisionedSubs}`,
+        raw: provisionedSubs,
+      },
       {
         label: "Webhook 5xx · 1h",
         value: `${webhook.errors5xx}`,


### PR DESCRIPTION
## Problem

The admin payments panel showed **"944 active subs · MRR $22,656"** — entirely fabricated.

Every one of those 944 premium subscriptions has a **NULL `stripe_subscription_id`**: they're auto-provisioned agent/comp accounts, not paying customers. There is no Stripe/payment/webhook table at all, and **real Stripe MRR is $0**.

Three separate `COUNT(*)` queries each multiplied an unfiltered active-sub count by $24:

| Surface | Query |
|---|---|
| `probePayments` (payments health panel) | `status='active' AND tier='premium'` |
| `getCommerceTelemetry` (commerce panel + hero MRR) | `status='active'` |
| dashboard route (`totalSubscriptions`, hero "944 subs") | `status='active'` |

An operator reading **any** of these would believe $22.6k MRR and 944 paying customers existed.

## Fix

Centralize "what counts as real revenue" in one server-only helper, `getSubscriptionRevenueBreakdown()`:

- `paidSubs` = active subs with a Stripe subscription (actual payers)
- `provisionedSubs` = active premium subs with **no** Stripe link (comp/agent, $0)
- `mrr` = `paidSubs × price` — provisioned subs are **never** revenue

All three call sites now go through it. The payments + commerce panels surface **paid vs provisioned** (so the 944 comp accounts stay visible — just not counted as money), and the hero "subs" stat counts paying subs only. With no Stripe-linked subs today, every surface truthfully reads **$0 MRR**.

The helper is deliberately a new **server-only** module (static `executeQuery`), kept out of the isomorphic `subscriptionService` whose lazy-DB pattern keeps `pg` out of client bundles — this also makes it unit-testable.

## Verification

- ✅ 4 new unit tests for `getSubscriptionRevenueBreakdown` (MRR from paid only; $0 with 944 provisioned; empty-set zeros; failure propagates so the panel goes offline, not a false $0).
- ✅ `typecheck` + `lint` clean (pre-commit hook).

## Note

This corrects *display* only — it does not touch provisioning. If comp/agent accounts should not be `tier='premium'` at all, that's a separate data-model decision.