### PR TITLE
fix(recipes): stop Redis reads from forcing /recipes/[id] dynamic

### DIFF
--- a/src/services/LocalRecipeService.ts
+++ b/src/services/LocalRecipeService.ts
@@ -1,3 +1,5 @@
+import { unstable_cache } from "next/cache";
+import { after } from "next/server";
 import { getValidatedAssetUrl } from "@/lib/assets";
 import { executeQuery } from "@/lib/database";
 import { redisGet, redisSet, redisDel } from "@/lib/redis";
@@ -247,6 +249,39 @@ function mapRowToRecipe(row: DbRecipeRow & { read_model?: any }): Recipe {
 const REDIS_CATALOG_KEY = "recipes:catalog:all";
 const REDIS_TTL_SECONDS = 5 * 60; // 5 minutes — matches in-process TTL
 
+// The Upstash Redis client's GET call is a plain uncached fetch(), which
+// Next 15 (uncached-by-default) flags as "dynamic API usage" — fatal for
+// /recipes/[recipeId], which relies on ISR (revalidate = 3600). Wrapping the
+// read in unstable_cache tells Next's Data Cache to own this read instead,
+// so it no longer forces the route to bail from static to dynamic mid-render.
+const getCachedCatalogFromRedis = unstable_cache(
+  async (): Promise<Recipe[] | null> => {
+    try {
+      return await redisGet<Recipe[]>(REDIS_CATALOG_KEY);
+    } catch (err) {
+      logger.warn("Redis cache read failed, falling through to DB:", err);
+      return null;
+    }
+  },
+  ["recipe-catalog-redis-read"],
+  { revalidate: REDIS_TTL_SECONDS },
+);
+
+/**
+ * Defer a fire-and-forget write until after the response is sent, via
+ * next/server's `after()` — keeps it outside the render's dynamic-API
+ * detection window. Falls back to firing immediately when called outside a
+ * Next.js request scope (e.g. the standalone Hono API server), where
+ * `after()` throws.
+ */
+function deferAfterResponse(work: () => void): void {
+  try {
+    after(work);
+  } catch {
+    work();
+  }
+}
+
 export class LocalRecipeService {
   private static _allRecipes: Recipe[] | null = null;
   private static _allRecipesLoadedAt: number | null = null;
@@ -285,16 +320,12 @@ export class LocalRecipeService {
     }
 
     // L2: Redis catalog cache (cross-instance — target <20ms)
-    try {
-      const cached = await redisGet<Recipe[]>(REDIS_CATALOG_KEY);
-      if (cached && Array.isArray(cached) && cached.length > 0) {
-        this._allRecipes = cached;
-        this._allRecipesLoadedAt = Date.now();
-        this._catalogDegraded = false;
-        return cached;
-      }
-    } catch (err) {
-      logger.warn("Redis cache read failed, falling through to DB:", err);
+    const cached = await getCachedCatalogFromRedis();
+    if (cached && Array.isArray(cached) && cached.length > 0) {
+      this._allRecipes = cached;
+      this._allRecipesLoadedAt = Date.now();
+      this._catalogDegraded = false;
+      return cached;
     }
 
     // L3: PostgreSQL
@@ -314,8 +345,12 @@ export class LocalRecipeService {
       this._allRecipesLoadedAt = Date.now();
       this._catalogDegraded = false;
 
-      // Populate Redis asynchronously so we don't block the response
-      redisSet(REDIS_CATALOG_KEY, recipes, REDIS_TTL_SECONDS).catch(() => {});
+      // Populate Redis asynchronously, after the response is sent — keeps
+      // this fire-and-forget write outside the render's dynamic-API
+      // detection window (same reasoning as getCachedCatalogFromRedis above).
+      deferAfterResponse(() => {
+        redisSet(REDIS_CATALOG_KEY, recipes, REDIS_TTL_SECONDS).catch(() => {});
+      });
 
       // Part 3: Warm Image Asset Cache
       this.warmImageAssetCache(recipes);


### PR DESCRIPTION
## Summary

Follow-up from the same production-readiness audit as #597/#598/#599 (all merged). This one came from actually checking Vercel's runtime error logs for the first time this session (the MCP connection had been down all session until now).

Found a chronic (~2-month-old, dozens of occurrences/day, most recently minutes before this fix) production error on `/recipes/[recipeId]`:

```
Error: Page changed from static to dynamic at runtime /recipes/<id>,
reason: no-store fetch https://<upstash-host>/pipeline /recipes/[recipeId]
```

## Root cause

`LocalRecipeService.getAllRecipes()`'s L2 Redis-catalog read calls `@upstash/redis`'s `client.get()`, which issues a plain uncached `fetch()` under the hood. Next.js 15 fetches are **uncached by default** (a behavior change from Next 14), so Next's static-generation analysis flags this as dynamic API usage — which conflicts with the route's ISR config (`revalidate = 3600`) that every recipe detail page relies on.

## Impact

Narrower than it first looked: I confirmed a direct page load still works fine — the failures are specifically on the background `.rsc` prefetch Next does when a recipe card scrolls into view (`<Link>` prefetching). So the cost was wasted serverless invocations and log noise rather than a visibly broken page for users, but it's real production error volume nonetheless.

## Fix

- Wrap the Redis GET in `unstable_cache` (matching the existing convention already used in `HistoricalStatsService.ts`) so Next's Data Cache owns the read instead of flagging it as an uncached dynamic fetch.
- Defer the fire-and-forget Redis SET (populated after a DB-fallback fetch) via `next/server`'s `after()` so it also runs post-response, outside the render's dynamic-API detection window.
- `after()` throws outside a Next.js request scope, and `getAllRecipes()` is also called from the standalone Hono API server (`src/server/hono-api.ts` — dev-only, not part of the deployed Railway topology, but guarded defensively regardless) — wrapped in a try/catch fallback that just fires the write immediately in that case.

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors (pre-existing warnings only)
- [x] `bun run build` — succeeds, no dynamic-server-usage warnings in the build log
- [ ] Will confirm the error stops recurring in Vercel's runtime logs once this deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)