### PR TITLE
fix(dashboard): stop fabricating Cost Burndown — show honest "no billing source"

### DIFF
--- a/src/app/api/admin/dashboard/route.ts
+++ b/src/app/api/admin/dashboard/route.ts
@@ -245,7 +245,7 @@ export async function GET(request: NextRequest) {
     const featureFlags = await featureFlagsPromise;
     const practitionerGeo = await practitionerGeoPromise;
     const cohortRetention = await cohortRetentionPromise;
-    const costBurndown = await getCostBurndown(dbObservability.dbSizeBytes, dbObservability.activeConnections);
+    const costBurndown = await getCostBurndown();
 
     // Resolve the admin identity from the validated session rather than
     // hardcoding a single operator. Falls back to the session token payload

--- a/src/services/__tests__/getCostBurndown.test.ts
+++ b/src/services/__tests__/getCostBurndown.test.ts
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment node
+ *
+ * Guards the Cost Burndown panel against re-fabrication. There is no billing
+ * integration, so the panel must report the honest "no source" state (empty
+ * items, live=false) — which the UI renders as "connect Vercel + Railway
+ * billing APIs to populate" — rather than hardcoded/derived dollar figures
+ * flagged "● LIVE".
+ */
+
+jest.mock("@/lib/database", () => ({ executeQuery: jest.fn() }));
+
+import { getCostBurndown } from "@/services/dashboardPanelsService";
+
+describe("getCostBurndown", () => {
+  it("returns the honest no-billing-source state (no fabricated figures)", async () => {
+    const result = await getCostBurndown();
+    expect(result.live).toBe(false);
+    expect(result.items).toEqual([]);
+    expect(result.totalMtd).toBe(0);
+    expect(result.projectedTotal).toBe(0);
+  });
+});

--- a/src/services/dashboardPanelsService.ts
+++ b/src/services/dashboardPanelsService.ts
@@ -1063,50 +1063,21 @@ export interface CostBurndownData {
   live: boolean;
 }
 
-export async function getCostBurndown(dbSize: number, activeConnections: number): Promise<CostBurndownData> {
-  const dbSizeGb = dbSize / (1024 * 1024 * 1024);
-  const dbStorageCost = Math.max(5.0, dbSizeGb * 10);
-  const dbComputeCost = Math.max(10.0, activeConnections * 0.5);
-  const nextjsVercelCost = 20.00;
-  const railwayPythonCost = 7.00;
-
-  const items: CostItem[] = [
-    {
-      resource: "Postgres Database",
-      provider: "Railway",
-      costMtd: dbComputeCost + dbStorageCost,
-      limit: 35.00,
-      unit: "vCPU/RAM/GB",
-      pct: (dbComputeCost + dbStorageCost) / 35.00,
-    },
-    {
-      resource: "Planetary Agents API",
-      provider: "Railway",
-      costMtd: railwayPythonCost,
-      limit: 10.00,
-      unit: "shared-cpu",
-      pct: railwayPythonCost / 10.00,
-    },
-    {
-      resource: "App Hosting (alchm)",
-      provider: "Vercel",
-      costMtd: nextjsVercelCost,
-      limit: 20.00,
-      unit: "pro-seats",
-      pct: nextjsVercelCost / 20.00,
-    },
-  ];
-
-  const totalMtd = items.reduce((sum, item) => sum + item.costMtd, 0);
-  const dayOfMonth = new Date().getDate();
-  const daysInMonth = new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0).getDate();
-  const projectedTotal = (totalMtd / dayOfMonth) * daysInMonth;
-
+export async function getCostBurndown(): Promise<CostBurndownData> {
+  // There is no billing integration: neither Vercel nor Railway spend is pulled
+  // from any provider API. This panel previously FABRICATED its figures —
+  // hardcoded $20 Vercel / $7 Railway, plus a "Postgres" cost derived from DB
+  // size × connections with arbitrary multipliers — and flagged itself "● LIVE",
+  // so an operator read invented numbers as real month-to-date spend (and made
+  // infra decisions on them). Return the honest "no source" state instead; the
+  // panel already renders a "connect Vercel + Railway billing APIs to populate"
+  // prompt with a "○ NO SOURCE" badge for exactly this case. Wiring real billing
+  // aggregation is a separate build, tracked on its own.
   return {
-    items,
-    totalMtd,
-    projectedTotal,
-    live: true,
+    items: [],
+    totalMtd: 0,
+    projectedTotal: 0,
+    live: false,
   };
 }
 


### PR DESCRIPTION
## Why
Operator-trust hardening (final part of ranked fix #5). The **Cost Burndown · MTD** panel invented every number it displayed, then flagged itself **● LIVE**:
- App Hosting (Vercel): hardcoded **$20**
- Planetary Agents API (Railway): hardcoded **$7**
- Postgres: derived from `DB size × 10 + activeConnections × 0.5` (arbitrary multipliers, not billing)
- Projected month total: linear extrapolation of the above

There is **no Vercel/Railway billing integration**, so an operator read fabricated figures as real month-to-date spend — and might size infra on them.

## What
`getCostBurndown()` now returns the honest **no-source** state (`items: []`, `live: false`). The panel **already has a built-in truthful empty state** for this case — it renders *"No billing aggregation wired · connect Vercel + Railway billing APIs to populate"* with a **○ NO SOURCE** badge — so **no UI change is needed**. Also drops the now-unused `dbSize`/`activeConnections` args at the single call site.

Per the readiness method: where a feature genuinely isn't built, the surface should tell the truth ("not configured") instead of faking it, and the missing build is flagged separately (a "wire real billing aggregation" follow-up).

## Verification
- ✅ Regression test (`getCostBurndown.test.ts`): asserts `live:false` + empty items + zeroed totals, so the panel can't silently regress to fabricating.
- ✅ `typecheck` + `lint` clean.
- Visual: with empty items the existing `CostBurndown` component (`extras.tsx:1042`) shows the dashed "No billing aggregation wired" card + "○ NO SOURCE" — the intended honest state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)