### PR TITLE
fix: stop internal "Hsca" cuisine code from leaking into public UI

### DIFF
--- a/src/data/cuisineFlavorProfiles.ts
+++ b/src/data/cuisineFlavorProfiles.ts
@@ -598,32 +598,9 @@ export const cuisineFlavorProfiles: Record<string, CuisineFlavorProfile> = {
     seasonalPreference: ["autumn", "winter"],
     dietarySuitability: ["omnivore", "some-vegetarian"],
   },
-  hsca: {
-    id: "hsca",
-    name: "HSCA",
-    description:
-      "Holistic Health and Macrobiotic clean cuisine focusing on energetic harmony and restorative elemental balance.",
-    flavorProfiles: {
-      spicy: 0.3,
-      sweet: 0.4,
-      sour: 0.4,
-      bitter: 0.4,
-      salty: 0.5,
-      umami: 0.6,
-    },
-    elementalAlignment: {
-      Fire: 0.25,
-      Earth: 0.35,
-      Water: 0.25,
-      Air: 0.15,
-    },
-    signatureTechniques: ["steaming", "simmering", "raw", "fermenting"],
-    signatureIngredients: ["kombu", "miso", "kuzu", "brown rice", "ginger"],
-    traditionalMealPatterns: ["three-tier clean eating", "macrobiotic balance"],
-    planetaryResonance: ["Moon", "Saturn", "Venus"],
-    seasonalPreference: ["all"],
-    dietarySuitability: ["vegan", "vegetarian", "macrobiotic", "gluten-free"],
-  },
+  // HSCA is intentionally absent: internal archive collection, not a real
+  // cuisine — it must never be recommended or displayed publicly (see
+  // src/utils/internalCuisineCodes.ts).
 
   // More cuisines as needed...
 };

--- a/src/data/cuisines/index.ts
+++ b/src/data/cuisines/index.ts
@@ -113,12 +113,10 @@ export const CUISINES_METADATA: Record<string, Partial<Cuisine>> = {
     description: "Fresh, light flavors with an emphasis on herbs and clear broths.",
     imageUrl: cuisineImages.Vietnamese,
   },
-  HSCA: {
-    name: "HSCA",
-    elementalProperties: { Fire: 0.25, Earth: 0.35, Water: 0.25, Air: 0.15 },
-    description: "Holistic Health and Macrobiotic clean cuisine focusing on energetic harmony and elemental balance.",
-    imageUrl: cuisineImages.HSCA,
-  },
+  // HSCA is intentionally absent: it is an internal archive collection, not
+  // a real cuisine, and must never surface on public cuisine browse/detail
+  // pages (see src/utils/internalCuisineCodes.ts). Its dishes stay loadable
+  // through cuisineImports for the static recipe payload.
 };
 
 /**
@@ -182,6 +180,7 @@ export const PRIMARY_CUISINE_KEYS = Object.keys(cuisineImports);
 const cuisinesMapBase: Record<string, Cuisine> = {};
 PRIMARY_CUISINE_KEYS.forEach(key => {
   const meta = CUISINES_METADATA[key];
+  if (!meta) return; // internal collections (HSCA) have no public metadata
   (cuisinesMapBase as any)[key] = {
     ...meta,
     id: key.toLowerCase(),

--- a/src/data/cuisines/middle-eastern.ts
+++ b/src/data/cuisines/middle-eastern.ts
@@ -3106,7 +3106,7 @@ export const middleEastern: Cuisine = {
           astrologicalAffinities: {"planets":["Mars","Moon"],"signs":["scorpio","cancer"],"lunarPhases":["Waning Gibbous"]},
           alchemicalProperties: {"Spirit":2.79,"Essence":3.52,"Matter":3.75,"Substance":3.47},
           thermodynamicProperties: {"heat":0.0609,"entropy":0.3264,"reactivity":2.0274,"gregsEnergy":-0.6007,"kalchm":0.1379,"monica":1.3128},
-          substitutions: [{"originalIngredient":"globe eggplants","substituteOptions":["Japanese eggplants (thinner, char faster)","zucchini for a milder version"]},{"originalIngredient":"tahini","substituteOptions":["Greek yogurt for a lighter, less smoky version"]},{"originalIngredient":"extra virgin olive oil","substituteOptions":["omit for low-fat HSCA baseline"]}],
+          substitutions: [{"originalIngredient":"globe eggplants","substituteOptions":["Japanese eggplants (thinner, char faster)","zucchini for a milder version"]},{"originalIngredient":"tahini","substituteOptions":["Greek yogurt for a lighter, less smoky version"]},{"originalIngredient":"extra virgin olive oil","substituteOptions":["omit for a low-fat version"]}],
             nutritionPerServing: {"calories":33,"proteinG":1,"carbsG":2,"fatG":1,"fiberG":2,"sodiumMg":292,"sugarG":1,"vitamins":["Vitamin B1","Vitamin B6","Vitamin K","Vitamin C","Vitamin E"],"minerals":["Manganese","Copper","Selenium","Magnesium","Calcium"]}
         },
         {

--- a/src/data/cuisines/russian.ts
+++ b/src/data/cuisines/russian.ts
@@ -280,7 +280,7 @@ export const russian: Cuisine = {
 
           alchemicalProperties: {"Spirit":5.92,"Essence":6.77,"Matter":7.53,"Substance":6.83},
           thermodynamicProperties: {"heat":0.0722,"entropy":0.3584,"reactivity":2.0845,"gregsEnergy":-0.6748,"kalchm":0.0078,"monica":0.3064},
-          substitutions: [{"originalIngredient":"beef soup bones","substituteOptions":["vegetable stock (HSCA vegan variation)","mushroom and dried porcini broth (vegetarian)","chicken carcass"]},{"originalIngredient":"beef chuck","substituteOptions":["omit for HSCA vegan variation","pork ribs","smoked sausage (for a lighter weekday version)"]},{"originalIngredient":"smetana (sour cream)","substituteOptions":["Tofu Sour Cream (HSCA vegan variation)","creme fraiche"]}],
+          substitutions: [{"originalIngredient":"beef soup bones","substituteOptions":["vegetable stock (vegan variation)","mushroom and dried porcini broth (vegetarian)","chicken carcass"]},{"originalIngredient":"beef chuck","substituteOptions":["omit for vegan variation","pork ribs","smoked sausage (for a lighter weekday version)"]},{"originalIngredient":"smetana (sour cream)","substituteOptions":["Tofu Sour Cream (vegan variation)","creme fraiche"]}],
             nutritionPerServing: {"calories":421,"proteinG":42,"carbsG":5,"fatG":24,"fiberG":1,"sodiumMg":119,"sugarG":2,"vitamins":["Vitamin B12","Vitamin B6","Niacin","Riboflavin","Thiamin","Vitamin C","Vitamin K","Vitamin A","Folate"],"minerals":["Zinc","Iron","Phosphorus","Selenium","Magnesium","Potassium","Manganese","Calcium"]}
         },
         {

--- a/src/data/ingredientRecipeIndex.ts
+++ b/src/data/ingredientRecipeIndex.ts
@@ -12,6 +12,7 @@
  * measurement pulled verbatim from the recipe.
  */
 
+import { isInternalCuisineCode } from "@/utils/internalCuisineCodes";
 import rawIndex from "./generated/ingredientRecipeIndex.json";
 
 export interface IngredientRecipeMatch {
@@ -167,7 +168,12 @@ export function resolveIngredientSlug(input: string): string | null {
  */
 export function getRecipesForIngredient(slug: string): IngredientRecipeMatch[] {
   const resolved = resolveIngredientSlug(slug) ?? slug;
-  return INDEX[resolved] ?? [];
+  const matches = INDEX[resolved] ?? [];
+  // Internal archive codes (e.g. "hsca") must never surface as cuisine
+  // labels — group those matches under "other" instead.
+  return matches.map((m) =>
+    isInternalCuisineCode(m.cuisine) ? { ...m, cuisine: "other" } : m,
+  );
 }
 
 /**

--- a/src/services/LocalRecipeService.ts
+++ b/src/services/LocalRecipeService.ts
@@ -6,6 +6,7 @@ import type {
   Recipe,
   RecipeIngredient,
 } from "@/types/recipe";
+import { publicCuisine } from "@/utils/internalCuisineCodes";
 import { logger } from "@/utils/logger";
 import { getAssetUrl } from "@/utils/urlUtils";
 
@@ -174,7 +175,7 @@ function mapRowToRecipe(row: DbRecipeRow & { read_model?: any }): Recipe {
       image: imageUrl,
       imageUrl,
       description: rm.description || row.description || undefined,
-      cuisine: rm.cuisine || row.cuisine || undefined,
+      cuisine: publicCuisine(rm.cuisine || row.cuisine),
       ingredients: normalizeIngredients(rm.ingredients),
       instructions: normalizeInstructions(rm.instructions),
       prepTime: String(rm.prep_time_minutes ?? row.prep_time_minutes ?? 0),
@@ -216,7 +217,7 @@ function mapRowToRecipe(row: DbRecipeRow & { read_model?: any }): Recipe {
     image: imageUrl,
     imageUrl,
     description: row.description ?? undefined,
-    cuisine: row.cuisine ?? row.cuisine_type ?? undefined,
+    cuisine: publicCuisine(row.cuisine ?? row.cuisine_type),
     ingredients: normalizeIngredients(row.ingredients),
     instructions: normalizeInstructions(row.instructions),
     prepTime: String(prepTime),

--- a/src/utils/internalCuisineCodes.ts
+++ b/src/utils/internalCuisineCodes.ts
@@ -1,0 +1,31 @@
+/**
+ * Internal archive/collection codes that appear in the recipes DB `cuisine`
+ * field (both the `cuisine` column and `read_model->>'cuisine'`) but are not
+ * real cuisines. They must never surface publicly — neither as a visible
+ * label nor in schema.org structured data (recipeCuisine / keywords).
+ *
+ * "Hsca" is the archive code of the bulk-imported recipe collection
+ * (see scripts/generateHscaCuisine.ts); ~500 public recipes carry it.
+ * The read_model is periodically recomputed by backfill pipelines, so the
+ * durable fix is this display-level guard rather than nulling the DB value.
+ */
+const INTERNAL_CUISINE_CODES = new Set(["hsca"]);
+
+export function isInternalCuisineCode(value: unknown): boolean {
+  return (
+    typeof value === "string" &&
+    INTERNAL_CUISINE_CODES.has(value.trim().toLowerCase())
+  );
+}
+
+/**
+ * Pass a cuisine value through only if it is publicly displayable.
+ * Internal archive codes (and empty values) come back as undefined so
+ * callers render nothing instead of the code.
+ */
+export function publicCuisine(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || isInternalCuisineCode(trimmed)) return undefined;
+  return trimmed;
+}


### PR DESCRIPTION
## Summary

Follow-up from the same production-readiness audit as #597/#598 (both merged). Live-reproduced on `/recipes`: a recipe card showed **"Hsca"** as its cuisine tag. "HSCA" is the archive code of a bulk-imported recipe collection (~500 recipes carry it in the DB `cuisine` field / `read_model`), not a real cuisine — it was never meant to be user-facing.

## What a reviewer should know

- This exact fix was already built and adversarially verified in a separate worktree on 2026-07-04 but never committed. I found the worktree, confirmed the target files hadn't diverged since, and ported it over.
- Adds a display-level guard (`src/utils/internalCuisineCodes.ts`) rather than nulling the DB value, since the `read_model` is periodically recomputed by backfill pipelines and would just reintroduce the leak.
- Wired into the two places a recipe's cuisine field reaches a user: `LocalRecipeService`'s DB row → `Recipe` mapping, and the ingredient → recipe index.
- Removes the public-facing HSCA entries from `cuisineFlavorProfiles` and `CUISINES_METADATA` (with a guard so the metadata lookup doesn't crash on the now-absent key) — the underlying recipe data stays loadable through `cuisineImports` so those ~500 recipes keep showing up, just without the internal cuisine label.
- Also cleans three leftover "HSCA" mentions in recipe substitution text (middle-eastern.ts, russian.ts).
- Two internal cuisine-key iteration lists (`recipeStandardization.ts`, `data/recipes.ts`) still reference `"HSCA"` — that's intentional, they're what pulls the collection's recipes into the shared pool; the leak only happens at display time, which this PR closes.

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors (pre-existing warnings only)
- [x] Live-browser-reproduced the leak on `/recipes` before the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)