### PR TITLE
fix(dashboard): stop leaking placeholder coverage entries into ingredient recommendations

### DIFF
--- a/src/app/api/recommendations/ingredients/route.ts
+++ b/src/app/api/recommendations/ingredients/route.ts
@@ -15,6 +15,7 @@ import { NextResponse } from "next/server";
 import { calculatePlanetaryHoursInfluence } from "@/calculations/core/planetaryInfluences";
 import { unifiedIngredients } from "@/data/unified/ingredients";
 import type { UnifiedIngredient } from "@/data/unified/unifiedTypes";
+import { isBoilerplateCoverageIngredient } from "@/lib/ingredients/coverageQuality";
 import { rateLimit } from "@/lib/rateLimit";
 import {
   RecommendedIngredientsResponseSchema,
@@ -106,8 +107,15 @@ export async function GET(request: Request) {
     const skyWeights = calculateElementalInfluences(alignment);
     const { hourRuler } = calculatePlanetaryHoursInfluence(now);
 
-    // Score every unified ingredient against the live sky.
-    const scored = Object.values(unifiedIngredients).map((ing) => {
+    // Score every unified ingredient against the live sky. Auto-generated
+    // recipe-coverage entries that still carry the boilerplate description
+    // (dish names, recipe fragments, e.g. "thit kho tau") are excluded — they
+    // exist only for recipe→ingredient mapping and must not surface as
+    // recommended ingredients. This mirrors the browse surfaces, which already
+    // hide them via the same predicate.
+    const scored = Object.values(unifiedIngredients)
+      .filter((ing) => !isBoilerplateCoverageIngredient(ing))
+      .map((ing) => {
       const elemental: ElementalProperties = ing.elementalProperties ?? {
         Fire: 0.25,
         Water: 0.25,

--- a/src/lib/ingredients/coverageQuality.test.ts
+++ b/src/lib/ingredients/coverageQuality.test.ts
@@ -1,0 +1,37 @@
+import { isBoilerplateCoverageIngredient } from "@/lib/ingredients/coverageQuality";
+
+describe("isBoilerplateCoverageIngredient", () => {
+  it("flags the auto-generated boilerplate description", () => {
+    expect(
+      isBoilerplateCoverageIngredient({
+        description:
+          "Foo is a recipe-linked ingredient captured from live cuisine data to ensure full coverage.",
+      }),
+    ).toBe(true);
+  });
+
+  it("flags explicit schema stand-ins", () => {
+    expect(
+      isBoilerplateCoverageIngredient({
+        description:
+          "Schema stand-in for recipe-specific binder or emulsifier. Replace with concrete ingredient names during recipe curation.",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not flag a real curated ingredient", () => {
+    expect(
+      isBoilerplateCoverageIngredient({
+        description:
+          "Brick-red Yucatecan seasoning paste of ground annatto, spices, and vinegar.",
+      }),
+    ).toBe(false);
+  });
+
+  it("is safe on missing / non-string descriptions", () => {
+    expect(isBoilerplateCoverageIngredient(null)).toBe(false);
+    expect(isBoilerplateCoverageIngredient(undefined)).toBe(false);
+    expect(isBoilerplateCoverageIngredient({})).toBe(false);
+    expect(isBoilerplateCoverageIngredient({ description: 42 })).toBe(false);
+  });
+});

--- a/src/lib/ingredients/coverageQuality.ts
+++ b/src/lib/ingredients/coverageQuality.ts
@@ -9,19 +9,25 @@
  * surfaces (the home Ingredient Recommender and `/ingredients`) where they appear
  * indistinguishable from curated entries.
  *
- * This predicate flags those boilerplate entries so the browse surfaces can hide
- * them while the catalog keeps them for mapping. Coverage entries that were given
- * a real description via `coverageCurationOverrides.ts` are NOT flagged.
+ * This predicate flags those non-real entries so the browse surfaces (and the
+ * dashboard ingredient-recommendations route) can hide them while the catalog
+ * keeps them for mapping. Coverage entries that were given a real description
+ * via `coverageCurationOverrides.ts` are NOT flagged.
  *
- * The marker phrase is the exact copy emitted by `generatedDescription()` in the
- * generator script; keep the two in sync if that copy ever changes.
+ * Two markers are recognised:
+ *  - the boilerplate copy emitted by `generatedDescription()` in the generator
+ *    script (keep the two in sync if that copy ever changes); and
+ *  - explicit "schema stand-in" placeholders (e.g. "alchemical binding agent"),
+ *    which name no real food and exist only as recipe-schema slots.
  */
 const BOILERPLATE_DESCRIPTION_MARKER =
   "recipe-linked ingredient captured from live cuisine data";
+const SCHEMA_STANDIN_MARKER = "Schema stand-in";
 
 /**
- * True when `ingredient` is an auto-generated coverage entry that still carries
- * the boilerplate description. Works on both the full `Ingredient` shape and the
+ * True when `ingredient` is an auto-generated coverage entry that is not a real
+ * food — either it still carries the boilerplate description or it is an
+ * explicit schema stand-in. Works on both the full `Ingredient` shape and the
  * `UnifiedIngredient` shape (both surface `description` at the top level).
  */
 export function isBoilerplateCoverageIngredient(
@@ -30,6 +36,7 @@ export function isBoilerplateCoverageIngredient(
   const description = ingredient?.description;
   return (
     typeof description === "string" &&
-    description.includes(BOILERPLATE_DESCRIPTION_MARKER)
+    (description.includes(BOILERPLATE_DESCRIPTION_MARKER) ||
+      description.includes(SCHEMA_STANDIN_MARKER))
   );
 }


### PR DESCRIPTION
## Summary

`GET /api/recommendations/ingredients` (the dashboard "Recommended Ingredients" panel) ranked **every** `unifiedIngredients` entry by elemental match and returned the top N — including auto-generated recipe-coverage stubs. So a user could be recommended a **dish name** ("thit kho tau"), a recipe fragment, or a **schema stand-in** ("alchemical binding agent") as if it were an ingredient.

The browse surfaces (home Ingredient Recommender, `/ingredients`) already hide these via `isBoilerplateCoverageIngredient` — this route was the one place that didn't.

## Changes
- Filter the candidate pool through `isBoilerplateCoverageIngredient` before scoring, mirroring browse. Pool **1027 → 928** (99 non-real entries excluded).
- Extend the **shared** predicate (`src/lib/ingredients/coverageQuality.ts`) to also flag explicit `"Schema stand-in"` placeholders, so browse and this route stay consistent — fixed in one central place rather than a route-local string check. (This also hides the lone schema stand-in from browse, where it was leaking too.)
- New `coverageQuality.test.ts` — both markers + nullish safety (4 tests).

## Verification
- After the filter: `thit kho tau`, `alchemical binding agent` excluded; `Olive Oil`, `garlic` retained.
- typecheck + lint clean; predicate tests pass.

## Reflection
Centralizing on the predicate (rather than filtering by `provenance: "generated"`) is deliberate: many generated coverage entries are *real* curated ingredients that should still surface. The description-marker approach keeps browse and recommendations using one definition of "not a real food."

🤖 Generated with [Claude Code](https://claude.com/claude-code)