### PR TITLE
fix(commensal): foundation repair — dead matching engine, split-brain storage, blocking, races, rate limits

### DIFF
--- a/database/init/59-commensalships-unordered-pair.sql
+++ b/database/init/59-commensalships-unordered-pair.sql
@@ -1,0 +1,30 @@
+-- database/init/59-commensalships-unordered-pair.sql
+-- Close the reciprocal-request race on commensalships.
+--
+-- The existing UNIQUE (requester_id, addressee_id) constraint is ORDERED, so
+-- concurrent A->B and B->A requests could both insert, leaving two rows for
+-- the same companion pair. Application code now auto-accepts a pending
+-- reverse-direction request instead of inserting, and this index makes the
+-- race impossible at the database level.
+--
+-- NOTE: plain CREATE UNIQUE INDEX (NOT CONCURRENTLY) — the migration runner
+-- wraps each file in a transaction and CONCURRENTLY cannot run inside one.
+
+-- Step 1: dedupe any reciprocal rows that already slipped in. For each
+-- unordered pair keep exactly one row — prefer an accepted row over a
+-- non-accepted one, then the oldest (created_at, id as final tie-break).
+WITH ranked AS (
+  SELECT id,
+         ROW_NUMBER() OVER (
+           PARTITION BY LEAST(requester_id, addressee_id),
+                        GREATEST(requester_id, addressee_id)
+           ORDER BY (status = 'accepted') DESC, created_at ASC, id ASC
+         ) AS rn
+    FROM commensalships
+)
+DELETE FROM commensalships
+ WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+-- Step 2: enforce uniqueness on the unordered pair.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_commensalships_pair
+  ON commensalships (LEAST(requester_id, addressee_id), GREATEST(requester_id, addressee_id));

--- a/src/app/(alchm)/commensal/page.tsx
+++ b/src/app/(alchm)/commensal/page.tsx
@@ -30,12 +30,17 @@ interface GuestEntry {
   natalChart?: NatalChart | null;
 }
 
+/** Max guests per session — mirrors the API's 12-guest schema cap. */
+const TABLE_CAPACITY = 12;
+
 interface GuestFormProps {
   onAdd: (name: string, data: BirthData) => void;
   onCompanionSaved?: () => void;
+  /** When true the table is full — submissions are disabled. */
+  atCapacity?: boolean;
 }
 
-function GuestForm({ onAdd, onCompanionSaved }: GuestFormProps) {
+function GuestForm({ onAdd, onCompanionSaved, atCapacity = false }: GuestFormProps) {
   const { status: authStatus } = useSession();
   const [name, setName] = useState("");
   const [dateTime, setDateTime] = useState("");
@@ -48,6 +53,7 @@ function GuestForm({ onAdd, onCompanionSaved }: GuestFormProps) {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (atCapacity) return;
     if (name && dateTime && latitude && longitude) {
       const data: BirthData = {
         dateTime: new Date(dateTime).toISOString(),
@@ -80,9 +86,7 @@ function GuestForm({ onAdd, onCompanionSaved }: GuestFormProps) {
             }
 
             // Companion saved successfully!
-            setSuccessMsg(
-              `✓ Saved ${name}! Quest complete: Earned 20 Matter tokens.`,
-            );
+            setSuccessMsg(`✓ ${name} is at your table.`);
 
             // Trigger global token widget update
             if (typeof window !== "undefined") {
@@ -122,7 +126,7 @@ function GuestForm({ onAdd, onCompanionSaved }: GuestFormProps) {
         // Fallback for anonymous users: add locally
         onAdd(name, data);
         setSuccessMsg(
-          `Added locally. Sign in to save permanently & earn 20 Matter tokens!`,
+          "Added for this session. Sign in to keep them at your table.",
         );
         setName("");
         setDateTime("");
@@ -202,11 +206,17 @@ function GuestForm({ onAdd, onCompanionSaved }: GuestFormProps) {
 
       <button
         type="submit"
-        disabled={loading || !name || !dateTime || !latitude || !longitude}
+        disabled={
+          loading || atCapacity || !name || !dateTime || !latitude || !longitude
+        }
         className="w-full py-2.5 bg-gradient-to-r from-alchm-copper to-alchm-violet text-white text-sm font-bold rounded-lg hover:opacity-90 disabled:opacity-50 transition-all flex items-center justify-center gap-2"
       >
         {loading ? "Calculating heavens & saving..." : "Add guest & Save Chart"}
       </button>
+
+      {atCapacity && (
+        <p className="text-[11px] text-amber-200/80">A table seats twelve.</p>
+      )}
 
       {successMsg && (
         <div className="px-3 py-2 rounded-lg bg-emerald-500/10 border border-emerald-400/20 text-xs text-emerald-200">
@@ -247,12 +257,15 @@ export default function CommensalPage() {
     void run({ guests, location: searchLocation });
   };
 
+  const atCapacity = guests.length >= TABLE_CAPACITY;
+
   const handleInviteCompanion = (
     id: string,
     name: string,
     birthData: BirthData,
     natalChart: NatalChart | null,
   ) => {
+    if (guests.length >= TABLE_CAPACITY) return;
     if (
       guests.some(
         (guest) =>
@@ -303,8 +316,8 @@ export default function CommensalPage() {
           </h1>
           <p className="mt-4 text-white/60 max-w-2xl mx-auto text-lg">
             Add birth data for yourself and your companions. We&apos;ll find
-            real-time, perfectly balanced meals, recipes, and local restaurants
-            (via Foursquare) tailored for your group&apos;s composite energy.
+            real-time, perfectly balanced meals, recipes, and nearby
+            restaurants tailored for your group&apos;s composite energy.
           </p>
         </div>
 
@@ -316,15 +329,21 @@ export default function CommensalPage() {
           <aside className="md:col-span-1 space-y-5">
             <GuestForm
               onAdd={(name, data) =>
-                setGuests((prev) => [...prev, { name, birthData: data }])
+                setGuests((prev) =>
+                  prev.length >= TABLE_CAPACITY
+                    ? prev
+                    : [...prev, { name, birthData: data }],
+                )
               }
               onCompanionSaved={() => setRefreshTrigger((prev) => prev + 1)}
+              atCapacity={atCapacity}
             />
 
             <CompanionSuggestions
               onInvite={handleInviteCompanion}
               activeGuests={guests}
               refreshTrigger={refreshTrigger}
+              inviteDisabled={atCapacity}
             />
 
             <div className="glass-card-premium rounded-2xl p-5 border border-white/10">
@@ -372,8 +391,8 @@ export default function CommensalPage() {
                 showCoordinates={false}
               />
               <p className="text-[11px] text-white/40 mt-2 leading-relaxed">
-                Optional — leave blank to skip restaurant suggestions. We pass
-                exact coordinates to Foursquare for accurate local matches.
+                Optional — leave blank to skip restaurant suggestions. We use
+                your exact coordinates to find accurate nearby matches.
               </p>
             </div>
 

--- a/src/app/api/commensal/companions/__tests__/route.test.ts
+++ b/src/app/api/commensal/companions/__tests__/route.test.ts
@@ -7,8 +7,14 @@ jest.mock("next/server", () => ({
     json: jest.fn((body, init) => ({
       status: init?.status ?? 200,
       json: async () => body,
+      headers: init?.headers ?? {},
     })),
   },
+}));
+
+// Force the rate limiter onto its in-memory fallback (no Redis in tests).
+jest.mock("@/lib/redis", () => ({
+  getRedisClient: () => null,
 }));
 
 jest.mock("@/lib/database", () => ({
@@ -36,10 +42,22 @@ import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
 import { commensalDatabase } from "@/services/commensalDatabaseService";
 import { GET } from "../route";
 
-function makeRequest(url = "http://localhost/api/commensal/companions"): any {
+// Each request gets a unique client IP by default so the per-IP rate limiter
+// (whose in-memory store persists across tests in this file) never bleeds
+// between unrelated tests. Pass an explicit `ip` to simulate one client.
+let ipCounter = 0;
+function makeRequest(
+  url = "http://localhost/api/commensal/companions",
+  ip?: string,
+): any {
+  const addr = ip ?? `10.8.${Math.floor(++ipCounter / 250)}.${ipCounter % 250}`;
   return {
     url,
     method: "GET",
+    headers: {
+      get: (key: string) =>
+        key.toLowerCase() === "x-forwarded-for" ? addr : null,
+    },
   } as unknown as any;
 }
 
@@ -212,5 +230,25 @@ describe("GET /api/commensal/companions", () => {
     expect(data.savedCompanions[0].natalChart).toEqual(
       expect.objectContaining({ dominantElement: "Water" }),
     );
+  });
+
+  it("returns 429 once a single IP exceeds the per-minute cap", async () => {
+    const IP = "203.0.113.99";
+
+    // The moderate unauthenticated cap is 30/min — the first 30 pass.
+    for (let i = 0; i < 30; i++) {
+      const res = await GET(makeRequest(undefined, IP));
+      expect(res.status).toBe(200);
+    }
+
+    const res = await GET(makeRequest(undefined, IP));
+    const data = await res.json();
+
+    expect(res.status).toBe(429);
+    expect(data.error).toBe("rate_limit_exceeded");
+
+    // Other clients are unaffected — the limit is per-IP.
+    const other = await GET(makeRequest(undefined, "203.0.113.100"));
+    expect(other.status).toBe(200);
   });
 });

--- a/src/app/api/commensal/companions/route.ts
+++ b/src/app/api/commensal/companions/route.ts
@@ -11,6 +11,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
 import { executeQuery } from "@/lib/database";
 import { fetchAgentsForDate } from "@/lib/planetaryAgentsClient";
+import { rateLimit } from "@/lib/rateLimit";
 import { commensalDatabase } from "@/services/commensalDatabaseService";
 import type { BirthData, NatalChart } from "@/types/natalChart";
 import { safeJsonParse } from "@/utils/typeGuards";
@@ -64,7 +65,17 @@ function errorSummary(error: unknown): string {
   return "unavailable";
 }
 
+// Unauthenticated and fans out to the external PA API — moderate per-IP cap.
+const COMPANIONS_LIMIT = {
+  window: 60_000,
+  max: 30,
+  bucket: "commensal-companions",
+} as const;
+
 export async function GET(_req: NextRequest) {
+  const rl = await rateLimit(_req, COMPANIONS_LIMIT);
+  if (!rl.allowed) return rl.response!;
+
   const warnings: string[] = [];
 
   // Planetary activations and the local roster are independent sources. A

--- a/src/app/api/commensal/guest-recommendations/__tests__/route.test.ts
+++ b/src/app/api/commensal/guest-recommendations/__tests__/route.test.ts
@@ -8,6 +8,7 @@
  *   - empty guests array (400)
  *   - single-member group (composite math still valid)
  *   - large group (10 guests, payload schema unchanged)
+ *   - per-IP rate limiting (429 past the strict unauthenticated cap)
  */
 
 // Mock next/server before any imports.
@@ -16,8 +17,14 @@ jest.mock("next/server", () => ({
     json: jest.fn((body, init) => ({
       status: init?.status ?? 200,
       json: async () => body,
+      headers: init?.headers ?? {},
     })),
   },
+}));
+
+// Force the rate limiter onto its in-memory fallback (no Redis in tests).
+jest.mock("@/lib/redis", () => ({
+  getRedisClient: () => null,
 }));
 
 import { EnhancedRecommendationService } from "@/services/EnhancedRecommendationService";
@@ -49,9 +56,18 @@ jest.mock("@/utils/recommendation/methodRecommendation", () => ({
   getRecommendedCookingMethods: jest.fn(),
 }));
 
-function makeRequest(body: unknown): Request {
+// Each request gets a unique client IP by default so the per-IP rate limiter
+// (whose in-memory store persists across tests in this file) never bleeds
+// between unrelated tests. Pass an explicit `ip` to simulate one client.
+let ipCounter = 0;
+function makeRequest(body: unknown, ip?: string): Request {
+  const addr = ip ?? `10.9.${Math.floor(++ipCounter / 250)}.${ipCounter % 250}`;
   return {
     json: async () => body,
+    headers: {
+      get: (key: string) =>
+        key.toLowerCase() === "x-forwarded-for" ? addr : null,
+    },
   } as unknown as Request;
 }
 
@@ -298,6 +314,28 @@ describe("POST /api/commensal/guest-recommendations", () => {
 
     expect(res.status).toBe(400);
     expect(data.success).toBe(false);
+  });
+
+  it("returns 429 once a single IP exceeds the per-minute cap", async () => {
+    const IP = "203.0.113.7";
+    const body = { guests: [makeGuest("Repeat")] };
+
+    // The strict unauthenticated cap is 10/min — the first 10 pass.
+    for (let i = 0; i < 10; i++) {
+      const res = await POST(makeRequest(body, IP));
+      expect(res.status).toBe(200);
+    }
+
+    const res = await POST(makeRequest(body, IP));
+    const data = await res.json();
+
+    expect(res.status).toBe(429);
+    expect(data.error).toBe("rate_limit_exceeded");
+    expect(typeof data.retryAfter).toBe("number");
+
+    // Other clients are unaffected — the limit is per-IP.
+    const other = await POST(makeRequest(body, "203.0.113.8"));
+    expect(other.status).toBe(200);
   });
 });
 

--- a/src/app/api/commensal/guest-recommendations/route.ts
+++ b/src/app/api/commensal/guest-recommendations/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { rateLimit } from "@/lib/rateLimit";
 import { EnhancedRecommendationService } from "@/services/EnhancedRecommendationService";
 import { calculateCompositeNatalChart } from "@/services/groupNatalChartService";
 import { calculateNatalChart } from "@/services/natalChartService";
@@ -33,7 +34,17 @@ const bodySchema = z.object({
   guests: z.array(guestSchema).min(1, "At least one guest is required").max(12),
 });
 
+// Unauthenticated AND computationally heavy (up to 12 natal charts plus a
+// full recipe-catalog scoring pass per call) — strict per-IP cap.
+const GUEST_RECS_LIMIT = {
+  window: 60_000,
+  max: 10,
+  bucket: "commensal-guest-recs",
+} as const;
+
 export async function POST(req: Request) {
+  const rl = await rateLimit(req, GUEST_RECS_LIMIT);
+  if (!rl.allowed) return rl.response!;
   try {
     const raw = await req.json().catch(() => null);
     const parsed = bodySchema.safeParse(raw);

--- a/src/app/api/commensal/save-group/__tests__/route.test.ts
+++ b/src/app/api/commensal/save-group/__tests__/route.test.ts
@@ -3,10 +3,12 @@
  *
  * Tests for POST /api/commensal/save-group — transactional write path.
  *
- * The companion inserts and the dining-group registration must commit or roll
- * back as one unit: a failed group registration used to strand orphaned
- * companion rows. Uses the REAL commensalDatabaseService against a mocked
- * transaction client so the BEGIN/COMMIT/ROLLBACK semantics are exercised.
+ * The companion inserts and the dining-group profile dual-write all run on
+ * ONE transaction client: a failure anywhere (companion insert OR group
+ * registration) rolls the whole write back. Uses the REAL
+ * commensalDatabaseService against a mocked transaction client so the
+ * BEGIN/COMMIT/ROLLBACK semantics are exercised. Also covers the server-side
+ * input caps (12 guests, 100-char group name) and the per-user rate limit.
  */
 
 // Stable delegates: jest `resetModules` re-runs mock factories per test, so
@@ -34,6 +36,7 @@ jest.mock("next/server", () => ({
     json: jest.fn((body, init) => ({
       status: init?.status ?? 200,
       json: async () => body,
+      headers: init?.headers ?? {},
     })),
   },
 }));
@@ -43,14 +46,13 @@ jest.mock("@/lib/database", () => ({
   withTransaction: (...args: unknown[]) => (mockWithTransaction as any)(...args),
 }));
 
-jest.mock("@/lib/auth/validateRequest", () => ({
-  getDatabaseUserFromRequest: jest.fn(),
+// Force the rate limiter onto its in-memory fallback (no Redis in tests).
+jest.mock("@/lib/redis", () => ({
+  getRedisClient: () => null,
 }));
 
-jest.mock("@/services/userDatabaseService", () => ({
-  userDatabase: {
-    updateUserProfile: jest.fn(),
-  },
+jest.mock("@/lib/auth/validateRequest", () => ({
+  getDatabaseUserFromRequest: jest.fn(),
 }));
 
 jest.mock("@/lib/logger", () => ({
@@ -61,16 +63,25 @@ jest.mock("@/lib/logger", () => ({
 process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
 
 import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
-import { userDatabase } from "@/services/userDatabaseService";
 import { POST } from "../route";
 
-const USER = { id: "11111111-1111-1111-1111-111111111111", profile: { diningGroups: [] } };
+// The rate limit is per-user: give each test its own user id so the in-memory
+// limiter (which persists across tests in this file) never bleeds between
+// unrelated tests.
+let userCounter = 0;
+function makeUser(id?: string) {
+  return {
+    id: id ?? `00000000-0000-0000-0000-${String(++userCounter).padStart(12, "0")}`,
+    profile: { name: "Host", diningGroups: [], groupMembers: [] },
+  };
+}
 
 function makeRequest(body: unknown): any {
   return {
     url: "http://localhost/api/commensal/save-group",
     method: "POST",
     json: async () => body,
+    headers: { get: () => null },
   };
 }
 
@@ -86,10 +97,9 @@ function guest(name: string) {
   };
 }
 
+const clientCalls = () => mockClientQuery.mock.calls.map(([sql]) => String(sql));
 const companionInsertCalls = () =>
-  mockClientQuery.mock.calls.filter(([sql]) =>
-    String(sql).includes("INSERT INTO manual_companion_charts"),
-  );
+  clientCalls().filter((sql) => sql.includes("INSERT INTO manual_companion_charts"));
 
 beforeEach(() => {
   mockExecuteQuery.mockReset();
@@ -99,15 +109,18 @@ beforeEach(() => {
   mockTx.rolledBack = 0;
   mockClientQuery.mockResolvedValue({ rows: [], rowCount: 1 });
   (getDatabaseUserFromRequest as jest.Mock).mockReset();
-  (getDatabaseUserFromRequest as jest.Mock).mockResolvedValue(USER);
-  (userDatabase.updateUserProfile as jest.Mock).mockReset();
+  (getDatabaseUserFromRequest as jest.Mock).mockResolvedValue(makeUser());
 });
 
 describe("POST /api/commensal/save-group", () => {
   it("rolls back the companion inserts when the dining-group registration fails", async () => {
-    (userDatabase.updateUserProfile as jest.Mock).mockRejectedValue(
-      new Error("profile write failed"),
-    );
+    // The registration dual-write starts with the users.profile update — fail it.
+    mockClientQuery.mockImplementation(async (sql: string) => {
+      if (String(sql).includes("UPDATE users")) {
+        throw new Error("profile write failed");
+      }
+      return { rows: [], rowCount: 1 };
+    });
 
     const res = await POST(
       makeRequest({ groupName: "Feast", guests: [guest("Alice"), guest("Bob")] }),
@@ -125,9 +138,7 @@ describe("POST /api/commensal/save-group", () => {
     expect(mockTx.committed).toBe(0);
   });
 
-  it("commits companions + group as one unit on success", async () => {
-    (userDatabase.updateUserProfile as jest.Mock).mockResolvedValue({});
-
+  it("commits companions + profile dual-write as one unit on the SAME client", async () => {
     const res = await POST(
       makeRequest({ groupName: "Feast", guests: [guest("Alice"), guest("Bob")] }),
     );
@@ -143,14 +154,23 @@ describe("POST /api/commensal/save-group", () => {
     expect(mockTx.committed).toBe(1);
     expect(mockTx.rolledBack).toBe(0);
 
-    // The registered group references exactly the created companion ids.
-    const updateArg = (userDatabase.updateUserProfile as jest.Mock).mock
-      .calls[0][1];
-    expect(updateArg.diningGroups[0].memberIds).toEqual(data.memberIds);
+    // The dining-group registration is the profile dual-write, issued on the
+    // transaction client (users.profile JSONB + canonical user_profiles):
+    expect(clientCalls().some((sql) => sql.includes("UPDATE users"))).toBe(true);
+    const upsert = mockClientQuery.mock.calls.find(([sql]) =>
+      String(sql).includes("INSERT INTO user_profiles"),
+    );
+    expect(upsert).toBeDefined();
+    // dining_groups param carries the new group with the created member ids.
+    const diningGroupsJson = JSON.parse(upsert![1][5]);
+    expect(diningGroupsJson).toHaveLength(1);
+    expect(diningGroupsJson[0].memberIds).toEqual(data.memberIds);
+
+    // No independently-pooled writes: everything went through the one client.
+    expect(mockExecuteQuery).not.toHaveBeenCalled();
   });
 
   it("rolls back everything when a companion insert itself fails midway", async () => {
-    (userDatabase.updateUserProfile as jest.Mock).mockResolvedValue({});
     mockClientQuery
       .mockResolvedValueOnce({ rows: [], rowCount: 1 })
       .mockRejectedValueOnce(new Error("insert blew up"));
@@ -163,6 +183,51 @@ describe("POST /api/commensal/save-group", () => {
     expect(mockTx.rolledBack).toBe(1);
     expect(mockTx.committed).toBe(0);
     // Registration never ran — the failure happened before it.
-    expect(userDatabase.updateUserProfile).not.toHaveBeenCalled();
+    expect(clientCalls().some((sql) => sql.includes("UPDATE users"))).toBe(false);
+  });
+
+  it("rejects more than 12 guests with a 400", async () => {
+    const guests = Array.from({ length: 13 }, (_, i) => guest(`G${i}`));
+
+    const res = await POST(makeRequest({ groupName: "Banquet", guests }));
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.message).toMatch(/twelve/i);
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects a groupName longer than 100 characters", async () => {
+    const res = await POST(
+      makeRequest({ groupName: "x".repeat(101), guests: [guest("Alice")] }),
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.message).toMatch(/100/);
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 once a single user exceeds the per-minute cap", async () => {
+    const heavyUser = makeUser("99999999-9999-9999-9999-999999999999");
+    (getDatabaseUserFromRequest as jest.Mock).mockResolvedValue(heavyUser);
+    const body = { groupName: "Feast", guests: [guest("Alice")] };
+
+    // The per-user cap is 10/min — the first 10 pass.
+    for (let i = 0; i < 10; i++) {
+      const res = await POST(makeRequest(body));
+      expect(res.status).toBe(201);
+    }
+
+    const res = await POST(makeRequest(body));
+    const data = await res.json();
+
+    expect(res.status).toBe(429);
+    expect(data.error).toBe("rate_limit_exceeded");
+
+    // A different user is unaffected — the limit is per-user.
+    (getDatabaseUserFromRequest as jest.Mock).mockResolvedValue(makeUser());
+    const other = await POST(makeRequest(body));
+    expect(other.status).toBe(201);
   });
 });

--- a/src/app/api/commensal/save-group/__tests__/route.test.ts
+++ b/src/app/api/commensal/save-group/__tests__/route.test.ts
@@ -1,0 +1,168 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for POST /api/commensal/save-group — transactional write path.
+ *
+ * The companion inserts and the dining-group registration must commit or roll
+ * back as one unit: a failed group registration used to strand orphaned
+ * companion rows. Uses the REAL commensalDatabaseService against a mocked
+ * transaction client so the BEGIN/COMMIT/ROLLBACK semantics are exercised.
+ */
+
+// Stable delegates: jest `resetModules` re-runs mock factories per test, so
+// factories forward to these single instances.
+const mockExecuteQuery = jest.fn();
+const mockClientQuery = jest.fn();
+const mockTx = { committed: 0, rolledBack: 0 };
+const mockWithTransaction = jest.fn(
+  async (operation: (client: { query: typeof mockClientQuery }) => Promise<unknown>) => {
+    // Mirrors src/lib/database/connection.ts withTransaction: run the
+    // operation on one client; COMMIT on success, ROLLBACK + rethrow on error.
+    try {
+      const result = await operation({ query: mockClientQuery });
+      mockTx.committed += 1;
+      return result;
+    } catch (error) {
+      mockTx.rolledBack += 1;
+      throw error;
+    }
+  },
+);
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body, init) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("@/lib/database", () => ({
+  executeQuery: (...args: unknown[]) => mockExecuteQuery(...args),
+  withTransaction: (...args: unknown[]) => (mockWithTransaction as any)(...args),
+}));
+
+jest.mock("@/lib/auth/validateRequest", () => ({
+  getDatabaseUserFromRequest: jest.fn(),
+}));
+
+jest.mock("@/services/userDatabaseService", () => ({
+  userDatabase: {
+    updateUserProfile: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/logger", () => ({
+  _logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+// The commensal service only talks to the DB when DATABASE_URL is set.
+process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
+
+import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
+import { userDatabase } from "@/services/userDatabaseService";
+import { POST } from "../route";
+
+const USER = { id: "11111111-1111-1111-1111-111111111111", profile: { diningGroups: [] } };
+
+function makeRequest(body: unknown): any {
+  return {
+    url: "http://localhost/api/commensal/save-group",
+    method: "POST",
+    json: async () => body,
+  };
+}
+
+function guest(name: string) {
+  return {
+    name,
+    relationship: "friend",
+    birthData: { dateTime: "1990-01-01T12:00:00Z", latitude: 40.7, longitude: -74.0 },
+    natalChart: {
+      dominantElement: "Fire",
+      elementalBalance: { Fire: 0.4, Water: 0.2, Earth: 0.2, Air: 0.2 },
+    },
+  };
+}
+
+const companionInsertCalls = () =>
+  mockClientQuery.mock.calls.filter(([sql]) =>
+    String(sql).includes("INSERT INTO manual_companion_charts"),
+  );
+
+beforeEach(() => {
+  mockExecuteQuery.mockReset();
+  mockClientQuery.mockReset();
+  mockWithTransaction.mockClear();
+  mockTx.committed = 0;
+  mockTx.rolledBack = 0;
+  mockClientQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+  (getDatabaseUserFromRequest as jest.Mock).mockReset();
+  (getDatabaseUserFromRequest as jest.Mock).mockResolvedValue(USER);
+  (userDatabase.updateUserProfile as jest.Mock).mockReset();
+});
+
+describe("POST /api/commensal/save-group", () => {
+  it("rolls back the companion inserts when the dining-group registration fails", async () => {
+    (userDatabase.updateUserProfile as jest.Mock).mockRejectedValue(
+      new Error("profile write failed"),
+    );
+
+    const res = await POST(
+      makeRequest({ groupName: "Feast", guests: [guest("Alice"), guest("Bob")] }),
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.message).toMatch(/Nothing was saved/);
+
+    // Both companions were inserted inside the transaction...
+    expect(companionInsertCalls()).toHaveLength(2);
+    // ...and the registration failure rolled the whole thing back.
+    expect(mockTx.rolledBack).toBe(1);
+    expect(mockTx.committed).toBe(0);
+  });
+
+  it("commits companions + group as one unit on success", async () => {
+    (userDatabase.updateUserProfile as jest.Mock).mockResolvedValue({});
+
+    const res = await POST(
+      makeRequest({ groupName: "Feast", guests: [guest("Alice"), guest("Bob")] }),
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(data.success).toBe(true);
+    expect(data.diningGroup.name).toBe("Feast");
+    expect(data.diningGroup.memberIds).toHaveLength(2);
+    expect(data.memberIds).toEqual(data.diningGroup.memberIds);
+
+    expect(companionInsertCalls()).toHaveLength(2);
+    expect(mockTx.committed).toBe(1);
+    expect(mockTx.rolledBack).toBe(0);
+
+    // The registered group references exactly the created companion ids.
+    const updateArg = (userDatabase.updateUserProfile as jest.Mock).mock
+      .calls[0][1];
+    expect(updateArg.diningGroups[0].memberIds).toEqual(data.memberIds);
+  });
+
+  it("rolls back everything when a companion insert itself fails midway", async () => {
+    (userDatabase.updateUserProfile as jest.Mock).mockResolvedValue({});
+    mockClientQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+      .mockRejectedValueOnce(new Error("insert blew up"));
+
+    const res = await POST(
+      makeRequest({ groupName: "Feast", guests: [guest("Alice"), guest("Bob")] }),
+    );
+
+    expect(res.status).toBe(500);
+    expect(mockTx.rolledBack).toBe(1);
+    expect(mockTx.committed).toBe(0);
+    // Registration never ran — the failure happened before it.
+    expect(userDatabase.updateUserProfile).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/commensal/save-group/route.ts
+++ b/src/app/api/commensal/save-group/route.ts
@@ -118,55 +118,46 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  // Persist companions sequentially so a partial failure halts cleanly with
-  // a clear error rather than fanning out partially-succeeded inserts.
-  const created: GroupMember[] = [];
-  for (const g of guests) {
-    const member = await commensalDatabase.createManualCompanion({
-      ownerId: user.id,
-      name: g.name,
-      relationship: g.relationship ?? "friend",
-      birthData: g.birthData,
-      natalChart: g.natalChart,
-    });
-    if (!member) {
-      _logger.error(
-        `[POST /api/commensal/save-group] Failed to save companion '${g.name}' for user ${user.id}`,
-      );
-      return NextResponse.json(
-        {
-          success: false,
-          message: "Failed to save group companions. Please try again.",
-        },
-        { status: 500 },
-      );
-    }
-    created.push(member);
-  }
-
-  const now = new Date().toISOString();
-  const newGroup: DiningGroup = {
-    id: `group_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`,
-    name: groupName.trim(),
-    memberIds: created.map((m) => m.id),
-    createdAt: now,
-    updatedAt: now,
-  };
-
+  // Persist companions AND register the group atomically: the companion
+  // inserts run on one transaction client, and the group registration happens
+  // before COMMIT — any failure rolls the whole write back, so there are
+  // never orphaned companions or a group without its members.
   const existingGroups = user.profile.diningGroups || [];
-  try {
-    await userDatabase.updateUserProfile(user.id, {
-      diningGroups: [...existingGroups, newGroup],
-    });
-  } catch (error) {
+  let newGroup: DiningGroup | null = null;
+
+  const created: GroupMember[] | null =
+    await commensalDatabase.createManualCompanionsAtomic(
+      user.id,
+      guests.map((g) => ({
+        name: g.name,
+        relationship: g.relationship ?? "friend",
+        birthData: g.birthData,
+        natalChart: g.natalChart,
+      })),
+      async (members) => {
+        const now = new Date().toISOString();
+        const group: DiningGroup = {
+          id: `group_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`,
+          name: groupName.trim(),
+          memberIds: members.map((m) => m.id),
+          createdAt: now,
+          updatedAt: now,
+        };
+        await userDatabase.updateUserProfile(user.id, {
+          diningGroups: [...existingGroups, group],
+        });
+        newGroup = group;
+      },
+    );
+
+  if (!created || !newGroup) {
     _logger.error(
-      "[POST /api/commensal/save-group] Failed to update profile",
-      error,
+      `[POST /api/commensal/save-group] Atomic save failed for user ${user.id} — rolled back`,
     );
     return NextResponse.json(
       {
         success: false,
-        message: "Companions saved, but group registration failed.",
+        message: "Failed to save the group. Nothing was saved — please try again.",
       },
       { status: 500 },
     );

--- a/src/app/api/commensal/save-group/route.ts
+++ b/src/app/api/commensal/save-group/route.ts
@@ -4,7 +4,7 @@
  * POST /api/commensal/save-group
  * Persists a guest commensal session for an authenticated user. Saves each
  * guest as a manual companion (in `manual_companion_charts`) and registers a
- * `DiningGroup` containing them in `user.profile.diningGroups`.
+ * `DiningGroup` containing them in the user's profile.
  *
  * Skips the legacy `groupMembers` JSONB validation used by
  * `/api/user/dining-groups` because new manual companions are stored in the
@@ -14,8 +14,8 @@
 import { NextResponse } from "next/server";
 import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
 import { _logger } from "@/lib/logger";
+import { rateLimit } from "@/lib/rateLimit";
 import { commensalDatabase } from "@/services/commensalDatabaseService";
-import { userDatabase } from "@/services/userDatabaseService";
 import type {
   BirthData,
   DiningGroup,
@@ -26,6 +26,18 @@ import type { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+/** Matches the recommendation engine's 12-guest schema cap. */
+const MAX_GUESTS = 12;
+const MAX_GROUP_NAME_LENGTH = 100;
+
+// Authenticated, but each guest is a natal-chart-sized JSONB insert — cap the
+// write volume per user.
+const SAVE_GROUP_LIMIT = {
+  window: 60_000,
+  max: 10,
+  bucket: "commensal-save-group",
+} as const;
 
 interface SaveGuest {
   name: string;
@@ -63,6 +75,12 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  const rl = await rateLimit(request, {
+    ...SAVE_GROUP_LIMIT,
+    identifier: user.id,
+  });
+  if (!rl.allowed) return rl.response!;
+
   let body: Record<string, unknown>;
   try {
     body = await request.json();
@@ -84,9 +102,27 @@ export async function POST(request: NextRequest) {
       { status: 400 },
     );
   }
+  if (groupName.trim().length > MAX_GROUP_NAME_LENGTH) {
+    return NextResponse.json(
+      {
+        success: false,
+        message: `groupName must be at most ${MAX_GROUP_NAME_LENGTH} characters`,
+      },
+      { status: 400 },
+    );
+  }
   if (!Array.isArray(guests) || guests.length === 0) {
     return NextResponse.json(
       { success: false, message: "guests array must not be empty" },
+      { status: 400 },
+    );
+  }
+  if (guests.length > MAX_GUESTS) {
+    return NextResponse.json(
+      {
+        success: false,
+        message: `A table seats twelve — at most ${MAX_GUESTS} guests per group.`,
+      },
       { status: 400 },
     );
   }
@@ -118,10 +154,11 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  // Persist companions AND register the group atomically: the companion
-  // inserts run on one transaction client, and the group registration happens
-  // before COMMIT — any failure rolls the whole write back, so there are
-  // never orphaned companions or a group without its members.
+  // Persist companions AND register the group atomically. Everything runs on
+  // ONE transaction client — the companion inserts and the dining-group
+  // profile dual-write below — so a failure anywhere rolls the entire write
+  // back. No other pooled connections are acquired inside the transaction
+  // (hold-and-acquire under concurrency would starve the small pool).
   const existingGroups = user.profile.diningGroups || [];
   let newGroup: DiningGroup | null = null;
 
@@ -134,7 +171,7 @@ export async function POST(request: NextRequest) {
         birthData: g.birthData,
         natalChart: g.natalChart,
       })),
-      async (members) => {
+      async (members, client) => {
         const now = new Date().toISOString();
         const group: DiningGroup = {
           id: `group_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`,
@@ -143,9 +180,53 @@ export async function POST(request: NextRequest) {
           createdAt: now,
           updatedAt: now,
         };
-        await userDatabase.updateUserProfile(user.id, {
+
+        // Dual-write the profile the same way updateUserProfile does — but on
+        // the transaction client so it commits/rolls back with the companion
+        // inserts. user_profiles columns are canonical; users.profile JSONB is
+        // kept in lockstep. (No user re-read: the route already loaded it.)
+        const updatedProfile = {
+          ...user.profile,
           diningGroups: [...existingGroups, group],
-        });
+          userId: user.id,
+        };
+        updatedProfile.onboardingComplete =
+          updatedProfile.onboardingComplete ??
+          !!(updatedProfile.birthData && updatedProfile.natalChart);
+        const onboardingComplete = updatedProfile.onboardingComplete === true;
+
+        await client.query(
+          `UPDATE users SET profile = $2, preferences = $3, updated_at = CURRENT_TIMESTAMP
+           WHERE id = $1::uuid`,
+          [
+            user.id,
+            JSON.stringify(updatedProfile),
+            JSON.stringify(updatedProfile.preferences || {}),
+          ],
+        );
+        await client.query(
+          `INSERT INTO user_profiles (user_id, name, birth_data, natal_chart, group_members, dining_groups, onboarding_completed)
+           VALUES ($1, $2, $3, $4, $5, $6, $7)
+           ON CONFLICT (user_id) DO UPDATE SET
+             name = EXCLUDED.name,
+             birth_data = EXCLUDED.birth_data,
+             natal_chart = EXCLUDED.natal_chart,
+             group_members = EXCLUDED.group_members,
+             dining_groups = EXCLUDED.dining_groups,
+             onboarding_completed = EXCLUDED.onboarding_completed,
+             onboarding_completed_at = CASE WHEN EXCLUDED.onboarding_completed AND NOT COALESCE(user_profiles.onboarding_completed, false) THEN CURRENT_TIMESTAMP ELSE user_profiles.onboarding_completed_at END,
+             updated_at = CURRENT_TIMESTAMP`,
+          [
+            user.id,
+            updatedProfile.name || "",
+            JSON.stringify(updatedProfile.birthData || {}),
+            JSON.stringify(updatedProfile.natalChart || {}),
+            JSON.stringify(updatedProfile.groupMembers || []),
+            JSON.stringify(updatedProfile.diningGroups || []),
+            onboardingComplete,
+          ],
+        );
+
         newGroup = group;
       },
     );

--- a/src/app/api/commensals/block/__tests__/route.test.ts
+++ b/src/app/api/commensals/block/__tests__/route.test.ts
@@ -77,15 +77,16 @@ describe("POST /api/commensals/block", () => {
     expect(commensalDatabase.blockCommensal).not.toHaveBeenCalled();
   });
 
-  it("blocks by targetUserId and returns the blocked commensalship", async () => {
+  it("blocks by targetUserId and returns success WITHOUT the commensalship body", async () => {
     (commensalDatabase.blockCommensal as jest.Mock).mockResolvedValue(blockedRow);
 
     const res = await POST(makeRequest({ targetUserId: TARGET }));
     const data = await res.json();
 
     expect(res.status).toBe(200);
-    expect(data.success).toBe(true);
-    expect(data.commensalship.status).toBe("blocked");
+    // The row carries both parties' emails and blocking works from a bare
+    // targetUserId — echoing it back would be an email-harvesting vector.
+    expect(data).toEqual({ success: true });
     expect(commensalDatabase.blockCommensal).toHaveBeenCalledWith(ME, {
       commensalshipId: undefined,
       targetUserId: TARGET,

--- a/src/app/api/commensals/block/__tests__/route.test.ts
+++ b/src/app/api/commensals/block/__tests__/route.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for POST /api/commensals/block — block/unblock a companion link.
+ */
+
+// Mock next/server before anything else
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body, init) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("@/lib/auth/validateRequest", () => ({
+  getUserIdFromRequest: jest.fn(),
+}));
+
+jest.mock("@/services/commensalDatabaseService", () => ({
+  commensalDatabase: {
+    blockCommensal: jest.fn(),
+    unblockCommensal: jest.fn(),
+  },
+}));
+
+import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { commensalDatabase } from "@/services/commensalDatabaseService";
+import { POST } from "../route";
+
+const ME = "user-me";
+const TARGET = "user-target";
+
+function makeRequest(body: unknown): any {
+  return {
+    url: "http://localhost/api/commensals/block",
+    method: "POST",
+    json: async () => body,
+  };
+}
+
+const blockedRow = {
+  id: "c-1",
+  requesterId: ME,
+  addresseeId: TARGET,
+  status: "blocked",
+  createdAt: "2026-07-01T00:00:00Z",
+  updatedAt: "2026-07-11T00:00:00Z",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (getUserIdFromRequest as jest.Mock).mockResolvedValue(ME);
+});
+
+describe("POST /api/commensals/block", () => {
+  it("returns 401 when unauthenticated", async () => {
+    (getUserIdFromRequest as jest.Mock).mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ targetUserId: TARGET }));
+
+    expect(res.status).toBe(401);
+    expect(commensalDatabase.blockCommensal).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when neither commensalshipId nor targetUserId is given", async () => {
+    const res = await POST(makeRequest({}));
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.message).toMatch(/commensalshipId or targetUserId/);
+  });
+
+  it("refuses self-blocking", async () => {
+    const res = await POST(makeRequest({ targetUserId: ME }));
+
+    expect(res.status).toBe(400);
+    expect(commensalDatabase.blockCommensal).not.toHaveBeenCalled();
+  });
+
+  it("blocks by targetUserId and returns the blocked commensalship", async () => {
+    (commensalDatabase.blockCommensal as jest.Mock).mockResolvedValue(blockedRow);
+
+    const res = await POST(makeRequest({ targetUserId: TARGET }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.commensalship.status).toBe("blocked");
+    expect(commensalDatabase.blockCommensal).toHaveBeenCalledWith(ME, {
+      commensalshipId: undefined,
+      targetUserId: TARGET,
+    });
+  });
+
+  it("blocks by commensalshipId", async () => {
+    (commensalDatabase.blockCommensal as jest.Mock).mockResolvedValue(blockedRow);
+
+    const res = await POST(makeRequest({ commensalshipId: "c-1" }));
+
+    expect(res.status).toBe(200);
+    expect(commensalDatabase.blockCommensal).toHaveBeenCalledWith(ME, {
+      commensalshipId: "c-1",
+      targetUserId: undefined,
+    });
+  });
+
+  it("returns 400 when the service cannot block (e.g. not a party)", async () => {
+    (commensalDatabase.blockCommensal as jest.Mock).mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ commensalshipId: "not-mine" }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it("unblocks with action: 'unblock'", async () => {
+    (commensalDatabase.unblockCommensal as jest.Mock).mockResolvedValue(true);
+
+    const res = await POST(
+      makeRequest({ targetUserId: TARGET, action: "unblock" }),
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(commensalDatabase.unblockCommensal).toHaveBeenCalledWith(ME, {
+      commensalshipId: undefined,
+      targetUserId: TARGET,
+    });
+    expect(commensalDatabase.blockCommensal).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when there is no blocked row to unblock", async () => {
+    (commensalDatabase.unblockCommensal as jest.Mock).mockResolvedValue(false);
+
+    const res = await POST(
+      makeRequest({ targetUserId: TARGET, action: "unblock" }),
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects unknown actions", async () => {
+    const res = await POST(
+      makeRequest({ targetUserId: TARGET, action: "obliterate" }),
+    );
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/commensals/block/route.ts
+++ b/src/app/api/commensals/block/route.ts
@@ -96,7 +96,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    return NextResponse.json({ success: true, commensalship: blocked });
+    // Deliberately body-less: the commensalship row carries both parties'
+    // emails, and blocking works from a bare targetUserId — echoing the row
+    // back would be a silent email-harvesting vector.
+    return NextResponse.json({ success: true });
   } catch (error) {
     console.error("Block commensal error:", error);
     return NextResponse.json(

--- a/src/app/api/commensals/block/route.ts
+++ b/src/app/api/commensals/block/route.ts
@@ -1,0 +1,107 @@
+/**
+ * Block Commensal API Route
+ * POST /api/commensals/block - Block (or unblock) a dining companion link.
+ *
+ * Body: { commensalshipId?: string; targetUserId?: string; action?: "block" | "unblock" }
+ * — one of commensalshipId or targetUserId is required.
+ *
+ * Either party may block. Blocking upserts the pair row to status='blocked'
+ * (creating one when no relationship exists yet); unblocking deletes the
+ * blocked row so a fresh request becomes possible. Blocked rows never appear
+ * in linked-commensal listings (those filter on status='accepted') and
+ * further requests for the pair are refused while blocked.
+ *
+ * Silent by design: no notifications are emitted for block or unblock.
+ */
+
+import { NextResponse } from "next/server";
+import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { commensalDatabase } from "@/services/commensalDatabaseService";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(request: NextRequest) {
+  try {
+    const userId = await getUserIdFromRequest(request);
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, message: "Authentication required" },
+        { status: 401 },
+      );
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { success: false, message: "Invalid JSON in request body" },
+        { status: 400 },
+      );
+    }
+
+    const { commensalshipId, targetUserId, action = "block" } = body as {
+      commensalshipId?: string;
+      targetUserId?: string;
+      action?: string;
+    };
+
+    if (action !== "block" && action !== "unblock") {
+      return NextResponse.json(
+        { success: false, message: "action must be 'block' or 'unblock'" },
+        { status: 400 },
+      );
+    }
+    const hasChipId =
+      typeof commensalshipId === "string" && commensalshipId.length > 0;
+    const hasTargetId =
+      typeof targetUserId === "string" && targetUserId.length > 0;
+    if (!hasChipId && !hasTargetId) {
+      return NextResponse.json(
+        { success: false, message: "commensalshipId or targetUserId is required" },
+        { status: 400 },
+      );
+    }
+    if (hasTargetId && targetUserId === userId) {
+      return NextResponse.json(
+        { success: false, message: "You cannot block yourself" },
+        { status: 400 },
+      );
+    }
+
+    if (action === "unblock") {
+      const removed = await commensalDatabase.unblockCommensal(userId, {
+        commensalshipId: hasChipId ? commensalshipId : undefined,
+        targetUserId: hasTargetId ? targetUserId : undefined,
+      });
+      if (!removed) {
+        return NextResponse.json(
+          { success: false, message: "No blocked companion link found" },
+          { status: 404 },
+        );
+      }
+      return NextResponse.json({ success: true });
+    }
+
+    const blocked = await commensalDatabase.blockCommensal(userId, {
+      commensalshipId: hasChipId ? commensalshipId : undefined,
+      targetUserId: hasTargetId ? targetUserId : undefined,
+    });
+    if (!blocked) {
+      return NextResponse.json(
+        { success: false, message: "Could not block this companion link" },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json({ success: true, commensalship: blocked });
+  } catch (error) {
+    console.error("Block commensal error:", error);
+    return NextResponse.json(
+      { success: false, message: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/commensals/request/route.ts
+++ b/src/app/api/commensals/request/route.ts
@@ -105,7 +105,14 @@ export async function POST(request: NextRequest) {
 
     feedDatabase.createEvent(userId, "commensal_request", { targetName }).catch(() => {});
 
-    if (!targetUserRecord || !targetUserRecord.isAgent) {
+    // Skip when the link is already accepted: a pending reverse-direction
+    // request auto-accepts inside createCommensalRequest (mutual interest),
+    // which notifies the original requester with commensal_accepted — a
+    // "wants to be your dining companion" ping here would be wrong.
+    if (
+      (!targetUserRecord || !targetUserRecord.isAgent) &&
+      finalCommensalship.status === "pending"
+    ) {
       notificationDatabase.createNotification(
         targetUserId,
         "commensal_request",

--- a/src/app/api/group-recommendations/__tests__/route.test.ts
+++ b/src/app/api/group-recommendations/__tests__/route.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for POST /api/group-recommendations — split-brain companion merge.
+ *
+ * Manual companions live in BOTH user_profiles.group_members JSONB (legacy)
+ * and the manual_companion_charts table (modern). The route must merge the
+ * two, so a companion saved only via the modern path still resolves.
+ */
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body, init) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("@/data/cuisines/index", () => ({
+  CUISINES: {
+    italian: {
+      name: "Italian",
+      elementalProperties: { Fire: 0.4, Water: 0.2, Earth: 0.2, Air: 0.2 },
+    },
+    japanese: {
+      name: "Japanese",
+      elementalProperties: { Fire: 0.1, Water: 0.5, Earth: 0.2, Air: 0.2 },
+    },
+  },
+}));
+
+jest.mock("@/lib/auth/validateRequest", () => ({
+  getDatabaseUserFromRequest: jest.fn(),
+}));
+
+jest.mock("@/services/subscriptionService", () => ({
+  subscriptionService: {
+    canUseFeature: jest.fn(() => Promise.resolve({ allowed: true })),
+  },
+}));
+
+jest.mock("@/services/commensalDatabaseService", () => ({
+  commensalDatabase: {
+    getManualCompanionsForUser: jest.fn(() => Promise.resolve([])),
+    getLinkedCommensalsForUser: jest.fn(() => Promise.resolve([])),
+  },
+}));
+
+jest.mock("@/lib/logger", () => ({
+  _logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
+import { commensalDatabase } from "@/services/commensalDatabaseService";
+import { POST } from "../route";
+
+const USER_ID = "user-1";
+
+function chart(balance: Record<string, number>) {
+  return {
+    birthData: { dateTime: "1990-01-01T12:00:00Z", latitude: 40, longitude: -74 },
+    elementalBalance: balance,
+    alchemicalProperties: { Spirit: 4, Essence: 7, Matter: 6, Substance: 2 },
+  };
+}
+
+function makeRequest(body: unknown): any {
+  return {
+    url: "http://localhost/api/group-recommendations",
+    method: "POST",
+    json: async () => body,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (getDatabaseUserFromRequest as jest.Mock).mockResolvedValue({
+    id: USER_ID,
+    profile: {
+      name: "Owner",
+      natalChart: undefined, // owner has no chart — only companions count
+      groupMembers: [
+        {
+          id: "legacy-1",
+          name: "Legacy Friend",
+          natalChart: chart({ Fire: 0.4, Water: 0.2, Earth: 0.2, Air: 0.2 }),
+        },
+      ],
+    },
+  });
+  (commensalDatabase.getManualCompanionsForUser as jest.Mock).mockResolvedValue([
+    {
+      id: "table-1",
+      name: "Table-Only Friend",
+      relationship: "friend",
+      birthData: { dateTime: "1992-05-05T08:00:00Z", latitude: 41, longitude: -73 },
+      natalChart: chart({ Fire: 0.1, Water: 0.6, Earth: 0.2, Air: 0.1 }),
+      createdAt: "2026-07-01T00:00:00Z",
+    },
+  ]);
+});
+
+describe("POST /api/group-recommendations", () => {
+  it("includes companions from the manual_companion_charts table (not only legacy JSONB)", async () => {
+    const res = await POST(
+      makeRequest({
+        commensalIds: ["legacy-1", "table-1"],
+        linkedUserIds: [],
+        strategy: "average",
+      }),
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    // Both storage locations resolved: legacy JSONB member AND table-only member.
+    expect(data.memberCount).toBe(2);
+    const memberNames = data.recommendations[0].memberScores.map(
+      (m: { memberName: string }) => m.memberName,
+    );
+    expect(memberNames).toContain("Table-Only Friend");
+    expect(memberNames).toContain("Legacy Friend");
+    expect(commensalDatabase.getManualCompanionsForUser).toHaveBeenCalledWith(
+      USER_ID,
+    );
+  });
+
+  it("resolves a table-only companion even when legacy groupMembers is empty", async () => {
+    (getDatabaseUserFromRequest as jest.Mock).mockResolvedValue({
+      id: USER_ID,
+      profile: { name: "Owner", natalChart: undefined, groupMembers: [] },
+    });
+
+    const res = await POST(
+      makeRequest({ commensalIds: ["table-1"], linkedUserIds: [] }),
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.memberCount).toBe(1);
+    expect(data.recommendations[0].memberScores[0].memberName).toBe(
+      "Table-Only Friend",
+    );
+  });
+
+  it("still serves legacy members when the table lookup fails", async () => {
+    (commensalDatabase.getManualCompanionsForUser as jest.Mock).mockRejectedValue(
+      new Error("relation does not exist"),
+    );
+
+    const res = await POST(
+      makeRequest({ commensalIds: ["legacy-1"], linkedUserIds: [] }),
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.memberCount).toBe(1);
+  });
+});

--- a/src/app/api/group-recommendations/route.ts
+++ b/src/app/api/group-recommendations/route.ts
@@ -6,6 +6,7 @@ import { commensalDatabase } from "@/services/commensalDatabaseService";
 import { subscriptionService } from "@/services/subscriptionService";
 import type { AlchemicalProperties } from "@/types/alchemy";
 import type { Element } from "@/types/celestial";
+import type { GroupMember } from "@/types/natalChart";
 import { extractPlanetaryPositions } from "@/utils/astrology/chartDataUtils";
 import { calculateEnhancedAlchemicalFromPlanets, isSectDiurnal } from "@/utils/planetaryAlchemyMapping";
 import type { NextRequest } from "next/server";
@@ -143,10 +144,27 @@ export async function POST(request: NextRequest) {
       alchemicalList.push(alch);
       memberInfo.push({ id: userId, name: currentUser.profile.name ?? "You", element: dominantElement(el) });
     }
-    // Manual commensals from the user's groupMembers
+    // Manual commensals live in TWO places: the modern manual_companion_charts
+    // table (written by POST /api/user/commensals and save-group) and the
+    // legacy user_profiles.group_members JSONB. Merge both sources — deduped
+    // by id, modern table rows winning — so companions saved via either path
+    // resolve here.
     if ((commensalIds).length > 0) {
-      const groupMembers = currentUser.profile.groupMembers || [];
-      for (const commensal of groupMembers) {
+      const legacyMembers: GroupMember[] = currentUser.profile.groupMembers || [];
+      let tableMembers: GroupMember[] = [];
+      try {
+        tableMembers = await commensalDatabase.getManualCompanionsForUser(userId);
+      } catch (err) {
+        _logger.error(
+          `[POST /api/group-recommendations] Manual companions lookup failed for user ${userId}`,
+          err,
+        );
+        // Table unavailable — fall back to legacy JSONB members only
+      }
+      const mergedById = new Map<string, GroupMember>();
+      for (const m of legacyMembers) mergedById.set(m.id, m);
+      for (const m of tableMembers) mergedById.set(m.id, m);
+      for (const commensal of mergedById.values()) {
         if (!(commensalIds).includes(commensal.id)) continue;
         const chart = commensal.natalChart;
         if (!chart) continue;

--- a/src/app/api/user/charts/route.ts
+++ b/src/app/api/user/charts/route.ts
@@ -60,6 +60,10 @@ function calcDominantModality(positions: Record<Planet, ZodiacSignType>): Modali
 
 function hasMissingPlanetPrecision(chart: SavedChart): boolean {
   const planets = chart.natalChart?.planets || [];
+  // Charts loaded from the prod saved_charts table carry NO stored planets
+  // (structured birth fields only) — an empty list means "rebuild", not
+  // "nothing missing".
+  if (planets.length === 0) return true;
   return planets.some(
     (planet) =>
       planet.name !== "Ascendant" &&
@@ -79,15 +83,30 @@ async function ensureSubArcminutePrecision(chart: SavedChart): Promise<SavedChar
       longitude: chart.birthData.longitude,
     });
 
-    const updatedPlanets = (chart.natalChart.planets || []).map((planet) => {
-      const raw = rawPositions[planet.name];
-      if (!raw || typeof raw.exactLongitude !== "number") return planet;
-      return {
-        ...planet,
-        position: raw.exactLongitude,
-        sign: raw.sign || planet.sign,
-      };
-    });
+    const existingPlanets = chart.natalChart?.planets || [];
+    const updatedPlanets: PlanetInfo[] =
+      existingPlanets.length > 0
+        ? existingPlanets.map((planet) => {
+            const raw = rawPositions[planet.name];
+            if (!raw || typeof raw.exactLongitude !== "number") return planet;
+            return {
+              ...planet,
+              position: raw.exactLongitude,
+              sign: raw.sign || planet.sign,
+            };
+          })
+        : // DB-loaded chart with no stored planets — build the full array from
+          // the computed positions so GET never returns planet-less charts.
+          Object.entries(rawPositions)
+            .filter(
+              ([, value]) =>
+                !!value?.sign && typeof value.exactLongitude === "number",
+            )
+            .map(([planetName, value]) => ({
+              name: planetName as Planet,
+              sign: value.sign,
+              position: value.exactLongitude,
+            }));
 
     const updatedPlanetaryPositions = { ...chart.natalChart.planetaryPositions };
     Object.entries(rawPositions).forEach(([planetName, value]) => {

--- a/src/app/api/user/dining-groups/[groupId]/__tests__/route.test.ts
+++ b/src/app/api/user/dining-groups/[groupId]/__tests__/route.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for PUT /api/user/dining-groups/[groupId] — the EDIT path of the
+ * dual-store member validation fix. Groups created by save-group reference
+ * manual_companion_charts ids, so PUT must accept ids from BOTH stores
+ * (legacy profile JSONB groupMembers + the modern table) or those groups are
+ * uneditable.
+ */
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body, init) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("@/lib/auth/validateRequest", () => ({
+  getDatabaseUserFromRequest: jest.fn(),
+}));
+
+jest.mock("@/services/userDatabaseService", () => ({
+  userDatabase: {
+    updateUserProfile: jest.fn(() => Promise.resolve({})),
+  },
+}));
+
+jest.mock("@/services/commensalDatabaseService", () => ({
+  commensalDatabase: {
+    getManualCompanionsForUser: jest.fn(() => Promise.resolve([])),
+  },
+}));
+
+jest.mock("@/lib/logger", () => ({
+  _logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
+import { commensalDatabase } from "@/services/commensalDatabaseService";
+import { userDatabase } from "@/services/userDatabaseService";
+import { PUT } from "../route";
+
+const USER_ID = "user-1";
+const GROUP_ID = "group-1";
+
+function makeRequest(body: unknown): any {
+  return {
+    url: `http://localhost/api/user/dining-groups/${GROUP_ID}`,
+    method: "PUT",
+    json: async () => body,
+  };
+}
+
+const routeParams = { params: Promise.resolve({ groupId: GROUP_ID }) };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (getDatabaseUserFromRequest as jest.Mock).mockResolvedValue({
+    id: USER_ID,
+    profile: {
+      groupMembers: [{ id: "legacy-1", name: "Legacy Friend" }],
+      diningGroups: [
+        {
+          id: GROUP_ID,
+          name: "Feast",
+          memberIds: ["legacy-1"],
+          createdAt: "2026-07-01T00:00:00Z",
+          updatedAt: "2026-07-01T00:00:00Z",
+        },
+      ],
+    },
+  });
+  (userDatabase.updateUserProfile as jest.Mock).mockResolvedValue({});
+});
+
+describe("PUT /api/user/dining-groups/[groupId]", () => {
+  it("accepts a memberId that exists ONLY in manual_companion_charts (save-group edit path)", async () => {
+    (commensalDatabase.getManualCompanionsForUser as jest.Mock).mockResolvedValue([
+      { id: "table-1", name: "Table-Only Friend" },
+    ]);
+
+    const res = await PUT(
+      makeRequest({ memberIds: ["legacy-1", "table-1"] }),
+      routeParams,
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.diningGroup.memberIds).toEqual(["legacy-1", "table-1"]);
+    expect(userDatabase.updateUserProfile).toHaveBeenCalledWith(USER_ID, {
+      diningGroups: [
+        expect.objectContaining({
+          id: GROUP_ID,
+          memberIds: ["legacy-1", "table-1"],
+        }),
+      ],
+    });
+  });
+
+  it("still rejects ids unknown to BOTH stores", async () => {
+    (commensalDatabase.getManualCompanionsForUser as jest.Mock).mockResolvedValue([
+      { id: "table-1", name: "Table-Only Friend" },
+    ]);
+
+    const res = await PUT(makeRequest({ memberIds: ["ghost-9"] }), routeParams);
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.message).toMatch(/ghost-9/);
+    expect(userDatabase.updateUserProfile).not.toHaveBeenCalled();
+  });
+
+  it("renames without touching members (no memberIds in body)", async () => {
+    const res = await PUT(makeRequest({ name: "New Name" }), routeParams);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.diningGroup.name).toBe("New Name");
+    // No member validation needed — the table lookup is skipped entirely.
+    expect(commensalDatabase.getManualCompanionsForUser).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/user/dining-groups/[groupId]/route.ts
+++ b/src/app/api/user/dining-groups/[groupId]/route.ts
@@ -7,6 +7,7 @@
 import { NextResponse } from "next/server";
 import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
 import { _logger } from "@/lib/logger";
+import { commensalDatabase } from "@/services/commensalDatabaseService";
 import { userDatabase } from "@/services/userDatabaseService";
 import type { NextRequest } from "next/server";
 
@@ -49,9 +50,17 @@ export async function PUT(
   }
   const { name, memberIds } = body as { name?: string; memberIds?: string[] };
 
-  // Validate memberIds if provided
+  // Validate memberIds if provided — a member may live in EITHER storage:
+  // legacy profile JSONB (groupMembers) or the modern manual_companion_charts
+  // table (written by /api/user/commensals and save-group).
   if (memberIds) {
     const knownIds = new Set((user.profile.groupMembers || []).map((m) => m.id));
+    try {
+      const tableCompanions = await commensalDatabase.getManualCompanionsForUser(user.id);
+      for (const m of tableCompanions) knownIds.add(m.id);
+    } catch (error) {
+      _logger.error(`[PUT /api/user/dining-groups/${groupId}] Manual companions lookup failed`, error);
+    }
     const invalid = memberIds.filter((id) => !knownIds.has(id));
     if (invalid.length > 0) {
       return NextResponse.json(

--- a/src/app/api/user/dining-groups/__tests__/route.test.ts
+++ b/src/app/api/user/dining-groups/__tests__/route.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for POST /api/user/dining-groups — member validation must accept ids
+ * from BOTH companion stores: legacy profile JSONB (groupMembers) and the
+ * modern manual_companion_charts table (written by save-group), otherwise
+ * groups created via save-group are uneditable.
+ */
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body, init) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("@/lib/auth/validateRequest", () => ({
+  getDatabaseUserFromRequest: jest.fn(),
+}));
+
+jest.mock("@/services/userDatabaseService", () => ({
+  userDatabase: {
+    updateUserProfile: jest.fn(() => Promise.resolve({})),
+  },
+}));
+
+jest.mock("@/services/commensalDatabaseService", () => ({
+  commensalDatabase: {
+    getManualCompanionsForUser: jest.fn(() => Promise.resolve([])),
+  },
+}));
+
+jest.mock("@/lib/logger", () => ({
+  _logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
+import { commensalDatabase } from "@/services/commensalDatabaseService";
+import { userDatabase } from "@/services/userDatabaseService";
+import { POST } from "../route";
+
+const USER_ID = "user-1";
+
+function makeRequest(body: unknown): any {
+  return {
+    url: "http://localhost/api/user/dining-groups",
+    method: "POST",
+    json: async () => body,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (getDatabaseUserFromRequest as jest.Mock).mockResolvedValue({
+    id: USER_ID,
+    profile: {
+      groupMembers: [{ id: "legacy-1", name: "Legacy Friend" }],
+      diningGroups: [],
+    },
+  });
+  (userDatabase.updateUserProfile as jest.Mock).mockResolvedValue({});
+});
+
+describe("POST /api/user/dining-groups", () => {
+  it("accepts a memberId that exists ONLY in manual_companion_charts", async () => {
+    (commensalDatabase.getManualCompanionsForUser as jest.Mock).mockResolvedValue([
+      { id: "table-1", name: "Table-Only Friend" },
+    ]);
+
+    const res = await POST(
+      makeRequest({ name: "Dinner Club", memberIds: ["table-1"] }),
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(data.success).toBe(true);
+    expect(data.diningGroup.memberIds).toEqual(["table-1"]);
+    expect(userDatabase.updateUserProfile).toHaveBeenCalledWith(USER_ID, {
+      diningGroups: [expect.objectContaining({ memberIds: ["table-1"] })],
+    });
+  });
+
+  it("accepts a mixed group spanning both stores", async () => {
+    (commensalDatabase.getManualCompanionsForUser as jest.Mock).mockResolvedValue([
+      { id: "table-1", name: "Table-Only Friend" },
+    ]);
+
+    const res = await POST(
+      makeRequest({ name: "Mixed", memberIds: ["legacy-1", "table-1"] }),
+    );
+
+    expect(res.status).toBe(201);
+  });
+
+  it("still rejects ids unknown to BOTH stores", async () => {
+    (commensalDatabase.getManualCompanionsForUser as jest.Mock).mockResolvedValue([
+      { id: "table-1", name: "Table-Only Friend" },
+    ]);
+
+    const res = await POST(
+      makeRequest({ name: "Bad", memberIds: ["ghost-9"] }),
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.message).toMatch(/ghost-9/);
+    expect(userDatabase.updateUserProfile).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/user/dining-groups/route.ts
+++ b/src/app/api/user/dining-groups/route.ts
@@ -7,6 +7,7 @@
 import { NextResponse } from "next/server";
 import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
 import { _logger } from "@/lib/logger";
+import { commensalDatabase } from "@/services/commensalDatabaseService";
 import { userDatabase } from "@/services/userDatabaseService";
 import type { DiningGroup } from "@/types/natalChart";
 import type { NextRequest } from "next/server";
@@ -61,8 +62,16 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Validate that all memberIds exist as commensals
+  // Validate that all memberIds exist as commensals — in EITHER storage:
+  // legacy profile JSONB (groupMembers) or the modern manual_companion_charts
+  // table (written by /api/user/commensals and save-group).
   const knownIds = new Set((user.profile.groupMembers || []).map((m) => m.id));
+  try {
+    const tableCompanions = await commensalDatabase.getManualCompanionsForUser(user.id);
+    for (const m of tableCompanions) knownIds.add(m.id);
+  } catch (error) {
+    _logger.error("[POST /api/user/dining-groups] Manual companions lookup failed", error);
+  }
   const invalidIds = memberIds.filter((id) => !knownIds.has(id));
   if (invalidIds.length > 0) {
     return NextResponse.json(

--- a/src/components/commensal/CompanionSuggestions.tsx
+++ b/src/components/commensal/CompanionSuggestions.tsx
@@ -41,6 +41,8 @@ interface CompanionSuggestionsProps {
   ) => void;
   activeGuests: Array<{ id?: string; name: string }>;
   refreshTrigger?: number;
+  /** When true the table is full (12 seats) — invite buttons are disabled. */
+  inviteDisabled?: boolean;
 }
 
 const ELEMENT_ICON: Record<string, React.ReactNode> = {
@@ -69,6 +71,7 @@ export function CompanionSuggestions({
   onInvite,
   activeGuests,
   refreshTrigger = 0,
+  inviteDisabled = false,
 }: CompanionSuggestionsProps) {
   const [activeAgents, setActiveAgents] = useState<Companion[]>([]);
   const [historicalAgents, setHistoricalAgents] = useState<Companion[]>([]);
@@ -309,11 +312,18 @@ export function CompanionSuggestions({
                       agent.natalChart,
                     )
                   }
-                  disabled={isAlreadyInvited}
+                  disabled={isAlreadyInvited || inviteDisabled}
+                  title={
+                    !isAlreadyInvited && inviteDisabled
+                      ? "A table seats twelve."
+                      : undefined
+                  }
                   className={`w-full py-1.5 rounded-lg text-xs font-bold transition-all ${
                     isAlreadyInvited
                       ? "bg-green-500/10 text-green-300 border border-green-500/20 cursor-default"
-                      : "bg-white/5 hover:bg-white/10 border border-white/10 text-purple-100 hover:text-white"
+                      : inviteDisabled
+                        ? "bg-white/5 border border-white/10 text-purple-100/40 cursor-not-allowed"
+                        : "bg-white/5 hover:bg-white/10 border border-white/10 text-purple-100 hover:text-white"
                   }`}
                 >
                   {isAlreadyInvited ? "Invited to Table" : "Invite to Table"}

--- a/src/components/commensal/CompanionSuggestions.tsx
+++ b/src/components/commensal/CompanionSuggestions.tsx
@@ -228,7 +228,7 @@ export function CompanionSuggestions({
                 : activeTab === "feed"
                   ? "No recent feed broadcasts found. Sync agentic updates from Planetary Agents."
                   : activeTab === "saved"
-                    ? "You haven't saved any custom companion charts yet. Add charts using the form to persist them here and earn ESMS tokens!"
+                    ? "You haven't saved any custom companion charts yet. Add charts using the form to keep them here."
                     : "The cosmic roster is currently empty."}
             </p>
           </div>

--- a/src/components/commensal/RestaurantList.tsx
+++ b/src/components/commensal/RestaurantList.tsx
@@ -26,9 +26,6 @@ export function RestaurantList({ restaurants, locationLabel }: Props) {
             )}
           </span>
         </h3>
-        <span className="text-[11px] text-purple-300/60 uppercase tracking-wider">
-          via Foursquare
-        </span>
       </div>
 
       <div className="grid sm:grid-cols-2 gap-4">

--- a/src/services/__tests__/commensalDatabaseService.test.ts
+++ b/src/services/__tests__/commensalDatabaseService.test.ts
@@ -261,3 +261,252 @@ describe("blocked rows stay out of the linked-commensal listing", () => {
     expect(sql).toContain("c.status = 'accepted'");
   });
 });
+
+describe("blockCommensal / unblockCommensal", () => {
+  const blockedJoinRow = {
+    id: "c-1",
+    requester_id: ME,
+    addressee_id: TARGET,
+    status: "blocked",
+    created_at: "2026-07-01T00:00:00Z",
+    updated_at: "2026-07-11T00:00:00Z",
+    requester_name: "Me",
+    requester_email: "me@example.com",
+    addressee_name: "Target",
+    addressee_email: "target@example.com",
+  };
+
+  it("upserts an EXISTING pair row to blocked (by targetUserId)", async () => {
+    const updates: Array<{ sql: string; params: unknown[] }> = [];
+    mockExecuteQuery.mockImplementation(async (sql: string, params: unknown[]) => {
+      if (sql.includes("SELECT id FROM commensalships")) {
+        return { rows: [{ id: "c-1" }], rowCount: 1 };
+      }
+      if (sql.includes("UPDATE commensalships")) {
+        updates.push({ sql, params });
+        return { rows: [], rowCount: 1 };
+      }
+      if (sql.includes("FROM commensalships c")) {
+        return { rows: [blockedJoinRow], rowCount: 1 };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    const result = await commensalDatabase.blockCommensal(ME, {
+      targetUserId: TARGET,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("blocked");
+    expect(updates).toHaveLength(1);
+    expect(updates[0].sql).toContain("SET status = 'blocked'");
+    expect(updates[0].params).toEqual(["c-1"]);
+    expect(sqlCalls().some((q) => q.includes("INSERT INTO"))).toBe(false);
+  });
+
+  it("creates a blocked row when NO relationship exists yet", async () => {
+    const inserts: Array<{ sql: string; params: unknown[] }> = [];
+    mockExecuteQuery.mockImplementation(async (sql: string, params: unknown[]) => {
+      if (sql.includes("SELECT id FROM commensalships")) {
+        return { rows: [], rowCount: 0 };
+      }
+      if (sql.includes("INSERT INTO commensalships")) {
+        inserts.push({ sql, params });
+        return { rows: [], rowCount: 1 };
+      }
+      if (sql.includes("FROM commensalships c")) {
+        return { rows: [blockedJoinRow], rowCount: 1 };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    const result = await commensalDatabase.blockCommensal(ME, {
+      targetUserId: TARGET,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("blocked");
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0].sql).toContain("'blocked'");
+    expect(inserts[0].params.slice(1)).toEqual([ME, TARGET]);
+  });
+
+  it("retries on a 23505 insert race and blocks the row that won", async () => {
+    let selectCount = 0;
+    mockExecuteQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT id FROM commensalships")) {
+        selectCount += 1;
+        // First look: no row. After the racing insert collides: the
+        // concurrent row exists — block that one instead.
+        if (selectCount === 1) return { rows: [], rowCount: 0 };
+        return { rows: [{ id: "c-2" }], rowCount: 1 };
+      }
+      if (sql.includes("INSERT INTO commensalships")) {
+        const err = new Error("duplicate key") as Error & { code?: string };
+        err.code = "23505";
+        throw err;
+      }
+      if (sql.includes("UPDATE commensalships")) {
+        return { rows: [], rowCount: 1 };
+      }
+      if (sql.includes("FROM commensalships c")) {
+        return { rows: [{ ...blockedJoinRow, id: "c-2" }], rowCount: 1 };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    const result = await commensalDatabase.blockCommensal(ME, {
+      targetUserId: TARGET,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("blocked");
+    expect(result!.id).toBe("c-2");
+  });
+
+  it("returns null when blocking by commensalshipId the actor is not a party to", async () => {
+    mockExecuteQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("UPDATE commensalships")) {
+        // Party guard in the WHERE clause matched nothing.
+        return { rows: [], rowCount: 0 };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    const result = await commensalDatabase.blockCommensal(ME, {
+      commensalshipId: "someone-elses",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("unblock deletes ONLY the blocked row between the two users", async () => {
+    const deletes: Array<{ sql: string; params: unknown[] }> = [];
+    mockExecuteQuery.mockImplementation(async (sql: string, params: unknown[]) => {
+      if (sql.includes("DELETE FROM commensalships")) {
+        deletes.push({ sql, params });
+        return { rows: [], rowCount: 1 };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    const removed = await commensalDatabase.unblockCommensal(ME, {
+      targetUserId: TARGET,
+    });
+
+    expect(removed).toBe(true);
+    expect(deletes).toHaveLength(1);
+    // Scoped to blocked status AND the exact unordered pair.
+    expect(deletes[0].sql).toContain("status = 'blocked'");
+    expect(deletes[0].sql).toContain(
+      "requester_id = $1::uuid AND addressee_id = $2::uuid",
+    );
+    expect(deletes[0].sql).toContain(
+      "requester_id = $2::uuid AND addressee_id = $1::uuid",
+    );
+    expect(deletes[0].params).toEqual([ME, TARGET]);
+  });
+
+  it("unblock returns false when there is no blocked row", async () => {
+    mockExecuteQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+    const removed = await commensalDatabase.unblockCommensal(ME, {
+      targetUserId: TARGET,
+    });
+
+    expect(removed).toBe(false);
+  });
+});
+
+describe("updateCommensalshipStatus — guarded accept", () => {
+  const checkRow = { requester_id: TARGET, addressee_id: ME, status: "pending" };
+  const joinRow = (status: string) => ({
+    id: "c-1",
+    requester_id: TARGET,
+    addressee_id: ME,
+    status,
+    created_at: "2026-07-01T00:00:00Z",
+    updated_at: "2026-07-11T00:00:00Z",
+    requester_name: "Target",
+    requester_email: "target@example.com",
+    addressee_name: "Me",
+    addressee_email: "me@example.com",
+  });
+
+  it("accepts with a status='pending' guard in the UPDATE", async () => {
+    const updates: string[] = [];
+    mockExecuteQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT requester_id, addressee_id, status")) {
+        return { rows: [checkRow], rowCount: 1 };
+      }
+      if (sql.includes("UPDATE commensalships")) {
+        updates.push(sql);
+        return { rows: [], rowCount: 1 };
+      }
+      if (sql.includes("FROM commensalships c")) {
+        return { rows: [joinRow("accepted")], rowCount: 1 };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    const result = await commensalDatabase.updateCommensalshipStatus(
+      "c-1",
+      "accepted",
+      ME,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("accepted");
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toContain("AND status = 'pending'");
+  });
+
+  it("refuses accept when a concurrent block landed between check and write", async () => {
+    mockExecuteQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT requester_id, addressee_id, status")) {
+        // Check still sees pending...
+        return { rows: [checkRow], rowCount: 1 };
+      }
+      if (sql.includes("UPDATE commensalships")) {
+        // ...but the guarded UPDATE matches nothing (row was just blocked).
+        return { rows: [], rowCount: 0 };
+      }
+      if (sql.includes("FROM commensalships c")) {
+        return { rows: [joinRow("blocked")], rowCount: 1 };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    const result = await commensalDatabase.updateCommensalshipStatus(
+      "c-1",
+      "accepted",
+      ME,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("keeps accept idempotent when the row was already accepted concurrently", async () => {
+    mockExecuteQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT requester_id, addressee_id, status")) {
+        return { rows: [checkRow], rowCount: 1 };
+      }
+      if (sql.includes("UPDATE commensalships")) {
+        return { rows: [], rowCount: 0 };
+      }
+      if (sql.includes("FROM commensalships c")) {
+        return { rows: [joinRow("accepted")], rowCount: 1 };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    const result = await commensalDatabase.updateCommensalshipStatus(
+      "c-1",
+      "accepted",
+      ME,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("accepted");
+  });
+});

--- a/src/services/__tests__/commensalDatabaseService.test.ts
+++ b/src/services/__tests__/commensalDatabaseService.test.ts
@@ -1,0 +1,263 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for commensalDatabaseService — the commensal write/read path.
+ *
+ * Why this exists: the matching engine shipped broken because
+ * getUserElementalProfile queried saved_charts columns that do not exist in
+ * prod AND kept its fallback inside the same try/catch, so the first throw
+ * silenced everything and every user resolved to null. These tests pin the
+ * sequential fallback chain (each step isolated) and the reciprocal-request
+ * auto-accept + block semantics.
+ */
+
+// Stable delegates: jest `resetModules` re-runs mock factories per test, so
+// factories forward to these single instances to keep assertions valid.
+const mockExecuteQuery = jest.fn();
+const mockWithTransaction = jest.fn();
+const mockCreateNotification = jest.fn();
+
+jest.mock("@/lib/database", () => ({
+  executeQuery: (...args: unknown[]) => mockExecuteQuery(...args),
+  withTransaction: (...args: unknown[]) => mockWithTransaction(...args),
+}));
+
+jest.mock("@/services/notificationDatabaseService", () => ({
+  notificationDatabase: {
+    createNotification: (...args: unknown[]) => mockCreateNotification(...args),
+  },
+}));
+
+jest.mock("@/lib/logger", () => ({
+  _logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// The service only talks to the DB when DATABASE_URL is set server-side.
+process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
+
+import { commensalDatabase } from "@/services/commensalDatabaseService";
+
+const ME = "11111111-1111-1111-1111-111111111111";
+const TARGET = "22222222-2222-2222-2222-222222222222";
+
+const BALANCE = { Fire: 0.4, Water: 0.2, Earth: 0.2, Air: 0.2 };
+const OTHER_BALANCE = { Fire: 0.1, Water: 0.6, Earth: 0.2, Air: 0.1 };
+
+/** Let fire-and-forget async chains (notifications) settle. */
+const flushAsync = () => new Promise((resolve) => setTimeout(resolve, 20));
+
+const sqlCalls = () => mockExecuteQuery.mock.calls.map(([q]) => String(q));
+
+beforeEach(() => {
+  mockExecuteQuery.mockReset();
+  mockWithTransaction.mockReset();
+  mockCreateNotification.mockReset();
+  mockCreateNotification.mockResolvedValue(undefined);
+});
+
+describe("getUserElementalProfile — sequential fallback chain", () => {
+  it("returns the balance from user_profiles.natal_chart (canonical hit)", async () => {
+    mockExecuteQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM user_profiles")) {
+        return {
+          rows: [{ natal_chart: { elementalBalance: BALANCE }, birth_data: {} }],
+          rowCount: 1,
+        };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    const profile = await commensalDatabase.getUserElementalProfile(ME);
+
+    expect(profile).toEqual(BALANCE);
+    // Canonical source answered — the JSONB fallback must not be consulted.
+    expect(sqlCalls().some((q) => q.includes("FROM users"))).toBe(false);
+    // The prod saved_charts table has no natal_chart column — never read here.
+    expect(sqlCalls().some((q) => q.includes("saved_charts"))).toBe(false);
+  });
+
+  it("falls back to users.profile JSONB when user_profiles has no usable chart", async () => {
+    mockExecuteQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM user_profiles")) {
+        return { rows: [], rowCount: 0 };
+      }
+      if (sql.includes("FROM users")) {
+        return {
+          rows: [{ profile: { natalChart: { elementalBalance: OTHER_BALANCE } } }],
+          rowCount: 1,
+        };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    const profile = await commensalDatabase.getUserElementalProfile(ME);
+
+    expect(profile).toEqual(OTHER_BALANCE);
+  });
+
+  it("returns null when both sources are empty", async () => {
+    mockExecuteQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+    const profile = await commensalDatabase.getUserElementalProfile(ME);
+
+    expect(profile).toBeNull();
+  });
+
+  it("a THROW in the user_profiles read does NOT prevent the JSONB fallback (regression)", async () => {
+    mockExecuteQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM user_profiles")) {
+        // Simulates prod schema drift: column/table mismatch throws.
+        throw new Error('column "natal_chart" does not exist');
+      }
+      if (sql.includes("FROM users")) {
+        return {
+          rows: [{ profile: { natalChart: { elementalBalance: BALANCE } } }],
+          rowCount: 1,
+        };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    const profile = await commensalDatabase.getUserElementalProfile(ME);
+
+    expect(profile).toEqual(BALANCE);
+  });
+});
+
+describe("createCommensalRequest — reciprocal-request handling", () => {
+  const commensalshipJoinRow = (status: string) => ({
+    id: "c-rev-1",
+    requester_id: TARGET,
+    addressee_id: ME,
+    status,
+    created_at: "2026-07-01T00:00:00Z",
+    updated_at: "2026-07-01T00:00:00Z",
+    requester_name: "Target",
+    requester_email: "target@example.com",
+    addressee_name: "Me",
+    addressee_email: "me@example.com",
+  });
+
+  it("auto-accepts an existing PENDING reverse-direction row instead of inserting", async () => {
+    const updates: string[] = [];
+    mockExecuteQuery.mockImplementation(async (sql: string, params: unknown[]) => {
+      if (sql.includes("SELECT id, status, requester_id FROM commensalships")) {
+        return {
+          rows: [{ id: "c-rev-1", status: "pending", requester_id: TARGET }],
+          rowCount: 1,
+        };
+      }
+      if (sql.includes("UPDATE commensalships")) {
+        updates.push(String(params[0]));
+        return { rows: [], rowCount: 1 };
+      }
+      if (sql.includes("FROM commensalships c")) {
+        return { rows: [commensalshipJoinRow("accepted")], rowCount: 1 };
+      }
+      if (sql.includes("FROM users")) {
+        return { rows: [{ name: "Me" }], rowCount: 1 };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    // TARGET already requested ME; now ME requests TARGET → mutual interest.
+    const result = await commensalDatabase.createCommensalRequest(ME, TARGET);
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("accepted");
+    expect(result!.id).toBe("c-rev-1");
+    // The existing row was accepted — no duplicate reciprocal insert.
+    expect(updates).toEqual(["c-rev-1"]);
+    expect(sqlCalls().some((q) => q.includes("INSERT INTO commensalships"))).toBe(
+      false,
+    );
+
+    // The ORIGINAL requester (the target of this call) gets the accepted ping.
+    await flushAsync();
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      TARGET,
+      "commensal_accepted",
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({
+        relatedUserId: ME,
+        metadata: { commensalshipId: "c-rev-1" },
+      }),
+    );
+  });
+
+  it("returns null (no insert, no accept) when the pair is blocked", async () => {
+    mockExecuteQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT id, status, requester_id FROM commensalships")) {
+        return {
+          rows: [{ id: "c-blk-1", status: "blocked", requester_id: TARGET }],
+          rowCount: 1,
+        };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    const result = await commensalDatabase.createCommensalRequest(ME, TARGET);
+
+    expect(result).toBeNull();
+    expect(sqlCalls().some((q) => q.includes("INSERT INTO"))).toBe(false);
+    expect(sqlCalls().some((q) => q.includes("UPDATE"))).toBe(false);
+    await flushAsync();
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+  });
+
+  it("resolves against the winner on a unique-violation race (23505) instead of erroring", async () => {
+    let selectCount = 0;
+    mockExecuteQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT id, status, requester_id FROM commensalships")) {
+        selectCount += 1;
+        // First look: nothing there. After the racing insert fails: the
+        // concurrent reverse row exists and is pending → auto-accept path.
+        if (selectCount === 1) return { rows: [], rowCount: 0 };
+        return {
+          rows: [{ id: "c-rev-1", status: "pending", requester_id: TARGET }],
+          rowCount: 1,
+        };
+      }
+      if (sql.includes("INSERT INTO commensalships")) {
+        const err = new Error("duplicate key value violates unique constraint") as Error & {
+          code?: string;
+        };
+        err.code = "23505";
+        throw err;
+      }
+      if (sql.includes("UPDATE commensalships")) {
+        return { rows: [], rowCount: 1 };
+      }
+      if (sql.includes("FROM commensalships c")) {
+        return { rows: [commensalshipJoinRow("accepted")], rowCount: 1 };
+      }
+      if (sql.includes("FROM users")) {
+        return { rows: [{ name: "Me" }], rowCount: 1 };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    const result = await commensalDatabase.createCommensalRequest(ME, TARGET);
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("accepted");
+  });
+});
+
+describe("blocked rows stay out of the linked-commensal listing", () => {
+  it("getLinkedCommensalsForUser only selects status = 'accepted' rows", async () => {
+    mockExecuteQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+    await commensalDatabase.getLinkedCommensalsForUser(ME);
+
+    expect(mockExecuteQuery).toHaveBeenCalledTimes(1);
+    const sql = String(mockExecuteQuery.mock.calls[0][0]);
+    expect(sql).toContain("c.status = 'accepted'");
+  });
+});

--- a/src/services/commensalDatabaseService.ts
+++ b/src/services/commensalDatabaseService.ts
@@ -65,13 +65,20 @@ interface LinkedCommensalRow {
   synced_at?: DbTimestamp;
 }
 
+/**
+ * Row shape of the PROD saved_charts table (database/init/10-social-schema.sql):
+ * structured birth fields keyed by (user_id, chart_name). There are no
+ * chart_type / birth_data JSONB / natal_chart columns in prod.
+ */
 interface SavedChartRow {
   id?: string | null;
-  owner_id?: string | null;
-  label?: string | null;
-  chart_type?: SavedChart["chartType"] | null;
-  birth_data?: string | BirthData | null;
-  natal_chart?: string | NatalChart | null;
+  user_id?: string | null;
+  chart_name?: string | null;
+  birth_date?: DbTimestamp;
+  birth_time?: string | null;
+  birth_latitude?: number | string | null;
+  birth_longitude?: number | string | null;
+  timezone_str?: string | null;
   is_primary?: boolean | null;
   created_at?: DbTimestamp;
   updated_at?: DbTimestamp;
@@ -185,6 +192,11 @@ class CommensalDatabaseService {
   /**
    * Send a commensal request from requester to addressee.
    * Prevents duplicates and self-requests.
+   *
+   * Mutual-interest shortcut: if the addressee already has a PENDING request
+   * pointing back at the requester, this call is treated as consent — the
+   * existing reverse row is auto-accepted (no reciprocal insert) and the
+   * original requester gets the commensal_accepted notification.
    */
   async createCommensalRequest(
     requesterId: string,
@@ -207,26 +219,66 @@ class CommensalDatabaseService {
 
     if (db) {
       try {
-        // Check for existing commensalship in either direction
-        const existing = await db.executeQuery(
-          `SELECT id, status FROM commensalships
-           WHERE (requester_id::text = $1 AND addressee_id::text = $2)
-              OR (requester_id::text = $2 AND addressee_id::text = $1)`,
-          [requesterId, addresseeId],
-        );
+        // Check for an existing commensalship in either direction. Returns
+        // undefined when no row exists (caller should insert), otherwise the
+        // resolved commensalship (or null when blocked).
+        const resolveExisting = async (): Promise<
+          Commensalship | null | undefined
+        > => {
+          const existing = await db.executeQuery(
+            `SELECT id, status, requester_id FROM commensalships
+             WHERE (requester_id = $1::uuid AND addressee_id = $2::uuid)
+                OR (requester_id = $2::uuid AND addressee_id = $1::uuid)`,
+            [requesterId, addresseeId],
+          );
+          if (existing.rows.length === 0) return undefined;
 
-        if (existing.rows.length > 0) {
           const row = existing.rows[0];
           if (row.status === "blocked") return null;
-          // Already exists — return existing
-          return await this.getCommensalshipById(row.id);
-        }
 
-        await db.executeQuery(
-          `INSERT INTO commensalships (id, requester_id, addressee_id, status)
-           VALUES ($1, $2::uuid, $3::uuid, 'pending')`,
-          [id, requesterId, addresseeId],
-        );
+          const isReversePending =
+            row.status === "pending" && String(row.requester_id) === addresseeId;
+          if (isReversePending) {
+            // The target already requested me — mutual interest. Accept their
+            // pending request instead of inserting a reciprocal row. The
+            // status guard makes concurrent accepts idempotent.
+            const updated = await db.executeQuery(
+              `UPDATE commensalships
+                  SET status = 'accepted', updated_at = CURRENT_TIMESTAMP
+                WHERE id = $1 AND status = 'pending'`,
+              [row.id],
+            );
+            if ((updated.rowCount ?? 0) > 0) {
+              // Fire-and-forget: never block the request path on notification.
+              void this.notifyAutoAccepted(
+                addresseeId,
+                requesterId,
+                String(row.id),
+              );
+            }
+          }
+          return await this.getCommensalshipById(String(row.id));
+        };
+
+        const preExisting = await resolveExisting();
+        if (preExisting !== undefined) return preExisting;
+
+        try {
+          await db.executeQuery(
+            `INSERT INTO commensalships (id, requester_id, addressee_id, status)
+             VALUES ($1, $2::uuid, $3::uuid, 'pending')`,
+            [id, requesterId, addresseeId],
+          );
+        } catch (insertError) {
+          // 23505 = unique violation: a concurrent request for this pair won
+          // the race (including the reverse direction, via the unordered-pair
+          // index idx_commensalships_pair). Resolve against what landed.
+          if ((insertError as { code?: string })?.code === "23505") {
+            const raced = await resolveExisting();
+            return raced ?? null;
+          }
+          throw insertError;
+        }
 
         // Fetch with names
         return await this.getCommensalshipById(id);
@@ -236,9 +288,67 @@ class CommensalDatabaseService {
       }
     }
 
-    // In-memory fallback
+    // In-memory fallback (mirrors the DB semantics, incl. mutual auto-accept)
+    const existingLocal = Array.from(commensalshipsStore.values()).find(
+      (c) =>
+        (c.requesterId === requesterId && c.addresseeId === addresseeId) ||
+        (c.requesterId === addresseeId && c.addresseeId === requesterId),
+    );
+    if (existingLocal) {
+      if (existingLocal.status === "blocked") return null;
+      if (
+        existingLocal.status === "pending" &&
+        existingLocal.requesterId === addresseeId
+      ) {
+        existingLocal.status = "accepted";
+        existingLocal.updatedAt = new Date().toISOString();
+      }
+      return existingLocal;
+    }
     commensalshipsStore.set(id, commensalship);
     return commensalship;
+  }
+
+  /**
+   * Notify the ORIGINAL requester that their pending request was accepted via
+   * the mutual-interest shortcut. Fire-and-forget; failures only warn.
+   */
+  private async notifyAutoAccepted(
+    originalRequesterId: string,
+    accepterId: string,
+    commensalshipId: string,
+  ): Promise<void> {
+    try {
+      let accepterName = "Someone";
+      const db = await getDbModule();
+      if (db) {
+        try {
+          const res = await db.executeQuery(
+            `SELECT COALESCE(NULLIF(profile->>'name', ''), NULLIF(name, ''), '') AS name
+               FROM users WHERE id = $1::uuid`,
+            [accepterId],
+          );
+          accepterName = res.rows[0]?.name || "Someone";
+        } catch {
+          // keep the generic fallback name
+        }
+      }
+      const { notificationDatabase } = await import(
+        "@/services/notificationDatabaseService"
+      );
+      await notificationDatabase.createNotification(
+        originalRequesterId,
+        "commensal_accepted",
+        "Dining Companion Request Accepted",
+        `${accepterName} accepted your dining companion request`,
+        {
+          relatedUserId: accepterId,
+          metadata: { commensalshipId },
+        },
+      );
+    } catch (error) {
+      _logger.warn("notifyAutoAccepted failed (non-blocking):", error);
+    }
   }
 
   /**
@@ -323,6 +433,165 @@ class CommensalDatabaseService {
     }
 
     commensalshipsStore.delete(commensalshipId);
+    return true;
+  }
+
+  /**
+   * Block a companion link. Either party may block. Upserts the pair row to
+   * status='blocked', creating one when no relationship exists yet.
+   * Blocked rows are excluded from linked-commensal listings (those filter on
+   * status='accepted') and createCommensalRequest returns null for the pair.
+   * Silent by design — no notifications for block/unblock.
+   */
+  async blockCommensal(
+    actingUserId: string,
+    opts: { commensalshipId?: string; targetUserId?: string },
+  ): Promise<Commensalship | null> {
+    const db = await getDbModule();
+
+    if (db) {
+      try {
+        if (opts.commensalshipId) {
+          const result = await db.executeQuery(
+            `UPDATE commensalships
+                SET status = 'blocked', updated_at = CURRENT_TIMESTAMP
+              WHERE id = $1
+                AND (requester_id = $2::uuid OR addressee_id = $2::uuid)`,
+            [opts.commensalshipId, actingUserId],
+          );
+          if ((result.rowCount ?? 0) === 0) return null;
+          return await this.getCommensalshipById(opts.commensalshipId);
+        }
+
+        if (opts.targetUserId) {
+          if (opts.targetUserId === actingUserId) return null;
+
+          const existing = await db.executeQuery(
+            `SELECT id FROM commensalships
+             WHERE (requester_id = $1::uuid AND addressee_id = $2::uuid)
+                OR (requester_id = $2::uuid AND addressee_id = $1::uuid)`,
+            [actingUserId, opts.targetUserId],
+          );
+          if (existing.rows.length > 0) {
+            const rowId = String(existing.rows[0].id);
+            await db.executeQuery(
+              `UPDATE commensalships
+                  SET status = 'blocked', updated_at = CURRENT_TIMESTAMP
+                WHERE id = $1`,
+              [rowId],
+            );
+            return await this.getCommensalshipById(rowId);
+          }
+
+          const id = `commensal_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`;
+          try {
+            await db.executeQuery(
+              `INSERT INTO commensalships (id, requester_id, addressee_id, status)
+               VALUES ($1, $2::uuid, $3::uuid, 'blocked')`,
+              [id, actingUserId, opts.targetUserId],
+            );
+          } catch (insertError) {
+            // Unordered-pair unique index: a concurrent row landed first —
+            // block that one instead.
+            if ((insertError as { code?: string })?.code === "23505") {
+              return await this.blockCommensal(actingUserId, opts);
+            }
+            throw insertError;
+          }
+          return await this.getCommensalshipById(id);
+        }
+
+        return null;
+      } catch (error) {
+        _logger.error("blockCommensal failed:", error);
+        return null;
+      }
+    }
+
+    // In-memory fallback
+    const local = opts.commensalshipId
+      ? commensalshipsStore.get(opts.commensalshipId)
+      : Array.from(commensalshipsStore.values()).find(
+          (c) =>
+            (c.requesterId === actingUserId && c.addresseeId === opts.targetUserId) ||
+            (c.requesterId === opts.targetUserId && c.addresseeId === actingUserId),
+        );
+    if (local) {
+      const isParty =
+        local.requesterId === actingUserId || local.addresseeId === actingUserId;
+      if (!isParty) return null;
+      local.status = "blocked";
+      local.updatedAt = new Date().toISOString();
+      return local;
+    }
+    if (opts.targetUserId && opts.targetUserId !== actingUserId) {
+      const now = new Date().toISOString();
+      const created: Commensalship = {
+        id: `commensal_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`,
+        requesterId: actingUserId,
+        addresseeId: opts.targetUserId,
+        status: "blocked",
+        createdAt: now,
+        updatedAt: now,
+      };
+      commensalshipsStore.set(created.id, created);
+      return created;
+    }
+    return null;
+  }
+
+  /**
+   * Unblock: delete the blocked pair row so a fresh request becomes possible.
+   * LIMITATION: the schema has no blocked_by column, so either party may clear
+   * a block (the blocker can simply re-block).
+   */
+  async unblockCommensal(
+    actingUserId: string,
+    opts: { commensalshipId?: string; targetUserId?: string },
+  ): Promise<boolean> {
+    const db = await getDbModule();
+
+    if (db) {
+      try {
+        if (opts.commensalshipId) {
+          const result = await db.executeQuery(
+            `DELETE FROM commensalships
+              WHERE id = $1 AND status = 'blocked'
+                AND (requester_id = $2::uuid OR addressee_id = $2::uuid)`,
+            [opts.commensalshipId, actingUserId],
+          );
+          return (result.rowCount ?? 0) > 0;
+        }
+        if (opts.targetUserId) {
+          const result = await db.executeQuery(
+            `DELETE FROM commensalships
+              WHERE status = 'blocked'
+                AND ((requester_id = $1::uuid AND addressee_id = $2::uuid)
+                  OR (requester_id = $2::uuid AND addressee_id = $1::uuid))`,
+            [actingUserId, opts.targetUserId],
+          );
+          return (result.rowCount ?? 0) > 0;
+        }
+        return false;
+      } catch (error) {
+        _logger.error("unblockCommensal failed:", error);
+        return false;
+      }
+    }
+
+    // In-memory fallback
+    const local = opts.commensalshipId
+      ? commensalshipsStore.get(opts.commensalshipId)
+      : Array.from(commensalshipsStore.values()).find(
+          (c) =>
+            (c.requesterId === actingUserId && c.addresseeId === opts.targetUserId) ||
+            (c.requesterId === opts.targetUserId && c.addresseeId === actingUserId),
+        );
+    if (!local || local.status !== "blocked") return false;
+    const isParty =
+      local.requesterId === actingUserId || local.addresseeId === actingUserId;
+    if (!isParty) return false;
+    commensalshipsStore.delete(local.id);
     return true;
   }
 
@@ -476,6 +745,9 @@ class CommensalDatabaseService {
   // ─── Saved Charts (Cosmic Identities) ───────────────────────
   // Moved here from the removed socialDatabaseService.
 
+  private static readonly SAVED_CHART_COLUMNS = `id, user_id, chart_name, birth_date, birth_time,
+          birth_latitude, birth_longitude, timezone_str, is_primary, created_at, updated_at`;
+
   async getSavedChartsForUser(userId: string): Promise<SavedChart[]> {
     const db = await getDbModule();
     if (db) {
@@ -483,7 +755,11 @@ class CommensalDatabaseService {
         // LIMIT is a safety ceiling, not pagination — a user's saved charts are
         // inherently few; the cap just bounds a pathological/abuse-driven read.
         const result = await db.executeQuery(
-          `SELECT * FROM saved_charts WHERE owner_id = $1 ORDER BY is_primary DESC, created_at ASC LIMIT 500`,
+          `SELECT ${CommensalDatabaseService.SAVED_CHART_COLUMNS}
+             FROM saved_charts
+            WHERE user_id = $1::uuid
+            ORDER BY is_primary DESC, created_at ASC
+            LIMIT 500`,
           [userId],
         );
         return result.rows.map((r: SavedChartRow) => this.rowToSavedChart(r));
@@ -495,6 +771,13 @@ class CommensalDatabaseService {
     return Array.from(savedChartsStore.values()).filter((c) => c.ownerId === userId);
   }
 
+  /**
+   * Persist a saved chart. Prod saved_charts stores structured birth fields
+   * only (no natal_chart JSONB), so the caller-computed natalChart/chartType
+   * are echoed back on the returned object for API-response shape but are not
+   * stored. Idempotent on (user_id, chart_name): re-saving an existing name
+   * returns the existing row instead of failing.
+   */
   async createSavedChart(data: {
     ownerId: string;
     label: string;
@@ -504,27 +787,71 @@ class CommensalDatabaseService {
     isPrimary?: boolean;
   }): Promise<SavedChart | null> {
     const db = await getDbModule();
-    const id = `chart_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`;
     const now = new Date().toISOString();
-    const chart: SavedChart = {
-      id, ownerId: data.ownerId, label: data.label, chartType: data.chartType,
-      birthData: data.birthData, natalChart: data.natalChart,
-      isPrimary: data.isPrimary ?? false, createdAt: now, updatedAt: now,
-    };
+
     if (db) {
       try {
-        await db.executeQuery(
-          `INSERT INTO saved_charts (id, owner_id, label, chart_type, birth_data, natal_chart, is_primary)
-           VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-          [id, data.ownerId, data.label, data.chartType,
-           JSON.stringify(data.birthData), JSON.stringify(data.natalChart), data.isPrimary ?? false],
+        const birthDate = new Date(data.birthData.dateTime);
+        if (Number.isNaN(birthDate.getTime())) {
+          _logger.error("createSavedChart: invalid birthData.dateTime");
+          return null;
+        }
+        const insert = await db.executeQuery(
+          `INSERT INTO saved_charts
+             (user_id, chart_name, birth_date, birth_time, birth_latitude,
+              birth_longitude, timezone_str, is_primary)
+           VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8)
+           ON CONFLICT (user_id, chart_name) DO NOTHING
+           RETURNING id, created_at, updated_at`,
+          [
+            data.ownerId,
+            data.label,
+            birthDate.toISOString(),
+            birthDate.toISOString().slice(11, 19), // "HH:MM:SS" (UTC)
+            data.birthData.latitude,
+            data.birthData.longitude,
+            data.birthData.timezone || "UTC",
+            data.isPrimary ?? false,
+          ],
         );
-        return chart;
+
+        if (insert.rows.length === 0) {
+          // (user_id, chart_name) already exists — return the existing chart.
+          const existing = await db.executeQuery(
+            `SELECT ${CommensalDatabaseService.SAVED_CHART_COLUMNS}
+               FROM saved_charts
+              WHERE user_id = $1::uuid AND chart_name = $2`,
+            [data.ownerId, data.label],
+          );
+          return existing.rows.length > 0
+            ? this.rowToSavedChart(existing.rows[0])
+            : null;
+        }
+
+        const row = insert.rows[0];
+        return {
+          id: dbString(row.id),
+          ownerId: data.ownerId,
+          label: data.label,
+          chartType: data.chartType,
+          birthData: data.birthData,
+          natalChart: data.natalChart,
+          isPrimary: data.isPrimary ?? false,
+          createdAt: dbIsoString(row.created_at, now),
+          updatedAt: dbIsoString(row.updated_at, now),
+        };
       } catch (error) {
         _logger.error("createSavedChart failed:", error);
         return null;
       }
     }
+
+    const id = `chart_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`;
+    const chart: SavedChart = {
+      id, ownerId: data.ownerId, label: data.label, chartType: data.chartType,
+      birthData: data.birthData, natalChart: data.natalChart,
+      isPrimary: data.isPrimary ?? false, createdAt: now, updatedAt: now,
+    };
     savedChartsStore.set(id, chart);
     return chart;
   }
@@ -532,11 +859,21 @@ class CommensalDatabaseService {
   private rowToSavedChart(row: SavedChartRow): SavedChart {
     return {
       id: dbString(row.id),
-      ownerId: dbString(row.owner_id),
-      label: dbString(row.label),
-      chartType: row.chart_type as SavedChart["chartType"],
-      birthData: readJsonColumn<BirthData>(row.birth_data, {} as BirthData),
-      natalChart: readJsonColumn<NatalChart>(row.natal_chart, {} as NatalChart),
+      ownerId: dbString(row.user_id),
+      label: dbString(row.chart_name),
+      // Prod saved_charts rows are user-owned cosmic identities (manual
+      // companions live in manual_companion_charts) — there is no chart_type
+      // column to read.
+      chartType: "cosmic_identity",
+      birthData: {
+        dateTime: dbIsoString(row.birth_date, ""),
+        latitude: Number(row.birth_latitude ?? 0),
+        longitude: Number(row.birth_longitude ?? 0),
+        timezone: row.timezone_str || undefined,
+      },
+      // No natal chart is stored in prod — callers needing planetary data must
+      // recompute from birthData. Empty object preserves the SavedChart shape.
+      natalChart: {} as NatalChart,
       isPrimary: row.is_primary === true,
       createdAt: dbIsoString(row.created_at),
       updatedAt: dbIsoString(row.updated_at),
@@ -603,6 +940,73 @@ class CommensalDatabaseService {
       }
     }
     return null;
+  }
+
+  /**
+   * Persist a batch of manual companions AND run a group-registration step as
+   * ONE atomic unit. All companion inserts go through a single checked-out
+   * client inside BEGIN/COMMIT; if any insert — or the registerGroup callback —
+   * throws, everything is rolled back (no orphaned companions, no group
+   * pointing at members that never landed).
+   *
+   * NOTE: registerGroup may use other services (e.g. updateUserProfile) that
+   * hold their own connection; its write commits independently, but a failure
+   * inside it still rolls the companion inserts back, which is the failure
+   * mode that used to strand orphans.
+   *
+   * Returns the created members, or null on failure (everything rolled back).
+   */
+  async createManualCompanionsAtomic(
+    ownerId: string,
+    companions: Array<{
+      name: string;
+      relationship?: string;
+      birthData: BirthData;
+      natalChart: NatalChart;
+    }>,
+    registerGroup: (created: GroupMember[]) => Promise<void>,
+  ): Promise<GroupMember[] | null> {
+    const db = await getDbModule();
+    if (!db) return null;
+
+    try {
+      return await db.withTransaction(async (client) => {
+        const created: GroupMember[] = [];
+        for (const c of companions) {
+          const id = `commensal_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`;
+          await client.query(
+            `INSERT INTO manual_companion_charts (id, owner_id, name, relationship, birth_data, natal_chart)
+             VALUES ($1, $2::uuid, $3, $4, $5, $6)`,
+            [
+              id,
+              ownerId,
+              c.name,
+              c.relationship || "friend",
+              JSON.stringify(c.birthData),
+              JSON.stringify(c.natalChart),
+            ],
+          );
+          created.push({
+            id,
+            name: c.name,
+            relationship: normalizeGroupRelationship(c.relationship),
+            birthData: c.birthData,
+            natalChart: c.natalChart,
+            createdAt: new Date().toISOString(),
+          });
+        }
+        // Register the group while the companion inserts are still
+        // uncommitted: a failure here rolls them back too.
+        await registerGroup(created);
+        return created;
+      });
+    } catch (error) {
+      _logger.error(
+        "createManualCompanionsAtomic failed (rolled back):",
+        error,
+      );
+      return null;
+    }
   }
 
   async deleteManualCompanion(id: string, ownerId: string): Promise<boolean> {
@@ -694,9 +1098,18 @@ class CommensalDatabaseService {
   /**
    * Load a user's primary elemental profile.
    *
-   * Looks at saved_charts (preferring is_primary) and falls back to the
-   * users.profile JSONB (older path). Recomputes from planetaryPositions
-   * when a stored elementalBalance is missing or stale-shaped.
+   * Sequential fallback chain — each step is isolated in its OWN try/catch so
+   * a failure (e.g. schema drift) in one source can never mask the next:
+   *   1. user_profiles.natal_chart column — the canonical profile write target
+   *      (userDatabaseService.updateUserProfile dual-writes here).
+   *   2. users.profile JSONB ->'natalChart' — legacy write path; heals users
+   *      whose chart only ever landed in the profile blob.
+   *   3. Give up → null with a warn log.
+   *
+   * NOTE: prod saved_charts has NO natal_chart column (see
+   * database/init/10-social-schema.sql), so it is intentionally not consulted.
+   * Recomputes from planetaryPositions when a stored elementalBalance is
+   * missing or stale-shaped.
    *
    * Returns null when the user has no chart on file — callers must handle.
    */
@@ -706,46 +1119,55 @@ class CommensalDatabaseService {
     const db = await getDbModule();
     if (!db) return null;
 
+    // 1. Canonical: user_profiles structured columns.
     try {
-      const chartResult = await db.executeQuery(
-        `SELECT natal_chart, birth_data
-         FROM saved_charts
-         WHERE owner_id::text = $1
-         ORDER BY is_primary DESC, created_at ASC
-         LIMIT 1`,
+      const result = await db.executeQuery(
+        `SELECT natal_chart, birth_data FROM user_profiles WHERE user_id = $1::uuid`,
         [userId],
       );
-
-      if (chartResult.rows.length > 0) {
-        const profile = this.extractElementalProfile(chartResult.rows[0]);
+      if (result.rows.length > 0) {
+        const profile = this.extractElementalProfile(result.rows[0]);
         if (profile) return profile;
       }
+    } catch (error) {
+      _logger.warn(
+        "getUserElementalProfile: user_profiles read failed, falling back to users.profile JSONB:",
+        error,
+      );
+    }
 
-      // Fallback to users.profile JSONB (older path before saved_charts existed)
-      const profileResult = await db.executeQuery(
-        `SELECT profile FROM users WHERE id::text = $1`,
+    // 2. Legacy: users.profile JSONB.
+    try {
+      const result = await db.executeQuery(
+        `SELECT profile FROM users WHERE id = $1::uuid`,
         [userId],
       );
-
-      if (profileResult.rows.length > 0) {
-        const profile = typeof profileResult.rows[0].profile === "string"
-          ? safeJsonParse(profileResult.rows[0].profile)
-          : profileResult.rows[0].profile;
+      if (result.rows.length > 0) {
+        const profile = typeof result.rows[0].profile === "string"
+          ? safeJsonParse(result.rows[0].profile)
+          : result.rows[0].profile;
         const natalChart = profile?.natalChart || profile?.natal_chart;
         const birthData = profile?.birthData || profile?.birth_data;
         if (natalChart) {
-          return this.extractElementalProfile({
+          const extracted = this.extractElementalProfile({
             natal_chart: natalChart,
             birth_data: birthData,
           });
+          if (extracted) return extracted;
         }
       }
-
-      return null;
     } catch (error) {
-      _logger.error("getUserElementalProfile failed:", error);
-      return null;
+      _logger.warn(
+        "getUserElementalProfile: users.profile JSONB fallback failed:",
+        error,
+      );
     }
+
+    // 3. Nothing usable on file.
+    _logger.warn(
+      `getUserElementalProfile: no elemental profile found for user ${userId}`,
+    );
+    return null;
   }
 
   private extractElementalProfile(row: {

--- a/src/services/commensalDatabaseService.ts
+++ b/src/services/commensalDatabaseService.ts
@@ -20,6 +20,13 @@ import {
   isSectDiurnal,
 } from "@/utils/planetaryAlchemyMapping";
 import { safeJsonParse } from "@/utils/typeGuards";
+import type { PoolClient } from "pg";
+
+/**
+ * Minimal client surface handed to transactional callbacks — writes issued
+ * through it join the surrounding BEGIN/COMMIT.
+ */
+export type TransactionClient = Pick<PoolClient, "query">;
 
 const isServerWithDB = (): boolean => {
   return typeof window === "undefined" && !!process.env.DATABASE_URL;
@@ -122,6 +129,34 @@ const dbIsoString = (value: DbTimestamp, fallback = new Date().toISOString()): s
 const readJsonColumn = <T>(value: string | T | null | undefined, fallback: T): T => {
   if (typeof value === "string") return safeJsonParse<T>(value, fallback) ?? fallback;
   return value ?? fallback;
+};
+
+/**
+ * Local wall-clock "HH:MM:SS" at the birth location for a given instant —
+ * pre-drift prod saved_charts rows store birth_time as local wall time paired
+ * with timezone_str (the IANA zone). Falls back to the UTC clock (paired with
+ * timezone_str "UTC") when no/invalid timezone is supplied, keeping the two
+ * columns internally consistent.
+ */
+const localWallClock = (
+  instant: Date,
+  timeZone?: string,
+): { time: string; tz: string } => {
+  if (timeZone) {
+    try {
+      const time = new Intl.DateTimeFormat("en-GB", {
+        timeZone,
+        hourCycle: "h23",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      }).format(instant);
+      return { time, tz: timeZone };
+    } catch {
+      // Invalid IANA zone name — fall through to UTC.
+    }
+  }
+  return { time: instant.toISOString().slice(11, 19), tz: "UTC" };
 };
 
 const normalizeGroupRelationship = (
@@ -389,10 +424,19 @@ class CommensalDatabaseService {
         // Can't accept if already blocked
         if (status === "blocked" && newStatus === "accepted") return null;
 
-        await db.executeQuery(
-          `UPDATE commensalships SET status = $2::commensalship_status, updated_at = CURRENT_TIMESTAMP WHERE id = $1`,
+        // Accept is guarded (status='pending') so a concurrent block between
+        // the check above and this write can never be overwritten to accepted.
+        const guard = newStatus === "accepted" ? " AND status = 'pending'" : "";
+        const updated = await db.executeQuery(
+          `UPDATE commensalships SET status = $2::commensalship_status, updated_at = CURRENT_TIMESTAMP WHERE id = $1${guard}`,
           [commensalshipId, newStatus],
         );
+        if (newStatus === "accepted" && (updated.rowCount ?? 0) === 0) {
+          // The row changed under us. Re-read: an already-accepted row keeps
+          // accept idempotent; anything else (e.g. now blocked) is a refusal.
+          const current = await this.getCommensalshipById(commensalshipId);
+          return current?.status === "accepted" ? current : null;
+        }
 
         return await this.getCommensalshipById(commensalshipId);
       } catch (error) {
@@ -775,8 +819,9 @@ class CommensalDatabaseService {
    * Persist a saved chart. Prod saved_charts stores structured birth fields
    * only (no natal_chart JSONB), so the caller-computed natalChart/chartType
    * are echoed back on the returned object for API-response shape but are not
-   * stored. Idempotent on (user_id, chart_name): re-saving an existing name
-   * returns the existing row instead of failing.
+   * stored. Upserts on (user_id, chart_name): re-saving an existing name
+   * refreshes its birth fields instead of failing or silently discarding
+   * the caller's new data.
    */
   async createSavedChart(data: {
     ownerId: string;
@@ -796,39 +841,41 @@ class CommensalDatabaseService {
           _logger.error("createSavedChart: invalid birthData.dateTime");
           return null;
         }
+        // birth_time is LOCAL wall time at the birth location (matching
+        // pre-drift prod rows); birth_date is the birth instant (timestamptz
+        // normalizes to UTC internally, so the ISO instant is correct).
+        const wall = localWallClock(birthDate, data.birthData.timezone);
         const insert = await db.executeQuery(
           `INSERT INTO saved_charts
              (user_id, chart_name, birth_date, birth_time, birth_latitude,
               birth_longitude, timezone_str, is_primary)
            VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8)
-           ON CONFLICT (user_id, chart_name) DO NOTHING
+           ON CONFLICT (user_id, chart_name) DO UPDATE SET
+             birth_date = EXCLUDED.birth_date,
+             birth_time = EXCLUDED.birth_time,
+             birth_latitude = EXCLUDED.birth_latitude,
+             birth_longitude = EXCLUDED.birth_longitude,
+             timezone_str = EXCLUDED.timezone_str,
+             is_primary = EXCLUDED.is_primary,
+             updated_at = NOW()
            RETURNING id, created_at, updated_at`,
           [
             data.ownerId,
             data.label,
             birthDate.toISOString(),
-            birthDate.toISOString().slice(11, 19), // "HH:MM:SS" (UTC)
+            wall.time,
             data.birthData.latitude,
             data.birthData.longitude,
-            data.birthData.timezone || "UTC",
+            wall.tz,
             data.isPrimary ?? false,
           ],
         );
 
-        if (insert.rows.length === 0) {
-          // (user_id, chart_name) already exists — return the existing chart.
-          const existing = await db.executeQuery(
-            `SELECT ${CommensalDatabaseService.SAVED_CHART_COLUMNS}
-               FROM saved_charts
-              WHERE user_id = $1::uuid AND chart_name = $2`,
-            [data.ownerId, data.label],
-          );
-          return existing.rows.length > 0
-            ? this.rowToSavedChart(existing.rows[0])
-            : null;
-        }
-
         const row = insert.rows[0];
+        if (!row) {
+          _logger.error("createSavedChart: upsert returned no row");
+          return null;
+        }
         return {
           id: dbString(row.id),
           ownerId: data.ownerId,
@@ -944,15 +991,17 @@ class CommensalDatabaseService {
 
   /**
    * Persist a batch of manual companions AND run a group-registration step as
-   * ONE atomic unit. All companion inserts go through a single checked-out
-   * client inside BEGIN/COMMIT; if any insert — or the registerGroup callback —
-   * throws, everything is rolled back (no orphaned companions, no group
-   * pointing at members that never landed).
+   * ONE atomic unit. Everything — companion inserts and whatever registerGroup
+   * writes — runs on the SAME checked-out client inside one BEGIN/COMMIT, so a
+   * failure anywhere rolls the whole write back (no orphaned companions, no
+   * group pointing at members that never landed, and no group committed while
+   * its companions vanish).
    *
-   * NOTE: registerGroup may use other services (e.g. updateUserProfile) that
-   * hold their own connection; its write commits independently, but a failure
-   * inside it still rolls the companion inserts back, which is the failure
-   * mode that used to strand orphans.
+   * IMPORTANT: registerGroup receives the transaction client and MUST issue
+   * its writes through it. It must NOT acquire additional pooled connections
+   * (e.g. via other services) — the pool is small and hold-and-acquire under
+   * concurrency starves it, and any independently-committed write would break
+   * atomicity in the reverse direction.
    *
    * Returns the created members, or null on failure (everything rolled back).
    */
@@ -964,7 +1013,10 @@ class CommensalDatabaseService {
       birthData: BirthData;
       natalChart: NatalChart;
     }>,
-    registerGroup: (created: GroupMember[]) => Promise<void>,
+    registerGroup: (
+      created: GroupMember[],
+      client: TransactionClient,
+    ) => Promise<void>,
   ): Promise<GroupMember[] | null> {
     const db = await getDbModule();
     if (!db) return null;
@@ -995,9 +1047,8 @@ class CommensalDatabaseService {
             createdAt: new Date().toISOString(),
           });
         }
-        // Register the group while the companion inserts are still
-        // uncommitted: a failure here rolls them back too.
-        await registerGroup(created);
+        // Register the group on the same client, inside the same transaction.
+        await registerGroup(created, client);
         return created;
       });
     } catch (error) {


### PR DESCRIPTION
## Summary

PR 1 of the Commensal→Tables social program (roadmap: `docs/plans/tables-program-sequencing.md`). Repairs the broken foundations found in the 2026-07-11 commensal audit so the Table entity (PR 2) and messaging (PR 3) land on solid ground. Everything here is repair + hardening — no new product surface.

- **Revives the dead group-matching engine**: `getUserElementalProfile` queried `saved_charts` columns dropped from prod in May 2026 and its working fallback was unreachable in the same try/catch — it returned null for every user, so `groupDynamics` always computed empty results. Now a sequential fallback chain (`user_profiles.natal_chart` → `users.profile` JSONB → null), each step isolated. `getSavedChartsForUser`/`createSavedChart` (real callers: charts API, sign-in sync) rewritten to the prod schema with true upsert semantics and timezone-correct local birth times; empty DB-loaded charts now rebuild their planet arrays on read.
- **Heals split-brain companion storage**: group-recommendations and dining-groups (POST *and* PUT) now see companions from both `manual_companion_charts` and the legacy `group_members` JSONB — companions saved via the modern path were previously invisible to recommendations and save-group's groups were uneditable.
- **save-group is genuinely atomic**: companion inserts + dining-group registration share one transaction client (no nested pool acquisition — the previous design could stall the whole 5-connection pool under concurrency), with server-side caps (≤12 guests, groupName ≤100) and a 10/min per-user rate limit.
- **Blocking exists now**: `POST /api/commensals/block` (block/unblock, either party, silent, no email echo); accept is race-guarded (`AND status='pending'`) so it can no longer overwrite a concurrent block.
- **Reciprocal-request race closed**: migration 59 dedupes existing reciprocal rows and adds a unique unordered-pair index (plain, txn-safe); a pending reverse request now auto-accepts as mutual interest with the right notification.
- **Rate limits** on the two unauthenticated compute-heavy endpoints (guest-recommendations 10/min/IP — it computes up to 12 natal charts per call; companions 30/min/IP — it fans out to the PA API).
- **Copy doctrine sweep**: quest/token framing removed ("Quest complete: Earned 20 Matter tokens" → "✓ {name} is at your table."), Foursquare naming removed, 12-guest UI cap ("A table seats twelve.").

Adversarially reviewed pre-push (4 dimensions, every finding independently verified or refuted); all 6 confirmed findings plus 3 additional hand-verified ones fixed in the second commit.

## Test plan

- **9 suites / 59 passing tests** — the write path and matching engine previously had zero coverage (which is how the schema drift shipped silently). Covers: the fallback chain (including throw-doesn't-mask-fallback), dual-store merge + PUT edit path, save-group rollback + same-client dual-write + caps + 429, reverse-pending auto-accept, guarded accept vs concurrent block, block/unblock service semantics incl. the 23505 retry, and rate-limit 429s.
- `bun run typecheck` clean; lint clean on touched files.
- Migration 59 is idempotent and CONCURRENTLY-free (runner wraps each file in a transaction).

## Reflection

The audit's "probably dead code" call on the saved_charts helpers was wrong — they had two live callers — and the first "atomic" save-group attempt introduced a subtler defect (hold-and-acquire pool starvation) than the orphan bug it fixed. Both were caught by verification layers rather than the initial pass; the lesson is that transaction boundaries around callback-style APIs deserve review as a dedicated dimension, not as part of general correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)