### PR TITLE
fix(recipes): clean junk parenthetical descriptions, recover real seasons

### DIFF
--- a/scripts/cleanRecipeParentheticalDescriptions.ts
+++ b/scripts/cleanRecipeParentheticalDescriptions.ts
@@ -1,0 +1,162 @@
+/**
+ * Clean junk parenthetical "descriptions" and recover the real data they hide.
+ *
+ * 64 public recipes carry a description that is nothing but a parenthetical
+ * season/dietary tag — "(FALL/WINTER)", "(Spring/Summer)", "(Vegan)",
+ * "(Gluten-Free)". These render as the recipe's description (e.g. the detail
+ * page shows "(FALL/WINTER)" where prose should be), and the *real* season they
+ * encode is NOT in the structured fields: every one of these recipes has a
+ * uniform all-four-seasons placeholder in read_model.contexts[].seasonal.
+ *
+ * This script parses the parenthetical, writes the recovered season into
+ * read_model.contexts[].seasonal (replacing the all-seasons placeholder for the
+ * season-specific ones) and any dietary flag into dietary_tags, then clears the
+ * junk from both `description` and `read_model.description` (honest empty, which
+ * the recipe view already omits gracefully).
+ *
+ * Idempotent: once cleared, a recipe no longer matches the candidate filter.
+ *
+ * Run:
+ *   DATABASE_URL=postgresql://... bun scripts/cleanRecipeParentheticalDescriptions.ts --dry-run
+ *   DATABASE_URL=postgresql://... bun scripts/cleanRecipeParentheticalDescriptions.ts
+ */
+
+import pkg from "pg";
+
+const { Pool } = pkg;
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  throw new Error(
+    "DATABASE_URL is required — set it in the environment before running this script.",
+  );
+}
+
+const dryRun = process.argv.includes("--dry-run");
+
+const ALL_SEASONS = ["spring", "summer", "autumn", "winter"] as const;
+
+interface Parsed {
+  seasons: string[] | null; // null = leave seasonal untouched (year-round / none)
+  dietary: string[];
+}
+
+/** Parse a parenthetical tag into recovered seasons + dietary flags. */
+function parseParenthetical(desc: string): Parsed {
+  const t = desc.toLowerCase().replace(/[()]/g, " ").replace(/\s+/g, " ").trim();
+  const seasons = new Set<string>();
+  if (/\bspring\b/.test(t)) seasons.add("spring");
+  if (/\bsummer\b/.test(t)) seasons.add("summer");
+  if (/\b(fall|autumn)\b/.test(t)) seasons.add("autumn");
+  if (/\bwinter\b/.test(t)) seasons.add("winter");
+
+  // Map to canonical `dietary_restriction` enum labels (capitalized, spaced).
+  // Tags without a matching enum value (e.g. "wheat-free") are dropped rather
+  // than coerced — the junk description is still cleared, just no false tag.
+  const dietary: string[] = [];
+  if (/\bvegan\b/.test(t)) dietary.push("Vegan");
+  if (/\bvegetarian\b/.test(t)) dietary.push("Vegetarian");
+  if (/gluten[\s-]?free\b/.test(t)) dietary.push("Gluten Free");
+  if (/dairy[\s-]?free\b/.test(t)) dietary.push("Dairy Free");
+
+  // "year-round" → genuinely all seasons (the existing placeholder is correct);
+  // leave seasonal untouched. Season-specific tags override the placeholder.
+  const isYearRound = /year[\s-]?round/.test(t);
+  const orderedSeasons = ALL_SEASONS.filter((s) => seasons.has(s));
+  return {
+    seasons: orderedSeasons.length > 0 && !isYearRound ? orderedSeasons : null,
+    dietary,
+  };
+}
+
+interface Row {
+  id: string;
+  name: string;
+  description: string;
+  read_model: Record<string, unknown>;
+  dietary_tags: string[] | null;
+}
+
+async function main() {
+  const pool = new Pool({
+    connectionString: DATABASE_URL,
+    ssl: { rejectUnauthorized: false },
+    max: 4,
+  });
+
+  const { rows } = await pool.query<Row>(
+    `SELECT id, name, description, read_model, dietary_tags
+       FROM recipes
+      WHERE is_public = true
+        AND description ~ '^\\s*\\('
+        AND length(description) < 30`,
+  );
+
+  console.log(
+    `[clean-parens] candidates: ${rows.length}${dryRun ? " (DRY RUN)" : ""}`,
+  );
+
+  let cleared = 0;
+  let seasonsRecovered = 0;
+  let dietaryRecovered = 0;
+  const samples: string[] = [];
+
+  for (const row of rows) {
+    const parsed = parseParenthetical(row.description);
+    const rm = (row.read_model ?? {}) as Record<string, unknown>;
+
+    // Recover season into every context's seasonal array.
+    if (parsed.seasons && Array.isArray(rm.contexts)) {
+      rm.contexts = (rm.contexts as Array<Record<string, unknown>>).map((c) => ({
+        ...c,
+        seasonal: parsed.seasons,
+      }));
+      seasonsRecovered++;
+    }
+
+    // Merge dietary flags (dedup) into both the column and read_model.
+    let dietaryTags = Array.isArray(row.dietary_tags) ? [...row.dietary_tags] : [];
+    if (parsed.dietary.length > 0) {
+      const existing = new Set(dietaryTags.map((d) => d.toLowerCase()));
+      for (const d of parsed.dietary) {
+        if (!existing.has(d.toLowerCase())) dietaryTags.push(d);
+      }
+      rm.dietary_tags = dietaryTags;
+      dietaryRecovered++;
+    }
+
+    // Clear the junk description everywhere it's read from.
+    rm.description = "";
+
+    if (samples.length < 8) {
+      samples.push(
+        `${row.name}: "${row.description}" → seasons=${parsed.seasons?.join("/") ?? "(unchanged)"} dietary=${parsed.dietary.join(",") || "—"}`,
+      );
+    }
+
+    if (!dryRun) {
+      await pool.query(
+        `UPDATE recipes
+            SET description = '',
+                dietary_tags = $2::dietary_restriction[],
+                read_model = $3::jsonb,
+                updated_at = NOW()
+          WHERE id = $1`,
+        [row.id, dietaryTags, JSON.stringify(rm)],
+      );
+    }
+    cleared++;
+  }
+
+  console.log(
+    `[clean-parens] done: cleared=${cleared}, seasons_recovered=${seasonsRecovered}, dietary_recovered=${dietaryRecovered}`,
+  );
+  for (const s of samples) console.log(`  ${s}`);
+
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error("[clean-parens] FAILED:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

**64 public recipes** had a `description` that was nothing but a parenthetical season/dietary tag — `(FALL/WINTER)`, `(Spring/Summer)`, `(Vegan)`, `(Gluten-Free)`. These render verbatim as the recipe's description (the detail page shows `(FALL/WINTER)` where prose belongs).

Worse: the **real season** they encode was never in the structured fields — every one of these recipes carries a **uniform all-four-seasons placeholder** in `read_model.contexts[].seasonal`. So clearing the junk naively would *lose* real data.

## Change

`scripts/cleanRecipeParentheticalDescriptions.ts` parses each tag and:
- writes the recovered season into `read_model.contexts[].seasonal`, replacing the all-seasons placeholder for the **38 season-specific** recipes (`(Fall/Winter)` → `autumn,winter`);
- merges any dietary flag into `dietary_tags` (**6** recipes: vegan/gluten-free/wheat-free);
- clears the junk from both `description` and `read_model.description` — honest empty, which the recipe view already omits gracefully.

Year-round tags are left as all-four-seasons (the placeholder is correct there). Idempotent — a cleared recipe no longer matches the candidate filter.

## Verification (dry-run vs live prod)

`64 cleared, 38 seasons recovered, 6 dietary recovered`. Samples:
- `Massaged Kale Salad … "(Fall/Winter)" → seasons=autumn/winter`
- `COFFEE GRANITA "(SPRING/SUMMER)" → seasons=spring/summer`
- `MUSHROOMS A LA GRECQUE "(YEAR-ROUND)" → (unchanged)`

## Scope note

The **421 genuinely-empty** descriptions are deliberately left as honest blanks (the view omits them; recipe names like `CREAM OF CURRIED SWEET POTATO SOUP` are self-describing). Auto-composing prose risks the exact templated-boilerplate the broader audit warns against — real curated descriptions are a content-authoring task, tracked separately, not fabricated here.

## Test plan

- [x] Dry-run against live prod: 64/38/6 parsed correctly
- [x] `bun run typecheck` / `lint` clean (pre-commit)
- [ ] Run the script against prod, then re-query to confirm 0 parenthetical-only descriptions remain and the 38 recipes now have specific seasons

🤖 Generated with [Claude Code](https://claude.com/claude-code)