### PR TITLE
feat(chain): hardening batch — reconcile cron, incident alerts, Privy server-wallet custody

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -482,3 +482,12 @@ NEXT_PUBLIC_SPACETIME_LIVE_COMMENSAL=  # live dinner-party lobby
 # Seed ETL (scripts/spacetime/seedCulinary.ts) connection target:
 SPACETIME_URI=ws://localhost:3000
 SPACETIME_MODULE=alchm-culinary
+
+# ── Privy server-wallet custody (chain operator, replaces raw keys) ─────────
+# Wallet ids from scripts/provision-privy-server-wallets.ts --apply
+PRIVY_MINTER_WALLET_ID=
+PRIVY_REDEEMER_WALLET_ID=
+# Required only if an authorization keypair is registered in the Privy Dashboard
+PRIVY_AUTHORIZATION_PRIVATE_KEY=
+# EsmsToken admin key — only needed by the provisioning script's role grants
+ESMS_ADMIN_PRIVATE_KEY=

--- a/scripts/provision-privy-server-wallets.ts
+++ b/scripts/provision-privy-server-wallets.ts
@@ -1,0 +1,163 @@
+/**
+ * Provision the Privy SERVER wallets that take over ESMS operator custody
+ * from the raw env keys (one of which leaked in chat — testnet-only, but the
+ * mainnet path requires no raw keys at all).
+ *
+ * Creates (idempotently, via fixed idempotency keys) two app-owned Ethereum
+ * server wallets — MINTER (claimMint) and REDEEMER (redeemFor) — then either
+ * grants MINTER_ROLE/BURNER_ROLE on the EsmsToken automatically (when
+ * ESMS_ADMIN_PRIVATE_KEY is provided) or prints the exact `cast` commands for
+ * whoever holds the admin key.
+ *
+ * The chain code already PREFERS these wallets: minter.ts/redeemer.ts try
+ * PRIVY_MINTER_WALLET_ID / PRIVY_REDEEMER_WALLET_ID before any raw key, so
+ * custody flips by setting the printed env vars — no deploy-time code change.
+ *
+ * SAFE BY DEFAULT: dry-run (creates nothing). Pass --apply to create wallets
+ * (and grant roles when the admin key is present).
+ *
+ * Requires: NEXT_PUBLIC_PRIVY_APP_ID, PRIVY_APP_SECRET
+ *           (+ PRIVY_AUTHORIZATION_PRIVATE_KEY if the app has an
+ *            authorization keypair registered in the Privy Dashboard).
+ * Optional: ESMS_CONTRACT_ADDRESS + ESMS_ADMIN_PRIVATE_KEY (+ BASE_SEPOLIA_RPC_URL)
+ *           to grant roles in the same run.
+ *
+ * Usage:
+ *   bun scripts/provision-privy-server-wallets.ts            # dry-run
+ *   bun scripts/provision-privy-server-wallets.ts --apply    # create + grant
+ *
+ * @file scripts/provision-privy-server-wallets.ts
+ */
+import { PrivyClient } from "@privy-io/server-auth";
+import { createWalletClient, createPublicClient, http, keccak256, toHex, type Address, type Hex } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { base, baseSepolia } from "viem/chains";
+
+const APPLY = process.argv.includes("--apply");
+
+const ROLE_ABI = [
+  {
+    type: "function",
+    name: "grantRole",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "role", type: "bytes32" },
+      { name: "account", type: "address" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "hasRole",
+    stateMutability: "view",
+    inputs: [
+      { name: "role", type: "bytes32" },
+      { name: "account", type: "address" },
+    ],
+    outputs: [{ type: "bool" }],
+  },
+] as const;
+
+async function main() {
+  const appId = process.env.NEXT_PUBLIC_PRIVY_APP_ID;
+  const appSecret = process.env.PRIVY_APP_SECRET;
+  if (!appId || !appSecret) {
+    console.error("NEXT_PUBLIC_PRIVY_APP_ID and PRIVY_APP_SECRET are required.");
+    process.exit(1);
+  }
+  const authKey = process.env.PRIVY_AUTHORIZATION_PRIVATE_KEY;
+  const privy = new PrivyClient(
+    appId,
+    appSecret,
+    authKey ? { walletApi: { authorizationPrivateKey: authKey } } : undefined,
+  );
+
+  console.log(`Mode: ${APPLY ? "APPLY" : "dry-run (pass --apply to create)"}\n`);
+
+  const wallets: Array<{ role: "MINTER" | "REDEEMER"; envVar: string; id?: string; address?: string }> = [
+    { role: "MINTER", envVar: "PRIVY_MINTER_WALLET_ID" },
+    { role: "REDEEMER", envVar: "PRIVY_REDEEMER_WALLET_ID" },
+  ];
+
+  for (const w of wallets) {
+    if (!APPLY) {
+      console.log(`[dry-run] would create app-owned ethereum server wallet for ${w.role}`);
+      continue;
+    }
+    // Fixed idempotency key per role: re-running never creates duplicates.
+    const res = await privy.walletApi.createWallet({
+      chainType: "ethereum",
+      idempotencyKey: `alchm-esms-${w.role.toLowerCase()}-v1`,
+    });
+    w.id = res.id;
+    w.address = res.address;
+    console.log(`${w.role} server wallet: id=${res.id} address=${res.address}`);
+  }
+
+  if (!APPLY) {
+    console.log("\nAfter --apply, set the printed ids in Vercel prod + .env.local, e.g.:");
+    console.log("  PRIVY_MINTER_WALLET_ID=<minter id>");
+    console.log("  PRIVY_REDEEMER_WALLET_ID=<redeemer id>");
+    return;
+  }
+
+  console.log("\nEnv to set (Vercel production + .env.local):");
+  for (const w of wallets) console.log(`  ${w.envVar}=${w.id}`);
+
+  // ── Role grants on EsmsToken ──────────────────────────────────────────────
+  const contract = process.env.ESMS_CONTRACT_ADDRESS as Address | undefined;
+  if (!contract) {
+    console.log("\nESMS_CONTRACT_ADDRESS unset — skipping role grants.");
+    return;
+  }
+  const MINTER_ROLE = keccak256(toHex("MINTER_ROLE"));
+  const BURNER_ROLE = keccak256(toHex("BURNER_ROLE"));
+  const grants: Array<{ role: Hex; label: string; account: Address }> = [
+    { role: MINTER_ROLE, label: "MINTER_ROLE", account: wallets[0].address as Address },
+    { role: BURNER_ROLE, label: "BURNER_ROLE", account: wallets[1].address as Address },
+  ];
+
+  const adminKey = process.env.ESMS_ADMIN_PRIVATE_KEY as Hex | undefined;
+  const chain = (process.env.NEXT_PUBLIC_ESMS_CHAIN || "base-sepolia") === "base" ? base : baseSepolia;
+  const rpc = chain.id === base.id ? process.env.BASE_RPC_URL : process.env.BASE_SEPOLIA_RPC_URL;
+
+  if (!adminKey) {
+    console.log("\nESMS_ADMIN_PRIVATE_KEY unset — run these as the contract admin:");
+    for (const g of grants) {
+      console.log(
+        `  cast send ${contract} "grantRole(bytes32,address)" ${g.role} ${g.account} --rpc-url ${rpc ?? chain.rpcUrls.default.http[0]} --private-key <ADMIN_KEY>`,
+      );
+    }
+    return;
+  }
+
+  const admin = privateKeyToAccount(adminKey);
+  const publicClient = createPublicClient({ chain, transport: http(rpc) });
+  const walletClient = createWalletClient({ account: admin, chain, transport: http(rpc) });
+  for (const g of grants) {
+    const has = await publicClient.readContract({
+      address: contract,
+      abi: ROLE_ABI,
+      functionName: "hasRole",
+      args: [g.role, g.account],
+    });
+    if (has) {
+      console.log(`${g.label} already granted to ${g.account}`);
+      continue;
+    }
+    const tx = await walletClient.writeContract({
+      address: contract,
+      abi: ROLE_ABI,
+      functionName: "grantRole",
+      args: [g.role, g.account],
+    });
+    console.log(`${g.label} → ${g.account} tx=${tx}`);
+    await publicClient.waitForTransactionReceipt({ hash: tx, timeout: 60_000 });
+  }
+  console.log("\nDone. Custody flips once the PRIVY_*_WALLET_ID env vars are deployed.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/cron/chain-reconcile/route.ts
+++ b/src/app/api/cron/chain-reconcile/route.ts
@@ -1,0 +1,118 @@
+/**
+ * GET /api/cron/chain-reconcile — hourly at :45 (vercel.json).
+ *
+ * Heals the seams between the Postgres ledgers and the Base contracts (see
+ * chainReconcileService): settles stuck ESMS claims, grants burned-but-lost
+ * one-time shop purchases, checks the per-wallet mint invariant, and mints
+ * recipe NFTs stranded in pending_chain. Problems dispatch through
+ * alertService (Slack + operator email + alert_events → admin dashboard),
+ * with distinct components so the 60-min cooldown never masks one problem
+ * class behind another.
+ */
+
+import { NextResponse } from "next/server";
+import { isAuthorizedCron } from "@/app/api/cron/_lib/cronAuth";
+import { _logger } from "@/lib/logger";
+import { dispatchAlert } from "@/services/alertService";
+import {
+  backfillPendingNfts,
+  checkWalletInvariants,
+  healBurnedPurchases,
+  settleStaleClaims,
+} from "@/services/chainReconcileService";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+export async function GET(request: NextRequest) {
+  if (!isAuthorizedCron(request)) {
+    return NextResponse.json({ success: false, message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    // Sequential on purpose: shared RPC + one signer wallet — parallel jobs
+    // would race nonces on the retry mints.
+    const claims = await settleStaleClaims(25);
+    const shop = await healBurnedPurchases(40);
+    const invariants = await checkWalletInvariants(20);
+    const nfts = await backfillPendingNfts(3);
+
+    const alerts: string[] = [];
+
+    if (claims.failures > 0) {
+      await dispatchAlert({
+        component: "chain-claims",
+        componentLabel: "ESMS claim settler",
+        previous: "OK",
+        current: "DEGRADED",
+        severity: "warn",
+        title: `${claims.failures} stuck ESMS claim(s) failed to settle`,
+        message: `Scanned ${claims.scanned} stale claims: ${claims.reconciled} reconciled, ${claims.retried} re-sent, ${claims.failures} failed. See esms_onchain_claims.error for details.`,
+      });
+      alerts.push("chain-claims");
+    }
+
+    if (shop.failures > 0) {
+      await dispatchAlert({
+        component: "chain-shop",
+        componentLabel: "Shop burn↔grant audit",
+        previous: "OK",
+        current: "DEGRADED",
+        severity: "warn",
+        title: `Shop burn audit hit ${shop.failures} error(s)`,
+        message: `Checked ${shop.pairsChecked} (user, item) pairs; healed ${shop.healed}; ${shop.failures} reads/grants failed.`,
+      });
+      alerts.push("chain-shop");
+    }
+
+    if (invariants.violations.length > 0) {
+      await dispatchAlert({
+        component: "chain-invariant",
+        componentLabel: "Ledger↔chain invariant",
+        previous: "OK",
+        current: "INCIDENT",
+        severity: "error",
+        title: `On-chain ESMS exceeds ledger mints for ${invariants.violations.length} wallet/coin pair(s)`,
+        message: invariants.violations
+          .map((v) => `${v.wallet} ${v.coin}: chain=${v.onchain} ledger=${v.ledger}`)
+          .join("; ")
+          .slice(0, 900),
+      });
+      alerts.push("chain-invariant");
+    }
+
+    if (nfts.failures > 0) {
+      await dispatchAlert({
+        component: "chain-nft",
+        componentLabel: "Recipe NFT backfill",
+        previous: "OK",
+        current: "DEGRADED",
+        severity: "warn",
+        title: `${nfts.failures} pending recipe NFT(s) failed to mint`,
+        message: `Scanned ${nfts.scanned} pending_chain rows; minted ${nfts.minted}; ${nfts.failures} failed (they stay pending and retry next run).`,
+      });
+      alerts.push("chain-nft");
+    }
+
+    return NextResponse.json({
+      success: true,
+      claims,
+      shop,
+      invariants: {
+        walletsChecked: invariants.walletsChecked,
+        violations: invariants.violations,
+        failures: invariants.failures,
+      },
+      nfts,
+      alertsDispatched: alerts,
+    });
+  } catch (err) {
+    _logger.error("[cron/chain-reconcile] failed:", err);
+    return NextResponse.json(
+      { success: false, message: err instanceof Error ? err.message : "unknown" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/esms-chain/minter.ts
+++ b/src/lib/esms-chain/minter.ts
@@ -68,14 +68,14 @@ export async function mintEsmsClaim(params: {
   const walletId = process.env.PRIVY_MINTER_WALLET_ID
   const privy = walletId ? getPrivyClient() : null
   if (walletId && privy) {
-    // NOTE: verify the exact input shape against @privy-io/server-auth on first
-    // testnet run (walletId/caip2/tx-field nesting); cast to satisfy types here.
-    const res = (await (privy as any).walletApi.ethereum.sendTransaction({
+    // Typed against @privy-io/server-auth@1.32.x — a breaking SDK bump now
+    // fails tsc instead of exploding at runtime.
+    const res = await privy.walletApi.ethereum.sendTransaction({
       walletId,
-      caip2: esmsCaip2(),
+      caip2: esmsCaip2() as `eip155:${string}`,
       transaction: { to: contract, data },
-    })) as { hash?: Hex; transactionHash?: Hex }
-    const hash = res.hash ?? res.transactionHash
+    })
+    const hash = res.hash as Hex | undefined
     if (!hash) throw new Error('Privy sendTransaction returned no hash')
     return hash
   }

--- a/src/lib/esms-chain/redeemer.ts
+++ b/src/lib/esms-chain/redeemer.ts
@@ -82,12 +82,14 @@ export async function redeemEsmsFor(params: {
   const walletId = process.env.PRIVY_REDEEMER_WALLET_ID || process.env.PRIVY_MINTER_WALLET_ID
   const privy = walletId ? getPrivyClient() : null
   if (walletId && privy) {
-    const res = (await (privy as any).walletApi.ethereum.sendTransaction({
+    // Typed against @privy-io/server-auth@1.32.x — a breaking SDK bump now
+    // fails tsc instead of exploding at runtime.
+    const res = await privy.walletApi.ethereum.sendTransaction({
       walletId,
-      caip2: esmsCaip2(),
+      caip2: esmsCaip2() as `eip155:${string}`,
       transaction: { to: contract, data },
-    })) as { hash?: Hex; transactionHash?: Hex }
-    const hash = res.hash ?? res.transactionHash
+    })
+    const hash = res.hash as Hex | undefined
     if (!hash) throw new Error('Privy sendTransaction returned no hash')
     return hash
   }

--- a/src/lib/privy/server.ts
+++ b/src/lib/privy/server.ts
@@ -24,7 +24,16 @@ export function getPrivyClient(): PrivyClient | null {
   const appId = process.env.NEXT_PUBLIC_PRIVY_APP_ID;
   const appSecret = process.env.PRIVY_APP_SECRET;
   if (appId && appSecret) {
-    _client = new PrivyClient(appId, appSecret);
+    // If the app registers an authorization keypair in the Privy Dashboard,
+    // every walletApi call (createWallet, ethereum.sendTransaction for the
+    // server-wallet minter/redeemer) must be signed with its private key —
+    // without it those calls fail. Optional until a keypair is registered.
+    const authorizationPrivateKey = process.env.PRIVY_AUTHORIZATION_PRIVATE_KEY;
+    _client = new PrivyClient(
+      appId,
+      appSecret,
+      authorizationPrivateKey ? { walletApi: { authorizationPrivateKey } } : undefined,
+    );
   }
   return _client;
 }

--- a/src/services/chainReconcileService.ts
+++ b/src/services/chainReconcileService.ts
@@ -1,0 +1,310 @@
+/**
+ * Chain reconciliation — heals every seam between the Postgres ledgers and
+ * the Base (Sepolia) contracts. Four independent jobs, each safe to re-run:
+ *
+ * 1. settleStaleClaims — pending esms_onchain_claims older than 30min: if the
+ *    contract says claimed(claimId), mark minted; otherwise re-send the mint
+ *    (the contract's claimId uniqueness makes retries idempotent).
+ * 2. healBurnedPurchases — one-time shop items burn against a DETERMINISTIC
+ *    orderId (keccak of shop:<user>:<slug>:), so "burned on-chain but never
+ *    granted" is directly discoverable: recompute ids for wallet-linked users'
+ *    ungranted one-time items, read redeemedOrders(), grant what burned.
+ * 3. checkWalletInvariants — per wallet: on-chain balance must never EXCEED
+ *    the sum of ledger-minted claims (burns only decrease it). A violation
+ *    means tokens were minted outside the ledger → loud alert, no auto-fix.
+ * 4. backfillPendingNfts — recipe_nft_mints stuck in pending_chain (created
+ *    before the registry deployed, or whose mint send died): re-attempt the
+ *    sponsored mint from the stored commitments.
+ *
+ * Everything is capped per run and returns a summary the cron reports.
+ */
+
+import { keccak256, toHex, formatUnits } from "viem";
+import { executeQuery } from "@/lib/database";
+import {
+  esmsOnchainConfigured,
+  readEsmsBalances,
+  readEsmsClaimed,
+  readEsmsRedeemed,
+} from "@/lib/esms-chain/contract";
+import { mintEsmsClaim, minterConfigured } from "@/lib/esms-chain/minter";
+import { recipeNftEnabled } from "@/lib/recipe-nft/contract";
+import { defaultRecipient, mintRecipeOnChain } from "@/lib/recipe-nft/minter";
+import { esmsOnchainClaimService } from "@/services/esmsOnchainClaimService";
+import { getSelfBaseUrl } from "@/utils/urlUtils";
+import type { Address, Hex } from "viem";
+
+const EVM_ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+const HEX32 = /^0x[0-9a-fA-F]{64}$/;
+
+export interface ClaimSettlerSummary {
+  scanned: number;
+  reconciled: number; // claimed() was already true — marked minted
+  retried: number; // mint re-sent
+  failures: number;
+}
+
+export interface BurnHealSummary {
+  pairsChecked: number;
+  healed: number; // burned on-chain, grant inserted
+  failures: number;
+}
+
+export interface InvariantSummary {
+  walletsChecked: number;
+  violations: Array<{ wallet: string; coin: string; onchain: number; ledger: number }>;
+  failures: number;
+}
+
+export interface NftBackfillSummary {
+  scanned: number;
+  minted: number;
+  failures: number;
+}
+
+/** 1. Settle in-flight ESMS claims the request path lost track of. */
+export async function settleStaleClaims(limit = 25): Promise<ClaimSettlerSummary> {
+  const summary: ClaimSettlerSummary = { scanned: 0, reconciled: 0, retried: 0, failures: 0 };
+  if (!esmsOnchainConfigured()) return summary;
+
+  const stale = await esmsOnchainClaimService.listStalePending(30, limit);
+  for (const claim of stale) {
+    summary.scanned++;
+    try {
+      if (await readEsmsClaimed(claim.claimId)) {
+        await esmsOnchainClaimService.markMinted(claim.id);
+        summary.reconciled++;
+        continue;
+      }
+      if (!minterConfigured() || !EVM_ADDRESS.test(claim.walletAddress)) {
+        summary.failures++;
+        continue;
+      }
+      // Not on-chain → re-send with the SAME claimId (contract-idempotent).
+      // Confirmation is next run's job: claimed() flips once it mines.
+      const txHash = await mintEsmsClaim({
+        to: claim.walletAddress as Address,
+        claimId: claim.claimId,
+        amounts: {
+          spirit: String(claim.amounts.spirit),
+          essence: String(claim.amounts.essence),
+          matter: String(claim.amounts.matter),
+          substance: String(claim.amounts.substance),
+        },
+      });
+      await esmsOnchainClaimService.recordTxHash(claim.id, txHash);
+      summary.retried++;
+    } catch (err) {
+      summary.failures++;
+      await esmsOnchainClaimService.recordError(
+        claim.id,
+        `reconcile: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+  return summary;
+}
+
+/** Deterministic one-time shop orderId — must mirror the purchase route. */
+function oneTimeOrderId(userId: string, slug: string): Hex {
+  return keccak256(toHex(`shop:${userId}:${slug}:`));
+}
+
+/** 2. Grant one-time purchases whose burn confirmed but whose grant was lost. */
+export async function healBurnedPurchases(maxReads = 40): Promise<BurnHealSummary> {
+  const summary: BurnHealSummary = { pairsChecked: 0, healed: 0, failures: 0 };
+  if (!esmsOnchainConfigured()) return summary;
+
+  let pairs: Array<{ user_id: string; slug: string; item_id: string }> = [];
+  try {
+    // Wallet-linked users × active one-time items they DON'T own. The hourly
+    // hash shuffle rotates which slice of a large pair-space each run scans;
+    // healed pairs drop out of the set, so the scan always makes progress.
+    const res = await executeQuery<{ user_id: string; slug: string; item_id: string }>(
+      `SELECT u.id AS user_id, si.slug, si.id AS item_id
+       FROM users u
+       CROSS JOIN shop_items si
+       WHERE u.wallet_address IS NOT NULL
+         AND si.is_active = true AND si.is_one_time = true
+         AND NOT EXISTS (
+           SELECT 1 FROM user_purchases up
+           WHERE up.user_id = u.id AND up.shop_item_id = si.id
+         )
+       ORDER BY md5(u.id::text || si.slug || to_char(now(), 'YYYY-MM-DD-HH24'))
+       LIMIT $1`,
+      [Math.min(Math.max(maxReads, 1), 100)],
+    );
+    pairs = res.rows;
+  } catch (err) {
+    console.error("[chainReconcile] pair enumeration failed:", err);
+    summary.failures++;
+    return summary;
+  }
+
+  for (const pair of pairs) {
+    summary.pairsChecked++;
+    try {
+      const burned = await readEsmsRedeemed(oneTimeOrderId(pair.user_id, pair.slug));
+      if (!burned) continue;
+      await executeQuery(
+        `INSERT INTO user_purchases (user_id, shop_item_id, transaction_group_id)
+         SELECT $1, $2, uuid_generate_v4()
+         WHERE NOT EXISTS (
+           SELECT 1 FROM user_purchases WHERE user_id = $1 AND shop_item_id = $2
+         )`,
+        [pair.user_id, pair.item_id],
+      );
+      summary.healed++;
+    } catch {
+      summary.failures++;
+    }
+  }
+  return summary;
+}
+
+/** 3. On-chain balance must never exceed what the claim ledger minted. */
+export async function checkWalletInvariants(maxWallets = 20): Promise<InvariantSummary> {
+  const summary: InvariantSummary = { walletsChecked: 0, violations: [], failures: 0 };
+  if (!esmsOnchainConfigured()) return summary;
+
+  let rows: Array<{
+    wallet_address: string;
+    spirit: string;
+    essence: string;
+    matter: string;
+    substance: string;
+  }> = [];
+  try {
+    const res = await executeQuery<(typeof rows)[number]>(
+      `SELECT u.wallet_address,
+              COALESCE(SUM(c.spirit), 0) AS spirit,
+              COALESCE(SUM(c.essence), 0) AS essence,
+              COALESCE(SUM(c.matter), 0) AS matter,
+              COALESCE(SUM(c.substance), 0) AS substance
+       FROM users u
+       LEFT JOIN esms_onchain_claims c
+         ON c.user_id = u.id AND c.status = 'minted'
+       WHERE u.wallet_address IS NOT NULL
+       GROUP BY u.wallet_address
+       LIMIT $1`,
+      [Math.min(Math.max(maxWallets, 1), 100)],
+    );
+    rows = res.rows;
+  } catch (err) {
+    console.error("[chainReconcile] invariant enumeration failed:", err);
+    summary.failures++;
+    return summary;
+  }
+
+  const EPSILON = 0.0001;
+  for (const row of rows) {
+    if (!EVM_ADDRESS.test(row.wallet_address)) continue;
+    summary.walletsChecked++;
+    try {
+      const onchain = await readEsmsBalances(row.wallet_address as Address);
+      const chain = {
+        spirit: Number(formatUnits(onchain.spirit, 18)),
+        essence: Number(formatUnits(onchain.essence, 18)),
+        matter: Number(formatUnits(onchain.matter, 18)),
+        substance: Number(formatUnits(onchain.substance, 18)),
+      };
+      for (const coin of ["spirit", "essence", "matter", "substance"] as const) {
+        const ledger = parseFloat(row[coin]) || 0;
+        if (chain[coin] > ledger + EPSILON) {
+          summary.violations.push({
+            wallet: row.wallet_address,
+            coin,
+            onchain: chain[coin],
+            ledger,
+          });
+        }
+      }
+    } catch {
+      summary.failures++;
+    }
+  }
+  return summary;
+}
+
+/** 4. Mint recipe NFTs recorded before the registry was live (or whose send died). */
+export async function backfillPendingNfts(limit = 3): Promise<NftBackfillSummary> {
+  const summary: NftBackfillSummary = { scanned: 0, minted: 0, failures: 0 };
+  if (!recipeNftEnabled()) return summary;
+
+  let rows: Array<{
+    id: string;
+    user_id: string;
+    content_hash: string;
+    computation_hash: string;
+    ingredient_catalog_root: string;
+    engine_version: number;
+    metadata_uri: string | null;
+  }> = [];
+  try {
+    const res = await executeQuery<(typeof rows)[number]>(
+      `SELECT id, user_id, content_hash, computation_hash, ingredient_catalog_root,
+              engine_version, metadata_uri
+       FROM recipe_nft_mints
+       WHERE status = 'pending_chain'
+       ORDER BY created_at ASC
+       LIMIT $1`,
+      [Math.min(Math.max(limit, 1), 10)],
+    );
+    rows = res.rows;
+  } catch (err) {
+    console.error("[chainReconcile] pending-NFT scan failed:", err);
+    summary.failures++;
+    return summary;
+  }
+
+  const base = getSelfBaseUrl();
+  for (const row of rows) {
+    summary.scanned++;
+    if (
+      !HEX32.test(row.content_hash) ||
+      !HEX32.test(row.computation_hash) ||
+      !HEX32.test(row.ingredient_catalog_root)
+    ) {
+      summary.failures++;
+      continue;
+    }
+    try {
+      // Recipient wasn't stored at record time — resolve the user's CURRENT
+      // wallet, falling back to rights-holder custody (the claim-mint model).
+      let recipient: Address = defaultRecipient();
+      const walletRes = await executeQuery<{ wallet_address: string | null }>(
+        "SELECT wallet_address FROM users WHERE id = $1",
+        [row.user_id],
+      );
+      const wallet = walletRes.rows[0]?.wallet_address;
+      if (wallet && EVM_ADDRESS.test(wallet)) recipient = wallet as Address;
+
+      const result = await mintRecipeOnChain({
+        recipient,
+        commitments: {
+          contentHash: row.content_hash as Hex,
+          computationHash: row.computation_hash as Hex,
+          ingredientCatalogRoot: row.ingredient_catalog_root as Hex,
+        },
+        engineVersion: row.engine_version,
+        contentURI: `${base}/api/recipes/nft/content/${row.content_hash}`,
+        metadataURI: row.metadata_uri || `${base}/api/recipes/nft/metadata/${row.content_hash}`,
+      });
+
+      if (result.status === "minted" && result.txHash) {
+        await executeQuery(
+          `UPDATE recipe_nft_mints
+           SET status = 'minted', chain = $2, token_id = $3, tx_hash = $4, minted_at = now()
+           WHERE id = $1 AND status = 'pending_chain'`,
+          [row.id, result.chain ?? null, result.tokenId ?? null, result.txHash],
+        );
+        summary.minted++;
+      } else {
+        summary.failures++;
+      }
+    } catch {
+      summary.failures++;
+    }
+  }
+  return summary;
+}

--- a/src/services/esmsOnchainClaimService.ts
+++ b/src/services/esmsOnchainClaimService.ts
@@ -112,6 +112,27 @@ export const esmsOnchainClaimService = {
     }
   },
 
+  /**
+   * All in-flight claims older than `minAgeMinutes`, oldest first — the
+   * reconcile cron's worklist. Fresh claims are skipped so the cron never
+   * races a request that is still confirming its own mint.
+   */
+  async listStalePending(minAgeMinutes = 30, limit = 25): Promise<EsmsOnchainClaim[]> {
+    try {
+      const res = await executeQuery<ClaimRow>(
+        `SELECT * FROM esms_onchain_claims
+         WHERE status = 'pending'
+           AND updated_at < now() - ($1 || ' minutes')::interval
+         ORDER BY created_at ASC LIMIT $2`,
+        [String(Math.max(1, minAgeMinutes)), Math.min(Math.max(limit, 1), 100)],
+      );
+      return res.rows.map(rowToClaim);
+    } catch (err) {
+      console.error("[esmsOnchainClaimService] listStalePending failed:", err);
+      return [];
+    }
+  },
+
   /** The user's single in-flight claim, if any. */
   async findPending(userId: string): Promise<EsmsOnchainClaim | null> {
     try {

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,9 @@
   "installCommand": "bun install",
   "buildCommand": "bun run build",
   "framework": "nextjs",
-  "regions": ["iad1"],
+  "regions": [
+    "iad1"
+  ],
   "bunVersion": "1.3",
   "functions": {
     "src/app/api/**/*.ts": {
@@ -62,6 +64,10 @@
     {
       "path": "/api/cron/agents-daily-yield",
       "schedule": "30 0 * * *"
+    },
+    {
+      "path": "/api/cron/chain-reconcile",
+      "schedule": "45 * * * *"
     }
   ],
   "env": {


### PR DESCRIPTION
## PR 3 of the invisible-economy chain

PRs #576–#578 put real value in motion daily (claims mint on-chain, burns settle purchases, practices pay). This PR gives every seam between the Postgres ledgers and the Base contracts an **hourly healer and a loud alarm** — the hardening decisions from the planning session.

## What ships

### `/api/cron/chain-reconcile` (hourly at :45)
Four independent, capped, re-runnable jobs:

1. **Stuck-claim settler** — pending `esms_onchain_claims` older than 30min reconcile against `claimed()` or re-send with the same contract-idempotent claimId. An interrupted claim now heals without the user ever clicking again.
2. **Burn↔grant healer** — one-time shop orderIds are deterministic (`keccak(shop:<user>:<slug>:)`), so *burned on-chain but never granted* is directly discoverable: recompute ids for wallet-linked users' ungranted items, read `redeemedOrders()`, insert the missing grant. Hourly hash-shuffle rotates the scan slice.
3. **Ledger↔chain invariant** — per wallet, on-chain `balanceOfBatch` must never exceed the sum of ledger-minted claims. Violations = INCIDENT, never auto-fixed.
4. **Recipe-NFT backfill** — `pending_chain` rows re-attempt the sponsored mint from stored commitments (hex-validated; recipient re-resolved from the user's current wallet with rights-holder fallback).

### Alerts (dashboard + email, as decided)
Problems dispatch through the existing `alertService` — Slack + operator email + `alert_events` rows on the admin dashboard — with **distinct components per problem class** so the 60-minute cooldown never masks one class behind another.

### Privy server-wallet custody (mainnet path stays open)
- `scripts/provision-privy-server-wallets.ts` — idempotently creates MINTER + REDEEMER app-owned server wallets, prints the `PRIVY_*_WALLET_ID` env lines, and grants the on-chain roles itself when `ESMS_ADMIN_PRIVATE_KEY` is present (else prints the exact `cast` commands). Dry-run by default.
- `getPrivyClient()` supports `PRIVY_AUTHORIZATION_PRIVATE_KEY` (required once an authorization keypair is registered in the Privy Dashboard).
- The minter/redeemer `sendTransaction` calls are now **properly typed** against `@privy-io/server-auth` — the `(privy as any)` casts are gone, so SDK drift fails `tsc` instead of production.

## Verified (live chain + real DB)
- ✅ 401 without the cron secret
- ✅ Clean run: 9 wallets invariant-checked against Base Sepolia, 40 burn pairs audited, 0 stale claims, 0 violations, no alerts
- ✅ **Full alert pipeline proof**: deliberately hid a minted claim from the ledger → cron flagged exactly the right violation (matter: chain 23.81 vs ledger 13.81) → `alert_events` row written (severity `error`) → **operator email confirmed sent** (`dispatch.email.ok=true`) → ledger restored
- ✅ typecheck, lint, jest, production build green

*(Operator note: the alert-pipeline test sent one real "chain-invariant" email — that was the drill, not an incident.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)