### PR TITLE
feat(admin): operator handles for settlement, launch readiness, moderation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,7 +120,11 @@ node_modules/@next/swc-*
 lint-fix-log.txt
 .typescript-errors-metrics.json
 .explicit-any-metrics.json
-reports/
+# Root-anchored so it only ignores a top-level build-output reports/ dir — an
+# unanchored `reports/` silently swallowed source route dirs named `reports`
+# (e.g. src/app/api/admin/chat/reports/). Nested reports/ dirs are covered by
+# their own rules (archive/, .next).
+/reports/
 *-report.json
 .eslint-fix-tmp/
 *.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,3 +19,15 @@ The five canonical triage states are mapped 1-to-1 to the labels (`needs-triage`
 ### Domain docs
 
 Uses a single-context domain model layout with `CONTEXT.md` at the root and ADRs in `docs/adr/`. See `docs/agents/domain.md`.
+
+## Admin surface
+
+Operator UI lives under `src/app/admin/*` behind the sidebar in `admin/layout.tsx` (admin-role + `isAdminEmail` gated). Every panel reads a live source — never fabricate admin data; degrade to an honest `live: false`/"no source" state instead.
+
+- **Overview** (`/admin`) — panels in `src/components/admin/*Panel.tsx`, each self-polling via `useHardenedPolling`. Top of page is `LaunchReadinessPanel` (settlement backlog + config health).
+- **Dashboard ✦** (`/admin/dashboard`) — the "High Alchemist" full-bleed board in `src/app/admin/_dashboard/`, fed entirely by `GET /api/admin/dashboard` → `AdminDashboardData`.
+- **Settlements** (`/admin/settlements`) — restaurant ESMS settlement handle (retry/refund stuck crypto-food orders); `GET/POST /api/admin/restaurants/settlement`. Required before public payments launch (`docs/payments/CRYPTO_FOOD_PAYMENTS.md`).
+- **Moderation** — `/admin/chat-reports` (`/api/admin/chat/reports`) and `/admin/feed/comment-reports`.
+- **Settings** (`/admin/settings`) — live launch-readiness board over static platform facts.
+
+**Launch readiness** = presence-only env config for the revenue/on-chain subsystems (Stripe, restaurant crypto-food payments, on-chain ESMS, Recipe-NFT, Privy, Amazon Fresh, agent network, email). Source: `src/services/launchReadinessService.ts` → `GET /api/admin/launch-readiness`. It reports booleans only — never serialize a secret's value.

--- a/src/app/admin/_dashboard/panels.tsx
+++ b/src/app/admin/_dashboard/panels.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { useHardenedPolling } from "@/hooks/useHardenedPolling";
 import type {
   AuditEventsData,
   CatalogTrendingData,
@@ -1358,34 +1359,114 @@ export function AuditLogPanel({ data }: { data: AuditEventsData }) {
 // Moderation queue has no live source yet — there's no user-generated
 // content moderation pipeline. Honest empty state until we add one.
 // ============================================================
+function ModerationRow({
+  label,
+  href,
+  count,
+  alert,
+}: {
+  label: string;
+  href: string;
+  count: string;
+  alert: boolean;
+}) {
+  return (
+    <a
+      href={href}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "10px 12px",
+        border: "1px solid var(--line)",
+        borderRadius: 8,
+        background: "rgba(255,255,255,0.02)",
+        textDecoration: "none",
+      }}
+    >
+      <span style={{ fontSize: 12, color: "var(--fg-dim)" }}>{label}</span>
+      <span
+        className="t-num"
+        style={{ fontSize: 13, color: alert ? "var(--el-fire)" : "var(--fg-mute)" }}
+      >
+        {count} →
+      </span>
+    </a>
+  );
+}
+
+// Wired to the two live report queues: reported chat messages and reported feed
+// comments. Both endpoints are admin-guarded and return report arrays; we count
+// the open set (capped display) and deep-link to the full moderation screens.
 export function ModerationQueue() {
+  const [counts, setCounts] = React.useState<{
+    chat: number | null;
+    comment: number | null;
+  }>({ chat: null, comment: null });
+  const [live, setLive] = React.useState(false);
+
+  const poll = React.useCallback(async (): Promise<{ ok: boolean }> => {
+    const readCount = async (url: string): Promise<number | null> => {
+      try {
+        const res = await fetch(url, { cache: "no-store" });
+        if (!res.ok) return null;
+        const json = (await res.json()) as { reports?: unknown[] };
+        return Array.isArray(json.reports) ? json.reports.length : 0;
+      } catch {
+        return null;
+      }
+    };
+    const [chat, comment] = await Promise.all([
+      readCount("/api/admin/chat/reports?status=open&limit=200"),
+      readCount("/api/admin/feed/comment-reports?status=open&limit=200"),
+    ]);
+    setCounts({ chat, comment });
+    const ok = chat !== null || comment !== null;
+    setLive(ok);
+    return { ok };
+  }, []);
+
+  useHardenedPolling(poll, { baseIntervalMs: 60_000 });
+
+  const fmt = (n: number | null, cap = 200): string =>
+    n === null ? "—" : n >= cap ? `${cap}+` : String(n);
+  const openTotal = (counts.chat ?? 0) + (counts.comment ?? 0);
+  const anyAlert = openTotal > 0;
+
   return (
     <Card
       title="Moderation Queue"
-      subtitle="no moderation pipeline configured"
+      subtitle="open user-content reports"
       right={
         <span
           className="t-mono"
-          style={{ fontSize: 9, color: "var(--fg-mute)", letterSpacing: "0.14em" }}
+          style={{
+            fontSize: 9,
+            color: !live
+              ? "var(--fg-mute)"
+              : anyAlert
+                ? "var(--el-fire)"
+                : "var(--el-earth)",
+            letterSpacing: "0.14em",
+          }}
         >
-          ○ NO SOURCE
+          {!live ? "○ NO SOURCE" : anyAlert ? `● ${fmt(openTotal, 400)} OPEN` : "● CLEAR"}
         </span>
       }
     >
-      <div
-        style={{
-          padding: "32px 12px",
-          textAlign: "center",
-          border: "1px dashed var(--line)",
-          borderRadius: 8,
-        }}
-      >
-        <div style={{ fontSize: 11, color: "var(--fg-dim)", marginBottom: 4 }}>
-          No user content moderation pipeline
-        </div>
-        <div className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>
-          add a <code>moderation_queue</code> table + classifier when UGC ships
-        </div>
+      <div style={{ display: "grid", gap: 8 }}>
+        <ModerationRow
+          label="Chat message reports"
+          href="/admin/chat-reports"
+          count={fmt(counts.chat)}
+          alert={(counts.chat ?? 0) > 0}
+        />
+        <ModerationRow
+          label="Feed comment reports"
+          href="/admin/feed/comment-reports"
+          count={fmt(counts.comment)}
+          alert={(counts.comment ?? 0) > 0}
+        />
       </div>
     </Card>
   );

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -67,6 +67,9 @@ export default function AdminLayout({
     { href: "/admin/dashboard", label: "Dashboard ✦", icon: "🔭" },
     { href: "/admin/mcp", label: "MCP Network ✦", icon: "🔌" },
     { href: "/admin/users", label: "Users", icon: "👥" },
+    { href: "/admin/settlements", label: "Settlements", icon: "💳" },
+    { href: "/admin/chat-reports", label: "Chat Reports", icon: "🚩" },
+    { href: "/admin/feed/comment-reports", label: "Comment Reports", icon: "💬" },
     { href: "/admin/settings", label: "Settings", icon: "⚙️" },
   ];
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import React, { useState } from "react";
 import AdvancedMetricsPanel from "@/components/admin/AdvancedMetricsPanel";
 import ApiRouteHealthPanel from "@/components/admin/ApiRouteHealthPanel";
+import LaunchReadinessPanel from "@/components/admin/LaunchReadinessPanel";
 import LiveActivityPanel from "@/components/admin/LiveActivityPanel";
 import OnboardingFunnelPanel from "@/components/admin/OnboardingFunnelPanel";
 import SystemStatusPanel from "@/components/admin/SystemStatusPanel";
@@ -236,6 +237,11 @@ export default function AdminDashboardPage() {
           Welcome to the alchm.kitchen admin panel
         </p>
       </div>
+
+      {/* Launch readiness — settlement backlog + presence-only config for every
+          revenue / on-chain subsystem. First thing an operator should see: a
+          stuck restaurant order is a real-money hazard. Polls every 2 min. */}
+      <LaunchReadinessPanel variant="compact" />
 
       {/* Today's headline counts — 24h vs prior 24h. The "did anything happen
           today?" glance at the top of the dashboard. Polls every 60s. */}

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import React from "react";
+import LaunchReadinessPanel from "@/components/admin/LaunchReadinessPanel";
 
 /**
  * Admin Settings Page - System configuration overview
+ *
+ * Top: the live launch-readiness board (presence-only config for every
+ * revenue + on-chain subsystem, fed by /api/admin/launch-readiness).
+ * Below: static platform facts that don't move without a redeploy.
  */
 export default function AdminSettingsPage() {
   const settings = [
@@ -61,10 +66,20 @@ export default function AdminSettingsPage() {
       {/* Header */}
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-800">Settings</h1>
-        <p className="text-gray-600 mt-1">System configuration overview</p>
+        <p className="text-gray-600 mt-1">
+          Launch readiness &amp; system configuration overview
+        </p>
       </div>
 
-      {/* Settings Sections */}
+      {/* Live readiness board — which revenue / on-chain subsystems are wired */}
+      <div className="mb-10">
+        <LaunchReadinessPanel variant="full" />
+      </div>
+
+      {/* Static platform facts */}
+      <h2 className="text-sm font-semibold uppercase tracking-wider text-gray-400 mb-4">
+        Platform
+      </h2>
       <div className="space-y-6">
         {settings.map((section) => (
           <div key={section.section} className="bg-white rounded-lg shadow">

--- a/src/app/admin/settlements/page.tsx
+++ b/src/app/admin/settlements/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import React from "react";
+import SettlementPanel from "@/components/admin/SettlementPanel";
+
+/**
+ * /admin/settlements — restaurant ESMS settlement operator screen.
+ *
+ * The handle for the crypto-food payment rail: resolve orders where ESMS was
+ * debited but the restaurant's fiat transfer isn't confirmed. See
+ * docs/payments/CRYPTO_FOOD_PAYMENTS.md.
+ */
+export default function AdminSettlementsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl sm:text-3xl font-bold text-gray-800">
+          Restaurant Settlements
+        </h1>
+        <p className="text-sm sm:text-base text-gray-600 mt-1">
+          Resolve orders where ESMS was debited but the restaurant transfer is
+          unconfirmed. Retry re-issues the transfer idempotently; refund
+          re-credits ESMS only when no transfer exists.
+        </p>
+      </div>
+
+      <SettlementPanel />
+    </div>
+  );
+}

--- a/src/app/api/admin/chat/reports/[id]/route.ts
+++ b/src/app/api/admin/chat/reports/[id]/route.ts
@@ -1,0 +1,87 @@
+/**
+ * PATCH /api/admin/chat/reports/[id]  {status}
+ *
+ * Admin resolves a reported chat message: 'actioned' hides the message,
+ * 'dismissed' unhides it when nothing else keeps it hidden, 'reviewed' just
+ * closes the report. Backed by chatDatabase.resolveReport. Admin only.
+ *
+ * @file src/app/api/admin/chat/reports/[id]/route.ts
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import { validateAdminRequest } from "@/lib/auth/validateRequest";
+import { chatDatabase } from "@/services/chatDatabaseService";
+import type { MessageReportStatus } from "@/types/chat";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+// 'open' is the initial state, not a resolution target.
+const RESOLVE_STATUSES = new Set<Exclude<MessageReportStatus, "open">>([
+  "reviewed",
+  "dismissed",
+  "actioned",
+]);
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+export async function PATCH(request: NextRequest, { params }: Params) {
+  const auth = await validateAdminRequest(request);
+  if ("error" in auth) return auth.error;
+  const adminId = auth.user.userId;
+
+  const { id } = await params;
+  if (!id || !UUID.test(id)) {
+    return NextResponse.json(
+      { success: false, message: "Invalid report id" },
+      { status: 400 },
+    );
+  }
+
+  let body: { status?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json(
+      { success: false, message: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const status =
+    typeof body.status === "string" &&
+    RESOLVE_STATUSES.has(body.status as Exclude<MessageReportStatus, "open">)
+      ? (body.status as Exclude<MessageReportStatus, "open">)
+      : null;
+  if (!status) {
+    return NextResponse.json(
+      {
+        success: false,
+        message: "A valid status (reviewed, dismissed, actioned) is required",
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const updated = await chatDatabase.resolveReport(id, adminId, status);
+    if (!updated) {
+      return NextResponse.json(
+        { success: false, message: "Report not found" },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({ success: true, status, report: updated });
+  } catch (error) {
+    console.error("[admin/chat/reports] PATCH failed:", error);
+    return NextResponse.json(
+      { success: false, message: "Failed to update report" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/chat/reports/route.ts
+++ b/src/app/api/admin/chat/reports/route.ts
@@ -1,0 +1,48 @@
+/**
+ * GET /api/admin/chat/reports?status=open — list reported chat messages.
+ *
+ * The moderation queue behind /admin/chat-reports (docs/plans/pr3-messaging-plan.md §4).
+ * Backed by chatDatabase.listReports; joins message body + hidden state for the
+ * admin view. Admin only.
+ *
+ * @file src/app/api/admin/chat/reports/route.ts
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import { validateAdminRequest } from "@/lib/auth/validateRequest";
+import { chatDatabase } from "@/services/chatDatabaseService";
+import type { MessageReportStatus } from "@/types/chat";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const STATUSES = new Set<MessageReportStatus>([
+  "open",
+  "reviewed",
+  "dismissed",
+  "actioned",
+]);
+
+export async function GET(request: NextRequest) {
+  const auth = await validateAdminRequest(request);
+  if ("error" in auth) return auth.error;
+
+  const { searchParams } = new URL(request.url);
+  const statusRaw = searchParams.get("status");
+  const status =
+    statusRaw && STATUSES.has(statusRaw as MessageReportStatus)
+      ? (statusRaw as MessageReportStatus)
+      : undefined;
+  const limit = Number.parseInt(searchParams.get("limit") ?? "50", 10) || 50;
+
+  try {
+    const reports = await chatDatabase.listReports({ status, limit });
+    return NextResponse.json({ success: true, reports });
+  } catch (error) {
+    console.error("[admin/chat/reports] GET failed:", error);
+    return NextResponse.json(
+      { success: false, message: "Failed to load reports" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/launch-readiness/route.ts
+++ b/src/app/api/admin/launch-readiness/route.ts
@@ -1,0 +1,36 @@
+/**
+ * Admin Launch Readiness API
+ * GET /api/admin/launch-readiness — presence-only config readiness for the
+ * revenue + on-chain subsystems, plus the live restaurant settlement backlog.
+ *
+ * @requires Authentication - Admin role required
+ *
+ * Response shape: `LaunchReadinessReport` from
+ * src/services/launchReadinessService.ts. Only booleans and counts cross the
+ * wire — no secret value is ever serialized.
+ *
+ * @file src/app/api/admin/launch-readiness/route.ts
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import { validateAdminRequest } from "@/lib/auth/validateRequest";
+import { getLaunchReadiness } from "@/services/launchReadinessService";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  const authResult = await validateAdminRequest(request);
+  if ("error" in authResult) return authResult.error;
+
+  try {
+    const report = await getLaunchReadiness();
+    return NextResponse.json({ success: true, ...report });
+  } catch (error) {
+    console.error("[admin/launch-readiness] failed:", error);
+    return NextResponse.json(
+      { success: false, message: "Failed to compute launch readiness" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/admin/LaunchReadinessPanel.tsx
+++ b/src/components/admin/LaunchReadinessPanel.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+/**
+ * LaunchReadinessPanel — the config-side "are the moving pieces wired?" board.
+ *
+ * Reads /api/admin/launch-readiness, which reports presence-only booleans for
+ * every env-gated revenue + on-chain subsystem (Stripe, restaurant crypto-food
+ * payments, on-chain ESMS, Recipe NFT, Privy, Amazon Fresh, agent network,
+ * email) plus the live settlement backlog. No secret value is ever sent.
+ *
+ *   variant="compact" → single readiness strip for the /admin overview, with a
+ *                        settlement-backlog callout that links to the operator
+ *                        screen when orders are stuck.
+ *   variant="full"    → per-subsystem cards with every individual env check,
+ *                        for the Settings readiness board.
+ */
+
+import Link from "next/link";
+import React from "react";
+import { useHardenedPolling } from "@/hooks/useHardenedPolling";
+
+type ReadinessStatus = "READY" | "PARTIAL" | "OFF";
+
+interface ReadinessCheck {
+  label: string;
+  source: string;
+  ok: boolean;
+  kind: "flag" | "secret" | "config";
+  isPublic: boolean;
+}
+
+interface SubsystemReadiness {
+  key: string;
+  label: string;
+  description: string;
+  status: ReadinessStatus;
+  configured: number;
+  total: number;
+  checks: ReadinessCheck[];
+}
+
+interface Report {
+  subsystems: SubsystemReadiness[];
+  settlement: { pending: number; live: boolean };
+  readyCount: number;
+  generatedAt: string;
+}
+
+const STATUS_STYLE: Record<ReadinessStatus, { chip: string; dot: string; label: string }> = {
+  READY: { chip: "bg-emerald-100 text-emerald-800", dot: "bg-emerald-500", label: "Ready" },
+  PARTIAL: { chip: "bg-amber-100 text-amber-800", dot: "bg-amber-500", label: "Partial" },
+  OFF: { chip: "bg-gray-200 text-gray-600", dot: "bg-gray-400", label: "Off" },
+};
+
+export default function LaunchReadinessPanel({
+  variant = "full",
+}: {
+  variant?: "compact" | "full";
+}) {
+  const [report, setReport] = React.useState<Report | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const poll = React.useCallback(async (): Promise<{ ok: boolean }> => {
+    try {
+      const res = await fetch("/api/admin/launch-readiness", { cache: "no-store" });
+      if (!res.ok) {
+        setError(`HTTP ${res.status}`);
+        return { ok: false };
+      }
+      const json = (await res.json()) as { success: boolean } & Report;
+      if (json.success) {
+        setReport(json);
+        setError(null);
+        return { ok: true };
+      }
+      setError("payload malformed");
+      return { ok: false };
+    } catch (_err) {
+      setError("offline");
+      return { ok: false };
+    }
+  }, []);
+
+  // Config presence only changes on a redeploy; the settlement backlog moves
+  // a little faster. A 2-minute cadence covers both.
+  useHardenedPolling(poll, { baseIntervalMs: 120_000 });
+
+  if (!report && !error) {
+    return (
+      <div className="bg-white rounded-xl shadow-lg border border-gray-100 p-6 text-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600 mx-auto mb-2" />
+        <p className="text-gray-500 text-xs">Loading launch readiness…</p>
+      </div>
+    );
+  }
+
+  if (error && !report) {
+    return (
+      <div className="bg-white rounded-xl shadow-lg border border-rose-200 p-4">
+        <p className="text-rose-700 text-sm">Readiness failed: {error}</p>
+        <button
+          type="button"
+          onClick={() => void poll()}
+          className="mt-2 px-3 py-1 bg-rose-600 text-white rounded text-xs hover:bg-rose-700"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!report) return null;
+
+  const backlog = report.settlement;
+
+  if (variant === "compact") {
+    return (
+      <div className="bg-white rounded-xl shadow-lg border border-gray-100 overflow-hidden">
+        <div className="px-4 sm:px-6 py-3 border-b border-gray-100 flex flex-wrap items-baseline justify-between gap-2">
+          <h2 className="text-lg font-bold text-gray-800">Launch Readiness</h2>
+          <Link
+            href="/admin/settings"
+            className="text-[11px] font-bold text-purple-600 hover:text-purple-800"
+          >
+            CONFIG →
+          </Link>
+        </div>
+
+        {/* Settlement backlog callout — the one signal an operator must not
+            miss. Green when clear, loud amber when orders are stuck. */}
+        <Link
+          href="/admin/settlements"
+          className={`flex items-center justify-between px-4 sm:px-6 py-3 border-b transition-colors ${
+            backlog.pending > 0
+              ? "bg-amber-50 hover:bg-amber-100 border-amber-100"
+              : "bg-emerald-50 hover:bg-emerald-100 border-emerald-100"
+          }`}
+        >
+          <span className="text-sm font-semibold text-gray-800">
+            💳 Restaurant settlements
+          </span>
+          <span
+            className={`text-xs font-bold ${
+              backlog.pending > 0 ? "text-amber-800" : "text-emerald-800"
+            }`}
+          >
+            {!backlog.live
+              ? "no source"
+              : backlog.pending > 0
+                ? `${backlog.pending} pending →`
+                : "clear ✓"}
+          </span>
+        </Link>
+
+        <div className="flex flex-wrap gap-2 p-3 sm:p-4">
+          {report.subsystems.map((s) => {
+            const style = STATUS_STYLE[s.status];
+            return (
+              <span
+                key={s.key}
+                title={`${s.label} · ${s.configured}/${s.total} configured`}
+                className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-semibold ${style.chip}`}
+              >
+                <span className={`h-1.5 w-1.5 rounded-full ${style.dot}`} />
+                {s.label.split(" · ")[0]} {s.configured}/{s.total}
+              </span>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  // variant === "full"
+  return (
+    <div className="space-y-4">
+      <div className="bg-white rounded-xl shadow-lg border border-gray-100 overflow-hidden">
+        <div className="px-6 py-4 border-b border-gray-100 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-bold text-gray-800">Launch Readiness</h2>
+            <p className="text-xs text-gray-500">
+              Presence-only config for revenue &amp; on-chain subsystems — values
+              are never read, only whether each var is set.
+            </p>
+          </div>
+          <span className="px-3 py-1 rounded-full text-xs font-bold bg-purple-100 text-purple-800">
+            {report.readyCount}/{report.subsystems.length} ready
+          </span>
+        </div>
+
+        <Link
+          href="/admin/settlements"
+          className={`flex items-center justify-between px-6 py-3 border-b transition-colors ${
+            backlog.pending > 0
+              ? "bg-amber-50 hover:bg-amber-100 border-amber-100"
+              : "bg-emerald-50 hover:bg-emerald-100 border-emerald-100"
+          }`}
+        >
+          <span className="text-sm font-semibold text-gray-800">
+            💳 Restaurant settlement backlog
+          </span>
+          <span
+            className={`text-xs font-bold ${
+              backlog.pending > 0 ? "text-amber-800" : "text-emerald-800"
+            }`}
+          >
+            {!backlog.live
+              ? "no source"
+              : backlog.pending > 0
+                ? `${backlog.pending} orders awaiting resolution →`
+                : "clear — no stuck orders ✓"}
+          </span>
+        </Link>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {report.subsystems.map((s) => {
+          const style = STATUS_STYLE[s.status];
+          return (
+            <div
+              key={s.key}
+              className="bg-white rounded-xl shadow border border-gray-100 overflow-hidden"
+            >
+              <div className="px-5 py-3 border-b border-gray-100 flex items-start justify-between gap-3">
+                <div>
+                  <h3 className="text-sm font-bold text-gray-800">{s.label}</h3>
+                  <p className="text-[11px] text-gray-500 mt-0.5">
+                    {s.description}
+                  </p>
+                </div>
+                <span
+                  className={`flex-shrink-0 flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-bold ${style.chip}`}
+                >
+                  <span className={`h-1.5 w-1.5 rounded-full ${style.dot}`} />
+                  {style.label} {s.configured}/{s.total}
+                </span>
+              </div>
+              <ul className="divide-y divide-gray-50">
+                {s.checks.map((c) => (
+                  <li
+                    key={c.source}
+                    className="flex items-center justify-between px-5 py-2 text-xs"
+                  >
+                    <span className="flex items-center gap-2 min-w-0">
+                      <span
+                        className={
+                          c.ok ? "text-emerald-600" : "text-gray-300"
+                        }
+                      >
+                        {c.ok ? "●" : "○"}
+                      </span>
+                      <span className="text-gray-700">{c.label}</span>
+                      {c.isPublic && (
+                        <span className="text-[9px] uppercase font-bold text-gray-300">
+                          public
+                        </span>
+                      )}
+                    </span>
+                    <code className="text-[10px] text-gray-400 font-mono truncate ml-2">
+                      {c.source}
+                    </code>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/SettlementPanel.tsx
+++ b/src/components/admin/SettlementPanel.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+/**
+ * SettlementPanel — operator handle for the restaurant ESMS settlement rail.
+ *
+ * A "settlement_pending" order is a real-money hazard: the user's ESMS was
+ * already debited, but the Stripe transfer that pays the restaurant its fiat
+ * hasn't been confirmed. This panel is the workflow required by
+ * docs/payments/CRYPTO_FOOD_PAYMENTS.md before a public launch — it lists every
+ * stuck order and lets the operator resolve each one:
+ *
+ *   • Retry  — re-issue the Stripe transfer under the SAME idempotency key, so
+ *              a transfer that actually went through the first time is returned
+ *              rather than double-paid. Marks the order paid + re-fulfills.
+ *   • Refund — only after Stripe confirms NO transfer exists, re-credit the
+ *              exact ESMS basket the order debited and mark it refunded.
+ *
+ * Backed by /api/admin/restaurants/settlement (GET list, POST resolve).
+ */
+
+import React from "react";
+import { useHardenedPolling } from "@/hooks/useHardenedPolling";
+
+interface PendingOrder {
+  id: string;
+  user_id: string | null;
+  restaurant_name: string;
+  currency: string;
+  transfer_amount_cents: number;
+  stripe_connected_account_id: string | null;
+  stripe_transfer_id: string | null;
+  status: string;
+  payment_status: string | null;
+  transfer_status: string | null;
+  created_at: string;
+}
+
+interface ActionResult {
+  orderId: string;
+  success: boolean;
+  message: string;
+  action: "retry" | "refund";
+}
+
+function formatMoney(cents: number, currency: string): string {
+  const amount = (cents / 100).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  return `${currency?.toUpperCase() || "USD"} ${amount}`;
+}
+
+function formatAge(iso: string): string {
+  const ageMs = Date.now() - new Date(iso).getTime();
+  if (Number.isNaN(ageMs)) return "—";
+  if (ageMs < 3_600_000) return `${Math.max(1, Math.round(ageMs / 60_000))}m`;
+  if (ageMs < 86_400_000) return `${Math.round(ageMs / 3_600_000)}h`;
+  return `${Math.round(ageMs / 86_400_000)}d`;
+}
+
+export default function SettlementPanel() {
+  const [orders, setOrders] = React.useState<PendingOrder[]>([]);
+  const [loaded, setLoaded] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [busyId, setBusyId] = React.useState<string | null>(null);
+  const [result, setResult] = React.useState<ActionResult | null>(null);
+
+  const poll = React.useCallback(async (): Promise<{ ok: boolean }> => {
+    try {
+      const res = await fetch("/api/admin/restaurants/settlement", {
+        cache: "no-store",
+      });
+      if (!res.ok) {
+        setError(`HTTP ${res.status}`);
+        return { ok: false };
+      }
+      const json = (await res.json()) as {
+        success: boolean;
+        pending?: PendingOrder[];
+        message?: string;
+      };
+      if (json.success) {
+        setOrders(json.pending ?? []);
+        setError(null);
+        setLoaded(true);
+        return { ok: true };
+      }
+      setError(json.message ?? "Payload malformed");
+      return { ok: false };
+    } catch (_err) {
+      setError("Failed to reach settlement API");
+      return { ok: false };
+    }
+  }, []);
+
+  // Settlement rows change only when an order fails or an operator acts, so a
+  // relaxed cadence is plenty; the resolve handler refreshes immediately.
+  useHardenedPolling(poll, { baseIntervalMs: 45_000 });
+
+  const resolve = async (orderId: string, action: "retry" | "refund") => {
+    // Refund re-credits ESMS and is irreversible from this screen — confirm it.
+    if (action === "refund") {
+      // eslint-disable-next-line no-alert
+      const ok = window.confirm(
+        "Refund ESMS for this order?\n\nOnly do this if the restaurant was NOT paid. " +
+          "The exact debited token basket is re-credited to the user and the order " +
+          "is marked refunded. This cannot be undone here.",
+      );
+      if (!ok) return;
+    }
+    try {
+      setBusyId(orderId);
+      setResult(null);
+      const res = await fetch("/api/admin/restaurants/settlement", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ orderId, action }),
+      });
+      const json = (await res.json()) as {
+        success: boolean;
+        message?: string;
+        status?: string;
+        transferId?: string;
+      };
+      setResult({
+        orderId,
+        action,
+        success: json.success,
+        message: json.success
+          ? action === "retry"
+            ? `Transfer settled${json.transferId ? ` · ${json.transferId}` : ""} — order marked paid.`
+            : "ESMS re-credited — order marked refunded."
+          : json.message ?? `HTTP ${res.status}`,
+      });
+      await poll();
+    } catch (err) {
+      setResult({
+        orderId,
+        action,
+        success: false,
+        message: err instanceof Error ? err.message : "Request failed",
+      });
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-xl shadow-lg border border-gray-100 overflow-hidden">
+      <div className="px-4 sm:px-6 py-4 border-b border-gray-100 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-bold text-gray-800">
+            Restaurant Settlements
+          </h2>
+          <p className="text-xs text-gray-500">
+            ESMS debited · restaurant transfer not confirmed
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <span
+            className={`px-2.5 py-1 rounded-full text-xs font-bold ${
+              orders.length === 0
+                ? "bg-emerald-100 text-emerald-800"
+                : "bg-amber-100 text-amber-800"
+            }`}
+          >
+            {loaded ? `${orders.length} pending` : "…"}
+          </span>
+          <button
+            type="button"
+            onClick={() => void poll()}
+            className="text-xs font-semibold text-purple-600 hover:text-purple-800"
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="px-4 sm:px-6 py-3 bg-rose-50 border-b border-rose-100 text-sm text-rose-700">
+          Settlement API error: {error}
+        </div>
+      )}
+
+      {result && (
+        <div
+          className={`px-4 sm:px-6 py-3 border-b text-xs font-mono ${
+            result.success
+              ? "bg-emerald-50 border-emerald-100 text-emerald-900"
+              : "bg-rose-50 border-rose-100 text-rose-900"
+          }`}
+        >
+          <span className="font-bold uppercase">
+            {result.action} · {result.success ? "OK" : "FAILED"}
+          </span>{" "}
+          — {result.message}
+        </div>
+      )}
+
+      {!loaded && !error ? (
+        <div className="p-8 text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600 mx-auto mb-2" />
+          <p className="text-gray-500 text-xs">Loading pending settlements…</p>
+        </div>
+      ) : orders.length === 0 ? (
+        <div className="p-10 text-center">
+          <p className="text-3xl mb-2">✅</p>
+          <p className="text-sm font-semibold text-gray-700">
+            No orders awaiting settlement
+          </p>
+          <p className="text-xs text-gray-400 mt-1">
+            The restaurant payment rail is clear.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-4 sm:px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                  Restaurant
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                  Transfer
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                  State
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                  Age
+                </th>
+                <th className="px-4 sm:px-6 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                  Resolve
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {orders.map((order) => {
+                const busy = busyId === order.id;
+                const canRetry =
+                  Boolean(order.stripe_connected_account_id) &&
+                  order.transfer_amount_cents > 0;
+                return (
+                  <tr key={order.id} className="hover:bg-gray-50 align-top">
+                    <td className="px-4 sm:px-6 py-4">
+                      <p className="font-medium text-gray-800">
+                        {order.restaurant_name || "—"}
+                      </p>
+                      <p className="text-[11px] text-gray-400 font-mono">
+                        {order.id}
+                      </p>
+                      {order.user_id && (
+                        <p className="text-[11px] text-gray-400 font-mono">
+                          user · {order.user_id.slice(0, 8)}
+                        </p>
+                      )}
+                    </td>
+                    <td className="px-4 py-4">
+                      <p className="font-semibold text-gray-800 font-mono">
+                        {formatMoney(order.transfer_amount_cents, order.currency)}
+                      </p>
+                      <p className="text-[11px] text-gray-400 font-mono">
+                        {order.stripe_connected_account_id
+                          ? `→ ${order.stripe_connected_account_id}`
+                          : "no connected account"}
+                      </p>
+                    </td>
+                    <td className="px-4 py-4">
+                      <span className="inline-block px-2 py-0.5 rounded text-[10px] font-bold bg-amber-100 text-amber-800">
+                        {order.status}
+                      </span>
+                      {order.transfer_status && (
+                        <p className="text-[11px] text-gray-500 font-mono mt-1">
+                          transfer · {order.transfer_status}
+                        </p>
+                      )}
+                    </td>
+                    <td className="px-4 py-4 text-gray-500 font-mono text-xs">
+                      {formatAge(order.created_at)}
+                    </td>
+                    <td className="px-4 sm:px-6 py-4">
+                      <div className="flex justify-end gap-2">
+                        <button
+                          type="button"
+                          disabled={busy || !canRetry}
+                          title={
+                            canRetry
+                              ? "Re-issue the Stripe transfer (idempotent)"
+                              : "Missing connected account or amount"
+                          }
+                          onClick={() => void resolve(order.id, "retry")}
+                          className="px-3 py-1.5 rounded-lg text-xs font-bold bg-indigo-600 text-white hover:bg-indigo-700 active:scale-95 disabled:bg-gray-200 disabled:text-gray-400 disabled:scale-100 transition"
+                        >
+                          {busy ? "…" : "Retry"}
+                        </button>
+                        <button
+                          type="button"
+                          disabled={busy}
+                          title="Re-credit ESMS (only if the restaurant was not paid)"
+                          onClick={() => void resolve(order.id, "refund")}
+                          className="px-3 py-1.5 rounded-lg text-xs font-bold bg-rose-50 text-rose-700 border border-rose-200 hover:bg-rose-100 active:scale-95 disabled:opacity-50 disabled:scale-100 transition"
+                        >
+                          {busy ? "…" : "Refund"}
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/services/launchReadinessService.ts
+++ b/src/services/launchReadinessService.ts
@@ -1,0 +1,245 @@
+/**
+ * launchReadinessService — presence-only configuration readiness for the
+ * revenue + on-chain "moving pieces" that ship alongside the core app.
+ *
+ * Every subsystem here (Stripe Pro, restaurant crypto-food payments, the
+ * on-chain ESMS economy, Recipe-NFT minting, Privy server wallets, the Amazon
+ * Fresh affiliate sink, the cross-project agent network, transactional email)
+ * is gated behind environment variables. This service reports, per subsystem,
+ * WHICH of those env vars are configured — as booleans only. It never reads a
+ * secret's value; `Boolean(process.env.X)` collapses the value to a presence
+ * flag before it leaves the server. The API route that wraps this is admin-
+ * guarded, and the payload is safe to render in the admin UI.
+ *
+ * It also surfaces the one live operational signal that determines whether the
+ * restaurant payment rail is safe to leave running: the settlement backlog
+ * (orders where ESMS was debited but the restaurant transfer isn't confirmed).
+ *
+ * @file src/services/launchReadinessService.ts
+ */
+
+import { executeQuery } from "@/lib/database";
+import { _logger } from "@/lib/logger";
+
+/** A single env-driven config check. `ok` is the only value that leaves here. */
+export interface ReadinessCheck {
+  /** Human label, e.g. "Stripe secret key". */
+  label: string;
+  /** The env var backing it, e.g. "STRIPE_SECRET_KEY" — name only, no value. */
+  source: string;
+  /** Whether the var is configured (secrets) or enabled (flags). */
+  ok: boolean;
+  /**
+   * "flag"   → must equal "true" to count as ok (feature toggles),
+   * "secret" → server-only credential, present when non-empty,
+   * "config" → non-secret setting (price id, chain, country), present when set.
+   */
+  kind: "flag" | "secret" | "config";
+  /** true for NEXT_PUBLIC_* vars — resolved at build time, not runtime. */
+  isPublic: boolean;
+}
+
+export type ReadinessStatus = "READY" | "PARTIAL" | "OFF";
+
+export interface SubsystemReadiness {
+  key: string;
+  label: string;
+  description: string;
+  status: ReadinessStatus;
+  configured: number;
+  total: number;
+  checks: ReadinessCheck[];
+}
+
+export interface SettlementBacklog {
+  /** Orders awaiting settlement (debited, transfer unconfirmed). */
+  pending: number;
+  /** false when restaurant_order_intents is absent or the query failed. */
+  live: boolean;
+}
+
+export interface LaunchReadinessReport {
+  subsystems: SubsystemReadiness[];
+  settlement: SettlementBacklog;
+  /** Count of subsystems fully READY. */
+  readyCount: number;
+  generatedAt: string;
+}
+
+// ── env helpers ─────────────────────────────────────────────────────────────
+// Both collapse the value to a boolean immediately — a secret's contents never
+// escape this module.
+const isSet = (name: string): boolean => Boolean(process.env[name]?.trim());
+const isEnabled = (name: string): boolean =>
+  process.env[name]?.trim().toLowerCase() === "true";
+
+function check(
+  label: string,
+  source: string,
+  kind: ReadinessCheck["kind"],
+): ReadinessCheck {
+  return {
+    label,
+    source,
+    kind,
+    ok: kind === "flag" ? isEnabled(source) : isSet(source),
+    isPublic: source.startsWith("NEXT_PUBLIC_"),
+  };
+}
+
+/** anyOf — one check that passes if ANY of the given vars is set (e.g. the
+ * mainnet OR testnet RPC url). */
+function anyOf(
+  label: string,
+  sources: string[],
+  kind: ReadinessCheck["kind"],
+): ReadinessCheck {
+  return {
+    label,
+    source: sources.join(" / "),
+    kind,
+    ok: sources.some((s) => (kind === "flag" ? isEnabled(s) : isSet(s))),
+    isPublic: sources.every((s) => s.startsWith("NEXT_PUBLIC_")),
+  };
+}
+
+function subsystem(
+  key: string,
+  label: string,
+  description: string,
+  checks: ReadinessCheck[],
+): SubsystemReadiness {
+  const configured = checks.filter((c) => c.ok).length;
+  const total = checks.length;
+  const status: ReadinessStatus =
+    configured === total ? "READY" : configured === 0 ? "OFF" : "PARTIAL";
+  return { key, label, description, status, configured, total, checks };
+}
+
+async function getSettlementBacklog(): Promise<SettlementBacklog> {
+  try {
+    const result = await executeQuery<{ count: string }>(
+      `SELECT COUNT(*)::integer AS count
+         FROM restaurant_order_intents
+        WHERE status = 'settlement_pending'
+           OR transfer_status = 'retry_required'`,
+    );
+    return { pending: Number(result.rows[0]?.count ?? 0), live: true };
+  } catch (error) {
+    _logger.warn("[launchReadiness] settlement backlog query failed:", error);
+    return { pending: 0, live: false };
+  }
+}
+
+/**
+ * Build the readiness report. Config checks are synchronous env reads; only the
+ * settlement backlog touches the database.
+ */
+export async function getLaunchReadiness(): Promise<LaunchReadinessReport> {
+  const subsystems: SubsystemReadiness[] = [
+    subsystem(
+      "stripe-pro",
+      "Stripe · Pro subscriptions",
+      "Recurring Pro-tier billing + webhook reconciliation.",
+      [
+        check("Secret key", "STRIPE_SECRET_KEY", "secret"),
+        check("Webhook signing secret", "STRIPE_WEBHOOK_SECRET", "secret"),
+        check("Publishable key", "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY", "config"),
+        check("Pro price id", "NEXT_PUBLIC_STRIPE_PREMIUM_PRICE_ID", "config"),
+      ],
+    ),
+    subsystem(
+      "restaurant-esms",
+      "Restaurant · crypto-food payments",
+      "Pay a restaurant bill in ESMS; Stripe transfer settles the fiat leg.",
+      [
+        check(
+          "Payments enabled",
+          "NEXT_PUBLIC_ESMS_RESTAURANT_PAYMENTS_ENABLED",
+          "flag",
+        ),
+        check(
+          "Stripe crypto rail enabled",
+          "NEXT_PUBLIC_STRIPE_RESTAURANT_CRYPTO_ENABLED",
+          "flag",
+        ),
+        check("Connect country", "STRIPE_RESTAURANT_CONNECT_COUNTRY", "config"),
+        check("Order price id", "STRIPE_RESTAURANT_ORDER_PRICE_ID", "config"),
+        check(
+          "Cents-per-token rate",
+          "NEXT_PUBLIC_ESMS_RESTAURANT_CENTS_PER_TOKEN",
+          "config",
+        ),
+      ],
+    ),
+    subsystem(
+      "onchain-esms",
+      "On-chain · ESMS economy",
+      "Soulbound ESMS balances mirrored on Base.",
+      [
+        check("On-chain enabled", "NEXT_PUBLIC_ESMS_ONCHAIN_ENABLED", "flag"),
+        check("Chain", "NEXT_PUBLIC_ESMS_CHAIN", "config"),
+        check("Token contract", "ESMS_CONTRACT_ADDRESS", "config"),
+        anyOf("RPC endpoint", ["BASE_RPC_URL", "BASE_SEPOLIA_RPC_URL"], "config"),
+        check("Minter key", "MINTER_PRIVATE_KEY", "secret"),
+      ],
+    ),
+    subsystem(
+      "recipe-nft",
+      "On-chain · Recipe NFT minting",
+      "Spend ESMS to mint a recipe as an on-chain NFT.",
+      [
+        check("Minting enabled", "NEXT_PUBLIC_RECIPE_NFT_ENABLED", "flag"),
+        check("Chain", "NEXT_PUBLIC_RECIPE_NFT_CHAIN", "config"),
+        check("Recipe registry", "NEXT_PUBLIC_RECIPE_REGISTRY_ADDRESS", "config"),
+        check("Rights registry", "NEXT_PUBLIC_RIGHTS_REGISTRY_ADDRESS", "config"),
+        check("Rights id", "NEXT_PUBLIC_ALCHM_RIGHTS_ID", "config"),
+        check("Recipe minter key", "RECIPE_MINTER_PRIVATE_KEY", "secret"),
+      ],
+    ),
+    subsystem(
+      "privy",
+      "Privy · server wallets",
+      "Embedded EVM wallets + social login for on-chain actions.",
+      [
+        check("App id", "NEXT_PUBLIC_PRIVY_APP_ID", "config"),
+        check("App secret", "PRIVY_APP_SECRET", "secret"),
+        check("Authorization key", "PRIVY_AUTHORIZATION_PRIVATE_KEY", "secret"),
+        check("Minter wallet id", "PRIVY_MINTER_WALLET_ID", "config"),
+        check("Redeemer wallet id", "PRIVY_REDEEMER_WALLET_ID", "config"),
+      ],
+    ),
+    subsystem(
+      "amazon-fresh",
+      "Amazon · affiliate grocery sink",
+      "Turns ingredient lists into affiliate Amazon Fresh carts.",
+      [
+        check("Associate tag", "NEXT_PUBLIC_AMAZON_ASSOCIATE_TAG", "config"),
+        check("PA-API access key", "AMAZON_PAAPI_ACCESS_KEY", "secret"),
+        check("PA-API secret key", "AMAZON_PAAPI_SECRET_KEY", "secret"),
+        check("PA-API partner tag", "AMAZON_PAAPI_PARTNER_TAG", "config"),
+      ],
+    ),
+    subsystem(
+      "agent-network",
+      "Agents · cross-project sync",
+      "Signed channel to the Planetary Agents backend.",
+      [check("Internal API secret", "INTERNAL_API_SECRET", "secret")],
+    ),
+    subsystem(
+      "email",
+      "Email · transactional",
+      "Transit updates, meal-plan digests, bulletins.",
+      [check("Resend API key", "RESEND_API_KEY", "secret")],
+    ),
+  ];
+
+  const settlement = await getSettlementBacklog();
+
+  return {
+    subsystems,
+    settlement,
+    readyCount: subsystems.filter((s) => s.status === "READY").length,
+    generatedAt: new Date().toISOString(),
+  };
+}


### PR DESCRIPTION
## What & why

The admin panel had a mature dashboard but several **built-but-unreachable "moving pieces"** — backends with no operator handle. This wires them up so the platform reads as finished and launch-ready.

| Moving piece | Before | Now |
|---|---|---|
| **Restaurant ESMS settlement** (retry/refund stuck crypto-food orders) | full API, **zero UI** — a real-money hazard | new `/admin/settlements` + `SettlementPanel` driving the existing retry/refund API |
| **Launch config** (Stripe, on-chain ESMS, Recipe-NFT, Privy, restaurant payments, Amazon Fresh, agents, email) | invisible | `launchReadinessService` + `GET /api/admin/launch-readiness` — **presence-only booleans, never secret values** — rendered compact on `/admin`, full on `/admin/settings` |
| **Chat-message moderation** | page called `/api/admin/chat/reports[/:id]` that **never existed** — dead screen | built both routes (the `chatDatabase` backend was already there) |
| Chat / Comment report pages | orphaned, unreachable | added to the sidebar nav |
| `ModerationQueue` dashboard panel | static "no pipeline configured" stub | live open-report counts + deep-links |

## Root-cause fix: a `.gitignore` footgun
`/admin/chat-reports` was dead because `.gitignore` had an **unanchored `reports/`** rule (sitting among lint-artifact ignores) that silently ignored `src/app/api/admin/chat/reports/` — every prior attempt to add that endpoint was invisible to git. Root-anchored it to `/reports/`. `archive/reports` stays ignored via its own `archive/` rule.

## Verification
- ✅ `bun run typecheck` clean (compiled every new page + component)
- ✅ ESLint clean on all changed files (pre-commit hook passed)
- ✅ All 3 new API routes return live `401 Authentication required` — import chains load and execute, guarded correctly (not 404/500)
- ⚠️ Authed admin UI not rendered in-sandbox (Google-OAuth gate); typecheck + route-level checks stand in

🤖 Generated with [Claude Code](https://claude.com/claude-code)