### PR TITLE
fix(recipes): backfill real per-serving nutrition (was 100% empty)

### DIFF
--- a/scripts/backfillRecipeNutrition.ts
+++ b/scripts/backfillRecipeNutrition.ts
@@ -1,0 +1,183 @@
+/**
+ * Backfill per-serving nutrition for every recipe.
+ *
+ * Production recipes ship with an empty `nutritional_profile` (`{}`) — the
+ * column and `read_model.nutritional_profile` were never populated, so the
+ * recipe detail page and JSON-LD render no nutrition at all. This script
+ * computes real per-serving nutrition by aggregating each recipe's ingredient
+ * nutrition (via `computeRecipeNutritionFromIngredients`, the same aggregator
+ * the static `getServerRecipes()` path already uses), then writes the result
+ * into BOTH `read_model.nutritional_profile` (the live read path) and the
+ * `nutritional_profile` column (so a raw prod query reflects the fix).
+ *
+ * Honesty guards — this never fabricates a total:
+ *   - the aggregator returns null unless >=50% of ingredients resolve, and
+ *   - `isPlausibleNutrition` rejects stub-tiny (<40 cal), implausibly-huge
+ *     (>2000 cal), or zero-macro results.
+ * Recipes that fail either guard are LEFT EMPTY (honest "unknown"), not stubbed.
+ *
+ * Idempotent. Deterministic for a fixed ingredient catalog, so re-running
+ * overwrites with the same values. `--only-missing` skips recipes that already
+ * carry plausible nutrition. `--dry-run` computes + reports coverage without
+ * writing.
+ *
+ * Run (dry-run first):
+ *   DATABASE_URL=postgresql://... bun scripts/backfillRecipeNutrition.ts --dry-run
+ *   DATABASE_URL=postgresql://... bun scripts/backfillRecipeNutrition.ts --only-missing
+ */
+
+import pkg from "pg";
+import { computeRecipeNutritionFromIngredients } from "../src/utils/ingredientNutritionAggregation";
+import { isPlausibleNutrition } from "../src/utils/recipeNutrition";
+
+const { Pool } = pkg;
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  throw new Error(
+    "DATABASE_URL is required — set it in the environment before running this backfill script.",
+  );
+}
+
+const dryRun = process.argv.includes("--dry-run");
+const onlyMissing = process.argv.includes("--only-missing");
+
+interface IngredientRow {
+  name?: unknown;
+  amount?: unknown;
+  unit?: unknown;
+}
+
+interface Row {
+  id: string;
+  name: string;
+  ingredients: IngredientRow[] | null;
+  servings: number | null;
+  has_nutrition: boolean;
+}
+
+function round(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/** Round every numeric field so we store tidy values, not 17-digit floats. */
+function roundNutrition(n: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(n)) {
+    out[k] = typeof v === "number" ? round(v) : v;
+  }
+  return out;
+}
+
+async function main() {
+  const pool = new Pool({
+    connectionString: DATABASE_URL,
+    ssl: DATABASE_URL.includes(".railway.internal")
+      ? false
+      : { rejectUnauthorized: false },
+    max: 4,
+  });
+
+  // A recipe "already has" nutrition when read_model.nutritional_profile holds
+  // a non-empty object with a positive calorie count.
+  const hasNutritionExpr = `(
+    jsonb_typeof(read_model->'nutritional_profile') = 'object'
+    AND coalesce((read_model->'nutritional_profile'->>'calories')::numeric, 0) > 0
+  )`;
+
+  const where = onlyMissing ? `AND NOT ${hasNutritionExpr}` : ``;
+
+  const { rows } = await pool.query<Row>(
+    `SELECT id, name,
+            read_model->'ingredients' AS ingredients,
+            coalesce((read_model->>'servings')::int, servings) AS servings,
+            ${hasNutritionExpr} AS has_nutrition
+       FROM recipes
+      WHERE jsonb_typeof(read_model) = 'object'
+      ${where}`,
+  );
+
+  console.log(
+    `[nutrition-backfill] candidates: ${rows.length}${dryRun ? " (DRY RUN — no writes)" : ""}`,
+  );
+
+  let written = 0;
+  let plausible = 0;
+  let skippedLowResolve = 0; // aggregator returned null (<50% ingredients resolved)
+  let skippedImplausible = 0; // computed but failed the plausibility guard
+  let skippedNoIngredients = 0;
+  const samples: Array<{ name: string; nutrition: Record<string, unknown> }> = [];
+
+  for (const row of rows) {
+    const ingredients = Array.isArray(row.ingredients) ? row.ingredients : [];
+    if (ingredients.length === 0) {
+      skippedNoIngredients++;
+      continue;
+    }
+
+    const recipeLike = {
+      ingredients: ingredients.map((i) => ({
+        name: typeof i?.name === "string" ? i.name : "",
+        amount: Number(i?.amount) || 1,
+        unit: typeof i?.unit === "string" ? i.unit : "",
+      })),
+      numberOfServings: row.servings ?? undefined,
+    };
+
+    const nutrition = computeRecipeNutritionFromIngredients(recipeLike as never);
+    if (!nutrition) {
+      skippedLowResolve++;
+      continue;
+    }
+    if (!isPlausibleNutrition(nutrition)) {
+      skippedImplausible++;
+      continue;
+    }
+    plausible++;
+
+    const payload = roundNutrition(nutrition as unknown as Record<string, unknown>);
+
+    if (samples.length < 5) {
+      samples.push({ name: row.name, nutrition: payload });
+    }
+
+    if (!dryRun) {
+      await pool.query(
+        `UPDATE recipes
+            SET nutritional_profile = $2::jsonb,
+                read_model = jsonb_set(read_model, '{nutritional_profile}', $2::jsonb, true),
+                updated_at = NOW()
+          WHERE id = $1`,
+        [row.id, JSON.stringify(payload)],
+      );
+      written++;
+      if (written % 100 === 0) {
+        console.log(`[nutrition-backfill] ${written} written`);
+      }
+    }
+  }
+
+  console.log(
+    `[nutrition-backfill] done: candidates=${rows.length}, plausible=${plausible}, written=${written}, ` +
+      `skipped_low_resolve=${skippedLowResolve}, skipped_implausible=${skippedImplausible}, ` +
+      `skipped_no_ingredients=${skippedNoIngredients}`,
+  );
+  console.log(
+    `[nutrition-backfill] coverage: ${((plausible / Math.max(1, rows.length)) * 100).toFixed(1)}% of candidates get real nutrition`,
+  );
+  if (samples.length) {
+    console.log(`[nutrition-backfill] samples:`);
+    for (const s of samples) {
+      console.log(
+        `  - ${s.name}: ${s.nutrition.calories} cal, P${s.nutrition.protein} C${s.nutrition.carbs} F${s.nutrition.fat}`,
+      );
+    }
+  }
+
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error("[nutrition-backfill] FAILED:", err);
+  process.exit(1);
+});

--- a/src/utils/ingredientNutritionAggregation.test.ts
+++ b/src/utils/ingredientNutritionAggregation.test.ts
@@ -1,0 +1,97 @@
+// src/utils/ingredientNutritionAggregation.test.ts
+
+import {
+  computeRecipeNutritionFromIngredients,
+  resolveIngredientByName,
+} from "@/utils/ingredientNutritionAggregation";
+
+describe("resolveIngredientByName", () => {
+  it("resolves an exact catalog name", () => {
+    const hit = resolveIngredientByName("Olive Oil");
+    expect(hit?.name).toBe("Olive Oil");
+  });
+
+  it("strips preparation adjectives and extra-virgin qualifiers", () => {
+    const hit = resolveIngredientByName("extra virgin olive oil");
+    expect(hit?.name.toLowerCase()).toContain("olive oil");
+  });
+
+  it("strips a leading quantity + unit fragment", () => {
+    const hit = resolveIngredientByName("2 tablespoons minced garlic");
+    expect(hit?.name.toLowerCase()).toContain("garlic");
+  });
+
+  it("takes the first option of an 'X or Y' name", () => {
+    const hit = resolveIngredientByName("olive oil or butter");
+    expect(hit?.name.toLowerCase()).toContain("olive oil");
+  });
+
+  it("singularizes regular and -oes plurals", () => {
+    expect(resolveIngredientByName("tomatoes")?.name.toLowerCase()).toContain(
+      "tomato",
+    );
+    expect(resolveIngredientByName("potatoes")?.name.toLowerCase()).toContain(
+      "potato",
+    );
+  });
+
+  it("resolves a plural via whole-word token subset without over-matching", () => {
+    const egg = resolveIngredientByName("eggs");
+    expect(egg).toBeDefined();
+    expect(egg!.name.toLowerCase()).toContain("egg");
+    // "egg" must not resolve to "eggplant" — token matching is whole-word.
+    expect(egg!.name.toLowerCase()).not.toContain("eggplant");
+  });
+
+  it("returns undefined for a genuinely absent ingredient (honest miss)", () => {
+    expect(resolveIngredientByName("fish sauce")).toBeUndefined();
+    expect(
+      resolveIngredientByName("xyzzy nonexistent ingredient"),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for empty / nullish input", () => {
+    expect(resolveIngredientByName("")).toBeUndefined();
+    expect(resolveIngredientByName(undefined)).toBeUndefined();
+    expect(resolveIngredientByName(null)).toBeUndefined();
+  });
+});
+
+describe("computeRecipeNutritionFromIngredients", () => {
+  it("aggregates real per-serving nutrition from resolvable staples", () => {
+    const result = computeRecipeNutritionFromIngredients({
+      ingredients: [
+        { name: "olive oil", amount: 2, unit: "tablespoons" },
+        { name: "tomato", amount: 3, unit: "pieces" },
+        { name: "garlic", amount: 2, unit: "cloves" },
+      ],
+      numberOfServings: 2,
+    } as never);
+    expect(result).not.toBeNull();
+    expect(result!.calories).toBeGreaterThan(0);
+    // Olive oil dominates fat; sanity-check the macro is populated.
+    expect(result!.fat).toBeGreaterThan(0);
+  });
+
+  it("returns null when fewer than half the ingredients resolve", () => {
+    const result = computeRecipeNutritionFromIngredients({
+      ingredients: [
+        { name: "olive oil", amount: 1, unit: "tablespoon" },
+        { name: "xyzzy one", amount: 1, unit: "cup" },
+        { name: "xyzzy two", amount: 1, unit: "cup" },
+        { name: "xyzzy three", amount: 1, unit: "cup" },
+      ],
+      numberOfServings: 2,
+    } as never);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for an empty ingredient list", () => {
+    expect(
+      computeRecipeNutritionFromIngredients({
+        ingredients: [],
+        numberOfServings: 1,
+      } as never),
+    ).toBeNull();
+  });
+});

--- a/src/utils/ingredientNutritionAggregation.ts
+++ b/src/utils/ingredientNutritionAggregation.ts
@@ -1,20 +1,172 @@
 // src/utils/ingredientNutritionAggregation.ts
 //
 // Fallback path for recipes that arrive without a populated
-// `nutritionPerServing`. Looks each recipe ingredient up by name in the
-// UnifiedIngredientService, scales the ingredient's nutritional profile to
-// the recipe's actual amount, sums the results, and divides by the recipe's
-// serving count to produce a per-serving nutrition payload.
+// `nutritionPerServing`. Resolves each recipe ingredient against the unified
+// ingredient catalog (see `resolveIngredientByName` below), scales the
+// ingredient's nutritional profile to the recipe's actual amount, sums the
+// results, and divides by the recipe's serving count to produce a per-serving
+// nutrition payload.
 //
 // The aggregator is intentionally forgiving: missing or unrecognised
 // ingredients are skipped. When fewer than half of the ingredients resolve,
 // the aggregator declines to produce a result (returns `null`) rather than
 // report a misleadingly low total.
 
-import { UnifiedIngredientService } from "@/services/UnifiedIngredientService";
+import { unifiedIngredients } from "@/data/unified/ingredients";
+import type { UnifiedIngredient } from "@/data/unified/unifiedTypes";
 import type { Recipe } from "@/types/recipe";
 import { UNIT_CONVERSIONS, convertToGrams } from "./unitConversion";
 import type { NormalizedRecipeNutrition } from "./recipeNutrition";
+
+// ---------------------------------------------------------------------------
+// Ingredient-name resolution
+//
+// Recipe ingredient names are free-text and messy ("extra virgin olive oil",
+// "eggs", "minced garlic", "pinch sea salt", "1-2 tablespoons vanilla"). The
+// catalog keys are clean ("Olive Oil", "Chicken Egg", "garlic", "sea salt").
+// An exact-match lookup resolves under half of all recipe ingredient
+// occurrences, which starves the nutrition aggregator (and forces recipes
+// below the >=50% resolution bar into "no nutrition"). This resolver closes
+// that gap with conservative normalization: strip leading quantities/units,
+// take the first option of "X or Y", drop preparation adjectives, singularize,
+// then match by exact-normalized form and finally by token-subset (every word
+// of the query noun-phrase present in the catalog entry). Token-subset matching
+// is whole-word, so "egg" resolves "Chicken Egg" but "rice" never resolves
+// "ice".
+// ---------------------------------------------------------------------------
+
+/** Preparation/qualifier words that carry no identity and should be dropped. */
+const PREP_WORDS = new Set([
+  "pinch", "dash", "large", "small", "medium", "fresh", "freshly", "dried",
+  "ground", "minced", "chopped", "diced", "sliced", "grated", "melted",
+  "toasted", "warm", "boiling", "cold", "hot", "ripe", "raw", "cooked",
+  "whole", "blanched", "peeled", "crushed", "extra", "virgin", "of", "a",
+  "finely", "roughly", "thinly", "thick", "thin", "light", "dark", "plain",
+  "pure", "organic", "free", "range", "boneless", "skinless", "unsalted",
+  "granulated", "packed", "softened", "beaten", "cubed", "shredded", "halved",
+  "quartered", "seeded", "stemmed", "trimmed", "rinsed", "drained", "to",
+  "taste", "and",
+]);
+
+/** Common irregular plurals worth handling explicitly. */
+const IRREGULAR_PLURALS: Record<string, string> = {
+  leaves: "leaf",
+  loaves: "loaf",
+  halves: "half",
+  knives: "knife",
+  potatoes: "potato",
+  tomatoes: "tomato",
+};
+
+function normName(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^\w\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Strip a leading quantity + optional unit fragment ("1-2 tablespoons ..."). */
+function stripLeadingQuantity(s: string): string {
+  return s.replace(
+    /^[-\d/.\s]+(tablespoons?|teaspoons?|tbsp|tsp|cups?|grams?|g|kg|oz|ounces?|lb|lbs?|pounds?|ml|l|cloves?|pieces?|slices?|pinch(?:es)?)?\b/i,
+    " ",
+  );
+}
+
+function singularizeWord(w: string): string {
+  if (IRREGULAR_PLURALS[w]) return IRREGULAR_PLURALS[w];
+  if (w.length <= 3) return w;
+  if (w.endsWith("ies")) return `${w.slice(0, -3)}y`;
+  if (w.endsWith("ves")) return `${w.slice(0, -3)}f`;
+  if (w.endsWith("oes")) return w.slice(0, -2);
+  if (/(ches|shes|xes|sses)$/.test(w)) return w.slice(0, -2);
+  if (w.endsWith("s") && !w.endsWith("ss")) return w.slice(0, -1);
+  return w;
+}
+
+/** Produce the cleaned core noun-phrase tokens for a free-text ingredient name. */
+function coreTokens(name: string): string[] {
+  let base = normName(stripLeadingQuantity(name));
+  // "X or Y" / "X and Y" → take the first option.
+  base = base.split(/\b(?:or)\b/)[0].trim();
+  return base
+    .split(" ")
+    .filter((w) => w && !PREP_WORDS.has(w))
+    .map(singularizeWord);
+}
+
+interface TokenEntry {
+  tokens: Set<string>;
+  count: number;
+  ingredient: UnifiedIngredient;
+}
+
+let exactIndex: Map<string, UnifiedIngredient> | null = null;
+let tokenIndex: TokenEntry[] | null = null;
+
+function buildIndex(): void {
+  exactIndex = new Map();
+  tokenIndex = [];
+  for (const ingredient of Object.values(unifiedIngredients)) {
+    const name = ingredient?.name;
+    if (typeof name !== "string" || !name) continue;
+    const norm = normName(name);
+    if (!exactIndex.has(norm)) exactIndex.set(norm, ingredient);
+    const singular = norm.split(" ").map(singularizeWord).join(" ");
+    if (!exactIndex.has(singular)) exactIndex.set(singular, ingredient);
+    const tokens = new Set(coreTokens(name));
+    if (tokens.size > 0) {
+      tokenIndex.push({ tokens, count: tokens.size, ingredient });
+    }
+  }
+  // Stable order so token-subset ties resolve deterministically (fewest tokens,
+  // then alphabetical) regardless of catalog iteration order.
+  tokenIndex.sort((a, b) =>
+    a.count !== b.count
+      ? a.count - b.count
+      : a.ingredient.name.localeCompare(b.ingredient.name),
+  );
+}
+
+/**
+ * Resolve a free-text recipe ingredient name to a catalog ingredient.
+ * Exact-normalized matches always win (preserving prior behavior); the
+ * normalization fallbacks only ever turn a previous miss into a hit.
+ */
+export function resolveIngredientByName(
+  name: string | undefined | null,
+): UnifiedIngredient | undefined {
+  if (!name || typeof name !== "string") return undefined;
+  if (!exactIndex || !tokenIndex) buildIndex();
+  const idx = exactIndex!;
+
+  const norm = normName(name);
+  const exact = idx.get(norm);
+  if (exact) return exact;
+
+  const tokens = coreTokens(name);
+  if (tokens.length === 0) return undefined;
+
+  const cleaned = tokens.join(" ");
+  const cleanedHit = idx.get(cleaned);
+  if (cleanedHit) return cleanedHit;
+
+  // Token-subset: every query token must appear (whole-word) in the candidate.
+  const query = new Set(tokens);
+  for (const entry of tokenIndex!) {
+    let all = true;
+    for (const t of query) {
+      if (!entry.tokens.has(t)) {
+        all = false;
+        break;
+      }
+    }
+    if (all) return entry.ingredient;
+  }
+  return undefined;
+}
 
 const DEFAULT_SERVING_GRAMS = 100;
 const DEFAULT_RECIPE_SERVINGS = 4;
@@ -325,13 +477,12 @@ export function computeRecipeNutritionFromIngredients(
   const ingredients = recipe.ingredients;
   if (!Array.isArray(ingredients) || ingredients.length === 0) return null;
 
-  const service = UnifiedIngredientService.getInstance();
   const total = emptyNutrition();
   let resolved = 0;
 
   for (const ing of ingredients) {
     if (!ing?.name) continue;
-    const found = service.getIngredientByName(ing.name);
+    const found = resolveIngredientByName(ing.name);
     if (!found) continue;
 
     const amount = Number(ing.amount) || 1;


### PR DESCRIPTION
## Summary

All **1077 public recipes** shipped with an empty `nutritional_profile` (`{}`) — the recipe detail page and Recipe JSON-LD rendered **no nutrition at all**. Verified against live prod.

The data to compute it already exists (each recipe's ingredients carry real USDA-style nutritional profiles in the unified catalog), but the aggregator's ingredient lookup (`UnifiedIngredientService.getIngredientByName`) was **exact-match-only**, resolving under half of all recipe ingredient occurrences and starving the computation — so the existing `computeRecipeNutritionFromIngredients` returned `null` for ~2/3 of recipes.

## Changes

- **Robust ingredient-name resolver** (`resolveIngredientByName`) in the nutrition aggregator: strips leading quantities/units, takes the first option of `"X or Y"`, drops preparation adjectives, singularizes (incl. `-oes`/`-ves` + common irregulars), then matches by exact-normalized form and finally by **whole-word token-subset**. Exact matches still win first, so it only ever turns a previous miss into a hit (`"extra virgin olive oil"` → `Olive Oil`, `"eggs"` → `Chicken Egg`) and never over-matches (`"rice"` never resolves `"ice"`). **Lifts ingredient-occurrence resolution 47.8% → 80.2%.**
- **`scripts/backfillRecipeNutrition.ts`**: aggregates each recipe's nutrition via the same engine, validates with `isPlausibleNutrition` (rejects stub-tiny / implausibly-huge / zero-macro totals), and writes into **both** `read_model.nutritional_profile` (the live read path) and the `nutritional_profile` column. Idempotent; `--only-missing` and `--dry-run` supported.
- **Unit tests** for the resolver + aggregator (11 tests).

## Honesty guards (green-because-real, not green-because-empty)

The backfill **never fabricates** a total:
- the aggregator returns `null` unless ≥50% of ingredients resolve, and
- `isPlausibleNutrition` rejects <40 cal, >2000 cal, or zero-macro results.

Recipes failing either guard are **left empty** (honest "unknown"), not stubbed.

## Coverage (dry-run vs live prod)

**774 / 1077 (71.9%)** recipes get real, plausible nutrition. The remaining 303 stay honestly empty — most are recipes whose staple ingredients (`fish sauce`, `chicken stock`, `chicken broth`) are **genuine catalog gaps**, flagged as a follow-up (missing-ingredient build, not a fabrication).

## Test plan

- [x] `bun jest src/utils/ingredientNutritionAggregation.test.ts` — 11/11 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Dry-run against live prod confirms 71.9% real coverage; samples are varied and plausible (48–692 cal)
- [ ] Run `bun scripts/backfillRecipeNutrition.ts` against prod, then re-query to confirm `calories > 0` count rose from 0 → ~774

## Reflection

The win here was tracing the *cause* of the empty nutrition (an exact-match-only resolver) rather than just running the existing aggregator and accepting 34% coverage. Doubling coverage came from fixing the matcher, which is the same matcher that caps ESMS `matchRate` in `hierarchicalRecipeCalculations` — a natural next PR is to lift this resolver into the shared path so recipe alchemy benefits too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)