### PR TITLE
feat(economy): invisible practice rewards — natural actions quietly earn ESMS

### DIFF
--- a/database/init/57-practice-events.sql
+++ b/database/init/57-practice-events.sql
@@ -1,0 +1,33 @@
+-- ==========================================
+-- INVISIBLE PRACTICE REWARDS
+-- Migration 57: the ledger of "practices" — natural product actions (cooking a
+-- recipe, acting on a recommendation, visiting the feed, discovering a surface)
+-- that earn small ESMS rewards invisibly. No quest UI reads this; it exists for
+-- dedupe, the delight toast, personalization signal, and the (PR2) celestial
+-- budget + composite dashboard.
+-- Created: July 2026
+-- ==========================================
+
+CREATE TABLE IF NOT EXISTS practice_events (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    practice_type VARCHAR(40) NOT NULL,      -- cooked_recipe | recommendation_acted | ...
+    -- Dedupe scope key: '<target>:<YYYY-MM-DD>' for daily practices,
+    -- '<target>' for once-ever practices. The unique constraint IS the dedupe.
+    dedupe_key VARCHAR(255) NOT NULL,
+    target_id VARCHAR(255),                  -- recipe id, surface key, feed event id…
+    token_type VARCHAR(20) NOT NULL CHECK (token_type IN ('Spirit', 'Essence', 'Matter', 'Substance')),
+    -- amount 0 = the act was recorded (signal still counts) but the day's cap
+    -- was already reached, so no credit was issued.
+    amount DECIMAL(12, 4) NOT NULL DEFAULT 0,
+    hint TEXT,                               -- the causal line shown in the delight toast
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uniq_practice_dedupe UNIQUE (user_id, practice_type, dedupe_key)
+);
+
+COMMENT ON TABLE practice_events IS 'Invisible-reward ledger: one row per recognized natural action. Rewards credit token_transactions with source_type=practice_reward; amount 0 rows are capped-but-recorded signal.';
+
+CREATE INDEX IF NOT EXISTS idx_practice_events_user_day
+    ON practice_events (user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_practice_events_type_day
+    ON practice_events (practice_type, created_at DESC);

--- a/src/app/(alchm)/feed/page.tsx
+++ b/src/app/(alchm)/feed/page.tsx
@@ -12,6 +12,7 @@ import React, {
 } from "react";
 import { HistoricalAgentFeedCard } from "@/components/feed/HistoricalAgentFeedItems";
 import { useLiveFeedEvents } from "@/hooks/useLiveFeedEvents";
+import { firePractice } from "@/lib/economy/practiceClient";
 import { narrateFeedEvent } from "@/lib/feed/eventNarration";
 import type { HistoricalAgentFeedItem } from "@/lib/feed/historicalAgentFeed";
 import { fetchHistoricalAgentFeed } from "@/lib/feed/historicalAgentFeedSource";
@@ -248,6 +249,12 @@ export default function FeedPage() {
       requestInFlight.current = false;
       setIsRefreshing(false);
     }
+  }, []);
+
+  // Joining the commons quietly counts (invisible practice, dedupes daily
+  // server-side; silent no-op for signed-out visitors).
+  useEffect(() => {
+    firePractice("feed_visit");
   }, []);
 
   // The 30s HTTP poll stays in place: it covers agents/transactions/swap

--- a/src/app/api/economy/practice/route.ts
+++ b/src/app/api/economy/practice/route.ts
@@ -1,0 +1,80 @@
+/**
+ * POST /api/economy/practice — the invisible reward engine's single door.
+ *
+ * The client reports a natural action ({ type, targetId? }); the server
+ * decides whether it's new (dedupe), whether it still pays today (cap), and
+ * credits the coin. Responses are deliberately quiet: non-rewarding outcomes
+ * are 200s with { rewarded: false } so the UI never surfaces an error for an
+ * act that simply didn't pay — invisibility cuts both ways.
+ *
+ * GET /api/economy/practice — bootstrap payload for the client layer: which
+ * surfaces this user has already discovered (so first-visit events aren't
+ * re-fired every page load).
+ *
+ * Client-asserted events are the repo's accepted quest philosophy (tokens are
+ * the throttle); exposure is bounded by per-act dedupe + daily caps
+ * (~15 ESMS/day ceiling across all practices) + the rate limit here.
+ */
+
+import { NextResponse } from "next/server";
+import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
+import { SERVER_ONLY_PRACTICES, type PracticeType } from "@/lib/economy/practices";
+import { rateLimit } from "@/lib/rateLimit";
+import { practiceRewardService } from "@/services/practiceRewardService";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  const user = await getDatabaseUserFromRequest(request);
+  if (!user) {
+    return NextResponse.json({ success: false, message: "Authentication required" }, { status: 401 });
+  }
+  const discovered = await practiceRewardService.discoveredSurfaces(user.id);
+  return NextResponse.json({ success: true, discoveredSurfaces: discovered });
+}
+
+export async function POST(request: NextRequest) {
+  const user = await getDatabaseUserFromRequest(request);
+  if (!user) {
+    return NextResponse.json({ success: false, message: "Authentication required" }, { status: 401 });
+  }
+
+  const rl = await rateLimit(request, {
+    window: 60_000,
+    max: 30,
+    bucket: "economy-practice",
+    identifier: user.id,
+  });
+  if (!rl.allowed) return rl.response!;
+
+  let body: { type?: unknown; targetId?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ success: false, message: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const type = typeof body.type === "string" ? body.type : "";
+  // Transition-gated practices (cooked-it, photos) are recognized by the
+  // routes that observe the real data change — never by a bare client POST.
+  if (SERVER_ONLY_PRACTICES.has(type as PracticeType)) {
+    return NextResponse.json({ success: false, rewarded: false, reason: "invalid" }, { status: 400 });
+  }
+  const result = await practiceRewardService.recognize(user.id, type, body.targetId);
+
+  if (result.reason === "invalid") {
+    return NextResponse.json({ success: false, rewarded: false, reason: "invalid" }, { status: 400 });
+  }
+
+  return NextResponse.json({
+    success: true,
+    rewarded: result.rewarded,
+    reason: result.reason,
+    tokenType: result.tokenType,
+    amount: result.amount,
+    hint: result.hint,
+    balances: result.balances ?? undefined,
+  });
+}

--- a/src/app/api/users/me/recipes/[recipeId]/route.ts
+++ b/src/app/api/users/me/recipes/[recipeId]/route.ts
@@ -6,8 +6,10 @@
  */
 
 import { NextResponse } from "next/server";
-import { auth } from "@/lib/auth/auth";
+import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
 import { executeQuery } from "@/lib/database/connection";
+import { practiceRewardService } from "@/services/practiceRewardService";
+import { reportQuestEventBestEffort } from "@/services/questEventReporter";
 import type { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
@@ -33,12 +35,11 @@ async function getAggregateMadeCount(recipeId: string): Promise<number> {
 }
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ recipeId: string }> },
 ) {
   const { recipeId } = await params;
-  const session = await auth();
-  const userId = session?.user?.id;
+  const userId = await getUserIdFromRequest(request);
 
   try {
     let resolvedId = recipeId;
@@ -100,8 +101,7 @@ export async function POST(
   { params }: { params: Promise<{ recipeId: string }> },
 ) {
   const { recipeId } = await params;
-  const session = await auth();
-  const userId = session?.user?.id;
+  const userId = await getUserIdFromRequest(request);
   if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -120,24 +120,55 @@ export async function POST(
     typeof body.review === "string" ? body.review.slice(0, 500) : "";
 
   try {
-    await executeQuery(
-      `INSERT INTO user_recipe_interactions (user_id, recipe_id, made_it, rating, review)
+    // Mirror GET's slug→UUID resolution so the same recipe can't produce two
+    // interaction rows (and two cook rewards) under its slug and its id.
+    let resolvedId = recipeId;
+    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(recipeId);
+    if (!isUuid) {
+      const { LocalRecipeService } = await import("@/services/LocalRecipeService");
+      const recipe = await LocalRecipeService.getRecipeById(recipeId);
+      if (recipe?.id) resolvedId = String(recipe.id);
+    }
+    // Capture the PRIOR made_it in the same statement: the false→true
+    // transition is what counts as "cooked it" for the invisible reward
+    // (toggling off and back on can't re-pay — the practice ledger dedupes
+    // per day on top of this).
+    const upsert = await executeQuery<{ prior_made_it: boolean | null }>(
+      `WITH prior AS (
+         SELECT made_it FROM user_recipe_interactions
+         WHERE user_id = $1 AND recipe_id = $2
+       )
+       INSERT INTO user_recipe_interactions (user_id, recipe_id, made_it, rating, review)
        VALUES ($1, $2, $3, $4, $5)
        ON CONFLICT (user_id, recipe_id) DO UPDATE SET
          made_it = EXCLUDED.made_it,
          rating = EXCLUDED.rating,
          review = EXCLUDED.review,
-         updated_at = CURRENT_TIMESTAMP`,
-      [userId, recipeId, madeIt, rating || null, review || null],
+         updated_at = CURRENT_TIMESTAMP
+       RETURNING (SELECT made_it FROM prior) AS prior_made_it`,
+      [userId, resolvedId, madeIt, rating || null, review || null],
     );
 
-    const madeCount = await getAggregateMadeCount(recipeId);
+    // Invisible practice: a genuine new "I made this" quietly earns Matter.
+    // Best-effort — the interaction save never fails because of the reward.
+    let reward: { tokenType: string; amount: number; hint: string } | null = null;
+    const priorMadeIt = upsert.rows[0]?.prior_made_it === true;
+    if (madeIt && !priorMadeIt) {
+      reportQuestEventBestEffort(userId, "cook_recipe");
+      const result = await practiceRewardService.recognize(userId, "cooked_recipe", resolvedId);
+      if (result.rewarded && result.tokenType && result.amount && result.hint) {
+        reward = { tokenType: result.tokenType, amount: result.amount, hint: result.hint };
+      }
+    }
+
+    const madeCount = await getAggregateMadeCount(resolvedId);
     return NextResponse.json({
       authenticated: true,
       madeIt,
       rating,
       review,
       madeCount,
+      reward,
     });
   } catch (error) {
     console.error("[POST /api/users/me/recipes/:id]", error);
@@ -149,12 +180,11 @@ export async function POST(
 }
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ recipeId: string }> },
 ) {
   const { recipeId } = await params;
-  const session = await auth();
-  const userId = session?.user?.id;
+  const userId = await getUserIdFromRequest(request);
   if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,6 +2,7 @@
 
 import { SessionProvider } from "next-auth/react";
 import React from "react";
+import { PracticeDelightHost } from "@/components/economy/PracticeDelightHost";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { MasterQuestBroadcastListener } from "@/components/MasterQuestBroadcastListener";
 import { ToastProvider } from "@/components/ToastProvider";
@@ -33,6 +34,8 @@ export default function Providers({ children }: { children: React.ReactNode }) {
                       <SpacetimeProvider>
                         <GroceryCartProvider>
                           <MasterQuestBroadcastListener />
+                          {/* Invisible-reward reveals: toast + token rain */}
+                          <PracticeDelightHost />
                           {children}
                         </GroceryCartProvider>
                       </SpacetimeProvider>

--- a/src/components/RestaurantDiscovery/BestMatchExplorer.tsx
+++ b/src/components/RestaurantDiscovery/BestMatchExplorer.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/RestaurantDiscovery/restaurantDisplay";
 import { useToast } from "@/components/ToastProvider";
 import { useUser } from "@/contexts/UserContext";
+import { firePractice } from "@/lib/economy/practiceClient";
 import {
   useUserLocation,
   type CitySuggestion,
@@ -638,8 +639,14 @@ export function BestMatchExplorer({
             source={source}
             cuisine={cuisine}
             saved={savedIds.has(hero.business.id)}
-            onReserve={() => setReservingItem(hero)}
-            onSave={() => void saveRestaurant(hero, source)}
+            onReserve={() => {
+              firePractice("recommendation_acted", `restaurant:${hero.business.id}`);
+              setReservingItem(hero);
+            }}
+            onSave={() => {
+              firePractice("recommendation_acted", `restaurant:${hero.business.id}`);
+              void saveRestaurant(hero, source);
+            }}
             onLog={() => setLoggingItem(hero)}
           />
 
@@ -661,8 +668,14 @@ export function BestMatchExplorer({
                     entry={entry}
                     source={source}
                     saved={savedIds.has(entry.business.id)}
-                    onReserve={() => setReservingItem(entry)}
-                    onSave={() => void saveRestaurant(entry, source)}
+                    onReserve={() => {
+                      firePractice("recommendation_acted", `restaurant:${entry.business.id}`);
+                      setReservingItem(entry);
+                    }}
+                    onSave={() => {
+                      firePractice("recommendation_acted", `restaurant:${entry.business.id}`);
+                      void saveRestaurant(entry, source);
+                    }}
                     onLog={() => setLoggingItem(entry)}
                   />
                 ))}

--- a/src/components/economy/PracticeDelightHost.tsx
+++ b/src/components/economy/PracticeDelightHost.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+/**
+ * The delight host — the only place invisible practice rewards become visible.
+ *
+ * Globally mounted (providers tree, like MasterQuestBroadcastListener). Listens
+ * for PRACTICE_REWARD_EVENT from anywhere (firePractice results, server-granted
+ * cooked-it rewards) and reveals the moment: a warm toast with the causal hint,
+ * a token-rain splash in the reward's coin, and a site-wide balance refresh via
+ * the existing tokenEconomy event bus. No other UI acknowledges practices exist.
+ */
+
+import { usePathname } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import { TokenRainParticles } from "@/components/economy/TokenRainParticles";
+import { useToast } from "@/components/ToastProvider";
+import { emitTokenEconomyUpdate } from "@/hooks/useTokenEconomy";
+import {
+  PRACTICE_REWARD_EVENT,
+  discoverSurface,
+  type PracticeReward,
+} from "@/lib/economy/practiceClient";
+import { DISCOVERABLE_SURFACES } from "@/lib/economy/practices";
+import type { TokenType } from "@/types/economy";
+
+const COIN_SYMBOLS: Record<string, string> = {
+  Spirit: "🝇",
+  Essence: "🝑",
+  Matter: "🝙",
+  Substance: "🝉",
+};
+
+const TOKEN_TYPES = new Set(["Spirit", "Essence", "Matter", "Substance"]);
+
+function formatAmount(n: number): string {
+  return Number.isInteger(n) ? String(n) : n.toFixed(1);
+}
+
+export function PracticeDelightHost(): JSX.Element {
+  const { showToast } = useToast();
+  const [splash, setSplash] = useState(false);
+  const [splashCoin, setSplashCoin] = useState<TokenType[]>(["Spirit"]);
+  // Rewards can arrive faster than the 2.4s rain — queue so each gets its moment.
+  const queue = useRef<PracticeReward[]>([]);
+  const playing = useRef(false);
+
+  const playNext = useCallback(() => {
+    const reward = queue.current.shift();
+    if (!reward) {
+      playing.current = false;
+      return;
+    }
+    playing.current = true;
+
+    const symbol = COIN_SYMBOLS[reward.tokenType] ?? "✨";
+    showToast(`+${formatAmount(reward.amount)} ${symbol} — ${reward.hint}`, "success", {
+      duration: 4200,
+    });
+    if (TOKEN_TYPES.has(reward.tokenType)) {
+      setSplashCoin([reward.tokenType as TokenType]);
+      setSplash(true);
+    }
+    const coinKey = reward.tokenType.toLowerCase() as Lowercase<TokenType>;
+    emitTokenEconomyUpdate({ source: "quest", credits: { [coinKey]: reward.amount } });
+  }, [showToast]);
+
+  useEffect(() => {
+    const onReward = (e: Event) => {
+      const detail = (e as CustomEvent<PracticeReward>).detail;
+      if (!detail || typeof detail.amount !== "number" || detail.amount <= 0) return;
+      queue.current.push(detail);
+      if (!playing.current) playNext();
+    };
+    window.addEventListener(PRACTICE_REWARD_EVENT, onReward);
+    return () => window.removeEventListener(PRACTICE_REWARD_EVENT, onReward);
+  }, [playNext]);
+
+  // Exploration firsts: the first-ever visit to each major surface quietly
+  // pays once. One pathname watcher here covers every route — no per-page
+  // wiring, nothing rendered.
+  const pathname = usePathname();
+  const { status } = useSession();
+  useEffect(() => {
+    if (status !== "authenticated" || !pathname) return;
+    const segment = pathname.split("/").filter(Boolean)[0];
+    if (segment && DISCOVERABLE_SURFACES.has(segment)) {
+      discoverSurface(segment);
+    }
+  }, [pathname, status]);
+
+  return (
+    <TokenRainParticles
+      trigger={splash}
+      tokenTypes={splashCoin}
+      count={14}
+      onComplete={() => {
+        setSplash(false);
+        // Small gap so back-to-back rains read as distinct moments.
+        setTimeout(playNext, 250);
+      }}
+    />
+  );
+}

--- a/src/components/home/CuisineCard.tsx
+++ b/src/components/home/CuisineCard.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import React, { useState } from "react";
 import { getCuisineProfile } from "@/data/cuisineFlavorProfiles";
+import { firePractice } from "@/lib/economy/practiceClient";
 import { getCuisineByDisplayName } from "@/utils/cuisineSlug";
 
 type OnDoubleClickCuisine = (cuisineName: string) => void;
@@ -158,6 +159,9 @@ export function CuisineCard({
   const cuisineSlug = encodeURIComponent(cuisine.cuisine.toLowerCase());
   const cookHref = `/recipes?cuisine=${cuisineSlug}`;
   const orderHref = `/restaurants?cuisine=${cuisineSlug}`;
+  // Following the sky's suggestion quietly counts (invisible practice; deduped
+  // per cuisine per day server-side, silent for signed-out visitors).
+  const acted = () => firePractice("recommendation_acted", `cuisine:${cuisine.cuisine}`);
   const imageUrl = cuisine.imageUrl ?? getCuisineByDisplayName(cuisine.cuisine)?.meta.imageUrl;
 
   const icon = PLANET_ICONS[cuisine.planet] || "☉";
@@ -178,6 +182,7 @@ export function CuisineCard({
         onClick={(e) => {
           if (onSelectCuisine) {
             e.preventDefault();
+            acted();
             onSelectCuisine(cuisine.cuisine);
           }
         }}
@@ -294,6 +299,7 @@ export function CuisineCard({
           role="link"
           tabIndex={0}
           onClick={() => {
+            acted();
             if (onSelectCuisine) {
               onSelectCuisine(cuisine.cuisine);
             } else {
@@ -302,6 +308,7 @@ export function CuisineCard({
           }}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
+              acted();
               if (onSelectCuisine) {
                 onSelectCuisine(cuisine.cuisine);
               } else {
@@ -422,6 +429,7 @@ export function CuisineCard({
         <div className="grid grid-cols-2 gap-2 px-5 pb-5 relative z-40">
           <Link
             href={cookHref}
+            onClick={acted}
             className="group/btn relative flex items-center justify-center gap-1.5 px-3 py-2.5 rounded-xl bg-gradient-to-br from-amber-500 to-orange-600 hover:from-amber-400 hover:to-orange-500 text-white text-[10px] font-black uppercase tracking-widest shadow-lg shadow-amber-900/30 border border-amber-400/40 transition-all"
             aria-label={`Cook ${cuisine.cuisine} at home`}
           >
@@ -430,7 +438,10 @@ export function CuisineCard({
           </Link>
           {onSelectCuisine ? (
             <button
-              onClick={() => onSelectCuisine(cuisine.cuisine)}
+              onClick={() => {
+                acted();
+                onSelectCuisine(cuisine.cuisine);
+              }}
               className="group/btn relative flex items-center justify-center gap-1.5 px-3 py-2.5 rounded-xl bg-gradient-to-br from-purple-500 to-pink-600 hover:from-purple-400 hover:to-pink-500 text-white text-[10px] font-black uppercase tracking-widest shadow-lg shadow-purple-900/30 border border-purple-400/40 transition-all"
               aria-label={`Find ${cuisine.cuisine} restaurants near me`}
             >
@@ -440,6 +451,7 @@ export function CuisineCard({
           ) : (
             <Link
               href={orderHref}
+              onClick={acted}
               className="group/btn relative flex items-center justify-center gap-1.5 px-3 py-2.5 rounded-xl bg-gradient-to-br from-purple-500 to-pink-600 hover:from-purple-400 hover:to-pink-500 text-white text-[10px] font-black uppercase tracking-widest shadow-lg shadow-purple-900/30 border border-purple-400/40 transition-all"
               aria-label={`Find ${cuisine.cuisine} restaurants near me`}
             >

--- a/src/components/recipes/SocialSection.tsx
+++ b/src/components/recipes/SocialSection.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { revealPracticeReward } from "@/lib/economy/practiceClient";
 
 const STORAGE_PREFIX = "alchm:recipe-social:v1:";
 
@@ -134,6 +135,11 @@ export function SocialSection({ recipeId }: Props) {
       if (!res.ok) throw new Error(`status ${res.status}`);
       const data = await res.json();
       if (typeof data.madeCount === "number") setMadeCount(data.madeCount);
+      // A genuine first "I made this" quietly earns — the server decides; we
+      // just hand the moment to the global delight host.
+      if (data.reward?.amount > 0) {
+        revealPracticeReward(data.reward);
+      }
     } catch (err) {
       console.warn("social save failed (cached locally):", err);
     } finally {

--- a/src/hooks/useTransitGroupChat.ts
+++ b/src/hooks/useTransitGroupChat.ts
@@ -17,6 +17,7 @@
 import { track } from "@vercel/analytics";
 import { useCallback, useState } from "react";
 import type { TransitParticipant, TransitDescriptor } from "@/lib/agents/transitAgents";
+import { firePractice } from "@/lib/economy/practiceClient";
 
 export function useTransitGroupChat() {
   const [pending, setPending] = useState(false);
@@ -53,6 +54,9 @@ export function useTransitGroupChat() {
         const data = (await res.json().catch(() => ({}))) as { url?: string };
 
         if (data.url) {
+          // Taking a seat under this transit quietly counts (invisible
+          // practice; once-ever per transit key, server-deduped).
+          firePractice("chat_joined", descriptor.key);
           if (tab) {
             try {
               tab.opener = null;

--- a/src/lib/economy/practiceClient.ts
+++ b/src/lib/economy/practiceClient.ts
@@ -1,0 +1,100 @@
+/**
+ * Client half of the invisible reward layer.
+ *
+ * Surfaces never render reward UI of their own — they either (a) call
+ * firePractice() for client-observed acts (visiting the feed, discovering a
+ * surface, acting on a recommendation) or (b) receive a `reward` object from a
+ * server route that recognized the act itself (cooked-it) and hand it to
+ * revealPracticeReward(). Either way the globally-mounted PracticeDelightHost
+ * does the revealing: toast + token rain + balance-bar refresh.
+ *
+ * Everything here is fire-and-forget and silent on failure: an act that
+ * doesn't pay must never surface an error — invisibility cuts both ways.
+ */
+
+export const PRACTICE_REWARD_EVENT = "practice:reward";
+
+export interface PracticeReward {
+  tokenType: string;
+  amount: number;
+  hint: string;
+}
+
+/** Hand a server-granted reward to the delight host. */
+export function revealPracticeReward(reward: PracticeReward): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(PRACTICE_REWARD_EVENT, { detail: reward }));
+}
+
+// Session-scoped dedupe so repeat client events don't even hit the network;
+// the server's practice ledger stays the authority.
+const firedThisSession = new Set<string>();
+
+// After a 401 (signed-out visitor) stop posting for the rest of the page
+// session — anon acts can't earn, so the traffic is pure waste.
+let anonDisabled = false;
+
+/** Report a client-observed act. Silent, deduped, never throws. */
+export function firePractice(type: string, targetId?: string): void {
+  if (typeof window === "undefined" || anonDisabled) return;
+  const key = `${type}:${targetId ?? "-"}`;
+  if (firedThisSession.has(key)) return;
+  firedThisSession.add(key);
+
+  void fetch("/api/economy/practice", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ type, targetId }),
+  })
+    .then(async (res) => {
+      if (res.status === 401) {
+        anonDisabled = true;
+        return;
+      }
+      if (!res.ok) return;
+      const json = (await res.json()) as {
+        rewarded?: boolean;
+        tokenType?: string;
+        amount?: number;
+        hint?: string;
+      };
+      if (json.rewarded && json.tokenType && json.amount && json.hint) {
+        revealPracticeReward({ tokenType: json.tokenType, amount: json.amount, hint: json.hint });
+      }
+    })
+    .catch(() => {
+      /* invisible — a missed reward is not an error */
+    });
+}
+
+const DISCOVERED_CACHE_KEY = "alchm:practice:discovered";
+
+function discoveredCache(): Set<string> {
+  try {
+    const raw = window.localStorage.getItem(DISCOVERED_CACHE_KEY);
+    return new Set(raw ? (JSON.parse(raw) as string[]) : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function rememberDiscovered(surface: string): void {
+  try {
+    const cache = discoveredCache();
+    cache.add(surface);
+    window.localStorage.setItem(DISCOVERED_CACHE_KEY, JSON.stringify([...cache]));
+  } catch {
+    /* private mode etc. — the server dedupes authoritatively */
+  }
+}
+
+/**
+ * First-ever visit to a surface quietly pays once. localStorage keeps repeat
+ * visits off the network; the server's once-ever dedupe is the real gate.
+ */
+export function discoverSurface(surface: string): void {
+  if (typeof window === "undefined") return;
+  if (discoveredCache().has(surface)) return;
+  rememberDiscovered(surface);
+  firePractice("surface_discovered", surface);
+}

--- a/src/lib/economy/practices.ts
+++ b/src/lib/economy/practices.ts
@@ -1,0 +1,177 @@
+/**
+ * The practice catalog — the invisible reward layer's rulebook.
+ *
+ * A "practice" is a natural product action that quietly earns ESMS: no quest
+ * UI advertises it; the reward reveals itself as a delight toast the moment it
+ * happens. Each practice maps to ONE coin (the act's alchemical nature), has a
+ * dedupe scope (how often the same act can pay), a per-day rewarded cap, and a
+ * pool of causal hint lines for the toast.
+ *
+ * PR2 note: `baseAmount` is the flat testbed rate. The transit-modulated
+ * multiplier and per-user celestial budget slot in at
+ * practiceRewardService.computeReward() without touching this catalog.
+ */
+
+import type { TokenType } from "@/types/economy";
+
+export type PracticeType =
+  | "cooked_recipe"
+  | "photo_added"
+  | "recommendation_acted"
+  | "feed_visit"
+  | "feed_reaction"
+  | "chat_joined"
+  | "surface_discovered";
+
+export type DedupeScope = "daily" | "ever";
+
+export interface PracticeDefinition {
+  type: PracticeType;
+  /** The coin this act transmutes into (cooking = Matter, social = Spirit…). */
+  tokenType: TokenType;
+  baseAmount: number;
+  /** How often the same (user, target) can be rewarded. */
+  dedupe: DedupeScope;
+  /** Max rewarded events of this type per user per day (0-amount rows still record past the cap). */
+  dailyCap: number;
+  /** Whether a targetId is required to scope the dedupe key. */
+  requiresTarget: boolean;
+  /** Causal lines for the delight toast — rotated deterministically. */
+  hints: string[];
+}
+
+export const PRACTICES: Record<PracticeType, PracticeDefinition> = {
+  cooked_recipe: {
+    type: "cooked_recipe",
+    tokenType: "Matter",
+    baseAmount: 4,
+    dedupe: "daily",
+    dailyCap: 3,
+    requiresTarget: true,
+    hints: [
+      "The Work remembers what your hands made",
+      "Matter answers to a lit stove",
+      "A dish cooked is a spell completed",
+      "The kitchen is the true athanor",
+    ],
+  },
+  photo_added: {
+    type: "photo_added",
+    tokenType: "Matter",
+    baseAmount: 2,
+    dedupe: "ever",
+    dailyCap: 3,
+    requiresTarget: true,
+    hints: [
+      "Proof of the Work, sealed in light",
+      "The plate, witnessed",
+    ],
+  },
+  recommendation_acted: {
+    type: "recommendation_acted",
+    tokenType: "Essence",
+    baseAmount: 1,
+    dedupe: "daily",
+    dailyCap: 5,
+    requiresTarget: true,
+    hints: [
+      "You followed the current — Essence flows",
+      "The stars suggested; you listened",
+      "Alignment tastes better when acted on",
+    ],
+  },
+  feed_visit: {
+    type: "feed_visit",
+    tokenType: "Spirit",
+    baseAmount: 1,
+    dedupe: "daily",
+    dailyCap: 1,
+    requiresTarget: false,
+    hints: [
+      "You joined the commons under today's sky",
+      "Spirit gathers where alchemists meet",
+    ],
+  },
+  feed_reaction: {
+    type: "feed_reaction",
+    tokenType: "Spirit",
+    baseAmount: 0.5,
+    dedupe: "ever",
+    dailyCap: 3,
+    requiresTarget: true,
+    hints: [
+      "A spark passed between charts",
+      "Recognition is its own small ritual",
+    ],
+  },
+  chat_joined: {
+    type: "chat_joined",
+    tokenType: "Spirit",
+    baseAmount: 2,
+    dedupe: "ever",
+    dailyCap: 2,
+    requiresTarget: true,
+    hints: [
+      "You took a seat beneath the transit",
+      "The table under this sky welcomes you",
+    ],
+  },
+  surface_discovered: {
+    type: "surface_discovered",
+    tokenType: "Substance",
+    baseAmount: 2,
+    dedupe: "ever",
+    dailyCap: 4,
+    requiresTarget: true,
+    hints: [
+      "A new chamber of the kitchen, unlocked",
+      "Substance rewards the explorer",
+      "The map grows as you walk it",
+    ],
+  },
+};
+
+/**
+ * Practices that only SERVER code may recognize (via practiceRewardService
+ * directly) — they hinge on a real data transition the server observes (e.g.
+ * made_it flipping false→true). The public /api/economy/practice door rejects
+ * them so a bare POST can't fake a cooked dish.
+ */
+export const SERVER_ONLY_PRACTICES: ReadonlySet<PracticeType> = new Set([
+  "cooked_recipe",
+  "photo_added",
+]);
+
+/**
+ * Surfaces eligible for the once-ever discovery reward, keyed by the route's
+ * first path segment (an allowlist so a client can't invent infinite
+ * "surfaces"). Keep in sync with src/app's navigable top-level routes.
+ */
+export const DISCOVERABLE_SURFACES = new Set([
+  "cuisines",
+  "restaurants",
+  "cosmic-recipe",
+  "recipe-builder",
+  "lab",
+  "lab-book",
+  "sauces",
+  "cooking-methods",
+  "planetary-chart",
+  "feed",
+  "shop",
+  "account",
+  "quantities",
+  "menu-planner",
+  "ingredients",
+  "commensal",
+  "pantry",
+  "birth-chart",
+]);
+
+/** Deterministic hint rotation — stable per (user, day) so retries repeat the line. */
+export function pickHint(def: PracticeDefinition, userId: string, dayKey: string): string {
+  let h = 0;
+  const s = `${userId}:${def.type}:${dayKey}`;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return def.hints[h % def.hints.length];
+}

--- a/src/services/practiceRewardService.ts
+++ b/src/services/practiceRewardService.ts
@@ -1,0 +1,149 @@
+/**
+ * Invisible practice rewards — recognize a natural product action, dedupe it,
+ * credit the coin, and hand back the delight line.
+ *
+ * Flow per event: validate against the catalog → INSERT the practice_events
+ * row (the unique constraint IS the dedupe — a duplicate act is a silent
+ * no-op) → count today's rewarded rows against the daily cap (past the cap the
+ * act still records with amount 0, keeping the personalization signal) →
+ * credit token_transactions (source_type 'practice_reward', idempotency key
+ * mirroring the dedupe key so ledger and practice ledger can never disagree).
+ *
+ * PR2 slots transit modulation + the per-user celestial budget into
+ * computeReward() — everything else stays put.
+ */
+
+import { executeQuery } from "@/lib/database";
+import {
+  DISCOVERABLE_SURFACES,
+  PRACTICES,
+  pickHint,
+  type PracticeDefinition,
+  type PracticeType,
+} from "@/lib/economy/practices";
+import { tokenEconomy } from "@/services/TokenEconomyService";
+import type { TokenBalances } from "@/types/economy";
+
+export interface PracticeResult {
+  rewarded: boolean;
+  /** 'already' = dedupe hit; 'capped' = recorded but past today's cap; 'invalid' = bad input. */
+  reason?: "already" | "capped" | "invalid" | "error";
+  tokenType?: string;
+  amount?: number;
+  hint?: string;
+  balances?: TokenBalances | null;
+}
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** Normalize a client target into a bounded, index-friendly key segment. */
+function normalizeTarget(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const t = raw.trim().slice(0, 180);
+  return /^[\w:./-]+$/.test(t) ? t : null;
+}
+
+function dedupeKeyFor(def: PracticeDefinition, target: string | null): string {
+  const base = target ?? "-";
+  return def.dedupe === "daily" ? `${base}:${todayKey()}` : base;
+}
+
+/** Flat PR1 rate. PR2 replaces this with sky × chart modulation + budget. */
+function computeReward(def: PracticeDefinition): number {
+  return def.baseAmount;
+}
+
+export const practiceRewardService = {
+  async recognize(userId: string, type: string, rawTarget?: unknown): Promise<PracticeResult> {
+    const def = PRACTICES[type as PracticeType];
+    if (!def) return { rewarded: false, reason: "invalid" };
+
+    const target = normalizeTarget(rawTarget);
+    if (def.requiresTarget && !target) return { rewarded: false, reason: "invalid" };
+    if (def.type === "surface_discovered" && (!target || !DISCOVERABLE_SURFACES.has(target))) {
+      return { rewarded: false, reason: "invalid" };
+    }
+
+    const dedupeKey = dedupeKeyFor(def, target);
+    const day = todayKey();
+    const hint = pickHint(def, userId, day);
+
+    try {
+      // One statement decides everything: the insert only lands if this act is
+      // new (unique dedupe), and the amount is zero when today's rewarded rows
+      // already reached the cap — no separate read races the write.
+      const res = await executeQuery<{ amount: string }>(
+        `WITH todays AS (
+           SELECT COUNT(*) AS rewarded_today
+           FROM practice_events
+           WHERE user_id = $1 AND practice_type = $2
+             AND amount > 0 AND created_at >= $6::date
+         ),
+         ins AS (
+           INSERT INTO practice_events (user_id, practice_type, dedupe_key, target_id, token_type, amount, hint)
+           SELECT $1, $2, $3, $4, $5,
+                  CASE WHEN t.rewarded_today < $7 THEN $8::decimal ELSE 0 END,
+                  $9
+           FROM todays t
+           ON CONFLICT ON CONSTRAINT uniq_practice_dedupe DO NOTHING
+           RETURNING amount
+         )
+         SELECT amount FROM ins`,
+        [
+          userId,
+          def.type,
+          dedupeKey,
+          target,
+          def.tokenType,
+          day,
+          def.dailyCap,
+          computeReward(def),
+          hint,
+        ],
+      );
+
+      if (res.rows.length === 0) {
+        // Dedupe hit — this exact act already recognized. Stay silent.
+        return { rewarded: false, reason: "already" };
+      }
+
+      const amount = parseFloat(res.rows[0].amount) || 0;
+      if (amount <= 0) {
+        return { rewarded: false, reason: "capped" };
+      }
+
+      const balances = await tokenEconomy.creditTokens(
+        userId,
+        def.tokenType,
+        amount,
+        "practice_reward",
+        {
+          sourceId: def.type,
+          description: hint,
+          idempotencyKey: `practice:${userId}:${def.type}:${dedupeKey}`,
+        },
+      );
+
+      return { rewarded: true, tokenType: def.tokenType, amount, hint, balances };
+    } catch (err) {
+      console.error("[practiceRewardService] recognize failed:", err);
+      return { rewarded: false, reason: "error" };
+    }
+  },
+
+  /** The surfaces a user has already discovered (client seeds its local cache). */
+  async discoveredSurfaces(userId: string): Promise<string[]> {
+    try {
+      const res = await executeQuery<{ target_id: string }>(
+        `SELECT target_id FROM practice_events
+         WHERE user_id = $1 AND practice_type = 'surface_discovered'`,
+        [userId],
+      );
+      return res.rows.map((r) => r.target_id).filter(Boolean);
+    } catch {
+      return [];
+    }
+  },
+};

--- a/src/types/economy.ts
+++ b/src/types/economy.ts
@@ -83,7 +83,15 @@ export type TransactionSourceType =
    * and was verified never-claimed on-chain. Idempotency key shape:
    * `onchain_claim_refund:<claimRowId>`.
    */
-  | "onchain_claim_refund";
+  | "onchain_claim_refund"
+  /**
+   * Invisible practice reward — a natural product action (cooking a recipe,
+   * acting on a recommendation, feed presence, discovering a surface) that
+   * quietly pays. No quest UI advertises these; the delight toast reveals
+   * them. source_id is the practice type; idempotency key shape:
+   * `practice:<userId>:<type>:<dedupeKey>`. See src/lib/economy/practices.ts.
+   */
+  | "practice_reward";
 
 // ─── Token Balances ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## PR 1 of the invisible-economy chain

Per the program plan: **no quest UI anywhere** — users act naturally, and the reward reveals itself as a delight moment. This PR ships the engine, the highest-value capture (cooked-it), and the reveal layer. PR 2 adds transit-modulated amounts + the celestial budget + the grimoire; PR 3 adds social pull; PR 4 the Amazon ordering sink.

## What ships

### The engine
- **Practice catalog** — 7 natural actions mapped to their alchemical coin: cooking → 🝙 Matter, acting on recommendations → 🝑 Essence, feed/chat presence → 🝇 Spirit, first-ever surface discovery → 🝉 Substance. Each has a dedupe scope (daily / once-ever), a per-day rewarded cap, and rotating in-world hint lines.
- **`practice_events` ledger** (migration 57, already applied): the unique dedupe constraint IS the farm guard; acts past the daily cap still record with amount 0 so the personalization signal survives.
- **`practiceRewardService.recognize()`** — dedupe + cap + amount decided in a single SQL statement (no read/write race), credits via the existing token ledger (`practice_reward` source, mirrored idempotency keys).
- **`POST /api/economy/practice`** — rate-limited single door; non-rewarding outcomes are quiet 200s (invisibility cuts both ways); `SERVER_ONLY` guard rejects client-fired `cooked_recipe`/`photo_added`.

### Cooked-it (server-observed, not client-asserted)
The existing “I made this” button now quietly pays: the interaction route captures prior `made_it` in the upsert and only a **genuine false→true transition** rewards (+ fires the `cook_recipe` quest event for existing achievement arcs). Also fixes slug-vs-UUID double-row/double-reward and standardizes the route on `getUserIdFromRequest`.

### The reveal
**`PracticeDelightHost`** (global): queued delight moments — toast with the causal hint ("+4 🝙 — The kitchen is the true athanor") + token-rain splash in the reward's coin + site-wide balance refresh. Also hosts the pathname watcher paying first-ever surface discoveries against a route allowlist.

### Wired surfaces
SocialSection (cook rewards), feed page (daily presence), transit group-chat joins (once per transit), cuisine cards + restaurant Best Match (acted-on recommendations), every allowlisted route (discovery).

## Verified (live engine, real DB)
- ✅ First acts reward with hints; exact balance math (1🝇 + 5🝑 + 12🝙 + 2🝉 across the suite)
- ✅ Dedupe silence (same surface / same day / same transit), toggle-farm blocked, caps hold (cook 3/day, recs 5/day, 6th rec → capped)
- ✅ Allowlist + unknown-type rejection, anon → 401, client-fired cooked_recipe → rejected
- ✅ typecheck, lint, jest, production build green; all test rows + credits reverted

**Reviewer note:** the toast + token-rain reveal deserves one human click of “I made this” in preview — the moment is the product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)