### PR TITLE
fix(recipes): reconcile nutrition + recompute degenerate elemental after ingredient staples

### DIFF
--- a/scripts/backfillHscaElementalProperties.ts
+++ b/scripts/backfillHscaElementalProperties.ts
@@ -163,15 +163,33 @@ async function main() {
     max: 4,
   });
 
-  const where = onlyMissing
-    ? `AND NOT (read_model ? 'elemental_properties')`
-    : ``;
+  // Recompute elemental for every public recipe whose elemental is MISSING or
+  // the degenerate uniform 0.25/0.25/0.25/0.25 placeholder (recipes whose
+  // ingredients didn't resolve when first computed). `--only-missing` narrows
+  // to strictly-missing; `--all` recomputes every public recipe.
+  // (Replaces the original one-off `created_at = '2026-05-24'` batch filter so
+  // newly-resolvable recipes — e.g. after ingredient staples land — get fixed.)
+  const degenerateElemental = `(
+    NOT (read_model ? 'elemental_properties')
+    OR (
+      (read_model->'elemental_properties'->>'fire')::numeric = 0.25
+      AND (read_model->'elemental_properties'->>'water')::numeric = 0.25
+      AND (read_model->'elemental_properties'->>'earth')::numeric = 0.25
+      AND (read_model->'elemental_properties'->>'air')::numeric = 0.25
+    )
+  )`;
+  const where = process.argv.includes("--all")
+    ? ``
+    : onlyMissing
+      ? `AND NOT (read_model ? 'elemental_properties')`
+      : `AND ${degenerateElemental}`;
 
   const { rows } = await pool.query<Row>(
     `SELECT id, name,
             ARRAY(SELECT jsonb_array_elements(read_model->'ingredients')->>'name') AS ingredient_names
        FROM recipes
-      WHERE created_at::date = '2026-05-24'
+      WHERE is_public = true
+        AND jsonb_typeof(read_model) = 'object'
       ${where}`,
   );
 

--- a/scripts/backfillRecipeNutrition.ts
+++ b/scripts/backfillRecipeNutrition.ts
@@ -41,6 +41,17 @@ if (!DATABASE_URL) {
 
 const dryRun = process.argv.includes("--dry-run");
 const onlyMissing = process.argv.includes("--only-missing");
+// --reconcile also CLEARS nutrition for recipes that can no longer produce a
+// plausible total — needed after the ingredient catalog's fake nutrition stubs
+// were nulled (PR #560), which had poisoned some recipes' aggregated nutrition.
+// Mutually exclusive with --only-missing (reconcile must see every recipe).
+const reconcile = process.argv.includes("--reconcile");
+
+if (reconcile && onlyMissing) {
+  throw new Error(
+    "--reconcile and --only-missing are mutually exclusive: reconcile must evaluate every recipe.",
+  );
+}
 
 interface IngredientRow {
   name?: unknown;
@@ -103,10 +114,25 @@ async function main() {
 
   let written = 0;
   let plausible = 0;
+  let cleared = 0; // stale nutrition wiped under --reconcile
   let skippedLowResolve = 0; // aggregator returned null (<50% ingredients resolved)
   let skippedImplausible = 0; // computed but failed the plausibility guard
   let skippedNoIngredients = 0;
   const samples: Array<{ name: string; nutrition: Record<string, unknown> }> = [];
+
+  // Clear a recipe's nutrition back to the honest-empty state ({}), which the
+  // recipe view omits (it requires calories > 0).
+  const clearNutrition = async (id: string) => {
+    if (dryRun) return;
+    await pool.query(
+      `UPDATE recipes
+          SET nutritional_profile = '{}'::jsonb,
+              read_model = jsonb_set(read_model, '{nutritional_profile}', '{}'::jsonb, true),
+              updated_at = NOW()
+        WHERE id = $1`,
+      [id],
+    );
+  };
 
   for (const row of rows) {
     const ingredients = Array.isArray(row.ingredients) ? row.ingredients : [];
@@ -125,12 +151,15 @@ async function main() {
     };
 
     const nutrition = computeRecipeNutritionFromIngredients(recipeLike as never);
-    if (!nutrition) {
-      skippedLowResolve++;
-      continue;
-    }
-    if (!isPlausibleNutrition(nutrition)) {
-      skippedImplausible++;
+    if (!nutrition || !isPlausibleNutrition(nutrition)) {
+      if (!nutrition) skippedLowResolve++;
+      else skippedImplausible++;
+      // De-poison: if this recipe currently shows nutrition we can no longer
+      // substantiate, wipe it back to honest-empty.
+      if (reconcile && row.has_nutrition) {
+        await clearNutrition(row.id);
+        cleared++;
+      }
       continue;
     }
     plausible++;
@@ -159,7 +188,7 @@ async function main() {
 
   console.log(
     `[nutrition-backfill] done: candidates=${rows.length}, plausible=${plausible}, written=${written}, ` +
-      `skipped_low_resolve=${skippedLowResolve}, skipped_implausible=${skippedImplausible}, ` +
+      `cleared=${cleared}, skipped_low_resolve=${skippedLowResolve}, skipped_implausible=${skippedImplausible}, ` +
       `skipped_no_ingredients=${skippedNoIngredients}`,
   );
   console.log(


### PR DESCRIPTION
## Summary

Follow-up to the parallel ingredient-catalog cleanup (#559/#560/#561/#563). Now that the catalog has real staples and the fabricated nutrition stubs are gone, I re-ran the three recipe backfills against prod and verified.

### 1. Nutrition — new `--reconcile` mode (de-poison)
#560 nulled the 208 fabricated nutrition stubs (`100cal/1g/10g/1g`) that had **poisoned** recipe nutrition — the #555 aggregator was *summing* them instead of skipping. A plain re-run only *writes* plausible totals, so poisoned recipes that can no longer be substantiated would keep stale values. `--reconcile` additionally **clears** nutrition back to honest-empty for any recipe that no longer computes a plausible total.

> **746** recipes get fresh stub-free nutrition · **67** stub-poisoned recipes cleared to empty.
> 774 → 746 is a **de-poisoning correction** (the old 774 was inflated by fake stub data), not a regression — green-because-real.

### 2. Elemental — generalize the HSCA backfill
Replaced the one-off `WHERE created_at = '2026-05-24'` batch filter with "all public recipes whose elemental is missing or the degenerate `0.25/0.25/0.25/0.25` placeholder" (default), plus an `--all` escape hatch. The staples resolve every previously-degenerate recipe.

> uniform-0.25 elemental **16 → 0** (0 zero-matches)

### 3. ESMS — re-ran `backfillRecipeAlchemicalQuantities`
> ESMS zero-match **25 → 11** (the other 14 were the hollow recipes de-published in #558)

## Prod verification (1063 public recipes)

| Metric | Result |
|---|---|
| real nutrition | 746 (all stub-free) |
| uniform-0.25 elemental | **0** (was 16) |
| ESMS zero-match | 11 (was 25) |

## ⚠️ Flagged for the ingredient side
ESMS `matchRate` did **not** benefit from the staples: `recipeAlchemicalQuantities` builds its map from raw collections that (a) don't import `misc/cookingStaples` and (b) require explicit `alchemicalProperties`, which the staples lack (they carry `elementalProperties` only). To lift ESMS too, the staples need `alchemicalProperties` added (or the engine should derive ESMS from elemental, like `unifiedIngredients` does).

## Test plan
- [x] 18 recipe unit tests pass (incl. the ingredient session's new staple-resolution tests)
- [x] `bun run typecheck` / `lint` clean
- [x] All three backfills re-run against live prod and re-queried (numbers above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)