### PR TITLE
fix(auth): make the new-user signup grant resilient + detectable

### DIFF
--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -317,6 +317,15 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             if (!dbUser) return;
             logger.info(`Starting background tasks for ${user.email}`);
             
+            // Welcome token grant — run FIRST. It's the cheapest, most
+            // user-critical background task, so completing it before the slower
+            // natal-chart calc and emails minimises the chance it's dropped if
+            // this fire-and-forget task is frozen after the sign-in response is
+            // sent. The helper is idempotent + retried internally, and re-runs
+            // on every sign-in, so a once-failed grant self-heals next time.
+            const { tokenEconomy } = await import("@/services/TokenEconomyService");
+            await tokenEconomy.grantSignupBonus(dbUser.id);
+
             // 0. Calculate and synchronize natal chart if birth data is present but not computed
             const profile = (dbUser)?.profile || {};
             if (profile.birthData && (!profile.natalChart || !profile.onboardingComplete)) {
@@ -444,31 +453,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
                 });
                 logger.info(`Auto-provisioned premium for ${user.email}`);
               }
-            }
-
-            // 1b. Welcome token grant — every new user starts with a small
-            // even balance so they can try a couple of actions before
-            // claiming their first daily Cosmic Yield (which itself requires
-            // a completed natal chart). Idempotent via the per-user key, so
-            // repeated sign-ins do not re-grant.
-            try {
-              const { tokenEconomy } = await import("@/services/TokenEconomyService");
-              await tokenEconomy.creditMultipleTokens(
-                dbUser.id,
-                [
-                  { tokenType: "Spirit", amount: 15 },
-                  { tokenType: "Essence", amount: 15 },
-                  { tokenType: "Matter", amount: 15 },
-                  { tokenType: "Substance", amount: 15 },
-                ],
-                "signup_grant",
-                {
-                  description: "Welcome to Alchm.kitchen — starter cosmic balance",
-                  idempotencyKey: `signup_grant:${dbUser.id}`,
-                },
-              );
-            } catch (grantError) {
-              logger.warn("Welcome token grant failed (non-blocking):", grantError);
             }
 
             // 2. Send emails

--- a/src/services/TokenEconomyService.ts
+++ b/src/services/TokenEconomyService.ts
@@ -400,6 +400,65 @@ class TokenEconomyService {
   }
 
   // ═══════════════════════════════════════════════════════════════════
+  // SIGNUP GRANT
+  // ═══════════════════════════════════════════════════════════════════
+
+  /** Welcome grant: every new user starts with this even ESMS balance. */
+  static readonly SIGNUP_GRANT_PER_TOKEN = 15;
+
+  /**
+   * Grant (or heal) a new user's one-time welcome balance.
+   *
+   * Idempotent via the per-user key `signup_grant:<userId>` (per-token under
+   * the hood), so it is safe to call on every sign-in: an already-granted user
+   * is a cheap no-op, and a user whose grant failed once is healed the next
+   * time they sign in.
+   *
+   * Resilient by design. `creditMultipleTokens` swallows DB errors and returns
+   * `null` rather than throwing, so the previous caller's try/catch was dead
+   * code — a transient blip (likely during a cold-start sign-in storm at
+   * influx) dropped the grant silently and left the user token-broke with no
+   * signal. Here we treat a `null` result as failure, retry a few times with
+   * short backoff (the grant is all-or-nothing + idempotent, so a replay can
+   * never double-credit), and on final failure log a distinct, greppable error.
+   *
+   * @returns true if the grant is in place (freshly applied or already
+   *          present), false if every attempt failed.
+   */
+  async grantSignupBonus(userId: string): Promise<boolean> {
+    const amount = TokenEconomyService.SIGNUP_GRANT_PER_TOKEN;
+    const credits = (
+      ["Spirit", "Essence", "Matter", "Substance"] as TokenType[]
+    ).map((tokenType) => ({ tokenType, amount }));
+    const backoffsMs = [0, 250, 750];
+
+    for (let attempt = 0; attempt < backoffsMs.length; attempt++) {
+      if (backoffsMs[attempt] > 0) {
+        await new Promise((resolve) => setTimeout(resolve, backoffsMs[attempt]));
+      }
+      const result = await this.creditMultipleTokens(
+        userId,
+        credits,
+        "signup_grant",
+        {
+          description: "Welcome to Alchm.kitchen — starter cosmic balance",
+          idempotencyKey: `signup_grant:${userId}`,
+        },
+      );
+      if (result !== null) return true;
+      _logger.warn(
+        `[TokenEconomy] signup grant attempt ${attempt + 1}/${backoffsMs.length} failed for ${userId}`,
+      );
+    }
+
+    _logger.error(
+      `[TokenEconomy] signup_grant_failed — exhausted retries for user ${userId}; ` +
+        "starting balance stays zero until a later sign-in re-attempts the grant",
+    );
+    return false;
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
   // DAILY CLAIM TRACKING
   // ═══════════════════════════════════════════════════════════════════
 

--- a/src/services/__tests__/TokenEconomyService.grantSignupBonus.test.ts
+++ b/src/services/__tests__/TokenEconomyService.grantSignupBonus.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for tokenEconomy.grantSignupBonus — the resilient welcome-grant path.
+ *
+ * Why this exists: creditMultipleTokens swallows DB errors and returns `null`
+ * (it never throws), so the previous sign-in caller's try/catch was dead code
+ * and a transient blip dropped a new user's grant silently. grantSignupBonus
+ * treats `null` as failure, retries (the grant is idempotent, so a replay can
+ * never double-credit), and reports a hard failure instead of staying silent.
+ */
+
+import { tokenEconomy } from "@/services/TokenEconomyService";
+import type { TokenBalances } from "@/types/economy";
+
+const FAKE_BALANCES = {} as TokenBalances; // truthy => "grant applied"
+const USER = "11111111-2222-3333-4444-555555555555";
+
+describe("tokenEconomy.grantSignupBonus", () => {
+  let credit: jest.SpyInstance;
+
+  beforeEach(() => {
+    credit = jest.spyOn(tokenEconomy, "creditMultipleTokens");
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("grants 15 of each ESMS token under the per-user idempotency key and returns true", async () => {
+    credit.mockResolvedValue(FAKE_BALANCES);
+
+    const ok = await tokenEconomy.grantSignupBonus(USER);
+
+    expect(ok).toBe(true);
+    expect(credit).toHaveBeenCalledTimes(1);
+    expect(credit).toHaveBeenCalledWith(
+      USER,
+      expect.arrayContaining([
+        { tokenType: "Spirit", amount: 15 },
+        { tokenType: "Essence", amount: 15 },
+        { tokenType: "Matter", amount: 15 },
+        { tokenType: "Substance", amount: 15 },
+      ]),
+      "signup_grant",
+      expect.objectContaining({ idempotencyKey: `signup_grant:${USER}` }),
+    );
+  });
+
+  it("retries when a credit attempt returns null, then succeeds", async () => {
+    credit
+      .mockResolvedValueOnce(null) // transient blip
+      .mockResolvedValueOnce(FAKE_BALANCES); // retry succeeds
+
+    const ok = await tokenEconomy.grantSignupBonus(USER);
+
+    expect(ok).toBe(true);
+    expect(credit).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns false after exhausting retries when every attempt fails", async () => {
+    credit.mockResolvedValue(null);
+
+    const ok = await tokenEconomy.grantSignupBonus(USER);
+
+    expect(ok).toBe(false);
+    expect(credit).toHaveBeenCalledTimes(3); // bounded, not infinite
+  });
+});


### PR DESCRIPTION
## Why
Pre-influx new-user-journey hardening (ranked fix #4). A brand-new user's **welcome grant** (15 of each ESMS token) is what lets them try a couple of actions before their first daily Cosmic Yield. It ran in the sign-in callback's **fire-and-forget background IIFE**, with two latent failure modes that only bite under real load:

1. **Silent drop on a transient blip.** `creditMultipleTokens` catches its own DB errors and returns `null` — it never throws. So the previous caller's `try/catch (grantError)` was **dead code**: a failed grant returned null, was ignored, and the user was left **token-broke from birth** with no signal until they hit a 402 on their *second* generation (the first is free). Detection: zero.
2. **Never runs at all on a cold start.** The grant sat *after* a slow natal-chart computation in a task that isn't awaited — on Vercel that IIFE can be frozen after the sign-in response is sent, so the grant may never execute.

In prod all **7** real OAuth users have their grant today (verified), so this isn't currently broken — but a cold-start sign-in storm at influx is exactly when both modes trigger.

## What
- **New `tokenEconomy.grantSignupBonus(userId)`** (`TokenEconomyService.ts`): treats a `null` credit result as failure and **retries with short backoff** (the grant is all-or-nothing + per-token idempotent via `signup_grant:<userId>`, so a replay can never double-credit). On final failure it logs a **distinct, greppable `signup_grant_failed` error** instead of staying silent. Centralizes the 15-each amount that was inline in `auth.ts`.
- **Runs FIRST** in the sign-in background tasks (before natal-chart calc + emails) so the cheapest, most user-critical task is least likely to be cut short.
- **Self-heals**: it re-runs every sign-in (idempotent), so a user whose first-sign-in grant failed is topped up on their next sign-in.

## Verification
- ✅ New unit tests: success / retry-then-succeed / exhausted-retries-returns-false (`TokenEconomyService.grantSignupBonus.test.ts`, 3/3).
- ✅ `typecheck` + `lint` clean (pre-commit `verify`).
- ⏭️ Not browser-verified: exercising it needs a real Google OAuth new-user sign-in (no local OAuth/DB). Post-deploy it's observable via `token_transactions` (`source_type='signup_grant'` rows per new OAuth user) and the new `signup_grant_failed` error log if anything fails.

## Follow-ups (separate concern, not here)
- The deeper guarantee would be granting atomically inside the user-creation transaction so it can't depend on a survivable background task at all — noted as a candidate if we want belt-and-suspenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)