### PR TITLE
chore(lint): clear all eslint warnings across src

### DIFF
--- a/src/app/(alchm)/messages/page.tsx
+++ b/src/app/(alchm)/messages/page.tsx
@@ -6,8 +6,8 @@
  * shows a quiet "not available yet" state rather than 404ing.
  */
 
-import { GradientText } from "@/components/tables/ui/GradientText";
 import { InboxList } from "@/components/chat/InboxList";
+import { GradientText } from "@/components/tables/ui/GradientText";
 import { useChatInbox } from "@/hooks/useChatInbox";
 import {
   isCirclesEnabledClient,

--- a/src/app/(alchm)/philosophers-stone/page.tsx
+++ b/src/app/(alchm)/philosophers-stone/page.tsx
@@ -21,7 +21,6 @@ import {
   Archive,
 } from 'lucide-react'
 import { useState, useEffect, useCallback } from 'react'
-import type { ChangeEvent, KeyboardEvent } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
@@ -40,6 +39,7 @@ import {
   deriveStatsFromChart,
   calculateAverage,
 } from '@/lib/sacred-7-stats'
+import type { ChangeEvent, KeyboardEvent } from 'react'
 
 interface AgentCreationData {
   name: string

--- a/src/components/chat/ConversationView.tsx
+++ b/src/components/chat/ConversationView.tsx
@@ -33,9 +33,15 @@ export function ConversationView({
   const viewerId = convo.viewerId;
   const [reportTarget, setReportTarget] = useState<ChatMessage | null>(null);
 
+  // Mark the thread read whenever new messages arrive. Hoisting the two values
+  // the effect actually depends on keeps the dependency list exact (rather than
+  // depending on the whole `convo` object, which is a fresh reference each render
+  // and would re-fire markRead on every render).
+  const markRead = convo.markRead;
+  const messageCount = convo.messages.length;
   useEffect(() => {
-    void convo.markRead();
-  }, [convo.markRead, convo.messages.length]);
+    void markRead();
+  }, [markRead, messageCount]);
 
   const renderMenu = (message: ChatMessage) => {
     if (message.pending || message.deletedAt) return null;

--- a/src/components/chat/InboxList.tsx
+++ b/src/components/chat/InboxList.tsx
@@ -9,8 +9,8 @@
 
 import Link from "next/link";
 import { formatNotificationTimeAgo } from "@/hooks/useNotifications";
-import { SenderAvatar, elementForSender } from "./MessageBubble";
 import type { InboxEntry } from "@/types/chat";
+import { SenderAvatar, elementForSender } from "./MessageBubble";
 import type { JSX } from "react";
 
 export interface InboxListProps {

--- a/src/components/food-diary/DiaryAnalytics.tsx
+++ b/src/components/food-diary/DiaryAnalytics.tsx
@@ -24,12 +24,12 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import type { TooltipValueType } from "recharts";
 import type {
   DailyFoodDiarySummary,
   WeeklyFoodDiarySummary,
 } from "@/types/foodDiary";
 import type { NutritionalSummary } from "@/types/nutrition";
+import type { TooltipValueType } from "recharts";
 
 interface AnalyticsProps {
   weeklySummary: WeeklyFoodDiarySummary | null;

--- a/src/components/nav/MessagesBadge.tsx
+++ b/src/components/nav/MessagesBadge.tsx
@@ -11,8 +11,8 @@
 import { MessageCircle } from "lucide-react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
-import { isCirclesEnabledClient, isDmsEnabledClient } from "@/lib/chat/flags";
 import { useChatUnread } from "@/hooks/useChatUnread";
+import { isCirclesEnabledClient, isDmsEnabledClient } from "@/lib/chat/flags";
 import type { JSX } from "react";
 
 export default function MessagesBadge(): JSX.Element | null {

--- a/src/data/unified/cuisineIntegrations.ts
+++ b/src/data/unified/cuisineIntegrations.ts
@@ -29,11 +29,11 @@ const unifiedSeasonalSystem = {
   autumn: { dominantElement: "Earth", supportingElements: ["Fire"] },
   winter: { dominantElement: "Water", supportingElements: ["Earth"] },
 };
-type SeasonalProfilePlaceholder = {
+interface SeasonalProfilePlaceholder {
   ingredients: never[];
   flavors: never[];
   techniques: never[];
-};
+}
 // `Season` includes "fall" (alias of "autumn") and "all", but this
 // placeholder was only ever populated for the four calendar seasons; both
 // are declared explicitly (mapped to `undefined`) so indexing by any `Season`
@@ -49,18 +49,9 @@ const unifiedSeasonalProfiles: Record<
   winter: { ingredients: [], flavors: [], techniques: [] },
   all: undefined,
 };
-const unifiedIngredients = {
-  // Placeholder for unified ingredient system;
-  getAllIngredients: () => [],
-  getIngredientsByCategory: (_category: string) => [],
-  getIngredientProperties: (_ingredient: string) => ({}),
-};
-// Name-indexed ingredient lookup used by the fusion helpers below. Kept as a
-// separate typed map (rather than an index signature on `unifiedIngredients`
-// above) because that object's own keys are utility method names, not
-// ingredient names; it is intentionally empty (placeholder), matching the
-// previous behavior where indexing `unifiedIngredients` by an arbitrary
-// ingredient name never resolved real ingredient data.
+// Name-indexed ingredient lookup used by the fusion helpers below.
+// Intentionally empty (placeholder): indexing it by an arbitrary ingredient
+// name never resolves real ingredient data, matching the previous behavior.
 const unifiedIngredientsByName: Record<string, UnifiedIngredient> = {};
 // Import existing cuisine data
 // ===== ENHANCED CUISINE INTEGRATION INTERFACES =====;

--- a/src/utils/globalDominantElement.ts
+++ b/src/utils/globalDominantElement.ts
@@ -13,11 +13,8 @@ type ElementalProfileFn = (props: Record<string, number>) => {
 };
 
 declare global {
-  // eslint-disable-next-line no-var
   var getDominantElement: DominantElementFn | undefined;
-  // eslint-disable-next-line no-var
   var getElementalCharacteristics: ElementalCharacteristicsFn | undefined;
-  // eslint-disable-next-line no-var
   var getElementalProfile: ElementalProfileFn | undefined;
 }
 

--- a/src/utils/recipe/recipeCore.ts
+++ b/src/utils/recipe/recipeCore.ts
@@ -36,7 +36,7 @@ const logger = createLogger("RecipeCore");
 
 type ElementKey = "Fire" | "Water" | "Earth" | "Air";
 
-const ELEMENT_KEYS: Array<ElementKey> = ["Fire", "Water", "Earth", "Air"];
+const ELEMENT_KEYS: ElementKey[] = ["Fire", "Water", "Earth", "Air"];
 const WEEK_DAYS: WeekDay[] = [
   "Sunday",
   "Monday",


### PR DESCRIPTION
Clears the 12 eslint warnings surfaced by the pre-push hook so the tree lints clean at `--max-warnings=0`. All warnings pre-date this work; none block (the hook runs at `--max-warnings=10000`), but they add noise to every push.

## Changes
- **import/order** (auto-fixed, pure reordering): `messages/page`, `philosophers-stone/page`, `InboxList`, `DiaryAnalytics`, `MessagesBadge`
- **@typescript-eslint/array-type**: `ElementKey[]` over `Array<ElementKey>` (`recipeCore`)
- **consistent-type-definitions**: `interface` over `type` (`cuisineIntegrations`)
- **no-unused-vars**: remove the dead `unifiedIngredients` placeholder object (only `unifiedIngredientsByName` is consumed); rewrite its now-dangling comment
- remove three unused `eslint-disable no-var` directives (`globalDominantElement`)
- **react-hooks/exhaustive-deps** (`ConversationView`): hoist `convo.markRead` and `convo.messages.length` into locals so the effect's deps are exact rather than depending on the whole `convo` object (which is a fresh reference each render)

## Verification
- `bun run typecheck` — clean
- `bun run lint` — 0 warnings, 0 errors (even at `--max-warnings=0`)
- No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)