### PR TITLE
perf(feed): cache Live Network Feed pollers + jitter the poll to cut DB pressure

### DIFF
--- a/src/__tests__/lib/redisCached.test.ts
+++ b/src/__tests__/lib/redisCached.test.ts
@@ -1,0 +1,78 @@
+// Mock @upstash/redis with a controllable in-memory store so the read-through
+// cache path is exercised deterministically — no network, no real Upstash.
+const mockStore = new Map<string, unknown>();
+jest.mock("@upstash/redis", () => ({
+  Redis: jest.fn().mockImplementation(() => ({
+    get: jest.fn(async (key: string) =>
+      mockStore.has(key) ? mockStore.get(key) : null,
+    ),
+    set: jest.fn(async (key: string, value: unknown) => {
+      mockStore.set(key, value);
+      return "OK";
+    }),
+    del: jest.fn(async (key: string) => (mockStore.delete(key) ? 1 : 0)),
+  })),
+}));
+
+describe("redisCached", () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    mockStore.clear();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  function configureUpstash() {
+    process.env.UPSTASH_REDIS_REST_URL = "https://example.upstash.io";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "test-token";
+  }
+
+  it("runs the loader on a miss, caches it, and serves the next call from cache", async () => {
+    configureUpstash();
+    const { redisCached } = await import("@/lib/redis");
+
+    const loader = jest.fn(async () => [{ id: 1 }]);
+    const first = await redisCached("feed:recent:40:0", 30, loader);
+    const second = await redisCached("feed:recent:40:0", 30, loader);
+
+    expect(first).toEqual([{ id: 1 }]);
+    expect(second).toEqual([{ id: 1 }]);
+    expect(loader).toHaveBeenCalledTimes(1); // second served from cache
+  });
+
+  it("caches an empty array as a valid hit (does not treat [] as a miss)", async () => {
+    configureUpstash();
+    const { redisCached } = await import("@/lib/redis");
+
+    const loader = jest.fn(async () => [] as unknown[]);
+    await redisCached("k:empty", 30, loader);
+    const again = await redisCached("k:empty", 30, loader);
+
+    expect(again).toEqual([]);
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys are independent", async () => {
+    configureUpstash();
+    const { redisCached } = await import("@/lib/redis");
+
+    expect(await redisCached("a", 30, async () => "A")).toBe("A");
+    expect(await redisCached("b", 30, async () => "B")).toBe("B");
+  });
+
+  it("fails open when Upstash is unconfigured: loader runs every call, value still returned", async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    const { redisCached } = await import("@/lib/redis");
+
+    const loader = jest.fn(async () => 42);
+    expect(await redisCached("k:noredis", 30, loader)).toBe(42);
+    expect(await redisCached("k:noredis", 30, loader)).toBe(42);
+    expect(loader).toHaveBeenCalledTimes(2); // no cache available → no dedupe
+  });
+});

--- a/src/app/(alchm)/feed/page.tsx
+++ b/src/app/(alchm)/feed/page.tsx
@@ -255,10 +255,20 @@ export default function FeedPage() {
   // the feed itself when the SpacetimeDB subscription below isn't live.
   useEffect(() => {
     void refreshAll();
-    const id = window.setInterval(() => {
-      if (document.visibilityState === "visible") void refreshAll();
-    }, 30_000);
-    return () => window.clearInterval(id);
+    // Jittered ~30–40s poll (not a fixed setInterval): spreading each client's
+    // tick over a 10s window stops thousands of tabs from hitting /api/feed and
+    // its companion tickers in lockstep, which would spike DB connections at
+    // influx. Re-jitter every tick so clients don't re-converge over time.
+    let timer = 0;
+    const schedule = () => {
+      const delay = 30_000 + Math.floor(Math.random() * 10_000);
+      timer = window.setTimeout(() => {
+        if (document.visibilityState === "visible") void refreshAll();
+        schedule();
+      }, delay);
+    };
+    schedule();
+    return () => window.clearTimeout(timer);
   }, [refreshAll]);
 
   // Real-time feed events pushed over the SpacetimeDB WebSocket (the

--- a/src/app/api/community/agents/route.ts
+++ b/src/app/api/community/agents/route.ts
@@ -8,9 +8,16 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 import { executeQuery } from "@/lib/database";
+import { redisCached } from "@/lib/redis";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+// Polled every ~30s by the Live Network Feed. The backing query aggregates
+// feed_events across every active agent, so a per-client poll storm is the
+// expensive case. The agent roster changes slowly, so a short shared cache is
+// safe and collapses the storm to one query per limit per TTL (fails open).
+const AGENTS_CACHE_TTL_SECONDS = 30;
 
 interface AgentRow {
   user_id: string;
@@ -28,38 +35,53 @@ export async function GET(req: NextRequest) {
   const limit = Math.min(parseInt(searchParams.get("limit") || "60", 10), 200);
 
   try {
-    const result = await executeQuery<AgentRow>(
-      `SELECT u.id AS user_id,
-              u.email,
-              up.name,
-              up.bio,
-              up.dominant_element,
-              up.monica_constant,
-              MAX(f.created_at) AS last_action_at,
-              COUNT(f.id) AS action_count
-         FROM users u
-         LEFT JOIN user_profiles up ON up.user_id = u.id
-         LEFT JOIN feed_events f ON f.actor_id = u.id
-        WHERE COALESCE(u.is_agent, false) = true
-          AND u.is_active = true
-        GROUP BY u.id, u.email, up.name, up.bio, up.dominant_element, up.monica_constant
-        ORDER BY MAX(f.created_at) DESC NULLS LAST
-        LIMIT $1`,
-      [limit],
+    const agents = await redisCached(
+      `community:agents:${limit}`,
+      AGENTS_CACHE_TTL_SECONDS,
+      async () => {
+        const result = await executeQuery<AgentRow>(
+          `SELECT u.id AS user_id,
+                  u.email,
+                  up.name,
+                  up.bio,
+                  up.dominant_element,
+                  up.monica_constant,
+                  MAX(f.created_at) AS last_action_at,
+                  COUNT(f.id) AS action_count
+             FROM users u
+             LEFT JOIN user_profiles up ON up.user_id = u.id
+             LEFT JOIN feed_events f ON f.actor_id = u.id
+            WHERE COALESCE(u.is_agent, false) = true
+              AND u.is_active = true
+            GROUP BY u.id, u.email, up.name, up.bio, up.dominant_element, up.monica_constant
+            ORDER BY MAX(f.created_at) DESC NULLS LAST
+            LIMIT $1`,
+          [limit],
+        );
+
+        return result.rows.map((row) => ({
+          userId: row.user_id,
+          handle: row.email,
+          name: row.name || row.email.split("@")[0],
+          bio: row.bio,
+          dominantElement: row.dominant_element,
+          monicaConstant: row.monica_constant
+            ? parseFloat(row.monica_constant)
+            : null,
+          lastActionAt: row.last_action_at,
+          actionCount: parseInt(row.action_count, 10) || 0,
+        }));
+      },
     );
 
-    const agents = result.rows.map((row) => ({
-      userId: row.user_id,
-      handle: row.email,
-      name: row.name || row.email.split("@")[0],
-      bio: row.bio,
-      dominantElement: row.dominant_element,
-      monicaConstant: row.monica_constant ? parseFloat(row.monica_constant) : null,
-      lastActionAt: row.last_action_at,
-      actionCount: parseInt(row.action_count, 10) || 0,
-    }));
-
-    return NextResponse.json({ success: true, agents });
+    return NextResponse.json(
+      { success: true, agents },
+      {
+        headers: {
+          "Cache-Control": `public, s-maxage=${AGENTS_CACHE_TTL_SECONDS}, stale-while-revalidate=60`,
+        },
+      },
+    );
   } catch (error) {
     console.error("[GET /api/community/agents]", error);
     return NextResponse.json(

--- a/src/app/api/economy/transactions/recent/route.ts
+++ b/src/app/api/economy/transactions/recent/route.ts
@@ -8,9 +8,16 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 import { executeQuery } from "@/lib/database";
+import { redisCached } from "@/lib/redis";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+// Public, globally-shared ticker polled every ~30s by the Live Network Feed.
+// A short shared cache collapses the per-client poll storm into one query per
+// limit per TTL (fails open to a direct read). A handful of seconds of lag on
+// a "recent transactions" ticker is imperceptible.
+const TXNS_CACHE_TTL_SECONDS = 10;
 
 interface TxnRow {
   id: string;
@@ -30,39 +37,52 @@ export async function GET(req: NextRequest) {
   const limit = Math.min(parseInt(searchParams.get("limit") || "30", 10), 100);
 
   try {
-    const result = await executeQuery<TxnRow>(
-      `SELECT t.id::text,
-              t.transaction_group_id::text,
-              t.user_id::text,
-              t.token_type,
-              t.amount::text,
-              t.source_type,
-              t.description,
-              t.created_at,
-              u.is_agent,
-              up.name AS actor_name
-         FROM token_transactions t
-         JOIN users u ON u.id = t.user_id
-         LEFT JOIN user_profiles up ON up.user_id = u.id
-        ORDER BY t.created_at DESC
-        LIMIT $1`,
-      [limit],
+    const transactions = await redisCached(
+      `economy:txns:recent:${limit}`,
+      TXNS_CACHE_TTL_SECONDS,
+      async () => {
+        const result = await executeQuery<TxnRow>(
+          `SELECT t.id::text,
+                  t.transaction_group_id::text,
+                  t.user_id::text,
+                  t.token_type,
+                  t.amount::text,
+                  t.source_type,
+                  t.description,
+                  t.created_at,
+                  u.is_agent,
+                  up.name AS actor_name
+             FROM token_transactions t
+             JOIN users u ON u.id = t.user_id
+             LEFT JOIN user_profiles up ON up.user_id = u.id
+            ORDER BY t.created_at DESC
+            LIMIT $1`,
+          [limit],
+        );
+
+        return result.rows.map((row) => ({
+          id: row.id,
+          transactionGroupId: row.transaction_group_id,
+          userId: row.user_id,
+          tokenType: row.token_type,
+          amount: parseFloat(row.amount) || 0,
+          sourceType: row.source_type,
+          description: row.description,
+          createdAt: row.created_at,
+          actorIsAgent: row.is_agent === true,
+          actorName: row.actor_name || (row.is_agent ? "Agent" : "Alchemist"),
+        }));
+      },
     );
 
-    const transactions = result.rows.map((row) => ({
-      id: row.id,
-      transactionGroupId: row.transaction_group_id,
-      userId: row.user_id,
-      tokenType: row.token_type,
-      amount: parseFloat(row.amount) || 0,
-      sourceType: row.source_type,
-      description: row.description,
-      createdAt: row.created_at,
-      actorIsAgent: row.is_agent === true,
-      actorName: row.actor_name || (row.is_agent ? "Agent" : "Alchemist"),
-    }));
-
-    return NextResponse.json({ success: true, transactions });
+    return NextResponse.json(
+      { success: true, transactions },
+      {
+        headers: {
+          "Cache-Control": `public, s-maxage=${TXNS_CACHE_TTL_SECONDS}, stale-while-revalidate=30`,
+        },
+      },
+    );
   } catch (error) {
     console.error("[GET /api/economy/transactions/recent]", error);
     return NextResponse.json(

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -19,6 +19,7 @@
 
 import { timingSafeEqual } from "node:crypto";
 import { NextResponse } from "next/server";
+import { redisCached } from "@/lib/redis";
 import { feedDatabase } from "@/services/feedDatabaseService";
 import { feedEmitTracker } from "@/services/feedEmitTracker";
 import { notificationDatabase } from "@/services/notificationDatabaseService";
@@ -85,18 +86,39 @@ async function extractWebhookPreview(request: Request) {
   }
 }
 
+// The public GET feed is polled ~every 30s per client. Under a real-user
+// influx that fans out into one getRecentEvents() query per client per poll,
+// against a 100-connection Postgres. A brief shared cache collapses every
+// client's polls into at most one DB read per (limit,offset) per TTL; the
+// matching s-maxage lets the Vercel edge absorb repeat hits where it isn't
+// cookie-bypassed. Both layers fail open — a Redis miss/outage reads the DB
+// directly. ~12s of feed staleness is invisible (the real-time path is the
+// SpacetimeDB subscription; this HTTP poll is the degraded fallback).
+const FEED_CACHE_TTL_SECONDS = 12;
+
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
     const limit = Math.min(parseInt(searchParams.get("limit") ?? "20", 10), 100);
     const offset = parseInt(searchParams.get("offset") || "0", 10);
 
-    const events = await feedDatabase.getRecentEvents(limit, offset);
+    const events = await redisCached(
+      `feed:recent:${limit}:${offset}`,
+      FEED_CACHE_TTL_SECONDS,
+      () => feedDatabase.getRecentEvents(limit, offset),
+    );
 
-    return NextResponse.json({
-      success: true,
-      events,
-    });
+    return NextResponse.json(
+      {
+        success: true,
+        events,
+      },
+      {
+        headers: {
+          "Cache-Control": `public, s-maxage=${FEED_CACHE_TTL_SECONDS}, stale-while-revalidate=30`,
+        },
+      },
+    );
   } catch (error) {
     console.error("Feed fetch error:", error);
     return NextResponse.json(

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -63,3 +63,26 @@ export async function redisDel(key: string): Promise<void> {
     console.error("[Redis] DEL failed:", err);
   }
 }
+
+/**
+ * Read-through cache. Returns the cached value for `key`; on a miss it runs
+ * `loader`, caches the result for `ttlSeconds`, and returns it.
+ *
+ * Fails OPEN: if Upstash is unconfigured or errors, redisGet/redisSet degrade
+ * to null/no-op, so the caller transparently falls back to `loader` (a direct
+ * read) rather than surfacing an error. Intended for short TTLs on hot,
+ * globally-shared read endpoints (e.g. the Live Network Feed pollers), where a
+ * few seconds of staleness is fine and the goal is to collapse a poll storm
+ * into at most one backing query per key per TTL.
+ */
+export async function redisCached<T>(
+  key: string,
+  ttlSeconds: number,
+  loader: () => Promise<T>,
+): Promise<T> {
+  const cached = await redisGet<T>(key);
+  if (cached !== null && cached !== undefined) return cached;
+  const fresh = await loader();
+  await redisSet(key, fresh, ttlSeconds);
+  return fresh;
+}


### PR DESCRIPTION
## Why
Pre-influx scale hardening. The `/feed` (Live Network Feed) page polls **four endpoints every 30s per client**. Three are public, globally-shared reads that hit Postgres on **every** poll:

- `/api/feed` — recent feed events
- `/api/community/agents` — a `feed_events` aggregate (`users ⋈ user_profiles ⋈ feed_events` GROUP BY) over **every** agent (~4,500 rows)
- `/api/economy/transactions/recent` — the public token ticker

At a real-user influx, N clients polling in lockstep fan out into N DB query-sets every 30s against a **100-connection** Postgres that the app pools at **5 conns/instance in direct mode (no PgBouncer)**. So **connection exhaustion — not slow queries — is the first thing to break** (~20 concurrent Vercel instances saturate the ceiling). Indexes are already present; the lever here is collapsing redundant reads.

## What
Two low-risk changes:

1. **Short read-through Redis cache** on the three public read endpoints via a new `redisCached(key, ttl, loader)` helper (`src/lib/redis.ts`): **12s** feed / **30s** agents / **10s** txns, keyed by `limit`/`offset`. All clients' polls collapse into **at most one backing query per key per TTL**.
   - **Fails OPEN**: a Redis miss/outage (or unconfigured Upstash) reads the DB directly — never an error.
   - A matching `Cache-Control: public, s-maxage=<ttl>, stale-while-revalidate=…` lets the Vercel edge absorb repeats where the request isn't cookie-bypassed (best-effort; the Redis layer is the load-bearing DB protection).
   - A few seconds of ticker staleness is invisible — the feed's real-time path is the SpacetimeDB subscription; this HTTP poll is the documented degraded fallback.
2. **Jittered poll** (`src/app/(alchm)/feed/page.tsx`): replace the fixed 30s `setInterval` with a re-jittered **30–40s** self-scheduling timeout so thousands of tabs don't hit the endpoints in a synchronized thundering herd. (The existing in-flight guard and visibility check are preserved.)

## Verification
- ✅ New unit test for the read-through helper — hit / miss / empty-array-is-a-hit / fails-open-when-unconfigured (`src/__tests__/lib/redisCached.test.ts`, 4/4 passing).
- ✅ `typecheck` + `lint` clean (pre-commit `verify`).
- ⏭️ Not browser-verified locally: dev env has no `DATABASE_URL`/`UPSTASH`, so a local server can't exercise these DB+Redis-backed endpoints. **Post-deploy** the effect is observable on the admin dashboard's *Database · Active Connections* / slow-query panels under load and via Upstash cache-hit metrics.

## Scope / follow-ups (not in this PR — one concern each)
- The root connection-ceiling fix is to route prod `DATABASE_URL` through **PgBouncer (transaction mode)**; this PR reduces the blast radius, it doesn't replace that.
- `/api/economy/swap-rates` (4th poll) is already in-memory computed (no DB); left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)