### PR TITLE
fix(dashboard): Practitioner Cohorts — read canonical sources, not vestigial JSONB

### DIFF
--- a/src/services/__tests__/getPractitionerCohorts.test.ts
+++ b/src/services/__tests__/getPractitionerCohorts.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment node
+ *
+ * Regression guard for the Practitioner Cohorts panel. It must report:
+ *  - paidPro from the SAME revenue breakdown that drives the Commerce MRR panel
+ *    (Stripe-backed payers only) — never the ~950 comp/provisioned premium subs,
+ *    which used to make "Paid Pro" contradict "MRR $0".
+ *  - onboarded + elemental from the canonical user_profiles columns, NOT the
+ *    vestigial users.profile JSONB (which showed ~61 onboarded / 99.6% Unknown).
+ */
+
+jest.mock("@/lib/database", () => ({ executeQuery: jest.fn() }));
+jest.mock("@/services/subscriptionRevenueService", () => ({
+  getSubscriptionRevenueBreakdown: jest.fn(),
+}));
+
+import { executeQuery } from "@/lib/database";
+import { getSubscriptionRevenueBreakdown } from "@/services/subscriptionRevenueService";
+import { getPractitionerCohorts } from "@/services/dashboardPanelsService";
+
+const mockQ = executeQuery as jest.Mock;
+const mockRev = getSubscriptionRevenueBreakdown as jest.Mock;
+
+describe("getPractitionerCohorts", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("uses canonical sources + revenue paidSubs (never JSONB, never all-active subs)", async () => {
+    // 955 provisioned premium, 0 paying — the trap the old query fell into.
+    mockRev.mockResolvedValue({ paidSubs: 0, provisionedSubs: 955, mrr: 0 });
+    mockQ.mockImplementation((sql: string) => {
+      if (/FROM users\b/.test(sql) && /is_active/.test(sql))
+        return Promise.resolve({ rows: [{ count: 200 }] }); // active
+      if (/FROM users\b/.test(sql))
+        return Promise.resolve({ rows: [{ count: 4528 }] }); // total signups
+      if (/user_profiles/.test(sql) && /onboarding_completed/.test(sql))
+        return Promise.resolve({ rows: [{ count: 5 }] });
+      if (/user_interactions/.test(sql))
+        return Promise.resolve({ rows: [{ count: 3 }] });
+      if (/dominant_element/.test(sql))
+        return Promise.resolve({
+          rows: [
+            { element: "Fire", count: 918 },
+            { element: "Earth", count: 921 },
+          ],
+        });
+      return Promise.resolve({ rows: [{ count: 0 }] });
+    });
+
+    const result = await getPractitionerCohorts();
+
+    expect(result.funnel.paidPro).toBe(0); // from revenue.paidSubs, NOT 955
+    expect(result.funnel.onboarded).toBe(5); // canonical onboarding_completed
+    expect(result.funnel.signup).toBe(4528);
+    expect(result.elementalBreakdown).toEqual([
+      { element: "Fire", count: 918 },
+      { element: "Earth", count: 921 },
+    ]);
+
+    // The vestigial users.profile JSONB must NOT be queried for cohorts.
+    const sqls = mockQ.mock.calls.map((c) => String(c[0]));
+    expect(sqls.some((s) => /profile->/.test(s))).toBe(false);
+  });
+});

--- a/src/services/dashboardPanelsService.ts
+++ b/src/services/dashboardPanelsService.ts
@@ -572,18 +572,26 @@ export async function getEnginePerformance(): Promise<EnginePerformanceData> {
 
 export async function getPractitionerCohorts(): Promise<PractitionerCohortsData> {
   try {
-    const [totalUsersRes, onboardedRes, activeRes, firstCookRes, paidProRes, elementalRes] = await Promise.all([
+    // Read onboarding + elemental signature from the canonical user_profiles
+    // columns, NOT the vestigial users.profile JSONB (which rowToUserWithProfile
+    // never reads back). The JSONB lagged reality badly — it showed ~61
+    // "onboarded" and a 99.6%-"Unknown" elemental split, while the normalized
+    // columns give the honest counts the rest of the dashboard already uses.
+    // paidPro comes from the same revenue breakdown that drives the Commerce
+    // MRR panel, so "Paid Pro" can never again contradict "MRR $0" by counting
+    // the ~950 comp/provisioned premium accounts as conversions.
+    const [totalUsersRes, onboardedRes, activeRes, firstCookRes, revenue, elementalRes] = await Promise.all([
       executeQuery("SELECT COUNT(*)::integer AS count FROM users"),
-      executeQuery("SELECT COUNT(*)::integer AS count FROM users WHERE (profile->>'birthData') IS NOT NULL AND (profile->>'natalChart') IS NOT NULL"),
+      executeQuery("SELECT COUNT(*)::integer AS count FROM user_profiles WHERE onboarding_completed = true"),
       executeQuery("SELECT COUNT(*)::integer AS count FROM users WHERE is_active = true"),
       executeQuery("SELECT COUNT(DISTINCT user_id)::integer AS count FROM user_interactions WHERE interaction_type = 'recipe_cook'"),
-      executeQuery("SELECT COUNT(*)::integer AS count FROM user_subscriptions WHERE status = 'active'").catch(() => ({ rows: [{ count: 0 }] })),
+      getSubscriptionRevenueBreakdown().catch(() => ({ paidSubs: 0, provisionedSubs: 0, mrr: 0 })),
       executeQuery(`
-        SELECT 
-          COALESCE(profile->'natalChart'->>'dominantElement', 'Unknown') AS element,
+        SELECT
+          COALESCE(dominant_element, 'Unknown') AS element,
           COUNT(*)::integer AS count
-        FROM users 
-        WHERE profile->'natalChart' IS NOT NULL 
+        FROM user_profiles
+        WHERE dominant_element IS NOT NULL
         GROUP BY element
       `),
     ]);
@@ -592,7 +600,7 @@ export async function getPractitionerCohorts(): Promise<PractitionerCohortsData>
     const onboarded = Number(onboardedRes.rows[0]?.count ?? 0);
     const active = Number(activeRes.rows[0]?.count ?? 0);
     const firstCook = Number(firstCookRes.rows[0]?.count ?? 0);
-    const paidPro = Number(paidProRes.rows[0]?.count ?? 0);
+    const paidPro = Number(revenue.paidSubs ?? 0);
 
     const elementalBreakdown = (elementalRes.rows as Array<{ element: string; count: number }>).map((r) => ({
       element: String(r.element),


### PR DESCRIPTION
## Why
Operator-trust hardening (part of ranked fix #5). With the health banner now honest, the **Practitioner Cohorts** panel still reported three misleading numbers:

1. **"Paid Pro" counted all active subs** (`COUNT(*) FROM user_subscriptions WHERE status='active'` ≈ **955**) — so it claimed ~955 paying pros while the Commerce panel correctly shows **MRR $0**. Those subs are comp/agent accounts with no Stripe link.
2. **"Onboarded" + the elemental breakdown read the vestigial `users.profile` JSONB**, which `rowToUserWithProfile` never reads back. Live, that JSONB showed **~61 onboarded** and a **99.6%-"Unknown"** elemental split.

## What
- **Paid Pro** now comes from the same `getSubscriptionRevenueBreakdown().paidSubs` that drives the MRR panel → the two can never contradict (reads **0** until a real Stripe payment lands).
- **Onboarded** now reads canonical `user_profiles.onboarding_completed` (the same flag the onboarding funnel + JWT use) → honest **5**, not a fabricated 61.
- **Elemental breakdown** now reads canonical `user_profiles.dominant_element` → a real, balanced distribution (live: Earth 921 / Fire 918 / Air 917 / Water 916) instead of 99.6% "Unknown".

Pure read-source corrections — no ranking/economy logic touched.

## Verification
- ✅ Regression test (`getPractitionerCohorts.test.ts`): asserts `paidPro` comes from the revenue breakdown (not the 955 provisioned), `onboarded` from the canonical flag, elemental from `dominant_element`, and that **no `profile->` JSONB query is issued for cohorts**.
- ✅ Live prod queried to choose definitions: `onboarding_completed=true`=5 (≈ headline's birth+natal=4), `dominant_element` populated for 3,672 users across 4 balanced elements.
- ✅ `typecheck` + `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)