### PR TITLE
fix(onboarding): bound the Agent Forge ignite request with a client timeout

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -130,6 +130,13 @@ export default function OnboardingPage() {
     setViewState("projecting");
     setLoadingStep(0);
 
+    // Bound the request so a slow/stalled function (cold start or 504 under
+    // load) can't trap a first-time user on the projection screen forever. The
+    // server caps recipe generation at 20s and persists the constitution before
+    // it, so a timeout here is safe to surface as a retry.
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 45_000);
+
     try {
       const response = await fetch("/api/agent-forge/ignite", {
         method: "POST",
@@ -137,7 +144,8 @@ export default function OnboardingPage() {
         body: JSON.stringify({
           dob: birthDateTime,
           city: birthLocation.displayName
-        })
+        }),
+        signal: controller.signal
       });
 
       if (!response.ok) {
@@ -174,8 +182,15 @@ export default function OnboardingPage() {
       setViewState("transmuted");
     } catch (err: any) {
       console.error("Agent Forge Onboarding Error:", err);
-      setError(err?.message || "An unexpected eclipse interrupted your onboarding. Please try again.");
+      const isTimeout = err?.name === "AbortError";
+      setError(
+        isTimeout
+          ? "The celestial forge is taking longer than usual. Your alignment may already be saved — please try again."
+          : err?.message || "An unexpected eclipse interrupted your onboarding. Please try again."
+      );
       setViewState("input");
+    } finally {
+      clearTimeout(timeout);
     }
   };
 


### PR DESCRIPTION
## Why
A new user's onboarding hinges on `POST /api/agent-forge/ignite` (geocode → natal chart → ESMS constitution → first cosmic recipe via LLM). The server is well-bounded — it persists the constitution **before** recipe generation and caps the recipe step at 20s, degrading to `cosmicRecipe: null` on timeout — but the **client** `fetch` had no timeout. Under launch-day load (cold starts, occasional 504s), a first-time user could sit on the animated "projection" screen indefinitely with no way out. Bad first impression right as the business cards drive traffic.

## What
- `src/app/onboarding/page.tsx` — wrap the ignite `fetch` in a 45s `AbortController` (comfortably above the server's 20s recipe cap). On `AbortError`, return to the input step with a friendly, accurate retry message ("…taking longer than usual. Your alignment may already be saved — please try again.") instead of an endless spinner.

The existing loading animation, success reveal, and error handling are otherwise unchanged.

## Verification
- `tsc --noEmit` → 0 errors; eslint → 0 errors.
- Logic-only change on an auth-gated page; full submit path requires Google OAuth so it wasn't exercised in a local browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)