### PR TITLE
fix(ingredients): share the free-text resolver, lift ESMS matchRate

### DIFF
--- a/src/services/UnifiedIngredientService.ts
+++ b/src/services/UnifiedIngredientService.ts
@@ -23,6 +23,7 @@ import type {
   ThermodynamicProperties,
 } from "@/types/alchemy";
 import { alchemicalEngine } from "@/utils/alchemyInitializer";
+import { resolveIngredientByName } from "@/utils/ingredientResolution";
 import { calculateThermodynamicMetrics as calcThermo } from "@/utils/monicaKalchmCalculations";
 import type { Recipe } from "../types/recipe";
 
@@ -139,7 +140,15 @@ export class UnifiedIngredientService implements IngredientServiceInterface {
   }
 
   /**
-   * Get ingredient by name
+   * Get ingredient by name.
+   *
+   * Exact (case-insensitive) match wins first, preserving prior behavior. When
+   * no exact match exists, fall back to the shared conservative free-text
+   * resolver (strip quantities/units, drop prep adjectives, singularize,
+   * token-subset). Because exact still wins, this only ever turns a previous
+   * miss into a hit — directly lifting the ESMS `matchRate` in
+   * `hierarchicalRecipeCalculations.ts`, which calls this for each recipe
+   * ingredient.
    */
   getIngredientByName(name: string): UnifiedIngredient | undefined {
     const normalizedName = name.toLowerCase().trim();
@@ -153,7 +162,7 @@ export class UnifiedIngredientService implements IngredientServiceInterface {
       }
     }
 
-    return undefined;
+    return resolveIngredientByName(name);
   }
 
   /**

--- a/src/utils/ingredientNutritionAggregation.ts
+++ b/src/utils/ingredientNutritionAggregation.ts
@@ -12,161 +12,16 @@
 // the aggregator declines to produce a result (returns `null`) rather than
 // report a misleadingly low total.
 
-import { unifiedIngredients } from "@/data/unified/ingredients";
-import type { UnifiedIngredient } from "@/data/unified/unifiedTypes";
 import type { Recipe } from "@/types/recipe";
+import { resolveIngredientByName } from "./ingredientResolution";
 import { UNIT_CONVERSIONS, convertToGrams } from "./unitConversion";
 import type { NormalizedRecipeNutrition } from "./recipeNutrition";
 
-// ---------------------------------------------------------------------------
-// Ingredient-name resolution
-//
-// Recipe ingredient names are free-text and messy ("extra virgin olive oil",
-// "eggs", "minced garlic", "pinch sea salt", "1-2 tablespoons vanilla"). The
-// catalog keys are clean ("Olive Oil", "Chicken Egg", "garlic", "sea salt").
-// An exact-match lookup resolves under half of all recipe ingredient
-// occurrences, which starves the nutrition aggregator (and forces recipes
-// below the >=50% resolution bar into "no nutrition"). This resolver closes
-// that gap with conservative normalization: strip leading quantities/units,
-// take the first option of "X or Y", drop preparation adjectives, singularize,
-// then match by exact-normalized form and finally by token-subset (every word
-// of the query noun-phrase present in the catalog entry). Token-subset matching
-// is whole-word, so "egg" resolves "Chicken Egg" but "rice" never resolves
-// "ice".
-// ---------------------------------------------------------------------------
-
-/** Preparation/qualifier words that carry no identity and should be dropped. */
-const PREP_WORDS = new Set([
-  "pinch", "dash", "large", "small", "medium", "fresh", "freshly", "dried",
-  "ground", "minced", "chopped", "diced", "sliced", "grated", "melted",
-  "toasted", "warm", "boiling", "cold", "hot", "ripe", "raw", "cooked",
-  "whole", "blanched", "peeled", "crushed", "extra", "virgin", "of", "a",
-  "finely", "roughly", "thinly", "thick", "thin", "light", "dark", "plain",
-  "pure", "organic", "free", "range", "boneless", "skinless", "unsalted",
-  "granulated", "packed", "softened", "beaten", "cubed", "shredded", "halved",
-  "quartered", "seeded", "stemmed", "trimmed", "rinsed", "drained", "to",
-  "taste", "and",
-]);
-
-/** Common irregular plurals worth handling explicitly. */
-const IRREGULAR_PLURALS: Record<string, string> = {
-  leaves: "leaf",
-  loaves: "loaf",
-  halves: "half",
-  knives: "knife",
-  potatoes: "potato",
-  tomatoes: "tomato",
-};
-
-function normName(s: string): string {
-  return s
-    .toLowerCase()
-    .normalize("NFKD")
-    .replace(/[^\w\s]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-/** Strip a leading quantity + optional unit fragment ("1-2 tablespoons ..."). */
-function stripLeadingQuantity(s: string): string {
-  return s.replace(
-    /^[-\d/.\s]+(tablespoons?|teaspoons?|tbsp|tsp|cups?|grams?|g|kg|oz|ounces?|lb|lbs?|pounds?|ml|l|cloves?|pieces?|slices?|pinch(?:es)?)?\b/i,
-    " ",
-  );
-}
-
-function singularizeWord(w: string): string {
-  if (IRREGULAR_PLURALS[w]) return IRREGULAR_PLURALS[w];
-  if (w.length <= 3) return w;
-  if (w.endsWith("ies")) return `${w.slice(0, -3)}y`;
-  if (w.endsWith("ves")) return `${w.slice(0, -3)}f`;
-  if (w.endsWith("oes")) return w.slice(0, -2);
-  if (/(ches|shes|xes|sses)$/.test(w)) return w.slice(0, -2);
-  if (w.endsWith("s") && !w.endsWith("ss")) return w.slice(0, -1);
-  return w;
-}
-
-/** Produce the cleaned core noun-phrase tokens for a free-text ingredient name. */
-function coreTokens(name: string): string[] {
-  let base = normName(stripLeadingQuantity(name));
-  // "X or Y" / "X and Y" → take the first option.
-  base = base.split(/\b(?:or)\b/)[0].trim();
-  return base
-    .split(" ")
-    .filter((w) => w && !PREP_WORDS.has(w))
-    .map(singularizeWord);
-}
-
-interface TokenEntry {
-  tokens: Set<string>;
-  count: number;
-  ingredient: UnifiedIngredient;
-}
-
-let exactIndex: Map<string, UnifiedIngredient> | null = null;
-let tokenIndex: TokenEntry[] | null = null;
-
-function buildIndex(): void {
-  exactIndex = new Map();
-  tokenIndex = [];
-  for (const ingredient of Object.values(unifiedIngredients)) {
-    const name = ingredient?.name;
-    if (typeof name !== "string" || !name) continue;
-    const norm = normName(name);
-    if (!exactIndex.has(norm)) exactIndex.set(norm, ingredient);
-    const singular = norm.split(" ").map(singularizeWord).join(" ");
-    if (!exactIndex.has(singular)) exactIndex.set(singular, ingredient);
-    const tokens = new Set(coreTokens(name));
-    if (tokens.size > 0) {
-      tokenIndex.push({ tokens, count: tokens.size, ingredient });
-    }
-  }
-  // Stable order so token-subset ties resolve deterministically (fewest tokens,
-  // then alphabetical) regardless of catalog iteration order.
-  tokenIndex.sort((a, b) =>
-    a.count !== b.count
-      ? a.count - b.count
-      : a.ingredient.name.localeCompare(b.ingredient.name),
-  );
-}
-
-/**
- * Resolve a free-text recipe ingredient name to a catalog ingredient.
- * Exact-normalized matches always win (preserving prior behavior); the
- * normalization fallbacks only ever turn a previous miss into a hit.
- */
-export function resolveIngredientByName(
-  name: string | undefined | null,
-): UnifiedIngredient | undefined {
-  if (!name || typeof name !== "string") return undefined;
-  if (!exactIndex || !tokenIndex) buildIndex();
-  const idx = exactIndex!;
-
-  const norm = normName(name);
-  const exact = idx.get(norm);
-  if (exact) return exact;
-
-  const tokens = coreTokens(name);
-  if (tokens.length === 0) return undefined;
-
-  const cleaned = tokens.join(" ");
-  const cleanedHit = idx.get(cleaned);
-  if (cleanedHit) return cleanedHit;
-
-  // Token-subset: every query token must appear (whole-word) in the candidate.
-  const query = new Set(tokens);
-  for (const entry of tokenIndex!) {
-    let all = true;
-    for (const t of query) {
-      if (!entry.tokens.has(t)) {
-        all = false;
-        break;
-      }
-    }
-    if (all) return entry.ingredient;
-  }
-  return undefined;
-}
+// `resolveIngredientByName` (added here in #555) was lifted into the shared
+// `./ingredientResolution` module so other consumers — notably
+// `UnifiedIngredientService.getIngredientByName` — can use the same matching.
+// Re-exported for backward compatibility with existing importers and tests.
+export { resolveIngredientByName };
 
 const DEFAULT_SERVING_GRAMS = 100;
 const DEFAULT_RECIPE_SERVINGS = 4;

--- a/src/utils/ingredientResolution.test.ts
+++ b/src/utils/ingredientResolution.test.ts
@@ -1,0 +1,50 @@
+// src/utils/ingredientResolution.test.ts
+
+import {
+  resolveIngredientByName,
+  normName,
+} from "@/utils/ingredientResolution";
+
+describe("ingredientResolution.normName", () => {
+  it("treats underscores like spaces (slug-form catalog names)", () => {
+    expect(normName("rice_vinegar")).toBe("rice vinegar");
+    expect(normName("Extra-Virgin Olive Oil")).toBe("extra virgin olive oil");
+  });
+});
+
+describe("resolveIngredientByName (shared)", () => {
+  it("resolves an exact catalog name", () => {
+    expect(resolveIngredientByName("Olive Oil")?.name).toBe("Olive Oil");
+  });
+
+  it("resolves a slug-named catalog entry from its human form", () => {
+    // Several catalog entries store the slug in `name` ("rice_vinegar").
+    // Normalizing underscores lets the human phrase resolve them.
+    const hit = resolveIngredientByName("rice vinegar");
+    expect(hit).toBeDefined();
+    expect(hit!.name.toLowerCase()).toContain("rice");
+    expect(hit!.name.toLowerCase()).toContain("vinegar");
+  });
+
+  it("strips prep adjectives and leading quantity/unit", () => {
+    expect(
+      resolveIngredientByName("2 tablespoons minced garlic")?.name.toLowerCase(),
+    ).toContain("garlic");
+  });
+
+  it("does not over-match across word boundaries", () => {
+    // Whole-word token subset: "egg" resolves an egg, never "eggplant".
+    const egg = resolveIngredientByName("eggs");
+    expect(egg).toBeDefined();
+    expect(egg!.name.toLowerCase()).not.toContain("eggplant");
+    // If "rice" resolves at all, it must be a rice — never "ice".
+    const rice = resolveIngredientByName("rice");
+    if (rice) expect(rice.name.toLowerCase()).toContain("rice");
+  });
+
+  it("returns undefined for nullish / empty input", () => {
+    expect(resolveIngredientByName("")).toBeUndefined();
+    expect(resolveIngredientByName(undefined)).toBeUndefined();
+    expect(resolveIngredientByName(null)).toBeUndefined();
+  });
+});

--- a/src/utils/ingredientResolution.ts
+++ b/src/utils/ingredientResolution.ts
@@ -1,0 +1,169 @@
+// src/utils/ingredientResolution.ts
+//
+// Shared free-text → catalog ingredient resolver.
+//
+// Recipe ingredient names (and other free-text references) are messy
+// ("extra virgin olive oil", "eggs", "minced garlic", "pinch sea salt",
+// "1-2 tablespoons vanilla"). The catalog keys are clean ("Olive Oil",
+// "Chicken Egg", "garlic", "sea salt"). An exact-match lookup resolves under
+// half of all recipe ingredient occurrences.
+//
+// This resolver closes that gap with conservative normalization: strip leading
+// quantities/units, take the first option of "X or Y", drop preparation
+// adjectives, singularize, then match by exact-normalized form and finally by
+// token-subset (every word of the query noun-phrase present in the catalog
+// entry). Token-subset matching is whole-word, so "egg" resolves "Chicken Egg"
+// but "rice" never resolves "ice".
+//
+// Originally lived inside `ingredientNutritionAggregation.ts` (added in #555 for
+// recipe nutrition). Lifted here so other consumers — notably
+// `UnifiedIngredientService.getIngredientByName`, which backs the ESMS
+// `matchRate` in `hierarchicalRecipeCalculations.ts` — can share it. Exact
+// matches always win first, so adopting it only ever turns a previous miss into
+// a hit (monotonic).
+
+import { unifiedIngredients } from "@/data/unified/ingredients";
+import type { UnifiedIngredient } from "@/data/unified/unifiedTypes";
+
+/** Preparation/qualifier words that carry no identity and should be dropped. */
+const PREP_WORDS = new Set([
+  "pinch", "dash", "large", "small", "medium", "fresh", "freshly", "dried",
+  "ground", "minced", "chopped", "diced", "sliced", "grated", "melted",
+  "toasted", "warm", "boiling", "cold", "hot", "ripe", "raw", "cooked",
+  "whole", "blanched", "peeled", "crushed", "extra", "virgin", "of", "a",
+  "finely", "roughly", "thinly", "thick", "thin", "light", "dark", "plain",
+  "pure", "organic", "free", "range", "boneless", "skinless", "unsalted",
+  "granulated", "packed", "softened", "beaten", "cubed", "shredded", "halved",
+  "quartered", "seeded", "stemmed", "trimmed", "rinsed", "drained", "to",
+  "taste", "and",
+]);
+
+/** Common irregular plurals worth handling explicitly. */
+const IRREGULAR_PLURALS: Record<string, string> = {
+  leaves: "leaf",
+  loaves: "loaf",
+  halves: "half",
+  knives: "knife",
+  potatoes: "potato",
+  tomatoes: "tomato",
+};
+
+export function normName(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFKD")
+    // Treat underscores like spaces: some catalog `name` fields carry the slug
+    // form ("rice_vinegar") instead of the human name, which would otherwise
+    // never resolve against space-separated free-text.
+    .replace(/_/g, " ")
+    .replace(/[^\w\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Strip a leading quantity + optional unit fragment ("1-2 tablespoons ..."). */
+function stripLeadingQuantity(s: string): string {
+  return s.replace(
+    /^[-\d/.\s]+(tablespoons?|teaspoons?|tbsp|tsp|cups?|grams?|g|kg|oz|ounces?|lb|lbs?|pounds?|ml|l|cloves?|pieces?|slices?|pinch(?:es)?)?\b/i,
+    " ",
+  );
+}
+
+function singularizeWord(w: string): string {
+  if (IRREGULAR_PLURALS[w]) return IRREGULAR_PLURALS[w];
+  if (w.length <= 3) return w;
+  if (w.endsWith("ies")) return `${w.slice(0, -3)}y`;
+  if (w.endsWith("ves")) return `${w.slice(0, -3)}f`;
+  if (w.endsWith("oes")) return w.slice(0, -2);
+  if (/(ches|shes|xes|sses)$/.test(w)) return w.slice(0, -2);
+  if (w.endsWith("s") && !w.endsWith("ss")) return w.slice(0, -1);
+  return w;
+}
+
+/** Produce the cleaned core noun-phrase tokens for a free-text ingredient name. */
+function coreTokens(name: string): string[] {
+  let base = normName(stripLeadingQuantity(name));
+  // "X or Y" / "X and Y" → take the first option.
+  base = base.split(/\b(?:or)\b/)[0].trim();
+  return base
+    .split(" ")
+    .filter((w) => w && !PREP_WORDS.has(w))
+    .map(singularizeWord);
+}
+
+interface TokenEntry {
+  tokens: Set<string>;
+  count: number;
+  ingredient: UnifiedIngredient;
+}
+
+let exactIndex: Map<string, UnifiedIngredient> | null = null;
+let tokenIndex: TokenEntry[] | null = null;
+
+function buildIndex(): void {
+  exactIndex = new Map();
+  tokenIndex = [];
+  for (const ingredient of Object.values(unifiedIngredients)) {
+    const name = ingredient?.name;
+    if (typeof name !== "string" || !name) continue;
+    const norm = normName(name);
+    if (!exactIndex.has(norm)) exactIndex.set(norm, ingredient);
+    const singular = norm.split(" ").map(singularizeWord).join(" ");
+    if (!exactIndex.has(singular)) exactIndex.set(singular, ingredient);
+    const tokens = new Set(coreTokens(name));
+    if (tokens.size > 0) {
+      tokenIndex.push({ tokens, count: tokens.size, ingredient });
+    }
+  }
+  // Stable order so token-subset ties resolve deterministically (fewest tokens,
+  // then alphabetical) regardless of catalog iteration order.
+  tokenIndex.sort((a, b) =>
+    a.count !== b.count
+      ? a.count - b.count
+      : a.ingredient.name.localeCompare(b.ingredient.name),
+  );
+}
+
+/**
+ * Resolve a free-text ingredient name to a catalog ingredient.
+ * Exact-normalized matches always win (preserving prior behavior); the
+ * normalization fallbacks only ever turn a previous miss into a hit.
+ */
+export function resolveIngredientByName(
+  name: string | undefined | null,
+): UnifiedIngredient | undefined {
+  if (!name || typeof name !== "string") return undefined;
+  if (!exactIndex || !tokenIndex) buildIndex();
+  const idx = exactIndex!;
+
+  const norm = normName(name);
+  const exact = idx.get(norm);
+  if (exact) return exact;
+
+  const tokens = coreTokens(name);
+  if (tokens.length === 0) return undefined;
+
+  const cleaned = tokens.join(" ");
+  const cleanedHit = idx.get(cleaned);
+  if (cleanedHit) return cleanedHit;
+
+  // Token-subset: every query token must appear (whole-word) in the candidate.
+  const query = new Set(tokens);
+  for (const entry of tokenIndex!) {
+    let all = true;
+    for (const t of query) {
+      if (!entry.tokens.has(t)) {
+        all = false;
+        break;
+      }
+    }
+    if (all) return entry.ingredient;
+  }
+  return undefined;
+}
+
+/** Test-only hook: drop the memoized indexes so a fresh catalog is reindexed. */
+export function __resetIngredientResolutionIndex(): void {
+  exactIndex = null;
+  tokenIndex = null;
+}


### PR DESCRIPTION
## Summary

Follow-up to #555. The conservative free-text → catalog ingredient resolver added in #555 was scoped **inside** `src/utils/ingredientNutritionAggregation.ts`, so only the recipe-nutrition aggregator used it. The same exact-match-only gap (`UnifiedIngredientService.getIngredientByName`) caps the ESMS `matchRate` in `src/utils/hierarchicalRecipeCalculations.ts:206,216`, which calls it once per recipe ingredient.

This PR lifts the resolver into a shared module and adopts it in the service — **monotonic**: exact match still wins first, so it only ever turns a previous miss into a hit.

## Changes
- **New `src/utils/ingredientResolution.ts`** — the resolver (strip qty/units, `"X or Y"`→first, drop prep adjectives, singularize incl `-oes`/`-ves`/irregulars, exact-normalized → whole-word token-subset).
- `ingredientNutritionAggregation.ts` imports + **re-exports** it (zero behavior change; existing importers and the `#555` test are untouched).
- `UnifiedIngredientService.getIngredientByName` falls back to the shared resolver **only after** its exact-match loop misses.
- `normName` now treats `_` as a space, so the **17 catalog entries whose `name` carries the slug form** (`rice_vinegar`, `apple_cider_vinegar`, `red_wine_vinegar`, …) finally resolve from their human phrase.

## Verification (against live `unifiedIngredients`, 1027 entries)
- Before: `resolveIngredientByName("rice vinegar")` → **MISSING**. After: → `rice_vinegar`. Same for `apple cider vinegar`, `red wine vinegar`.
- Over-match guard holds: `"rice"` → `rice` (never `ice`); `"eggs"` → `Chicken Egg` (never `eggplant`).
- Genuine absences still miss honestly (`fish sauce` — added in a later PR).
- New `ingredientResolution.test.ts` + the existing 11 aggregation tests = **17 passing**. `typecheck` + `lint` clean.

## Why this matters
This is the keystone of the ingredient-placeholder cleanup: it lifts ESMS `matchRate` app-wide and lets the recipe session's `backfillRecipeNutrition` / `backfillRecipeAlchemicalQuantities` re-runs resolve more ingredients. Subsequent PRs (kill the 100/1/10/1 nutrition stub; rescue stranded staples; filter boilerplate from the dashboard) build on it.

## Reflection
The slug-in-`name` issue (17 entries) is a symptom of a broader display-quality gap — those names also render as `rice_vinegar` in the UI. I fixed only the *resolution* half here (monotonic, in scope); the *display* half is a separate, larger normalization pass worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)