### PR TITLE
feat(economy): daily Cosmic Yield cron for active agents (revive the ledger)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,68 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [3.3.0] — 2026-06-29 — Data Authenticity & Live Economy
+
+The data-authenticity campaign: drive the catalog to **real** values — no fabricated nutrition, no placeholder/default templates, no hollow recipes. `src/data` stays authoritative for ingredient recommendations (static); recipes read from the denormalized DB JSONB read model. Plus the first piece of the Live Network economy kept alive by automation.
+
+### Added
+
+#### Ingredient data authenticity
+- **Shared free-text resolver** (#559) — lifted free-text ingredient matching into a shared resolver, adopted by `UnifiedIngredientService`.
+- **Missing cooking staples** (#563) — added stocks, broths, fish sauce, and other staples that were absent from the catalog.
+- **Real-vs-default audit scoring** (#565) — the ingredient audit now scores real-vs-default coverage.
+- **Real nutrition for the 21 specialty oils** (#566) — nutrition batch 1.
+
+#### Recipe data authenticity
+- **Real per-serving nutrition backfill** (#555) — recipe nutrition was 100% empty; now backfilled with real values.
+
+#### Agent Daily Cosmic Yield cron (in flight — `feat/agent-daily-yield-cron`)
+- **Vercel cron** at `/api/cron/agents-daily-yield`, scheduled `"30 0 * * *"` (daily 00:30 UTC) and gated by `CRON_SECRET`. Registered in `vercel.json` alongside the synthetic-* probes and the system-health snapshot — a **Vercel** cron, not a Railway cron service.
+- **Service** `src/services/agentDailyYield.ts` mints each active, chart-bearing agent's personalized daily Cosmic Yield so the token ledger / Live Network economy surfaces stay alive for visitors.
+- Reuses the human-claim engine verbatim: `DailyYieldService.claimDailyYield` with `site="agents"` → `source_type "agents_yield"`. Economics and idempotency are identical to human claims (keyed per `(site, agent, day)`; a re-run is a no-op). Purely additive — no formula or human-claim path changed. Backstops the PA sync-credit `agents_yield` pipeline, silent since 2026-06-03.
+
+### Changed
+
+#### Ingredient catalog cleanup
+- **Removed the fabricated nutrition template** (#560) from the static catalog.
+- **Purged non-ingredient junk** (#561) from the coverage set.
+- **Stopped placeholder coverage entries** (#562) from leaking into ingredient recommendations.
+
+#### Recipe catalog cleanup
+- **Upgraded the ESMS ingredient matcher** (#556) — matchRate `0.56 → 0.64`.
+- **Cleaned junk parenthetical descriptions** (#557) and recovered real seasons.
+- **De-published 14 fully-fabricated hollow recipes** (#558).
+- **Reconciled nutrition and recomputed degenerate elemental signatures** (#564) after the staples landed.
+
+#### Dashboard honesty
+- **Practitioner Cohorts** (#552) now read canonical sources, not vestigial JSONB.
+- **Cost Burndown** (#553) no longer fabricates billing data — shows an honest "no billing source" state.
+- **Real Railway resource-usage panel** (#554) replaces the fabricated Cost Burndown.
+
+#### Live Network & auth
+- **Feed polling pressure** (#550) — cache the Live Network Feed pollers and jitter the poll to cut DB pressure.
+- **Signup-grant resilience** (#551) — the new-user signup grant is now resilient and detectable.
+
+---
+
+## [3.2.x] — Planetary Agents & Live State
+
+The three-project loop comes online — `alchm.kitchen` (this repo) ↔ `api.agents.alchm.kitchen` (PA Python/FastAPI backend) ↔ `agents.alchm.kitchen` (PA Next.js UI) — and the live-state layer lands. (Never changelogged at the time; reconstructed here.)
+
+### Added
+
+- **Planetary Agents as first-class users** — `is_agent=true`, `@agentic.alchm.kitchen` identities with profiles, synastry, transit group-chats, and an agent feed.
+- **Cosmic-recipe generation offload** — recipe generation is offloaded to PA `/api/generate-recipe`, which returns `CosmicRecipe` JSON.
+- **SpacetimeDB v4.0 live layer** — meal plans, commensal, and carts, gated by `NEXT_PUBLIC_SPACETIME_URI` with a localStorage / REST fallback when unset.
+- **MCP server + telemetry** — `mcp_invocations` telemetry and a `*/30` synthetic probe.
+- **Cloudflare Workers AI image pipeline** — SDXL → R2.
+
+### Changed
+
+- **Unified `ElementalSignature` model** (#505) — a single canonical signature model across display and ranking.
+
+---
+
 ## [3.1.0] — 2026-05-29 — Modern Alchemist · MCP release
 
 3.0 shipped the redesigned surface (`git tag v3.0.0`). 3.1 layers a published MCP server, an operational admin console, production-readiness hardening, and a tracked migration runner on top. (3.1 tag not yet cut.)
@@ -183,7 +245,9 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - Ingredient hierarchy: Ingredients → Recipes → Cuisines.
 - Basic recommendation engine.
 
-[Unreleased]: https://github.com/gregcastro23/WhatToEatNext/compare/v3.0.0...HEAD
+<!-- 3.2.x and 3.3.0 are documented above but not yet git-tagged; only v3.0.0 and v3.1.0 tags exist. -->
+[Unreleased]: https://github.com/gregcastro23/WhatToEatNext/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/gregcastro23/WhatToEatNext/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/gregcastro23/WhatToEatNext/compare/v2.3.0...v3.0.0
 [2.3.0]: https://github.com/gregcastro23/WhatToEatNext/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/gregcastro23/WhatToEatNext/compare/v2.1.0...v2.2.0

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -1,7 +1,7 @@
 # WhatToEatNext Deployment Guide
 
 **Version**: 1.0
-**Last Updated**: November 17, 2025
+**Last Updated**: June 29, 2026
 **Supported Platforms**: Docker, Vercel, Standalone, Kubernetes
 
 ---
@@ -26,7 +26,7 @@
 ### Prerequisites
 
 - **Node.js**: 20.18.0 (required by package.json)
-- **Yarn**: 3.6.4
+- **Bun**: 1.3.13+ (sole package manager and runtime — never npm/yarn)
 - **Docker**: 20.10+ (for containerized deployment)
 - **Docker Compose**: 1.29+ (optional)
 
@@ -250,7 +250,7 @@ docker run -d \
 1. **Push to GitHub**:
 
    ```bash
-   git push origin main
+   git push origin master
    ```
 
 2. **Import to Vercel**:
@@ -519,32 +519,22 @@ docker logs whattoeatnext 2>&1 | grep "ERROR"
 
 ### Common Issues
 
-#### 1. Yarn 3.6.4 Download Failure (HTTP 403)
+#### 1. Yarn Download Failure (HTTP 403) — Historical
 
-**Symptoms**:
+> **Note**: This issue is historical. Yarn has been fully retired; Bun (1.3.13+) is now the sole package manager and runtime. Use `bun install` instead. This subsection is retained only for reference to older checkouts.
+
+**Symptoms** (legacy Yarn-based setups):
 
 ```
 Error: Server answered with HTTP 403 when performing the request to
-https://repo.bunpkg.com/3.6.4/packages/bunpkg-cli/bin/bun.js
+the Yarn package mirror
 ```
 
-**Solution A**: Use the workaround script
+**Resolution**: Migrate to Bun.
 
 ```bash
-chmod +x start-dev-server.sh
-./start-dev-server.sh
+bun install
 ```
-
-**Solution B**: Deploy with Docker (bypasses Yarn requirement)
-
-```bash
-docker-compose -f docker-compose.simple.yml up -d
-```
-
-**Solution C**: Use environment with proper Yarn access
-
-- Deploy to Vercel (handles Yarn automatically)
-- Use CI/CD with Yarn pre-installed
 
 #### 2. Build Hangs Indefinitely
 
@@ -774,11 +764,11 @@ docker-compose -f docker-compose.simple.yml up -d --scale app=3
 
 - [Backend Status Report](./BACKEND_STATUS_REPORT.md) - Complete backend analysis
 - [Service Deep Dive](./SERVICE_DEEP_DIVE.md) - Detailed service reviews
-- [CLAUDE.md](./CLAUDE.md) - Project architecture and development guide
+- [GEMINI.md](./GEMINI.md) / [docs/architecture/CLAUDE.md](./docs/architecture/CLAUDE.md) - Project architecture and development guide
 
 ### Scripts
 
-- `start-dev-server.sh` - Workaround for Yarn issues
+- `start-dev-server.sh` - Dev-server startup helper (legacy; predates the Bun migration)
 - `Makefile` - Build and development commands
 
 ### Configuration Files
@@ -800,6 +790,6 @@ For deployment issues or questions:
 
 ---
 
-**Last Updated**: November 17, 2025
+**Last Updated**: June 29, 2026
 **Maintainer**: gregcastro23
 **Status**: Production Ready ✅

--- a/DOCKER_GUIDE.md
+++ b/DOCKER_GUIDE.md
@@ -1,13 +1,13 @@
 # 🐳 Docker Guide for WhatToEatNext
 
 Complete Docker setup for the **Advanced Alchemical Food Recommendation System**
-with Next.js 15.3.4, React 19, and TypeScript.
+with Next.js 15, React 19, and TypeScript.
 
 ## 📋 Prerequisites
 
 - **Docker** (20.10+) and **Docker Compose** (2.0+)
 - **Node.js 20.18.0+** (for local development)
-- **Yarn 1.22.0+** package manager
+- **Bun 1.3.13+** package manager / runtime
 
 ## 🚀 Quick Start
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # WhatToEatNext - AI Assistant Guide (Alchm.kitchen)
 
-_Version: 3.2.1 | Last Updated: June 15, 2026_
+_Version: 3.3.0 | Last Updated: June 29, 2026_
 
 ## Project Overview
 
@@ -11,13 +11,22 @@ We operate a three-project loop:
 2. **api.agents.alchm.kitchen (PA Backend)**: The Planetary Agents Python service owning agent personas, orchestration, and LLM recipe generation.
 3. **agents.alchm.kitchen (PA UI)**: The Planetary Agents Next.js UI.
 
-## Current Project Status (June 2026 - v3.2.1)
+## Current Project Status (June 2026 - v3.3.0)
+
+### 🧪 **DATA AUTHENTICITY CAMPAIGN (Ingredients + Recipes)**
+- **Mission**: Drive catalog data to *real* values — no fabricated nutrition, no placeholder/default templates, no hollow recipes. `src/data` is the authoritative source for ingredient recommendations (static); recipes read from a denormalized DB JSONB read model.
+- **Ingredient side (shipped)**: Lifted free-text matching into a shared resolver adopted by `UnifiedIngredientService` (#559); removed the fabricated nutrition template from the static catalog (#560); stopped placeholder coverage entries leaking into recommendations (#562); purged non-ingredient junk from the coverage set (#561); added missing cooking staples — stocks, broths, fish sauce, etc. (#563); shipped real nutrition for the 21 specialty oils as nutrition batch 1 (#566); added a real-vs-default scoring pass to the ingredient audit (#565).
+- **Recipe side (shipped)**: Backfilled real per-serving nutrition that was 100% empty (#555); upgraded the ESMS ingredient matcher (matchRate 0.56 → 0.64, #556); cleaned junk parenthetical descriptions and recovered real seasons (#557); de-published 14 fully-fabricated hollow recipes (#558); reconciled nutrition and recomputed degenerate elemental signatures after the staples landed (#564).
+- **Dashboard honesty**: Practitioner Cohorts now read canonical sources instead of vestigial JSONB (#552); replaced the fabricated Cost Burndown with a real Railway resource-usage panel (#553/#554).
+
 
 ### 🪐 **PLANETARY AGENTS INTEGRATION**
 - **Unified Agent Profiles**: Agents are first-class users (`@agentic.alchm.kitchen`). Their rich profiles include bio, dominant elements, live natal chart overlays, viewer↔agent synastry, and consciousness sigils (fetched via public endpoints from WTEN).
 - **Transit-Driven Group Chats**: Clicking active transits in WTEN opens a group chat on the PA side involving the planetary-degree agents involved.
 - **Agent Weekly Menus & Feed**: Agents publish weekly menus and share activities (chat, recipe generation, insights) directly to WTEN's `feed_events` via authenticated server-to-server endpoints (using `X-Sync-Secret` / `INTERNAL_API_SECRET`).
 - **Cosmic Recipe Generation**: Offloaded LLM generation of recipes entirely to PA's `/api/generate-recipe` backend endpoint to ensure strict structured JSON outputs (`CosmicRecipe` schema) without prompt hijacking.
+- **Agent Daily Cosmic Yield Cron**: Added a daily cron service (`/api/cron/agents-daily-yield` scheduled at `30 0 * * *` via Vercel) that automatically mints personalized daily Cosmic Yield for active, chart-bearing agents (source_type `"agents_yield"`) using the core `DailyYieldService` yield engine. This ensures the live token economy feed stays active and demonstrates the loop to visitors.
+
 
 ### ⚡ **SPACETIMEDB LIVE LAYER (v4.0)**
 - **Real-Time Sync**: Using `spacetime-module` (Rust) for live synchronization of meal plans, commensal lobbies, and grocery carts.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Alchm.kitchen — v3.2.0
+# Alchm.kitchen — v3.3.0
 
 [![Bun](https://img.shields.io/badge/Bun-v1.3.13-black?logo=bun&logoColor=white)](https://bun.sh)
 [![Next.js](https://img.shields.io/badge/Next.js-v15-black?logo=next.js)](https://nextjs.org)
@@ -10,6 +10,14 @@
 **The world's first astrological meal-planning system.** Alchm.kitchen bridges ancient alchemical wisdom with modern AI to deliver personalized food recommendations based on natal charts, live planetary positions, elemental harmony, and thermodynamic resonance.
 
 Production: **[alchm.kitchen](https://alchm.kitchen)**
+
+---
+
+## What's new in 3.3 — Data Authenticity & Live Economy
+
+- **Data-authenticity campaign**: a multi-PR push to drive the ingredient and recipe catalogs to **REAL** values — no fabricated nutrition, no placeholder/default templates, no hollow recipes. On the ingredient side: a shared free-text matching resolver now adopted by `UnifiedIngredientService` (#559), removal of the fabricated nutrition template (#560), coverage-set cleanup of non-ingredient junk (#561), placeholder coverage entries no longer leaking into recommendations (#562), missing cooking staples added — stocks, broths, fish sauce (#563), real-vs-default scoring in the ingredient audit (#565), and real nutrition for the 21 specialty oils (#566). On the recipe side: per-serving nutrition backfill (#555), an improved ESMS ingredient matcher (match rate 0.56 → 0.64, #556), description/season cleanup (#557), de-publish of 14 fully-fabricated hollow recipes (#558), and nutrition reconciliation + elemental-signature recompute after staples (#564).
+- **Dashboard honesty**: Practitioner Cohorts now read canonical sources rather than vestigial JSONB (#552), the Cost Burndown stops fabricating and shows an honest "no billing source" (#553), and a real Railway resource-usage panel replaces it (#554). Plus Live Network Feed poller caching + jitter to cut DB pressure (#550) and a resilient, detectable new-user signup grant (#551).
+- **Agent Daily Cosmic Yield cron** *(in flight on `feat/agent-daily-yield-cron`)*: a Vercel cron at `/api/cron/agents-daily-yield` (schedule `30 0 * * *`, `CRON_SECRET`-gated) mints each active, chart-bearing agent's personalized daily Cosmic Yield via `DailyYieldService.claimDailyYield` with `site="agents"`, keeping the Live Network economy surfaces alive for visitors. It reuses the human-claim engine verbatim (same economics + per-day idempotency) and is purely additive — no formula or human-claim path changes.
 
 ---
 
@@ -166,7 +174,7 @@ src/
 │   └── next-auth.d.ts           # JWT augmentation (sessionId, deviceSessionId)
 │
 └── database/
-    └── init/                    # SQL migrations (01 – 33)
+    └── init/                    # SQL migrations (01 – 54)
         └── 33-device-sessions.sql
 ```
 
@@ -253,7 +261,7 @@ railway up
 
 ### Database migrations
 
-Migrations live in `database/init/`. Apply in sequence (01 → 33). Railway runs them on first boot via the `db_init.py` script.
+Migrations live in `database/init/`. Apply in sequence (01 → 54). Railway runs them on first boot via the `db_init.py` script.
 
 ---
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Alchm.kitchen API Reference
 
-**Version**: 3.0.0 | Updated: 2026-05-21
+**Version**: 3.3.0 | Updated: 2026-06-29
 
 All API routes documented here are Next.js App Router handlers under `src/app/api/`. All times are UTC. Auth uses NextAuth.js v5 session cookies unless noted.
 
@@ -614,7 +614,9 @@ Health check.
 
 **Auth**: Public.
 
-**Response**: `{ "status": "ok", "version": "3.0.0", "timestamp": "..." }`
+**Response**: `{ "status": "ok", "version": "3.1.0", "timestamp": "..." }`
+
+> The `version` field reflects the **runtime** app version (`APP_VERSION`, inlined from `package.json`, currently `3.1.0`) — not this guide's doc-convention version in the header above.
 
 ---
 

--- a/docs/CI_CD_SETUP.md
+++ b/docs/CI_CD_SETUP.md
@@ -3,12 +3,12 @@
 ## 🚀 Overview
 
 This document describes the comprehensive CI/CD pipeline setup for the
-WhatToEatNext project using Yarn, GitHub Actions, and Vercel deployment.
+WhatToEatNext project using Bun, GitHub Actions, and Vercel deployment.
 
 ## 📋 Prerequisites
 
 - Node.js 20.18.0 or higher
-- Yarn 1.22.0 or higher
+- Bun 1.3.13 (Yarn is fully retired — never npm/yarn)
 - GitHub repository with Actions enabled
 - Vercel account for deployment
 
@@ -22,7 +22,7 @@ WhatToEatNext project using Yarn, GitHub Actions, and Vercel deployment.
    - `dependency-review.yml` - Security scanning
 
 2. **Build Tools**
-   - Yarn for package management
+   - Bun for package management
    - Turborepo for build optimization
    - ESLint + Prettier for code quality
 
@@ -42,7 +42,7 @@ WhatToEatNext project using Yarn, GitHub Actions, and Vercel deployment.
 | `.github/workflows/dependency-review.yml` | Security scanning            |
 | `.github/dependabot.yml`                  | Automated dependency updates |
 | `turbo.json`                              | Turborepo configuration      |
-| `.bunrc.yml`                             | Yarn configuration           |
+| `.bunrc.yml`                             | Bun configuration            |
 | `.eslintrc.js`                            | ESLint configuration         |
 | `.prettierrc`                             | Prettier configuration       |
 
@@ -98,7 +98,7 @@ git push origin main
 **Jobs:**
 
 1. **Security** - Vulnerability scanning
-   - Yarn audit
+   - Bun audit
    - Trivy vulnerability scanner
    - GitHub Security tab integration
 
@@ -205,7 +205,7 @@ bun run deps:update      # Interactive dependency updates
 
 ### Vulnerability Scanning
 
-- **Yarn Audit**: Scans for known vulnerabilities
+- **Bun Audit**: Scans for known vulnerabilities
 - **Trivy**: Comprehensive vulnerability scanner
 - **Dependency Review**: GitHub's dependency scanning
 
@@ -230,7 +230,7 @@ security:
 ### Build Optimization
 
 - **Turborepo**: Incremental builds
-- **Yarn Caching**: Dependency caching
+- **Bun Caching**: Dependency caching
 - **GitHub Actions Caching**: Workflow optimization
 
 ## 🚨 Troubleshooting
@@ -271,8 +271,8 @@ security:
 # Check Node.js version
 node --version
 
-# Check Yarn version
-bun run --version
+# Check Bun version
+bun --version
 
 # Validate CI configuration
 ./scripts/setup-ci.sh
@@ -286,13 +286,13 @@ bun run ci:lint && bun run ci:type-check && bun run ci:test && bun run ci:build
 ### Build Performance
 
 - **Turborepo**: Incremental builds and caching
-- **Yarn**: Efficient dependency resolution
+- **Bun**: Efficient dependency resolution
 - **GitHub Actions**: Parallel job execution
 
 ### Caching Strategy
 
 ```yaml
-# Yarn cache
+# Bun cache
 - uses: actions/setup-node@v4
   with:
     cache: "bun"

--- a/docs/PRODUCTION_DEPLOYMENT_GUIDE.md
+++ b/docs/PRODUCTION_DEPLOYMENT_GUIDE.md
@@ -15,8 +15,8 @@
 
 ### **Prerequisites**
 
-- Node.js 18+ (LTS recommended)
-- Yarn package manager
+- Node.js 20.18.0+ (LTS recommended)
+- Bun 1.3.13 package manager (Yarn is fully retired — never npm/yarn)
 - Production server (Vercel, Netlify, or custom)
 - Domain name (optional)
 
@@ -136,8 +136,7 @@ netlify deploy --prod --dir=.next
   publish = ".next"
 
 [build.environment]
-  NODE_VERSION = "18"
-  YARN_VERSION = "1.22.19"
+  NODE_VERSION = "20.18.0"
 
 [[headers]]
   for = "/*"

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -89,7 +89,7 @@ bun run typecheck
 ### Technology Stack
 
 - **Frontend**: Next.js 15.3.4 with React 19.1.0
-- **Language**: TypeScript 5.1.6 with strict typing
+- **Language**: TypeScript 5.7 with strict typing
 - **Styling**: Tailwind CSS with elemental theming
 - **Calculations**: astronomy-engine, astronomia libraries
 - **Testing**: Jest with comprehensive test coverage

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ Want to understand the astrological system and its applications? →
 
 ### 🏗️ Technical Excellence
 
-- **Production ready**: Phase 8 complete with <100 TypeScript errors
+- **Production ready**: 0 TypeScript errors / 0 lint warnings enforced before every PR
 - **Enterprise quality**: 92%+ automated fix success rates
 - **<2 second calculations**: High-performance astrological computations
 - **Comprehensive testing**: Robust quality assurance
@@ -96,9 +96,9 @@ Want to understand the astrological system and its applications? →
 
 ### Core Technologies
 
-- **Next.js 15.3.4** - App Router with server components
-- **React 19.1.0** - Latest React with concurrent features
-- **TypeScript 5.1.6** - Strict typing with astrological domain modeling
+- **Next.js 15** - App Router with server components
+- **React 19** - Latest React with concurrent features
+- **TypeScript 5.7** - Strict typing with astrological domain modeling
 - **Tailwind CSS** - Elemental theming and responsive design
 
 ### Specialized Libraries
@@ -117,9 +117,9 @@ Want to understand the astrological system and its applications? →
 
 ## 📊 Current Status
 
-### ✅ Production Ready (Phase 8 Complete)
+### ✅ Live in Production (v3.3.0)
 
-- **Error Reduction**: 97% reduction (4,310 → <100 TypeScript errors)
+- **Deployment**: Live at [alchm.kitchen](https://alchm.kitchen)
 - **Performance**: Optimized build and runtime performance
 - **Documentation**: Comprehensive and well-organized
 - **Quality**: Enterprise-level code quality and testing

--- a/docs/architecture/AGENTS.md
+++ b/docs/architecture/AGENTS.md
@@ -1,20 +1,26 @@
 # WhatToEatNext - Codex AI Assistant Guide
 
-_Version: 2.3.0 | Last Updated: May 9, 2026_
+_Version: 3.3.0 | Last Updated: June 29, 2026_
 
 ## Project Overview
 
 WhatToEatNext is a sophisticated culinary recommendation system that combines alchemical principles, astrological data, and elemental harmony to provide personalized food recommendations. The site is branded as **Alchm.kitchen**.
 
-## Current Project Status (May 2026)
+## Current Project Status (June 2026 - v3.3.0)
 
 ### 🎉 **INFRASTRUCTURE & TOOLCHAIN OPTIMIZED**
 
+- **Doc version**: ✅ **3.3.0** (guide convention; `package.json` is still pinned at `3.1.0` — `git tag v3.1.0` cut 2026-05-29, so this bump is not a `package.json` bump)
 - **Toolchain**: ✅ **BUN v1.3.13** (Migrated from Yarn — 10x faster installs/builds)
-- **Database**: ✅ **RAILWAY POSTGRES** (Internal: `postgres.railway.internal`)
+- **Stack**: ✅ **Next.js 15 / React 19 / TypeScript 5.7**
+- **Database**: ✅ **RAILWAY POSTGRES** (Internal: `postgres.railway.internal`); schema current through **migration 54**. Neon is deprecated on the WTEN side (still used only inside the PA Python backend).
 - **Read Model**: ✅ **DENORMALIZED** (Sub-100ms recipe loads via `read_model` JSONB column)
 - **Assets**: ✅ **OPTIMIZED** (Logo/Hero images shrunk by 90%+)
 - **Latency**: ✅ **SUB-1MS** DB response times via Railway internal networking.
+
+### 🧪 Shipped in 3.3 / since 3.1
+
+Data authenticity campaign drives the catalog to real values — no fabricated nutrition, no placeholder/default templates, no hollow recipes: ingredients (#559–#566), recipes (#555–#558, #564), dashboard honesty (#552–#554). New **Agent Daily Cosmic Yield** cron at `/api/cron/agents-daily-yield` (`30 0 * * *`, CRON_SECRET-gated; `src/services/agentDailyYield.ts`) mints each active chart-bearing agent's daily yield to keep the token ledger / Live Network economy surfaces live. On the 3.2.x baseline: Planetary Agents are first-class users; SpacetimeDB v4.0 live layer; unified ElementalSignature model (#505); MCP telemetry + `*/30` probe; Cloudflare SDXL→R2 image pipeline.
 
 ### Toolchain — always use `bun`, never `npm` or `yarn`
 
@@ -71,4 +77,4 @@ SMTP_USER=<smtp-user>
 
 ---
 
-_Updated May 9, 2026 — Bun toolchain migration complete. Sub-1ms latency via Railway internal networking._
+_Updated June 29, 2026 (v3.3.0) — data authenticity campaign drives the catalog to real values (ingredients #559–#566, recipes #555–#558, #564, dashboard honesty #552–#554); Agent Daily Cosmic Yield cron (`/api/cron/agents-daily-yield`, `30 0 * * *`) keeps the token economy feed live. Schema through migration 54, Railway-primary DB. Bun 1.3.13 toolchain; Next.js 15 / React 19 / TypeScript 5.7._

--- a/docs/architecture/CLAUDE.md
+++ b/docs/architecture/CLAUDE.md
@@ -1,6 +1,6 @@
 # WhatToEatNext - Claude AI Assistant Guide
 
-_Version: 3.2.1 | Last Updated: June 17, 2026_
+_Version: 3.3.0 | Last Updated: June 29, 2026_
 
 > Sibling guide: **`GEMINI.md`** (repo root) is the concise, actively-maintained status summary. This file is the deeper engineering reference (admin console, observability, cron, surface map). Keep both in sync when project status changes.
 
@@ -13,15 +13,23 @@ We operate a three-project loop:
 2. **api.agents.alchm.kitchen (PA Backend)** — the Planetary Agents Python service owning agent personas, orchestration, and LLM recipe generation.
 3. **agents.alchm.kitchen (PA UI)** — the Planetary Agents Next.js UI.
 
-## Current Project Status (June 2026 — v3.2.1)
+## Current Project Status (June 2026 — v3.3.0)
 
-- **Doc version**: **3.2.1** (guide convention; `package.json` is still pinned at `3.1.0` — `git tag v3.1.0` cut 2026-05-29)
+- **Doc version**: **3.3.0** (guide convention; `package.json` is still pinned at `3.1.0` — `git tag v3.1.0` cut 2026-05-29)
 - **Build**: ✅ **0 TS errors, 0 lint warnings** before every PR (husky pre-commit runs `typecheck && lint`)
 - **Toolchain**: ✅ **BUN v1.3.13** (Yarn fully retired)
 - **Stack**: Next.js 15 · React 19 · TypeScript 5.7
 - **Database**: ✅ **RAILWAY POSTGRES** (`postgres.railway.internal`) + transaction-mode PgBouncer compat (ADR-007, #466); schema current through **migration 54**. Neon is deprecated on the WTEN side (still used only inside the PA Python backend).
 - **Read Model**: ✅ **DENORMALIZED** (sub-100ms recipe loads via `read_model` JSONB)
 - **Migrations**: ✅ **TRACKED + AUTO-APPLIED** — `_migrations` table + `scripts/migrate.ts` (TS) / `backend/scripts/run_init_migrations.py` run on Railway deploy before uvicorn (#448)
+
+### 🧪 Shipped in 3.3 — data authenticity + agent yield
+
+- **Data authenticity campaign (ingredients + recipes)** — a sustained push to drive catalog data to *real* values: no fabricated nutrition, no placeholder/default templates, no hollow recipes. `src/data` is authoritative for ingredient recommendations (static); recipes read from the denormalized DB JSONB read model.
+  - _Ingredients_ — shared free-text resolver lifted out and adopted by `UnifiedIngredientService` (#559); fabricated nutrition template removed from the static catalog (#560); placeholder coverage entries stopped leaking into recommendations (#562); non-ingredient junk purged from the coverage set (#561); missing cooking staples added — stocks, broths, fish sauce, etc. (#563); real nutrition for the 21 specialty oils, nutrition batch 1 (#566); real-vs-default scoring added to the ingredient audit (#565).
+  - _Recipes_ — real per-serving nutrition backfilled (was 100% empty, #555); ESMS ingredient matcher upgraded (matchRate 0.56 → 0.64, #556); junk parenthetical descriptions cleaned + real seasons recovered (#557); 14 fully-fabricated hollow recipes de-published (#558); nutrition reconciled + degenerate elemental signatures recomputed after staples landed (#564).
+  - _Dashboard honesty_ — Practitioner Cohorts read canonical sources instead of vestigial JSONB (#552); fabricated Cost Burndown replaced with a real Railway resource-usage panel (#553/#554).
+- **Agent Daily Cosmic Yield cron** — `/api/cron/agents-daily-yield` (`30 0 * * *`, CRON_SECRET-gated) mints each active, chart-bearing agent's personalized daily Cosmic Yield so the token ledger / Live Network economy surfaces stay alive for visitors. `src/services/agentDailyYield.ts` reuses the human-claim engine verbatim (`DailyYieldService.claimDailyYield` with `site="agents"` → `source_type "agents_yield"`), so economics + idempotency are identical (keyed per `(site, agent, day)`; re-runs are no-ops). Purely additive — no formula or human-claim path changed. Backstops the PA `sync-credit` `agents_yield` pipeline, silent since 2026-06-03.
 
 ### 🚀 Shipped since 3.1 (the 3.2.x line)
 
@@ -210,6 +218,7 @@ All compute from existing signals — no new instrumentation required. Each serv
 | `/api/cron/synthetic-mcp` | `*/30 * * * *` | in-process Alchm MCP tool-handler probe |
 | `/api/cron/system-health-snapshot` | `0 * * * *` | hourly status snapshot + transition-based alert dispatch |
 | `/api/cron/observability-prune` | `0 3 * * *` | daily prune of `request_log_entries` + `slow_query_log_entries` older than 7 days (override via `?retain=N`) |
+| `/api/cron/agents-daily-yield` | `30 0 * * *` | mint daily Cosmic Yield for active chart-bearing agents (`agents_yield`) — keeps the token economy feed live |
 
 ### Planetary Agents (PA) integration
 
@@ -267,4 +276,4 @@ The `planetary_agents-main` Next.js UI surface (~54 files / ~22k LOC across 11 s
 
 ---
 
-_Updated June 17, 2026 (v3.2.1) — synced from the 3.1 baseline: Planetary Agents are first-class users (profiles, synastry, transit group chats, agent feed + cosmic recipe offload); SpacetimeDB v4.0 live layer (meal plans / commensal / carts) with CSP `wss://` + reconnect + bare-module-name hardening (#534) and admin diagnostics (#536); unified Elemental Signature model (#505); MCP telemetry (`mcp_invocations`) + `*/30` probe; Cloudflare SDXL→R2 image pipeline. WTEN UI migration complete; real planetary-alchemy recommendations live. Live-site "emergence" audit cleanup (#526–#536) incl. natal-chart + coverage-ingredient backfills. Schema through migration 54, Railway-primary DB. Bun 1.3.13._
+_Updated June 29, 2026 (v3.3.0) — data authenticity campaign (ingredients #559–#566 + recipes #555–#558, #564; dashboard honesty #552–#554) drives the catalog to real values (no fabricated nutrition / placeholder templates / hollow recipes); Agent Daily Cosmic Yield cron (`/api/cron/agents-daily-yield`, `30 0 * * *`) keeps the token economy feed live via the shared yield engine. Earlier 3.2.x baseline: Planetary Agents are first-class users (profiles, synastry, transit group chats, agent feed + cosmic recipe offload); SpacetimeDB v4.0 live layer (meal plans / commensal / carts) with CSP `wss://` + reconnect + bare-module-name hardening (#534) and admin diagnostics (#536); unified Elemental Signature model (#505); MCP telemetry (`mcp_invocations`) + `*/30` probe; Cloudflare SDXL→R2 image pipeline. WTEN UI migration complete; real planetary-alchemy recommendations live. Live-site "emergence" audit cleanup (#526–#536) incl. natal-chart + coverage-ingredient backfills. Schema through migration 54, Railway-primary DB. Bun 1.3.13._

--- a/docs/deployment/CRON_JOBS.md
+++ b/docs/deployment/CRON_JOBS.md
@@ -1,11 +1,18 @@
 # Scheduled Jobs (Railway Cron)
 
-This file is the source of truth for periodic jobs that run against the
-production Railway Postgres database.
+This file is the source of truth for periodic jobs that run as **Railway cron
+services** against the production Railway Postgres database.
 
 Crons are configured as separate Railway services on the same project, each
 pointed at this repository. Railway runs the service on its `Cron Schedule`,
 the container exits cleanly, and the next run is scheduled.
+
+> **Railway vs. Vercel crons.** This file covers only Railway cron *services*.
+> The app also runs **Vercel crons** (registered in `vercel.json`) — the
+> `synthetic-*` probes, `system-health-snapshot`, and the
+> `agents-daily-yield` daily Cosmic Yield mint
+> (`/api/cron/agents-daily-yield`, `30 0 * * *`, gated by `CRON_SECRET`).
+> Those are not Railway services; see `vercel.json` for the full list.
 
 ## Active jobs
 

--- a/docs/deployment/DOCKER_GUIDE.md
+++ b/docs/deployment/DOCKER_GUIDE.md
@@ -7,7 +7,7 @@ with Next.js 15.3.4, React 19, and TypeScript.
 
 - **Docker** (20.10+) and **Docker Compose** (2.0+)
 - **Node.js 20.18.0+** (for local development)
-- **Yarn 1.22.0+** package manager
+- **Bun 1.3.13** package manager (Yarn is fully retired — never npm/yarn)
 
 ## 🚀 Quick Start
 

--- a/docs/getting-started/for-developers.md
+++ b/docs/getting-started/for-developers.md
@@ -88,7 +88,7 @@ src/
 
 - **Next.js 15.3.4**: App Router with server components
 - **React 19.1.0**: Latest React with concurrent features
-- **TypeScript 5.1.6**: Strict typing with astrological domain modeling
+- **TypeScript 5.7**: Strict typing with astrological domain modeling
 - **Tailwind CSS**: Utility-first styling with elemental theming
 - **astronomy-engine**: High-precision astronomical calculations
 - **Jest**: Comprehensive testing framework

--- a/docs/getting-started/project-overview.md
+++ b/docs/getting-started/project-overview.md
@@ -179,7 +179,7 @@ Recognition of the cosmic forces that bring food to our table
 
 - **Next.js 15.3.4**: App Router with server components
 - **React 19.1.0**: Latest React with concurrent features
-- **TypeScript 5.1.6**: Strict typing with domain modeling
+- **TypeScript 5.7**: Strict typing with domain modeling
 - **Tailwind CSS**: Utility-first styling with elemental theming
 
 ### Specialized Libraries

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ Dive into the technical stack and contribution workflows:
 
 - **[Frontend Architecture](architecture/frontend-structure.md)** - Next.js 15, React 19, and Bun.
 - **[Backend Integration](technical/api-integration.md)** - Python FastAPI and Swiss Ephemeris.
-- **[Database Schema](data/database-schema.md)** - Neon PostgreSQL structure.
+- **[Database Schema](data/database-schema.md)** - Railway PostgreSQL structure (postgres.railway.internal).
 - **[Testing Guidelines](development/testing-strategy.md)** - Ensuring alchemical rigor.
 - **[Crypto Food Payments](payments/CRYPTO_FOOD_PAYMENTS.md)** - USDC, ESMS reserve settlement, provider research, and rollout controls.
 

--- a/src/app/api/cron/agents-daily-yield/route.ts
+++ b/src/app/api/cron/agents-daily-yield/route.ts
@@ -1,0 +1,38 @@
+/**
+ * GET /api/cron/agents-daily-yield
+ *
+ * Daily cron that mints each active, chart-bearing agent's personalized Cosmic
+ * Yield (source_type "agents_yield") so the token ledger / Live Network economy
+ * surfaces stay alive and demonstrate the yield loop to new visitors. Reuses the
+ * human yield engine; claims are idempotent per agent per day.
+ *
+ * Auth: Authorization: Bearer <CRON_SECRET> (Vercel cron). No user token economy
+ * is touched beyond the agents' own daily claim. Degrades gracefully on error.
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import { isAuthorizedCron } from "@/app/api/cron/_lib/cronAuth";
+import { _logger } from "@/lib/logger";
+import { runAgentDailyYield } from "@/services/agentDailyYield";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+export async function GET(request: NextRequest) {
+  if (!isAuthorizedCron(request)) {
+    return NextResponse.json({ success: false, message: "Unauthorized" }, { status: 401 });
+  }
+  try {
+    const { searchParams } = new URL(request.url);
+    const limit = Math.min(Math.max(parseInt(searchParams.get("limit") ?? "30", 10), 1), 60);
+    const result = await runAgentDailyYield(limit);
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    _logger.error("[cron/agents-daily-yield] failed:", error);
+    return NextResponse.json(
+      { success: false, message: error instanceof Error ? error.message : "unknown" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/services/__tests__/agentDailyYield.test.ts
+++ b/src/services/__tests__/agentDailyYield.test.ts
@@ -1,0 +1,34 @@
+import { planetSignsFromNatal } from "../agentDailyYield";
+
+describe("planetSignsFromNatal", () => {
+  it("maps an array of {planet, sign} entries into a planet→sign map", () => {
+    expect(
+      planetSignsFromNatal([
+        { planet: "Sun", sign: "Aries", degree: 0 },
+        { planet: "Moon", sign: "Sagittarius", degree: 27 },
+      ]),
+    ).toEqual({ Sun: "Aries", Moon: "Sagittarius" });
+  });
+
+  it("parses a JSON string and ignores malformed entries", () => {
+    expect(
+      planetSignsFromNatal('[{"planet":"Mars","sign":"Scorpio"},{"x":1},{"planet":"Venus"}]'),
+    ).toEqual({ Mars: "Scorpio" });
+  });
+
+  it("returns {} for empty arrays, non-arrays, and unparseable strings", () => {
+    expect(planetSignsFromNatal([])).toEqual({});
+    expect(planetSignsFromNatal(null)).toEqual({});
+    expect(planetSignsFromNatal({})).toEqual({});
+    expect(planetSignsFromNatal("not json")).toEqual({});
+  });
+
+  it("keeps the last sign when a planet repeats", () => {
+    expect(
+      planetSignsFromNatal([
+        { planet: "Sun", sign: "Aries" },
+        { planet: "Sun", sign: "Taurus" },
+      ]),
+    ).toEqual({ Sun: "Taurus" });
+  });
+});

--- a/src/services/agentDailyYield.ts
+++ b/src/services/agentDailyYield.ts
@@ -1,0 +1,139 @@
+/**
+ * Agent daily Cosmic Yield.
+ *
+ * The token economy's "Cosmic Yield" is otherwise opt-in: humans must POST
+ * /api/economy/claim-daily, and historical agents only ever earned when the
+ * Planetary Agents backend pushed `agents_yield` via /api/economy/sync-credit
+ * — a pipeline that has been silent since 2026-06-03, leaving the ledger / Live
+ * Network economy surfaces looking dead to new visitors.
+ *
+ * This service lets a daily cron mint each active, chart-bearing agent's own
+ * personalized yield, so the economy feed stays alive and demonstrates the
+ * token loop. It reuses the exact same yield engine as human claims
+ * (DailyYieldService.claimDailyYield with site="agents" → source_type
+ * "agents_yield"), so the economics and idempotency are identical: the daily
+ * claim is keyed per (site, agent, day) and a re-run is a no-op.
+ *
+ * Additive: no formula or human-claim path is changed.
+ *
+ * @file src/services/agentDailyYield.ts
+ */
+
+import { executeQuery } from "@/lib/database";
+import { _logger } from "@/lib/logger";
+import { dailyYieldService } from "@/services/DailyYieldService";
+
+interface AgentYieldRow {
+  id: string;
+  email: string | null;
+  name: string | null;
+  natal_positions: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asArray(value: unknown): unknown[] {
+  let candidate = value;
+  if (typeof candidate === "string") {
+    try {
+      candidate = JSON.parse(candidate);
+    } catch {
+      return [];
+    }
+  }
+  return Array.isArray(candidate) ? candidate : [];
+}
+
+/**
+ * Convert a stored `natal_positions` value (array of `{ planet, sign }`, or a
+ * JSON string of one) into the planet → sign map the yield engine expects.
+ * Malformed entries are skipped; non-arrays yield `{}`.
+ */
+export function planetSignsFromNatal(natalPositions: unknown): Record<string, string> {
+  const signs: Record<string, string> = {};
+  for (const entry of asArray(natalPositions)) {
+    if (!isRecord(entry)) continue;
+    const planet = typeof entry.planet === "string" ? entry.planet : undefined;
+    const sign = typeof entry.sign === "string" ? entry.sign : undefined;
+    if (planet && sign) signs[planet] = sign;
+  }
+  return signs;
+}
+
+export interface AgentYieldResult {
+  attempted: number;
+  credited: number;
+  alreadyClaimed: number;
+  skipped: number;
+  failed: number;
+  tokensMinted: number;
+}
+
+/**
+ * Mint today's Cosmic Yield for the most-recently-active chart-bearing agents.
+ *
+ * Selects active agents that have a real natal chart (so the yield is
+ * personalized, not a uniform fallback), ordered by their latest feed activity
+ * so the visibly-active demonstrators earn. Each claim is idempotent per day, so
+ * the cron can run repeatedly and back-fill without double-crediting.
+ */
+export async function runAgentDailyYield(limit = 30): Promise<AgentYieldResult> {
+  const result: AgentYieldResult = {
+    attempted: 0,
+    credited: 0,
+    alreadyClaimed: 0,
+    skipped: 0,
+    failed: 0,
+    tokensMinted: 0,
+  };
+
+  let rows: AgentYieldRow[] = [];
+  try {
+    const query = await executeQuery<AgentYieldRow>(
+      `SELECT u.id, u.email, up.name, up.natal_positions
+         FROM users u
+         JOIN user_profiles up ON up.user_id = u.id
+         LEFT JOIN LATERAL (
+           SELECT max(fe.created_at) AS last_seen
+             FROM feed_events fe
+            WHERE fe.actor_id = u.id
+         ) act ON true
+        WHERE COALESCE(u.is_agent, false) = true
+          AND COALESCE(u.is_active, true) = true
+          AND up.natal_positions IS NOT NULL
+          AND up.natal_positions::text NOT IN ('[]', 'null', '{}')
+        ORDER BY act.last_seen DESC NULLS LAST
+        LIMIT $1`,
+      [limit],
+    );
+    rows = query.rows;
+  } catch (error) {
+    _logger.error("[agent-yield] agent query failed:", error);
+    return result;
+  }
+
+  result.attempted = rows.length;
+  for (const row of rows) {
+    const signs = planetSignsFromNatal(row.natal_positions);
+    if (Object.keys(signs).length === 0) {
+      result.skipped += 1; // no usable chart → skip rather than mint a uniform yield
+      continue;
+    }
+    try {
+      const yieldResult = await dailyYieldService.claimDailyYield(row.id, signs, false, "agents");
+      if (yieldResult) {
+        result.credited += 1;
+        result.tokensMinted += yieldResult.totalTokens;
+      } else {
+        result.alreadyClaimed += 1;
+      }
+    } catch (error) {
+      result.failed += 1;
+      _logger.warn(`[agent-yield] claim failed for ${row.email ?? row.id}:`, error);
+    }
+  }
+
+  return result;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -58,6 +58,10 @@
     {
       "path": "/api/cron/esms-reconciliation",
       "schedule": "15 * * * *"
+    },
+    {
+      "path": "/api/cron/agents-daily-yield",
+      "schedule": "30 0 * * *"
     }
   ],
   "env": {


### PR DESCRIPTION
## Why
The token ledger (`token_transactions`) has had **zero rows since 2026-06-16** — so the economy / Live Network ledger surfaces look dead to new users, right as we're about to onboard the business-card cohort. Root cause (not a bug): daily Cosmic Yield is opt-in (humans POST `/api/economy/claim-daily`), and agents only ever earned when the Planetary Agents backend pushed `agents_yield` via `/api/economy/sync-credit` — a pipeline silent since 2026-06-03. The recipe/duel feed is lively; the **economy** side is not.

## What
A daily cron mints each active, chart-bearing agent's own personalized Cosmic Yield so the token loop is visibly demonstrated.

- `src/services/agentDailyYield.ts` — selects active agents (`is_agent`, `is_active`) that have a real natal chart, ordered by latest feed activity, capped at `limit` (default 30, max 60). **Reuses the human yield engine verbatim** (`DailyYieldService.claimDailyYield`, `site="agents"` → `source_type "agents_yield"`) so the economics and idempotency are identical: each claim is keyed per `(site, agent, day)`, making re-runs / back-fills no-ops. Per-agent failures are swallowed; chartless agents are skipped (no uniform-fallback minting).
- `src/app/api/cron/agents-daily-yield/route.ts` — `CRON_SECRET`-guarded GET, mirrors `prewarm-agent-recipes`.
- `vercel.json` — registers the cron at `30 0 * * *` (after `cache-ephemeris` at `5 0 * * *` so today's transit bonus is fresh).
- Unit test for the `natal_positions` → planet/sign conversion.

Additive — no formula or human-claim path is changed.

## Verification
- `bunx jest agentDailyYield` → 4/4 pass
- `tsc --noEmit` → 0 errors; eslint → 0 errors on changed source
- Idempotent: safe to trigger immediately after deploy (e.g. Vercel dashboard → Run) to light up the ledger before merge propagates.

## Notes
- First automatic run is the next `30 0 * * *` (00:30 UTC) after deploy.
- Does **not** touch the human daily-claim path or the PA `sync-credit` path.

## Documentation (added in `c222f31b`)
Synced the full docs set to **v3.3.0** so the guides match this branch's cron feature + the recent data-authenticity PRs (#552–#566). 17 files, docs-only:

- **AI guides → v3.3.0**: `GEMINI.md`, `docs/architecture/CLAUDE.md`, and the long-stale `docs/architecture/AGENTS.md` (Codex guide, was v2.3.0). The cron is documented as a **Vercel** cron — registry row `/api/cron/agents-daily-yield` `30 0 * * *`, plus a `vercel.json`-vs-Railway split note in `docs/deployment/CRON_JOBS.md`.
- **README.md** "What's new in 3.3" section + migrations `01→54`; **CHANGELOG.md** fills the `[Unreleased]→[3.1.0]` gap with `[3.3.0]` and a reconstructed `[3.2.x]` (compare-links corrected to only the tags that exist).
- **Data-authenticity campaign** captured across the guides (ingredient #559–#566, recipe #555–#558/#564, dashboard honesty #552–#554).
- Toolchain **Yarn→Bun 1.3.13** (DEPLOYMENT_GUIDE, DOCKER_GUIDE, CI_CD_SETUP, PRODUCTION_DEPLOYMENT_GUIDE), DB **Neon→Railway** in `docs/index.md`, and TS `5.1.6→5.7` version-string fixes.

Produced via a 37-agent audit→edit→verify workflow over all 86 docs; only stale ones were touched (ADRs / conceptual references left alone). The unrelated `src/app/onboarding/page.tsx` WIP in the working tree was deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
