### PR TITLE
fix(tables): rate-limit adding table members

### DIFF
--- a/src/app/api/tables/[tableId]/members/route.ts
+++ b/src/app/api/tables/[tableId]/members/route.ts
@@ -9,6 +9,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { rateLimit } from "@/lib/rateLimit";
 import {
   tableDatabase,
   type AddMemberFailureReason,
@@ -22,6 +23,8 @@ export const runtime = "nodejs";
 interface RouteParams {
   params: Promise<{ tableId: string }>;
 }
+
+const MEMBERS_ADD_LIMIT = { window: 60_000, max: 20, bucket: "tables-members-add" } as const;
 
 const membersPostSchema = z
   .object({
@@ -93,6 +96,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         { status: 401 },
       );
     }
+
+    const rl = await rateLimit(request, { ...MEMBERS_ADD_LIMIT, identifier: hostId });
+    if (!rl.allowed) return rl.response!;
 
     let rawBody: unknown;
     try {


### PR DESCRIPTION
## Summary

Follow-up from the same production-readiness audit as #597 (merged) — found while auditing the newly-merged Tables/Chat surface area.

Every sibling mutation route in the Tables feature (comments, photos, invites, rsvp, join-request, table create, recompute, invite-redeem) rate-limits by host id; `POST /api/tables/[tableId]/members` didn't. A host could add and remove the same target user in a loop with no throttle — each add fires a `table_invite` notification (and push, if enabled), making this a notification-spam vector against a third party who never opted in.

## What a reviewer should know

Matches the existing `tables-*` rate-limit pattern exactly (20 requests/60s, keyed by host id) — same shape as `rsvp/route.ts`'s `RSVP_LIMIT`. No behavior change for normal usage.

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)