### PR TITLE
feat(economy): the Living Economy — Amazon Fresh ordering, cooked-it dish cards, transit invites, lunar tables

### DIFF
--- a/database/init/58-feed-reactions.sql
+++ b/database/init/58-feed-reactions.sql
@@ -1,0 +1,24 @@
+-- ==========================================
+-- FEED REACTIONS
+-- Migration 58: reactions on community feed events (cooked-it dish cards).
+-- One reaction per (event, user); the reaction row is the dedupe anchor for
+-- both invisible rewards — the reactor's feed_reaction and the poster's
+-- work_resonated practice.
+-- Created: July 2026
+-- ==========================================
+
+CREATE TABLE IF NOT EXISTS feed_reactions (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    event_id UUID NOT NULL REFERENCES feed_events(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    kind VARCHAR(20) NOT NULL DEFAULT 'spark',    -- spark | fire | water | earth | air
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uniq_feed_reaction UNIQUE (event_id, user_id)
+);
+
+COMMENT ON TABLE feed_reactions IS 'One reaction per user per feed event. Insert is the reward anchor: reactor earns feed_reaction, poster earns work_resonated (both practice-ledger deduped).';
+
+CREATE INDEX IF NOT EXISTS idx_feed_reactions_event
+    ON feed_reactions (event_id);
+CREATE INDEX IF NOT EXISTS idx_feed_reactions_user
+    ON feed_reactions (user_id, created_at DESC);

--- a/src/app/(alchm)/feed/page.tsx
+++ b/src/app/(alchm)/feed/page.tsx
@@ -10,7 +10,10 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { CookedDishCard } from "@/components/feed/CookedDishCard";
 import { HistoricalAgentFeedCard } from "@/components/feed/HistoricalAgentFeedItems";
+import { LunarTableStrip } from "@/components/feed/LunarTableStrip";
+import { TransitInviteBanner } from "@/components/feed/TransitInviteBanner";
 import { useLiveFeedEvents } from "@/hooks/useLiveFeedEvents";
 import { firePractice } from "@/lib/economy/practiceClient";
 import { narrateFeedEvent } from "@/lib/feed/eventNarration";
@@ -31,6 +34,7 @@ interface FeedEvent {
   eventType: string;
   metadataPayload: any;
   createdAt: string;
+  reactionCount?: number;
 }
 
 interface AgentSummary {
@@ -612,6 +616,10 @@ function FeedTab({
 
   return (
     <section aria-labelledby="activity-heading">
+      {/* Personal invite when today's sky touches the viewer's chart */}
+      <TransitInviteBanner />
+      {/* The sky's standing invitation — open or upcoming lunar table */}
+      <LunarTableStrip />
       <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <p className="text-[9px] font-black uppercase tracking-[0.28em] text-purple-300/55">
@@ -693,6 +701,19 @@ function FeedTab({
 function HumanFeedRow({ event }: { event: FeedEvent }) {
   const narration = getEventNarration(event);
   const actorHref = `/profile/${event.actorId}`;
+
+  // Cooked-it dish cards carry their own alchemical identity (chart-persona,
+  // signature, transit line) — rendered as a full card, not a narration row.
+  if (event.metadataPayload?.card === "cooked") {
+    return (
+      <CookedDishCard
+        eventId={event.id}
+        createdAtLabel={formatRelativeTime(event.createdAt)}
+        meta={event.metadataPayload}
+        initialCount={event.reactionCount ?? 0}
+      />
+    );
+  }
   return (
     <div className="glass-card-premium rounded-2xl p-5 transition-all flex items-start gap-4 border-white/8 hover:border-purple-500/20">
       <div className="w-10 h-10 rounded-full glass-base flex items-center justify-center text-xl shrink-0 border border-white/5 overflow-hidden">

--- a/src/app/admin/_dashboard/Dashboard.tsx
+++ b/src/app/admin/_dashboard/Dashboard.tsx
@@ -24,6 +24,7 @@ import {
   EngineHealth,
   CatalogState,
   CommercePanel,
+  LivingEconomyPanel,
   CommensalPulse,
   DeploysPanel,
   FeatureFlagsPanel,
@@ -179,6 +180,7 @@ export function Dashboard({ data }: DashboardProps) {
           <CatalogState realCards={catalogCards} trending={data.catalogTrending} />
           <CommensalPulse pageTelemetry={data.pageTelemetry} />
           <CommercePanel commerceSummary={data.commerce} />
+          <LivingEconomyPanel data={data.livingEconomy} />
         </div>
 
         <div className="dash-stack" style={{ display: "grid", gridTemplateColumns: "1.4fr 1fr", gap: 12, marginBottom: 12 }}>

--- a/src/app/admin/_dashboard/data.ts
+++ b/src/app/admin/_dashboard/data.ts
@@ -19,6 +19,7 @@ import type {
   CommerceSummaryData,
   PageTelemetryData,
   RecentAlertsData,
+  LivingEconomyMetrics,
   SecuritySummaryData,
   DeployHistoryEntry,
   FeatureFlagEntry,
@@ -147,6 +148,8 @@ export interface AdminDashboardData {
   liveActivity: { entries: ActivityEvent[]; live: boolean };
   /** Recent alert_events rows for the IncidentsPanel. */
   recentAlerts: RecentAlertsData;
+  /** Living Economy scorecard: affiliate clicks, cooked posts, feed DAU. */
+  livingEconomy?: LivingEconomyMetrics;
   /** request_log_entries aggregated 5xx/4xx by path for ErrorGroups. */
   errorGroups: ErrorGroupsData;
   /** auth_events rollup for SecurityPanel. */
@@ -276,6 +279,7 @@ export const FALLBACK_DATA: AdminDashboardData = {
   },
   liveActivity: { entries: [], live: false },
   recentAlerts: { entries: [], live: false },
+  livingEconomy: { affiliateClicksWeek: 0, cookedPostsWeek: 0, feedDauToday: 0, live: false },
   errorGroups: { groups: [], windowMinutes: 60, live: false },
   security: {
     signinSuccess24h: 0,

--- a/src/app/admin/_dashboard/panels.tsx
+++ b/src/app/admin/_dashboard/panels.tsx
@@ -924,6 +924,23 @@ export function CatalogState({
 // ============================================================
 // COMMERCE PANEL — MRR + orders
 // ============================================================
+export function LivingEconomyPanel({ data }: { data?: { affiliateClicksWeek: number; cookedPostsWeek: number; feedDauToday: number; live: boolean } }) {
+  const d = data ?? { affiliateClicksWeek: 0, cookedPostsWeek: 0, feedDauToday: 0, live: false };
+  return (
+    <Card
+      title="Living Economy"
+      subtitle={d.live ? "affiliate funnel · cook flywheel · social pull" : "offline — DB unreachable"}
+      right={<Legend label={d.live ? "LIVE" : "STALE"} color={d.live ? "var(--el-earth)" : "var(--el-fire)"} />}
+    >
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 8, padding: 12 }}>
+        <MiniStat label="Amazon handoffs / 7d" value={d.affiliateClicksWeek.toLocaleString()} />
+        <MiniStat label="Cooked posts / 7d" value={d.cookedPostsWeek.toLocaleString()} />
+        <MiniStat label="Feed DAU today" value={d.feedDauToday.toLocaleString()} />
+      </div>
+    </Card>
+  );
+}
+
 export function CommercePanel({ commerceSummary }: { commerceSummary: any }) {
   const summary = commerceSummary || { mrr: 0, paidSubs: 0, provisionedSubs: 0, recentOrders: [], live: false };
   const live = summary.live ?? false;

--- a/src/app/api/admin/dashboard/route.ts
+++ b/src/app/api/admin/dashboard/route.ts
@@ -29,6 +29,7 @@ import {
   getCommerceTelemetry,
   getPageTelemetry,
   getRecentAlerts,
+  getLivingEconomyMetrics,
   getSecuritySummary,
   getDeployHistory,
   getFeatureFlags,
@@ -183,6 +184,7 @@ export async function GET(request: NextRequest) {
     const systemStatusPromise = getSystemStatus();
     const liveActivityPromise = getLiveActivity();
     const recentAlertsPromise = getRecentAlerts();
+    const livingEconomyPromise = getLivingEconomyMetrics();
     const errorGroupsPromise = getErrorGroupSummary();
     const securityPromise = getSecuritySummary();
     const deploysPromise = Promise.resolve(getDeployHistory());
@@ -239,6 +241,7 @@ export async function GET(request: NextRequest) {
     const systemStatus = await systemStatusPromise;
     const liveActivityResult = await liveActivityPromise;
     const recentAlerts = await recentAlertsPromise;
+    const livingEconomy = await livingEconomyPromise;
     const errorGroups = await errorGroupsPromise;
     const security = await securityPromise;
     const deploys = await deploysPromise;
@@ -308,6 +311,7 @@ export async function GET(request: NextRequest) {
         live: liveActivityResult.live,
       },
       recentAlerts,
+      livingEconomy,
       errorGroups,
       security,
       deploys,

--- a/src/app/api/feed/react/route.ts
+++ b/src/app/api/feed/react/route.ts
@@ -1,0 +1,96 @@
+/**
+ * POST /api/feed/react — spark a feed event (one reaction per user per event).
+ *
+ * The reaction ROW is the proof both invisible rewards hang off: the reactor's
+ * `feed_reaction` and the poster's `work_resonated` are recognized HERE,
+ * server-side, keyed to the reaction insert — a bare practice POST can't fake
+ * either (both types are SERVER_ONLY in the practice catalog). Self-reactions
+ * are rejected; duplicate reactions are quiet no-ops.
+ */
+
+import { NextResponse } from "next/server";
+import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { executeQuery } from "@/lib/database";
+import { rateLimit } from "@/lib/rateLimit";
+import { practiceRewardService } from "@/services/practiceRewardService";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const KINDS = new Set(["spark", "fire", "water", "earth", "air"]);
+
+export async function POST(request: NextRequest) {
+  const userId = await getUserIdFromRequest(request);
+  if (!userId) {
+    return NextResponse.json({ success: false, message: "Authentication required" }, { status: 401 });
+  }
+
+  const rl = await rateLimit(request, { window: 60_000, max: 30, bucket: "feed-react", identifier: userId });
+  if (!rl.allowed) return rl.response!;
+
+  let body: { eventId?: unknown; kind?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ success: false, message: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const eventId = typeof body.eventId === "string" && UUID.test(body.eventId) ? body.eventId : null;
+  if (!eventId) {
+    return NextResponse.json({ success: false, message: "eventId is required" }, { status: 400 });
+  }
+  const kind = typeof body.kind === "string" && KINDS.has(body.kind) ? body.kind : "spark";
+
+  try {
+    const eventRes = await executeQuery<{ actor_id: string }>(
+      "SELECT actor_id FROM feed_events WHERE id = $1",
+      [eventId],
+    );
+    const posterId = eventRes.rows[0]?.actor_id;
+    if (!posterId) {
+      return NextResponse.json({ success: false, message: "Event not found" }, { status: 404 });
+    }
+    if (posterId === userId) {
+      return NextResponse.json({ success: false, message: "Your own work already knows you made it." }, { status: 400 });
+    }
+
+    const ins = await executeQuery<{ id: string }>(
+      `INSERT INTO feed_reactions (event_id, user_id, kind)
+       VALUES ($1, $2, $3)
+       ON CONFLICT ON CONSTRAINT uniq_feed_reaction DO NOTHING
+       RETURNING id`,
+      [eventId, userId, kind],
+    );
+    const isNew = ins.rows.length > 0;
+
+    let reward: { tokenType: string; amount: number; hint: string } | null = null;
+    if (isNew) {
+      // Reactor's spark (once-ever per event, capped daily by the catalog).
+      const reactorResult = await practiceRewardService.recognize(userId, "feed_reaction", eventId);
+      if (reactorResult.rewarded && reactorResult.tokenType && reactorResult.amount && reactorResult.hint) {
+        reward = { tokenType: reactorResult.tokenType, amount: reactorResult.amount, hint: reactorResult.hint };
+      }
+      // Poster's resonance (once-ever per event: the FIRST spark pays the
+      // maker; catalog caps how many works can resonate per day).
+      await practiceRewardService.recognize(posterId, "work_resonated", eventId);
+    }
+
+    const countRes = await executeQuery<{ n: string }>(
+      "SELECT COUNT(*)::int AS n FROM feed_reactions WHERE event_id = $1",
+      [eventId],
+    );
+
+    return NextResponse.json({
+      success: true,
+      reacted: true,
+      alreadyReacted: !isNew,
+      count: Number(countRes.rows[0]?.n ?? 0),
+      reward,
+    });
+  } catch (error) {
+    console.error("[feed/react] failed:", error);
+    return NextResponse.json({ success: false, message: "Reaction failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/feed/share/route.ts
+++ b/src/app/api/feed/share/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from "next/server";
-import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
+import { buildCookCardIdentity } from "@/lib/feed/cookCard";
+import { storeCookPhoto } from "@/lib/feed/cookPhotoStorage";
+import { nextLunarTable } from "@/lib/feed/lunarTables";
+import { rateLimit } from "@/lib/rateLimit";
 import { feedDatabase } from "@/services/feedDatabaseService";
 import { questService } from "@/services/QuestService";
 import type { NextRequest } from "next/server";
@@ -9,13 +13,17 @@ export const runtime = "nodejs";
 
 export async function POST(request: NextRequest) {
   try {
-    const userId = await getUserIdFromRequest(request);
+    const user = await getDatabaseUserFromRequest(request);
+    const userId = user?.id;
     if (!userId) {
       return NextResponse.json(
         { success: false, message: "Authentication required" },
         { status: 401 }
       );
     }
+
+    const rl = await rateLimit(request, { window: 60_000, max: 10, bucket: "feed-share", identifier: userId });
+    if (!rl.allowed) return rl.response!;
 
     const body = await request.json();
     const { shareType, shareName, payload } = body;
@@ -29,6 +37,7 @@ export async function POST(request: NextRequest) {
 
     let eventType: string;
     let questEvent: string;
+    let cardExtras: Record<string, unknown> = {};
 
     if (shareType === "menu") {
       eventType = "weekly_menu";
@@ -39,6 +48,38 @@ export async function POST(request: NextRequest) {
     } else if (shareType === "preferences") {
       eventType = "share_preferences_feed";
       questEvent = "share_preferences_feed";
+    } else if (shareType === "cooked") {
+      // Cooked-it dish card: chart-persona identity + transit line, computed
+      // once at share time; photo (a data URL from /api/food-lab/upload) is
+      // persisted to R2 so the feed row carries a URL, not base64. Posts made
+      // while a lunar table is open attach to it automatically.
+      eventType = "made_it";
+      questEvent = "share_recipe_feed";
+
+      const recipeName = typeof payload?.recipeName === "string" ? payload.recipeName.slice(0, 160) : null;
+      if (!recipeName) {
+        return NextResponse.json(
+          { success: false, message: "payload.recipeName is required for cooked shares" },
+          { status: 400 }
+        );
+      }
+
+      const identity = await buildCookCardIdentity(user.profile?.natalChart ?? null);
+
+      let photoUrl: string | null = null;
+      if (typeof payload?.photoDataUrl === "string") {
+        photoUrl = await storeCookPhoto(userId, payload.photoDataUrl);
+      }
+
+      const table = nextLunarTable();
+      cardExtras = {
+        card: "cooked",
+        persona: identity.persona,
+        signature: identity.signature,
+        transitLine: identity.transitLine,
+        photoUrl,
+        tableKey: table?.isOpen ? table.key : null,
+      };
     } else {
       return NextResponse.json(
         { success: false, message: `Invalid shareType: ${shareType}` },
@@ -46,10 +87,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Build metadata payload, ensuring shareName is passed
+    // Build metadata payload, ensuring shareName is passed. Cooked cards are
+    // ALWAYS pseudonymous (chart-persona) — shareName stays false so the feed
+    // never attaches a real name to a dish post.
+    const { photoDataUrl: _dropped, ...safePayload } = (payload || {}) as Record<string, unknown>;
     const metadataPayload = {
-      ...(payload || {}),
-      shareName: shareName === true,
+      ...safePayload,
+      ...cardExtras,
+      shareName: shareType === "cooked" ? false : shareName === true,
     };
 
     // 1. Record the feed event
@@ -68,6 +113,7 @@ export async function POST(request: NextRequest) {
       success: true,
       message: "Successfully shared to community feed!",
       completedQuests,
+      card: shareType === "cooked" ? cardExtras : undefined,
     });
   } catch (error) {
     console.error("Feed share POST error:", error);

--- a/src/app/recipes/[recipeId]/RecipeClient.tsx
+++ b/src/app/recipes/[recipeId]/RecipeClient.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { OrderIngredientsModal } from "@/components/order/OrderIngredientsModal";
 import { FutureRecipeSkeleton } from "@/components/premium/FutureRecipeSkeleton";
 import { TemporalFrictionGate } from "@/components/premium/TemporalFrictionGate";
 import { AddToMealPlanButton } from "@/components/recipes/AddToMealPlanButton";
@@ -703,6 +704,7 @@ export default function RecipeClient({ recipe, recommendedSauces, recommendedRec
   const { addRecipe: addRecipeToGroceryCart, open: openGroceryCart } = useGroceryCart();
   const { showToast } = useToast();
   const [addedToCart, setAddedToCart] = useState(false);
+  const [orderOpen, setOrderOpen] = useState(false);
 
   const handleAddToGroceryCart = useCallback(() => {
     if (!recipe || !recipe.ingredients || recipe.ingredients.length === 0) {
@@ -915,6 +917,15 @@ export default function RecipeClient({ recipe, recommendedSauces, recommendedRec
                   Add to grocery cart
                 </>
               )}
+            </button>
+
+            <button
+              type="button"
+              onClick={() => setOrderOpen(true)}
+              className="flex items-center gap-2 px-5 py-2.5 rounded-xl font-medium transition-all duration-200 bg-gradient-to-r from-cyan-600 to-teal-600 border border-cyan-400/40 text-white hover:from-cyan-500 hover:to-teal-500"
+            >
+              <span aria-hidden>🧺</span>
+              Order ingredients
             </button>
 
             <RiffOnThisLink recipe={recipe} />
@@ -1437,7 +1448,23 @@ export default function RecipeClient({ recipe, recommendedSauces, recommendedRec
             )}
 
             {/* Community (local-only shell) */}
-            <SocialSection recipeId={recipe.id} />
+            <SocialSection recipeId={recipe.id} recipeName={recipe.name} />
+
+            <OrderIngredientsModal
+              open={orderOpen}
+              onClose={() => setOrderOpen(false)}
+              title={recipe.name}
+              inputs={(recipe.ingredients || []).map((ing) => ({
+                name: ing.name,
+                amount: typeof ing.amount === "number" ? ing.amount : 1,
+                unit: ing.unit || "each",
+                category: ing.category,
+                optional: ing.optional,
+              }))}
+              scale={scale}
+              source="recipe_detail"
+              listTarget={`recipe:${recipe.id}`}
+            />
           </div>
         </div>
 

--- a/src/components/economy/DailyAlignmentWidget.tsx
+++ b/src/components/economy/DailyAlignmentWidget.tsx
@@ -15,10 +15,26 @@
  */
 
 import { AnimatePresence, motion } from 'framer-motion';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAlchemical } from '@/contexts/AlchemicalContext/hooks';
 import { useTokenEconomy } from '@/hooks/useTokenEconomy';
+import type { AgentEventFeedItem, RecipePostFeedItem } from '@/lib/feed/historicalAgentFeed';
+import { fetchHistoricalAgentFeed } from '@/lib/feed/historicalAgentFeedSource';
+
+// Sign → element, for matching resonant agent voices to the user's element.
+const SIGN_ELEMENT: Record<string, string> = {
+  aries: 'Fire', leo: 'Fire', sagittarius: 'Fire',
+  taurus: 'Earth', virgo: 'Earth', capricorn: 'Earth',
+  gemini: 'Air', libra: 'Air', aquarius: 'Air',
+  cancer: 'Water', scorpio: 'Water', pisces: 'Water',
+};
+
+function teaserLine(item: RecipePostFeedItem | AgentEventFeedItem): string {
+  if (item.type === 'recipe_post') return `shared ${item.recipe.name}`;
+  return 'channeled a new insight';
+}
 
 // ─── Element palette (for birth-element glow) ───────────────────────
 
@@ -52,6 +68,29 @@ export function DailyAlignmentWidget() {
     }
   })();
   const elementCfg = ELEMENT_GLOW[dominantElement] ?? ELEMENT_GLOW.Fire;
+
+  // Resonant-voice teaser: the freshest post from a historical agent whose
+  // sun sign shares the user's dominant element — a daily pull into the feed.
+  const [resonantItem, setResonantItem] = useState<RecipePostFeedItem | AgentEventFeedItem | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetchHistoricalAgentFeed()
+      .then((items) => {
+        if (cancelled || !Array.isArray(items)) return;
+        const match = items.find((item): item is RecipePostFeedItem | AgentEventFeedItem => {
+          if (item.type !== 'recipe_post' && item.type !== 'agent_event') return false;
+          const sun = String(item.agent?.birthchart?.sun ?? '').toLowerCase();
+          return SIGN_ELEMENT[sun] === dominantElement;
+        });
+        setResonantItem(match ?? null);
+      })
+      .catch(() => {
+        /* the teaser is decoration — silence on failure */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [dominantElement]);
 
   const handleAlign = () => {
     setGlowing(true);
@@ -121,6 +160,17 @@ export function DailyAlignmentWidget() {
               </span>
               <span className="text-[9px] text-amber-400/60 font-medium">day streak</span>
             </div>
+          )}
+
+          {/* Resonant voice — deep link into the commons */}
+          {resonantItem && (
+            <p className="mt-3 text-[11px] text-purple-300/70">
+              ✶ <span className="font-semibold text-purple-200">{resonantItem.agent.name}</span>{' '}
+              (a fellow {dominantElement} voice) {teaserLine(resonantItem)} —{' '}
+              <Link href="/feed" className="underline underline-offset-2 hover:text-purple-100">
+                hear it in the commons
+              </Link>
+            </p>
           )}
         </div>
 

--- a/src/components/economy/PracticeDelightHost.tsx
+++ b/src/components/economy/PracticeDelightHost.tsx
@@ -45,6 +45,28 @@ export function PracticeDelightHost(): JSX.Element {
   const queue = useRef<PracticeReward[]>([]);
   const playing = useRef(false);
 
+  // Wallet-funnel nudge: the FIRST cook reward of a session, for a user with
+  // no linked wallet, follows up with a one-tap path to the on-chain claim.
+  const nudgedThisSession = useRef(false);
+  const maybeNudgeWallet = useCallback(() => {
+    if (nudgedThisSession.current) return;
+    nudgedThisSession.current = true;
+    void fetch("/api/economy/claim-onchain", { cache: "no-store" })
+      .then(async (res) => {
+        if (!res.ok) return;
+        const json = (await res.json()) as { walletLinked?: boolean; configured?: boolean };
+        if (json.configured && json.walletLinked === false) {
+          setTimeout(() => {
+            showToast("Your earnings can live on-chain — claim them to a wallet of your own.", "info", {
+              duration: 8000,
+              action: { label: "Open the vault", onClick: () => { window.location.href = "/account"; } },
+            });
+          }, 3200);
+        }
+      })
+      .catch(() => {});
+  }, [showToast]);
+
   const playNext = useCallback(() => {
     const reward = queue.current.shift();
     if (!reward) {
@@ -57,13 +79,14 @@ export function PracticeDelightHost(): JSX.Element {
     showToast(`+${formatAmount(reward.amount)} ${symbol} — ${reward.hint}`, "success", {
       duration: 4200,
     });
+    if (reward.tokenType === "Matter") maybeNudgeWallet();
     if (TOKEN_TYPES.has(reward.tokenType)) {
       setSplashCoin([reward.tokenType as TokenType]);
       setSplash(true);
     }
     const coinKey = reward.tokenType.toLowerCase() as Lowercase<TokenType>;
     emitTokenEconomyUpdate({ source: "quest", credits: { [coinKey]: reward.amount } });
-  }, [showToast]);
+  }, [showToast, maybeNudgeWallet]);
 
   useEffect(() => {
     const onReward = (e: Event) => {

--- a/src/components/feed/CookedDishCard.tsx
+++ b/src/components/feed/CookedDishCard.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+/**
+ * Cooked-it dish card — how a shared Work appears in the commons.
+ *
+ * Renders the alchemical identity built at share time (chart-persona, never a
+ * real name; elemental signature chip; the transit line) around the dish
+ * photo, with the spark control. Sparking POSTs /api/feed/react — the server
+ * anchors both invisible rewards to the reaction row (reactor's feed_reaction,
+ * poster's work_resonated); reacted state is remembered locally so the button
+ * renders lit without a per-user bootstrap call.
+ */
+
+import Link from "next/link";
+import { useCallback, useEffect, useState, type JSX } from "react";
+import { revealPracticeReward } from "@/lib/economy/practiceClient";
+
+interface CookedCardMeta {
+  recipeName?: string;
+  recipeId?: string;
+  rating?: number;
+  persona?: string;
+  signature?: string | null;
+  transitLine?: string;
+  photoUrl?: string | null;
+  tableKey?: string | null;
+}
+
+interface CookedDishCardProps {
+  eventId: string;
+  createdAtLabel: string;
+  meta: CookedCardMeta;
+  initialCount: number;
+}
+
+const REACTED_CACHE_KEY = "alchm:feed:sparked";
+
+function sparkedCache(): Set<string> {
+  try {
+    const raw = window.localStorage.getItem(REACTED_CACHE_KEY);
+    return new Set(raw ? (JSON.parse(raw) as string[]) : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function rememberSpark(eventId: string): void {
+  try {
+    const cache = sparkedCache();
+    cache.add(eventId);
+    window.localStorage.setItem(REACTED_CACHE_KEY, JSON.stringify([...cache].slice(-500)));
+  } catch {
+    /* private mode */
+  }
+}
+
+export function CookedDishCard({ eventId, createdAtLabel, meta, initialCount }: CookedDishCardProps): JSX.Element {
+  const [count, setCount] = useState(initialCount);
+  const [sparked, setSparked] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    setSparked(sparkedCache().has(eventId));
+  }, [eventId]);
+
+  const spark = useCallback(async () => {
+    if (sparked || busy) return;
+    setBusy(true);
+    try {
+      const res = await fetch("/api/feed/react", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ eventId }),
+      });
+      const json = (await res.json()) as {
+        success?: boolean;
+        count?: number;
+        reward?: { tokenType: string; amount: number; hint: string } | null;
+      };
+      if (json.success) {
+        setSparked(true);
+        rememberSpark(eventId);
+        if (typeof json.count === "number") setCount(json.count);
+        if (json.reward) revealPracticeReward(json.reward);
+      }
+    } catch {
+      /* invisible — a missed spark is not an error */
+    } finally {
+      setBusy(false);
+    }
+  }, [eventId, sparked, busy]);
+
+  const dish = meta.recipeName || "a dish";
+  const recipeHref = meta.recipeId ? `/recipes/${encodeURIComponent(meta.recipeId)}` : null;
+
+  return (
+    <div className="glass-card-premium rounded-2xl overflow-hidden border-white/8 hover:border-purple-500/20 transition-all">
+      {meta.photoUrl && (
+        /* eslint-disable-next-line @next/next/no-img-element */
+        <img
+          src={meta.photoUrl}
+          alt={dish}
+          loading="lazy"
+          className="w-full max-h-72 object-cover border-b border-white/5"
+        />
+      )}
+      <div className="p-5">
+        <div className="flex items-start justify-between gap-3 flex-wrap">
+          <div className="min-w-0">
+            <p className="text-sm text-white/85">
+              <span className="font-bold text-purple-200">{meta.persona || "An alchemist of the kitchen"}</span>{" "}
+              made{" "}
+              {recipeHref ? (
+                <Link href={recipeHref} className="font-semibold text-white underline decoration-purple-400/30 underline-offset-2 hover:text-purple-100">
+                  {dish}
+                </Link>
+              ) : (
+                <span className="font-semibold text-white">{dish}</span>
+              )}
+              {typeof meta.rating === "number" && meta.rating > 0 && (
+                <span className="text-amber-300/90"> · {"★".repeat(Math.min(5, meta.rating))}</span>
+              )}
+            </p>
+            <p className="text-[11px] text-white/40 mt-1 italic">{meta.transitLine || "made under today's sky"}</p>
+          </div>
+          {meta.signature && (
+            <span className="shrink-0 text-[9px] font-black uppercase tracking-[0.14em] text-cyan-300/90 border border-cyan-500/25 rounded-full px-2.5 py-1">
+              {meta.signature}
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between gap-3 mt-3">
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => void spark()}
+              disabled={busy}
+              aria-pressed={sparked}
+              className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-xs font-semibold transition-all ${
+                sparked
+                  ? "border-amber-400/50 bg-amber-500/15 text-amber-200"
+                  : "border-white/10 bg-white/[0.03] text-white/50 hover:text-amber-200 hover:border-amber-500/40"
+              }`}
+            >
+              <span aria-hidden>✦</span>
+              {count > 0 ? count : "Spark"}
+            </button>
+            {meta.tableKey && (
+              <span className="text-[9px] font-mono uppercase tracking-widest text-purple-300/70">
+                {meta.tableKey.startsWith("full-moon") ? "🌕 Full Moon Feast" : "🌑 New Moon Table"}
+              </span>
+            )}
+          </div>
+          <span className="text-[10px] text-white/30 font-mono">{createdAtLabel}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/feed/LunarTableStrip.tsx
+++ b/src/components/feed/LunarTableStrip.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+/**
+ * The lunar table strip — the sky's standing invitation, pinned atop the feed.
+ *
+ * Pure astronomy, no rows: nextLunarTable() computes the open-or-upcoming
+ * new/full-moon table client-side. While a table is open the strip glows and
+ * cooked-it posts made in the window auto-attach (the share route stamps
+ * metadata.tableKey); before it opens it counts down.
+ */
+
+import Link from "next/link";
+import { useEffect, useState, type JSX } from "react";
+import { nextLunarTable, type LunarTable } from "@/lib/feed/lunarTables";
+
+function daysUntil(date: Date): string {
+  const ms = date.getTime() - Date.now();
+  if (ms <= 0) return "now";
+  const days = Math.floor(ms / 86_400_000);
+  if (days >= 2) return `in ${days} days`;
+  const hours = Math.round(ms / 3_600_000);
+  return days === 1 ? "tomorrow" : `in ${Math.max(1, hours)}h`;
+}
+
+export function LunarTableStrip(): JSX.Element | null {
+  const [table, setTable] = useState<LunarTable | null>(null);
+
+  useEffect(() => {
+    // Client-only: astronomy off the render path, refreshed hourly.
+    const compute = () => setTable(nextLunarTable());
+    compute();
+    const t = window.setInterval(compute, 3_600_000);
+    return () => window.clearInterval(t);
+  }, []);
+
+  if (!table) return null;
+  const moon = table.kind === "full-moon" ? "🌕" : "🌑";
+
+  return (
+    <div
+      className={`rounded-2xl border px-5 py-4 mb-4 flex items-center justify-between gap-4 flex-wrap ${
+        table.isOpen
+          ? "border-amber-400/40 bg-gradient-to-r from-amber-500/10 via-purple-500/10 to-transparent"
+          : "border-white/8 bg-white/[0.02]"
+      }`}
+    >
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-lg" aria-hidden>{moon}</span>
+          <span className="text-sm font-black uppercase tracking-[0.14em] text-white/85">{table.title}</span>
+          <span
+            className={`text-[9px] font-mono uppercase tracking-widest px-2 py-0.5 rounded-full border ${
+              table.isOpen
+                ? "text-amber-200 border-amber-400/40 bg-amber-500/10"
+                : "text-white/40 border-white/10"
+            }`}
+          >
+            {table.isOpen ? "table is open" : `opens ${daysUntil(table.opensAt)}`}
+          </span>
+        </div>
+        <p className="text-xs text-white/45 mt-1 max-w-xl">{table.invitation}</p>
+      </div>
+      {table.isOpen && (
+        <Link
+          href="/cuisines"
+          className="shrink-0 text-[10px] font-black uppercase tracking-widest text-amber-200 border border-amber-400/40 rounded-xl px-4 py-2 hover:bg-amber-500/10 transition-colors"
+        >
+          Cook for the table →
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/src/components/feed/TransitInviteBanner.tsx
+++ b/src/components/feed/TransitInviteBanner.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+/**
+ * Transit invite — "the sky calls your chart to a table".
+ *
+ * When a transiting planet sits conjunct (≤3° orb) a planet in the viewer's
+ * natal chart, a soft banner invites them into that transit's group chat via
+ * the existing useTransitGroupChat join mechanic (which also pays the
+ * once-ever chat_joined practice). Cross-planet hits use real ecliptic
+ * longitudes — transit from AlchemicalContext, natal from the stored chart.
+ * Dismissal is remembered per hit per day.
+ */
+
+import { useMemo, useState, type JSX } from "react";
+import { useAlchemical } from "@/contexts/AlchemicalContext/hooks";
+import { useUser } from "@/contexts/UserContext";
+import { useTransitGroupChat } from "@/hooks/useTransitGroupChat";
+import { toParticipant } from "@/lib/agents/transitAgents";
+
+const ORB_DEGREES = 3;
+const DISMISS_KEY = "alchm:transit-invite:dismissed";
+
+interface TransitHit {
+  transitPlanet: string;
+  transitSign: string;
+  transitDegree: number; // within-sign 0-29
+  natalPlanet: string;
+  orb: number;
+}
+
+function angularDelta(a: number, b: number): number {
+  const d = Math.abs(a - b) % 360;
+  return d > 180 ? 360 - d : d;
+}
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function dismissedToday(hitKey: string): boolean {
+  try {
+    const raw = window.localStorage.getItem(DISMISS_KEY);
+    return raw === `${todayKey()}:${hitKey}`;
+  } catch {
+    return false;
+  }
+}
+
+export function TransitInviteBanner(): JSX.Element | null {
+  const { state } = useAlchemical();
+  const { currentUser } = useUser();
+  const { open, pending } = useTransitGroupChat();
+  const [dismissed, setDismissed] = useState(false);
+
+  const hit = useMemo<TransitHit | null>(() => {
+    const natalPlanets = currentUser?.natalChart?.planets;
+    const transits = state?.planetaryPositions as
+      | Record<string, { sign?: string; degree?: number; exactLongitude?: number }>
+      | undefined;
+    if (!Array.isArray(natalPlanets) || natalPlanets.length === 0 || !transits) return null;
+
+    let best: TransitHit | null = null;
+    for (const [planetKey, pos] of Object.entries(transits)) {
+      const lon = typeof pos?.exactLongitude === "number" ? pos.exactLongitude : null;
+      if (lon === null || !pos?.sign) continue;
+      for (const natal of natalPlanets) {
+        if (typeof natal?.position !== "number" || !natal?.name) continue;
+        const orb = angularDelta(lon, natal.position);
+        if (orb <= ORB_DEGREES && (!best || orb < best.orb)) {
+          best = {
+            transitPlanet: planetKey,
+            transitSign: String(pos.sign),
+            transitDegree: Math.floor(typeof pos.degree === "number" ? pos.degree : lon % 30),
+            natalPlanet: String(natal.name),
+            orb,
+          };
+        }
+      }
+    }
+    return best;
+  }, [state?.planetaryPositions, currentUser?.natalChart?.planets]);
+
+  if (!hit) return null;
+
+  const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+  const hitKey = `${hit.transitPlanet}-${hit.natalPlanet}`;
+  if (dismissed || (typeof window !== "undefined" && dismissedToday(hitKey))) return null;
+
+  const participant = toParticipant({
+    planet: hit.transitPlanet,
+    sign: hit.transitSign,
+    degree: hit.transitDegree,
+  });
+  if (!participant) return null;
+
+  const label = `${cap(hit.transitPlanet)} crosses your natal ${cap(hit.natalPlanet)}`;
+
+  return (
+    <div className="rounded-2xl border border-purple-400/30 bg-gradient-to-r from-purple-500/15 via-indigo-500/10 to-transparent px-5 py-4 mb-4 flex items-center justify-between gap-4 flex-wrap">
+      <div className="min-w-0">
+        <p className="text-sm text-white/90">
+          <span aria-hidden>✶</span> <strong>{label}</strong>
+          <span className="text-white/50"> — a table is open under this transit.</span>
+        </p>
+        <p className="text-[11px] text-white/40 mt-0.5">
+          Sit with {participant.name} and the others gathered beneath the same degree.
+        </p>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <button
+          type="button"
+          disabled={pending}
+          onClick={() =>
+            void open([participant], { key: `natal-hit--${participant.id}`, label }, "natal-invite")
+          }
+          className="text-[10px] font-black uppercase tracking-widest text-purple-100 border border-purple-400/50 bg-purple-500/20 rounded-xl px-4 py-2 hover:bg-purple-500/30 transition-colors disabled:opacity-50"
+        >
+          {pending ? "Opening…" : "Take a seat →"}
+        </button>
+        <button
+          type="button"
+          aria-label="Dismiss invite"
+          onClick={() => {
+            setDismissed(true);
+            try {
+              window.localStorage.setItem(DISMISS_KEY, `${todayKey()}:${hitKey}`);
+            } catch {
+              /* private mode */
+            }
+          }}
+          className="text-white/30 hover:text-white/60 text-sm px-1"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/grocery-cart/GroceryCartDrawer.tsx
+++ b/src/components/grocery-cart/GroceryCartDrawer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { OrderIngredientsModal } from "@/components/order/OrderIngredientsModal";
 import { useToast } from "@/components/ToastProvider";
 import { useGroceryCart } from "@/contexts/GroceryCartContext";
 import { AMAZON_ASSOCIATE_TAG } from "@/data/amazon";
@@ -21,6 +22,7 @@ export function GroceryCartDrawer() {
   } = useGroceryCart();
   const { showToast } = useToast();
   const [checkingOut, setCheckingOut] = useState(false);
+  const [smartOrderOpen, setSmartOrderOpen] = useState(false);
 
   // Escape key handler — closes the drawer for keyboard users
   useEffect(() => {
@@ -309,7 +311,29 @@ export function GroceryCartDrawer() {
                   </>
                 )}
               </button>
+              <button
+                type="button"
+                onClick={() => setSmartOrderOpen(true)}
+                disabled={items.length === 0}
+                className="w-full px-4 py-2.5 rounded-xl border border-cyan-500/30 bg-cyan-500/10 text-cyan-200 font-semibold text-xs hover:bg-cyan-500/20 transition-all disabled:opacity-50"
+              >
+                🧺 Smart order list (staples &amp; pantry aware)
+              </button>
             </div>
+
+            <OrderIngredientsModal
+              open={smartOrderOpen}
+              onClose={() => setSmartOrderOpen(false)}
+              title="Your grocery cart"
+              inputs={items.map((item) => ({
+                name: item.name,
+                amount: item.quantity,
+                unit: item.unit,
+                category: item.category,
+              }))}
+              source="grocery_drawer"
+              listTarget="cart"
+            />
             <button
               type="button"
               onClick={clear}

--- a/src/components/menu-planner/GroceryListModal.tsx
+++ b/src/components/menu-planner/GroceryListModal.tsx
@@ -15,6 +15,7 @@ import {
   AMAZON_ASSOCIATE_TAG,
   getStandardizedQuantity,
 } from "@/data/amazon";
+import { firePractice } from "@/lib/economy/practiceClient";
 import { reportQuestEvent } from "@/lib/questReporter";
 import type { GroceryItem, GroceryCategory } from "@/types/menuPlanner";
 import { getGroupedGroceryList } from "@/utils/groceryListGenerator";
@@ -461,6 +462,8 @@ export default function GroceryListModal({
   };
 
   const handleOrderOnAmazon = () => {
+    // Conjuring the week's order list quietly counts (deduped per menu per day).
+    firePractice("list_conjured", `menu:${currentMenu?.id ?? "week"}`);
     setShowAmazonPreview(true);
     setAmazonError(null);
     setAmazonResolution(null);

--- a/src/components/order/OrderIngredientsModal.tsx
+++ b/src/components/order/OrderIngredientsModal.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+/**
+ * Order Ingredients — the one checklist modal every surface reuses (recipe
+ * detail, grocery cart, weekly menu, discovery drawer).
+ *
+ * Every ingredient row links to a TAGGED Amazon Fresh search (whole-catalog
+ * coverage, day one). Rows that resolve an ASIN via /api/amazon/search ride
+ * the existing Associates cart-POST instead — one tap fills a Fresh cart.
+ * Staples sit behind a toggle; unchecked items are remembered as "already
+ * have it" (pantry memory). Opening a list with items quietly counts as the
+ * list_conjured practice.
+ */
+
+import { ExternalLink, Loader2, ShoppingBasket, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from "react";
+import { preflightAndSubmitAmazonCart } from "@/lib/amazonCartHandoff";
+import { firePractice } from "@/lib/economy/practiceClient";
+import {
+  buildOrderList,
+  pantryCache,
+  setPantryItem,
+  type OrderInput,
+  type OrderListItem,
+} from "@/lib/order/orderList";
+import type { CheckoutPreflightSource } from "@/types/checkout";
+
+interface OrderIngredientsModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  inputs: OrderInput[];
+  /** Serving multiplier (servings / baseServings on recipe surfaces). */
+  scale?: number;
+  source: CheckoutPreflightSource;
+  /** Dedupe target for the list_conjured practice (e.g. `recipe:<id>`). */
+  listTarget: string;
+}
+
+export function OrderIngredientsModal({
+  open,
+  onClose,
+  title,
+  inputs,
+  scale = 1,
+  source,
+  listTarget,
+}: OrderIngredientsModalProps): JSX.Element | null {
+  const items = useMemo(() => buildOrderList(inputs, scale), [inputs, scale]);
+  const [checked, setChecked] = useState<Record<string, boolean>>({});
+  const [includeStaples, setIncludeStaples] = useState(false);
+  const [asins, setAsins] = useState<Record<string, string>>({});
+  const [resolving, setResolving] = useState(false);
+  const [sendingCart, setSendingCart] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+  const conjured = useRef(false);
+
+  // Seed checkbox state: pantry-remembered and staple rows start unchecked.
+  useEffect(() => {
+    if (!open) return;
+    const pantry = pantryCache();
+    const seed: Record<string, boolean> = {};
+    for (const item of items) {
+      seed[item.key] = !pantry.has(item.key) && !item.isStaple && !item.optional;
+    }
+    setChecked(seed);
+    setNotice(null);
+  }, [open, items]);
+
+  // The act of conjuring a list quietly counts (deduped per target per day).
+  useEffect(() => {
+    if (open && items.length > 0 && !conjured.current) {
+      conjured.current = true;
+      firePractice("list_conjured", listTarget);
+    }
+    if (!open) conjured.current = false;
+  }, [open, items.length, listTarget]);
+
+  // Batch-resolve ASINs so resolved rows can ride the one-tap Fresh cart.
+  useEffect(() => {
+    if (!open || items.length === 0) return;
+    let cancelled = false;
+    setResolving(true);
+    fetch("/api/amazon/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ingredients: items.map((i) => i.name) }),
+    })
+      .then(async (res) => {
+        if (!res.ok || cancelled) return;
+        const json = (await res.json()) as { results?: Array<{ ingredient: string; asin: string | null }> };
+        if (!json.results) return;
+        const map: Record<string, string> = {};
+        for (const r of json.results) {
+          if (!r.asin) continue;
+          const match = items.find((i) => i.name.toLowerCase() === r.ingredient.toLowerCase());
+          if (match) map[match.key] = r.asin;
+        }
+        if (!cancelled) setAsins(map);
+      })
+      .catch(() => {
+        /* search links cover everything anyway */
+      })
+      .finally(() => {
+        if (!cancelled) setResolving(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, items]);
+
+  const visible = useMemo(
+    () => items.filter((i) => includeStaples || !i.isStaple),
+    [items, includeStaples],
+  );
+  const selected = visible.filter((i) => checked[i.key]);
+  const cartable = selected.filter((i) => asins[i.key]);
+  const searchOnly = selected.filter((i) => !asins[i.key]);
+
+  const toggle = useCallback((item: OrderListItem) => {
+    setChecked((prev) => {
+      const next = !prev[item.key];
+      // Unchecking = "already have it" — remembered across sessions.
+      setPantryItem(item.key, !next);
+      return { ...prev, [item.key]: next };
+    });
+  }, []);
+
+  const openFreshCart = useCallback(async () => {
+    if (cartable.length === 0) return;
+    setSendingCart(true);
+    setNotice(null);
+    try {
+      await preflightAndSubmitAmazonCart({
+        source,
+        cartType: "fresh",
+        items: cartable.map((i) => ({
+          asin: asins[i.key],
+          qty: Math.max(1, Math.ceil(i.quantity)),
+          name: i.name,
+          category: i.category,
+        })),
+        metadata: { listTarget, itemCount: cartable.length },
+      });
+      setNotice(`Fresh cart opened with ${cartable.length} item${cartable.length === 1 ? "" : "s"}.`);
+    } catch {
+      setNotice("Couldn't open the Fresh cart — the search links below still work.");
+    } finally {
+      setSendingCart(false);
+    }
+  }, [cartable, asins, source, listTarget]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[120] flex items-end sm:items-center justify-center bg-black/70 backdrop-blur-sm p-0 sm:p-6"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Order ingredients — ${title}`}
+      onClick={onClose}
+    >
+      <div
+        className="w-full sm:max-w-lg max-h-[85vh] overflow-hidden flex flex-col rounded-t-2xl sm:rounded-2xl border border-purple-500/20 bg-[#0d0b14]/95 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-3 px-5 py-4 border-b border-white/5">
+          <div>
+            <div className="text-[10px] font-black uppercase tracking-[0.2em] text-purple-300/80">
+              Order Ingredients
+            </div>
+            <div className="text-sm font-semibold text-white/90 truncate max-w-[18rem]">{title}</div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="p-2 rounded-lg text-white/50 hover:text-white hover:bg-white/5 transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="px-5 py-3 flex items-center justify-between gap-3 border-b border-white/5">
+          <label className="flex items-center gap-2 text-[11px] text-white/50 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={includeStaples}
+              onChange={(e) => setIncludeStaples(e.target.checked)}
+              className="accent-purple-500"
+            />
+            Include staples (salt, oil, flour…)
+          </label>
+          {resolving && (
+            <span className="inline-flex items-center gap-1.5 text-[10px] font-mono text-white/30">
+              <Loader2 className="w-3 h-3 animate-spin" /> matching products
+            </span>
+          )}
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-3 space-y-1.5">
+          {visible.length === 0 && (
+            <p className="text-sm text-white/40 py-6 text-center">Nothing to order — the pantry provides.</p>
+          )}
+          {visible.map((item) => (
+            <div
+              key={item.key}
+              className={`flex items-center gap-3 rounded-lg px-3 py-2 border transition-colors ${
+                checked[item.key] ? "border-purple-500/25 bg-purple-500/5" : "border-white/5 bg-white/[0.02] opacity-60"
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={Boolean(checked[item.key])}
+                onChange={() => toggle(item)}
+                className="accent-purple-500 shrink-0"
+                aria-label={`Order ${item.name}`}
+              />
+              <div className="flex-1 min-w-0">
+                <span className="text-[13px] text-white/85 truncate block">{item.name}</span>
+                <span className="text-[10px] font-mono text-white/35">
+                  {item.quantity > 0 ? `${item.quantity} ${item.unit}` : item.unit}
+                  {asins[item.key] ? " · cart-ready" : ""}
+                  {item.isStaple ? " · staple" : ""}
+                </span>
+              </div>
+              <a
+                href={item.searchUrl}
+                target="_blank"
+                rel="sponsored noopener noreferrer"
+                className="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider text-cyan-300/90 hover:text-cyan-200 shrink-0"
+              >
+                Fresh <ExternalLink className="w-3 h-3" />
+              </a>
+            </div>
+          ))}
+        </div>
+
+        <div className="px-5 py-4 border-t border-white/5 space-y-2">
+          <button
+            type="button"
+            onClick={() => void openFreshCart()}
+            disabled={cartable.length === 0 || sendingCart}
+            className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 rounded-xl bg-gradient-to-br from-amber-500 to-orange-600 hover:from-amber-400 hover:to-orange-500 disabled:opacity-40 text-white text-xs font-black uppercase tracking-widest transition-all"
+          >
+            {sendingCart ? <Loader2 className="w-4 h-4 animate-spin" /> : <ShoppingBasket className="w-4 h-4" />}
+            {cartable.length > 0
+              ? `Open Fresh cart (${cartable.length} item${cartable.length === 1 ? "" : "s"})`
+              : "Use the Fresh links above"}
+          </button>
+          {searchOnly.length > 0 && cartable.length > 0 && (
+            <p className="text-[10px] text-white/35 text-center">
+              {searchOnly.length} item{searchOnly.length === 1 ? "" : "s"} without a product match — use their Fresh links.
+            </p>
+          )}
+          {notice && <p className="text-[11px] text-emerald-300/90 text-center">{notice}</p>}
+          <p className="text-[9px] text-white/25 text-center leading-relaxed">
+            As an Amazon Associate, alchm.kitchen earns from qualifying purchases. Unchecked items are
+            remembered as already in your pantry.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/recipe/CosmicRecipeGenerator.tsx
+++ b/src/components/recipe/CosmicRecipeGenerator.tsx
@@ -8,7 +8,7 @@ import { useToast } from '@/components/common/Toast';
 import { useRecipeBuilder } from '@/contexts/RecipeBuilderContext';
 import { useUser } from '@/contexts/UserContext';
 import type { MonicaOptimizedRecipe } from '@/data/unified/recipeBuilding';
-import { mintRecipe as submitRecipeMint, mintResultMessage } from '@/lib/recipe-nft/mintClient';
+import { mintRecipe as submitRecipeMint, mintResultMessage, quoteRecipeMint, type MintQuoteResult } from '@/lib/recipe-nft/mintClient';
 import type { cosmicRecipeSchema } from '@/types/cosmicRecipeSchema';
 import { getAllCuisineNames } from '@/utils/cuisine/cuisineIndex';
 import { saveRecipeToStore } from '@/utils/generatedRecipeStore';
@@ -132,6 +132,31 @@ export default function CosmicRecipeGenerator() {
   const [hasShared, setHasShared] = useState(false);
   const [isMinting, setIsMinting] = useState(false);
   const [hasMinted, setHasMinted] = useState(false);
+  const [mintQuote, setMintQuote] = useState<MintQuoteResult | null>(null);
+
+  // Cost-before-mint: quote the ESMS price once the recipe is saved so the
+  // mint button states its price instead of revealing it via a 402 toast.
+  useEffect(() => {
+    if (!object || !savedRecipeId) {
+      setMintQuote(null);
+      return;
+    }
+    let cancelled = false;
+    void quoteRecipeMint(object).then((q) => {
+      if (!cancelled) setMintQuote(q);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [savedRecipeId]);
+
+  const mintCostLabel = (() => {
+    if (!mintQuote?.enabled) return null;
+    const c = mintQuote.quote.liveCost;
+    const total = (c.spirit || 0) + (c.essence || 0) + (c.matter || 0) + (c.substance || 0);
+    return total > 0 ? `${Math.round(total * 10) / 10} ESMS` : null;
+  })();
 
   const handleMintNft = async () => {
     if (!object) return;
@@ -621,7 +646,13 @@ export default function CosmicRecipeGenerator() {
                   }`}
                   title="Spend ESMS equal to this recipe's alchemical fingerprint to mint it as an on-chain NFT"
                 >
-                  {hasMinted ? "✓ Minted" : isMinting ? "Minting…" : "⛓ Mint as NFT"}
+                  {hasMinted
+                    ? "✓ Minted"
+                    : isMinting
+                      ? "Minting…"
+                      : mintCostLabel
+                        ? `⛓ Mint as NFT · ${mintCostLabel}`
+                        : "⛓ Mint as NFT"}
                 </button>
               </div>
             )}

--- a/src/components/recipes/SocialSection.tsx
+++ b/src/components/recipes/SocialSection.tsx
@@ -43,9 +43,11 @@ function writeLocalState(recipeId: string, state: LocalSocialState) {
 
 interface Props {
   recipeId: string;
+  /** Enables the share-to-commons offer on cooked dishes. */
+  recipeName?: string;
 }
 
-export function SocialSection({ recipeId }: Props) {
+export function SocialSection({ recipeId, recipeName }: Props) {
   const { data: session, status } = useSession();
   const isAuthed = status === "authenticated";
 
@@ -54,6 +56,50 @@ export function SocialSection({ recipeId }: Props) {
   const [madeCount, setMadeCount] = useState<number>(0);
   const [tips, setTips] = useState<CommunityTip[]>([]);
   const [saving, setSaving] = useState(false);
+  const [shareState, setShareState] = useState<"idle" | "sharing" | "shared">("idle");
+
+  useEffect(() => {
+    try {
+      if (window.localStorage.getItem(`alchm:cooked-shared:${recipeId}`)) setShareState("shared");
+    } catch {
+      /* private mode */
+    }
+  }, [recipeId]);
+
+  // The moment of pride: cooked + photographed → one-tap offer to post the
+  // dish card (chart-persona identity, never a real name) to the commons.
+  const shareToCommons = async () => {
+    if (!recipeName || !state.photoDataUrl || shareState !== "idle") return;
+    setShareState("sharing");
+    try {
+      const res = await fetch("/api/feed/share", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          shareType: "cooked",
+          payload: {
+            recipeName,
+            recipeId,
+            rating: state.rating || undefined,
+            photoDataUrl: state.photoDataUrl,
+          },
+        }),
+      });
+      const json = await res.json();
+      if (json.success) {
+        setShareState("shared");
+        try {
+          window.localStorage.setItem(`alchm:cooked-shared:${recipeId}`, "1");
+        } catch {
+          /* private mode */
+        }
+      } else {
+        setShareState("idle");
+      }
+    } catch {
+      setShareState("idle");
+    }
+  };
 
   // Debounce review saves so each keystroke doesn't POST.
   const reviewDebounce = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -282,7 +328,27 @@ export function SocialSection({ recipeId }: Props) {
               &#x2715;
             </button>
           </div>
-        ) : (
+        ) : null}
+        {state.photoDataUrl && isAuthed && state.madeIt && recipeName && (
+          <div className="mt-3">
+            {shareState === "shared" ? (
+              <p className="text-xs text-emerald-300/90">✨ Shared to the commons — your work cooks under its own stars now.</p>
+            ) : (
+              <button
+                type="button"
+                onClick={() => void shareToCommons()}
+                disabled={shareState === "sharing"}
+                className="px-4 py-2 rounded-xl text-sm font-medium border bg-purple-500/10 border-purple-500/30 text-purple-200 hover:bg-purple-500/20 transition-colors disabled:opacity-60"
+              >
+                {shareState === "sharing" ? "Sharing…" : "Share to the commons ✨"}
+              </button>
+            )}
+            <p className="text-[10px] text-white/35 mt-1.5">
+              Posts appear under your chart-persona — never your name.
+            </p>
+          </div>
+        )}
+        {!state.photoDataUrl && (
           <label className="flex items-center justify-center gap-2 px-4 py-3 rounded-lg bg-white/5 border border-dashed border-white/15 text-sm text-white/60 hover:text-amber-200 hover:border-amber-500/40 cursor-pointer transition-colors">
             <span className="text-lg">{"\u{1F4F7}"}</span>
             Add a photo

--- a/src/lib/economy/practices.ts
+++ b/src/lib/economy/practices.ts
@@ -21,7 +21,9 @@ export type PracticeType =
   | "feed_visit"
   | "feed_reaction"
   | "chat_joined"
-  | "surface_discovered";
+  | "surface_discovered"
+  | "work_resonated"
+  | "list_conjured";
 
 export type DedupeScope = "daily" | "ever";
 
@@ -145,6 +147,36 @@ export const PRACTICES: Record<PracticeType, PracticeDefinition> = {
     description:
       "Cross the threshold of a chamber of the kitchen you have never entered.",
   },
+  work_resonated: {
+    type: "work_resonated",
+    tokenType: "Spirit",
+    baseAmount: 1,
+    dedupe: "ever",
+    dailyCap: 3,
+    requiresTarget: true,
+    hints: [
+      "Your work found its witnesses",
+      "The commons tasted what you made",
+      "A dish shared returns as Spirit",
+    ],
+    description:
+      "Share a finished Work and let it resonate — when others spark to your dish, Spirit returns to its maker.",
+  },
+  list_conjured: {
+    type: "list_conjured",
+    tokenType: "Substance",
+    baseAmount: 1,
+    dedupe: "daily",
+    dailyCap: 2,
+    requiresTarget: true,
+    hints: [
+      "Provisions summoned to the door",
+      "The pantry hears the call",
+      "Substance follows a well-made list",
+    ],
+    description:
+      "Conjure an ingredient order from a recipe or menu — the market answers those who prepare.",
+  },
 };
 
 /**
@@ -156,6 +188,10 @@ export const PRACTICES: Record<PracticeType, PracticeDefinition> = {
 export const SERVER_ONLY_PRACTICES: ReadonlySet<PracticeType> = new Set([
   "cooked_recipe",
   "photo_added",
+  // Both sides of a reaction are recognized inside POST /api/feed/react —
+  // the reaction ROW is the proof, a bare practice POST is not.
+  "feed_reaction",
+  "work_resonated",
 ]);
 
 /**

--- a/src/lib/feed/cookCard.ts
+++ b/src/lib/feed/cookCard.ts
@@ -1,0 +1,74 @@
+/**
+ * Cooked-it card metadata — SERVER ONLY.
+ *
+ * Builds the alchemical identity of a dish post at share time: the cook's
+ * chart-persona ("A Scorpio-Sun water cook" — pseudonymous by design, real
+ * names never appear on cooked-it cards), their elemental signature chip, and
+ * the transit line ("made under a waxing gibbous Moon in Pisces"). Everything
+ * is computed ONCE here and stored in the feed row's metadata — renders never
+ * recompute astronomy.
+ */
+
+import type { NatalChart } from "@/types/natalChart";
+import { extractPlanetaryPositions } from "@/utils/astrology/chartDataUtils";
+import { getLunarPhaseName, calculateLunarPhase, calculatemoonSign } from "@/utils/astrology/core";
+import { elementalSignature } from "@/utils/elemental";
+
+export interface CookCardIdentity {
+  /** e.g. "A Scorpio-Sun water cook" — never a real name. */
+  persona: string;
+  /** e.g. "Water & Earth" — the elemental signature short label. */
+  signature: string | null;
+  /** e.g. "made under a waxing gibbous Moon in Pisces". */
+  transitLine: string;
+}
+
+function capitalize(s: string): string {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1).toLowerCase() : s;
+}
+
+/** The chart-persona string. Chartless cooks get the humble default. */
+export function buildPersona(natalChart: NatalChart | null | undefined): string {
+  if (!natalChart) return "An alchemist of the kitchen";
+  const positions = extractPlanetaryPositions(natalChart) as Record<string, string>;
+  const sun = positions?.Sun ?? positions?.sun;
+  const element = natalChart.dominantElement;
+  if (sun && element) return `A ${capitalize(String(sun))}-Sun ${String(element).toLowerCase()} cook`;
+  if (sun) return `A ${capitalize(String(sun))}-Sun cook`;
+  if (element) return `A ${String(element).toLowerCase()}-leaning cook`;
+  return "An alchemist of the kitchen";
+}
+
+/** Full card identity: persona + signature chip + transit line for `at`. */
+export async function buildCookCardIdentity(
+  natalChart: NatalChart | null | undefined,
+  at = new Date(),
+): Promise<CookCardIdentity> {
+  const persona = buildPersona(natalChart);
+
+  let signature: string | null = null;
+  if (natalChart?.elementalBalance) {
+    try {
+      // celestial.ElementalProperties lacks the index signature alchemy's
+      // variant declares — same four keys at runtime.
+      signature = elementalSignature({ ...natalChart.elementalBalance }).shortLabel;
+    } catch {
+      signature = null;
+    }
+  }
+
+  let transitLine = "made under today's sky";
+  try {
+    const [phase, moonSign] = await Promise.all([
+      calculateLunarPhase(at).then(getLunarPhaseName),
+      calculatemoonSign(at),
+    ]);
+    // "new moon"/"full moon" phase names would double the word before "Moon".
+    const phaseLabel = String(phase).replace(/\s*moon$/i, "");
+    transitLine = `made under a ${phaseLabel} Moon in ${capitalize(String(moonSign))}`;
+  } catch {
+    /* astronomy hiccup — keep the graceful default */
+  }
+
+  return { persona, signature, transitLine };
+}

--- a/src/lib/feed/cookPhotoStorage.ts
+++ b/src/lib/feed/cookPhotoStorage.ts
@@ -1,0 +1,76 @@
+/**
+ * Cook-photo storage — user dish photos for cooked-it feed posts, stored in
+ * the same R2 bucket the recipe-NFT hero images use (SERVER ONLY).
+ *
+ * Input is the data URL the existing /api/food-lab/upload endpoint already
+ * produces (validated jpeg/png/webp, ≤5MB). We persist it under
+ * cook-photos/<userId>/<hash>.<ext> and return the public URL — a feed row
+ * carries a short URL instead of half a megabyte of base64 JSONB.
+ */
+
+import { createHash } from "crypto";
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+
+const CF_ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID;
+const R2_ACCESS_KEY_ID = process.env.R2_ACCESS_KEY_ID;
+const R2_SECRET_ACCESS_KEY = process.env.R2_SECRET_ACCESS_KEY;
+const R2_BUCKET = process.env.R2_BUCKET_NAME || "alchm-assets";
+const R2_DOMAIN = (process.env.NEXT_PUBLIC_R2_DOMAIN || "https://assets.alchm.kitchen").replace(/\/$/, "");
+
+const MAX_BYTES = 5 * 1024 * 1024;
+const MIME_EXT: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+};
+
+export function cookPhotoStorageConfigured(): boolean {
+  return Boolean(CF_ACCOUNT_ID && R2_ACCESS_KEY_ID && R2_SECRET_ACCESS_KEY);
+}
+
+let _s3: S3Client | null = null;
+function r2(): S3Client {
+  if (!_s3) {
+    _s3 = new S3Client({
+      region: "auto",
+      endpoint: `https://${CF_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+      credentials: {
+        accessKeyId: R2_ACCESS_KEY_ID as string,
+        secretAccessKey: R2_SECRET_ACCESS_KEY as string,
+      },
+    });
+  }
+  return _s3;
+}
+
+/**
+ * Persist a dish-photo data URL to R2. Returns the public URL, or null when
+ * storage is unconfigured, the payload is malformed, or the write fails —
+ * callers post the card without a photo rather than failing the share.
+ */
+export async function storeCookPhoto(userId: string, dataUrl: string): Promise<string | null> {
+  if (!cookPhotoStorageConfigured()) return null;
+  const match = /^data:(image\/(?:jpeg|png|webp));base64,([A-Za-z0-9+/=]+)$/.exec(dataUrl);
+  if (!match) return null;
+  const [, mime, b64] = match;
+  const buf = Buffer.from(b64, "base64");
+  if (buf.length === 0 || buf.length > MAX_BYTES) return null;
+
+  const hash = createHash("sha256").update(buf).digest("hex").slice(0, 24);
+  const key = `cook-photos/${userId}/${hash}.${MIME_EXT[mime]}`;
+  try {
+    await r2().send(
+      new PutObjectCommand({
+        Bucket: R2_BUCKET,
+        Key: key,
+        Body: new Uint8Array(buf),
+        ContentType: mime,
+        CacheControl: "public, max-age=31536000, immutable",
+      }),
+    );
+    return `${R2_DOMAIN}/${key}`;
+  } catch (err) {
+    console.error("[cookPhotoStorage] R2 put failed:", err);
+    return null;
+  }
+}

--- a/src/lib/feed/lunarTables.ts
+++ b/src/lib/feed/lunarTables.ts
@@ -1,0 +1,110 @@
+/**
+ * Lunar auto-tables — the communal cook-alongs the sky schedules.
+ *
+ * A "table" opens around each new and full moon (24h before → 36h after the
+ * exact event) with a deterministic key like `full-moon-2026-07-29`. There are
+ * NO database rows: the current/next table is pure astronomy (suncalc), the
+ * feed renders a pinned strip from this module, and cooked-it posts made while
+ * a table is open carry `metadata.tableKey` so the table's thread is just a
+ * feed filter. Isomorphic (server + client) and deterministic per timestamp.
+ */
+
+import SunCalc from "suncalc";
+
+export interface LunarTable {
+  key: string; // e.g. "full-moon-2026-07-29" (UTC date of the exact event)
+  kind: "full-moon" | "new-moon";
+  title: string; // "Full Moon Feast" | "New Moon Table"
+  invitation: string;
+  /** Exact astronomical moment of the event. */
+  peakAt: Date;
+  opensAt: Date;
+  closesAt: Date;
+  /** True when `now` falls inside the open window. */
+  isOpen: boolean;
+}
+
+const OPEN_BEFORE_MS = 24 * 60 * 60 * 1000;
+const OPEN_AFTER_MS = 36 * 60 * 60 * 1000;
+
+const TITLES: Record<LunarTable["kind"], { title: string; invitation: string }> = {
+  "full-moon": {
+    title: "Full Moon Feast",
+    invitation: "Cook something abundant under the full light — the table is set for everyone beneath it.",
+  },
+  "new-moon": {
+    title: "New Moon Table",
+    invitation: "Begin something under the dark sky — simple dishes, new intentions, shared quietly.",
+  },
+};
+
+/**
+ * Find the exact moment the moon phase crosses `target` (0 = new, 0.5 = full),
+ * scanning hourly then bisecting to the minute.
+ */
+function findPhaseCrossing(from: Date, target: 0 | 0.5, horizonDays: number): Date | null {
+  const HOUR = 60 * 60 * 1000;
+  // Signed distance from target in phase space (wraps at 1).
+  const dist = (d: Date) => {
+    const p = SunCalc.getMoonIllumination(d).phase;
+    let delta = p - target;
+    if (delta > 0.5) delta -= 1;
+    if (delta < -0.5) delta += 1;
+    return delta;
+  };
+
+  let prev = from;
+  let prevDist = dist(prev);
+  for (let h = 1; h <= horizonDays * 24; h++) {
+    const cur = new Date(from.getTime() + h * HOUR);
+    const curDist = dist(cur);
+    // Crossing: distance flips sign from negative (approaching) to positive (past).
+    if (prevDist < 0 && curDist >= 0) {
+      let lo = prev.getTime();
+      let hi = cur.getTime();
+      for (let i = 0; i < 12; i++) {
+        const mid = (lo + hi) / 2;
+        if (dist(new Date(mid)) < 0) lo = mid;
+        else hi = mid;
+      }
+      return new Date(hi);
+    }
+    prev = cur;
+    prevDist = curDist;
+  }
+  return null;
+}
+
+function toTable(kind: LunarTable["kind"], peakAt: Date, now: Date): LunarTable {
+  const opensAt = new Date(peakAt.getTime() - OPEN_BEFORE_MS);
+  const closesAt = new Date(peakAt.getTime() + OPEN_AFTER_MS);
+  const dateKey = peakAt.toISOString().slice(0, 10);
+  return {
+    key: `${kind}-${dateKey}`,
+    kind,
+    ...TITLES[kind],
+    peakAt,
+    opensAt,
+    closesAt,
+    isOpen: now >= opensAt && now <= closesAt,
+  };
+}
+
+/**
+ * The currently-open table, or the next one on the calendar. Starts the scan
+ * slightly in the past so a table whose peak just passed (still inside its
+ * open window) is found.
+ */
+export function nextLunarTable(now = new Date()): LunarTable | null {
+  const scanFrom = new Date(now.getTime() - OPEN_AFTER_MS);
+  const candidates: LunarTable[] = [];
+  const full = findPhaseCrossing(scanFrom, 0.5, 35);
+  if (full) candidates.push(toTable("full-moon", full, now));
+  const newMoon = findPhaseCrossing(scanFrom, 0, 35);
+  if (newMoon) candidates.push(toTable("new-moon", newMoon, now));
+  if (candidates.length === 0) return null;
+
+  candidates.sort((a, b) => a.peakAt.getTime() - b.peakAt.getTime());
+  // Prefer an open table; otherwise the soonest upcoming one.
+  return candidates.find((t) => t.isOpen) ?? candidates.find((t) => t.peakAt.getTime() >= now.getTime()) ?? candidates[0];
+}

--- a/src/lib/order/orderList.ts
+++ b/src/lib/order/orderList.ts
@@ -1,0 +1,154 @@
+/**
+ * Order-list builder — turns recipe/menu/cart ingredients into the checklist
+ * the OrderIngredientsModal renders. Pure functions, isomorphic.
+ *
+ * Smarts (all four from the planning round): serving-scaled quantities,
+ * cross-recipe merge (slug(name)+unit keying, mirroring GroceryCartContext),
+ * a curated staples set default-excluded behind a toggle, and pantry memory —
+ * items the user marks "already have" live in localStorage and default
+ * unchecked forever after.
+ *
+ * Every item gets a tagged Amazon Fresh SEARCH link (works for the whole
+ * catalog day one); items that resolve an ASIN via /api/amazon/search ride
+ * the existing Associates cart-POST instead.
+ */
+
+import { AMAZON_ASSOCIATE_TAG } from "@/data/amazon";
+
+export interface OrderInput {
+  name: string;
+  amount?: number;
+  unit?: string;
+  category?: string;
+  optional?: boolean;
+}
+
+export interface OrderListItem {
+  key: string; // slug(name)__slug(unit)
+  name: string;
+  quantity: number;
+  unit: string;
+  category?: string;
+  isStaple: boolean;
+  optional: boolean;
+  searchUrl: string;
+  asin: string | null;
+}
+
+/**
+ * Pantry-class staples most kitchens already hold — default-excluded from
+ * order lists behind the "include staples" toggle. Matched on the slugged
+ * name CONTAINING one of these tokens.
+ */
+const STAPLE_TOKENS = [
+  "salt",
+  "black-pepper",
+  "pepper",
+  "water",
+  "olive-oil",
+  "vegetable-oil",
+  "canola-oil",
+  "sugar",
+  "flour",
+  "baking-powder",
+  "baking-soda",
+  "soy-sauce",
+  "vinegar",
+  "butter",
+  "garlic-powder",
+  "onion-powder",
+  "cooking-spray",
+  "ice",
+];
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function isStapleName(name: string): boolean {
+  const slug = slugify(name);
+  return STAPLE_TOKENS.some((t) => slug === t || slug.endsWith(`-${t}`) || slug.startsWith(`${t}-`) || slug.includes(`-${t}-`));
+}
+
+/** Tagged Amazon Fresh search URL for an ingredient name. */
+export function freshSearchUrl(name: string): string {
+  const params = new URLSearchParams({
+    k: name.trim(),
+    i: "amazonfresh",
+  });
+  if (AMAZON_ASSOCIATE_TAG) params.set("tag", AMAZON_ASSOCIATE_TAG);
+  return `https://www.amazon.com/s?${params.toString()}`;
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * Build the merged, scaled order list. `scale` multiplies every amount
+ * (servings / baseServings on recipe surfaces; 1 elsewhere). Items merge by
+ * (name, unit) slug key across everything passed in.
+ */
+export function buildOrderList(inputs: OrderInput[], scale = 1): OrderListItem[] {
+  const merged = new Map<string, OrderListItem>();
+  for (const input of inputs) {
+    const name = (input.name || "").trim();
+    if (!name) continue;
+    const unit = (input.unit || "each").trim();
+    const key = `${slugify(name)}__${slugify(unit)}`;
+    const amount = typeof input.amount === "number" && Number.isFinite(input.amount) ? input.amount : 1;
+    const quantity = round2(Math.max(0, amount) * Math.max(0, scale));
+
+    const existing = merged.get(key);
+    if (existing) {
+      existing.quantity = round2(existing.quantity + quantity);
+      existing.optional = existing.optional && Boolean(input.optional);
+    } else {
+      merged.set(key, {
+        key,
+        name,
+        quantity,
+        unit,
+        category: input.category,
+        isStaple: isStapleName(name),
+        optional: Boolean(input.optional),
+        searchUrl: freshSearchUrl(name),
+        asin: null,
+      });
+    }
+  }
+  // Non-staples first, then staples; alphabetical within each group.
+  return [...merged.values()].sort((a, b) =>
+    a.isStaple === b.isStaple ? a.name.localeCompare(b.name) : a.isStaple ? 1 : -1,
+  );
+}
+
+// ── Pantry memory (client-side) ─────────────────────────────────────────────
+
+const PANTRY_CACHE_KEY = "alchm:order:pantry";
+
+export function pantryCache(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = window.localStorage.getItem(PANTRY_CACHE_KEY);
+    return new Set(raw ? (JSON.parse(raw) as string[]) : []);
+  } catch {
+    return new Set();
+  }
+}
+
+export function setPantryItem(key: string, inPantry: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    const cache = pantryCache();
+    if (inPantry) cache.add(key);
+    else cache.delete(key);
+    window.localStorage.setItem(PANTRY_CACHE_KEY, JSON.stringify([...cache]));
+  } catch {
+    /* private mode — pantry memory just doesn't persist */
+  }
+}

--- a/src/services/dashboardPanelsService.ts
+++ b/src/services/dashboardPanelsService.ts
@@ -817,6 +817,54 @@ export async function getRecentAlerts(
   }
 }
 
+// ─── Living Economy · the release's three success numbers ─────────────
+
+export interface LivingEconomyMetrics {
+  /** Amazon cart handoffs in the trailing 7 days (cart_handoff_intents). */
+  affiliateClicksWeek: number;
+  /** Cooked-it dish cards posted in the trailing 7 days. */
+  cookedPostsWeek: number;
+  /** Distinct users whose feed_visit practice fired today. */
+  feedDauToday: number;
+  live: boolean;
+}
+
+/**
+ * The composite scorecard for the Living Economy release: affiliate-funnel
+ * top (handoffs), the cook→share flywheel (dish cards), and social pull
+ * (feed DAU via the practice ledger). Never throws.
+ */
+export async function getLivingEconomyMetrics(): Promise<LivingEconomyMetrics> {
+  try {
+    const result = await executeQuery<{
+      affiliate_clicks: string;
+      cooked_posts: string;
+      feed_dau: string;
+    }>(
+      `SELECT
+         (SELECT COUNT(*) FROM cart_handoff_intents
+           WHERE created_at >= now() - interval '7 days') AS affiliate_clicks,
+         (SELECT COUNT(*) FROM feed_events
+           WHERE event_type = 'made_it'
+             AND metadata_payload->>'card' = 'cooked'
+             AND created_at >= now() - interval '7 days') AS cooked_posts,
+         (SELECT COUNT(DISTINCT user_id) FROM practice_events
+           WHERE practice_type = 'feed_visit'
+             AND created_at >= CURRENT_DATE) AS feed_dau`,
+    );
+    const row = result.rows[0];
+    return {
+      affiliateClicksWeek: Number(row?.affiliate_clicks ?? 0),
+      cookedPostsWeek: Number(row?.cooked_posts ?? 0),
+      feedDauToday: Number(row?.feed_dau ?? 0),
+      live: true,
+    };
+  } catch (error) {
+    _logger.warn("[getLivingEconomyMetrics] failed:", error);
+    return { affiliateClicksWeek: 0, cookedPostsWeek: 0, feedDauToday: 0, live: false };
+  }
+}
+
 // ─── Error Groups · request_log_entries rollup ────────────────────────
 
 export interface ErrorGroupEntry {

--- a/src/services/feedDatabaseService.ts
+++ b/src/services/feedDatabaseService.ts
@@ -21,6 +21,8 @@ export interface FeedEvent {
    * for human actors: their email must not leak through this public endpoint.
    */
   actorSlug?: string;
+  /** Spark count from feed_reactions (recent-events read path only). */
+  reactionCount?: number;
 }
 
 class FeedDatabaseService {
@@ -110,10 +112,14 @@ class FeedDatabaseService {
   async getRecentEvents(limit: number = 50, offset: number = 0): Promise<FeedEvent[]> {
     try {
       const result = await executeQuery(
-        `SELECT f.*, u.is_agent, u.email as actor_email, u.image as actor_image, up.name as actor_name
+        `SELECT f.*, u.is_agent, u.email as actor_email, u.image as actor_image, up.name as actor_name,
+                COALESCE(r.n, 0) AS reaction_count
          FROM feed_events f
          JOIN users u ON f.actor_id = u.id
          LEFT JOIN user_profiles up ON u.id = up.user_id
+         LEFT JOIN LATERAL (
+           SELECT COUNT(*)::int AS n FROM feed_reactions fr WHERE fr.event_id = f.id
+         ) r ON true
          ORDER BY f.created_at DESC
          LIMIT $1 OFFSET $2`,
         [limit, offset]
@@ -158,6 +164,7 @@ class FeedDatabaseService {
           actorImage,
           actorIsAgent: isAgent,
           actorSlug,
+          reactionCount: Number(row.reaction_count) || 0,
         };
       });
     } catch (error) {


### PR DESCRIPTION
## The mega-release

From the second 20-question planning round: **the flywheel closes** — cook → share under your stars → gather at tables → order the ingredients (commission) → the practices quietly pay. One PR by explicit choice.

## Ordering (revenue)

- **OrderIngredientsModal** — one reusable checklist: serving-scaled quantities, cross-recipe merge, curated staples behind a toggle, and pantry memory (unchecked = "already have it", remembered forever). Every row carries a **tagged Amazon Fresh search link** (`rel=sponsored`, Associates disclosure shown); ASIN-resolved rows ride the existing Associates **cart-POST** for a one-tap Fresh cart.
- Wired on: recipe detail (new **Order ingredients** button), grocery cart drawer (**Smart order list**), menu planner (existing Amazon flow + reward). Discovery funnels through CuisineCard → recipe pages.
- New `list_conjured` practice rewards **order-list creation** (daily-capped, deduped) — deliberately *not* click-through: the most Associates-safe reading of the "reward commission actions" decision. ⚠️ Residual policy note: Amazon prohibits incentivizing link *use*; rewarding the in-app list act is the defensible line we chose.

## Cooked-it dish cards (social)

- **"Share to the commons ✨"** appears at the moment of pride (made-it + photo). The card is built once server-side: **chart-persona** ("A Cancer-Sun water cook" — never a real name), elemental-signature chip, **transit line** ("made under a waxing gibbous Moon in Pisces"), photo persisted to **R2**.
- **Spark economy** (migration 58, applied): one reaction per user per event anchors both invisible rewards server-side — reactor's `feed_reaction` + poster's new `work_resonated`, both transit-modulated, both SERVER_ONLY. Self-reactions get an in-world rejection.

## Gathering (social pull)

- **TransitInviteBanner** — real cross-planet conjunction detection (transit ecliptic longitude vs natal position, 3° orb) → "Mars crosses your natal Sun — a table is open" → one tap into that transit's group chat.
- **LunarTableStrip** — new/full-moon tables from pure astronomy (phase-crossing bisection, zero DB rows); posts made while a table is open auto-attach via `tableKey`.
- **Resonant-voice teaser** on the daily ritual widget: the freshest historical-agent post sharing the viewer's element, deep-linking into the commons.

## Pulled-in deferrals

- **Wallet funnel**: first Matter reward of a session for a wallet-less user → "Open the vault" toast action
- **Mint-quote surfacing**: the mint button now states its live ESMS price
- **LivingEconomyPanel** (admin): Amazon handoffs/7d · cooked posts/7d · feed DAU today — the release's three success numbers
- **Restaurant ESMS flags**: env-only flip at deploy (`NEXT_PUBLIC_ESMS_RESTAURANT_PAYMENTS_ENABLED=true` + `_CENTS_PER_TOKEN=1` + redeploy; note: needs a Stripe-connected partner row to complete an order)

## Verified live (real DB, real R2, two real accounts — then reverted)

- ✅ Cooked share end-to-end: persona/signature/transit computed from the real natal chart, photo landed on `assets.alchm.kitchen`, card + count render in the feed API
- ✅ Spark E2E: self-reaction rejected; cross-user spark paid **0.51🝇 to the reactor and 0.94🝇 to the poster** — the celestial modulation composing all the way through; duplicates quiet
- ✅ Link audit: tag intact across unicode/special chars; staples classified; merge+scale math exact
- ✅ typecheck, lint, jest, production build green

**Reviewer note:** worth a human pass on  (dish card + strip + banner) and one "Order ingredients" tap on any recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)