### PR TITLE
fix(ingredients): remove fabricated nutrition template (100/1/10/1) from static catalog

### DIFF
--- a/scripts/fixStubIngredientNutrition.ts
+++ b/scripts/fixStubIngredientNutrition.ts
@@ -1,0 +1,198 @@
+/**
+ * Remove the fabricated `{ protein: 1, carbs: 10, fat: 1, fiber: 1 }` macro
+ * template (usually paired with `calories: 100`) from the static ingredient
+ * catalog.
+ *
+ * Background: an earlier generation pass stamped that exact macro template onto
+ * 208 `unifiedIngredients` entries. It is not just cosmetic — the recipe
+ * nutrition aggregator (`computeRecipeNutritionFromIngredients`, #555) reads
+ * `calories`/`macros`, so every recipe that used a stubbed ingredient was
+ * silently credited fabricated calories/macros per serving instead of the
+ * contribution being skipped.
+ *
+ * The template fingerprint is the macros `{ protein: 1, carbs: 10, fat: 1 }`
+ * (the companion `calories` is sometimes 100, sometimes a real value with only
+ * the macros faked). This script eliminates it per entry type:
+ *  - GRAINS: real per-100g nutrition, derived from the real `calories_per_100g`
+ *    / `protein_g` / `fiber_g` already present on each entry (carbs/fat from
+ *    standard whole-grain composition).
+ *  - DRIED HERBS: a real per-teaspoon dried-leaf-herb profile (~3 cal/tsp).
+ *  - FRESH/AROMATIC HERBS: a real per-tablespoon fresh-herb profile (~1 cal).
+ *  - SQUASH/GOURDS: real macros (the existing calories are already real — only
+ *    the macros were faked).
+ *  - COVERAGE ENTRIES (recipeCoverageIngredients): honest-null — the fabricated
+ *    `calories`/`macros` are removed, leaving `serving_size`/`source` so the
+ *    aggregator skips them and browse shows no badge. Real nutrition for the
+ *    genuinely-real coverage ingredients is curated separately with the staples.
+ *
+ * Herb macro contribution is uniform and negligible at this granularity; the
+ * point is to kill the false claim (a teaspoon of dried basil is not 100 cal).
+ *
+ * Idempotent: only entries still carrying the template macros are touched.
+ *
+ *   bun scripts/fixStubIngredientNutrition.ts
+ */
+import * as path from "path";
+import { fileURLToPath } from "url";
+import {
+  Project,
+  SyntaxKind,
+  type ObjectLiteralExpression,
+  type PropertyAssignment,
+} from "ts-morph";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, "..");
+const ING = path.join(REPO_ROOT, "src", "data", "ingredients");
+
+type Mode = "grain" | "driedHerb" | "freshHerb" | "squash" | "coverage";
+interface Target {
+  file: string;
+  varName: string;
+  mode: Mode;
+}
+
+const TARGETS: Target[] = [
+  { file: path.join(ING, "grains", "wholeGrains.ts"), varName: "rawWholeGrains", mode: "grain" },
+  { file: path.join(ING, "herbs", "driedHerbs.ts"), varName: "rawDriedHerbs", mode: "driedHerb" },
+  { file: path.join(ING, "herbs", "aromatic.ts"), varName: "rawAromaticHerbs", mode: "freshHerb" },
+  { file: path.join(ING, "vegetables", "squash.ts"), varName: "rawSquash", mode: "squash" },
+  { file: path.join(ING, "misc", "recipeCoverageIngredients.ts"), varName: "recipeCoverageIngredients", mode: "coverage" },
+];
+
+// Standard whole-grain carbs/fat per 100g dry (calories/protein/fiber come from
+// the real `_per_100g` values already on each entry).
+const GRAIN_CARBS_FAT: Record<string, { carbs: number; fat: number }> = {
+  kamut: { carbs: 70.4, fat: 2.2 },
+  spelt_berries: { carbs: 70.2, fat: 2.4 },
+  einkorn: { carbs: 68.6, fat: 2.5 },
+  rye_berries: { carbs: 75.9, fat: 1.6 },
+  wild_rice: { carbs: 74.9, fat: 1.1 },
+  triticale: { carbs: 72.1, fat: 2.0 },
+  barley: { carbs: 73.5, fat: 2.3 },
+};
+
+// Real macros per 100g raw (calories on each entry are already real).
+const SQUASH_MACROS: Record<string, { protein: number; carbs: number; fat: number; fiber: number }> = {
+  zucchini: { protein: 1.2, carbs: 3.1, fat: 0.3, fiber: 1.0 },
+  "butternut squash": { protein: 1.0, carbs: 11.7, fat: 0.1, fiber: 2.0 },
+  pumpkin: { protein: 1.0, carbs: 6.5, fat: 0.1, fiber: 0.5 },
+  "acorn squash": { protein: 1.1, carbs: 15.0, fat: 0.1, fiber: 2.1 },
+};
+
+const DRIED_HERB = {
+  serving_size: "1 tsp (1 g)",
+  calories: 3,
+  macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 },
+};
+const FRESH_HERB = {
+  serving_size: "1 tbsp (2 g)",
+  calories: 1,
+  macros: { protein: 0.1, carbs: 0.2, fat: 0.02, fiber: 0.1 },
+};
+
+function getPA(obj: ObjectLiteralExpression, name: string): PropertyAssignment | undefined {
+  return obj.getProperty(name)?.asKind(SyntaxKind.PropertyAssignment);
+}
+function numOf(pa: PropertyAssignment | undefined): number | undefined {
+  if (!pa) return undefined;
+  const n = Number(pa.getInitializer()?.getText());
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/** True iff this nutritionalProfile carries the fabricated macro template. */
+function hasTemplateMacros(np: ObjectLiteralExpression): boolean {
+  const macros = getPA(np, "macros")?.getInitializer()?.asKind(SyntaxKind.ObjectLiteralExpression);
+  if (!macros) return false;
+  return (
+    numOf(getPA(macros, "protein")) === 1 &&
+    numOf(getPA(macros, "carbs")) === 10 &&
+    numOf(getPA(macros, "fat")) === 1
+  );
+}
+
+function setServingSize(np: ObjectLiteralExpression, value: string): void {
+  const existing = getPA(np, "serving_size");
+  if (existing) existing.setInitializer(JSON.stringify(value));
+  else np.insertPropertyAssignment(0, { name: "serving_size", initializer: JSON.stringify(value) });
+}
+function setCalories(np: ObjectLiteralExpression, value: number): void {
+  const existing = getPA(np, "calories");
+  if (existing) existing.setInitializer(String(value));
+  else np.addPropertyAssignment({ name: "calories", initializer: String(value) });
+}
+function setMacros(np: ObjectLiteralExpression, m: Record<string, number>): void {
+  const inner = Object.entries(m).map(([k, v]) => `${k}: ${v}`).join(", ");
+  getPA(np, "macros")!.setInitializer(`{ ${inner} }`);
+}
+
+const counts: Record<Mode, number> = { grain: 0, driedHerb: 0, freshHerb: 0, squash: 0, coverage: 0 };
+
+for (const target of TARGETS) {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    compilerOptions: { noEmit: true, skipLibCheck: true, target: 99 },
+  });
+  const sf = project.addSourceFileAtPath(target.file);
+  const obj = sf
+    .getVariableDeclaration(target.varName)
+    ?.getInitializer()
+    ?.asKind(SyntaxKind.ObjectLiteralExpression);
+  if (!obj) throw new Error(`Could not find ${target.varName} object in ${target.file}`);
+
+  for (const prop of obj.getProperties()) {
+    const pa = prop.asKind(SyntaxKind.PropertyAssignment);
+    if (!pa) continue;
+    const slug = pa.getName().replace(/^["'`]|["'`]$/g, "");
+    const entry = pa.getInitializer()?.asKind(SyntaxKind.ObjectLiteralExpression);
+    if (!entry) continue;
+    const np = getPA(entry, "nutritionalProfile")?.getInitializer()?.asKind(SyntaxKind.ObjectLiteralExpression);
+    if (!np || !hasTemplateMacros(np)) continue;
+
+    switch (target.mode) {
+      case "grain": {
+        const cal = numOf(getPA(np, "calories_per_100g"));
+        const protein = numOf(getPA(np, "protein_g"));
+        const fiber = numOf(getPA(np, "fiber_g"));
+        const cf = GRAIN_CARBS_FAT[slug];
+        if (cal == null || protein == null || fiber == null || !cf) {
+          throw new Error(`Grain ${slug} missing real _per_100g data or carbs/fat map entry`);
+        }
+        setServingSize(np, "100 g dry");
+        setCalories(np, cal);
+        setMacros(np, { protein, carbs: cf.carbs, fat: cf.fat, fiber });
+        break;
+      }
+      case "driedHerb":
+        setServingSize(np, DRIED_HERB.serving_size);
+        setCalories(np, DRIED_HERB.calories);
+        setMacros(np, DRIED_HERB.macros);
+        break;
+      case "freshHerb":
+        setServingSize(np, FRESH_HERB.serving_size);
+        setCalories(np, FRESH_HERB.calories);
+        setMacros(np, FRESH_HERB.macros);
+        break;
+      case "squash": {
+        const m = SQUASH_MACROS[slug];
+        if (!m) throw new Error(`Squash ${slug} missing macros map entry`);
+        setServingSize(np, "100 g raw");
+        setMacros(np, m); // calories already real — leave it
+        break;
+      }
+      case "coverage":
+        getPA(np, "calories")?.remove();
+        getPA(np, "macros")?.remove();
+        break;
+    }
+    counts[target.mode]++;
+  }
+
+  sf.saveSync();
+}
+
+console.log(
+  `Fixed template-macro nutrition — grains: ${counts.grain}, dried herbs: ${counts.driedHerb}, ` +
+    `fresh herbs: ${counts.freshHerb}, squash: ${counts.squash}, coverage(honest-null): ${counts.coverage}`,
+);

--- a/src/data/ingredients/grains/wholeGrains.ts
+++ b/src/data/ingredients/grains/wholeGrains.ts
@@ -464,14 +464,15 @@ const rawWholeGrains = {
       },
     },
     nutritionalProfile: {
-      protein: "high protein content",
+        serving_size: "100 g dry",
+        protein: "high protein content",
       minerals: ["selenium", "zinc", "magnesium"],
       vitamins: ["e", "b-complex"],
       calories_per_100g: 337,
       protein_g: 14.7,
       fiber_g: 11.1,
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 337,
+        macros: { protein: 14.7, carbs: 70.4, fat: 2.2, fiber: 11.1 }
     },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.0, sour: 0.0, bitter: 0.0, umami: 0.1, spicy: 0.0 }, aroma: { earthy: 0.6, nutty: 0.5, roasted: 0.2 }, texture: { chewy: 0.5, firm: 0.3, soft: 0.2 } },
       culinaryProfile: { flavorProfile: { primary: ["neutral"], secondary: ["starchy", "nutty"], notes: "Absorbs surrounding flavors; gains complexity via toasting." }, cookingMethods: ["boil", "steam", "bake", "pilaf", "risotto"], cuisineAffinity: ["Asian", "Mediterranean", "Middle-Eastern", "Latin"], preparationTips: ["Rinse until water runs clear to remove excess starch.", "Toast briefly in fat before adding liquid to deepen flavor."] },
@@ -518,14 +519,15 @@ const rawWholeGrains = {
       },
     },
     nutritionalProfile: {
-      protein: "high quality",
+        serving_size: "100 g dry",
+        protein: "high quality",
       minerals: ["manganese", "phosphorus", "iron"],
       vitamins: ["b3", "b6", "thiamin"],
       calories_per_100g: 338,
       protein_g: 14.6,
       fiber_g: 10.7,
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 338,
+        macros: { protein: 14.6, carbs: 70.2, fat: 2.4, fiber: 10.7 }
     },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.0, sour: 0.0, bitter: 0.0, umami: 0.1, spicy: 0.0 }, aroma: { earthy: 0.6, nutty: 0.5, roasted: 0.2 }, texture: { chewy: 0.5, firm: 0.3, soft: 0.2 } },
       culinaryProfile: { flavorProfile: { primary: ["neutral"], secondary: ["starchy", "nutty"], notes: "Absorbs surrounding flavors; gains complexity via toasting." }, cookingMethods: ["boil", "steam", "bake", "pilaf", "risotto"], cuisineAffinity: ["Asian", "Mediterranean", "Middle-Eastern", "Latin"], preparationTips: ["Rinse until water runs clear to remove excess starch.", "Toast briefly in fat before adding liquid to deepen flavor."] },
@@ -572,14 +574,15 @@ const rawWholeGrains = {
       },
     },
     nutritionalProfile: {
-      protein: "high protein",
+        serving_size: "100 g dry",
+        protein: "high protein",
       minerals: ["zinc", "iron", "manganese"],
       vitamins: ["a", "b-complex"],
       calories_per_100g: 340,
       protein_g: 15.3,
       fiber_g: 8.7,
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 340,
+        macros: { protein: 15.3, carbs: 68.6, fat: 2.5, fiber: 8.7 }
     },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.0, sour: 0.0, bitter: 0.0, umami: 0.1, spicy: 0.0 }, aroma: { earthy: 0.6, nutty: 0.5, roasted: 0.2 }, texture: { chewy: 0.5, firm: 0.3, soft: 0.2 } },
       culinaryProfile: { flavorProfile: { primary: ["neutral"], secondary: ["starchy", "nutty"], notes: "Absorbs surrounding flavors; gains complexity via toasting." }, cookingMethods: ["boil", "steam", "bake", "pilaf", "risotto"], cuisineAffinity: ["Asian", "Mediterranean", "Middle-Eastern", "Latin"], preparationTips: ["Rinse until water runs clear to remove excess starch.", "Toast briefly in fat before adding liquid to deepen flavor."] },
@@ -626,14 +629,15 @@ const rawWholeGrains = {
       },
     },
     nutritionalProfile: {
-      protein: "moderate protein",
+        serving_size: "100 g dry",
+        protein: "moderate protein",
       minerals: ["manganese", "phosphorus", "magnesium"],
       vitamins: ["b1", "b3", "b6"],
       calories_per_100g: 338,
       protein_g: 10.3,
       fiber_g: 15.1,
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 338,
+        macros: { protein: 10.3, carbs: 75.9, fat: 1.6, fiber: 15.1 }
     },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.0, sour: 0.0, bitter: 0.0, umami: 0.1, spicy: 0.0 }, aroma: { earthy: 0.6, nutty: 0.5, roasted: 0.2 }, texture: { chewy: 0.5, firm: 0.3, soft: 0.2 } },
       culinaryProfile: { flavorProfile: { primary: ["neutral"], secondary: ["starchy", "nutty"], notes: "Absorbs surrounding flavors; gains complexity via toasting." }, cookingMethods: ["boil", "steam", "bake", "pilaf", "risotto"], cuisineAffinity: ["Asian", "Mediterranean", "Middle-Eastern", "Latin"], preparationTips: ["Rinse until water runs clear to remove excess starch.", "Toast briefly in fat before adding liquid to deepen flavor."] },
@@ -679,14 +683,15 @@ const rawWholeGrains = {
       },
     },
     nutritionalProfile: {
-      protein: "high protein",
+        serving_size: "100 g dry",
+        protein: "high protein",
       minerals: ["zinc", "phosphorus", "potassium"],
       vitamins: ["b6", "folate", "niacin"],
       calories_per_100g: 357,
       protein_g: 14.7,
       fiber_g: 6.2,
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 357,
+        macros: { protein: 14.7, carbs: 74.9, fat: 1.1, fiber: 6.2 }
     },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.0, sour: 0.0, bitter: 0.0, umami: 0.1, spicy: 0.0 }, aroma: { earthy: 0.6, nutty: 0.5, roasted: 0.2 }, texture: { chewy: 0.5, firm: 0.3, soft: 0.2 } },
       culinaryProfile: { flavorProfile: { primary: ["neutral"], secondary: ["starchy", "nutty"], notes: "Absorbs surrounding flavors; gains complexity via toasting." }, cookingMethods: ["boil", "steam", "bake", "pilaf", "risotto"], cuisineAffinity: ["Asian", "Mediterranean", "Middle-Eastern", "Latin"], preparationTips: ["Rinse until water runs clear to remove excess starch.", "Toast briefly in fat before adding liquid to deepen flavor."] },
@@ -733,14 +738,15 @@ const rawWholeGrains = {
       },
     },
     nutritionalProfile: {
-      protein: "high protein",
+        serving_size: "100 g dry",
+        protein: "high protein",
       minerals: ["manganese", "iron", "copper"],
       vitamins: ["b1", "b2", "folate"],
       calories_per_100g: 336,
       protein_g: 13.1,
       fiber_g: 9.8,
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 336,
+        macros: { protein: 13.1, carbs: 72.1, fat: 2, fiber: 9.8 }
     },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.0, sour: 0.0, bitter: 0.0, umami: 0.1, spicy: 0.0 }, aroma: { earthy: 0.6, nutty: 0.5, roasted: 0.2 }, texture: { chewy: 0.5, firm: 0.3, soft: 0.2 } },
       culinaryProfile: { flavorProfile: { primary: ["neutral"], secondary: ["starchy", "nutty"], notes: "Absorbs surrounding flavors; gains complexity via toasting." }, cookingMethods: ["boil", "steam", "bake", "pilaf", "risotto"], cuisineAffinity: ["Asian", "Mediterranean", "Middle-Eastern", "Latin"], preparationTips: ["Rinse until water runs clear to remove excess starch.", "Toast briefly in fat before adding liquid to deepen flavor."] },
@@ -842,14 +848,15 @@ const rawWholeGrains = {
       },
     },
     nutritionalProfile: {
-      protein: "moderate protein",
+        serving_size: "100 g dry",
+        protein: "moderate protein",
       minerals: ["manganese", "phosphorus", "magnesium"],
       vitamins: ["b1", "b3", "b6"],
       calories_per_100g: 338,
       protein_g: 10.3,
       fiber_g: 15.1,
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 338,
+        macros: { protein: 10.3, carbs: 73.5, fat: 2.3, fiber: 15.1 }
     },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.0, sour: 0.0, bitter: 0.0, umami: 0.1, spicy: 0.0 }, aroma: { earthy: 0.6, nutty: 0.5, roasted: 0.2 }, texture: { chewy: 0.5, firm: 0.3, soft: 0.2 } },
       culinaryProfile: { flavorProfile: { primary: ["neutral"], secondary: ["starchy", "nutty"], notes: "Absorbs surrounding flavors; gains complexity via toasting." }, cookingMethods: ["boil", "steam", "bake", "pilaf", "risotto"], cuisineAffinity: ["Asian", "Mediterranean", "Middle-Eastern", "Latin"], preparationTips: ["Rinse until water runs clear to remove excess starch.", "Toast briefly in fat before adding liquid to deepen flavor."] },

--- a/src/data/ingredients/herbs/aromatic.ts
+++ b/src/data/ingredients/herbs/aromatic.ts
@@ -13,14 +13,15 @@ const rawAromaticHerbs = {
     elementalProperties: { Air: 0.5, Fire: 0.3, Earth: 0.1, Water: 0.1 },
     qualities: ["aromatic", "fresh", "culinary"],
     nutritionalProfile: {
-      calories: 0,
+        serving_size: "1 tbsp (2 g)",
+        calories: 1,
       protein_g: 0,
       carbs_g: 0,
       fat_g: 0,
       fiber_g: 0,
       vitamins: [],
       minerals: [],
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        macros: { protein: 0.1, carbs: 0.2, fat: 0.02, fiber: 0.1 }
     },
     astrologicalProfile: {
       rulingPlanets: ["Mercury", "Venus"],
@@ -71,14 +72,15 @@ const rawAromaticHerbs = {
     elementalProperties: { Fire: 0.6, Air: 0.2, Earth: 0.1, Water: 0.1 },
     qualities: ["aromatic", "fresh", "culinary"],
     nutritionalProfile: {
-      calories: 0,
+        serving_size: "1 tbsp (2 g)",
+        calories: 1,
       protein_g: 0,
       carbs_g: 0,
       fat_g: 0,
       fiber_g: 0,
       vitamins: [],
       minerals: [],
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        macros: { protein: 0.1, carbs: 0.2, fat: 0.02, fiber: 0.1 }
     },
     astrologicalProfile: {
       rulingPlanets: ["Sun", "Mars"],
@@ -142,14 +144,15 @@ const rawAromaticHerbs = {
     elementalProperties: { Air: 0.5, Fire: 0.3, Earth: 0.2, Water: 0 },
     qualities: ["aromatic", "fresh", "culinary"],
     nutritionalProfile: {
-      calories: 0,
+        serving_size: "1 tbsp (2 g)",
+        calories: 1,
       protein_g: 0,
       carbs_g: 0,
       fat_g: 0,
       fiber_g: 0,
       vitamins: [],
       minerals: [],
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        macros: { protein: 0.1, carbs: 0.2, fat: 0.02, fiber: 0.1 }
     },
     astrologicalProfile: {
       rulingPlanets: ["Mercury", "Moon"],
@@ -250,14 +253,15 @@ const rawAromaticHerbs = {
     name: "Lemon Verbena",
     elementalProperties: { Air: 0.5, Fire: 0.3, Water: 0.1, Earth: 0.1 },
     nutritionalProfile: {
-      calories: 0,
+        serving_size: "1 tbsp (2 g)",
+        calories: 1,
       protein_g: 0,
       carbs_g: 0,
       fat_g: 0,
       fiber_g: 0,
       vitamins: [],
       minerals: [],
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        macros: { protein: 0.1, carbs: 0.2, fat: 0.02, fiber: 0.1 }
     },
     astrologicalProfile: {
       rulingPlanets: ["Mercury", "Venus"],
@@ -332,14 +336,15 @@ const rawAromaticHerbs = {
     name: "Savory",
     elementalProperties: { Fire: 0.4, Earth: 0.3, Air: 0.2, Water: 0.1 },
     nutritionalProfile: {
-      calories: 0,
+        serving_size: "1 tbsp (2 g)",
+        calories: 1,
       protein_g: 0,
       carbs_g: 0,
       fat_g: 0,
       fiber_g: 0,
       vitamins: [],
       minerals: [],
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        macros: { protein: 0.1, carbs: 0.2, fat: 0.02, fiber: 0.1 }
     },
     astrologicalProfile: {
       rulingPlanets: ["Mars", "Saturn"],
@@ -417,14 +422,15 @@ const rawAromaticHerbs = {
     name: "Curry Leaf",
     elementalProperties: { Fire: 0.4, Earth: 0.3, Air: 0.2, Water: 0.1 },
     nutritionalProfile: {
-      calories: 0,
+        serving_size: "1 tbsp (2 g)",
+        calories: 1,
       protein_g: 0,
       carbs_g: 0,
       fat_g: 0,
       fiber_g: 0,
       vitamins: [],
       minerals: [],
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        macros: { protein: 0.1, carbs: 0.2, fat: 0.02, fiber: 0.1 }
     },
     astrologicalProfile: {
       rulingPlanets: ["Mars", "Jupiter"],
@@ -506,14 +512,15 @@ const rawAromaticHerbs = {
     name: "Chervil",
     elementalProperties: { Air: 0.4, Earth: 0.3, Water: 0.2, Fire: 0.1 },
     nutritionalProfile: {
-      calories: 0,
+        serving_size: "1 tbsp (2 g)",
+        calories: 1,
       protein_g: 0,
       carbs_g: 0,
       fat_g: 0,
       fiber_g: 0,
       vitamins: [],
       minerals: [],
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        macros: { protein: 0.1, carbs: 0.2, fat: 0.02, fiber: 0.1 }
     },
     astrologicalProfile: {
       rulingPlanets: ["Mercury", "Moon"],
@@ -586,14 +593,15 @@ const rawAromaticHerbs = {
       Water: 0.1,
     },
     nutritionalProfile: {
-      calories: 0,
+        serving_size: "1 tbsp (2 g)",
+        calories: 1,
       protein_g: 0,
       carbs_g: 0,
       fat_g: 0,
       fiber_g: 0,
       vitamins: [],
       minerals: [],
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        macros: { protein: 0.1, carbs: 0.2, fat: 0.02, fiber: 0.1 }
     },
     qualities: ["cooling", "digestive", "balancing"],
     origin: ["Europe", "Asia"],
@@ -654,14 +662,15 @@ const rawAromaticHerbs = {
       Water: 0.1,
     },
     nutritionalProfile: {
-      calories: 0,
+        serving_size: "1 tbsp (2 g)",
+        calories: 1,
       protein_g: 0,
       carbs_g: 0,
       fat_g: 0,
       fiber_g: 0,
       vitamins: [],
       minerals: [],
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        macros: { protein: 0.1, carbs: 0.2, fat: 0.02, fiber: 0.1 }
     },
     qualities: ["warming", "digestive", "aromatic"],
     origin: ["Mediterranean", "Asia Minor"],
@@ -719,14 +728,15 @@ const rawAromaticHerbs = {
       Water: 0.1,
     },
     nutritionalProfile: {
-      calories: 0,
+        serving_size: "1 tbsp (2 g)",
+        calories: 1,
       protein_g: 0,
       carbs_g: 0,
       fat_g: 0,
       fiber_g: 0,
       vitamins: [],
       minerals: [],
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        macros: { protein: 0.1, carbs: 0.2, fat: 0.02, fiber: 0.1 }
     },
     qualities: ["warming", "digestive", "expectorant"],
     origin: ["Mediterranean", "Middle East"],

--- a/src/data/ingredients/herbs/driedHerbs.ts
+++ b/src/data/ingredients/herbs/driedHerbs.ts
@@ -25,12 +25,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["infused", "cooked"],
     conversionRatio: "1:3", // 1 part dried = 3 parts fresh;
     nutritionalProfile: {
-      vitamins: ["k", "a"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["k", "a"],
       minerals: ["calcium", "iron"],
       antioxidants: ["flavonoids", "anthocyanins"],
       volatileoils: ["eugenol", "linalool"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       crushing: "just before use",
@@ -88,12 +89,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["cooked", "infused"],
     conversionRatio: "1:3",
     nutritionalProfile: {
-      vitamins: ["k", "e"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["k", "e"],
       minerals: ["iron", "manganese"],
       antioxidants: ["rosmarinic acid", "thymol"],
       volatileoils: ["carvacrol", "thymol"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       crushing: "release oils before use",
@@ -145,12 +147,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["cooked", "infused", "brined"],
     conversionRatio: "1:3",
     nutritionalProfile: {
-      vitamins: ["c", "a"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["c", "a"],
       minerals: ["iron", "manganese"],
       antioxidants: ["thymol", "carvacrol"],
       volatileoils: ["thymol", "linalool"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       removing: "from stems if whole",
@@ -202,12 +205,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["cooked", "infused", "roasted"],
     conversionRatio: "1:3",
     nutritionalProfile: {
-      vitamins: ["a", "c"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["a", "c"],
       minerals: ["calcium", "iron"],
       antioxidants: ["carnosic acid", "rosmarinic acid"],
       volatileoils: ["pinene", "camphor"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       grinding: "recommended - leaves are tough",
@@ -259,12 +263,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["cooked", "infused", "rubbed"],
     conversionRatio: "1:4",
     nutritionalProfile: {
-      vitamins: ["k", "b6"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["k", "b6"],
       minerals: ["iron", "calcium"],
       antioxidants: ["rosmarinic acid", "carnosic acid"],
       volatileoils: ["thujone", "camphor"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       rubbing: "crumble between fingers",
@@ -320,12 +325,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["simmered", "infused", "brined"],
     conversionRatio: "1:2",
     nutritionalProfile: {
-      vitamins: ["a", "c"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["a", "c"],
       minerals: ["iron", "manganese"],
       antioxidants: ["linalool", "eugenol"],
       volatileoils: ["cineole", "eugenol"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       whole: "use whole and remove before serving",
@@ -377,12 +383,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["cooked", "infused"],
     conversionRatio: "1:3",
     nutritionalProfile: {
-      vitamins: ["k", "c"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["k", "c"],
       minerals: ["iron", "calcium"],
       antioxidants: ["rosmarinic acid", "ursolic acid"],
       volatileoils: ["sabinene", "terpinene"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       crushing: "gently before use",
@@ -433,12 +440,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["cooked", "infused", "marinades"],
     conversionRatio: "1:3",
     nutritionalProfile: {
-      vitamins: ["a", "c"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["a", "c"],
       minerals: ["iron", "manganese"],
       antioxidants: ["rosmarinic acid", "thymol"],
       volatileoils: ["carvacrol", "thymol"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       crushing: "before use",
@@ -489,12 +497,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["finishing", "infused"],
     conversionRatio: "1:3",
     nutritionalProfile: {
-      vitamins: ["c", "a"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["c", "a"],
       minerals: ["potassium", "calcium"],
       antioxidants: ["flavonoids", "carotenoids"],
       volatileoils: ["methyl chavicol", "limonene"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       crushing: "very gently",
@@ -545,12 +554,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["cooked", "infused", "sauces"],
     conversionRatio: "1:3",
     nutritionalProfile: {
-      vitamins: ["a", "c"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["a", "c"],
       minerals: ["calcium", "potassium"],
       antioxidants: ["quercetin", "rutin"],
       volatileoils: ["estragole", "ocimene"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       crushing: "gently to release oils",
@@ -601,12 +611,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["cooked", "pickling", "infused"],
     conversionRatio: "1:3",
     nutritionalProfile: {
-      vitamins: ["a", "c"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["a", "c"],
       minerals: ["manganese", "iron"],
       antioxidants: ["flavonoids", "monoterpenes"],
       volatileoils: ["carvone", "limonene"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       crushing: "before use",
@@ -657,12 +668,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["tea", "cooked", "infused"],
     conversionRatio: "1:4",
     nutritionalProfile: {
-      vitamins: ["a", "c"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["a", "c"],
       minerals: ["iron", "manganese"],
       antioxidants: ["rosmarinic acid", "flavonoids"],
       volatileoils: ["menthol", "menthone"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       crushing: "to release oils",
@@ -718,12 +730,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["cooked", "infused", "tea"],
     conversionRatio: "1:3",
     nutritionalProfile: {
-      vitamins: ["c", "b6"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["c", "b6"],
       minerals: ["calcium", "iron"],
       antioxidants: ["flavonoids", "anethole"],
       volatileoils: ["anethole", "fenchone"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       grinding: "just before use if whole",
@@ -779,12 +792,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["cooked", "garnish", "infused"],
     conversionRatio: "1:3",
     nutritionalProfile: {
-      vitamins: ["k", "c", "a"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["k", "c", "a"],
       minerals: ["iron", "calcium"],
       antioxidants: ["flavonoids", "luteolin"],
       volatileoils: ["myristicin", "apiol"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       crushing: "gently before use",
@@ -835,12 +849,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["cooked", "infused"],
     conversionRatio: "1:4",
     nutritionalProfile: {
-      vitamins: ["k", "a"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["k", "a"],
       minerals: ["potassium", "manganese"],
       antioxidants: ["quercetin", "kaempferol"],
       volatileoils: ["linalool", "decanal"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       crushing: "before use",
@@ -891,12 +906,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["garnish", "rehydrated", "cooked"],
     conversionRatio: "1:3",
     nutritionalProfile: {
-      vitamins: ["k", "c"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["k", "c"],
       minerals: ["calcium", "iron"],
       antioxidants: ["allicin", "quercetin"],
       volatileoils: ["allyl sulfides"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       rehydrating: "soak in warm water briefly",
@@ -947,12 +963,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["tea", "infused", "baking"],
     conversionRatio: "1:4",
     nutritionalProfile: {
-      vitamins: ["b", "c"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["b", "c"],
       minerals: ["calcium", "potassium"],
       antioxidants: ["rosmarinic acid", "flavonoids"],
       volatileoils: ["citral", "citronellal"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       crushing: "lightly before use",
@@ -1008,12 +1025,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["baking", "infused", "tea"],
     conversionRatio: "1:3",
     nutritionalProfile: {
-      vitamins: ["a", "c"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["a", "c"],
       minerals: ["calcium", "iron"],
       antioxidants: ["rosmarinic acid", "ursolic acid"],
       volatileoils: ["linalool", "linalyl acetate"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       crushing: "gently before use",
@@ -1069,12 +1087,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["cooked", "infused", "marinades"],
     conversionRatio: "1:3",
     nutritionalProfile: {
-      vitamins: ["k", "b6"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["k", "b6"],
       minerals: ["iron", "manganese"],
       antioxidants: ["rosmarinic acid", "carvacrol"],
       volatileoils: ["thymol", "carvacrol"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       crushing: "before use",
@@ -1125,12 +1144,13 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     cookingMethods: ["cooked", "infused", "seasoning"],
     conversionRatio: "1:3",
     nutritionalProfile: {
-      vitamins: ["b6", "c"],
+        serving_size: "1 tsp (1 g)",
+        vitamins: ["b6", "c"],
       minerals: ["iron", "magnesium"],
       antioxidants: ["quercetin", "kaempferol"],
       volatileoils: ["phthalides", "terpenes"],
-        calories: 100,
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        calories: 3,
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
     preparation: {
       crushing: "before use",
@@ -1182,14 +1202,15 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     category: "culinary_herb",
     qualities: ["nourishing"],
     nutritionalProfile: {
-      calories: 0,
+        serving_size: "1 tsp (1 g)",
+        calories: 3,
       protein_g: 0,
       carbs_g: 0,
       fat_g: 0,
       fiber_g: 0,
       vitamins: [],
       minerals: [],
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.0, sour: 0.0, bitter: 0.2, umami: 0.0, spicy: 0.0 }, aroma: { herbaceous: 0.9, grassy: 0.5, floral: 0.3 }, texture: { tender: 0.6, delicate: 0.5 } },
       culinaryProfile: { flavorProfile: { primary: ["herbaceous"], secondary: ["grassy", "bright"], notes: "Add fresh herbs at the end of cooking to preserve volatile oils; dried herbs go in early." }, cookingMethods: ["raw", "infuse", "finish", "chiffonade"], cuisineAffinity: ["Mediterranean", "French", "Middle-Eastern", "Asian"], preparationTips: ["Chop with a sharp knife to avoid bruising.", "Add fresh at service, dried during simmer."] },
@@ -1217,14 +1238,15 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     category: "culinary_herb",
     qualities: ["nourishing"],
     nutritionalProfile: {
-      calories: 0,
+        serving_size: "1 tsp (1 g)",
+        calories: 3,
       protein_g: 0,
       carbs_g: 0,
       fat_g: 0,
       fiber_g: 0,
       vitamins: [],
       minerals: [],
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.0, sour: 0.0, bitter: 0.2, umami: 0.0, spicy: 0.0 }, aroma: { herbaceous: 0.9, grassy: 0.5, floral: 0.3 }, texture: { tender: 0.6, delicate: 0.5 } },
       culinaryProfile: { flavorProfile: { primary: ["herbaceous"], secondary: ["grassy", "bright"], notes: "Add fresh herbs at the end of cooking to preserve volatile oils; dried herbs go in early." }, cookingMethods: ["raw", "infuse", "finish", "chiffonade"], cuisineAffinity: ["Mediterranean", "French", "Middle-Eastern", "Asian"], preparationTips: ["Chop with a sharp knife to avoid bruising.", "Add fresh at service, dried during simmer."] },
@@ -1253,14 +1275,15 @@ const rawDriedHerbs: Record<string, Partial<IngredientMapping>> = {
     category: "culinary_herb",
     qualities: ["nourishing"],
     nutritionalProfile: {
-      calories: 0,
+        serving_size: "1 tsp (1 g)",
+        calories: 3,
       protein_g: 0,
       carbs_g: 0,
       fat_g: 0,
       fiber_g: 0,
       vitamins: [],
       minerals: [],
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        macros: { protein: 0.1, carbs: 0.6, fat: 0.06, fiber: 0.4 }
     },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.0, sour: 0.0, bitter: 0.2, umami: 0.0, spicy: 0.0 }, aroma: { herbaceous: 0.9, grassy: 0.5, floral: 0.3 }, texture: { tender: 0.6, delicate: 0.5 } },
       culinaryProfile: { flavorProfile: { primary: ["herbaceous"], secondary: ["grassy", "bright"], notes: "Add fresh herbs at the end of cooking to preserve volatile oils; dried herbs go in early." }, cookingMethods: ["raw", "infuse", "finish", "chiffonade"], cuisineAffinity: ["Mediterranean", "French", "Middle-Eastern", "Asian"], preparationTips: ["Chop with a sharp knife to avoid bruising.", "Add fresh at service, dried during simmer."] },

--- a/src/data/ingredients/misc/recipeCoverageIngredients.ts
+++ b/src/data/ingredients/misc/recipeCoverageIngredients.ts
@@ -25,8 +25,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -86,8 +84,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -147,8 +143,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -208,8 +202,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -269,8 +261,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -330,8 +320,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -391,8 +379,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -452,8 +438,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -513,8 +497,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -574,8 +556,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -635,8 +615,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -696,8 +674,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -757,8 +733,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -818,8 +792,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -879,8 +851,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -940,8 +910,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -1001,8 +969,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -1063,8 +1029,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -1125,8 +1089,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -1186,8 +1148,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -1307,8 +1267,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -1368,8 +1326,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -1429,8 +1385,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -1490,8 +1444,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -1551,8 +1503,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -1612,8 +1562,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -1673,8 +1621,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -1734,8 +1680,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -1855,8 +1799,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -1916,8 +1858,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -2157,8 +2097,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -2338,8 +2276,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -2399,8 +2335,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -2580,8 +2514,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -2701,8 +2633,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -2762,8 +2692,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -2943,8 +2871,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -3304,8 +3230,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -3365,8 +3289,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -3486,8 +3408,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -3787,8 +3707,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -3849,8 +3767,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -4210,8 +4126,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -4511,8 +4425,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -4692,8 +4604,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -4753,8 +4663,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -4935,8 +4843,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -5116,8 +5022,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -5177,8 +5081,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -5238,8 +5140,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -5479,8 +5379,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -6020,8 +5918,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -6381,8 +6277,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -6683,8 +6577,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -7165,8 +7057,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -7226,8 +7116,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -7287,8 +7175,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -7348,8 +7234,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -7409,8 +7293,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -7530,8 +7412,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -7591,8 +7471,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -7652,8 +7530,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -7773,8 +7649,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -7834,8 +7708,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -7895,8 +7767,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -8076,8 +7946,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -8137,8 +8005,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -8198,8 +8064,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -8799,8 +8663,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -8860,8 +8722,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -8921,8 +8781,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -9222,8 +9080,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -9403,8 +9259,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -10904,8 +10758,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -10965,8 +10817,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -11026,8 +10876,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -11147,8 +10995,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -11208,8 +11054,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -11329,8 +11173,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -11630,8 +11472,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -11691,8 +11531,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -11992,8 +11830,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -12053,8 +11889,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -12114,8 +11948,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -12235,8 +12067,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -12416,8 +12246,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -12597,8 +12425,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -12658,8 +12484,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -12839,8 +12663,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -13020,8 +12842,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -13141,8 +12961,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -13322,8 +13140,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -13503,8 +13319,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -13624,8 +13438,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -13925,8 +13737,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -14046,8 +13856,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -14107,8 +13915,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -14228,8 +14034,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -14469,8 +14273,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -14590,8 +14392,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -14771,8 +14571,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -14892,8 +14690,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -15013,8 +14809,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -15194,8 +14988,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -15255,8 +15047,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -15436,8 +15226,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -15497,8 +15285,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -15678,8 +15464,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -15859,8 +15643,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -16280,8 +16062,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -16341,8 +16121,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -16402,8 +16180,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -16823,8 +16599,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -17484,8 +17258,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -17605,8 +17377,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -17666,8 +17436,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -17907,8 +17675,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -18448,8 +18214,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -18509,8 +18273,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -18570,8 +18332,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -18991,8 +18751,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -19532,8 +19290,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -19593,8 +19349,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -19654,8 +19408,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -19715,8 +19467,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -19776,8 +19526,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -20377,8 +20125,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -20798,8 +20544,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -21040,8 +20784,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -21701,8 +21443,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -21942,8 +21682,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -22063,8 +21801,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -22124,8 +21860,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -22485,8 +22219,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -22546,8 +22278,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -22667,8 +22397,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -22728,8 +22456,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -22789,8 +22515,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -22850,8 +22574,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -22911,8 +22633,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -23032,8 +22752,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -23093,8 +22811,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -23154,8 +22870,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -23215,8 +22929,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -23276,8 +22988,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -23337,8 +23047,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -23458,8 +23166,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -23519,8 +23225,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -23760,8 +23464,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -23821,8 +23523,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -23882,8 +23582,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -23943,8 +23641,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -24004,8 +23700,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -24065,8 +23759,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -24126,8 +23818,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -24247,8 +23937,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -24308,8 +23996,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -24369,8 +24055,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -24430,8 +24114,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -24491,8 +24173,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -24732,8 +24412,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -24853,8 +24531,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -25154,8 +24830,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -25275,8 +24949,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -25336,8 +25008,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -25397,8 +25067,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -25458,8 +25126,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -25519,8 +25185,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -25580,8 +25244,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -25641,8 +25303,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },
@@ -25762,8 +25422,6 @@ export const recipeCoverageIngredients: Record<
     nutritionalProfile: {
       serving_size: "1 serving",
       source: "Recipe-derived coverage entry",
-      calories: 100,
-      macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 },
       vitamins: {},
       minerals: {},
     },

--- a/src/data/ingredients/vegetables/squash.ts
+++ b/src/data/ingredients/vegetables/squash.ts
@@ -47,7 +47,8 @@ const rawSquash = {
     affinities: ["sage", "brown butter", "maple", "cinnamon", "pecans"],
     cookingMethods: ["roasted", "soup", "steamed", "puréed"],
     nutritionalProfile: {
-      calories: 45,
+        serving_size: "100 g raw",
+        calories: 45,
       protein_g: 1,
       carbs_g: 12,
       fat_g: 0.1,
@@ -58,7 +59,7 @@ const rawSquash = {
       antioxidants: ["beta-carotene"],
       glycemic_index: 51,
       notes: "High in beta-carotene and vitamin A",
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        macros: { protein: 1, carbs: 11.7, fat: 0.1, fiber: 2 }
     },
     preparation: {
       peeling: "required",
@@ -108,13 +109,14 @@ const rawSquash = {
     category: "vegetable",
     subCategory: "squash",
     nutritionalProfile: {
-      carbs_g: 3.11,
+        serving_size: "100 g raw",
+        carbs_g: 3.11,
       calories: 17,
       fiber_g: 1,
       protein_g: 1.21,
       vitamins: ["a", "c", "k", "b6", "folate"],
       minerals: ["potassium", "manganese", "magnesium"],
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        macros: { protein: 1.2, carbs: 3.1, fat: 0.3, fiber: 1 }
     },
     season: ["summer"],
     cookingMethods: ["saute", "roast", "grill", "raw", "steam", "bake"],
@@ -204,7 +206,8 @@ const rawSquash = {
     affinities: ["cinnamon", "nutmeg", "ginger", "cream", "sage"],
     cookingMethods: ["roasted", "steamed", "puréed", "soup"],
     nutritionalProfile: {
-      fiber: "high",
+        serving_size: "100 g raw",
+        fiber: "high",
       vitamins: ["a", "c", "e", "k"],
       minerals: ["potassium", "copper", "manganese"],
       calories: 26,
@@ -215,7 +218,7 @@ const rawSquash = {
       antioxidants: ["beta-carotene", "lutein", "zeaxanthin"],
       glycemic_index: 75,
       notes: "Excellent source of vitamin A and beta-carotene",
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        macros: { protein: 1, carbs: 6.5, fat: 0.1, fiber: 0.5 }
     },
     preparation: {
       cutting: "quarter, remove seeds",
@@ -289,7 +292,8 @@ const rawSquash = {
     affinities: ["butter", "maple", "thyme", "apple", "pecans"],
     cookingMethods: ["roasted", "stuffed", "steamed"],
     nutritionalProfile: {
-      fiber: "high",
+        serving_size: "100 g raw",
+        fiber: "high",
       vitamins: ["c", "b6", "a", "thiamin"],
       minerals: ["magnesium", "potassium", "manganese"],
       calories: 56,
@@ -300,7 +304,7 @@ const rawSquash = {
       sugar_g: 0,
       glycemic_index: 40,
       notes: "Good source of vitamin C and potassium",
-        macros: { protein: 1, carbs: 10, fat: 1, fiber: 1 }
+        macros: { protein: 1.1, carbs: 15, fat: 0.1, fiber: 2.1 }
     },
     preparation: {
       washing: true,


### PR DESCRIPTION
## Summary

The static ingredient catalog (`unifiedIngredients`, 1027 entries) carried the fabricated macro template `{ protein: 1, carbs: 10, fat: 1, fiber: 1 }` on **208 entries** — usually paired with `calories: 100`, but in 12 cases a real calorie value with only the macros faked.

This is **not cosmetic**. The recipe-nutrition aggregator added in #555 reads `calories`/`macros`, so every recipe using a stubbed ingredient was silently credited fabricated calories per serving instead of the contribution being skipped.

## Fix (new idempotent `scripts/fixStubIngredientNutrition.ts`)
Eliminates the template per entry type:

| Type | Count | Treatment |
|---|---|---|
| Grains | 7 | Real per-100g — derived from the real `calories_per_100g`/`protein_g`/`fiber_g` **already present** on each entry (+ standard whole-grain carbs/fat) |
| Dried herbs | 23 | Real per-tsp dried-leaf profile (~3 cal/tsp) |
| Fresh/aromatic herbs | 10 | Real per-tbsp fresh-herb profile (~1 cal) |
| Squash/gourds | 4 | Real macros — calories were already real, only macros faked |
| Coverage entries | 171 | **Honest-null** — fabricated calories/macros removed, leaving `serving_size`/`source` so the aggregator skips them and browse shows no badge |

The squash/grain entries turned out to already hold real per-100g data in non-standard keys (`carbs_g`, `protein_g`, …) — the stub was layered *on top* of it; the supplied macros match that real data.

Coverage entries are recipe-name/fragment stubs (`thit kho tau`, `alchemical binding agent`, …) plus some genuinely-real ingredients. Honest-null is the correct interim: it stops the poisoning immediately. Real nutrition for the genuinely-real coverage ingredients (cornstarch, mirin, tahini, …) is curated in the staples PR.

## Verification (against live `unifiedIngredients`)
- **0** template-macro `{1,10,1}` entries remain; **0** exact-`100/1/10/1` remain.
- Script is **idempotent** (re-run reports all zeros).
- `barley` 100g now aggregates to real macros (338 cal, 73.5g carb, 15.1g fiber); a nulled coverage entry returns no nutrition.
- typecheck + lint clean.

## ⚠️ Note for the recipe session
Re-run `scripts/backfillRecipeNutrition.ts` after this lands. Recipes whose stored nutrition was **inflated by stub coverage ingredients** will correctly recompute lower or drop to honestly-empty. This PR does not touch the DB.

## Reflection
The template appeared in two shapes (`cal:100` + stub macros, and real-calorie + stub macros), so the audit's first exact-`100/1/10/1` filter undercounted by 12 — worth fingerprinting on the macros, not the calories. Honest-null vs. real-backfill was split deliberately by confidence: real values only where a source is unambiguous (textbook foods / data already on the entry), null everywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)