### PR TITLE
feat(recipes): hourly ISR for recipe pages + on-demand revalidation endpoint

### DIFF
--- a/src/app/api/internal/revalidate/route.ts
+++ b/src/app/api/internal/revalidate/route.ts
@@ -1,0 +1,64 @@
+/**
+ * POST /api/internal/revalidate — on-demand ISR cache invalidation.
+ *
+ * Recipe detail pages are statically cached with hourly revalidation
+ * (src/app/recipes/[recipeId]/page.tsx). After a bulk data change — e.g. a
+ * description backfill — call this to refresh the prerendered HTML
+ * immediately instead of waiting out the revalidate window or redeploying.
+ *
+ * Auth: `Authorization: Bearer <CRON_SECRET>` — the same guard as
+ * /api/cron/*, so no extra env var needs provisioning.
+ *
+ * Body (optional JSON): `{ "paths": ["/recipes/abc", "/recipes/[recipeId]"] }`
+ * Each path must start with "/". A path containing a dynamic segment
+ * ("[recipeId]") is revalidated with type "page", which busts every cached
+ * page under that route. With no body, the default set below refreshes all
+ * recipe detail pages plus the sitemap.
+ *
+ * Example:
+ *   curl -X POST https://alchm.kitchen/api/internal/revalidate \
+ *        -H "Authorization: Bearer $CRON_SECRET"
+ *
+ * @file src/app/api/internal/revalidate/route.ts
+ */
+
+import { revalidatePath } from "next/cache";
+import { NextResponse, type NextRequest } from "next/server";
+import { isAuthorizedCron } from "@/app/api/cron/_lib/cronAuth";
+
+export const dynamic = "force-dynamic";
+
+const DEFAULT_PATHS = ["/recipes/[recipeId]", "/sitemap.xml"];
+
+export async function POST(request: NextRequest) {
+  if (!isAuthorizedCron(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = (await request.json().catch(() => null)) as {
+    paths?: unknown;
+  } | null;
+
+  let paths = DEFAULT_PATHS;
+  if (Array.isArray(body?.paths) && body.paths.length > 0) {
+    paths = body.paths.filter(
+      (p): p is string => typeof p === "string" && p.startsWith("/"),
+    );
+    if (paths.length === 0) {
+      return NextResponse.json(
+        { error: "paths must be strings starting with '/'" },
+        { status: 400 },
+      );
+    }
+  }
+
+  for (const path of paths) {
+    if (path.includes("[")) {
+      revalidatePath(path, "page");
+    } else {
+      revalidatePath(path);
+    }
+  }
+
+  return NextResponse.json({ revalidated: paths });
+}

--- a/src/app/recipes/[recipeId]/page.tsx
+++ b/src/app/recipes/[recipeId]/page.tsx
@@ -5,6 +5,15 @@ import { sauceRecommender } from "@/services/sauceRecommender";
 import RecipeClient from "./RecipeClient";
 import type { Metadata } from "next";
 
+// Recipe pages are generated on demand (generateStaticParams is normally
+// disabled below) and would otherwise stay cached until the next deploy —
+// DB-side content changes (description backfills, image swaps) never reached
+// already-rendered pages. Hourly ISR keeps the HTML at most 1h behind the DB;
+// the underlying LocalRecipeService Redis catalog cache is 5 min, so the page
+// regenerates from reasonably fresh data. POST /api/internal/revalidate
+// forces an immediate refresh after bulk backfills.
+export const revalidate = 3600;
+
 export async function generateStaticParams() {
   if (process.env.ENABLE_RECIPE_STATIC_PARAMS !== "true") {
     return [];
@@ -118,6 +127,17 @@ export default async function RecipePage({ params }: RecipePageProps) {
       } catch (err) {
         console.error("Error checking custom recipe in catalog fallback:", err);
       }
+    }
+    // With ISR enabled, notFound() is a cacheable result — a 404 rendered
+    // during a transient outage would poison this URL for the whole
+    // revalidate window. When the catalog was served from the degraded
+    // hardcoded fallback (DB unreachable / empty), the recipe may exist but
+    // be invisible, so fail the render instead: thrown errors are never
+    // cached and the next request retries against a healthy catalog.
+    if (LocalRecipeService.isCatalogDegraded()) {
+      throw new Error(
+        `Recipe catalog degraded while rendering /recipes/${recipeId}; refusing to cache a 404`,
+      );
     }
     notFound();
   }

--- a/src/services/LocalRecipeService.ts
+++ b/src/services/LocalRecipeService.ts
@@ -250,6 +250,18 @@ export class LocalRecipeService {
   private static _allRecipes: Recipe[] | null = null;
   private static _allRecipesLoadedAt: number | null = null;
   private static readonly CACHE_TTL_MS = REDIS_TTL_SECONDS * 1000;
+  private static _catalogDegraded = false;
+
+  /**
+   * True when the most recent catalog load fell back to the hardcoded local
+   * payload (DB empty or unreachable) instead of the authoritative Redis/DB
+   * path. DB-only recipes are invisible in that state, so a "not found" from
+   * getRecipeById is unreliable — ISR renderers use this to fail the render
+   * (uncached) rather than cache a 404 for the revalidate window.
+   */
+  static isCatalogDegraded(): boolean {
+    return this._catalogDegraded;
+  }
 
   private static isCacheFresh(): boolean {
     return (
@@ -277,6 +289,7 @@ export class LocalRecipeService {
       if (cached && Array.isArray(cached) && cached.length > 0) {
         this._allRecipes = cached;
         this._allRecipesLoadedAt = Date.now();
+        this._catalogDegraded = false;
         return cached;
       }
     } catch (err) {
@@ -292,11 +305,13 @@ export class LocalRecipeService {
         const { getServerRecipes } = await import("@/actions/recipes");
         this._allRecipes = await getServerRecipes();
         this._allRecipesLoadedAt = Date.now();
+        this._catalogDegraded = true;
         return this._allRecipes;
       }
 
       this._allRecipes = recipes;
       this._allRecipesLoadedAt = Date.now();
+      this._catalogDegraded = false;
 
       // Populate Redis asynchronously so we don't block the response
       redisSet(REDIS_CATALOG_KEY, recipes, REDIS_TTL_SECONDS).catch(() => {});
@@ -307,6 +322,7 @@ export class LocalRecipeService {
       return recipes;
     } catch (error) {
       logger.error("Error loading recipes from database, extracting raw local fallback:", error);
+      this._catalogDegraded = true;
       const { getServerRecipes } = await import("@/actions/recipes");
       return getServerRecipes();
     }
@@ -464,6 +480,7 @@ export class LocalRecipeService {
   static clearCache(): void {
     this._allRecipes = null;
     this._allRecipesLoadedAt = null;
+    this._catalogDegraded = false;
     redisDel(REDIS_CATALOG_KEY).catch(() => {});
   }
 }


### PR DESCRIPTION
## What

- `export const revalidate = 3600` on `/recipes/[recipeId]` — recipe detail pages now regenerate at most hourly instead of being cached until the next deploy.
- New `POST /api/internal/revalidate` for immediate ISR cache busting after bulk data changes. Guarded by the existing `CRON_SECRET` bearer check (same helper as `/api/cron/*`), so no new env var is needed. With no body it revalidates every recipe page plus the sitemap; accepts `{"paths": ["/recipes/some-id"]}` for targeted busting:
  ```
  curl -X POST https://alchm.kitchen/api/internal/revalidate \
       -H "Authorization: Bearer $CRON_SECRET"
  ```
- `LocalRecipeService.isCatalogDegraded()` + a guard in the page: when the catalog was served from the hardcoded fallback (DB unreachable/empty), a recipe miss now throws instead of calling `notFound()`.

## Why

With `generateStaticParams` effectively disabled, each recipe page was rendered on first visit and then cached indefinitely by Next/Vercel — DB-side content changes (like the 2026-07-03 backfill of 485 recipe descriptions) never appeared on already-rendered pages until a full redeploy. The dynamic API served fresh data; only the prerendered HTML was stale. 1h revalidation sits comfortably above the 5-minute LocalRecipeService Redis catalog TTL.

## Reviewer notes

- **Why the degraded guard matters:** thrown render errors are never stored in the ISR cache, but `notFound()` *is* a cacheable result. `getRecipeById` fails open to the old hardcoded payload when the DB is down, where DB-only recipes are invisible — without the guard, a transient outage could pin a real recipe URL to a 404 for the full revalidate window. With it, the request 500s uncached and self-heals on the next hit (same behavior as the known cold-render wart documented in `sitemap.ts`).
- **Known tradeoff:** a *successful* render from the degraded fallback catalog can still be cached with stale content — but now for at most an hour rather than until redeploy.
- `/recipes` listing intentionally untouched: it is a client component fetching from `/api/recipes` at request time; its static shell contains no recipe data.

## Verification (production build + `next start`)

- First render: `x-nextjs-cache: MISS`, `Cache-Control: s-maxage=3600, stale-while-revalidate`; second: `HIT`.
- `POST /api/internal/revalidate`: 401 without/with wrong token; authorized call returned `{"revalidated":["/recipes/[recipeId]","/sitemap.xml"]}` and flipped the cached page from `HIT` back to `MISS` (regenerated), then `HIT` again.
- Degraded-catalog miss (local run without `DATABASE_URL`): 500 with `Cache-Control: no-store` on every attempt — never cached.
- `next build` clean (no Dynamic-server-usage errors); typecheck + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)