### PR TITLE
feat(ingredients): real nutrition for the 21 specialty oils (nutrition batch 1)

### DIFF
--- a/scripts/data/nutritionEstimates.json
+++ b/scripts/data/nutritionEstimates.json
@@ -1,0 +1,27 @@
+{
+  "_note": "Researched best-estimate nutritionalProfiles keyed by ingredient slug, applied by scripts/enrichNutrition.ts to replace placeholder/default nutrition. vitamins/minerals are fraction-of-Daily-Value (0-1). source='researched estimate' marks them as honest estimates (NOT measured/USDA-exact). Grows per category batch — see project_ingredient_quality_campaign.",
+  "_batches": ["oils (seasonings) 2026-06-27"],
+  "estimates": {
+    "apricot kernel oil": { "serving_size": "1 tbsp (14g)", "calories": 120, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.05 }, "minerals": {}, "source": "researched estimate" },
+    "argan oil": { "serving_size": "1 tbsp (14g)", "calories": 120, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.04 }, "minerals": {}, "source": "researched estimate" },
+    "babassu oil": { "serving_size": "1 tbsp (14g)", "calories": 120, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": {}, "minerals": {}, "source": "researched estimate" },
+    "black seed oil": { "serving_size": "1 tbsp (14g)", "calories": 120, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.03 }, "minerals": {}, "source": "researched estimate" },
+    "camellia oil": { "serving_size": "1 tbsp (14g)", "calories": 120, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.04 }, "minerals": {}, "source": "researched estimate" },
+    "chili oil": { "serving_size": "1 tbsp (14g)", "calories": 123, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.12 }, "minerals": {}, "source": "researched estimate" },
+    "hazelnut oil": { "serving_size": "1 tbsp (14g)", "calories": 120, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.43 }, "minerals": {}, "source": "researched estimate" },
+    "hemp seed oil": { "serving_size": "1 tbsp (14g)", "calories": 125, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.07 }, "minerals": {}, "source": "researched estimate" },
+    "macadamia oil": { "serving_size": "1 tbsp (14g)", "calories": 120, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.04 }, "minerals": {}, "source": "researched estimate" },
+    "mustard oil": { "serving_size": "1 tbsp (14g)", "calories": 124, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.10 }, "minerals": {}, "source": "researched estimate" },
+    "mustard seed oil": { "serving_size": "1 tbsp (14g)", "calories": 124, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.10 }, "minerals": {}, "source": "researched estimate" },
+    "palm oil": { "serving_size": "1 tbsp (14g)", "calories": 120, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.15 }, "minerals": {}, "source": "researched estimate" },
+    "perilla oil": { "serving_size": "1 tbsp (14g)", "calories": 120, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.03 }, "minerals": {}, "source": "researched estimate" },
+    "pistachio oil": { "serving_size": "1 tbsp (14g)", "calories": 120, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.19 }, "minerals": {}, "source": "researched estimate" },
+    "red palm oil": { "serving_size": "1 tbsp (14g)", "calories": 120, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.20, "A": 0.60 }, "minerals": {}, "source": "researched estimate" },
+    "rice bran oil": { "serving_size": "1 tbsp (14g)", "calories": 120, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.29 }, "minerals": {}, "source": "researched estimate" },
+    "roasted pumpkin seed oil": { "serving_size": "1 tbsp (14g)", "calories": 120, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.06 }, "minerals": {}, "source": "researched estimate" },
+    "safflower oil": { "serving_size": "1 tbsp (14g)", "calories": 120, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.31 }, "minerals": {}, "source": "researched estimate" },
+    "shiso oil": { "serving_size": "1 tbsp (14g)", "calories": 120, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.03 }, "minerals": {}, "source": "researched estimate" },
+    "tea seed oil": { "serving_size": "1 tbsp (14g)", "calories": 120, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.04 }, "minerals": {}, "source": "researched estimate" },
+    "white truffle oil": { "serving_size": "1 tbsp (14g)", "calories": 119, "macros": { "protein": 0, "carbs": 0, "fat": 14, "fiber": 0 }, "vitamins": { "E": 0.10 }, "minerals": {}, "source": "researched estimate" }
+  }
+}

--- a/scripts/enrichNutrition.ts
+++ b/scripts/enrichNutrition.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env bun
+/**
+ * Replace placeholder/default ingredient nutrition with researched best-estimate
+ * values from scripts/data/nutritionEstimates.json (keyed by ingredient slug).
+ *
+ * Idempotent + non-destructive: only fills a nutritionalProfile that is missing
+ * or carries a placeholder source ("category default" / "Recipe-derived coverage
+ * entry" / "category estimate"). Genuinely-real nutrition (any other source) is
+ * NEVER overwritten. Grows per category batch — extend the JSON, re-run.
+ *
+ *   bun run scripts/enrichNutrition.ts            # apply
+ *   bun run scripts/enrichNutrition.ts --dry-run  # report only
+ */
+import fs from "fs";
+import path from "path";
+import { Project, SyntaxKind, ObjectLiteralExpression } from "ts-morph";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+const INGREDIENTS_DIR = path.join(ROOT, "src", "data", "ingredients");
+const MAP_PATH = path.join(ROOT, "scripts", "data", "nutritionEstimates.json");
+const PLACEHOLDER_SOURCE = /category default|Recipe-derived coverage entry|category estimate/i;
+const SKIP_FILES = new Set([
+  "index.ts",
+  "types.ts",
+  "ingredients.ts",
+  "ingredientSummaries.ts",
+  "flavorProfiles.ts",
+  "elementalProperties.ts",
+]);
+
+const dryRun = process.argv.includes("--dry-run");
+const estimates: Record<string, unknown> = JSON.parse(
+  fs.readFileSync(MAP_PATH, "utf8"),
+).estimates;
+
+/** Emit a TS object literal with bare identifier keys (matches the catalog style). */
+function toLiteral(v: unknown): string {
+  if (typeof v === "string") return JSON.stringify(v);
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  if (Array.isArray(v)) return `[${v.map(toLiteral).join(", ")}]`;
+  if (v && typeof v === "object") {
+    const parts = Object.entries(v).map(([k, val]) => {
+      const key = /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(k) ? k : JSON.stringify(k);
+      return `${key}: ${toLiteral(val)}`;
+    });
+    return `{ ${parts.join(", ")} }`;
+  }
+  return "null";
+}
+
+function walk(dir: string, out: string[]) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, out);
+    else if (e.name.endsWith(".ts") && !SKIP_FILES.has(e.name)) out.push(p);
+  }
+}
+
+const project = new Project({
+  skipAddingFilesFromTsConfig: true,
+  compilerOptions: { noEmit: true, skipLibCheck: true, target: 99 },
+});
+const files: string[] = [];
+walk(INGREDIENTS_DIR, files);
+
+let filled = 0;
+let skippedReal = 0;
+const touched: string[] = [];
+
+for (const file of files) {
+  const sf = project.addSourceFileAtPath(file);
+  let modified = false;
+  for (const decl of sf.getVariableDeclarations()) {
+    const root = decl.getInitializer()?.asKind(SyntaxKind.ObjectLiteralExpression);
+    if (!root) continue;
+    for (const prop of root.getProperties()) {
+      const pa = prop.asKind(SyntaxKind.PropertyAssignment);
+      if (!pa) continue;
+      const card = pa.getInitializer()?.asKind(SyntaxKind.ObjectLiteralExpression);
+      if (!card || !card.getProperty("name")) continue;
+      const slug = pa.getName().replace(/^["'`]|["'`]$/g, "");
+      const est = estimates[slug];
+      if (!est) continue;
+
+      const npProp = card.getProperty("nutritionalProfile")?.asKind(SyntaxKind.PropertyAssignment);
+      if (npProp) {
+        const npObj = npProp.getInitializer()?.asKind(SyntaxKind.ObjectLiteralExpression);
+        const source =
+          (npObj?.getProperty("source") as ObjectLiteralExpression | undefined) &&
+          npObj!
+            .getProperty("source")!
+            .asKind(SyntaxKind.PropertyAssignment)!
+            .getInitializer()
+            ?.getText();
+        // Only overwrite a placeholder/default profile — never real data.
+        if (!source || PLACEHOLDER_SOURCE.test(source)) {
+          if (!dryRun) npProp.setInitializer(toLiteral(est));
+          filled++;
+          touched.push(slug);
+          modified = true;
+        } else {
+          skippedReal++;
+        }
+      } else {
+        if (!dryRun) card.addPropertyAssignment({ name: "nutritionalProfile", initializer: toLiteral(est) });
+        filled++;
+        touched.push(slug);
+        modified = true;
+      }
+    }
+  }
+  if (modified && !dryRun) sf.saveSync();
+}
+
+console.log(`Nutrition estimates in map: ${Object.keys(estimates).length}`);
+console.log(`${dryRun ? "[dry-run] would fill" : "Filled"} ${filled} placeholder/missing nutritionalProfiles; skipped ${skippedReal} already-real.`);
+const missed = Object.keys(estimates).filter((s) => !touched.includes(s));
+if (missed.length) console.log(`  Not found in catalog (or already real): ${missed.join(", ")}`);

--- a/src/data/ingredients/seasonings/oils.ts
+++ b/src/data/ingredients/seasonings/oils.ts
@@ -363,7 +363,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 124, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.1 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -450,7 +450,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 120, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.29 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -487,7 +487,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 123, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.12 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -524,7 +524,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 120, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.03 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -561,7 +561,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 120, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.04 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -649,7 +649,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 120, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.04 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -686,7 +686,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 120, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.15 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -723,7 +723,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 120, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.04 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -760,7 +760,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 120, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.03 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -797,7 +797,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 120, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.04 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -834,7 +834,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 120, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.43 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -871,7 +871,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 120, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.19 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -908,7 +908,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 125, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.07 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -945,7 +945,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 120, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.03 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -1085,7 +1085,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 120, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.31 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -1122,7 +1122,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 119, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.1 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -1209,7 +1209,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 120, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.2, A: 0.6 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -1250,7 +1250,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 120, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.06 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -1291,7 +1291,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 124, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.1 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -1332,7 +1332,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 120, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: {  }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },
@@ -1369,7 +1369,7 @@ const rawOils: Record<string, Partial<IngredientMapping>> = {
     },
       astrologicalProfile: { rulingPlanets: ["Sun", "Moon"], favorableZodiac: ["cancer", "taurus"] },
       sensoryProfile: { taste: { sweet: 0.1, salty: 0.4, sour: 0.1, bitter: 0.1, umami: 0.3, spicy: 0.1 }, aroma: { savory: 0.6, aromatic: 0.4 }, texture: { varied: 0.5 } },
-      nutritionalProfile: { serving_size: "1 tsp", calories: 10, macros: { protein: 0.5, carbs: 2, fat: 0.2, fiber: 0.2 }, vitamins: {}, minerals: { sodium: 0.5 }, source: "category default" },
+      nutritionalProfile: { serving_size: "1 tbsp (14g)", calories: 120, macros: { protein: 0, carbs: 0, fat: 14, fiber: 0 }, vitamins: { E: 0.05 }, minerals: {  }, source: "researched estimate" },
       culinaryProfile: { flavorProfile: { primary: ["savory"], secondary: ["umami", "aromatic"], notes: "Balance salt, acid, and umami progressively throughout cooking." }, cookingMethods: ["season", "finish", "marinate"], cuisineAffinity: ["global"], preparationTips: ["Season in layers rather than all at once.", "Taste between additions."] },
       pairingRecommendations: { complementary: ["oil", "acid", "alliums", "herbs"], contrasting: ["sweeteners", "dairy"], toAvoid: [] }
 },


### PR DESCRIPTION
## Why
Campaign **step 3 (nutrition), batch 1**. The 21 specialty oils in `seasonings/oils.ts` carried a wrong placeholder template — **`calories: 10, fat: 0.2g, source: "category default"`** — on ingredients that are *pure oil* (~120 cal, 14g fat per tbsp). A clear "default masking reality" case the new audit gate flags as non-real.

## What
Replaced each oil's placeholder nutrition with a **researched best-estimate** (serving `1 tbsp (14g)`; real calories, macros `0/0/14/0`, vitamin E by oil — e.g. safflower/rice-bran/hazelnut high, red palm + vitamin A), **`source: "researched estimate"`** — honest about being an estimate, not measured/USDA-exact (per your "research + best estimate" call).

Tooling (reusable for the remaining batches):
- **`scripts/data/nutritionEstimates.json`** — per-slug nutrition map; grows one category batch at a time.
- **`scripts/enrichNutrition.ts`** — idempotent, **non-destructive** ts-morph patcher: fills only *missing or placeholder-sourced* profiles, **never overwrites real data** (re-run is a no-op).

## Verification
- `--dry-run` reviewed → 21 filled. Applied → idempotent re-run fills 0 / skips 21.
- **Audit gate:** non-real **441 → 420** (`nutrition_placeholder` 441 → 420).
- typecheck + lint clean.

## Next batches (same map + script)
herbs (20) · grains (32) · vegetables (36) · then the misc coverage stubs (331). Each its own PR, gate dropping each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)