### PR TITLE
feat(recommendations): composite palate bias for ingredients, sauces, and methods

### DIFF
--- a/src/components/recommendations/EnhancedCookingMethodRecommender.tsx
+++ b/src/components/recommendations/EnhancedCookingMethodRecommender.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/data/cooking/methods";
 import type { MethodPhysicalReference } from "@/data/cooking/physicalReference";
 import { METHOD_PHYSICAL_REFERENCE } from "@/data/cooking/physicalReference";
+import { useUserElementalBias } from "@/hooks/useUserElementalBias";
 import type {
   AlchemicalProperties,
   ElementalProperties,
@@ -409,6 +410,9 @@ export default function EnhancedCookingMethodRecommender({ onDoubleClickMethod }
   const [expandedTab, setExpandedTab] = useState<ExpandedTab>("overview");
   const [focusMode, setFocusMode] = useState<FocusMode>("harmony");
   const [userIntent, setUserIntent] = useState<UserIntent>(null);
+  // Visitor's elemental bias (chart/table) — adds the "Personal" harmony
+  // dimension; null keeps scoring bit-identical to unpersonalized.
+  const { bias: userBias, source: biasSource } = useUserElementalBias();
   const [showPillarsGuide, setShowPillarsGuide] = useState(false);
   const [planetaryPositions, setPlanetaryPositions] = useState<Record<string, string>>(DEFAULT_PLANETARY_POSITIONS);
   const [positionsSource, setPositionsSource] = useState<"real" | "fallback">("fallback");
@@ -584,6 +588,7 @@ export default function EnhancedCookingMethodRecommender({ onDoubleClickMethod }
           monica,
           duration: duration || undefined,
           kineticPower: kinetics?.power,
+          userElementalBias: userBias,
         },
         userIntent,
         {
@@ -616,7 +621,7 @@ export default function EnhancedCookingMethodRecommender({ onDoubleClickMethod }
 
     // Sort by Harmony Index (primary sort for all focus modes)
     return methods.sort((a, b) => b.harmony.harmonyIndex - a.harmony.harmonyIndex);
-  }, [selectedCategory, planetaryPositions, contextPlanetaryPositions, focusMode, userIntent, currentMoment]);
+  }, [selectedCategory, planetaryPositions, contextPlanetaryPositions, focusMode, userIntent, currentMoment, userBias]);
 
 
   const loadAlignedRecipes = useCallback(async (methodId: string) => {
@@ -768,6 +773,9 @@ export default function EnhancedCookingMethodRecommender({ onDoubleClickMethod }
                     { n: "Thermo", v: harmony.breakdown.thermoEfficiency },
                     { n: "Balance", v: harmony.breakdown.alchemicalBalance },
                     { n: "Speed", v: harmony.breakdown.speedFactor },
+                    ...(harmony.breakdown.personalAlignment != null
+                      ? [{ n: "Personal", v: harmony.breakdown.personalAlignment }]
+                      : []),
                   ].map(({ n, v }) => (
                     <div key={n} className="flex items-center gap-2 text-xs">
                       <span className="w-14 text-gray-500">{n}</span>
@@ -1258,9 +1266,16 @@ export default function EnhancedCookingMethodRecommender({ onDoubleClickMethod }
       <div className="rounded-xl border border-white/10 bg-transparent p-5 shadow-sm">
         <div className="flex items-center justify-between gap-2 mb-4">
           <h3 className="text-sm font-bold text-gray-200">Current Moment Metrics</h3>
-          <span className={`rounded-full px-2.5 py-1 text-[10px] font-bold ${momentStatus === "ready" ? "bg-emerald-100 text-emerald-700" : momentStatus === "loading" ? "bg-amber-100 text-amber-700" : "bg-red-100 text-red-700"
-            }`}>
-            {momentStatus === "ready" ? "LIVE /api/alchm-quantities" : momentStatus === "loading" ? "Loading..." : "Unavailable"}
+          <span className="flex items-center gap-2">
+            {userBias && (
+              <span className="rounded-full px-2.5 py-1 text-[10px] font-bold bg-violet-500/15 text-violet-300">
+                {biasSource === "chart" ? "Tuned to your chart" : "Tuned to your table"}
+              </span>
+            )}
+            <span className={`rounded-full px-2.5 py-1 text-[10px] font-bold ${momentStatus === "ready" ? "bg-emerald-100 text-emerald-700" : momentStatus === "loading" ? "bg-amber-100 text-amber-700" : "bg-red-100 text-red-700"
+              }`}>
+              {momentStatus === "ready" ? "LIVE /api/alchm-quantities" : momentStatus === "loading" ? "Loading..." : "Unavailable"}
+            </span>
           </span>
         </div>
         {currentMoment ? (

--- a/src/components/recommendations/EnhancedIngredientRecommender.tsx
+++ b/src/components/recommendations/EnhancedIngredientRecommender.tsx
@@ -17,6 +17,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { useAlchemical } from "@/contexts/AlchemicalContext/hooks";
 import type { UnifiedIngredient } from "@/data/unified/unifiedTypes";
 import { usePantry } from "@/hooks/usePantry";
+import { useUserElementalBias } from "@/hooks/useUserElementalBias";
 import { isBoilerplateCoverageIngredient } from "@/lib/ingredients/coverageQuality";
 import { IngredientService } from "@/services/IngredientService";
 import type {
@@ -873,14 +874,24 @@ export const EnhancedIngredientRecommender: React.FC<
     }
   }, [ingredientService]);
 
-  // Get current elemental properties from alchemical context
+  // Visitor's elemental bias (chart/table) — blended into the scoring
+  // target; null keeps scoring bit-identical to unpersonalized.
+  const { bias: userBias, source: biasSource } = useUserElementalBias();
+
+  // Get current elemental properties from alchemical context, personalized
+  // by the visitor's bias when present (70/30 moment/user, renormalized).
   const currentElementals: ElementalProperties = useMemo(() => {
-    if (alchemicalContext?.state?.elementalState) {
-      return alchemicalContext.state.elementalState;
-    }
-    // Default balanced elementals
-    return { Fire: 0.25, Water: 0.25, Earth: 0.25, Air: 0.25 };
-  }, [alchemicalContext]);
+    const base: ElementalProperties = alchemicalContext?.state?.elementalState
+      ? alchemicalContext.state.elementalState
+      : { Fire: 0.25, Water: 0.25, Earth: 0.25, Air: 0.25 };
+    if (!userBias) return base;
+    return normalizeForDisplay({
+      Fire: base.Fire * 0.7 + userBias.Fire * 0.3,
+      Water: base.Water * 0.7 + userBias.Water * 0.3,
+      Earth: base.Earth * 0.7 + userBias.Earth * 0.3,
+      Air: base.Air * 0.7 + userBias.Air * 0.3,
+    });
+  }, [alchemicalContext, userBias]);
 
   // Filter and score ingredients
   const scoredIngredients = useMemo(() => {
@@ -1111,6 +1122,11 @@ export const EnhancedIngredientRecommender: React.FC<
     : selectedCategoryName
       ? `Best ${selectedCategoryName.toLowerCase()} right now`
       : "Best matches right now";
+  const tunedLabel = userBias
+    ? biasSource === "chart"
+      ? " · tuned to your chart"
+      : " · tuned to your table"
+    : "";
 
   // Render category grid
   const renderCategoryGrid = () => (
@@ -2794,7 +2810,9 @@ export const EnhancedIngredientRecommender: React.FC<
 
       {/* Results count */}
       <div className="mb-4 text-sm text-slate-300">
-        {compact ? compactResultLabel : `Showing ${displayedIngredients.length}`}
+        {compact
+          ? `${compactResultLabel}${tunedLabel}`
+          : `Showing ${displayedIngredients.length}${tunedLabel}`}
         {!compact && remainingCount > 0
           ? ` of ${scoredIngredients.length}`
           : ""}

--- a/src/components/recommendations/EnhancedSauceRecommender.tsx
+++ b/src/components/recommendations/EnhancedSauceRecommender.tsx
@@ -10,6 +10,7 @@ import { useAlchemicalData } from "@/contexts/AlchemicalDataContext";
 import { allSauces } from "@/data/sauces";
 import { useAstrologicalState } from "@/hooks/useAstrologicalState";
 import { useCurrentSeason } from "@/hooks/useCurrentSeason";
+import { useUserElementalBias } from "@/hooks/useUserElementalBias";
 import {
   getCuisineFingerprint,
   listCuisines,
@@ -268,6 +269,10 @@ export default function EnhancedSauceRecommender() {
 
   const fingerprint = useMemo(() => getCuisineFingerprint(cuisineKey, cuisinesMapData || undefined), [cuisineKey, cuisinesMapData]);
 
+  // Visitor's elemental bias (chart/table) rides the context so the sauce
+  // similarity target is personalized; null keeps scoring bit-identical.
+  const { bias: userBias, source: biasSource } = useUserElementalBias();
+
   const ctx: CuisineSauceContext = useMemo(() => ({
     cuisine: cuisineKey, region, protein, vegetable, cookingMethod,
     dietary: dietary.length ? dietary : undefined,
@@ -275,7 +280,8 @@ export default function EnhancedSauceRecommender() {
     role, season,
     cosmic: cosmicSync ? { zodiac: astroState.currentZodiac, planetaryHour, isDaytime, lunarPhase } : undefined,
     cosmicWeight: cosmicSync ? 0.5 : 0,
-  }), [cuisineKey, region, protein, vegetable, cookingMethod, dietary, flavorTargets, role, season, cosmicSync, astroState.currentZodiac, planetaryHour, isDaytime, lunarPhase]);
+    userElementals: userBias ?? undefined,
+  }), [cuisineKey, region, protein, vegetable, cookingMethod, dietary, flavorTargets, role, season, cosmicSync, astroState.currentZodiac, planetaryHour, isDaytime, lunarPhase, userBias]);
 
   const handleRecommend = useCallback(() => {
     setLoading(true);
@@ -370,6 +376,11 @@ export default function EnhancedSauceRecommender() {
         <div className="mb-6 flex items-center justify-between">
           <h2 className="text-xl font-bold text-slate-800">Recommended Pairings</h2>
           <div className="flex gap-2">
+             {userBias && (
+               <span className="text-[10px] px-2 py-1 rounded border border-violet-300 bg-violet-50 text-violet-700 font-semibold">
+                 {biasSource === "chart" ? "Tuned to your chart" : "Tuned to your table"}
+               </span>
+             )}
              <button onClick={() => setStrictCuisine(!strictCuisine)} className={`text-[10px] px-2 py-1 rounded border transition-colors ${strictCuisine ? "bg-slate-800 text-white border-slate-800" : "bg-white text-slate-500 border-slate-200"}`}>Strict Cuisine</button>
              <button onClick={() => setCosmicSync(!cosmicSync)} className={`text-[10px] px-2 py-1 rounded border transition-colors ${cosmicSync ? "bg-purple-600 text-white border-purple-600" : "bg-white text-slate-500 border-slate-200"}`}>Cosmic Sync</button>
           </div>

--- a/src/utils/cuisine/cuisineSauceProfiler.ts
+++ b/src/utils/cuisine/cuisineSauceProfiler.ts
@@ -52,6 +52,12 @@ export interface CuisineSauceContext {
     lunarPhase?: string;
   };
   cosmicWeight?: number;
+  /**
+   * Visitor's elemental bias from useUserElementalBias (chart and/or guest
+   * table). When present it is blended (30%) into the cuisine's elemental
+   * target before sauce similarity; absent keeps scoring bit-identical.
+   */
+  userElementals?: { Fire: number; Water: number; Earth: number; Air: number } | null;
 }
 
 export interface CuisineFingerprint {
@@ -618,7 +624,28 @@ function astrologicalScore(sauce: UnifiedSauce, ctx: CuisineSauceContext, cuisin
 
 function elementalScore(sauce: UnifiedSauce, cuisine: Cuisine | null, ctx: CuisineSauceContext): { score: number; similarity: number } {
   if (!sauce.elementalProperties || !cuisine?.elementalProperties) return { score: 0.5, similarity: 0.5 };
-  const sim = cosineSimilarity(sauce.elementalProperties, cuisine.elementalProperties as ElementalProperties);
+  let target = cuisine.elementalProperties as ElementalProperties;
+  if (ctx.userElementals) {
+    // Personalize the comparison target: 70/30 cuisine/user blend,
+    // renormalized. Blending the target (rather than adding a cosine
+    // dimension, which compresses toward 1.0 on non-negative 4-vectors)
+    // keeps the existing pipeline and its discrimination intact.
+    const u = ctx.userElementals;
+    const blended = {
+      Fire: target.Fire * 0.7 + u.Fire * 0.3,
+      Water: target.Water * 0.7 + u.Water * 0.3,
+      Earth: target.Earth * 0.7 + u.Earth * 0.3,
+      Air: target.Air * 0.7 + u.Air * 0.3,
+    };
+    const sum = blended.Fire + blended.Water + blended.Earth + blended.Air || 1;
+    target = {
+      Fire: blended.Fire / sum,
+      Water: blended.Water / sum,
+      Earth: blended.Earth / sum,
+      Air: blended.Air / sum,
+    };
+  }
+  const sim = cosineSimilarity(sauce.elementalProperties, target);
   const adjusted = applyRoleAdjustment(ctx.role ?? "complement", sim);
   return { score: Math.max(0, Math.min(1, adjusted)), similarity: sim };
 }

--- a/src/utils/resonanceGapScoring.ts
+++ b/src/utils/resonanceGapScoring.ts
@@ -33,6 +33,13 @@ export interface ResonanceInput {
   duration?: { min: number; max: number };
   /** Kinetic power (P=IV) */
   kineticPower?: number;
+  /**
+   * Visitor's elemental bias from useUserElementalBias (chart and/or guest
+   * table). Optional: absent/null keeps scoring bit-identical to
+   * unpersonalized behavior — the personal dimension only exists when a
+   * bias is present.
+   */
+  userElementalBias?: { Fire: number; Water: number; Earth: number; Air: number } | null;
 }
 
 export interface AstrologicalStressContext {
@@ -59,6 +66,11 @@ export interface HarmonyResult {
     alchemicalBalance: number;
     /** Speed factor (lower duration = higher for "fast" intent) */
     speedFactor: number;
+    /**
+     * Alignment between the method's elemental effect and the visitor's
+     * bias — null when no bias was supplied (dimension inactive).
+     */
+    personalAlignment: number | null;
   };
 }
 
@@ -88,16 +100,27 @@ export function calculateHarmonyIndex(
   // 5. Speed Factor — based on method duration
   const speedFactor = calculateSpeedFactor(input.duration);
 
-  // Dynamic weighting based on stress context and focus mode
-  const weights = getWeights(userIntent, stressContext, focusMode);
+  // 6. Personal Alignment — only when the visitor has an elemental bias
+  const personalAlignment = input.userElementalBias
+    ? calculatePersonalAlignment(input.elementalEffect, input.userElementalBias)
+    : null;
 
-  // Weighted sum
+  // Dynamic weighting based on stress context and focus mode
+  const weights = getWeights(
+    userIntent,
+    stressContext,
+    focusMode,
+    personalAlignment !== null,
+  );
+
+  // Weighted sum (weights.personal is 0 when no bias — bit-identical path)
   const raw =
     stabilityResonance * weights.stability +
     intentAlignment * weights.intent +
     thermoEfficiency * weights.thermo +
     alchemicalBalance * weights.balance +
-    speedFactor * weights.speed;
+    speedFactor * weights.speed +
+    (personalAlignment ?? 0) * weights.personal;
 
   // Clamp to 0–100
   const harmonyIndex = Math.max(0, Math.min(100, raw));
@@ -111,6 +134,7 @@ export function calculateHarmonyIndex(
       thermoEfficiency,
       alchemicalBalance,
       speedFactor,
+      personalAlignment,
     },
   };
 }
@@ -189,6 +213,33 @@ function calculateAlchemicalBalance(esms: { Spirit: number; Essence: number; Mat
   return Math.max(20, Math.min(100, 100 - cv * 70));
 }
 
+/**
+ * Total-variation similarity between the method's elemental effect and the
+ * visitor's bias, both normalized. TV (unlike cosine on non-negative
+ * 4-vectors) spreads across the full 0–100 range, so the dimension
+ * actually discriminates between methods.
+ */
+function calculatePersonalAlignment(
+  effect: { Fire: number; Water: number; Earth: number; Air: number },
+  bias: { Fire: number; Water: number; Earth: number; Air: number },
+): number {
+  const norm = (v: { Fire: number; Water: number; Earth: number; Air: number }) => {
+    const sum = v.Fire + v.Water + v.Earth + v.Air;
+    if (!(sum > 0)) return null;
+    return { Fire: v.Fire / sum, Water: v.Water / sum, Earth: v.Earth / sum, Air: v.Air / sum };
+  };
+  const a = norm(effect);
+  const b = norm(bias);
+  if (!a || !b) return 50;
+  const tv =
+    0.5 *
+    (Math.abs(a.Fire - b.Fire) +
+      Math.abs(a.Water - b.Water) +
+      Math.abs(a.Earth - b.Earth) +
+      Math.abs(a.Air - b.Air));
+  return Math.max(0, Math.min(100, (1 - tv) * 100));
+}
+
 function calculateSpeedFactor(duration?: { min: number; max: number }): number {
   if (!duration) return 50;
   const avgMinutes = (duration.min + duration.max) / 2;
@@ -208,12 +259,14 @@ interface Weights {
   thermo: number;
   balance: number;
   speed: number;
+  personal: number;
 }
 
 function getWeights(
   userIntent: UserIntent,
   stressContext: AstrologicalStressContext,
   focusMode: FocusMode,
+  hasPersonalBias = false,
 ): Weights {
   // Base weights (sum to ~1.0)
   let weights: Weights = {
@@ -222,20 +275,35 @@ function getWeights(
     thermo: 0.25,
     balance: 0.20,
     speed: 0.10,
+    personal: 0,
   };
 
   // Focus mode overrides
   switch (focusMode) {
     case "quickest":
-      weights = { stability: 0.10, intent: 0.15, thermo: 0.15, balance: 0.10, speed: 0.50 };
+      weights = { stability: 0.10, intent: 0.15, thermo: 0.15, balance: 0.10, speed: 0.50, personal: 0 };
       break;
     case "stability":
-      weights = { stability: 0.45, intent: 0.10, thermo: 0.20, balance: 0.15, speed: 0.10 };
+      weights = { stability: 0.45, intent: 0.10, thermo: 0.20, balance: 0.15, speed: 0.10, personal: 0 };
       break;
     case "flavorful":
-      weights = { stability: 0.10, intent: 0.35, thermo: 0.25, balance: 0.20, speed: 0.10 };
+      weights = { stability: 0.10, intent: 0.35, thermo: 0.25, balance: 0.20, speed: 0.10, personal: 0 };
       break;
     // "harmony" uses default balanced weights
+  }
+
+  // Personal bias present: carve out a fixed share proportionally from the
+  // five base dimensions so each focus mode keeps its relative character.
+  if (hasPersonalBias) {
+    const personalShare = 0.15;
+    weights = {
+      stability: weights.stability * (1 - personalShare),
+      intent: weights.intent * (1 - personalShare),
+      thermo: weights.thermo * (1 - personalShare),
+      balance: weights.balance * (1 - personalShare),
+      speed: weights.speed * (1 - personalShare),
+      personal: personalShare,
+    };
   }
 
   // Dynamic weighting: high-stress astrological window boosts stability
@@ -243,7 +311,9 @@ function getWeights(
     const stabilityBoost = 0.15;
     weights.stability += stabilityBoost;
     // Redistribute from other dimensions proportionally
-    const others = ["intent", "thermo", "balance", "speed"] as const;
+    const others = hasPersonalBias
+      ? (["intent", "thermo", "balance", "speed", "personal"] as const)
+      : (["intent", "thermo", "balance", "speed"] as const);
     const totalOther = others.reduce((s, k) => s + weights[k], 0);
     for (const key of others) {
       weights[key] -= stabilityBoost * (weights[key] / totalOther);


### PR DESCRIPTION
## What

Completes Part 2 of the living-hero personalization (follow-up to #611): the three remaining homepage recommenders now consume the shared `useUserElementalBias` seam. A visitor's table (or signed-in chart) genuinely re-ranks all four recommenders; with no bias, every scoring path is bit-identical to before.

- **Ingredients** — bias blends 70/30 into the `currentElementals` scoring target (renormalized); honest "· tuned to your table/chart" label only when applied.
- **Sauces** — `CuisineSauceContext.userElementals` blends into the cuisine's elemental comparison target (keeps the cosine pipeline's discrimination rather than adding a compressed extra dimension); tuned chip in the results header.
- **Methods** — new sixth "Personal" harmony dimension (total-variation similarity, full 0–100 spread) taking a 0.15 weight share carved proportionally per focus mode, included in the high-stress redistribution; breakdown UI shows the Personal row + tuned chip. `baseAlchemicalProperties` untouched so displayed Kalchm/Monica stay truthful.

## Verification

- typecheck clean, zero-warning eslint on touched files, 148 suites / 1175 tests pass
- Browser A/B: Fire-leaning table → ingredient top-6 visibly reorders + labels appear; **clearing the table live-reverts rankings and labels in one click** (event-driven memos); methods render all six dimensions; sauce chip confirmed
- Local pre-commit repo lint fails only on another session's uncommitted untracked files — CI is the arbiter

🤖 Generated with [Claude Code](https://claude.com/claude-code)