### PR TITLE
fix(lab): populate ELEMENTAL BALANCE + THERMODYNAMICS for onboarded users

### DIFF
--- a/src/app/(alchm)/lab/page.tsx
+++ b/src/app/(alchm)/lab/page.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from "next/dynamic";
 import Link from "next/link";
-import { useEffect, useState, type JSX } from "react";
+import { useEffect, useState, type JSX, type ReactNode } from "react";
 import {
   AstrologicalClockPanel,
   CuisineExplorerPanel,
@@ -79,7 +79,7 @@ function AwaitingBackend({
 }: {
   title: string;
   endpoint: string;
-  note?: string;
+  note?: ReactNode;
 }): JSX.Element {
   return (
     <div
@@ -389,6 +389,22 @@ export default function LaboratoryDashboardPage(): JSX.Element {
     currentUser?.natalChart?.planets?.find((p) => p.name === "Sun")?.sign ?? null;
   const birthDate = currentUser?.birthData?.dateTime?.split("T")[0] ?? null;
 
+  // A signed-in user with no natal profile hasn't entered birth data yet — the
+  // old "Sign in to populate" copy was wrong for them. Branch the prompt: guests
+  // sign in first, signed-in users get a direct link to finish onboarding.
+  const noStatsNote: ReactNode = currentUser ? (
+    <>
+      Add your birth details to populate your natal profile.{" "}
+      <Link href="/onboarding" style={{ color: "var(--accent)", textDecoration: "underline" }}>
+        Complete onboarding →
+      </Link>
+    </>
+  ) : (
+    <>
+      Sign in and add your birth details to populate your natal profile.
+    </>
+  );
+
   return (
     <div
       style={{
@@ -495,7 +511,7 @@ export default function LaboratoryDashboardPage(): JSX.Element {
             <AwaitingBackend
               title="ELEMENTAL BALANCE"
               endpoint="user.stats"
-              note="No AlchemicalProfile on the current user. Sign in to populate."
+              note={noStatsNote}
             />
           )}
         </div>
@@ -512,7 +528,7 @@ export default function LaboratoryDashboardPage(): JSX.Element {
             <AwaitingBackend
               title="THERMODYNAMICS"
               endpoint="user.stats"
-              note="Spirit / Essence / Matter / Substance not yet populated."
+              note={noStatsNote}
             />
           )}
         </div>

--- a/src/app/api/agent-forge/__tests__/ignite.route.test.ts
+++ b/src/app/api/agent-forge/__tests__/ignite.route.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for POST /api/agent-forge/ignite
+ *
+ * Guards the onboarding dual-write fix. The /onboarding page posts here, and
+ * this route must persist onboarding through userDatabase.updateUserProfile()
+ * — which writes the normalized user_profiles columns (onboarding_completed,
+ * birth_data, natal_chart) that rowToUserWithProfile reads back into the
+ * session JWT and that the admin onboarding funnel + /lab stats panels read. A
+ * raw jsonb_set on the users.profile JSONB alone is invisible to all of them,
+ * which previously made the funnel report 0% completion and left /lab showing
+ * "AWAITING BACKEND" for onboarded users. These tests pin the contract so it
+ * can't silently regress.
+ */
+
+// next/server stub so NextResponse.json works without a web Response in jsdom.
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body, init) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("@/lib/auth/auth", () => ({ auth: jest.fn() }));
+jest.mock("@/lib/database", () => ({ executeQuery: jest.fn() }));
+jest.mock("@/lib/serviceUrls", () => ({
+  getServiceUrl: jest.fn(() => "https://api.agents.example"),
+}));
+jest.mock("@/services/geocodingService", () => ({
+  geocodeLocationSingle: jest.fn(),
+}));
+jest.mock("@/services/natalChartService", () => ({
+  calculateNatalChart: jest.fn(),
+}));
+jest.mock("@/services/RealAlchemizeService", () => ({
+  alchemize: jest.fn(() => ({ thermodynamicProperties: {} })),
+}));
+jest.mock("@/utils/astrology/positions", () => ({
+  getAccuratePlanetaryPositions: jest.fn(() => ({})),
+}));
+jest.mock("@/utils/astrology/signElement", () => ({
+  getDominantElementFromPositions: jest.fn(() => "Fire"),
+}));
+jest.mock("@/utils/planetaryAlchemyMapping", () => ({
+  calculateAlchemicalFromPlanets: jest.fn(() => ({})),
+}));
+jest.mock("@/services/userDatabaseService", () => ({
+  userDatabase: { updateUserProfile: jest.fn() },
+}));
+
+import { auth } from "@/lib/auth/auth";
+import { executeQuery } from "@/lib/database";
+import { geocodeLocationSingle } from "@/services/geocodingService";
+import { calculateNatalChart } from "@/services/natalChartService";
+import { userDatabase } from "@/services/userDatabaseService";
+import { POST } from "../ignite/route";
+
+const mockAuth = auth as unknown as jest.Mock;
+const mockGeocode = geocodeLocationSingle as unknown as jest.Mock;
+const mockCalcChart = calculateNatalChart as unknown as jest.Mock;
+const mockExecuteQuery = executeQuery as unknown as jest.Mock;
+const mockUpdateProfile = userDatabase.updateUserProfile as unknown as jest.Mock;
+
+// The recipe-gen fetch wraps its request in AbortSignal.timeout(); guard it so
+// the test is robust across the jsdom/Node global surface.
+if (typeof (AbortSignal as unknown as { timeout?: unknown }).timeout !== "function") {
+  (AbortSignal as unknown as { timeout: () => AbortSignal }).timeout = () =>
+    new AbortController().signal;
+}
+
+const MOCK_CHART = {
+  elementalBalance: { Fire: 0.4, Water: 0.3, Earth: 0.2, Air: 0.1 },
+  dominantElement: "Fire",
+  planets: [],
+};
+
+const VALID_BODY = { dob: "1990-05-15T10:30:00.000Z", city: "New York" };
+
+const EXPECTED_BIRTH_DATA = {
+  dateTime: "1990-05-15T10:30:00.000Z",
+  latitude: 40.7,
+  longitude: -74,
+  timezone: "America/New_York",
+};
+
+function makeRequest(body: unknown): Request {
+  return {
+    json: async () => body,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "cookie" ? "session=abc" : null,
+    },
+  } as unknown as Request;
+}
+
+describe("POST /api/agent-forge/ignite", () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    mockGeocode.mockResolvedValue({
+      latitude: 40.7,
+      longitude: -74,
+      estimatedTimezone: "America/New_York",
+    });
+    mockCalcChart.mockResolvedValue(MOCK_CHART);
+    mockExecuteQuery.mockResolvedValue({ rows: [] });
+    mockUpdateProfile.mockResolvedValue({ id: "user-123" });
+
+    // Recipe generation succeeds → happy path, never reaches the PA fallback.
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ recipe: { title: "Onboarding Meal" } }),
+      text: async () => "",
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("persists onboarding through updateUserProfile (onboardingComplete + chart + birthData)", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "user-123", email: "test@example.com" },
+    });
+
+    const res = await POST(makeRequest(VALID_BODY));
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateProfile).toHaveBeenCalledTimes(1);
+    expect(mockUpdateProfile).toHaveBeenCalledWith(
+      "user-123",
+      {
+        birthData: EXPECTED_BIRTH_DATA,
+        natalChart: MOCK_CHART,
+        onboardingComplete: true,
+      },
+      "test@example.com",
+    );
+  });
+
+  it("returns 401 and never writes the profile when the session has no user id", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const res = await POST(makeRequest(VALID_BODY));
+
+    expect(res.status).toBe(401);
+    expect(mockUpdateProfile).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when dob or city is missing", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "user-123", email: "test@example.com" },
+    });
+
+    const res = await POST(makeRequest({ city: "New York" }));
+
+    expect(res.status).toBe(400);
+    expect(mockUpdateProfile).not.toHaveBeenCalled();
+  });
+
+  it("still returns 200 and logs at error level when the profile write throws (non-blocking contract)", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "user-123", email: "test@example.com" },
+    });
+    mockUpdateProfile.mockRejectedValue(new Error("DB down"));
+
+    const res = await POST(makeRequest(VALID_BODY));
+
+    // The constitution is already stored, so a profile-write failure must not
+    // 500 the ignition — but it must surface in logs, not fail silently.
+    expect(res.status).toBe(200);
+    expect(mockUpdateProfile).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("profile persistence failed"),
+      expect.any(Error),
+    );
+  });
+});

--- a/src/app/api/agent-forge/ignite/route.ts
+++ b/src/app/api/agent-forge/ignite/route.ts
@@ -21,6 +21,7 @@ import { getServiceUrl } from "@/lib/serviceUrls";
 import { geocodeLocationSingle } from "@/services/geocodingService";
 import { calculateNatalChart } from "@/services/natalChartService";
 import { alchemize } from "@/services/RealAlchemizeService";
+import { userDatabase } from "@/services/userDatabaseService";
 import { getAccuratePlanetaryPositions } from "@/utils/astrology/positions";
 import { getDominantElementFromPositions } from "@/utils/astrology/signElement";
 import { calculateAlchemicalFromPlanets } from "@/utils/planetaryAlchemyMapping";
@@ -126,22 +127,33 @@ export async function POST(req: Request) {
         updated_at = NOW()
     `, [userId, spirit, essence, matter, substance, baseArchetype]);
 
-    // Also update users.profile.birthData, users.profile.natalChart, and users.profile.onboardingComplete if present
+    // Persist birth data, natal chart, and onboarding completion through the
+    // canonical profile writer. This dual-writes BOTH the users.profile JSONB
+    // AND the normalized user_profiles columns (birth_data, natal_chart,
+    // onboarding_completed, onboarding_completed_at). Those columns are the
+    // source of truth that rowToUserWithProfile reads back into the session JWT,
+    // that the admin onboarding funnel queries, and that the /lab ELEMENTAL
+    // BALANCE / THERMODYNAMICS panels derive from — a raw jsonb_set on
+    // users.profile alone is invisible to all of them, which is why
+    // ignite-onboarded users saw "AWAITING BACKEND" despite completing
+    // onboarding. updateUserProfile handles the JSONB write internally, so it
+    // fully replaces the previous raw UPDATE.
     try {
-      await executeQuery(`
-        UPDATE users 
-        SET profile = jsonb_set(
-          jsonb_set(
-            jsonb_set(COALESCE(profile, '{}'::jsonb), '{birthData}', $1::jsonb),
-            '{natalChart}', $2::jsonb
-          ),
-          '{onboardingComplete}', 'true'::jsonb
-        )
-        WHERE id = $3
-      `, [JSON.stringify(birthData), JSON.stringify(chart), userId]);
-      console.log(`[ignite] Updated user natal chart profile and marked onboarding complete.`);
+      await userDatabase.updateUserProfile(
+        userId,
+        { birthData, natalChart: chart, onboardingComplete: true },
+        session.user.email || undefined,
+      );
+      console.log(`[ignite] Persisted natal profile + marked onboarding complete (user_profiles synced).`);
     } catch (err) {
-      console.warn("[ignite] Failed to update user profile JSONB:", err);
+      // Non-blocking, to preserve the "never 500 a successful ignition" contract
+      // (the constitution is already stored above). But log at error level: a
+      // failure here means the user onboarded yet will NOT appear in the funnel
+      // or /lab stats, so it must surface in logs/alerts rather than fail silently.
+      console.error(
+        "[ignite] CRITICAL: profile persistence failed — onboarding will not be reflected in user_profiles/funnel/lab:",
+        err,
+      );
     }
 
     // 8. Recipe Generation (free-tier Groq/Gemini fallback)

--- a/src/services/userDatabaseService.ts
+++ b/src/services/userDatabaseService.ts
@@ -49,6 +49,10 @@ interface UserWithProfileRow {
   name?: string | null;
   birth_data?: string | UserProfile["birthData"] | null;
   natal_chart?: string | UserProfile["natalChart"] | null;
+  // users.profile JSONB (selected via `SELECT u.*`). Legacy fallback source for
+  // rows onboarded via /api/agent-forge/ignite before the dual-write fix, which
+  // wrote the natal chart / birth data here only, never to the columns above.
+  profile?: string | Record<string, unknown> | null;
   dietary_preferences?: string | Record<string, unknown> | null;
   preferences?: string | Record<string, unknown> | null;
   group_members?: string | UserProfile["groupMembers"] | null;
@@ -884,14 +888,32 @@ class UserDatabaseService {
     // Guarded JSON parsing: these are JSONB columns (node-postgres usually returns
     // them pre-parsed), but a text-typed or double-encoded value would otherwise
     // throw here and turn one corrupt row into a silent auth/profile-load outage.
-    const birthData = parseJsonColumn<UserProfile["birthData"] | undefined>(
+    const columnBirthData = parseJsonColumn<UserProfile["birthData"] | undefined>(
       row.birth_data,
       undefined,
     );
-    const natalChart = parseJsonColumn<UserProfile["natalChart"] | undefined>(
+    const columnNatalChart = parseJsonColumn<UserProfile["natalChart"] | undefined>(
       row.natal_chart,
       undefined,
     );
+
+    // Legacy heal: users onboarded via /api/agent-forge/ignite before the
+    // dual-write fix have their birth data + natal chart only in the
+    // users.profile JSONB, never in the canonical user_profiles columns. The
+    // column is authoritative when populated; fall back to the JSONB otherwise
+    // so their /lab ELEMENTAL BALANCE / THERMODYNAMICS panels derive stats
+    // instead of showing "AWAITING BACKEND". New writes go through
+    // updateUserProfile (dual-writes both), so the column wins going forward and
+    // this fallback only ever fires for un-backfilled legacy rows.
+    const jsonbProfile = parseJsonColumn<Record<string, unknown>>(row.profile, {});
+    const hasColumnBirthData = Object.keys(columnBirthData || {}).length > 0;
+    const hasColumnNatalChart = Object.keys(columnNatalChart || {}).length > 0;
+    const birthData = hasColumnBirthData
+      ? columnBirthData
+      : (jsonbProfile?.birthData as UserProfile["birthData"] | undefined);
+    const natalChart = hasColumnNatalChart
+      ? columnNatalChart
+      : (jsonbProfile?.natalChart as UserProfile["natalChart"] | undefined);
     const dietaryPreferences = parseJsonColumn<Record<string, unknown>>(
       row.dietary_preferences,
       {},
@@ -940,7 +962,11 @@ class UserDatabaseService {
         email: row.email,
         preferences,
         dietaryPreferences,
-        onboardingComplete: row.onboarding_completed === true,
+        // Same legacy heal as birthData/natalChart below: ignite-onboarded rows
+        // set onboardingComplete in the JSONB but not the column.
+        onboardingComplete:
+          row.onboarding_completed === true ||
+          jsonbProfile?.onboardingComplete === true,
         birthData:
           Object.keys(birthData || {}).length > 0 ? birthData : undefined,
         natalChart:


### PR DESCRIPTION
## What & why

The production `/lab` **ELEMENTAL BALANCE** and **THERMODYNAMICS** panels showed
`· AWAITING BACKEND` ("No AlchemicalProfile on the current user. Sign in to
populate." / "Spirit / Essence / Matter / Substance not yet populated.") for
users who were **signed in and had completed onboarding**.

**Root cause:** those panels render from `currentUser.stats`, which `UserContext`
derives client-side from `natalChart`. But the `/onboarding → POST /api/agent-forge/ignite`
funnel persisted the natal chart to the `users.profile` JSONB **only** (raw
`jsonb_set`), while the read path (`userDatabaseService.rowToUserWithProfile`)
reads `natalChart` **exclusively** from the canonical `user_profiles.natal_chart`
column. So ignite-onboarded users came back with `natalChart: undefined` → no
derived stats → AWAITING BACKEND. (The parallel `/profile → POST /api/onboarding`
funnel was fine — it already writes via `updateUserProfile`.) This is a recurrence
of the PR #507 source-of-truth bug class.

Notably, this exact fix was already written on 2026-06-04 as commit `8712d22d`
("ignite dual-writes user_profiles") on branch `fix/onboarding-zero-completion`,
but that PR was **never merged**, so the bug stayed live. This PR reproduces it
and adds a heal path for already-affected users.

## Changes

- **`api/agent-forge/ignite/route.ts`** — persist through
  `userDatabase.updateUserProfile(userId, { birthData, natalChart, onboardingComplete: true }, session.user.email)`
  instead of raw `jsonb_set`. That dual-writes the `users.profile` JSONB **and**
  the normalized `user_profiles` columns (`birth_data`, `natal_chart`,
  `onboarding_completed`) that the profile read, the admin onboarding funnel, and
  `/lab` all depend on. Failure now logs at `error` level (was `warn`); still
  non-blocking so a successful ignition never 500s. **Fixes every new onboardee.**
- **`services/userDatabaseService.ts`** — `rowToUserWithProfile` now falls back to
  the `users.profile` JSONB for `natalChart` / `birthData` / `onboardingComplete`
  when the columns are empty. **Heals users already onboarded via the buggy path,
  no data backfill required.** The column stays authoritative when populated, so
  there's no staleness and no behaviour change for `/profile`-onboarded users.
- **`app/(alchm)/lab/page.tsx`** — the old "Sign in to populate" copy was wrong
  for a signed-in user who simply hasn't entered birth data. The note now branches:
  guests get "Sign in and add your birth details…", signed-in users get a direct
  "Complete onboarding →" link. (`AwaitingBackend`'s `note` widened `string` → `ReactNode`.)
- **`api/agent-forge/__tests__/ignite.route.test.ts`** — new 4-test regression
  guard: pins that ignite persists via `updateUserProfile`, returns 401/400 without
  writing, and stays 200 + logs at error level when the profile write throws.

## Testing

- `bun run typecheck` → 0
- `eslint` (source files) → 0
- `bun run test` → **713 passed** (natalAlchemy suite + new ignite suite included)
- Guest `/lab` verified in a local preview — both panels now render the corrected
  copy, no console errors from the change.

## Reviewer notes

- **Not yet verified live:** whether a signed-in + onboarded user's panels populate
  end-to-end. That needs an authenticated browser session against `/lab` **after deploy**
  (WebFetch/preview can't auth). The logic is covered by unit tests + the deterministic
  read-path fallback.
- **Deferred — a current-sky "transit" fallback (make the panels show data for
  guests/no-chart users)** is intentionally NOT included: `RealAlchemizeService.alchemize`
  imports `fs` (server-only, can't run in the `"use client"` lab page), and the
  AlchemicalContext's `elementalState`/`alchemicalValues` are static defaults (never
  dispatched). A real version needs a client fetch to `/api/alchemize` + scale
  normalization — larger/riskier than this fix and not required to resolve the reported bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
