### PR TITLE
chore(audit): score real-vs-default in the ingredient audit

### DIFF
--- a/scripts/auditIngredients.ts
+++ b/scripts/auditIngredients.ts
@@ -19,6 +19,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { Project, SyntaxKind, ObjectLiteralExpression, PropertyAssignment } from "ts-morph";
+import { detectNonRealFlags, REALITY_MARKERS } from "./lib/ingredientReality";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -150,6 +151,9 @@ interface IngredientReport {
   score: number;
   scorePct: number;
   missing: string[];
+  /** Keys of any placeholder/default markers found — empty == real. */
+  realFlags: string[];
+  isReal: boolean;
 }
 
 function categoryFromFile(file: string): string {
@@ -231,6 +235,8 @@ function audit(): IngredientReport[] {
           }
         }
 
+        const realFlags = detectNonRealFlags(obj.getText());
+
         rows.push({
           slug,
           name,
@@ -239,6 +245,8 @@ function audit(): IngredientReport[] {
           score,
           scorePct: Math.round((score / MAX_SCORE) * 100),
           missing,
+          realFlags,
+          isReal: realFlags.length === 0,
         });
       }
     }
@@ -274,13 +282,28 @@ function writeReports(rows: IngredientReport[]) {
   lines.push("");
   lines.push("## Category Summary");
   lines.push("");
-  lines.push("| Category | Count | Avg % | < 50% | ≥ 80% |");
-  lines.push("| --- | --- | --- | --- | --- |");
+  lines.push("| Category | Count | Avg % | < 50% | ≥ 80% | Non-real |");
+  lines.push("| --- | --- | --- | --- | --- | --- |");
   for (const [cat, list] of [...byCategory.entries()].sort()) {
     const avg = Math.round(list.reduce((s, r) => s + r.scorePct, 0) / list.length);
     const weak = list.filter((r) => r.scorePct < 50).length;
     const strong = list.filter((r) => r.scorePct >= 80).length;
-    lines.push(`| ${cat} | ${list.length} | ${avg} | ${weak} | ${strong} |`);
+    const nonReal = list.filter((r) => !r.isReal).length;
+    lines.push(`| ${cat} | ${list.length} | ${avg} | ${weak} | ${strong} | ${nonReal} |`);
+  }
+  lines.push("");
+
+  // Real-vs-default: presence ≠ real. Drive these to 0.
+  const nonRealRows = rows.filter((r) => !r.isReal);
+  lines.push("## Real vs. default (placeholder/default values — drive to 0)");
+  lines.push("");
+  lines.push(`**Non-real ingredients:** ${nonRealRows.length} / ${rows.length}`);
+  lines.push("");
+  lines.push("| Marker | Count |");
+  lines.push("| --- | --- |");
+  for (const m of REALITY_MARKERS) {
+    const n = rows.filter((r) => r.realFlags.includes(m.key)).length;
+    lines.push(`| ${m.label} | ${n} |`);
   }
   lines.push("");
 
@@ -319,5 +342,11 @@ const weak = rows.filter((r) => r.scorePct < 50).length;
 const strong = rows.filter((r) => r.scorePct >= 80).length;
 // eslint-disable-next-line no-console
 console.log(`Audited ${rows.length} ingredients — avg ${avg}%, ${weak} below 50%, ${strong} at or above 80%.`);
+const nonReal = rows.filter((r) => !r.isReal).length;
+const byFlag = REALITY_MARKERS.map(
+  (m) => `${m.key}=${rows.filter((r) => r.realFlags.includes(m.key)).length}`,
+).join(", ");
+// eslint-disable-next-line no-console
+console.log(`Real-data check: ${nonReal} of ${rows.length} carry placeholder/default values (non-real). By marker: ${byFlag}.`);
 // eslint-disable-next-line no-console
 console.log(`Reports: ${path.relative(process.cwd(), jsonPath)}, ${path.relative(process.cwd(), mdPath)}`);

--- a/scripts/lib/__tests__/ingredientReality.test.ts
+++ b/scripts/lib/__tests__/ingredientReality.test.ts
@@ -1,0 +1,60 @@
+import { detectNonRealFlags } from "../ingredientReality";
+
+describe("detectNonRealFlags", () => {
+  it("returns no flags for a real, curated ingredient card", () => {
+    const real = `{
+      name: "Chicken",
+      description: "Domesticated fowl with mild, slightly sweet flesh that carries seasonings.",
+      elementalProperties: { Fire: 0.2, Water: 0.3, Air: 0.3, Earth: 0.2 },
+      qualities: ["adaptable", "mild", "versatile"],
+      nutritionalProfile: { calories: 165, source: "USDA FoodData Central" },
+    }`;
+    expect(detectNonRealFlags(real)).toEqual([]);
+  });
+
+  it("flags an auto-generated coverage stub", () => {
+    expect(detectNonRealFlags(`{ name: "x", provenance: "generated" }`)).toContain(
+      "generated_stub",
+    );
+  });
+
+  it("flags placeholder/default nutrition sources", () => {
+    expect(
+      detectNonRealFlags(`{ nutritionalProfile: { source: "Recipe-derived coverage entry" } }`),
+    ).toContain("nutrition_placeholder");
+    expect(
+      detectNonRealFlags(`{ nutritionalProfile: { source: "category default" } }`),
+    ).toContain("nutrition_placeholder");
+  });
+
+  it("flags boilerplate descriptions", () => {
+    expect(
+      detectNonRealFlags(`{ description: "Foo is a recipe-linked ingredient captured from live cuisine data." }`),
+    ).toContain("description_boilerplate");
+  });
+
+  it("flags the placeholder qualities array", () => {
+    expect(
+      detectNonRealFlags(`{ qualities: ["recipe-linked", "standardized"] }`),
+    ).toContain("qualities_placeholder");
+  });
+
+  it("flags a uniform 0.25 elemental default", () => {
+    expect(
+      detectNonRealFlags(`{ elementalProperties: { Fire: 0.25, Water: 0.25, Earth: 0.25, Air: 0.25 } }`),
+    ).toContain("elemental_uniform_default");
+  });
+
+  it("accumulates multiple markers on a fully-stubbed card", () => {
+    const stub = `{
+      name: "thit kho tau",
+      provenance: "generated",
+      description: "Thit Kho Tau is a recipe-linked ingredient captured from live cuisine data.",
+      qualities: ["recipe-linked", "standardized"],
+      nutritionalProfile: { source: "Recipe-derived coverage entry" },
+    }`;
+    expect(detectNonRealFlags(stub).sort()).toEqual(
+      ["description_boilerplate", "generated_stub", "nutrition_placeholder", "qualities_placeholder"].sort(),
+    );
+  });
+});

--- a/scripts/lib/ingredientReality.ts
+++ b/scripts/lib/ingredientReality.ts
@@ -1,0 +1,52 @@
+/**
+ * Real-vs-default detection for ingredient cards.
+ *
+ * The completeness rubric (auditIngredients) scores whether a field is PRESENT.
+ * These markers detect when a present field is actually a placeholder/default
+ * rather than real, curated/sourced data — so the campaign can drive the
+ * "non-real" count to 0, not just "presence" to 100%.
+ *
+ * Each marker is matched against an ingredient card's raw source text, so it
+ * works AST-free and is trivial to unit-test.
+ */
+export interface RealityMarker {
+  key: string;
+  label: string;
+  re: RegExp;
+}
+
+export const REALITY_MARKERS: RealityMarker[] = [
+  {
+    key: "generated_stub",
+    label: "Auto-generated coverage stub (provenance:generated)",
+    re: /provenance:\s*["']generated["']/,
+  },
+  {
+    key: "nutrition_placeholder",
+    label: "Placeholder/default nutrition source",
+    re: /"category default"|Recipe-derived coverage entry|"category estimate"/,
+  },
+  {
+    key: "description_boilerplate",
+    label: "Boilerplate description",
+    re: /recipe-linked ingredient captured|standardized baseline metadata|placeholder profile|refine with domain curation/i,
+  },
+  {
+    key: "qualities_placeholder",
+    label: "Placeholder qualities array",
+    re: /qualities:\s*\[\s*["']recipe-linked["']\s*,\s*["']standardized["']\s*\]/,
+  },
+  {
+    key: "elemental_uniform_default",
+    label: "Uniform 0.25 elemental default",
+    re: /Fire:\s*0\.25\s*,\s*Water:\s*0\.25\s*,\s*Earth:\s*0\.25\s*,\s*Air:\s*0\.25/,
+  },
+];
+
+/**
+ * Returns the keys of every non-real marker present in an ingredient card's
+ * source text. Empty array == no placeholder/default values detected (real).
+ */
+export function detectNonRealFlags(cardText: string): string[] {
+  return REALITY_MARKERS.filter((m) => m.re.test(cardText)).map((m) => m.key);
+}


### PR DESCRIPTION
## Why
Campaign step 2 — the "done" gate for the enrichment steps. `auditIngredients` scored field **presence** (96% "complete"), which masked the real problem: ~38% of those fields are **category-default / placeholder fills**, not real data. The audit couldn't distinguish them, so "97% complete" was misleading.

## What
`scripts/lib/ingredientReality.ts` (pure, unit-tested) detects placeholder/default markers in an ingredient card's source:
- auto-generated coverage stub (`provenance: "generated"`)
- default/coverage nutrition source (`"category default"`, `Recipe-derived coverage entry`, `"category estimate"`)
- boilerplate description (`recipe-linked ingredient captured`, `refine with domain curation`, …)
- the placeholder `qualities: ["recipe-linked", "standardized"]`
- uniform `0.25` elemental default

`auditIngredients` now records `realFlags` / `isReal` per ingredient and reports a **per-marker + per-category non-real count** + a console line. The campaign gate becomes "non-real → 0", not "presence → 100%".

## Baseline (current master)
```
Audited 1160 ingredients — avg 96% presence.
Real-data check: 441 of 1160 (38%) carry placeholder/default values (non-real).
  nutrition_placeholder=441 · generated_stub=331 · qualities_placeholder=331 · description_boilerplate=45 · elemental=0
```
This is the work-list for the nutrition + curation steps that follow.

## Verification
- 7 unit tests on the detector (each marker + a clean card + multi-marker). typecheck + lint clean.
- Tooling only — no data mutation, no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)