### PR TITLE
feat(admin): honest agent role panels & reasoning traces + recipe-NFT mint-failure refund

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -356,6 +356,37 @@ PRIVY_APP_SECRET=
 # PRIVY_MINTER_WALLET_ID) are PA-ONLY — WhatToEatNext needs none of them.
 
 # ============================================================================
+# RECIPE-NFT MINTING  (on-chain recipe provenance — OFF by default)
+# ============================================================================
+# The off-chain ESMS spend + alchemical-fingerprint commitment ship enabled; the
+# on-chain mint stays OFF until ALL the gate vars below are set. Until then
+# src/lib/recipe-nft/minter.ts records the ledger row as `pending_chain` and a
+# backfill (scripts/backfill-recipe-token-ids.ts) mints it once the protocol is
+# live. Deploy RecipeRegistry + AlchmRightsRegistry first — see docs/recipe-nft/DEPLOY.md.
+#
+# Chain to mint on. Unset or "base-sepolia" = testnet; "base" only for a
+# deliberate mainnet cutover (which also needs BASE_RPC_URL instead of the sepolia one).
+NEXT_PUBLIC_RECIPE_NFT_CHAIN=base-sepolia
+# Master gate. Literal "true" enables minting — but only once the three addresses
+# and the rights id below are all set; any other value keeps minting off.
+NEXT_PUBLIC_RECIPE_NFT_ENABLED=false
+# Deployed registry addresses, printed by DeployRecipeProtocol.s.sol. Must start with 0x.
+NEXT_PUBLIC_RECIPE_REGISTRY_ADDRESS=
+NEXT_PUBLIC_RIGHTS_REGISTRY_ADDRESS=
+# Genesis rights id (bytes32) printed by the deploy. It folds in the work hash, so
+# it changes on any redeploy / chain switch — re-read and re-set it each time.
+NEXT_PUBLIC_ALCHM_RIGHTS_ID=
+# Public URL where the license manifest (docs/recipe-nft/ALCHM-RECIPE-LICENSE-v1.md)
+# is pinned; surfaced in the mint UI and must match the on-chain licenseURI.
+NEXT_PUBLIC_ALCHM_LICENSE_URI=
+# RPC for receipt waits + on-chain license reads (testnet default shown).
+BASE_SEPOLIA_RPC_URL=https://sepolia.base.org
+# SERVER-ONLY sponsor wallet that pays gas for backend-sponsored mints. Must be the
+# rights holder or an authorized operator, and kept funded. NEVER commit a real
+# key — set this only in the deployment secret store (Vercel), never in this file.
+RECIPE_MINTER_PRIVATE_KEY=
+
+# ============================================================================
 # THIRD-PARTY SERVICES
 # ============================================================================
 

--- a/src/app/admin/_dashboard/agents.tsx
+++ b/src/app/admin/_dashboard/agents.tsx
@@ -49,6 +49,29 @@ interface AgentLeaderboardEntry {
   dominantElement: string | null;
 }
 
+interface AgentRoleOpsAction {
+  action: string;
+  count: number;
+}
+
+interface AgentRoleOpsEntry {
+  id: string;
+  label: string;
+  mandate: string;
+  agentCount: number;
+  events24h: number;
+  events7d: number;
+  lastActivityAt: string | null;
+  actions: AgentRoleOpsAction[];
+}
+
+interface AgentReasoningEntry {
+  agentId: string;
+  agentHandle: string;
+  timestamp: string;
+  preview: string;
+}
+
 type CosmicModifierKind =
   | "amplify"
   | "harmonize"
@@ -87,6 +110,12 @@ interface AgentNetworkData {
   dispatch: { entries: AgentDispatchEntry[]; live: boolean };
   leaderboard: { entries: AgentLeaderboardEntry[]; live: boolean };
   interactions: { entries: AgentInteractionEntry[]; live: boolean };
+  roleOps: { entries: AgentRoleOpsEntry[]; live: boolean };
+  reasoning: {
+    entries: AgentReasoningEntry[];
+    live: boolean;
+    instrumented: boolean;
+  };
   modifiers: {
     entries: CosmicModifierEntry[];
     netVelocity: number;
@@ -101,6 +130,8 @@ const EMPTY_NETWORK: AgentNetworkData = {
   dispatch: { entries: [], live: false },
   leaderboard: { entries: [], live: false },
   interactions: { entries: [], live: false },
+  roleOps: { entries: [], live: false },
+  reasoning: { entries: [], live: false, instrumented: false },
   modifiers: { entries: [], netVelocity: 0, live: false },
 };
 
@@ -204,7 +235,8 @@ export function AgentFeedControlRoom() {
     with: debouncedWith,
     topic: debouncedTopic,
   });
-  const { totals, roles, dispatch, leaderboard, interactions, modifiers } = data;
+  const { totals, roles, dispatch, leaderboard, interactions, roleOps, reasoning, modifiers } =
+    data;
   const activeDispatches = dispatch.entries.length;
   const isInteractionsFiltered =
     debouncedWith.length > 0 || debouncedTopic.length > 0;
@@ -292,6 +324,18 @@ export function AgentFeedControlRoom() {
           onTopicInputChange={setTopicInput}
           isFiltered={isInteractionsFiltered}
           onClearFilters={handleClearInteractionFilters}
+        />
+      </div>
+
+      <div style={{ marginTop: 12 }}>
+        <RoleOperations entries={roleOps.entries} live={roleOps.live} />
+      </div>
+
+      <div style={{ marginTop: 12 }}>
+        <ReasoningTracePanel
+          entries={reasoning.entries}
+          live={reasoning.live}
+          instrumented={reasoning.instrumented}
         />
       </div>
 
@@ -1328,6 +1372,362 @@ function AgentInteractionsPanel({
             </div>
           );
         })
+      )}
+    </Card>
+  );
+}
+
+// ============================================================
+// ROLE OPERATIONS
+// Per-role operational panels for the canonical agent roster, rebuilt over
+// real feed_events aggregates (see /api/admin/agents/network getRoleOps).
+// Each card degrades honestly: a role with no events shows IDLE / "no activity",
+// a failed source shows OFFLINE / "telemetry offline" — never fabricated work.
+// ============================================================
+function RoleOperations({
+  entries,
+  live,
+}: {
+  entries: AgentRoleOpsEntry[];
+  live: boolean;
+}) {
+  const activeRoles = entries.filter((r) => r.events7d > 0).length;
+  return (
+    <Card
+      title="Role Operations"
+      subtitle="per-role telemetry · canonical agent roster"
+      right={
+        <span
+          className="t-mono"
+          style={{
+            fontSize: 9,
+            color: live ? "var(--accent)" : "var(--fg-mute)",
+            letterSpacing: "0.14em",
+          }}
+          title={
+            live
+              ? `${activeRoles} of ${entries.length} roles active in 7d`
+              : "role telemetry source unavailable"
+          }
+        >
+          {live ? `● LIVE · ${activeRoles}/${entries.length} ACTIVE` : "○ STALE"}
+        </span>
+      }
+    >
+      {entries.length === 0 ? (
+        <div
+          className="t-mono"
+          style={{
+            padding: "20px 0",
+            textAlign: "center",
+            fontSize: 10,
+            color: "var(--fg-mute)",
+            letterSpacing: "0.1em",
+          }}
+        >
+          {live ? "no roles configured" : "role telemetry offline"}
+        </div>
+      ) : (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fill, minmax(248px, 1fr))",
+            gap: 10,
+          }}
+        >
+          {entries.map((role) => (
+            <RoleOpsCard key={role.id} role={role} live={live} />
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function RoleOpsCard({ role, live }: { role: AgentRoleOpsEntry; live: boolean }) {
+  const color = colorForRole(role.id);
+  const hasActivity = role.events7d > 0;
+  // Source-live but no events => honest IDLE; source down => OFFLINE.
+  const statusLabel = !live ? "○ OFFLINE" : hasActivity ? "● ACTIVE" : "○ IDLE";
+  const statusColor = live && hasActivity ? "var(--el-earth)" : "var(--fg-mute)";
+  const maxAction = role.actions.reduce((m, a) => Math.max(m, a.count), 0);
+  return (
+    <div
+      style={{
+        border: `1px solid color-mix(in oklch, ${color}, transparent 60%)`,
+        borderRadius: 10,
+        background: "rgba(0,0,0,0.18)",
+        padding: "10px 12px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 8,
+        }}
+      >
+        <span style={{ display: "flex", alignItems: "center", gap: 7, minWidth: 0 }}>
+          <span className="el-dot" style={{ background: color, boxShadow: `0 0 6px ${color}` }} />
+          <span
+            className="t-display"
+            style={{ fontSize: 14, color: "var(--fg)", letterSpacing: "0.02em" }}
+          >
+            {role.label}
+          </span>
+        </span>
+        <span
+          className="t-mono"
+          style={{
+            fontSize: 8.5,
+            color: statusColor,
+            letterSpacing: "0.12em",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {statusLabel}
+        </span>
+      </div>
+      <div className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)", marginTop: -4 }}>
+        {role.mandate}
+      </div>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 6 }}>
+        <RoleStat label="Agents" value={role.agentCount} />
+        <RoleStat label="24h" value={role.events24h} />
+        <RoleStat label="7d" value={role.events7d} />
+      </div>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+        <span className="t-tag" style={{ fontSize: 8 }}>
+          TOP ACTIONS · 7D
+        </span>
+        <span className="t-mono" style={{ fontSize: 8.5, color: "var(--fg-faint)" }}>
+          {role.lastActivityAt ? relativeTime(role.lastActivityAt) : "—"}
+        </span>
+      </div>
+      {role.actions.length === 0 ? (
+        <div
+          className="t-mono"
+          style={{
+            padding: "8px 0",
+            textAlign: "center",
+            fontSize: 9.5,
+            color: "var(--fg-mute)",
+            letterSpacing: "0.06em",
+          }}
+        >
+          {live ? `no ${role.label.toLowerCase()} events in 7d` : "telemetry offline"}
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
+          {role.actions.map((a) => {
+            const ratio = maxAction > 0 ? a.count / maxAction : 0;
+            return (
+              <div key={a.action}>
+                <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 2 }}>
+                  <span
+                    className="t-mono"
+                    style={{
+                      fontSize: 9.5,
+                      color: "var(--fg-dim)",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                      paddingRight: 8,
+                    }}
+                    title={a.action}
+                  >
+                    {a.action}
+                  </span>
+                  <span className="t-num" style={{ fontSize: 10, color: "var(--fg)" }}>
+                    {a.count.toLocaleString()}
+                  </span>
+                </div>
+                <div
+                  style={{
+                    height: 3,
+                    background: "rgba(255,255,255,0.04)",
+                    borderRadius: 999,
+                    overflow: "hidden",
+                  }}
+                >
+                  <div
+                    style={{
+                      width: `${Math.max(ratio * 100, 4)}%`,
+                      height: "100%",
+                      background: color,
+                      boxShadow: `0 0 6px ${color}`,
+                      opacity: 0.9,
+                    }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RoleStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div
+      style={{
+        border: "1px solid var(--line)",
+        borderRadius: 7,
+        padding: "5px 7px",
+        background: "rgba(255,255,255,0.015)",
+      }}
+    >
+      <div className="t-tag" style={{ fontSize: 7.5 }}>
+        {label}
+      </div>
+      <div className="t-num" style={{ fontSize: 14, color: "var(--fg)", marginTop: 1 }}>
+        {value.toLocaleString()}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================
+// REASONING TRACES
+// There is no step-level reasoning/trace store yet, so this panel is honest
+// about that: it surfaces each agent's latest agent_chat decision preview as
+// the closest available proxy (instrumented=false), never as a full trace.
+// ============================================================
+function ReasoningTracePanel({
+  entries,
+  live,
+  instrumented,
+}: {
+  entries: AgentReasoningEntry[];
+  live: boolean;
+  instrumented: boolean;
+}) {
+  const badge = instrumented
+    ? live
+      ? "● LIVE"
+      : "○ STALE"
+    : live
+      ? "◐ PROXY"
+      : "○ STALE";
+  const badgeColor = !live
+    ? "var(--fg-mute)"
+    : instrumented
+      ? "var(--el-earth)"
+      : "var(--accent-2)";
+  return (
+    <Card
+      title="Reasoning Traces · Decision Log"
+      subtitle="latest decision preview per agent"
+      right={
+        <span
+          className="t-mono"
+          style={{ fontSize: 9, color: badgeColor, letterSpacing: "0.14em" }}
+          title={
+            instrumented
+              ? "Live reasoning traces"
+              : "Proxy signal — agent_chat previews, not full reasoning traces"
+          }
+        >
+          {badge}
+        </span>
+      }
+    >
+      {!instrumented && (
+        <div
+          style={{
+            marginBottom: 10,
+            padding: "8px 10px",
+            border: "1px dashed var(--line)",
+            borderRadius: 8,
+          }}
+        >
+          <div className="t-tag" style={{ marginBottom: 4 }}>
+            STEP-LEVEL TRACES · NOT WIRED
+          </div>
+          <div className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>
+            Agents don&rsquo;t emit chain-of-thought yet. Showing each
+            agent&rsquo;s latest <code>agent_chat</code> decision preview as the
+            closest signal — add a reasoning event type or trace table to surface
+            full traces here.
+          </div>
+        </div>
+      )}
+      {entries.length === 0 ? (
+        <div
+          className="t-mono"
+          style={{
+            padding: "20px 0",
+            textAlign: "center",
+            fontSize: 10,
+            color: "var(--fg-mute)",
+            letterSpacing: "0.1em",
+          }}
+        >
+          {live ? "no agent decisions recorded" : "decision log offline"}
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          {entries.map((entry, i) => (
+            <div
+              key={`${entry.agentId}-${entry.timestamp}`}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "auto 1fr auto",
+                gap: 10,
+                alignItems: "baseline",
+                padding: "8px 0",
+                borderBottom: i === entries.length - 1 ? "none" : "1px solid var(--line)",
+              }}
+            >
+              <AgentProfileLink
+                userId={entry.agentId}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 6,
+                  color: "var(--fg)",
+                  fontFamily: "var(--f-mono)",
+                  fontSize: 10.5,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                <span
+                  className="el-dot"
+                  style={{
+                    background: colorForRole(entry.agentHandle),
+                    boxShadow: `0 0 6px ${colorForRole(entry.agentHandle)}`,
+                  }}
+                />
+                {entry.agentHandle}
+              </AgentProfileLink>
+              <span
+                style={{
+                  color: "var(--fg-dim)",
+                  fontSize: 10.5,
+                  fontStyle: "italic",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+                title={entry.preview}
+              >
+                &ldquo;{entry.preview}&rdquo;
+              </span>
+              <span
+                className="t-mono"
+                style={{ fontSize: 9, color: "var(--fg-mute)", whiteSpace: "nowrap" }}
+              >
+                {relativeTime(entry.timestamp)}
+              </span>
+            </div>
+          ))}
+        </div>
       )}
     </Card>
   );

--- a/src/app/api/admin/agents/network/route.ts
+++ b/src/app/api/admin/agents/network/route.ts
@@ -80,6 +80,34 @@ export interface AgentInteractionEntry {
   preview: string;
 }
 
+export interface AgentRoleOpsAction {
+  /** event_type suffix, e.g. `expiry_swept` from `pantry.expiry_swept`. */
+  action: string;
+  /** occurrences of this action in the trailing 7d window. */
+  count: number;
+}
+
+export interface AgentRoleOpsEntry {
+  id: string;
+  label: string;
+  /** Honest one-line description of what this role exists to do. */
+  mandate: string;
+  /** distinct agents whose events carry this role prefix, last 7d. */
+  agentCount: number;
+  events24h: number;
+  events7d: number;
+  lastActivityAt: string | null;
+  /** top event-type suffixes for this role, busiest first. */
+  actions: AgentRoleOpsAction[];
+}
+
+export interface AgentReasoningEntry {
+  agentId: string;
+  agentHandle: string;
+  timestamp: string;
+  preview: string;
+}
+
 export interface AgentNetworkPayload {
   generatedAt: string;
   totals: {
@@ -94,6 +122,19 @@ export interface AgentNetworkPayload {
   dispatch: { entries: AgentDispatchEntry[]; live: boolean };
   leaderboard: { entries: AgentLeaderboardEntry[]; live: boolean };
   interactions: { entries: AgentInteractionEntry[]; live: boolean };
+  /**
+   * Per-role operational telemetry for the canonical agent roles, rebuilt
+   * over real `feed_events` aggregates (no fixtures). Degrades independently
+   * to an empty `live: false` block when the source query fails.
+   */
+  roleOps: { entries: AgentRoleOpsEntry[]; live: boolean };
+  /**
+   * Closest-available reasoning signal: each agent's latest decision preview
+   * from `agent_chat` metadata. `instrumented: false` records the honest truth
+   * that step-level chain-of-thought traces are not captured yet — the panel
+   * surfaces these previews as a proxy, not as full reasoning traces.
+   */
+  reasoning: { entries: AgentReasoningEntry[]; live: boolean; instrumented: boolean };
   /**
    * Active astrological aspects, framed as signed influences on agent
    * interaction velocity. Derived from the live ephemeris via
@@ -437,6 +478,183 @@ async function getInteractions(
   }
 }
 
+/**
+ * Canonical agent roles surfaced as dedicated operational panels. Roles are
+ * inferred from the `<role>.<action>` event_type prefix (there is no role
+ * column yet), so a role with no matching events legitimately renders an
+ * honest empty state rather than fabricated activity. The `mandate` is a
+ * description of intent, not telemetry.
+ */
+const ROLE_OPS_DEFS: ReadonlyArray<{ id: string; label: string; mandate: string }> = [
+  { id: "sous-chef", label: "Sous-Chef", mandate: "prep & mise-en-place" },
+  { id: "galileo", label: "Galileo", mandate: "vision & image rendering" },
+  { id: "substitution", label: "Substitution", mandate: "ingredient swaps" },
+  { id: "pantry", label: "Pantry", mandate: "inventory & expiry sweeps" },
+  { id: "procurement", label: "Procurement", mandate: "sourcing & supply" },
+  { id: "lineage", label: "Lineage", mandate: "recipe provenance" },
+];
+
+const ROLE_OPS_ACTIONS_CAP = 6;
+const REASONING_LIMIT = 8;
+
+async function getRoleOps(): Promise<AgentNetworkPayload["roleOps"]> {
+  try {
+    const roleIds = ROLE_OPS_DEFS.map((r) => r.id);
+    // GROUPING SETS gives us, per role, one role-level rollup row (action IS
+    // NULL — correct DISTINCT agent count + 24h/7d totals + last activity) plus
+    // one row per action for the breakdown — all in a single 7d scan.
+    const result = await executeQuery<{
+      role: string;
+      action: string | null;
+      agent_count: number;
+      events_24h: number;
+      events_7d: number;
+      last_activity: Date | null;
+    }>(
+      `WITH agent_events AS (
+         SELECT f.actor_id,
+                f.created_at,
+                split_part(f.event_type, '.', 1) AS role,
+                COALESCE(NULLIF(split_part(f.event_type, '.', 2), ''), '(unlabeled)') AS action
+         FROM feed_events f
+         JOIN users u ON u.id = f.actor_id AND u.is_agent = true
+         WHERE f.created_at > NOW() - INTERVAL '7 days'
+           AND split_part(f.event_type, '.', 1) = ANY($1::text[])
+       )
+       SELECT
+         role,
+         action,
+         COUNT(DISTINCT actor_id)::int AS agent_count,
+         COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '24 hours')::int AS events_24h,
+         COUNT(*)::int AS events_7d,
+         MAX(created_at) AS last_activity
+       FROM agent_events
+       GROUP BY GROUPING SETS ((role), (role, action))
+       ORDER BY role`,
+      [roleIds],
+    );
+
+    interface Bucket {
+      agentCount: number;
+      events24h: number;
+      events7d: number;
+      lastActivityAt: string | null;
+      actions: AgentRoleOpsAction[];
+    }
+    const byRole = new Map<string, Bucket>();
+    for (const def of ROLE_OPS_DEFS) {
+      byRole.set(def.id, {
+        agentCount: 0,
+        events24h: 0,
+        events7d: 0,
+        lastActivityAt: null,
+        actions: [],
+      });
+    }
+    for (const row of result.rows) {
+      const bucket = byRole.get(row.role);
+      if (!bucket) continue;
+      if (row.action === null) {
+        bucket.agentCount = row.agent_count;
+        bucket.events24h = row.events_24h;
+        bucket.events7d = row.events_7d;
+        bucket.lastActivityAt = row.last_activity
+          ? new Date(row.last_activity).toISOString()
+          : null;
+      } else {
+        bucket.actions.push({ action: row.action, count: row.events_7d });
+      }
+    }
+
+    const entries: AgentRoleOpsEntry[] = ROLE_OPS_DEFS.map((def) => {
+      const b = byRole.get(def.id) as Bucket;
+      return {
+        id: def.id,
+        label: def.label,
+        mandate: def.mandate,
+        agentCount: b.agentCount,
+        events24h: b.events24h,
+        events7d: b.events7d,
+        lastActivityAt: b.lastActivityAt,
+        actions: b.actions
+          .sort((a, c) => c.count - a.count)
+          .slice(0, ROLE_OPS_ACTIONS_CAP),
+      };
+    });
+
+    return { entries, live: true };
+  } catch (error) {
+    console.error("[admin/agents/network] roleOps query failed:", error);
+    // Still hand back the canonical role shells so the panels render an honest
+    // "telemetry offline" state instead of disappearing.
+    const entries: AgentRoleOpsEntry[] = ROLE_OPS_DEFS.map((def) => ({
+      id: def.id,
+      label: def.label,
+      mandate: def.mandate,
+      agentCount: 0,
+      events24h: 0,
+      events7d: 0,
+      lastActivityAt: null,
+      actions: [],
+    }));
+    return { entries, live: false };
+  }
+}
+
+async function getReasoning(
+  limit = REASONING_LIMIT,
+): Promise<AgentNetworkPayload["reasoning"]> {
+  try {
+    // The latest decision preview per distinct agent. There is no reasoning /
+    // trace store yet, so this `agent_chat` preview is the closest real signal
+    // we can honestly surface; `instrumented` stays false to say so.
+    const result = await executeQuery<{
+      agent_id: string;
+      handle: string | null;
+      created_at: Date;
+      preview: string;
+    }>(
+      `SELECT t.agent_id, t.handle, t.created_at, t.preview
+         FROM (
+           SELECT DISTINCT ON (f.actor_id)
+             f.actor_id::text AS agent_id,
+             COALESCE(up.name, u.name, split_part(u.email, '@', 1)) AS handle,
+             f.created_at,
+             COALESCE(
+               f.metadata_payload->>'responsePreview',
+               f.metadata_payload->>'messagePreview',
+               f.metadata_payload->>'message'
+             ) AS preview
+           FROM feed_events f
+           JOIN users u ON u.id = f.actor_id AND u.is_agent = true
+           LEFT JOIN user_profiles up ON up.user_id = u.id
+           WHERE f.event_type = 'agent_chat'
+             AND COALESCE(
+               f.metadata_payload->>'responsePreview',
+               f.metadata_payload->>'messagePreview',
+               f.metadata_payload->>'message'
+             ) IS NOT NULL
+           ORDER BY f.actor_id, f.created_at DESC
+         ) t
+        ORDER BY t.created_at DESC
+        LIMIT $1`,
+      [limit],
+    );
+
+    const entries: AgentReasoningEntry[] = result.rows.map((row) => ({
+      agentId: row.agent_id,
+      agentHandle: row.handle || "agent",
+      timestamp: new Date(row.created_at).toISOString(),
+      preview: row.preview,
+    }));
+
+    return { entries, live: true, instrumented: false };
+  } catch (error) {
+    console.error("[admin/agents/network] reasoning query failed:", error);
+    return { entries: [], live: false, instrumented: false };
+  }
+}
+
 export async function GET(request: NextRequest) {
   const authResult = await validateAdminRequest(request);
   if ("error" in authResult) {
@@ -494,6 +712,8 @@ export async function GET(request: NextRequest) {
         dispatch,
         leaderboard,
         interactions,
+        roleOps,
+        reasoning,
         modifiers,
       ] = await Promise.all([
         getTotals(),
@@ -501,6 +721,8 @@ export async function GET(request: NextRequest) {
         getDispatch(dispatchLimit),
         getLeaderboard(leaderboardLimit),
         getInteractions(15, { withAgent: withFilter, topic: topicFilter }),
+        getRoleOps(),
+        getReasoning(),
         modifierTask,
       ]);
       return {
@@ -510,6 +732,8 @@ export async function GET(request: NextRequest) {
         dispatch,
         leaderboard,
         interactions,
+        roleOps,
+        reasoning,
         modifiers,
       };
     },

--- a/src/app/api/recipes/mint/route.ts
+++ b/src/app/api/recipes/mint/route.ts
@@ -146,6 +146,34 @@ export async function POST(request: NextRequest) {
     metadataURI,
   });
 
+  if (chainResult.status === "failed") {
+    // Refund the debited tokens immediately since the mint failed on-chain
+    await tokenEconomy.creditMultipleTokens(
+      userId,
+      [
+        { tokenType: "Spirit", amount: cost.spirit },
+        { tokenType: "Essence", amount: cost.essence },
+        { tokenType: "Matter", amount: cost.matter },
+        { tokenType: "Substance", amount: cost.substance },
+      ],
+      "mint_refund",
+      {
+        sourceId: purchase.transactionGroupId,
+        description: `Refund — mint failed on-chain: ${recipe.title}`,
+        idempotencyKey: `mint_refund:${purchase.transactionGroupId}`,
+      },
+    );
+
+    return NextResponse.json(
+      {
+        error: "mint_failed",
+        reason: chainResult.reason,
+        refunded: true,
+      },
+      { status: 500 },
+    );
+  }
+
   const ledgerRow = {
     userId,
     recipeId: recipe.id,

--- a/src/lib/recipe-nft/contract.ts
+++ b/src/lib/recipe-nft/contract.ts
@@ -11,7 +11,7 @@ import { createPublicClient, http, type Address, type Hex } from "viem";
 import { base, baseSepolia } from "viem/chains";
 
 /** Genesis rights holder + first recipe recipient (chosen during design). */
-export const RIGHTS_HOLDER: Address = "0x553C2a3f193d5E7F41cF50cEB32069dbc6951931";
+export const RIGHTS_HOLDER: Address = "0x554F991D030aDF539CBD2ff3D896951C6f089804";
 
 /** ERC-2981 creator royalty: 5% (contract cap is 10% = 1000 bps). */
 export const RECIPE_ROYALTY_BPS = 500;


### PR DESCRIPTION
## Summary
Rebuilds the deep role-specific panels on the **High Alchemist dashboard** (`/admin/dashboard`) that were stripped in the earlier honesty audit — this time backed by **real `feed_events` telemetry**, not fixtures. Bundles three small recipe-NFT changes that landed on the same branch (env docs, a mint-failure refund safety fix, and a rights-holder address reconcile).

## Dashboard role panels (main change)
`src/app/api/admin/agents/network/route.ts` gains two independently-degrading sections on the existing admin telemetry endpoint:
- **`roleOps`** — real per-role aggregates for the 6 canonical roles (sous-chef, galileo, substitution, pantry, procurement, lineage) via a single `GROUPING SETS` query over `feed_events`: distinct agent count, 24h/7d volume, last activity, and a top-actions breakdown. Roles with no events return honest zero-shells.
- **`reasoning`** — each agent's latest `agent_chat` decision preview, flagged `instrumented: false` to be honest that step-level traces aren't captured yet.

`src/app/admin/_dashboard/agents.tsx` adds `RoleOperations` + `ReasoningTracePanel`, matching the existing `Card` / `● LIVE` / dashed-`NOT WIRED` conventions. Each panel degrades **independently** to `live:false` ("offline") or an honest empty state ("no … events in 7d"), per the brief — and notably **does not** revert the old fixture panels (the `sous-242`/`galileo-12` fake rows the audit removed); it rebuilds over real aggregates.

## Recipe-NFT (bundled)
- **`fix(recipes)`** — `mint/route.ts` now refunds the 4-coin ESMS debit, writes **no** ledger row, and returns `500` when an on-chain mint returns `status:'failed'`, so a reverting mint can't burn a user's ESMS. Preserves the prior `minted`→never-refund and `pending_chain`→record-receipt behavior; per-debit idempotency key (`mint_refund:<transactionGroupId>`).
- **`docs(recipe-nft)`** — documents the `NEXT_PUBLIC_RECIPE_*` + `RECIPE_MINTER_PRIVATE_KEY` env vars in `.env.example` (placeholders only, with a "never commit a key" note).
- **`chore(recipe-nft)`** — points the default `RIGHTS_HOLDER` recipient at the current on-chain rights holder.

## Verification
- `bun run verify` green — **0 TS errors, 0 lint warnings** (husky pre-commit gate).
- Route + page compile and load cleanly (admin endpoint returns `401`, page `302` — auth, not a `500`).
- Adversarial correctness + security review: **clean** — parameterized SQL (role ids are a hardcoded const, no untrusted interpolation), same `validateAdminRequest` admin gate, no secrets in the diff, no new PII class beyond what admins already see.

## Context & follow-ups (not blocking)
- The recipe-NFT protocol is deployed + authorized on **Base Sepolia (testnet)** and minting is functional in local dev; **prod Vercel env is intentionally unset**, so the on-chain mint path (and the new refund block) is dormant in production.
- **Before mainnet:** regenerate fresh KMS-backed keys (deployer/admin + a dedicated minter ≠ the ESMS settlement wallet) and hand admin to a Safe multisig.
- **Hardening (once minting is live):** a deterministically-failing recipe can be retried unboundedly — net-zero for the user, but a DB / sponsor-gas / image-gen amplification vector. Consider recording a `failed` row or per-content-hash rate-limit before refunding.
- Reasoning traces are a proxy (latest `agent_chat` preview) until step-level trace instrumentation exists; the panel labels this honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
