### PR TITLE
feat(economy): testnet go-live — claim-to-chain bridge, Bazaar storefront, tokenomics integrity

### DIFF
--- a/database/init/56-esms-onchain-claims.sql
+++ b/database/init/56-esms-onchain-claims.sql
@@ -1,0 +1,41 @@
+-- ==========================================
+-- ESMS ON-CHAIN CLAIMS
+-- Migration 56: bridge ledger — off-chain earned ESMS → on-chain soulbound
+-- ERC-1155 (EsmsToken.claimMint on Base). One row per claim attempt; claim_id
+-- is the bytes32 the contract enforces uniqueness on, so a row can always be
+-- reconciled against the chain (claimed(claim_id)) no matter where the flow
+-- was interrupted.
+-- Created: July 2026
+-- ==========================================
+
+CREATE TABLE IF NOT EXISTS esms_onchain_claims (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    wallet_address VARCHAR(42) NOT NULL,           -- recipient at claim time
+    claim_id VARCHAR(66) NOT NULL UNIQUE,          -- bytes32 hex; on-chain idempotency key
+    spirit DECIMAL(12, 4) NOT NULL DEFAULT 0,
+    essence DECIMAL(12, 4) NOT NULL DEFAULT 0,
+    matter DECIMAL(12, 4) NOT NULL DEFAULT 0,
+    substance DECIMAL(12, 4) NOT NULL DEFAULT 0,
+    -- pending: debited off-chain, mint not yet confirmed (retryable — the
+    --          contract's claimId uniqueness makes re-mints safe)
+    -- minted:  claimMint confirmed on-chain
+    -- refunded: mint permanently failed and the debit was re-credited
+    status VARCHAR(20) NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'minted', 'refunded')),
+    tx_hash VARCHAR(66),
+    error TEXT,
+    transaction_group_id UUID,                     -- the off-chain debit group
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE esms_onchain_claims IS 'Claim bridge: each row moves a snapshot of off-chain ESMS balance on-chain via EsmsToken.claimMint. claim_id doubles as the contract-level idempotency key.';
+
+-- One in-flight claim per user: a new claim may not start until the previous
+-- one is minted or refunded (reconciled on the next request).
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_esms_onchain_claims_pending
+    ON esms_onchain_claims (user_id) WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_esms_onchain_claims_user
+    ON esms_onchain_claims (user_id, created_at DESC);

--- a/src/app/(alchm)/account/page.tsx
+++ b/src/app/(alchm)/account/page.tsx
@@ -15,7 +15,8 @@ import { PrivyProvider, usePrivy, useWallets, useFundWallet } from "@privy-io/re
 import { ArrowLeft, Check, CheckCircle2, Copy, ShieldAlert, Sparkles, Wallet } from "lucide-react";
 import Link from "next/link";
 import { useCallback, useEffect, useState, type JSX } from "react";
-import { base } from "viem/chains";
+import { base, baseSepolia } from "viem/chains";
+import { OnchainEsmsPanel } from "@/components/account/OnchainEsmsPanel";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -29,6 +30,11 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
 const PRIVY_APP_ID = process.env.NEXT_PUBLIC_PRIVY_APP_ID || "cmi9t84qs00acl80dam2j8195";
+
+// Follow the ESMS deployment chain (Base Sepolia on testnet, Base on mainnet)
+// so wallet signing, funding, and the on-chain panel all agree with where the
+// contracts actually live.
+const ESMS_CHAIN = process.env.NEXT_PUBLIC_ESMS_CHAIN === "base" ? base : baseSepolia;
 
 interface DBConnectionStatus {
   connected: boolean;
@@ -167,7 +173,9 @@ function AccountInner(): JSX.Element {
   }, [ready, login]);
 
   // Open Privy's fiat on-ramp to fund the embedded Base wallet. If the user
-  // isn't authenticated with Privy this session, prompt login first.
+  // isn't authenticated with Privy this session, prompt login first. Hidden on
+  // testnet: claim mints and shop burns are backend-sponsored, so the wallet
+  // needs no gas — and fiat on-ramps can't fund Sepolia anyway.
   const handleFund = useCallback(async (): Promise<void> => {
     if (!walletAddress) return;
     if (!authenticated) {
@@ -175,7 +183,7 @@ function AccountInner(): JSX.Element {
       return;
     }
     try {
-      await fundWallet({ address: walletAddress, options: { chain: base } });
+      await fundWallet({ address: walletAddress, options: { chain: ESMS_CHAIN } });
     } catch {
       /* user exited the on-ramp or it's unsupported in their region */
     }
@@ -384,7 +392,7 @@ function AccountInner(): JSX.Element {
                   <div style={{ background: "rgba(0,0,0,0.2)", border: "1px solid rgba(255,255,255,0.03)", borderRadius: 6, padding: "14px 16px", display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
                     <div>
                       <div style={{ fontSize: 9, fontFamily: "var(--font-mono, monospace)", color: "var(--fg-mute, #718096)", marginBottom: 4 }}>
-                        EMBEDDED WALLET · BASE
+                        EMBEDDED WALLET · {ESMS_CHAIN.name.toUpperCase()}
                       </div>
                       <button
                         type="button"
@@ -400,15 +408,21 @@ function AccountInner(): JSX.Element {
                         )}
                       </button>
                     </div>
-                    <Button
-                      onClick={() => { void handleFund(); }}
-                      disabled={!ready}
-                      className="glowing-btn"
-                      style={{ padding: "10px 18px" }}
-                    >
-                      <Wallet style={{ width: 14, height: 14, marginRight: 6 }} />
-                      Fund Wallet
-                    </Button>
+                    {ESMS_CHAIN.testnet ? (
+                      <span style={{ fontSize: 11, color: "var(--fg-mute, #718096)", fontFamily: "var(--font-mono, monospace)" }}>
+                        TESTNET · GAS SPONSORED
+                      </span>
+                    ) : (
+                      <Button
+                        onClick={() => { void handleFund(); }}
+                        disabled={!ready}
+                        className="glowing-btn"
+                        style={{ padding: "10px 18px" }}
+                      >
+                        <Wallet style={{ width: 14, height: 14, marginRight: 6 }} />
+                        Fund Wallet
+                      </Button>
+                    )}
                   </div>
                 )}
 
@@ -445,6 +459,9 @@ function AccountInner(): JSX.Element {
           </div>
         </div>
       )}
+
+      {/* On-chain ESMS vault: site vs wallet balances + sponsored claim bridge */}
+      {!authError && !loading && <OnchainEsmsPanel />}
 
       {/* Branded modal dialog to present conflict / link error details beautifully */}
       <AlertDialog open={conflictOpen} onOpenChange={setConflictOpen}>
@@ -489,8 +506,8 @@ export default function AccountPage(): JSX.Element {
           ethereum: { createOnLogin: "users-without-wallets" },
           solana: { createOnLogin: "off" },
         },
-        defaultChain: base,
-        supportedChains: [base],
+        defaultChain: ESMS_CHAIN,
+        supportedChains: ESMS_CHAIN.id === base.id ? [base] : [ESMS_CHAIN, base],
         appearance: {
           theme: "dark",
           accentColor: "#805ad5", // Alchm purple accent

--- a/src/app/(alchm)/profile/page.tsx
+++ b/src/app/(alchm)/profile/page.tsx
@@ -271,16 +271,30 @@ function PremiumDashboard({
                     <h2 className="text-[10px] font-black text-white/30 uppercase tracking-[0.4em]">
                       Full Token Economy
                     </h2>
-                    <Link
-                      href="/quantities"
-                      className="text-[10px] font-black text-purple-400 hover:text-purple-300 uppercase tracking-[0.3em] transition-colors"
-                    >
-                      Open Ledger →
-                    </Link>
+                    <div className="flex items-center gap-4">
+                      <Link
+                        href="/shop"
+                        className="text-[10px] font-black text-cyan-400 hover:text-cyan-300 uppercase tracking-[0.3em] transition-colors"
+                      >
+                        Visit Bazaar →
+                      </Link>
+                      <Link
+                        href="/account"
+                        className="text-[10px] font-black text-emerald-400 hover:text-emerald-300 uppercase tracking-[0.3em] transition-colors"
+                      >
+                        Wallet Vault →
+                      </Link>
+                      <Link
+                        href="/quantities"
+                        className="text-[10px] font-black text-purple-400 hover:text-purple-300 uppercase tracking-[0.3em] transition-colors"
+                      >
+                        Open Ledger →
+                      </Link>
+                    </div>
                   </div>
                   <p className="text-white/20 text-xs mb-6">
-                    Your Spirit 🝇, Essence 🝑, Matter 🝙, and Substance 🝉 token balances. 
-                    As a Premium Premium you earn 2× daily yields.
+                    Your Spirit 🝇, Essence 🝑, Matter 🝙, and Substance 🝉 token balances.
+                    As a Premium member you earn 2× daily yields.
                   </p>
                   <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                     {[
@@ -624,7 +638,7 @@ function FreeDashboard({
                         <div className="flex items-center gap-3 mb-2">
                           <span className="text-amber-400 text-lg">✦</span>
                           <h3 className="text-lg font-black text-white tracking-tight">
-                            Ascend to Premium Premium
+                            Ascend to Premium
                           </h3>
                         </div>
                         <p className="text-white/40 text-sm max-w-lg leading-relaxed">

--- a/src/app/(alchm)/shop/page.tsx
+++ b/src/app/(alchm)/shop/page.tsx
@@ -1,0 +1,523 @@
+"use client";
+
+/**
+ * /shop — the ESMS Bazaar storefront.
+ *
+ * The on-chain spend surface: items are bought by BURNING the buyer's claimed
+ * soulbound ESMS (EsmsToken.redeemFor on Base) — the burn is the payment. Flow:
+ *   1. POST /api/economy/shop/purchase {itemId} → EIP-712 RedeemAuthorization
+ *      challenge (mode:'sign') with a 10-minute deadline.
+ *   2. The buyer signs it with their Privy embedded wallet (eth_signTypedData_v4
+ *      — an off-chain signature, no gas).
+ *   3. POST again with {signature, deadline} → the backend settlement wallet
+ *      submits the sponsored burn and grants the entitlement.
+ *
+ * PrivyProvider is scoped HERE (like /account) so the web3 SDK stays out of
+ * every other route's bundle. Earned tokens must first be claimed on-chain via
+ * the vault on /account — the storefront cross-links when balance is short.
+ */
+
+import { PrivyProvider, usePrivy, useWallets } from "@privy-io/react-auth";
+import {
+  ArrowLeft,
+  BadgeCheck,
+  ExternalLink,
+  Flame,
+  Loader2,
+  Sparkles,
+  Wallet,
+} from "lucide-react";
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
+import { base, baseSepolia } from "viem/chains";
+import { Button } from "@/components/ui/button";
+
+const PRIVY_APP_ID = process.env.NEXT_PUBLIC_PRIVY_APP_ID || "cmi9t84qs00acl80dam2j8195";
+const ESMS_CHAIN = process.env.NEXT_PUBLIC_ESMS_CHAIN === "base" ? base : baseSepolia;
+
+interface CoinAmounts {
+  spirit: number;
+  essence: number;
+  matter: number;
+  substance: number;
+}
+
+interface ShopItem {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  category: string;
+  isOneTime: boolean;
+  baseCost: CoinAmounts;
+  liveCost: CoinAmounts;
+  owned: boolean;
+}
+
+interface OnchainStatus {
+  configured: boolean;
+  walletAddress: string | null;
+  walletLinked: boolean;
+  offchain: CoinAmounts;
+  onchain: CoinAmounts | null;
+  chain: { chainName: string; testnet: boolean; explorerBaseUrl: string | null };
+}
+
+interface SignChallenge {
+  domain: { name: string; version: string; chainId: number; verifyingContract: string };
+  types: Record<string, Array<{ name: string; type: string }>>;
+  primaryType: string;
+  message: Record<string, unknown>;
+}
+
+type BuyPhase = "idle" | "requesting" | "signing" | "settling";
+
+const COINS: Array<{ key: keyof CoinAmounts; symbol: string; color: string }> = [
+  { key: "spirit", symbol: "🝇", color: "#fbbf24" },
+  { key: "essence", symbol: "🝑", color: "#60a5fa" },
+  { key: "matter", symbol: "🝙", color: "#34d399" },
+  { key: "substance", symbol: "🝉", color: "#c084fc" },
+];
+
+function fmt(n: number): string {
+  return n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+}
+
+function CostRow({ cost, compare }: { cost: CoinAmounts; compare?: CoinAmounts | null }): JSX.Element {
+  return (
+    <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+      {COINS.map((c) =>
+        cost[c.key] > 0 ? (
+          <span key={c.key} style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 12.5 }}>
+            <span style={{ color: c.color, fontSize: 14 }}>{c.symbol}</span>
+            <span
+              style={{
+                fontFamily: "var(--font-mono, monospace)",
+                color: compare && compare[c.key] < cost[c.key] ? "#ef4444" : "#e2e8f0",
+              }}
+            >
+              {fmt(cost[c.key])}
+            </span>
+          </span>
+        ) : null,
+      )}
+    </div>
+  );
+}
+
+function canAffordOnchain(cost: CoinAmounts, onchain: CoinAmounts | null): boolean {
+  if (!onchain) return false;
+  return (
+    onchain.spirit >= cost.spirit &&
+    onchain.essence >= cost.essence &&
+    onchain.matter >= cost.matter &&
+    onchain.substance >= cost.substance
+  );
+}
+
+function ShopInner(): JSX.Element {
+  const { login, ready, authenticated } = usePrivy();
+  const { wallets } = useWallets();
+
+  const [items, setItems] = useState<ShopItem[] | null>(null);
+  const [status, setStatus] = useState<OnchainStatus | null>(null);
+  const [authError, setAuthError] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [buying, setBuying] = useState<{ slug: string; phase: BuyPhase } | null>(null);
+  const [notice, setNotice] = useState<{ kind: "ok" | "err"; text: string; txUrl?: string | null } | null>(null);
+
+  const embeddedWallet = useMemo(
+    () => wallets.find((w) => w.walletClientType === "privy"),
+    [wallets],
+  );
+
+  const refresh = useCallback(async (): Promise<void> => {
+    try {
+      const [shopRes, chainRes] = await Promise.all([
+        fetch("/api/economy/shop?category=all", { cache: "no-store" }),
+        fetch("/api/economy/claim-onchain", { cache: "no-store" }),
+      ]);
+      if (shopRes.status === 401 || chainRes.status === 401) {
+        setAuthError(true);
+        return;
+      }
+      if (shopRes.ok) {
+        const json = (await shopRes.json()) as { items?: ShopItem[] };
+        setItems(json.items ?? []);
+      }
+      if (chainRes.ok) {
+        setStatus((await chainRes.json()) as OnchainStatus);
+      }
+    } catch {
+      /* transient — surfaces as empty state */
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleBuy = useCallback(
+    async (item: ShopItem): Promise<void> => {
+      setNotice(null);
+      setBuying({ slug: item.slug, phase: "requesting" });
+      try {
+        const r1 = await fetch("/api/economy/shop/purchase", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ itemId: item.slug }),
+        });
+        const j1 = (await r1.json()) as {
+          ok?: boolean;
+          alreadyOwned?: boolean;
+          reconciled?: boolean;
+          txHash?: string;
+          mode?: string;
+          orderId?: string;
+          deadline?: string;
+          challenge?: SignChallenge;
+          error?: string;
+          code?: string;
+        };
+
+        if (j1.ok) {
+          const txUrl =
+            j1.txHash && status?.chain.explorerBaseUrl
+              ? `${status.chain.explorerBaseUrl}/tx/${j1.txHash}`
+              : null;
+          setNotice({
+            kind: "ok",
+            text: j1.alreadyOwned
+              ? `${item.title} is already yours.`
+              : `${item.title} acquired — ESMS burned on-chain.`,
+            txUrl,
+          });
+          return;
+        }
+
+        if (j1.code === "no_wallet") {
+          setNotice({ kind: "err", text: "Link your Privy wallet first — visit your Account page." });
+          return;
+        }
+        if (j1.code === "onchain_unconfigured" || j1.code === "redeemer_unconfigured") {
+          setNotice({ kind: "err", text: "On-chain purchases aren't configured on this server yet." });
+          return;
+        }
+
+        if (j1.mode === "sign" && j1.challenge && j1.deadline) {
+          // The signature must come from the linked wallet the server challenged.
+          if (!authenticated) {
+            login();
+            setNotice({ kind: "err", text: "Authenticate with Privy, then tap Buy again." });
+            return;
+          }
+          const from = String(j1.challenge.message.from || "");
+          const signer = embeddedWallet;
+          if (!signer || signer.address.toLowerCase() !== from.toLowerCase()) {
+            setNotice({
+              kind: "err",
+              text: "Your Privy session wallet doesn't match your linked wallet — relink on the Account page.",
+            });
+            return;
+          }
+
+          setBuying({ slug: item.slug, phase: "signing" });
+          // eth_signTypedData_v4 needs the EIP712Domain type alongside the
+          // challenge's primary type.
+          const typedData = {
+            ...j1.challenge,
+            types: {
+              EIP712Domain: [
+                { name: "name", type: "string" },
+                { name: "version", type: "string" },
+                { name: "chainId", type: "uint256" },
+                { name: "verifyingContract", type: "address" },
+              ],
+              ...j1.challenge.types,
+            },
+          };
+          const provider = await signer.getEthereumProvider();
+          const signature = (await provider.request({
+            method: "eth_signTypedData_v4",
+            params: [signer.address, JSON.stringify(typedData)],
+          })) as string;
+
+          setBuying({ slug: item.slug, phase: "settling" });
+          const r2 = await fetch("/api/economy/shop/purchase", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ itemId: item.slug, signature, deadline: j1.deadline }),
+          });
+          const j2 = (await r2.json()) as { ok?: boolean; txHash?: string; error?: string; code?: string };
+          if (j2.ok) {
+            const txUrl =
+              j2.txHash && status?.chain.explorerBaseUrl
+                ? `${status.chain.explorerBaseUrl}/tx/${j2.txHash}`
+                : null;
+            setNotice({ kind: "ok", text: `${item.title} acquired — ESMS burned on-chain.`, txUrl });
+          } else {
+            setNotice({ kind: "err", text: j2.error || "The on-chain burn failed — nothing was spent. Try again." });
+          }
+          return;
+        }
+
+        setNotice({ kind: "err", text: j1.error || "Purchase failed — try again." });
+      } catch (err) {
+        const rejected = err instanceof Error && /reject|denied|cancell?ed/i.test(err.message);
+        setNotice({
+          kind: "err",
+          text: rejected ? "Signature declined — nothing was spent." : "Network error — nothing was spent. Try again.",
+        });
+      } finally {
+        setBuying(null);
+        void refresh();
+      }
+    },
+    [authenticated, embeddedWallet, login, refresh, status],
+  );
+
+  const onchainTotal = status?.onchain
+    ? status.onchain.spirit + status.onchain.essence + status.onchain.matter + status.onchain.substance
+    : 0;
+
+  return (
+    <div className="bazaar-container">
+      <style>{`
+        .bazaar-container {
+          max-width: 920px;
+          margin: 0 auto;
+          padding: 72px 24px;
+          color: var(--fg, #e2e8f0);
+        }
+        .bazaar-card {
+          background: rgba(18, 16, 26, 0.45);
+          backdrop-filter: blur(16px);
+          -webkit-backdrop-filter: blur(16px);
+          border: 1px solid rgba(139, 92, 246, 0.15);
+          border-radius: 16px;
+          padding: 24px;
+          transition: border-color 0.3s ease;
+        }
+        .bazaar-card:hover { border-color: rgba(139, 92, 246, 0.3); }
+        .bazaar-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+          gap: 16px;
+        }
+        .bazaar-btn {
+          background: linear-gradient(135deg, #7c3aed 0%, #4c1d95 100%) !important;
+          color: white !important;
+          border: none !important;
+          box-shadow: 0 4px 14px 0 rgba(124, 58, 237, 0.4) !important;
+        }
+        .bazaar-btn:disabled { opacity: 0.45; }
+        @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+      `}</style>
+
+      <Link
+        href="/"
+        style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 11, fontFamily: "var(--f-mono, monospace)", letterSpacing: "0.08em", color: "var(--fg-mute, #a0aec0)", textDecoration: "none", marginBottom: 16, width: "fit-content" }}
+      >
+        <ArrowLeft style={{ width: 12, height: 12 }} />
+        RETURN HOME
+      </Link>
+
+      <header style={{ marginBottom: 28 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, color: "#a78bfa", marginBottom: 8, fontSize: 11, letterSpacing: "0.2em", fontFamily: "var(--font-mono, monospace)" }}>
+          <Sparkles style={{ width: 14, height: 14 }} />
+          ESMS BAZAAR · {ESMS_CHAIN.name.toUpperCase()}
+          {ESMS_CHAIN.testnet ? " · TESTNET" : ""}
+        </div>
+        <h1 className="t-display" style={{ fontSize: 36, margin: 0, fontWeight: 500, letterSpacing: "-0.02em" }}>
+          The Alchemist&apos;s Bazaar
+        </h1>
+        <p style={{ color: "var(--fg-mute, #718096)", fontSize: 14, lineHeight: 1.6, marginTop: 8, marginBottom: 0, maxWidth: 640 }}>
+          Spend your claimed on-chain ESMS. Each purchase burns soulbound tokens from your wallet —
+          a gasless signature is your consent, the burn is your receipt.
+        </p>
+      </header>
+
+      {authError ? (
+        <div className="bazaar-card">
+          <p style={{ margin: 0, fontSize: 14 }}>Sign in to browse the Bazaar.</p>
+          <div style={{ marginTop: 16 }}>
+            <Link href="/api/auth/signin?callbackUrl=/shop">
+              <Button className="bazaar-btn">Sign In</Button>
+            </Link>
+          </div>
+        </div>
+      ) : loading ? (
+        <div className="bazaar-card" style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <Loader2 style={{ width: 16, height: 16, animation: "spin 1.2s linear infinite" }} />
+          <span style={{ fontSize: 13, fontFamily: "var(--font-mono, monospace)", color: "var(--fg-mute, #a0aec0)" }}>
+            Unfurling the market stalls…
+          </span>
+        </div>
+      ) : (
+        <>
+          {/* Wallet strip */}
+          <div className="bazaar-card" style={{ marginBottom: 20, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, flexWrap: "wrap" }}>
+            <div>
+              <div style={{ fontSize: 9, fontFamily: "var(--font-mono, monospace)", color: "var(--fg-mute, #718096)", letterSpacing: "0.08em", marginBottom: 6 }}>
+                WALLET BALANCE (ON-CHAIN · SPENDABLE)
+              </div>
+              {status?.walletLinked ? (
+                <CostRow cost={status.onchain ?? { spirit: 0, essence: 0, matter: 0, substance: 0 }} />
+              ) : (
+                <span style={{ fontSize: 13, color: "var(--fg-mute, #a0aec0)" }}>No wallet linked yet.</span>
+              )}
+            </div>
+            <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
+              {!status?.walletLinked && (
+                <Link href="/account">
+                  <Button className="bazaar-btn" style={{ padding: "10px 16px" }}>
+                    <Wallet style={{ width: 14, height: 14, marginRight: 6 }} />
+                    Link Wallet
+                  </Button>
+                </Link>
+              )}
+              {status?.walletLinked && onchainTotal <= 0 && (
+                <Link href="/account" style={{ fontSize: 12.5, color: "#a78bfa", textDecoration: "none" }}>
+                  Claim your earned ESMS on-chain →
+                </Link>
+              )}
+              {status?.walletLinked && !authenticated && (
+                <Button onClick={login} disabled={!ready} className="bazaar-btn" style={{ padding: "10px 16px" }}>
+                  Unlock signing
+                </Button>
+              )}
+            </div>
+          </div>
+
+          {status && !status.configured && (
+            <div style={{ fontSize: 12.5, color: "#d97706", background: "rgba(217,119,6,0.08)", border: "1px solid rgba(217,119,6,0.25)", borderRadius: 8, padding: "12px 16px", marginBottom: 20 }}>
+              On-chain commerce isn&apos;t configured on this server yet — browsing only.
+            </div>
+          )}
+
+          {notice && (
+            <div
+              style={{
+                fontSize: 13,
+                color: notice.kind === "ok" ? "#34d399" : "#ef4444",
+                background: notice.kind === "ok" ? "rgba(52,211,153,0.08)" : "rgba(239,68,68,0.08)",
+                border: `1px solid ${notice.kind === "ok" ? "rgba(52,211,153,0.25)" : "rgba(239,68,68,0.25)"}`,
+                borderRadius: 8,
+                padding: "12px 16px",
+                marginBottom: 20,
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                flexWrap: "wrap",
+              }}
+            >
+              <span>{notice.text}</span>
+              {notice.txUrl && (
+                <a href={notice.txUrl} target="_blank" rel="noopener noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: 4, color: "#a78bfa", fontFamily: "var(--font-mono, monospace)", fontSize: 12, textDecoration: "none" }}>
+                  view burn <ExternalLink style={{ width: 12, height: 12 }} />
+                </a>
+              )}
+            </div>
+          )}
+
+          {/* Stalls */}
+          {items && items.length > 0 ? (
+            <div className="bazaar-grid">
+              {items.map((item) => {
+                const affordable = canAffordOnchain(item.baseCost, status?.onchain ?? null);
+                const busy = buying?.slug === item.slug;
+                const disabled =
+                  !status?.configured || !status?.walletLinked || (item.owned && item.isOneTime) || busy || !affordable;
+                return (
+                  <div key={item.slug} className="bazaar-card" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 8 }}>
+                      <div style={{ fontSize: 15, fontWeight: 600 }}>{item.title}</div>
+                      <span style={{ fontSize: 9, fontFamily: "var(--font-mono, monospace)", letterSpacing: "0.06em", color: "#a78bfa", border: "1px solid rgba(139,92,246,0.3)", borderRadius: 999, padding: "2px 8px", whiteSpace: "nowrap" }}>
+                        {item.category.toUpperCase()}
+                      </span>
+                    </div>
+                    {item.description && (
+                      <p style={{ margin: 0, fontSize: 12.5, color: "var(--fg-mute, #a0aec0)", lineHeight: 1.5 }}>
+                        {item.description}
+                      </p>
+                    )}
+                    <div style={{ marginTop: "auto", display: "flex", flexDirection: "column", gap: 10 }}>
+                      <CostRow cost={item.baseCost} compare={status?.onchain ?? null} />
+                      {item.owned && item.isOneTime ? (
+                        <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: 12.5, color: "#34d399" }}>
+                          <BadgeCheck style={{ width: 14, height: 14 }} /> Owned
+                        </span>
+                      ) : (
+                        <Button
+                          onClick={() => void handleBuy(item)}
+                          disabled={disabled}
+                          className="bazaar-btn"
+                          style={{ padding: "10px 14px", width: "100%" }}
+                          title={
+                            !status?.walletLinked
+                              ? "Link your wallet first"
+                              : !affordable
+                                ? "Not enough claimed ESMS in your wallet"
+                                : undefined
+                          }
+                        >
+                          {busy ? (
+                            <>
+                              <Loader2 style={{ width: 13, height: 13, marginRight: 6, animation: "spin 1.2s linear infinite" }} />
+                              {buying?.phase === "signing"
+                                ? "Awaiting signature…"
+                                : buying?.phase === "settling"
+                                  ? "Burning on-chain…"
+                                  : "Preparing…"}
+                            </>
+                          ) : (
+                            <>
+                              <Flame style={{ width: 13, height: 13, marginRight: 6 }} />
+                              Burn to buy
+                            </>
+                          )}
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="bazaar-card">
+              <p style={{ margin: 0, fontSize: 13.5, color: "var(--fg-mute, #a0aec0)" }}>
+                The stalls are being restocked — check back soon.
+              </p>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function ShopPage(): JSX.Element {
+  return (
+    <PrivyProvider
+      appId={PRIVY_APP_ID}
+      config={{
+        loginMethods: ["email", "google", "wallet"],
+        embeddedWallets: {
+          ethereum: { createOnLogin: "users-without-wallets" },
+          solana: { createOnLogin: "off" },
+        },
+        defaultChain: ESMS_CHAIN,
+        supportedChains: ESMS_CHAIN.id === base.id ? [base] : [ESMS_CHAIN, base],
+        appearance: {
+          theme: "dark",
+          accentColor: "#805ad5",
+          logo: "/alchm-icon-192.png",
+        },
+      }}
+    >
+      <ShopInner />
+    </PrivyProvider>
+  );
+}

--- a/src/app/api/economy/claim-daily/route.ts
+++ b/src/app/api/economy/claim-daily/route.ts
@@ -86,10 +86,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const milestoneNote = yieldResult.milestoneBonus
+      ? ` 🔥 ${yieldResult.milestoneBonus.days}-day streak milestone: +${yieldResult.milestoneBonus.totalTokens} bonus tokens!`
+      : "";
     const response: ClaimDailyResponse = {
       success: true,
       yield: yieldResult,
-      message: `✨ Cosmic Yield collected! +${yieldResult.totalTokens.toFixed(1)} tokens across Spirit, Essence, Matter & Substance.`,
+      message: `✨ Cosmic Yield collected! +${yieldResult.totalTokens.toFixed(1)} tokens across Spirit, Essence, Matter & Substance.${milestoneNote}`,
     };
 
     // Record the action in the community feed

--- a/src/app/api/economy/claim-onchain/route.ts
+++ b/src/app/api/economy/claim-onchain/route.ts
@@ -1,0 +1,416 @@
+/**
+ * ESMS claim-to-chain bridge.
+ *
+ * GET  /api/economy/claim-onchain — wallet panel status: link state, off-chain
+ *      vs on-chain balances, the in-flight claim (if any), recent claim history.
+ * POST /api/economy/claim-onchain — move the user's entire off-chain balance
+ *      on-chain: atomically debit all four coins from the Postgres ledger, then
+ *      mint the same amounts to the user's linked Privy wallet via
+ *      EsmsToken.claimMint (backend-sponsored — the user pays no gas).
+ *
+ * Safety model: the bytes32 claim_id is enforced unique BY THE CONTRACT, so a
+ * pending claim can always be retried or reconciled without double-minting.
+ * The debit commits before the mint; a mint that may have broadcast is never
+ * refunded — the claim stays pending and the next POST reconciles it against
+ * claimed(claim_id). Refunds only happen after the chain confirms the claim
+ * was never minted (reverted receipt + claimed() false).
+ */
+
+import { NextResponse } from "next/server";
+import { formatUnits } from "viem";
+import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
+import { executeQuery } from "@/lib/database";
+import {
+  esmsChain,
+  esmsContractAddress,
+  esmsOnchainConfigured,
+  esmsPublicClient,
+  readEsmsBalances,
+  readEsmsClaimed,
+} from "@/lib/esms-chain/contract";
+import { mintEsmsClaim, minterConfigured } from "@/lib/esms-chain/minter";
+import { rateLimit } from "@/lib/rateLimit";
+import {
+  esmsOnchainClaimService,
+  type EsmsClaimAmounts,
+  type EsmsOnchainClaim,
+} from "@/services/esmsOnchainClaimService";
+import { tokenEconomy } from "@/services/TokenEconomyService";
+import type { NextRequest } from "next/server";
+import type { Address, Hex } from "viem";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+// Debit + mint + receipt wait can straddle two Base blocks plus RPC retries.
+export const maxDuration = 60;
+
+const EVM_ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+
+/** Resolve the user's linked wallet: session field first, then the users row. */
+async function resolveWallet(user: { id: string; walletAddress?: string | null }): Promise<Address | null> {
+  const fromSession = user.walletAddress;
+  if (fromSession && EVM_ADDRESS.test(fromSession)) return fromSession as Address;
+  try {
+    const res = await executeQuery<{ wallet_address: string | null }>(
+      "SELECT wallet_address FROM users WHERE id = $1",
+      [user.id],
+    );
+    const addr = res.rows[0]?.wallet_address;
+    return addr && EVM_ADDRESS.test(addr) ? (addr as Address) : null;
+  } catch {
+    return null;
+  }
+}
+
+function chainMeta() {
+  const chain = esmsChain();
+  return {
+    chainId: chain.id,
+    chainName: chain.name,
+    testnet: chain.testnet ?? false,
+    contractAddress: esmsOnchainConfigured() ? esmsContractAddress() : null,
+    explorerBaseUrl: chain.blockExplorers?.default?.url ?? null,
+  };
+}
+
+async function readOnchainOrNull(wallet: Address) {
+  try {
+    const b = await readEsmsBalances(wallet);
+    return {
+      spirit: Number(formatUnits(b.spirit, 18)),
+      essence: Number(formatUnits(b.essence, 18)),
+      matter: Number(formatUnits(b.matter, 18)),
+      substance: Number(formatUnits(b.substance, 18)),
+    };
+  } catch (err) {
+    console.warn("[economy/claim-onchain] on-chain balance read failed:", err);
+    return null;
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const user = await getDatabaseUserFromRequest(request);
+  if (!user) {
+    return NextResponse.json({ success: false, message: "Authentication required" }, { status: 401 });
+  }
+
+  const configured = esmsOnchainConfigured() && minterConfigured();
+  const wallet = await resolveWallet(user);
+  const [offchain, pending, recent, onchain] = await Promise.all([
+    tokenEconomy.getBalances(user.id),
+    esmsOnchainClaimService.findPending(user.id),
+    esmsOnchainClaimService.listRecent(user.id, 10),
+    wallet && esmsOnchainConfigured() ? readOnchainOrNull(wallet) : Promise.resolve(null),
+  ]);
+
+  return NextResponse.json({
+    success: true,
+    configured,
+    walletAddress: wallet,
+    walletLinked: Boolean(wallet),
+    offchain: {
+      spirit: offchain.spirit,
+      essence: offchain.essence,
+      matter: offchain.matter,
+      substance: offchain.substance,
+    },
+    onchain,
+    pendingClaim: pending,
+    recentClaims: recent,
+    chain: chainMeta(),
+  });
+}
+
+/** Floor to the ledger's 4-dp precision so debit and mint agree exactly. */
+function floor4(n: number): number {
+  return Math.floor(n * 10_000) / 10_000;
+}
+
+function claimToResponse(claim: EsmsOnchainClaim, extra?: Record<string, unknown>) {
+  const meta = chainMeta();
+  return {
+    claimId: claim.claimId,
+    amounts: claim.amounts,
+    status: claim.status,
+    txHash: claim.txHash,
+    explorerUrl:
+      claim.txHash && meta.explorerBaseUrl ? `${meta.explorerBaseUrl}/tx/${claim.txHash}` : null,
+    ...extra,
+  };
+}
+
+/**
+ * Confirm a sent claim mint: wait for the receipt, fall back to claimed() when
+ * the receipt times out. Marks the row and returns the final status.
+ */
+async function confirmMint(claim: EsmsOnchainClaim, txHash: Hex): Promise<"minted" | "pending" | "reverted"> {
+  await esmsOnchainClaimService.recordTxHash(claim.id, txHash);
+  try {
+    const receipt = await esmsPublicClient().waitForTransactionReceipt({
+      hash: txHash,
+      timeout: 45_000,
+    });
+    if (receipt.status === "success") {
+      await esmsOnchainClaimService.markMinted(claim.id, txHash);
+      return "minted";
+    }
+    return "reverted";
+  } catch {
+    // Timeout / RPC error — the tx may still mine. claimed() is the tiebreaker;
+    // if it is not yet visible the claim stays pending and reconciles later.
+    try {
+      if (await readEsmsClaimed(claim.claimId)) {
+        await esmsOnchainClaimService.markMinted(claim.id, txHash);
+        return "minted";
+      }
+    } catch {
+      // chain unreadable — stay pending
+    }
+    await esmsOnchainClaimService.recordError(claim.id, "receipt timeout — reconciling on next request");
+    return "pending";
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const user = await getDatabaseUserFromRequest(request);
+  if (!user) {
+    return NextResponse.json({ success: false, message: "Authentication required" }, { status: 401 });
+  }
+
+  const rl = await rateLimit(request, {
+    window: 60_000,
+    max: 3,
+    bucket: "economy-claim-onchain",
+    identifier: user.id,
+  });
+  if (!rl.allowed) return rl.response!;
+
+  if (!esmsOnchainConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "On-chain ESMS is not deployed.", code: "onchain_unconfigured" },
+      { status: 503 },
+    );
+  }
+  if (!minterConfigured()) {
+    return NextResponse.json(
+      { success: false, error: "ESMS claim minter is not configured.", code: "minter_unconfigured" },
+      { status: 503 },
+    );
+  }
+
+  const wallet = await resolveWallet(user);
+  if (!wallet) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Link your Privy wallet before claiming ESMS on-chain.",
+        code: "no_wallet",
+      },
+      { status: 400 },
+    );
+  }
+
+  // ── Reconcile any in-flight claim before opening a new one ────────────────
+  const pending = await esmsOnchainClaimService.findPending(user.id);
+  if (pending) {
+    let alreadyClaimed = false;
+    try {
+      alreadyClaimed = await readEsmsClaimed(pending.claimId);
+    } catch {
+      return NextResponse.json(
+        { success: false, error: "Could not reach the chain to reconcile your pending claim.", code: "chain_unavailable" },
+        { status: 502 },
+      );
+    }
+
+    if (alreadyClaimed) {
+      await esmsOnchainClaimService.markMinted(pending.id);
+      return NextResponse.json({
+        success: true,
+        reconciled: true,
+        claim: claimToResponse({ ...pending, status: "minted" }),
+      });
+    }
+
+    // Not on-chain yet → retry the SAME claim id (contract-safe). Mint to the
+    // user's current wallet — the claim id carries no recipient commitment.
+    try {
+      const txHash = await mintEsmsClaim({
+        to: wallet,
+        claimId: pending.claimId,
+        amounts: {
+          spirit: String(pending.amounts.spirit),
+          essence: String(pending.amounts.essence),
+          matter: String(pending.amounts.matter),
+          substance: String(pending.amounts.substance),
+        },
+      });
+      const status = await confirmMint(pending, txHash);
+      if (status === "minted") {
+        return NextResponse.json({
+          success: true,
+          retried: true,
+          claim: claimToResponse({ ...pending, status: "minted", txHash }),
+        });
+      }
+      if (status === "pending") {
+        return NextResponse.json(
+          { success: false, code: "mint_pending", retryable: true, claim: claimToResponse({ ...pending, txHash }) },
+          { status: 202 },
+        );
+      }
+      // Reverted with claimed() false → the debit never produced on-chain value.
+      await tokenEconomy.creditMultipleTokens(
+        user.id,
+        [
+          { tokenType: "Spirit", amount: pending.amounts.spirit },
+          { tokenType: "Essence", amount: pending.amounts.essence },
+          { tokenType: "Matter", amount: pending.amounts.matter },
+          { tokenType: "Substance", amount: pending.amounts.substance },
+        ],
+        "onchain_claim_refund",
+        {
+          sourceId: pending.id,
+          description: "Refund — on-chain ESMS claim reverted",
+          idempotencyKey: `onchain_claim_refund:${pending.id}`,
+        },
+      );
+      await esmsOnchainClaimService.markRefunded(pending.id, "claimMint reverted");
+      return NextResponse.json(
+        { success: false, error: "The on-chain claim reverted; your tokens were returned.", code: "mint_reverted", refunded: true },
+        { status: 502 },
+      );
+    } catch (err) {
+      // The tx may or may not have broadcast — never refund here. Stay pending.
+      await esmsOnchainClaimService.recordError(pending.id, err instanceof Error ? err.message : String(err));
+      return NextResponse.json(
+        { success: false, error: "Claim mint could not be sent — try again.", code: "mint_failed", retryable: true },
+        { status: 502 },
+      );
+    }
+  }
+
+  // ── Open a new claim for the full off-chain balance ───────────────────────
+  const balances = await tokenEconomy.getBalances(user.id);
+  const amounts: EsmsClaimAmounts = {
+    spirit: floor4(balances.spirit),
+    essence: floor4(balances.essence),
+    matter: floor4(balances.matter),
+    substance: floor4(balances.substance),
+  };
+  const total = amounts.spirit + amounts.essence + amounts.matter + amounts.substance;
+  if (total <= 0) {
+    return NextResponse.json(
+      { success: false, error: "No ESMS to claim — earn some first.", code: "nothing_to_claim" },
+      { status: 400 },
+    );
+  }
+
+  const claim = await esmsOnchainClaimService.createPending({
+    userId: user.id,
+    walletAddress: wallet,
+    amounts,
+  });
+  if (!claim) {
+    // Most likely the one-pending-claim-per-user index raced — reconcile next call.
+    return NextResponse.json(
+      { success: false, error: "A claim is already in progress — try again.", code: "claim_in_progress", retryable: true },
+      { status: 409 },
+    );
+  }
+
+  const debit = await tokenEconomy.debitAllTokens(user.id, amounts, "onchain_claim", {
+    sourceId: claim.id,
+    description: `Claimed to wallet ${wallet}`,
+    idempotencyKey: `onchain_claim:${claim.id}`,
+  });
+  if (!debit.success) {
+    // Nothing was debited (single-statement CTE) — close the claim row.
+    await esmsOnchainClaimService.markRefunded(claim.id, `debit failed: ${debit.reason}`);
+    const status = debit.reason === "insufficient_funds" ? 409 : 503;
+    return NextResponse.json(
+      { success: false, error: "Could not reserve your off-chain balance.", code: debit.reason },
+      { status },
+    );
+  }
+  await esmsOnchainClaimService.attachDebit(claim.id, debit.transactionGroupId);
+
+  try {
+    const txHash = await mintEsmsClaim({
+      to: wallet,
+      claimId: claim.claimId,
+      amounts: {
+        spirit: String(amounts.spirit),
+        essence: String(amounts.essence),
+        matter: String(amounts.matter),
+        substance: String(amounts.substance),
+      },
+    });
+    const status = await confirmMint(claim, txHash);
+    if (status === "minted") {
+      const onchain = await readOnchainOrNull(wallet);
+      return NextResponse.json({
+        success: true,
+        claim: claimToResponse({ ...claim, status: "minted", txHash }),
+        offchain: {
+          spirit: debit.balances.spirit,
+          essence: debit.balances.essence,
+          matter: debit.balances.matter,
+          substance: debit.balances.substance,
+        },
+        onchain,
+      });
+    }
+    if (status === "pending") {
+      return NextResponse.json(
+        { success: false, code: "mint_pending", retryable: true, claim: claimToResponse({ ...claim, txHash }) },
+        { status: 202 },
+      );
+    }
+    // Reverted — verify never-claimed, then refund the debit.
+    let claimedOnchain = false;
+    try {
+      claimedOnchain = await readEsmsClaimed(claim.claimId);
+    } catch {
+      // unreadable — keep pending, reconcile later
+    }
+    if (!claimedOnchain) {
+      await tokenEconomy.creditMultipleTokens(
+        user.id,
+        [
+          { tokenType: "Spirit", amount: amounts.spirit },
+          { tokenType: "Essence", amount: amounts.essence },
+          { tokenType: "Matter", amount: amounts.matter },
+          { tokenType: "Substance", amount: amounts.substance },
+        ],
+        "onchain_claim_refund",
+        {
+          sourceId: claim.id,
+          description: "Refund — on-chain ESMS claim reverted",
+          idempotencyKey: `onchain_claim_refund:${claim.id}`,
+        },
+      );
+      await esmsOnchainClaimService.markRefunded(claim.id, "claimMint reverted");
+      return NextResponse.json(
+        { success: false, error: "The on-chain claim reverted; your tokens were returned.", code: "mint_reverted", refunded: true },
+        { status: 502 },
+      );
+    }
+    await esmsOnchainClaimService.markMinted(claim.id, txHash);
+    return NextResponse.json({ success: true, claim: claimToResponse({ ...claim, status: "minted", txHash }) });
+  } catch (err) {
+    // Send failed — the tx may or may not have broadcast. Never refund blind:
+    // the claim stays pending and the next POST reconciles against claimed().
+    await esmsOnchainClaimService.recordError(claim.id, err instanceof Error ? err.message : String(err));
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Claim mint could not be confirmed — your balance is reserved and the claim will retry.",
+        code: "mint_failed",
+        retryable: true,
+        claim: claimToResponse(claim),
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/api/economy/shop/purchase/route.ts
+++ b/src/app/api/economy/shop/purchase/route.ts
@@ -17,6 +17,8 @@ import { tokenEconomy } from "@/services/TokenEconomyService";
 import type { Address, Hex } from 'viem'
 
 export const dynamic = 'force-dynamic'
+// The sponsored burn now waits for its receipt before granting.
+export const maxDuration = 60
 
 const TX_PATTERN = /^0x[0-9a-f]{64}$/i
 
@@ -165,6 +167,17 @@ export async function POST(request: Request) {
 
   try {
     const burnTx = await redeemEsmsFor({ from: wallet, orderId, amounts, deadline: BigInt(String(body.deadline)), sig })
+    // Never grant on an unverified send: wait for the receipt and require the
+    // {Redeemed} event for this exact orderId. A reverted burn (insufficient
+    // balance, expired deadline) must not unlock the item — and a receipt
+    // timeout is safe to retry because redeemedOrders reconciles at the top.
+    const burned = await verifyRedeem({ txHash: burnTx, orderId, from: wallet })
+    if (!burned) {
+      return NextResponse.json(
+        { error: 'The on-chain ESMS burn did not confirm — nothing was granted.', code: 'burn_unconfirmed', retryable: true, txHash: burnTx },
+        { status: 502 }
+      )
+    }
     await grantPurchase();
     return NextResponse.json({ ok: true, itemId: shopItemSlug, orderId, txHash: burnTx })
   } catch (err) {

--- a/src/app/api/economy/shop/route.ts
+++ b/src/app/api/economy/shop/route.ts
@@ -25,11 +25,23 @@ export async function GET(request: NextRequest) {
     const url = new URL(request.url);
     const category = url.searchParams.get("category") || "feature";
 
-    const [balances, items, pricing] = await Promise.all([
+    const [balances, items, pricing, ownedRes] = await Promise.all([
       tokenEconomy.getBalances(user.id),
-      tokenEconomy.getShopItems({ category, onlyActive: true }),
+      // "all" → the whole storefront (used by the /shop Bazaar page)
+      tokenEconomy.getShopItems({ category: category === "all" ? undefined : category, onlyActive: true }),
       getLivePricingContext(),
+      import("@/lib/database")
+        .then((db) =>
+          db.executeQuery<{ slug: string }>(
+            `SELECT si.slug FROM user_purchases up
+             JOIN shop_items si ON si.id = up.shop_item_id
+             WHERE up.user_id = $1`,
+            [user.id],
+          ),
+        )
+        .catch(() => ({ rows: [] as Array<{ slug: string }> })),
     ]);
+    const ownedSlugs = new Set(ownedRes.rows.map((r) => r.slug));
 
     const shopItems = items.map(item => {
       const baseCost = {
@@ -55,6 +67,7 @@ export async function GET(request: NextRequest) {
         baseCost,
         liveCost,
         canAfford,
+        owned: ownedSlugs.has(item.slug),
       };
     });
 

--- a/src/app/api/economy/swap/route.ts
+++ b/src/app/api/economy/swap/route.ts
@@ -121,12 +121,40 @@ export async function POST(request: NextRequest) {
       { description: creditDescription, transactionGroupId: groupId },
     );
 
+    if (!newBalances) {
+      // The debit committed but the credit didn't — refund the spent coins so
+      // the swap is all-or-nothing instead of silently destroying tokens.
+      const refunded = await tokenEconomy.creditTokens(
+        userId,
+        fromToken,
+        costAmount,
+        "transmutation",
+        {
+          description: `Refund — swap credit failed (${debitDescription})`,
+          transactionGroupId: groupId,
+          idempotencyKey: `swap_refund:${groupId}`,
+        },
+      );
+      if (!refunded) {
+        console.error("[POST /api/economy/swap] credit AND refund failed — tokens need manual reconcile:", {
+          userId,
+          groupId,
+          fromToken,
+          costAmount,
+        });
+      }
+      return NextResponse.json(
+        { success: false, message: "Swap failed — your coins were returned. Try again.", refunded: !!refunded },
+        { status: 500 },
+      );
+    }
+
     return NextResponse.json({
       success: true,
       result: {
         spent: { tokenType: fromToken, amount: costAmount },
         received: { tokenType: toToken, amount },
-        newBalances: newBalances || afterDebit,
+        newBalances,
       },
       rate: rateEntry,
       planetaryContext: {

--- a/src/app/api/economy/transactions/route.ts
+++ b/src/app/api/economy/transactions/route.ts
@@ -23,7 +23,9 @@ export async function GET(request: NextRequest) {
     }
 
     const url = new URL(request.url);
-    const limit = Math.min(parseInt(url.searchParams.get("limit") || "20", 10), 50);
+    // Clamp at 100 — the balance-trends chart requests the full 100 for its
+    // history window (the old 50 cap silently halved it).
+    const limit = Math.min(parseInt(url.searchParams.get("limit") || "20", 10), 100);
     const offset = parseInt(url.searchParams.get("offset") || "0", 10);
 
     const { transactions, total } = await tokenEconomy.getTransactions(userId, { limit, offset });

--- a/src/app/api/quests/masters-pantry/route.ts
+++ b/src/app/api/quests/masters-pantry/route.ts
@@ -63,10 +63,34 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: "Invalid data" }, { status: 400 });
     }
 
+    // Anti-farm guards: one reward per ingredient per day (idempotency key) and
+    // a hard daily ceiling — previously this credited 2 Matter per POST at the
+    // 60/min rate limit with no dedupe, i.e. ~120 Matter/min for a curl loop.
+    const today = new Date().toISOString().slice(0, 10);
+    const DAILY_VERIFICATION_CAP = 5;
+    const capRes = await executeQuery(
+      `SELECT COUNT(*)::int AS n FROM token_transactions
+       WHERE user_id = $1 AND source_type = 'quest_reward' AND source_id = 'masters-pantry'
+         AND created_at >= $2::date`,
+      [user.id, today],
+    ).catch(() => ({ rows: [{ n: 0 }] }));
+    if ((capRes.rows[0]?.n ?? 0) >= DAILY_VERIFICATION_CAP) {
+      return NextResponse.json(
+        { success: false, error: "The Master's Pantry is closed for today — return tomorrow.", code: "daily_cap" },
+        { status: 429 },
+      );
+    }
+
     // Award Matter (🝙) tokens
-    // Let's assume the user successfully verified it
-    await tokenEconomy.creditTokens(user.id, "Matter", 2, "quest_reward", { description: "The Master's Pantry - Verification" });
-    
+    const credited = await tokenEconomy.creditTokens(user.id, "Matter", 2, "quest_reward", {
+      sourceId: "masters-pantry",
+      description: "The Master's Pantry - Verification",
+      idempotencyKey: `masters_pantry:${user.id}:${String(ingredientId)}:${today}`,
+    });
+    if (!credited) {
+      return NextResponse.json({ success: false, error: "Verification could not be recorded" }, { status: 500 });
+    }
+
     // Also report the event for the quest system
     await questService.reportEvent(user.id, "masters_pantry_verified");
 

--- a/src/components/account/OnchainEsmsPanel.tsx
+++ b/src/components/account/OnchainEsmsPanel.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+/**
+ * On-chain ESMS wallet panel — the user-facing half of the claim-to-chain
+ * bridge. Shows site (off-chain ledger) vs wallet (on-chain soulbound ERC-1155)
+ * balances side by side, a one-click backend-sponsored "Claim to wallet"
+ * action, in-flight claim reconciliation, and recent claim history with
+ * explorer links. Pure fetch()-driven: no web3 SDK needed here because claim
+ * minting is sponsored server-side (the user pays no gas and signs nothing).
+ */
+
+import { ArrowDownToLine, ExternalLink, Loader2, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useState, type JSX } from "react";
+import { Button } from "@/components/ui/button";
+
+interface CoinAmounts {
+  spirit: number;
+  essence: number;
+  matter: number;
+  substance: number;
+}
+
+interface ClaimInfo {
+  claimId: string;
+  amounts: CoinAmounts;
+  status: "pending" | "minted" | "refunded";
+  txHash: string | null;
+  explorerUrl?: string | null;
+  createdAt?: string;
+}
+
+interface OnchainStatus {
+  success: boolean;
+  configured: boolean;
+  walletAddress: string | null;
+  walletLinked: boolean;
+  offchain: CoinAmounts;
+  onchain: CoinAmounts | null;
+  pendingClaim: (ClaimInfo & { id: string }) | null;
+  recentClaims: Array<ClaimInfo & { id: string; createdAt: string }>;
+  chain: {
+    chainId: number;
+    chainName: string;
+    testnet: boolean;
+    contractAddress: string | null;
+    explorerBaseUrl: string | null;
+  };
+}
+
+const COINS: Array<{ key: keyof CoinAmounts; label: string; symbol: string; color: string }> = [
+  { key: "spirit", label: "Spirit", symbol: "🝇", color: "#fbbf24" },
+  { key: "essence", label: "Essence", symbol: "🝑", color: "#60a5fa" },
+  { key: "matter", label: "Matter", symbol: "🝙", color: "#34d399" },
+  { key: "substance", label: "Substance", symbol: "🝉", color: "#c084fc" },
+];
+
+function fmt(n: number): string {
+  return n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+}
+
+function totalOf(a: CoinAmounts | null): number {
+  if (!a) return 0;
+  return a.spirit + a.essence + a.matter + a.substance;
+}
+
+function CoinRow({ amounts }: { amounts: CoinAmounts | null }): JSX.Element {
+  return (
+    <div style={{ display: "flex", gap: 14, flexWrap: "wrap" }}>
+      {COINS.map((c) => (
+        <span key={c.key} style={{ display: "inline-flex", alignItems: "center", gap: 5, fontSize: 13 }}>
+          <span style={{ color: c.color, fontSize: 15 }}>{c.symbol}</span>
+          <span style={{ fontFamily: "var(--font-mono, monospace)", color: "#e2e8f0" }}>
+            {amounts ? fmt(amounts[c.key]) : "—"}
+          </span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function OnchainEsmsPanel(): JSX.Element | null {
+  const [status, setStatus] = useState<OnchainStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [claiming, setClaiming] = useState(false);
+  const [notice, setNotice] = useState<{ kind: "ok" | "err"; text: string } | null>(null);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    try {
+      const res = await fetch("/api/economy/claim-onchain", { cache: "no-store" });
+      if (!res.ok) {
+        setStatus(null);
+        return;
+      }
+      setStatus((await res.json()) as OnchainStatus);
+    } catch {
+      setStatus(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleClaim = useCallback(async (): Promise<void> => {
+    setClaiming(true);
+    setNotice(null);
+    try {
+      const res = await fetch("/api/economy/claim-onchain", { method: "POST" });
+      const json = (await res.json()) as {
+        success?: boolean;
+        error?: string;
+        code?: string;
+        retryable?: boolean;
+        claim?: ClaimInfo;
+      };
+      if (json.success) {
+        const claimed = json.claim ? totalOf(json.claim.amounts) : 0;
+        setNotice({
+          kind: "ok",
+          text: claimed > 0 ? `Claimed ${fmt(claimed)} ESMS to your wallet on-chain.` : "Claim settled on-chain.",
+        });
+      } else if (json.code === "mint_pending") {
+        setNotice({ kind: "ok", text: "Claim submitted — confirming on-chain. Check back in a moment." });
+      } else {
+        setNotice({ kind: "err", text: json.error || "Claim failed — try again." });
+      }
+    } catch {
+      setNotice({ kind: "err", text: "Network error — try again." });
+    } finally {
+      setClaiming(false);
+      void refresh();
+    }
+  }, [refresh]);
+
+  // Silent panel while loading or when the API is unreachable/signed-out.
+  if (loading) return null;
+  if (!status) return null;
+
+  const claimable = totalOf(status.offchain);
+  const pending = status.pendingClaim;
+  const canClaim = status.configured && status.walletLinked && !claiming && (claimable > 0 || Boolean(pending));
+
+  return (
+    <div className="alchm-card" style={{ marginTop: 24 }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 20, position: "relative", zIndex: 1 }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ fontSize: 10, fontFamily: "var(--font-mono, monospace)", color: "var(--fg-mute, #718096)", letterSpacing: "0.08em", marginBottom: 4 }}>
+              ON-CHAIN ESMS · {status.chain.chainName.toUpperCase()}
+              {status.chain.testnet ? " · TESTNET" : ""}
+            </div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: "#e2e8f0" }}>Soulbound Token Vault</div>
+          </div>
+          <button
+            type="button"
+            onClick={() => void refresh()}
+            title="Refresh balances"
+            style={{ background: "none", border: "none", cursor: "pointer", color: "var(--fg-mute, #718096)", padding: 4 }}
+          >
+            <RefreshCw style={{ width: 14, height: 14 }} />
+          </button>
+        </div>
+
+        {!status.configured && (
+          <div style={{ fontSize: 12, color: "#d97706", background: "rgba(217,119,6,0.08)", border: "1px solid rgba(217,119,6,0.25)", borderRadius: 6, padding: "10px 14px" }}>
+            On-chain claiming isn&apos;t configured on this server yet — your tokens keep accruing off-chain.
+          </div>
+        )}
+
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: 12 }}>
+          <div className="glass-status-box" style={{ flexDirection: "column", alignItems: "flex-start" }}>
+            <div style={{ fontSize: 9, fontFamily: "var(--font-mono, monospace)", color: "var(--fg-mute, #718096)", marginBottom: 8 }}>
+              SITE BALANCE (CLAIMABLE)
+            </div>
+            <CoinRow amounts={status.offchain} />
+          </div>
+          <div className="glass-status-box" style={{ flexDirection: "column", alignItems: "flex-start" }}>
+            <div style={{ fontSize: 9, fontFamily: "var(--font-mono, monospace)", color: "var(--fg-mute, #718096)", marginBottom: 8 }}>
+              WALLET BALANCE (ON-CHAIN)
+            </div>
+            <CoinRow amounts={status.onchain} />
+          </div>
+        </div>
+
+        {pending && (
+          <div style={{ fontSize: 12, color: "#a78bfa", background: "rgba(139,92,246,0.08)", border: "1px solid rgba(139,92,246,0.25)", borderRadius: 6, padding: "10px 14px", display: "flex", alignItems: "center", gap: 8 }}>
+            <Loader2 style={{ width: 13, height: 13, animation: "spin 1.2s linear infinite" }} />
+            A claim of {fmt(totalOf(pending.amounts))} ESMS is in flight — claiming again will settle it first.
+          </div>
+        )}
+
+        <div style={{ display: "flex", alignItems: "center", gap: 14, flexWrap: "wrap" }}>
+          <Button
+            onClick={() => void handleClaim()}
+            disabled={!canClaim}
+            className="glowing-btn"
+            style={{ padding: "12px 20px" }}
+          >
+            {claiming ? (
+              <Loader2 style={{ width: 14, height: 14, marginRight: 6, animation: "spin 1.2s linear infinite" }} />
+            ) : (
+              <ArrowDownToLine style={{ width: 14, height: 14, marginRight: 6 }} />
+            )}
+            {pending ? "Settle pending claim" : "Claim all to wallet"}
+          </Button>
+          {!status.walletLinked && (
+            <span style={{ fontSize: 12, color: "var(--fg-mute, #718096)" }}>
+              Link your Privy identity above to unlock on-chain claims.
+            </span>
+          )}
+          {status.walletLinked && claimable <= 0 && !pending && (
+            <span style={{ fontSize: 12, color: "var(--fg-mute, #718096)" }}>
+              Nothing to claim yet — collect your daily Cosmic Yield first.
+            </span>
+          )}
+          <span style={{ fontSize: 11, color: "var(--fg-mute, #718096)", fontFamily: "var(--font-mono, monospace)" }}>
+            Gas-free · sponsored mint
+          </span>
+        </div>
+
+        {notice && (
+          <div
+            style={{
+              fontSize: 12.5,
+              color: notice.kind === "ok" ? "#34d399" : "#ef4444",
+              background: notice.kind === "ok" ? "rgba(52,211,153,0.08)" : "rgba(239,68,68,0.08)",
+              border: `1px solid ${notice.kind === "ok" ? "rgba(52,211,153,0.25)" : "rgba(239,68,68,0.25)"}`,
+              borderRadius: 6,
+              padding: "10px 14px",
+            }}
+          >
+            {notice.text}
+          </div>
+        )}
+
+        {status.recentClaims.length > 0 && (
+          <div>
+            <div style={{ fontSize: 9, fontFamily: "var(--font-mono, monospace)", color: "var(--fg-mute, #718096)", marginBottom: 8 }}>
+              CLAIM HISTORY
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              {status.recentClaims.slice(0, 5).map((c) => {
+                const txUrl =
+                  c.txHash && status.chain.explorerBaseUrl
+                    ? `${status.chain.explorerBaseUrl}/tx/${c.txHash}`
+                    : null;
+                return (
+                  <div
+                    key={c.id}
+                    style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, fontSize: 12, background: "rgba(0,0,0,0.2)", border: "1px solid rgba(255,255,255,0.03)", borderRadius: 6, padding: "8px 12px" }}
+                  >
+                    <span style={{ fontFamily: "var(--font-mono, monospace)", color: "#cbd5e1" }}>
+                      {fmt(totalOf(c.amounts))} ESMS
+                    </span>
+                    <span
+                      style={{
+                        fontSize: 10,
+                        fontFamily: "var(--font-mono, monospace)",
+                        letterSpacing: "0.05em",
+                        color: c.status === "minted" ? "#34d399" : c.status === "pending" ? "#d97706" : "#ef4444",
+                      }}
+                    >
+                      {c.status.toUpperCase()}
+                    </span>
+                    {txUrl ? (
+                      <a
+                        href={txUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{ display: "inline-flex", alignItems: "center", gap: 4, color: "#a78bfa", textDecoration: "none", fontSize: 11, fontFamily: "var(--font-mono, monospace)" }}
+                      >
+                        tx <ExternalLink style={{ width: 11, height: 11 }} />
+                      </a>
+                    ) : (
+                      <span style={{ fontSize: 11, color: "var(--fg-mute, #718096)" }}>—</span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/home/FeaturedRecipe.tsx
+++ b/src/components/home/FeaturedRecipe.tsx
@@ -37,6 +37,16 @@ const ELEMENT_ROWS = [
 const MIN_SERVINGS = 1;
 const MAX_SERVINGS = 24;
 
+// Real recipe-NFT protocol wiring for the ledger showcase (env-driven; the
+// showcase previously displayed hardcoded mock registry/token/block values).
+const REGISTRY_ADDRESS = process.env.NEXT_PUBLIC_RECIPE_REGISTRY_ADDRESS || "";
+const RIGHTS_ID = process.env.NEXT_PUBLIC_ALCHM_RIGHTS_ID || "";
+const IS_TESTNET = (process.env.NEXT_PUBLIC_RECIPE_NFT_CHAIN ?? "base-sepolia") !== "base";
+const NFT_ENABLED =
+  process.env.NEXT_PUBLIC_RECIPE_NFT_ENABLED === "true" && Boolean(REGISTRY_ADDRESS) && Boolean(RIGHTS_ID);
+const CHAIN_LABEL = IS_TESTNET ? "Base Sepolia" : "Base";
+const EXPLORER_BASE = IS_TESTNET ? "https://sepolia.basescan.org" : "https://basescan.org";
+
 function parseQty(raw: string): number | null {
   const s = raw.trim();
   const mixed = s.match(/^(\d+)\s+(\d+)\/(\d+)$/);
@@ -253,23 +263,40 @@ export function FeaturedRecipe() {
                 <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-cyan-500/10 border border-cyan-500/20 text-[9px] font-extrabold text-cyan-300 uppercase tracking-widest">
                   ⛓ Base Ledger Showcase
                 </span>
-                <span className="text-[9px] font-semibold text-emerald-400 flex items-center gap-1">
-                  <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-ping" />
-                  ✓ Minted & Verified
-                </span>
+                {NFT_ENABLED ? (
+                  <span className="text-[9px] font-semibold text-emerald-400 flex items-center gap-1">
+                    <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-ping" />
+                    Registry Live{IS_TESTNET ? " · Testnet" : ""}
+                  </span>
+                ) : (
+                  <span className="text-[9px] font-semibold text-amber-400 flex items-center gap-1">
+                    <span className="w-1.5 h-1.5 rounded-full bg-amber-500" />
+                    Wiring Deploy
+                  </span>
+                )}
               </div>
 
-              {/* Ledger metadata list */}
+              {/* Ledger metadata list — real protocol wiring, no mock values */}
               <div className="space-y-2.5 font-mono text-[10px] text-white/70">
                 <div className="flex justify-between border-b border-white/[0.03] pb-1.5">
-                  <span className="text-white/35 uppercase tracking-wider font-bold">Ledger Registry</span>
-                  <span className="text-white/80 text-right truncate max-w-[150px]" title="0x47b92B08f75b7b98e72322af505f0628e932b7e">
-                    0x47b92B08...3df9
-                  </span>
+                  <span className="text-white/35 uppercase tracking-wider font-bold">Recipe Registry</span>
+                  {REGISTRY_ADDRESS ? (
+                    <a
+                      href={`${EXPLORER_BASE}/address/${REGISTRY_ADDRESS}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-cyan-300/90 hover:text-cyan-200 text-right truncate max-w-[150px] transition-colors"
+                      title={REGISTRY_ADDRESS}
+                    >
+                      {REGISTRY_ADDRESS.substring(0, 10)}…{REGISTRY_ADDRESS.substring(REGISTRY_ADDRESS.length - 4)}
+                    </a>
+                  ) : (
+                    <span className="text-white/40">pending deploy</span>
+                  )}
                 </div>
                 <div className="flex justify-between border-b border-white/[0.03] pb-1.5">
-                  <span className="text-white/35 uppercase tracking-wider font-bold">Token ID</span>
-                  <span className="text-cyan-300 font-extrabold">#1002</span>
+                  <span className="text-white/35 uppercase tracking-wider font-bold">Chain</span>
+                  <span className="text-cyan-300 font-extrabold">{CHAIN_LABEL}</span>
                 </div>
                 <div className="flex justify-between border-b border-white/[0.03] pb-1.5">
                   <span className="text-white/35 uppercase tracking-wider font-bold">Alchemical Weight</span>
@@ -282,8 +309,14 @@ export function FeaturedRecipe() {
                   </span>
                 </div>
                 <div className="flex justify-between border-b border-white/[0.03] pb-1.5">
-                  <span className="text-white/35 uppercase tracking-wider font-bold">Provenance Block</span>
-                  <span className="text-white/80">#18,349,202</span>
+                  <span className="text-white/35 uppercase tracking-wider font-bold">Rights Anchor</span>
+                  {RIGHTS_ID ? (
+                    <span className="text-white/80 text-right truncate max-w-[150px]" title={RIGHTS_ID}>
+                      {RIGHTS_ID.substring(0, 10)}…{RIGHTS_ID.substring(RIGHTS_ID.length - 6)}
+                    </span>
+                  ) : (
+                    <span className="text-white/40">pending anchor</span>
+                  )}
                 </div>
                 <div className="flex justify-between border-b border-white/[0.03] pb-1.5">
                   <span className="text-white/35 uppercase tracking-wider font-bold">Alchm License</span>
@@ -292,16 +325,17 @@ export function FeaturedRecipe() {
               </div>
 
               <p className="text-[10px] text-white/40 leading-relaxed">
-                Alchm.kitchen publishes a new curated recipe on-chain monthly. This ledger record serves as proof-of-provenance. Minting is sponsored and preserved immutably.
+                Every minted recipe anchors its content hash to the Alchm rights registry on {CHAIN_LABEL}.
+                Minting is backend-sponsored — your ESMS is the only cost, and the record is immutable.
               </p>
             </div>
 
             <div className="relative z-10 pt-4 border-t border-white/[0.06] mt-4">
               <Link
-                href="/recipe-builder"
+                href="/cosmic-recipe"
                 className="w-full inline-flex items-center justify-center gap-1.5 px-4 py-2.5 rounded-xl bg-cyan-500/10 hover:bg-cyan-500/20 border border-cyan-500/25 hover:border-cyan-500/40 text-cyan-300 font-bold text-xs transition-all duration-200 group"
               >
-                ✨ Build &amp; Mint Your Own Recipe
+                ✨ Conjure &amp; Mint Your Own Recipe
                 <span className="group-hover:translate-x-0.5 transition-transform duration-200">&rarr;</span>
               </Link>
             </div>

--- a/src/lib/esms-chain/minter.ts
+++ b/src/lib/esms-chain/minter.ts
@@ -34,6 +34,14 @@ function toOnchainAmounts(a: EsmsAmounts): bigint[] {
   return [a.spirit, a.essence, a.matter, a.substance].map(v => parseUnits(v || '0', 18))
 }
 
+/** True when a claim-mint custody path is configured (Privy server wallet or raw key). */
+export function minterConfigured(): boolean {
+  return Boolean(
+    (process.env.PRIVY_MINTER_WALLET_ID && getPrivyClient()) ||
+    process.env.MINTER_PRIVATE_KEY
+  )
+}
+
 /**
  * Mint a settled claim. `claimId` is a bytes32 hex (also the off-chain idempotency
  * key); the contract rejects a repeat claimId, so retries never double-mint.
@@ -54,10 +62,12 @@ export async function mintEsmsClaim(params: {
     args: [to, claimId, ids, values],
   })
 
-  // Preferred: Privy server wallet (no raw key, gas-sponsorable).
+  // Preferred: Privy server wallet (no raw key, gas-sponsorable). getPrivyClient()
+  // is null when PRIVY_APP_SECRET is unset — fall through to the raw-key signer
+  // instead of crashing on the null client.
   const walletId = process.env.PRIVY_MINTER_WALLET_ID
-  if (walletId) {
-    const privy = getPrivyClient()
+  const privy = walletId ? getPrivyClient() : null
+  if (walletId && privy) {
     // NOTE: verify the exact input shape against @privy-io/server-auth on first
     // testnet run (walletId/caip2/tx-field nesting); cast to satisfy types here.
     const res = (await (privy as any).walletApi.ethereum.sendTransaction({

--- a/src/lib/esms-chain/redeemer.ts
+++ b/src/lib/esms-chain/redeemer.ts
@@ -46,8 +46,8 @@ export function toOnchainAmounts(a: EsmsAmounts): bigint[] {
 /** True when a backend settlement (BURNER) wallet is configured for sponsored burns. */
 export function redeemerConfigured(): boolean {
   return Boolean(
-    process.env.PRIVY_REDEEMER_WALLET_ID ||
-    process.env.PRIVY_MINTER_WALLET_ID ||
+    ((process.env.PRIVY_REDEEMER_WALLET_ID || process.env.PRIVY_MINTER_WALLET_ID) &&
+      getPrivyClient()) ||
     process.env.REDEEMER_PRIVATE_KEY ||
     process.env.MINTER_PRIVATE_KEY
   )
@@ -77,9 +77,11 @@ export async function redeemEsmsFor(params: {
 
   // Preferred: Privy server wallet (no raw key, gas-sponsorable). Reuse the
   // minter wallet id when a single backend wallet holds both MINTER and BURNER.
+  // getPrivyClient() is null when PRIVY_APP_SECRET is unset — fall through to
+  // the raw-key signer instead of crashing on the null client.
   const walletId = process.env.PRIVY_REDEEMER_WALLET_ID || process.env.PRIVY_MINTER_WALLET_ID
-  if (walletId) {
-    const privy = getPrivyClient()
+  const privy = walletId ? getPrivyClient() : null
+  if (walletId && privy) {
     const res = (await (privy as any).walletApi.ethereum.sendTransaction({
       walletId,
       caip2: esmsCaip2(),

--- a/src/lib/recipe-nft/contract.ts
+++ b/src/lib/recipe-nft/contract.ts
@@ -163,7 +163,7 @@ export function recipeNftEnabled(): boolean {
   );
 }
 
-function recipeNftRpcUrl(): string | undefined {
+export function recipeNftRpcUrl(): string | undefined {
   return recipeNftChain().id === base.id
     ? process.env.BASE_RPC_URL
     : process.env.BASE_SEPOLIA_RPC_URL;

--- a/src/lib/recipe-nft/minter.ts
+++ b/src/lib/recipe-nft/minter.ts
@@ -21,6 +21,7 @@ import {
   recipeNftChain,
   recipeNftEnabled,
   recipeNftPublicClient,
+  recipeNftRpcUrl,
   recipeRegistryAbi,
   recipeRegistryAddress,
   rightsRegistryAbi,
@@ -84,7 +85,10 @@ export async function mintRecipeOnChain(input: MintOnChainInput): Promise<MintOn
       args: [rightsId],
     }));
 
-    const walletClient = createWalletClient({ account, chain, transport: http() });
+    // Route writes through the configured RPC (falls back to the chain's
+    // default public RPC when unset) — previously http() ignored
+    // BASE_RPC_URL/BASE_SEPOLIA_RPC_URL for the mint tx.
+    const walletClient = createWalletClient({ account, chain, transport: http(recipeNftRpcUrl()) });
 
     const txHash = await walletClient.writeContract({
       address: registry,

--- a/src/services/DailyYieldService.ts
+++ b/src/services/DailyYieldService.ts
@@ -21,6 +21,7 @@ import {
   PREMIUM_YIELD_MULTIPLIER,
   TRANSIT_BONUS_SCALE,
   getHoldingsMultiplier,
+  getStreakMilestone,
   getStreakMultiplier,
 } from "@/types/economy";
 import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
@@ -342,6 +343,33 @@ class DailyYieldService {
     const updatedStreak = await streakService.getStreak(userId);
     await reportQuestEventBestEffort(userId, "maintain_streak");
 
+    // 9. Streak milestone bonus — fires the day the streak hits a milestone.
+    // Day-scoped idempotency: a rebuilt streak re-earns the milestone later,
+    // but a retry/race today can never double-credit.
+    let milestoneBonus: { days: number; totalTokens: number } | undefined;
+    const milestone = getStreakMilestone(updatedStreak.currentStreak);
+    if (milestone) {
+      const perToken = Math.round((milestone.totalTokens / 4) * 100) / 100;
+      const bonusBalances = await tokenEconomy.creditMultipleTokens(
+        userId,
+        [
+          { tokenType: "Spirit", amount: perToken },
+          { tokenType: "Essence", amount: perToken },
+          { tokenType: "Matter", amount: perToken },
+          { tokenType: "Substance", amount: perToken },
+        ],
+        "streak_bonus",
+        {
+          sourceId: `milestone-${milestone.days}`,
+          description: `🔥 ${milestone.days}-day streak milestone bonus`,
+          idempotencyKey: `streak_bonus:${userId}:m${milestone.days}:${todayStr}`,
+        },
+      );
+      if (bonusBalances) {
+        milestoneBonus = milestone;
+      }
+    }
+
     return {
       baseTokens: BASE_DAILY_TOKENS,
       streakMultiplier,
@@ -351,6 +379,7 @@ class DailyYieldService {
       transitBonus,
       newBalances,
       streakCount: updatedStreak.currentStreak,
+      milestoneBonus,
     };
   }
 }

--- a/src/services/QuestService.ts
+++ b/src/services/QuestService.ts
@@ -452,23 +452,33 @@ class QuestService {
     }
 
     const periodStart = periodStartStr !== undefined ? periodStartStr : getPeriodStartForType(quest.questType);
+    const periodCondition = periodStart !== null
+      ? `AND period_start = $3`
+      : `AND period_start IS NULL`;
+    const stampParams = periodStart !== null
+      ? [new Date().toISOString(), userId, quest.id, periodStart]
+      : [new Date().toISOString(), userId, quest.id];
+    const unstampParams = periodStart !== null
+      ? [userId, quest.id, periodStart]
+      : [userId, quest.id];
 
     if (db) {
       try {
-        const periodCondition = periodStart !== null
-          ? `AND period_start = $3`
-          : `AND period_start IS NULL`;
-        const params = periodStart !== null
-          ? [new Date().toISOString(), userId, quest.id, periodStart]
-          : [new Date().toISOString(), userId, quest.id];
-
-        await db.executeQuery(
+        // Atomic claim gate: only the caller whose UPDATE flips claimed_at from
+        // NULL wins — two concurrent claims can both pass the pre-check above,
+        // but only one gets a row back here.
+        const stamped = await db.executeQuery(
           `UPDATE user_quest_progress
            SET claimed_at = $1
            WHERE user_id = $2 AND quest_id = $3
-             ${periodCondition}`,
-          params,
+             ${periodCondition}
+             AND claimed_at IS NULL
+           RETURNING user_id`,
+          stampParams,
         );
+        if (stamped.rows.length === 0) {
+          return { success: false, tokensAwarded: 0, tokenType: "", message: "Reward already claimed" };
+        }
       } catch (error) {
         _logger.error("[QuestService] claimQuestReward DB failed:", error);
         return { success: false, tokensAwarded: 0, tokenType: "", message: "Database error" };
@@ -482,7 +492,30 @@ class QuestService {
       memoryProgress.set(key, { ...mem, claimedAt: new Date().toISOString() });
     }
 
-    const reward = await this.awardQuestReward(userId, quest);
+    const reward = await this.awardQuestReward(userId, quest, periodStart);
+    if (!reward.credited) {
+      // The stamp committed but the credit didn't — release the stamp so the
+      // reward isn't permanently burned; the period-scoped idempotency key
+      // keeps the retry from ever double-crediting.
+      if (db) {
+        try {
+          await db.executeQuery(
+            `UPDATE user_quest_progress
+             SET claimed_at = NULL
+             WHERE user_id = $1 AND quest_id = $2
+               ${periodStart !== null ? "AND period_start = $3" : "AND period_start IS NULL"}`,
+            unstampParams,
+          );
+        } catch (error) {
+          _logger.error(
+            "[QuestService] claim credit failed AND stamp release failed — reward needs manual reconcile:",
+            { userId, questSlug, periodStart, error },
+          );
+        }
+      }
+      return { success: false, tokensAwarded: 0, tokenType: "", message: "Reward crediting failed — try again." };
+    }
+
     return {
       success: true,
       tokensAwarded: reward.tokensAwarded,
@@ -492,21 +525,25 @@ class QuestService {
   }
 
   /**
-   * Award tokens for completing a quest.
+   * Award tokens for completing a quest. `credited: false` means nothing was
+   * written (the caller must release the claim stamp). The idempotency key is
+   * PERIOD-scoped — the previous day-scoped key collided when a current and a
+   * prior period of the same quest were both claimed on the same day, silently
+   * dropping the second reward.
    */
   private async awardQuestReward(
     userId: string,
     quest: QuestDefinition,
-  ): Promise<{ questSlug: string; tokensAwarded: number; tokenType: string }> {
-    const todayStr = new Date().toISOString().slice(0, 10);
-    const idemKey = `quest_claim:${userId}:${quest.slug}:${todayStr}`;
+    periodStart: string | null,
+  ): Promise<{ questSlug: string; tokensAwarded: number; tokenType: string; credited: boolean }> {
+    const idemKey = `quest_claim:${userId}:${quest.slug}:${periodStart || "all"}`;
 
     if (quest.tokenRewardType === "all") {
       // Split evenly across all 4 token types
       const perToken = Math.round((quest.tokenRewardAmount / 4) * 100) / 100;
       const credits = TOKEN_TYPES.map((t: TokenType) => ({ tokenType: t, amount: perToken }));
 
-      await tokenEconomy.creditMultipleTokens(userId, credits, "quest_reward", {
+      const balances = await tokenEconomy.creditMultipleTokens(userId, credits, "quest_reward", {
         sourceId: quest.slug,
         description: `Quest completed: ${quest.title}`,
         idempotencyKey: idemKey,
@@ -516,9 +553,10 @@ class QuestService {
         questSlug: quest.slug,
         tokensAwarded: quest.tokenRewardAmount,
         tokenType: "all",
+        credited: balances !== null,
       };
     } else {
-      await tokenEconomy.creditTokens(
+      const balances = await tokenEconomy.creditTokens(
         userId,
         quest.tokenRewardType,
         quest.tokenRewardAmount,
@@ -534,6 +572,7 @@ class QuestService {
         questSlug: quest.slug,
         tokensAwarded: quest.tokenRewardAmount,
         tokenType: quest.tokenRewardType,
+        credited: balances !== null,
       };
     }
   }

--- a/src/services/TokenEconomyService.ts
+++ b/src/services/TokenEconomyService.ts
@@ -317,6 +317,146 @@ class TokenEconomyService {
   }
 
   /**
+   * Atomically debit all four coins at once (e.g. moving a balance snapshot
+   * on-chain via an ESMS claim). Same one-statement CTE shape as
+   * purchaseShopItem — balance check, per-axis ledger rows, and the balance
+   * update either all commit or none do — but with no shop item involved.
+   * Per-axis idempotency keys (`<key>:<TokenType>`) make a retry after a
+   * network error a clean `already_applied` instead of a double debit.
+   */
+  async debitAllTokens(
+    userId: string,
+    amounts: { spirit: number; essence: number; matter: number; substance: number },
+    sourceType: TransactionSourceType,
+    opts?: {
+      sourceId?: string;
+      description?: string;
+      idempotencyKey?: string;
+    },
+  ): Promise<
+    | { success: true; balances: TokenBalances; transactionGroupId: string }
+    | { success: false; reason: "insufficient_funds" | "already_applied" | "debit_failed" }
+  > {
+    const db = await getDbModule();
+    const idemKey = opts?.idempotencyKey ?? null;
+
+    if (db) {
+      try {
+        if (idemKey) {
+          const dup = await db.executeQuery(
+            `SELECT 1 FROM token_transactions WHERE idempotency_key LIKE $1 LIMIT 1`,
+            [`${idemKey}:%`],
+          );
+          if (dup.rows.length > 0) {
+            return { success: false, reason: "already_applied" };
+          }
+        }
+
+        const result = await db.executeQuery(
+          `WITH ensure_balance AS (
+            INSERT INTO token_balances (user_id) VALUES ($1)
+            ON CONFLICT (user_id) DO NOTHING
+          ),
+          balance_check AS (
+            SELECT * FROM token_balances WHERE user_id = $1
+            AND spirit >= $2 AND essence >= $3 AND matter >= $4 AND substance >= $5
+          ),
+          new_group AS (
+            SELECT uuid_generate_v4() AS gid
+          ),
+          debit_spirit AS (
+            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+            SELECT g.gid, $1, 'Spirit', -$2, $6, $7, $8,
+                   CASE WHEN $9::text IS NOT NULL THEN $9 || ':Spirit' ELSE NULL END
+            FROM balance_check bc, new_group g
+            WHERE $2 > 0
+            RETURNING id
+          ),
+          debit_essence AS (
+            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+            SELECT g.gid, $1, 'Essence', -$3, $6, $7, $8,
+                   CASE WHEN $9::text IS NOT NULL THEN $9 || ':Essence' ELSE NULL END
+            FROM balance_check bc, new_group g
+            WHERE $3 > 0
+            RETURNING id
+          ),
+          debit_matter AS (
+            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+            SELECT g.gid, $1, 'Matter', -$4, $6, $7, $8,
+                   CASE WHEN $9::text IS NOT NULL THEN $9 || ':Matter' ELSE NULL END
+            FROM balance_check bc, new_group g
+            WHERE $4 > 0
+            RETURNING id
+          ),
+          debit_substance AS (
+            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+            SELECT g.gid, $1, 'Substance', -$5, $6, $7, $8,
+                   CASE WHEN $9::text IS NOT NULL THEN $9 || ':Substance' ELSE NULL END
+            FROM balance_check bc, new_group g
+            WHERE $5 > 0
+            RETURNING id
+          ),
+          updated AS (
+            UPDATE token_balances
+            SET spirit = token_balances.spirit - $2,
+                essence = token_balances.essence - $3,
+                matter = token_balances.matter - $4,
+                substance = token_balances.substance - $5,
+                updated_at = now()
+            FROM balance_check bc
+            WHERE token_balances.user_id = $1
+            RETURNING token_balances.*
+          )
+          SELECT u.*, g.gid AS txn_group_id FROM updated u, new_group g`,
+          [
+            userId,
+            amounts.spirit,
+            amounts.essence,
+            amounts.matter,
+            amounts.substance,
+            sourceType,
+            opts?.sourceId || null,
+            opts?.description || null,
+            idemKey,
+          ],
+        );
+
+        if (result.rows.length === 0) {
+          return { success: false, reason: "insufficient_funds" };
+        }
+        return {
+          success: true,
+          balances: rowToBalances(result.rows[0]),
+          transactionGroupId: result.rows[0].txn_group_id,
+        };
+      } catch (error) {
+        if ((error as { code?: string })?.code === "23505") {
+          return { success: false, reason: "already_applied" };
+        }
+        _logger.error("[TokenEconomy] debitAllTokens failed:", error);
+        return { success: false, reason: "debit_failed" };
+      }
+    }
+
+    // In-memory fallback: honest affordability check across all four axes.
+    const balances = await this.getBalances(userId);
+    if (
+      balances.spirit < amounts.spirit ||
+      balances.essence < amounts.essence ||
+      balances.matter < amounts.matter ||
+      balances.substance < amounts.substance
+    ) {
+      return { success: false, reason: "insufficient_funds" };
+    }
+    balances.spirit -= amounts.spirit;
+    balances.essence -= amounts.essence;
+    balances.matter -= amounts.matter;
+    balances.substance -= amounts.substance;
+    balances.updatedAt = new Date().toISOString();
+    return { success: true, balances, transactionGroupId: `mem_${Date.now()}` };
+  }
+
+  /**
    * Credit multiple token types at once (for 'all' rewards or daily yield).
    */
   async creditMultipleTokens(

--- a/src/services/esmsOnchainClaimService.ts
+++ b/src/services/esmsOnchainClaimService.ts
@@ -1,0 +1,215 @@
+/**
+ * Persistence for ESMS on-chain claims — the bridge ledger that moves a user's
+ * off-chain earned balance onto the soulbound EsmsToken (Base) via claimMint.
+ *
+ * Lifecycle: pending (off-chain debit committed, mint in flight/retryable) →
+ * minted (claimMint confirmed) | refunded (permanently failed, debit re-credited).
+ * claim_id is the bytes32 the CONTRACT enforces uniqueness on, so any pending
+ * row can always be reconciled against readEsmsClaimed(claim_id) — retries never
+ * double-mint and an interrupted request never strands tokens.
+ */
+
+import { randomUUID } from "crypto";
+import { keccak256, toHex } from "viem";
+import { executeQuery } from "@/lib/database";
+import type { Hex } from "viem";
+
+export interface EsmsClaimAmounts {
+  spirit: number;
+  essence: number;
+  matter: number;
+  substance: number;
+}
+
+export interface EsmsOnchainClaim {
+  id: string;
+  userId: string;
+  walletAddress: string;
+  claimId: Hex;
+  amounts: EsmsClaimAmounts;
+  status: "pending" | "minted" | "refunded";
+  txHash: string | null;
+  error: string | null;
+  transactionGroupId: string | null;
+  createdAt: string;
+}
+
+interface ClaimRow {
+  id: string;
+  user_id: string;
+  wallet_address: string;
+  claim_id: string;
+  spirit: string;
+  essence: string;
+  matter: string;
+  substance: string;
+  status: "pending" | "minted" | "refunded";
+  tx_hash: string | null;
+  error: string | null;
+  transaction_group_id: string | null;
+  created_at: string;
+}
+
+function rowToClaim(row: ClaimRow): EsmsOnchainClaim {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    walletAddress: row.wallet_address,
+    claimId: row.claim_id as Hex,
+    amounts: {
+      spirit: parseFloat(row.spirit) || 0,
+      essence: parseFloat(row.essence) || 0,
+      matter: parseFloat(row.matter) || 0,
+      substance: parseFloat(row.substance) || 0,
+    },
+    status: row.status,
+    txHash: row.tx_hash,
+    error: row.error,
+    transactionGroupId: row.transaction_group_id,
+    createdAt: row.created_at,
+  };
+}
+
+/** Deterministic bytes32 claim id for a claim row (the on-chain idempotency key). */
+export function deriveClaimId(claimRowId: string): Hex {
+  return keccak256(toHex(`esms-claim:${claimRowId}`));
+}
+
+export const esmsOnchainClaimService = {
+  /**
+   * Open a new pending claim. Returns null on DB error — including the partial
+   * unique index rejecting a second in-flight claim for the same user (the
+   * caller should reconcile the existing pending claim instead).
+   */
+  async createPending(input: {
+    userId: string;
+    walletAddress: string;
+    amounts: EsmsClaimAmounts;
+  }): Promise<EsmsOnchainClaim | null> {
+    const id = randomUUID();
+    const claimId = deriveClaimId(id);
+    try {
+      const res = await executeQuery<ClaimRow>(
+        `INSERT INTO esms_onchain_claims
+           (id, user_id, wallet_address, claim_id, spirit, essence, matter, substance)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         RETURNING *`,
+        [
+          id,
+          input.userId,
+          input.walletAddress,
+          claimId,
+          input.amounts.spirit,
+          input.amounts.essence,
+          input.amounts.matter,
+          input.amounts.substance,
+        ],
+      );
+      return res.rows[0] ? rowToClaim(res.rows[0]) : null;
+    } catch (err) {
+      console.error("[esmsOnchainClaimService] createPending failed:", err);
+      return null;
+    }
+  },
+
+  /** The user's single in-flight claim, if any. */
+  async findPending(userId: string): Promise<EsmsOnchainClaim | null> {
+    try {
+      const res = await executeQuery<ClaimRow>(
+        `SELECT * FROM esms_onchain_claims
+         WHERE user_id = $1 AND status = 'pending'
+         ORDER BY created_at DESC LIMIT 1`,
+        [userId],
+      );
+      return res.rows[0] ? rowToClaim(res.rows[0]) : null;
+    } catch (err) {
+      console.error("[esmsOnchainClaimService] findPending failed:", err);
+      return null;
+    }
+  },
+
+  /** Recent claim history for the wallet panel. */
+  async listRecent(userId: string, limit = 10): Promise<EsmsOnchainClaim[]> {
+    try {
+      const res = await executeQuery<ClaimRow>(
+        `SELECT * FROM esms_onchain_claims
+         WHERE user_id = $1
+         ORDER BY created_at DESC LIMIT $2`,
+        [userId, Math.min(Math.max(limit, 1), 50)],
+      );
+      return res.rows.map(rowToClaim);
+    } catch (err) {
+      console.error("[esmsOnchainClaimService] listRecent failed:", err);
+      return [];
+    }
+  },
+
+  /** Attach the off-chain debit's transaction group to the claim row. */
+  async attachDebit(id: string, transactionGroupId: string): Promise<void> {
+    try {
+      await executeQuery(
+        `UPDATE esms_onchain_claims
+         SET transaction_group_id = $2, updated_at = now()
+         WHERE id = $1`,
+        [id, transactionGroupId],
+      );
+    } catch (err) {
+      console.error("[esmsOnchainClaimService] attachDebit failed:", err);
+    }
+  },
+
+  /** Record a mint tx hash while it confirms (row stays pending until verified). */
+  async recordTxHash(id: string, txHash: string): Promise<void> {
+    try {
+      await executeQuery(
+        `UPDATE esms_onchain_claims
+         SET tx_hash = $2, error = NULL, updated_at = now()
+         WHERE id = $1`,
+        [id, txHash],
+      );
+    } catch (err) {
+      console.error("[esmsOnchainClaimService] recordTxHash failed:", err);
+    }
+  },
+
+  async markMinted(id: string, txHash?: string | null): Promise<void> {
+    try {
+      await executeQuery(
+        `UPDATE esms_onchain_claims
+         SET status = 'minted', tx_hash = COALESCE($2, tx_hash), error = NULL, updated_at = now()
+         WHERE id = $1`,
+        [id, txHash ?? null],
+      );
+    } catch (err) {
+      console.error("[esmsOnchainClaimService] markMinted failed:", err);
+    }
+  },
+
+  /** Keep the row pending (retryable) but remember why the last attempt failed. */
+  async recordError(id: string, error: string): Promise<void> {
+    try {
+      await executeQuery(
+        `UPDATE esms_onchain_claims
+         SET error = $2, updated_at = now()
+         WHERE id = $1`,
+        [id, error.slice(0, 1000)],
+      );
+    } catch (err) {
+      console.error("[esmsOnchainClaimService] recordError failed:", err);
+    }
+  },
+
+  /** Close a claim whose debit was re-credited (only for never-mined claims). */
+  async markRefunded(id: string, error: string): Promise<void> {
+    try {
+      await executeQuery(
+        `UPDATE esms_onchain_claims
+         SET status = 'refunded', error = $2, updated_at = now()
+         WHERE id = $1 AND status = 'pending'`,
+        [id, error.slice(0, 1000)],
+      );
+    } catch (err) {
+      console.error("[esmsOnchainClaimService] markRefunded failed:", err);
+    }
+  },
+};

--- a/src/types/economy.ts
+++ b/src/types/economy.ts
@@ -69,7 +69,21 @@ export type TransactionSourceType =
    * Makes the off-chain spend exactly-once per content hash. Idempotency key
    * shape: `mint_refund:<contentHash>`. See src/app/api/recipes/mint/route.ts.
    */
-  | "mint_refund";
+  | "mint_refund"
+  /**
+   * Debit that moves a snapshot of the user's off-chain balance on-chain: the
+   * four coins are debited atomically and EsmsToken.claimMint mints the same
+   * amounts (18-dp scaled) to the user's linked wallet. source_id is the
+   * esms_onchain_claims row id; idempotency key shape: `onchain_claim:<claimRowId>`.
+   * See src/app/api/economy/claim-onchain/route.ts.
+   */
+  | "onchain_claim"
+  /**
+   * Re-credit of an `onchain_claim` debit when the claim could not be minted
+   * and was verified never-claimed on-chain. Idempotency key shape:
+   * `onchain_claim_refund:<claimRowId>`.
+   */
+  | "onchain_claim_refund";
 
 // ─── Token Balances ────────────────────────────────────────────────────
 
@@ -143,6 +157,11 @@ export interface DailyYieldResult {
   };
   newBalances: TokenBalances;
   streakCount: number;
+  /** Set when this claim crossed a streak milestone and its bonus was granted. */
+  milestoneBonus?: {
+    days: number;
+    totalTokens: number;
+  };
 }
 
 // ─── Streaks ───────────────────────────────────────────────────────────
@@ -257,6 +276,28 @@ export function getStreakMultiplier(streakCount: number): number {
 
 /** Bonus scale factor for transit ESMS deltas */
 export const TRANSIT_BONUS_SCALE = 2.0;
+
+// ─── Streak Milestone Bonuses ────────────────────────────────────────────
+
+/**
+ * One-shot bonus (total ESMS, split evenly across the four coins) granted the
+ * day a claim streak reaches each milestone — the `streak_bonus` ledger source.
+ * Rebuilding a broken streak re-earns the milestone (it can't double-fire on
+ * the same day thanks to the day-scoped idempotency key).
+ */
+export const STREAK_MILESTONE_BONUSES: ReadonlyArray<{ days: number; totalTokens: number }> = [
+  { days: 7, totalTokens: 10 },
+  { days: 14, totalTokens: 16 },
+  { days: 30, totalTokens: 40 },
+  { days: 60, totalTokens: 80 },
+  { days: 100, totalTokens: 150 },
+  { days: 365, totalTokens: 500 },
+];
+
+/** The milestone hit exactly at `streakCount`, if any. */
+export function getStreakMilestone(streakCount: number): { days: number; totalTokens: number } | null {
+  return STREAK_MILESTONE_BONUSES.find((m) => m.days === streakCount) ?? null;
+}
 
 // ─── Holdings-Scaled Yield ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Why

The on-chain economy was deployed but disconnected: `mintEsmsClaim` had **zero callers**, so no user could ever move earned ESMS on-chain — and the shop's on-chain burn dead-ended on empty wallet balances with an error telling users to "claim ESMS to chain" via a flow that didn't exist. This PR completes the loop: **earn off-chain → claim to wallet → burn to buy**.

## What

### Claim bridge (the missing keystone)
- `GET/POST /api/economy/claim-onchain` — atomically debits the user's full off-chain balance (new `TokenEconomyService.debitAllTokens`, single-statement CTE, per-axis idempotency keys) and mints it to their linked Privy wallet via `EsmsToken.claimMint`. Backend-sponsored: users pay no gas and sign nothing.
- `esms_onchain_claims` bridge ledger (migration 56, **already applied to the canonical DB**). The bytes32 `claim_id` is contract-unique, so any interrupted claim reconciles against `claimed()` — retries never double-mint, and a mint that may have broadcast is never blind-refunded.
- **OnchainEsmsPanel** on `/account`: site vs wallet balances, one-click claim, pending-claim settlement, history with Basescan links.

### Bazaar storefront
- New `/shop` page (PrivyProvider-scoped like `/account`): browse the catalog with owned/affordable states, sign the EIP-712 `RedeemAuthorization` with the embedded wallet (`eth_signTypedData_v4`), settle through the sponsored `redeemFor` burn.
- Purchase route now **verifies the burn receipt** ({Redeemed} event) before granting — a reverted burn no longer unlocks the item.

### Tokenomics integrity
- Quest claims: atomic `claimed_at` stamp (RETURNING guard), stamp released if the credit fails (was permanently burning rewards), period-scoped idempotency.
- Swap: refunds the debit when the credit fails (was destroying coins and reporting success).
- Master's Pantry: per-ingredient-per-day idempotency + 5/day cap (was farmable at ~120 Matter/min).
- Streak milestone bonuses (7/14/30/60/100/365d) — wires the defined-but-unused `streak_bonus` source.
- Transactions clamp raised to the 100 the trends chart requests; "Premium Premium" copy fixed.

### Chain-layer hardening
- `minterConfigured()` gate + Privy-null guards (no crash when wallet id is set but `PRIVY_APP_SECRET` is empty).
- Recipe-NFT mint writes use the configured RPC URL (was pinned to the default public RPC).
- `/account` + `/shop` Privy chain config follows `NEXT_PUBLIC_ESMS_CHAIN` (was hardcoded to Base mainnet while contracts live on Sepolia); Fund Wallet hidden on testnet.
- Home ledger showcase now shows the **real** RecipeRegistry address, rights anchor, and chain — replacing fabricated mock values (`0x47b92B08…`, Token #1002, fake block).

## Verification (live, Base Sepolia)

- ✅ Real end-to-end claim: 41.35 ESMS minted to `0xFf84…814f` — [tx 0x72b94fcf…](https://sepolia.basescan.org/tx/0x72b94fcfd6eb567d9b19f501e3c3560fc2edfb617d078fa6d0903a18fe8b6dd7); off-chain ledger zeroed, on-chain `balanceOfBatch` matches exactly, claim history shows `minted`.
- ✅ Purchase challenge returns the correct EIP-712 payload (domain chainId 84532, real contract, deterministic orderId).
- ✅ Master's Pantry: replay blocked, 6th credit of the day → `daily_cap`.
- ✅ Contracts + roles verified on-chain: ESMS proxy, RecipeRegistry, RightsRegistry deployed; operator holds MINTER_ROLE + BURNER_ROLE and is authorized on the rights anchor.
- ✅ typecheck, lint, jest (privy route, token economy suites), production build all green.

## Deploy notes

Vercel prod needs the chain env vars (currently absent — `esmsOnchainConfigured()` is false in prod): `ESMS_CONTRACT_ADDRESS`, `NEXT_PUBLIC_ESMS_CHAIN`, `MINTER_PRIVATE_KEY`, `REDEEMER_PRIVATE_KEY`, `RECIPE_MINTER_PRIVATE_KEY`, `NEXT_PUBLIC_RECIPE_*`, `NEXT_PUBLIC_ALCHM_RIGHTS_ID`, `NEXT_PUBLIC_ALCHM_LICENSE_URI`. Migration 56 is already applied to the canonical Railway DB.

⚠️ Testnet keys only — the operator key was previously flagged as leaked; fresh KMS keys + Safe admin required before any mainnet flip (tracked in project memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)