### PR TITLE
feat(astro): planetary free-body diagrams — every force, drawn

### DIFF
--- a/docs/design/planet-fbd-stitch-prompt.md
+++ b/docs/design/planet-fbd-stitch-prompt.md
@@ -1,0 +1,387 @@
+# Planetary Free-Body Diagrams — Stitch Design Prompt
+
+Ready-to-paste prompts for **Google Stitch** to design the **Planetary Free-Body Diagram
+cards** — a per-planet force-vector card that decomposes everything the alchemical engine
+knows about a planet (aspects, sign pull, sect pull, dignity, momentum) into a physics-style
+free-body diagram, plus the two page surfaces that host them: the upgraded `/planetary-chart`
+(current sky) and the birth-chart page (natal). Built from the engine contract in
+`src/calculations/planetaryFBD.ts` — every vector Stitch draws corresponds to a real
+engine-native quantity.
+
+**Division of labor:** Stitch owns the *visual design* — card anatomy, vector styling, page
+composition. Code-side we already have the full data contract (`buildFreeBodyDiagrams` →
+`PlanetFBD[]`), the kinematics model, the dignity table, and the canonical planet colors —
+see **Wiring notes** at the end. Do not let Stitch invent data the engine doesn't produce.
+
+**How to use:** Paste the **Global Style Block** first, then paste each **Screen prompt** as
+its own generation (Stitch generates one screen per prompt; keep the style block at the top
+of each so every screen stays on-brand). Generate **Screen 2 (card anatomy)** first — the
+card is the atom; Screens 1 and 3 are compositions of it.
+
+---
+
+## Design decisions locked in
+
+| # | Decision | Choice |
+|---|----------|--------|
+| Placement | Where the cards live | **Birth-chart page (natal cards)** + an **upgraded `/planetary-chart`** (current sky). The chart wheels stay; cards are added around them |
+| Access | Gating | `/planetary-chart` becomes **fully public — the premium gate is removed**. No locked states in the design |
+| Data | Freshness | **Server-computed per page load, no polling.** No live-updating chrome, no pulsing "LIVE" dots — a computed-at timestamp is the honesty device |
+| Bodies | Card inventory | **The ten modern planets** (Sun→Pluto), one card each. Ascendant participates as an aspect *source* but gets no card |
+| Forces | Vectors per card | **Aspect vectors** (majors + minors, magnitude = cosine-bell strength × orb-budget weight maxOrb/8) + **sign/element pull (0.6)** + **sect pull (0.4)** + **dignity boost/drag** + **momentum** |
+| Geometry | Vector directions | Aspects point at **true ecliptic bearings** (0° = ahead along the zodiac, CCW); element/sect/dignity/momentum use **fixed compasses**: Fire↑ Air→ Water↓ Earth← and Spirit↑ Essence→ Matter↓ Substance← |
+| Kinematics | Applying vs separating | **Applying** = solid filled arrowhead pointing IN at the planet + countdown ("applying · 2.3d to exact"). **Separating** = open outlined arrowhead angled away. Stationary = no arrowhead verdict |
+| Magnitudes | Honesty | **Real engine values, normalized per card** (max = 1, visibility floor 0.12). Raw numbers revealed on hover/tap — never printed as fake precision on the resting card |
+| Backdrop | Card background | A **zoomed arc segment of the zodiac** centered on the planet's exact degree°minute′, with a fine **arc-minute ruler** (15′ majors, 5′ fine ticks) and the occupied sign's glyph as a watermark |
+| Resultant | The headline vector | The **ESMS alchemical tendency** (x = Essence−Substance, y = Spirit−Matter) drawn in the signature gradient, plus elemental push, net harmony, and physics readouts (charge Q, momentum p, speed ω in ′/day, alchemical weight m) |
+| Natal degrade | Stored charts | Natal charts carry no daily motions → cards show a **"STATIC CHART · MOTION UNAVAILABLE"** chip, **no applying/separating verdicts, no momentum vector**. Never fake motion |
+| Wheel overlays | Birth-chart wheel | The natal/transit wheel gains **aspect chords** (harmony teal / tension ember, width ∝ strength) and **radial element sign-vectors** at each natal planet |
+| Interaction | This round | **Hover/tap reveals raw values. No animation** — vectors are static ink; motion is a later round |
+
+### Hard constraints the design MUST respect
+- **Every vector is an engine quantity.** Aspect strength (cosine-bell 0–1), type weight
+  (maxOrb/8 = 0.25–1.0), sign 0.6, sect 0.4, dignity |multiplier−1| (±15%/level, floor
+  ×0.5), momentum |speed × alchemical weight|. Stitch must not invent extra forces,
+  gauges, or scores.
+- **Two compass systems, never conflated.** Fire/Water/Earth/Air (element rose) and
+  Spirit/Essence/Matter/Substance (ESMS rose) are different four-part readings. Element
+  vectors use element colors; the ESMS resultant uses the signature gradient and ESMS
+  glyphs (🜀 🜁 🜃 🜄). Both micro compass roses appear on every card so the axes are
+  always legible.
+- **Card space is polar, zodiac-anchored:** 0° = the direction of increasing ecliptic
+  longitude ("ahead" along the zodiac), increasing counterclockwise. The arc-ruler
+  backdrop makes this physical — "ahead" on the ruler IS 0°.
+- **Per-card normalization:** the longest vector on a card renders at full length; all
+  others scale to it with a 0.12 minimum visible length. Cards are NOT cross-comparable
+  by vector length — the physics footer carries the absolute numbers.
+- **Honest degradation:** no speeds → no kinematics, no momentum, and the static-chart
+  chip. No polling → no live chrome. Missing dignity (score 0 / peregrine) → no dignity
+  vector at all, just the "PEREGRINE" chip.
+- **No animation this round.** No orbit spins, no pulsing, no particle garnish. Hover
+  states are tooltip + highlight only.
+- No lorem ipsum — use the real copy strings and real example numbers given in each
+  screen prompt.
+
+---
+
+## GLOBAL STYLE BLOCK  *(prepend to every screen prompt)*
+
+```
+STYLE: A refined culinary-astrology app's astronomy surface, DARK theme only (never
+white/light surfaces). Premium, precise, quietly technical — think a beautifully typeset
+observatory notebook, NOT a sci-fi console, NOT a game HUD. Clear hierarchy, generous
+spacing, one focal diagram per card.
+
+COLOR PALETTE (dark, use these exact hex):
+- Backgrounds (darkest→lightest surfaces): #07060B, #0E0C16, #15121F, #1C1829, #241F33
+- Text: #F2EDFF (primary), #B5ADCC (secondary/labels), #6E6884 (muted)
+- Primary accent (violet): #B85AF0
+- Secondary accent (copper-gold): #DEA54B
+- Element accents (element vectors, dots, compass roses): Fire #F87171, Earth #34D399,
+  Air #C084FC, Water #60A5FA
+- Aspect polarity: harmony teal #2DD4BF (conjunction/trine/sextile), tension ember
+  #FB923C (opposition/square), neutral #B5ADCC (minor aspects)
+- Signature gradient: 135° copper→violet (#DEA54B → #B85AF0) — reserved for the ESMS
+  resultant vector and the page hero glow only.
+- Canonical planet colors (approximations of the app's oklch tokens; exact tokens applied
+  in build): Sun #DEA54B (copper), Moon #D6CFE8 (pale lavender-silver), Mercury #E3D3A3
+  (airy pale gold), Venus #ECA9A0 (warm rose), Mars #E06A50 (ember red), Jupiter #E5B36B
+  (amber), Saturn #8E8A9C (lead gray-violet), Uranus #5BC8D9 (electric cyan), Neptune
+  #7D8FE0 (deep indigo), Pluto #C06A9E (dark magenta).
+
+SURFACES: Translucent "glass" cards — subtle white 4–8% fill, 1px hairline border, soft
+backdrop blur, rounded corners (14–16px). Diagram ink is thin, precise hairlines — an
+instrument-drawing feel, never neon glow.
+
+TYPOGRAPHY:
+- Headings: an elegant serif (Cormorant Garamond), medium weight, tight letter-spacing.
+- Body: a clean humanist sans (Manrope).
+- All small labels, numbers, coordinates, readouts: a monospace (JetBrains Mono),
+  UPPERCASE, wide letter-spacing (~0.12em), tabular figures. This mono-caps micro-label
+  treatment is the brand signature — every degree, orb, and physics number wears it.
+
+ICONOGRAPHY: Planetary glyphs ☉ ☽ ☿ ♀ ♂ ♃ ♄ ♅ ♆ ♇, zodiac glyphs ♈–♓, aspect glyphs
+☌ ☍ △ □ ⚹ ⚻ ⚺, the retrograde mark ℞, and the four ESMS alchemical symbols 🜀 (Spirit)
+🜁 (Essence) 🜃 (Matter) 🜄 (Substance). Small element dots. Minimal line icons elsewhere.
+No occult ornament beyond these glyph sets, no fake telemetry, no crosshair gauges.
+
+MOOD: The sky as a solved diagram — calm, exact, a little reverent. Every line earns
+its ink.
+```
+
+---
+
+## SCREEN 1 — Planetary Ecosystem (/planetary-chart, desktop 1440px)
+
+```
+[PREPEND GLOBAL STYLE BLOCK]
+
+SCREEN: "Planetary Ecosystem" — the upgraded /planetary-chart page, desktop 1440px,
+fully public (design NO premium locks, NO upgrade prompts). Three stacked zones: sky
+telemetry header, the chart wheel, then the ten-card free-body-diagram grid.
+
+PAGE HEADER: serif title "The Sky, Resolved" with a mono-caps subline "CURRENT SKY ·
+COMPUTED 19 JUL 2026 · 14:32 UTC" (a computed-at stamp, NOT a live badge — no pulsing
+dots anywhere on this page). Below it, the SKY TELEMETRY STRIP: six compact mono-caps
+stat tiles in one row — "HEAT 0.42" · "ENTROPY 0.31" · "REACTIVITY 0.27" · "GREGS
+ENERGY 1.86" · "KALCHM 3.14" · "MONICA 0.98". Each tile: glass chip, muted mono-caps
+label on top, larger tabular number below, a hairline divider between tiles. No gauges,
+no sparklines — clean figures.
+
+CHART WHEEL (center, kept): the existing circular planetary chart occupies the middle
+zone (~560px), zodiac ring with sign glyphs, ten planet glyphs at their true longitudes,
+aspect lines across the wheel colored by polarity (harmony teal #2DD4BF / tension ember
+#FB923C, width proportional to strength). Flank it left/right with two quiet glass
+panels: left = a mono-caps position table (PLANET · SIGN · DEG°MIN′ · SPEED ′/DAY, ten
+rows, ℞ marks on retrogrades); right = an aspect ledger (glyph pair, type, orb, and an
+"applying · 2.3d" or "separating · 5.1d" mono verdict per row).
+
+FBD GRID (below the wheel): mono-caps section label "FREE-BODY DIAGRAMS · TEN BODIES ·
+FORCES TO SCALE PER CARD". A 2-row × 5-column grid of square-ish FBD cards (~264px),
+Sun→Pluto in canonical order, each rendered per the FBD CARD ANATOMY spec (compact
+variant: header row, arc-ruler backdrop, vectors, resultant, slim physics footer — the
+corner compass roses may shrink to 24px at this size). Each card's planet glyph orb uses
+that planet's canonical color so the grid reads as one system: copper Sun, silver Moon,
+pale-gold Mercury, rose Venus, ember Mars, amber Jupiter, lead Saturn, cyan Uranus,
+indigo Neptune, magenta Pluto.
+
+Show ONE card in its hover state (Mars): a small dark tooltip pinned to one aspect
+vector reading "□ SATURN · orb 2°14′ · strength 72% × weight 0.88 · applying · 3.1d to
+exact" in mono-caps, and the hovered vector highlighted while siblings dim slightly.
+
+MOBILE NOTES (390px): the telemetry strip becomes a 3×2 grid of stat chips; the wheel
+scales to full width; the FBD grid collapses to ONE column (cards full-width, ~340px
+tall); the position table and aspect ledger fold into collapsible sections under the
+wheel. Same computed-at stamp, same no-live-chrome rule.
+
+Do NOT include: premium locks or upgrade banners, live/pulsing indicators, auto-refresh
+chrome, invented metrics beyond the six named, gauges or radial dials in the telemetry
+strip.
+```
+
+---
+
+## SCREEN 2 — FBD Card Anatomy (one card, full size) — THE ATOM
+
+```
+[PREPEND GLOBAL STYLE BLOCK]
+
+SCREEN: One "Planetary Free-Body Diagram" card at full size (~420×520px) on the dark
+canvas, plus its hover-tooltip state as an inset. This is the atom of the whole feature —
+design it as a precise instrument drawing. Use MARS as the specimen with these exact
+real-shaped values.
+
+CARD HEADER ROW: left — the planet glyph ♂ inside a small circular orb tinted Mars ember
+#E06A50, then "Mars" in serif 20px. Right — a mono-caps position readout "♑ 18°42′"
+(sign glyph + degree°minute′, tabular mono), a small "℞" badge in a hairline pill ONLY
+when retrograde (show it OFF for Mars here), and a DIGNITY CHIP: "EXALTED ×1.30" in a
+harmony-teal-tinted pill (dignity states: EXALTED DOMICILE / EXALTED / DIGNIFIED /
+PEREGRINE / DETRIMENT / FALL / DEBILITATED; boosts tint teal, drags tint ember,
+PEREGRINE stays neutral gray with no vector).
+
+BACKDROP — ZOOMED ARC RULER: the card's diagram zone is backed by a gently curved
+horizontal band (a zoomed segment of the zodiac arc, curvature subtle, ~8° of arc
+implied) centered on the planet's exact position 18°42′. A fine ruler runs along the
+band: major ticks every 15′ with tiny mono labels ("18°30′", "18°45′", "19°00′"), fine
+ticks every 5′, hairline weight, muted #6E6884. Behind the ruler, the occupied sign's
+glyph (♑) as a huge, very-low-opacity watermark. The ruler's "ahead" direction
+(increasing longitude) points RIGHT — this anchors the vector space: 0° = right = ahead
+along the zodiac, angles increase counterclockwise.
+
+CENTRAL NODE + VECTORS: the planet sits at the card's center as a small filled circle in
+its planet color with the ♂ glyph. Force vectors radiate from it as thin precise arrows,
+length = normalized magnitude (longest force = full length, everything else to scale,
+nothing shorter than 12% so all forces stay visible):
+- ASPECT VECTORS point at the TRUE BEARING of the partner body along the ecliptic.
+  Color by polarity (harmony teal / tension ember / neutral gray for minors). Label at
+  the tip: aspect glyph + partner in mono-caps ("△ VENUS", "□ SATURN", "⚹ MOON").
+  APPLYING aspects get a SOLID FILLED arrowhead pointing IN at the planet plus a
+  countdown micro-label "applying · 2.3d to exact"; SEPARATING aspects get an OPEN
+  OUTLINED arrowhead angled away from the planet with "separating · 5.1d". Draw three
+  aspects on this card: △ VENUS (teal, long, applying · 2.3d), □ SATURN (ember, medium,
+  separating · 5.1d), ⚹ MOON (teal, short, applying · 0.8d).
+- SIGN PULL: one element-colored vector along the sign's element axis — Capricorn →
+  Earth, so it points LEFT (Earth ← 180°) in Earth green #34D399, labeled "CAPRICORN →
+  EARTH · 0.60".
+- SECT PULL: a slightly shorter vector along the sect element axis, labeled "SECT →
+  FIRE · 0.40", Fire red #F87171 pointing UP (Fire ↑ 90°).
+- DIGNITY: a short boost vector ALONG the sign-element axis (teal-tinted, labeled
+  "EXALTED +30%"); if the planet were debilitated it would point AGAINST that axis in
+  ember. Peregrine planets get no dignity vector.
+- MOMENTUM: a vector at 0° (right, direct motion) labeled "MOMENTUM", muted violet tint;
+  retrograde planets flip it to 180° and label it "℞ MOMENTUM".
+- ESMS RESULTANT (the headline): one heavier arrow in the 135° copper→violet signature
+  gradient, at its ESMS-rose angle, with the dominant ESMS alchemical symbol at its tip
+  in a tiny circle (🜀 Spirit / 🜁 Essence / 🜃 Matter / 🜄 Substance — use 🜁 here) and a
+  mono-caps label "TENDENCY → ESSENCE".
+
+CORNER MICRO COMPASS ROSES (both always present, ~34px):
+- bottom-left: the ELEMENT rose — four tiny spokes labeled with element dots, Fire up /
+  Air right / Water down / Earth left, in the four element colors.
+- bottom-right: the ESMS rose — four tiny spokes labeled 🜀 up / 🜁 right / 🜃 down /
+  🜄 left, rendered in muted copper.
+
+TELEMETRY FOOTER: a slim hairline-topped strip of mono-caps readouts in two rows.
+Row 1 — the ESMS quartet: "🜀 0.42 · 🜁 0.88 · 🜃 0.31 · 🜄 0.19". Row 2 — physics:
+"Q 0.50 · p 0.38 · ω 31.2′/DAY · m 0.61 · HARMONY +1.4" (charge, momentum, speed in
+arc-minutes/day, alchemical weight, net harmony; harmony is signed — tint + teal,
+− ember).
+
+HOVER TOOLTIP INSET: the same card with the □ SATURN vector hovered — vector and label
+at full opacity, siblings dimmed to ~40%, and a small dark tooltip: "SQUARE · ORB 2°14′
+· STRENGTH 72% × WEIGHT 0.88 · SEPARATING · 5.1D SINCE EXACT" plus a second muted line
+"ESMS Δ 🜀 −0.04 · 🜃 +0.09". Raw numbers live HERE, not on the resting card.
+
+MOBILE NOTES (390px): the card runs full-width; labels may drop to glyph-only at the
+vector tips with the full text moving into the tap-tooltip; both compass roses stay; the
+footer wraps to a 2×2 chip grid. Tap = the hover state.
+
+Do NOT include: animation cues, motion blur, orbit rings around the node, radial gauge
+chrome, invented forces, glow-heavy neon strokes, or numbers without their engine
+sources.
+```
+
+---
+
+## SCREEN 3 — Natal Cartography (birth-chart page, desktop 1440px)
+
+```
+[PREPEND GLOBAL STYLE BLOCK]
+
+SCREEN: "Natal Cartography" — the birth-chart page upgraded with vector overlays on the
+wheel and a natal FBD card row, desktop 1440px. State: a signed-in user's stored natal
+chart (which carries NO planetary speeds — this screen demonstrates the honest static
+degrade).
+
+TOP: keep the page's existing header idiom — serif title "Your Birth Chart" + a
+mono-caps subline "NATAL · 14 MAR 1991 · 08:42 · BROOKLYN NY". Beside it, one honest
+status chip in a hairline pill: "STATIC CHART · MOTION UNAVAILABLE" (muted gray, no
+alarm styling — this is a fact, not an error).
+
+NATAL WHEEL (center, upgraded): the existing natal/transit wheel, now with two new
+overlay families —
+1. ASPECT CHORDS: straight chords connecting aspecting natal planets across the wheel's
+   interior, harmony teal #2DD4BF for conjunction/trine/sextile, tension ember #FB923C
+   for opposition/square, neutral #B5ADCC hairlines for minors; chord WIDTH proportional
+   to aspect strength (exact aspects visibly heavier). Chords sit under the planet
+   glyphs, ~60% opacity so the wheel stays readable.
+2. ELEMENT SIGN-VECTORS: at each natal planet, a short RADIAL vector pointing outward
+   from the wheel center through the planet, colored by the planet's SIGN element (Fire
+   #F87171 / Earth #34D399 / Air #C084FC / Water #60A5FA), length modest and uniform —
+   these mark each planet's elemental pull, they do not compete with the chords.
+A small legend chip row under the wheel: "— HARMONY · — TENSION · — MINOR · ↑ SIGN
+ELEMENT" in mono-caps with the matching stroke samples.
+
+NATAL FBD CARD ROW (below the wheel): mono-caps section label "NATAL FREE-BODY DIAGRAMS
+· STATIC CHART". A horizontally scrolling row of the ten FBD cards (compact ~264px
+variant from the card-anatomy spec), Sun→Pluto, with the natal degrade applied to EVERY
+card: a small "STATIC CHART · MOTION UNAVAILABLE" chip in the header area, NO momentum
+vector, NO applying/separating arrowhead verdicts on aspect vectors (aspect arrows keep
+their bearing/length/color but end in plain neutral arrowheads, and their micro-labels
+read only "orb 3°05′ · strength 64%" — no countdowns), and the footer physics row drops
+p and ω, showing "Q 0.50 · m 0.61 · HARMONY +0.9" only. Everything else — sign pull,
+sect pull, dignity, ESMS resultant, both compass roses, ESMS quartet — remains, because
+none of it needs motion. Show a subtle horizontal-scroll affordance (edge fade + "10
+BODIES →" mono hint).
+
+MOBILE NOTES (390px): wheel full-width with the legend row wrapping to two lines; the
+card row stays a horizontal swipe rail with snap points, one card ~85% viewport width;
+the static-chart status chip moves directly under the page title.
+
+Do NOT include: fake motion on natal cards (no countdowns, no applying/separating
+anywhere on this screen), transit-vs-natal confusion (this screen is natal-only ink),
+premium locks, animation cues.
+```
+
+---
+
+## CONDENSED ONE-SHOT PROMPT  *(single paragraph, for Stitch quick mode)*
+
+Use this when you want one block instead of the per-screen set (attach the structured
+prompt above as extra context for finer detail).
+
+```
+Design a "Planetary Free-Body Diagram" card for a refined dark-theme culinary-astrology
+app — a physics-style force diagram for one planet, drawn like a precise observatory
+instrument, NOT a sci-fi HUD. Palette: backgrounds #07060B→#241F33, text #F2EDFF/#B5ADCC/
+#6E6884, violet #B85AF0, copper #DEA54B, element colors Fire #F87171 Earth #34D399 Air
+#C084FC Water #60A5FA, harmony teal #2DD4BF, tension ember #FB923C, and a 135°
+copper→violet gradient reserved for the resultant vector. Glass card (white 4–8% fill,
+1px hairline border, soft blur, 14–16px radius), serif headings (Cormorant Garamond),
+Manrope body, and UPPERCASE wide-tracked JetBrains Mono for every number and micro-label.
+Card for MARS: header row with the ♂ glyph in an ember-tinted orb, "Mars" in serif, a
+mono readout "♑ 18°42′", and a teal dignity chip "EXALTED ×1.30". The diagram zone is
+backed by a gently curved zoomed zodiac-arc band centered on 18°42′ with a fine
+arc-minute ruler (15′ major ticks with tiny mono labels, 5′ fine ticks) and a huge
+low-opacity ♑ watermark; increasing longitude points right. From a central ember planet
+node, thin precise force vectors radiate to scale: three aspect vectors at true bearings
+— "△ VENUS" (teal, solid filled arrowhead pointing in at the planet, micro-label
+"applying · 2.3d to exact"), "□ SATURN" (ember, open outlined arrowhead angled away,
+"separating · 5.1d"), "⚹ MOON" (teal, short, applying) — plus an Earth-green sign-pull
+vector left labeled "CAPRICORN → EARTH · 0.60", a Fire-red sect vector up "SECT → FIRE ·
+0.40", a short teal dignity boost "EXALTED +30%", a muted momentum vector right, and one
+heavier copper→violet gradient RESULTANT arrow tipped with the alchemical symbol 🜁 and
+labeled "TENDENCY → ESSENCE". Two 34px micro compass roses in the bottom corners:
+elements (Fire↑ Air→ Water↓ Earth←) bottom-left in element colors, ESMS (🜀↑ 🜁→ 🜃↓ 🜄←)
+bottom-right in muted copper. Slim mono telemetry footer: "🜀 0.42 · 🜁 0.88 · 🜃 0.31 ·
+🜄 0.19" over "Q 0.50 · p 0.38 · ω 31.2′/DAY · m 0.61 · HARMONY +1.4". Include a hover
+inset: one vector highlighted, siblings dimmed, dark tooltip with the raw numbers
+("SQUARE · ORB 2°14′ · STRENGTH 72% × WEIGHT 0.88 · SEPARATING · 5.1D SINCE EXACT").
+Static ink only — no animation, no gauges, no neon glow, no invented metrics.
+```
+
+**Retarget trick:** keep everything through the typography sentence, then swap the layout
+description to aim the one-shot at a page composition instead (the /planetary-chart
+telemetry strip + wheel + 2×5 card grid, or the natal wheel with teal/ember aspect chords,
+radial sign-vectors, and the static-chart card row).
+
+---
+
+## After Stitch generates — wiring notes (for the follow-up implementation)
+
+When the Stitch output comes back, we wire it into the codebase against these anchors:
+
+- **Data contract (already written):** `src/calculations/planetaryFBD.ts` —
+  `buildFreeBodyDiagrams({ positions, perPlanet })` → `PlanetFBD[]`. Every visual element
+  maps 1:1: `vectors[]` (kind aspect/sign/sect/dignity/momentum, `angleDeg` in card space,
+  `normalized` display length with the 0.12 floor, `detail` = the tooltip string),
+  `resultant` (ESMS angle/magnitude/dominant + `elementalPush` + `netHarmony`), `physics`
+  (charge/momentum/speed/arcminutesPerDay/alchmWeight), `dignity`, `kinematicsAvailable`,
+  and `normalizationScale` (the raw magnitude that renders at full length). The card is a
+  pure renderer of this shape — no design-side math.
+- **Card component (new):** `src/components/ui/alchm/PlanetFBDCard.tsx` — SVG mapping from
+  card space is `x = cos(θ), y = −sin(θ)`. Applying/separating arrowhead treatment keys off
+  `vector.aspect.kinematics.state`; natal cards arrive with `kinematics: null` per aspect
+  and `kinematicsAvailable: false` per card → render the STATIC CHART chip and plain
+  arrowheads. Tooltip content comes verbatim from `vector.detail` + `aspect.esmsDelta`.
+- **Planet colors/glyphs:** `src/components/ui/alchm/planetColors.ts` — `planetColor()` /
+  `planetGlyph()` are canonical; the hexes in the style block are mock-only approximations
+  of its oklch tokens. Do not add a fourth planet-color convention.
+- **ESMS glyphs:** reuse the `ThermoQuartet` convention — 🜀 Spirit, 🜁 Essence, 🜃 Matter,
+  🜄 Substance.
+- **Current-sky page:** `src/app/(alchm)/planetary-chart/page.tsx` — REMOVE the
+  `PremiumGate` wrapper (`advancedPlanetaryCharts`), keep the existing `PlanetaryChart`
+  wheel + `useChartData`, add the telemetry strip (HEAT/ENTROPY/REACTIVITY/GREGS ENERGY/
+  KALCHM/MONICA from the alchemical result) and the 2×5 FBD grid. Positions from
+  `useChartData` carry `longitudeSpeed` → full kinematics. Server-computed per load; the
+  existing 60s auto-refresh may stay code-side but the design shows a computed-at stamp,
+  never live chrome.
+- **Natal wheel overlays:** `src/components/dashboard/NatalTransitChart.tsx` — add the
+  aspect-chord layer (polarity color, width ∝ strength, from
+  `buildAspectsFromChartPlanets`/`calculateComprehensiveAspects`) and the radial
+  sign-element vector layer at each natal planet.
+- **Natal page:** `src/app/(alchm)/birth-chart/page.tsx` — mount the horizontal natal FBD
+  card row fed by the stored chart (no speeds → honest degrade path). Per-planet ESMS
+  contributions come from `alchemizeDetailed().perPlanet` (`FBDPerPlanetContribution` is
+  its structural mirror; `planetaryFBD.ts` deliberately never imports the fs-bound
+  service — compute server-side and pass the plain object down).
+- **Kinematics:** `src/utils/aspectKinematics.ts` — `computeAspectKinematics` is shared
+  with `/api/alchm-quantities/aspects`; countdown copy = `applying · {daysToExact}d to
+  exact` / `separating · {d}d since exact`; `stationary` (|orb velocity| < 1e-4) gets
+  neither arrowhead verdict.
+- **Dignity:** `src/calculations/planetaryDignity.ts` — chip label from `dignityLabel`
+  (exalted domicile → debilitated), multiplier from `dignityMultiplier` (±15%/level,
+  floor ×0.5); score 0 = PEREGRINE chip, no vector.
+- **Verify bar:** typecheck + zero-warning eslint; `/planetary-chart` renders logged-out
+  (gate gone); natal cards show no countdowns/momentum; hover tooltips show raw engine
+  numbers matching `vector.detail`.

--- a/src/__tests__/calculations/planetaryFBD.test.ts
+++ b/src/__tests__/calculations/planetaryFBD.test.ts
@@ -1,0 +1,775 @@
+/**
+ * Tests for planetaryFBD — the free-body-diagram builder.
+ *
+ * The builder no longer accepts a caller-supplied `perPlanet` stub: it derives
+ * every ESMS number from the engine's own three-layer decomposition
+ * (calculateEnhancedAlchemicalFromPlanetsDetailed). That makes the cards a
+ * DECOMPOSITION of the sky rather than a lookalike recomputation, so the
+ * headline test here is the reconciliation invariant:
+ *
+ *   Σ cards[].esms + totals.groundingVessel.esms === totals.esms
+ *
+ * The remaining suites use small hand-computable synthetic skies where the
+ * expected geometry is obvious by inspection.
+ */
+import {
+  ELEMENT_ANGLES,
+  buildFreeBodyDiagrams,
+  formatDegMin,
+  normalizeAngle,
+  signedDeltaDeg,
+  type BuildFBDInput,
+  type FBDPositionInput,
+  type PlanetFBD,
+} from "@/calculations/planetaryFBD";
+import { getAspectESMSEffect } from "@/utils/aspectESMSEffects";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Axis = "Spirit" | "Essence" | "Matter" | "Substance";
+const AXES: Axis[] = ["Spirit", "Essence", "Matter", "Substance"];
+
+/** Reconciliation tolerance — the invariant is exact up to float accumulation. */
+const EPSILON = 1e-9;
+
+function byPlanet(cards: PlanetFBD[], planet: string): PlanetFBD {
+  const card = cards.find((c) => c.planet === planet);
+  if (!card) throw new Error(`no card for ${planet}`);
+  return card;
+}
+
+function sumCardEsms(cards: PlanetFBD[]): Record<Axis, number> {
+  return cards.reduce<Record<Axis, number>>(
+    (acc, card) => {
+      for (const axis of AXES) acc[axis] += card.esms[axis];
+      return acc;
+    },
+    { Spirit: 0, Essence: 0, Matter: 0, Substance: 0 },
+  );
+}
+
+/**
+ * A full ten-planet sky with self-consistent sign/longitude pairs, producing 19
+ * aspects. No Ascendant is supplied, so the engine injects the grounding
+ * vessel — exactly the "live sky" path that has no computed rising sign.
+ *
+ * The longitudes are deliberately off round numbers so that no pair lands
+ * EXACTLY on an aspect's maximum orb. A max-orb pair has cosine-bell strength
+ * exactly 0, and calculateAspectESMSModifications' `aspect.strength || 1.0`
+ * then reads that 0 as "no strength supplied" and applies the effect at FULL
+ * weight — so the engine's Layer-3 total would disagree with the per-aspect
+ * deltas the cards split. That is an upstream quirk in aspectESMSEffects, not
+ * an FBD behaviour, so this fixture stays clear of the degenerate case.
+ */
+const RICH_SKY_POSITIONS: Record<string, FBDPositionInput> = {
+  Sun: { sign: "leo", degree: 15.4, exactLongitude: 135.4, longitudeSpeed: 0.98 },
+  Moon: { sign: "cancer", degree: 2.3, exactLongitude: 92.3, longitudeSpeed: 13.2 },
+  Mercury: { sign: "virgo", degree: 1.7, exactLongitude: 151.7, longitudeSpeed: 1.4 },
+  Venus: { sign: "virgo", degree: 20.9, exactLongitude: 170.9, longitudeSpeed: 1.1 },
+  Mars: { sign: "cancer", degree: 10.2, exactLongitude: 100.2, longitudeSpeed: 0.52 },
+  Jupiter: { sign: "aries", degree: 0.6, exactLongitude: 0.6, longitudeSpeed: 0.13 },
+  Saturn: { sign: "pisces", degree: 7.8, exactLongitude: 337.8, longitudeSpeed: 0.03 },
+  Uranus: { sign: "taurus", degree: 11.5, exactLongitude: 41.5, longitudeSpeed: 0.04 },
+  Neptune: { sign: "pisces", degree: 24.6, exactLongitude: 354.6, longitudeSpeed: -0.01 },
+  Pluto: { sign: "aquarius", degree: 0.9, exactLongitude: 300.9, longitudeSpeed: -0.02 },
+};
+
+// ---------------------------------------------------------------------------
+// THE KEY INVARIANT — the cards must decompose the sky, not approximate it
+// ---------------------------------------------------------------------------
+
+describe("buildFreeBodyDiagrams — reconciliation invariant", () => {
+  for (const diurnal of [true, false]) {
+    describe(`${diurnal ? "day" : "night"} chart`, () => {
+      const { cards, totals } = buildFreeBodyDiagrams({
+        positions: RICH_SKY_POSITIONS,
+        diurnal,
+      });
+
+      test("every one of the ten planets gets a card", () => {
+        expect(cards).toHaveLength(10);
+      });
+
+      test("Σ cards[].esms + groundingVessel.esms === totals.esms on all four axes", () => {
+        const vessel = totals.groundingVessel;
+        expect(vessel).not.toBeNull();
+        const summed = sumCardEsms(cards);
+
+        for (const axis of AXES) {
+          const reconciled = summed[axis] + (vessel?.esms[axis] ?? 0);
+          expect(Math.abs(reconciled - totals.esms[axis])).toBeLessThan(EPSILON);
+        }
+      });
+
+      test("the grounding vessel is injected when no Ascendant is supplied", () => {
+        expect(totals.groundingVessel?.injected).toBe(true);
+        // Physical Vessel = flat (+1) to all four, weight 1.0, dignity Neutral.
+        for (const axis of AXES) {
+          expect(totals.groundingVessel?.esms[axis]).toBeCloseTo(1, 9);
+        }
+      });
+
+      test("the aspect layer is already inside totals.esms, not added on top", () => {
+        for (const axis of AXES) {
+          expect(Number.isFinite(totals.aspectModifications[axis])).toBe(true);
+        }
+        // Σ cards already carries the FULL aspect layer: each pair effect is
+        // split in half across two cards, so the halves re-add to the whole.
+        const summed = sumCardEsms(cards);
+        const vessel = totals.groundingVessel;
+        for (const axis of AXES) {
+          const planetBaseLayer =
+            summed[axis] - totals.aspectModifications[axis];
+          const engineBaseLayer =
+            totals.esms[axis] - totals.aspectModifications[axis] - (vessel?.esms[axis] ?? 0);
+          expect(planetBaseLayer).toBeCloseTo(engineBaseLayer, 9);
+        }
+      });
+    });
+  }
+
+  test("in a DAY chart Matter/Substance come entirely from the grounding vessel", () => {
+    // Every planet maps to Spirit/Essence in the diurnal sect, so the planets'
+    // base Matter/Substance is 0 and the whole material floor is the vessel.
+    // A regression that drops the vessel makes the cards claim Q = 0 for the
+    // entire sky — which is why this is asserted separately from the sum.
+    const { cards, totals } = buildFreeBodyDiagrams({
+      positions: RICH_SKY_POSITIONS,
+      diurnal: true,
+    });
+    const summed = sumCardEsms(cards);
+
+    for (const axis of ["Matter", "Substance"] as Axis[]) {
+      // Whatever Matter/Substance the cards carry is purely the aspect layer.
+      expect(summed[axis]).toBeCloseTo(totals.aspectModifications[axis], 9);
+      // …and the vessel supplies a real, non-zero material floor.
+      expect(totals.groundingVessel?.esms[axis]).toBeGreaterThan(0);
+    }
+  });
+
+  test("in a NIGHT chart the planets themselves carry Matter", () => {
+    const { cards, totals } = buildFreeBodyDiagrams({
+      positions: RICH_SKY_POSITIONS,
+      diurnal: false,
+    });
+    const summed = sumCardEsms(cards);
+    expect(summed.Matter - totals.aspectModifications.Matter).toBeGreaterThan(0);
+  });
+
+  test("a SUPPLIED Ascendant is still card-less, still reconciles, and is not flagged injected", () => {
+    // 18° virgo aspects neither body, so the only aspect is the Mars–Venus
+    // trine and the vessel's contribution is purely Layer 1×2.
+    const { cards, totals } = buildFreeBodyDiagrams({
+      positions: {
+        Mars: { sign: "cancer", degree: 10, exactLongitude: 100 },
+        Venus: { sign: "scorpio", degree: 10, exactLongitude: 220 },
+        Ascendant: { sign: "virgo", degree: 18, exactLongitude: 168 },
+      },
+      diurnal: true,
+    });
+
+    expect(cards.map((c) => c.planet)).toEqual(["Venus", "Mars"]);
+    expect(cards.find((c) => c.planet === "Ascendant")).toBeUndefined();
+    // Supplied rather than injected this time.
+    expect(totals.groundingVessel?.injected).toBe(false);
+
+    const summed = sumCardEsms(cards);
+    for (const axis of AXES) {
+      const reconciled = summed[axis] + (totals.groundingVessel?.esms[axis] ?? 0);
+      expect(Math.abs(reconciled - totals.esms[axis])).toBeLessThan(EPSILON);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signedDeltaDeg / normalizeAngle / formatDegMin
+// ---------------------------------------------------------------------------
+
+describe("signedDeltaDeg", () => {
+  test("wraps forward across 0° Aries: 350° → 10° is +20", () => {
+    expect(signedDeltaDeg(350, 10)).toBeCloseTo(20, 9);
+  });
+
+  test("wraps backward across 0° Aries: 10° → 350° is −20", () => {
+    expect(signedDeltaDeg(10, 350)).toBeCloseTo(-20, 9);
+  });
+
+  test("±180° boundary lands in (−180, 180]", () => {
+    expect(signedDeltaDeg(0, 180)).toBeCloseTo(180, 9);
+    expect(signedDeltaDeg(180, 0)).toBeCloseTo(180, 9); // −180 excluded → +180
+    expect(signedDeltaDeg(90, 270)).toBeCloseTo(180, 9);
+    expect(signedDeltaDeg(270, 90)).toBeCloseTo(180, 9);
+  });
+
+  test("plain offsets stay signed", () => {
+    expect(signedDeltaDeg(100, 220)).toBeCloseTo(120, 9);
+    expect(signedDeltaDeg(220, 100)).toBeCloseTo(-120, 9);
+    expect(signedDeltaDeg(45, 45)).toBeCloseTo(0, 9);
+  });
+});
+
+describe("normalizeAngle", () => {
+  test("maps into [0, 360)", () => {
+    expect(normalizeAngle(-120)).toBeCloseTo(240, 9);
+    expect(normalizeAngle(370)).toBeCloseTo(10, 9);
+    expect(normalizeAngle(360)).toBeCloseTo(0, 9);
+    expect(normalizeAngle(450)).toBeCloseTo(90, 9);
+    expect(normalizeAngle(-360)).toBeCloseTo(0, 9);
+  });
+});
+
+describe("formatDegMin", () => {
+  test("zero-pads arc-minutes", () => {
+    expect(formatDegMin(18, 42)).toBe("18°42′");
+    expect(formatDegMin(3, 5)).toBe("3°05′");
+    expect(formatDegMin(0, 0)).toBe("0°00′");
+  });
+
+  test("floors fractional inputs rather than rounding into 60", () => {
+    expect(formatDegMin(12.9, 59.9)).toBe("12°59′");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Aspect vectors — exact trine (harmonious) and exact square (challenging)
+// ---------------------------------------------------------------------------
+
+const TRINE_SKY: BuildFBDInput = {
+  // Mars 10° cancer (fall) and Venus 10° scorpio (detriment) — exactly 120°.
+  positions: {
+    Mars: { sign: "cancer", degree: 10, exactLongitude: 100, longitudeSpeed: 0.5 },
+    Venus: { sign: "scorpio", degree: 10, exactLongitude: 220, longitudeSpeed: 1.2 },
+  },
+  diurnal: true,
+};
+
+describe("aspect vectors (exact trine)", () => {
+  const { cards } = buildFreeBodyDiagrams(TRINE_SKY);
+
+  test("the only aspect in a two-body sky 120° apart is one exact trine", () => {
+    const mars = byPlanet(cards, "Mars");
+    const aspectVectors = mars.vectors.filter((v) => v.kind === "aspect");
+    expect(aspectVectors).toHaveLength(1);
+    expect(aspectVectors[0].source).toBe("Venus");
+    expect(aspectVectors[0].aspect?.type).toBe("trine");
+  });
+
+  test("bearing, magnitude and polarity of an exact trine", () => {
+    const mars = byPlanet(cards, "Mars");
+    const trine = mars.vectors.find((v) => v.kind === "aspect");
+
+    expect(trine?.aspect?.orb).toBeCloseTo(0, 9);
+    expect(trine?.aspect?.strength).toBeCloseTo(1, 9);
+    // Trine's engine orb budget is 8 → baseWeight 8/8 = 1.
+    expect(trine?.aspect?.baseWeight).toBeCloseTo(1, 9);
+    // angleDeg is the NORMALIZED signed ecliptic offset to the other body.
+    expect(trine?.aspect?.offsetDeg).toBeCloseTo(120, 9);
+    expect(trine?.angleDeg).toBeCloseTo(normalizeAngle(signedDeltaDeg(100, 220)), 9);
+    // magnitude = strength × baseWeight = 1 × (8/8) = 1 at exact orb.
+    expect(trine?.magnitude).toBeCloseTo(1, 9);
+    expect(trine?.polarity).toBe("harmonious");
+  });
+
+  test("the partner card sees the mirrored bearing (240°)", () => {
+    const venus = byPlanet(cards, "Venus");
+    const trine = venus.vectors.find((v) => v.kind === "aspect");
+    expect(trine?.source).toBe("Mars");
+    expect(trine?.angleDeg).toBeCloseTo(240, 9);
+    expect(trine?.aspect?.offsetDeg).toBeCloseTo(-120, 9);
+  });
+
+  test("each card carries HALF the pair's ESMS delta, so the pair re-adds to one", () => {
+    const mars = byPlanet(cards, "Mars");
+    const venus = byPlanet(cards, "Venus");
+    const strength = mars.vectors.find((v) => v.kind === "aspect")?.aspect?.strength ?? NaN;
+    const effect = getAspectESMSEffect("Mars", "Venus", "trine");
+
+    const marsDelta = mars.vectors.find((v) => v.kind === "aspect")?.aspect?.esmsDelta;
+    expect(marsDelta?.Spirit).toBeCloseTo(effect.Spirit * strength, 9);
+    expect(marsDelta?.Essence).toBeCloseTo(effect.Essence * strength, 9);
+    expect(mars.vectors.find((v) => v.kind === "aspect")?.aspect?.description).toBe(
+      effect.description,
+    );
+
+    // netHarmony: one harmonious aspect at strength 1 on each card.
+    expect(mars.resultant.netHarmony).toBeCloseTo(strength, 9);
+    expect(venus.resultant.netHarmony).toBeCloseTo(strength, 9);
+  });
+
+  test("physics.charge is aspect-INCLUSIVE — it equals the card's own Matter + Substance", () => {
+    for (const card of cards) {
+      expect(card.physics.charge).toBeCloseTo(
+        card.esms.Matter + card.esms.Substance,
+        9,
+      );
+      // esms and resultant.esms are the same aspect-inclusive row.
+      expect(card.resultant.esms.Matter).toBeCloseTo(card.esms.Matter, 9);
+      expect(card.resultant.esms.Substance).toBeCloseTo(card.esms.Substance, 9);
+    }
+  });
+});
+
+describe("aspect vectors (exact square)", () => {
+  test("a 90° separation is a challenging square weighted 7/8", () => {
+    const { cards } = buildFreeBodyDiagrams({
+      positions: {
+        Mars: { sign: "cancer", degree: 10, exactLongitude: 100 },
+        Saturn: { sign: "libra", degree: 10, exactLongitude: 190 },
+      },
+      diurnal: true,
+    });
+
+    const square = byPlanet(cards, "Mars").vectors.find((v) => v.kind === "aspect");
+    expect(square?.aspect?.type).toBe("square");
+    expect(square?.aspect?.orb).toBeCloseTo(0, 9);
+    expect(square?.aspect?.strength).toBeCloseTo(1, 9);
+    expect(square?.aspect?.baseWeight).toBeCloseTo(7 / 8, 9);
+    expect(square?.magnitude).toBeCloseTo(7 / 8, 9);
+    expect(square?.angleDeg).toBeCloseTo(90, 9);
+    expect(square?.polarity).toBe("challenging");
+    // Challenging aspects push netHarmony negative.
+    expect(byPlanet(cards, "Mars").resultant.netHarmony).toBeCloseTo(-1, 9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Applying vs separating
+// ---------------------------------------------------------------------------
+
+/** Mars 100°, Venus 222° — a 2° orb off an exact trine, so the orb can close. */
+function wideTrine(marsSpeed?: number, venusSpeed?: number): BuildFBDInput {
+  return {
+    positions: {
+      Mars: {
+        sign: "cancer",
+        degree: 10,
+        exactLongitude: 100,
+        ...(marsSpeed === undefined ? {} : { longitudeSpeed: marsSpeed }),
+      },
+      Venus: {
+        sign: "scorpio",
+        degree: 12,
+        exactLongitude: 222,
+        ...(venusSpeed === undefined ? {} : { longitudeSpeed: venusSpeed }),
+      },
+    },
+    diurnal: true,
+  };
+}
+
+describe("aspect kinematics (applying / separating / degraded)", () => {
+  test("closing the orb reads as applying", () => {
+    // Mars (behind) gains on Venus → the 122° separation shrinks toward 120°.
+    const { cards } = buildFreeBodyDiagrams(wideTrine(1.0, 0.2));
+    const mars = byPlanet(cards, "Mars");
+    const k = mars.vectors.find((v) => v.kind === "aspect")?.aspect?.kinematics;
+
+    expect(k).not.toBeNull();
+    expect(k?.applying).toBe(true);
+    expect(k?.state).toBe("applying");
+    expect(k?.orbVelocity).toBeLessThan(0);
+    expect(k?.relativeAngularVelocity).toBeCloseTo(1.0 - 0.2, 9);
+    expect(mars.kinematicsAvailable).toBe(true);
+  });
+
+  test("opening the orb reads as separating", () => {
+    const { cards } = buildFreeBodyDiagrams(wideTrine(0.2, 1.0));
+    const k = byPlanet(cards, "Mars").vectors.find((v) => v.kind === "aspect")?.aspect
+      ?.kinematics;
+
+    expect(k).not.toBeNull();
+    expect(k?.applying).toBe(false);
+    expect(k?.state).toBe("separating");
+    expect(k?.orbVelocity).toBeGreaterThan(0);
+    expect(k?.relativeAngularVelocity).toBeCloseTo(0.2 - 1.0, 9);
+  });
+
+  test("no speeds at all (stored natal chart) degrades honestly", () => {
+    const { cards } = buildFreeBodyDiagrams(wideTrine());
+    const mars = byPlanet(cards, "Mars");
+
+    // The aspect is still drawn — only its verdict is withheld.
+    expect(mars.vectors.find((v) => v.kind === "aspect")).toBeDefined();
+    expect(mars.vectors.find((v) => v.kind === "aspect")?.aspect?.kinematics).toBeNull();
+    expect(mars.kinematicsAvailable).toBe(false);
+    expect(mars.vectors.find((v) => v.kind === "momentum")).toBeUndefined();
+    expect(mars.physics.momentum).toBeNull();
+    expect(mars.physics.speedDegPerDay).toBeNull();
+    expect(mars.physics.arcminutesPerDay).toBeNull();
+    expect(
+      mars.vectors.find((v) => v.kind === "aspect")?.detail,
+    ).toContain("motion unavailable");
+  });
+
+  test("partner speed missing: the card keeps its own motion, the pair degrades", () => {
+    const { cards } = buildFreeBodyDiagrams(wideTrine(0.5, undefined));
+    const mars = byPlanet(cards, "Mars");
+    const venus = byPlanet(cards, "Venus");
+
+    expect(mars.kinematicsAvailable).toBe(true);
+    expect(mars.vectors.find((v) => v.kind === "momentum")).toBeDefined();
+    expect(mars.vectors.find((v) => v.kind === "aspect")?.aspect?.kinematics).toBeNull();
+
+    expect(venus.kinematicsAvailable).toBe(false);
+    expect(venus.vectors.find((v) => v.kind === "momentum")).toBeUndefined();
+  });
+
+  test("longitudeSpeed of exactly 0 is the 'unknown motion' sentinel, not a standstill", () => {
+    const { cards } = buildFreeBodyDiagrams({
+      positions: {
+        Mars: { sign: "cancer", degree: 10, exactLongitude: 100, longitudeSpeed: 0 },
+        Venus: { sign: "scorpio", degree: 12, exactLongitude: 222, longitudeSpeed: 1.2 },
+      },
+      diurnal: true,
+    });
+    const mars = byPlanet(cards, "Mars");
+
+    expect(mars.kinematicsAvailable).toBe(false);
+    expect(mars.vectors.find((v) => v.id === "momentum")).toBeUndefined();
+    expect(mars.vectors.find((v) => v.kind === "momentum")).toBeUndefined();
+    expect(mars.physics.momentum).toBeNull();
+    expect(mars.physics.speedDegPerDay).toBeNull();
+    expect(mars.physics.arcminutesPerDay).toBeNull();
+    // …and the pair's verdict is withheld rather than invented.
+    expect(mars.vectors.find((v) => v.kind === "aspect")?.aspect?.kinematics).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sign / sect pulls
+// ---------------------------------------------------------------------------
+
+describe("sign and sect pulls", () => {
+  const { cards } = buildFreeBodyDiagrams(TRINE_SKY);
+
+  test("sign pull: 0.6 along the occupied sign's element axis", () => {
+    const mars = byPlanet(cards, "Mars");
+    const signVec = mars.vectors.find((v) => v.kind === "sign");
+    expect(signVec?.magnitude).toBeCloseTo(0.6, 9);
+    expect(signVec?.angleDeg).toBeCloseTo(ELEMENT_ANGLES.Water, 9); // cancer → Water ↓ 270°
+    expect(signVec?.source).toBe("cancer");
+    expect(mars.signElement).toBe("Water");
+  });
+
+  test("sect pull: 0.4 along the planet's SECTARIAN element axis (Mars by day → Fire)", () => {
+    const mars = byPlanet(cards, "Mars");
+    const sectVec = mars.vectors.find((v) => v.kind === "sect");
+    expect(sectVec?.magnitude).toBeCloseTo(0.4, 9);
+    expect(sectVec?.angleDeg).toBeCloseTo(ELEMENT_ANGLES.Fire, 9);
+    expect(sectVec?.source).toBe("Fire");
+  });
+
+  test("the elements row is the engine's 0.6 sign + 0.4 sect blend", () => {
+    const mars = byPlanet(cards, "Mars");
+    expect(mars.elements.Water).toBeCloseTo(0.6, 9); // cancer
+    expect(mars.elements.Fire).toBeCloseTo(0.4, 9); // Mars diurnal sect
+    expect(mars.elements.Earth).toBeCloseTo(0, 9);
+    expect(mars.elements.Air).toBeCloseTo(0, 9);
+    expect(mars.resultant.elementalPush.dominant).toBe("Water");
+  });
+
+  test("sect flips at night: Mars nocturnal is Water, stacking on the sign", () => {
+    const { cards: night } = buildFreeBodyDiagrams({ ...TRINE_SKY, diurnal: false });
+    const mars = byPlanet(night, "Mars");
+    expect(mars.elements.Water).toBeCloseTo(1.0, 9); // 0.6 sign + 0.4 sect
+    expect(mars.vectors.find((v) => v.kind === "sect")?.angleDeg).toBeCloseTo(
+      ELEMENT_ANGLES.Water,
+      9,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dignity — the ESMS scale (±10 / ±7), NOT the ±15%-per-level food scale
+// ---------------------------------------------------------------------------
+
+function singleBody(planet: string, sign: string, exactLongitude: number) {
+  return buildFreeBodyDiagrams({
+    positions: {
+      [planet]: { sign, degree: exactLongitude % 30, exactLongitude },
+    },
+    diurnal: true,
+  }).cards[0];
+}
+
+describe("dignity vector", () => {
+  test("FALL (Venus in virgo): −10 ESMS points, ×0.90, dragging against the sign axis", () => {
+    const venus = singleBody("Venus", "virgo", 171);
+
+    expect(venus.dignity.type).toBe("Fall");
+    expect(venus.dignity.esmsScale).toBe(-10);
+    expect(venus.dignity.multiplier).toBeCloseTo(0.9, 9);
+
+    const dignityVec = venus.vectors.find((v) => v.kind === "dignity");
+    expect(dignityVec).toBeDefined();
+    // |multiplier − 1| = 0.10 — the ESMS scale, not a 30% food-scale swing.
+    expect(dignityVec?.magnitude).toBeCloseTo(0.1, 9);
+    // virgo → Earth (180°), flipped 180° because the dignity drags.
+    expect(dignityVec?.angleDeg).toBeCloseTo(normalizeAngle(ELEMENT_ANGLES.Earth + 180), 9);
+    expect(dignityVec?.polarity).toBe("challenging");
+  });
+
+  test("EXALTATION (Sun in aries): +7 ESMS points, ×1.07 — never the food scale's 1.30", () => {
+    const sun = singleBody("Sun", "aries", 5);
+
+    expect(sun.dignity.type).toBe("Exaltation");
+    expect(sun.dignity.esmsScale).toBe(7);
+    expect(sun.dignity.multiplier).toBeCloseTo(1.07, 9);
+    // Guard against re-introducing the ±15%-per-level food scale.
+    expect(sun.dignity.multiplier).not.toBeCloseTo(1.3, 2);
+
+    const dignityVec = sun.vectors.find((v) => v.kind === "dignity");
+    expect(dignityVec?.magnitude).toBeCloseTo(0.07, 9);
+    // aries → Fire (90°), ALONG the axis because the dignity boosts.
+    expect(dignityVec?.angleDeg).toBeCloseTo(ELEMENT_ANGLES.Fire, 9);
+    expect(dignityVec?.polarity).toBe("harmonious");
+  });
+
+  test("DOMICILE (Sun in leo): +10 ESMS points, ×1.10, along the sign axis", () => {
+    const sun = singleBody("Sun", "leo", 135);
+
+    expect(sun.dignity.type).toBe("Domicile");
+    expect(sun.dignity.esmsScale).toBe(10);
+    expect(sun.dignity.multiplier).toBeCloseTo(1.1, 9);
+
+    const dignityVec = sun.vectors.find((v) => v.kind === "dignity");
+    expect(dignityVec?.magnitude).toBeCloseTo(0.1, 9);
+    expect(dignityVec?.angleDeg).toBeCloseTo(ELEMENT_ANGLES.Fire, 9); // leo → Fire
+    expect(dignityVec?.polarity).toBe("harmonious");
+  });
+
+  test("DETRIMENT (Venus in aries): −7 ESMS points, ×0.93, flipped", () => {
+    const venus = singleBody("Venus", "aries", 12);
+
+    expect(venus.dignity.type).toBe("Detriment");
+    expect(venus.dignity.esmsScale).toBe(-7);
+    expect(venus.dignity.multiplier).toBeCloseTo(0.93, 9);
+    const dignityVec = venus.vectors.find((v) => v.kind === "dignity");
+    expect(dignityVec?.magnitude).toBeCloseTo(0.07, 9);
+    expect(dignityVec?.angleDeg).toBeCloseTo(normalizeAngle(ELEMENT_ANGLES.Fire + 180), 9);
+  });
+
+  test("NEUTRAL: no dignity vector at all (scale 0 would be a zero-length arrow)", () => {
+    const jupiter = singleBody("Jupiter", "leo", 135);
+
+    expect(jupiter.dignity.type).toBe("Neutral");
+    expect(jupiter.dignity.esmsScale).toBe(0);
+    expect(jupiter.dignity.multiplier).toBeCloseTo(1, 9);
+    expect(jupiter.vectors.find((v) => v.kind === "dignity")).toBeUndefined();
+  });
+
+  test("the multiplier the card reports is the one the engine applied: 1 + esmsScale/100", () => {
+    const { cards } = buildFreeBodyDiagrams({
+      positions: RICH_SKY_POSITIONS,
+      diurnal: true,
+    });
+    for (const card of cards) {
+      expect(card.dignity.multiplier).toBeCloseTo(1 + card.dignity.esmsScale / 100, 12);
+      expect([10, 7, 0, -7, -10]).toContain(card.dignity.esmsScale);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-card normalization
+// ---------------------------------------------------------------------------
+
+describe("per-card normalization", () => {
+  test("the largest-magnitude vector normalizes to 1 and everything sits in [0.12, 1]", () => {
+    const { cards } = buildFreeBodyDiagrams(TRINE_SKY);
+
+    for (const card of cards) {
+      const maxMagnitude = Math.max(...card.vectors.map((v) => v.magnitude));
+      expect(card.normalizationScale).toBeCloseTo(maxMagnitude, 9);
+
+      const biggest = card.vectors.find((v) => v.magnitude === maxMagnitude);
+      expect(biggest?.normalized).toBeCloseTo(1, 9);
+
+      for (const vector of card.vectors) {
+        expect(vector.normalized).toBeGreaterThanOrEqual(0.12);
+        expect(vector.normalized).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  test("a vector under 12% of the card max is clamped to the visibility floor", () => {
+    // Mars card max is the exact trine (1.0); its Fall dignity is only 0.10.
+    const mars = byPlanet(buildFreeBodyDiagrams(TRINE_SKY).cards, "Mars");
+    const dignity = mars.vectors.find((v) => v.kind === "dignity");
+    expect(dignity?.magnitude).toBeCloseTo(0.1, 9);
+    expect(dignity?.normalized).toBeCloseTo(0.12, 9); // floored, raw preserved
+  });
+
+  test("a card with no aspects normalizes against its own sign pull", () => {
+    const jupiter = singleBody("Jupiter", "leo", 135);
+    expect(jupiter.vectors.map((v) => v.kind).sort()).toEqual(["sect", "sign"]);
+    expect(jupiter.normalizationScale).toBeCloseTo(0.6, 9);
+    expect(jupiter.vectors.find((v) => v.kind === "sign")?.normalized).toBeCloseTo(1, 9);
+    expect(jupiter.vectors.find((v) => v.kind === "sect")?.normalized).toBeCloseTo(
+      0.4 / 0.6,
+      9,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Momentum direction
+// ---------------------------------------------------------------------------
+
+describe("momentum vector", () => {
+  test("direct motion points ahead along the zodiac (0°)", () => {
+    const { cards } = buildFreeBodyDiagrams({
+      positions: {
+        Mars: { sign: "cancer", degree: 10, exactLongitude: 100, longitudeSpeed: 0.5 },
+      },
+      diurnal: true,
+    });
+    const mars = cards[0];
+    const momentum = mars.vectors.find((v) => v.kind === "momentum");
+
+    expect(momentum?.angleDeg).toBeCloseTo(0, 9);
+    expect(momentum?.label).toBe("MOMENTUM");
+    // |speed × alchmWeight| — the weight is engine-supplied, so read it back.
+    expect(momentum?.magnitude).toBeCloseTo(0.5 * mars.physics.alchmWeight, 9);
+    expect(mars.physics.momentum).toBeCloseTo(0.5 * mars.physics.alchmWeight, 9);
+    expect(mars.physics.speedDegPerDay).toBeCloseTo(0.5, 9);
+    expect(mars.physics.arcminutesPerDay).toBeCloseTo(30, 9);
+  });
+
+  test("retrograde motion points backward (180°)", () => {
+    const { cards } = buildFreeBodyDiagrams({
+      positions: {
+        Mars: {
+          sign: "cancer",
+          degree: 10,
+          exactLongitude: 100,
+          longitudeSpeed: -0.2,
+          isRetrograde: true,
+        },
+      },
+      diurnal: true,
+    });
+    const mars = cards[0];
+    const momentum = mars.vectors.find((v) => v.kind === "momentum");
+
+    expect(mars.isRetrograde).toBe(true);
+    expect(momentum?.angleDeg).toBeCloseTo(180, 9);
+    expect(momentum?.label).toBe("℞ MOMENTUM");
+    expect(momentum?.magnitude).toBeCloseTo(0.2 * mars.physics.alchmWeight, 9);
+    expect(mars.physics.momentum).toBeCloseTo(-0.2 * mars.physics.alchmWeight, 9);
+    expect(mars.physics.arcminutesPerDay).toBeCloseTo(-12, 9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Orb formatting — whole arc-minutes, never "°60′"
+// ---------------------------------------------------------------------------
+
+describe("orb formatting", () => {
+  test("an orb a hair under a whole degree rolls up to the next degree, not 60′", () => {
+    // Separation 122.9999° → 2.9999° off an exact trine. Rounding the minutes
+    // independently of a floored degree would render this as "2°60′".
+    const { cards } = buildFreeBodyDiagrams({
+      positions: {
+        Mars: { sign: "cancer", degree: 10, exactLongitude: 100 },
+        Venus: { sign: "scorpio", degree: 12, exactLongitude: 222.9999 },
+      },
+      diurnal: true,
+    });
+
+    const detail = byPlanet(cards, "Mars").vectors.find((v) => v.kind === "aspect")?.detail;
+    expect(detail).toBeDefined();
+    expect(detail).not.toContain("°60′");
+    expect(detail).toContain("3°00′");
+  });
+
+  test("no aspect vector on any card ever renders 60 arc-minutes", () => {
+    const { cards } = buildFreeBodyDiagrams({
+      positions: RICH_SKY_POSITIONS,
+      diurnal: true,
+    });
+    for (const card of cards) {
+      for (const vector of card.vectors) {
+        expect(vector.detail).not.toContain("°60′");
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Excluded bodies — the cards must draw the aspect universe Layer 3 consumes
+// ---------------------------------------------------------------------------
+
+describe("excluded aspect bodies", () => {
+  test("a North Node sitting on an exact aspect produces no vector anywhere", () => {
+    const { cards, totals } = buildFreeBodyDiagrams({
+      positions: {
+        Mars: { sign: "cancer", degree: 10, exactLongitude: 100 },
+        Venus: { sign: "scorpio", degree: 10, exactLongitude: 220 },
+        // 340° is an exact trine to Mars AND an exact sextile-family angle to
+        // Venus — if nodes leaked in, both cards would gain phantom forces.
+        "North Node": { sign: "pisces", degree: 10, exactLongitude: 340 },
+      },
+      diurnal: true,
+    });
+
+    expect(cards.find((c) => c.planet === "North Node")).toBeUndefined();
+    for (const card of cards) {
+      expect(card.vectors.some((v) => v.source === "North Node")).toBe(false);
+      expect(
+        card.vectors.some((v) => v.aspect?.otherPlanet === "North Node"),
+      ).toBe(false);
+    }
+    // Mars still sees only its one real aspect (the Venus trine).
+    expect(byPlanet(cards, "Mars").vectors.filter((v) => v.kind === "aspect")).toHaveLength(1);
+
+    // …and the node contributes nothing to the sky totals either, so the
+    // invariant still closes.
+    const summed = sumCardEsms(cards);
+    for (const axis of AXES) {
+      const reconciled = summed[axis] + (totals.groundingVessel?.esms[axis] ?? 0);
+      expect(Math.abs(reconciled - totals.esms[axis])).toBeLessThan(EPSILON);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Card identity fields
+// ---------------------------------------------------------------------------
+
+describe("card identity", () => {
+  test("degree/minute are derived from the resolved longitude", () => {
+    const { cards } = buildFreeBodyDiagrams({
+      positions: {
+        Mars: { sign: "cancer", degree: 10, minute: 30, exactLongitude: 100.5 },
+      },
+      diurnal: true,
+    });
+    const mars = cards[0];
+
+    expect(mars.sign).toBe("cancer");
+    expect(mars.signElement).toBe("Water");
+    expect(mars.degree).toBe(10);
+    expect(mars.minute).toBe(30);
+    expect(mars.exactLongitude).toBeCloseTo(100.5, 9);
+  });
+
+  test("longitude falls back to sign + degree + minute when exactLongitude is absent", () => {
+    const { cards } = buildFreeBodyDiagrams({
+      positions: { Mars: { sign: "cancer", degree: 10, minute: 30 } },
+      diurnal: true,
+    });
+    expect(cards[0].exactLongitude).toBeCloseTo(100.5, 9);
+  });
+
+  test("only the requested planets get cards", () => {
+    const { cards } = buildFreeBodyDiagrams({
+      positions: RICH_SKY_POSITIONS,
+      diurnal: true,
+      planets: ["Sun", "Moon"],
+    });
+    expect(cards.map((c) => c.planet)).toEqual(["Sun", "Moon"]);
+  });
+});

--- a/src/__tests__/utils/aspectKinematics.test.ts
+++ b/src/__tests__/utils/aspectKinematics.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for aspectKinematics — the shared applying/separating finite-difference
+ * model used by /api/alchm-quantities/aspects and the free-body-diagram builder.
+ *
+ * All scenarios are hand-computable: simple longitude/speed pairs where the
+ * expected orb change per day is obvious by inspection.
+ */
+import {
+  computeAspectKinematics,
+  computeOrb,
+  STATIONARY_EPS,
+} from "@/utils/aspectKinematics";
+
+describe("computeOrb", () => {
+  test("distance from an exact square is zero", () => {
+    expect(computeOrb(10, 100, 90)).toBeCloseTo(0, 9);
+  });
+
+  test("simple square orb", () => {
+    // 92° apart on a 90° aspect → 2° orb.
+    expect(computeOrb(0, 92, 90)).toBeCloseTo(2, 9);
+  });
+
+  test("wraps across 0° Aries", () => {
+    // 350° and 10° are 20° apart, not 340°.
+    expect(computeOrb(350, 10, 0)).toBeCloseTo(20, 9);
+  });
+
+  test("uses minimal separation (never above 180°)", () => {
+    expect(computeOrb(0, 180, 180)).toBeCloseTo(0, 9);
+    expect(computeOrb(355, 5, 90)).toBeCloseTo(80, 9);
+  });
+});
+
+describe("computeAspectKinematics", () => {
+  test("applying: faster body behind, closing a 92° square at 1°/day", () => {
+    // Body 1 at 0° moving +1°/day, body 2 held at 92°: separation shrinks
+    // toward the exact 90° square, so the 2° orb closes at exactly 1°/day.
+    const k = computeAspectKinematics(0, 92, 90, 1.0, 0);
+
+    expect(k.orbVelocity).toBeCloseTo(-1.0, 6);
+    expect(k.applying).toBe(true);
+    expect(k.state).toBe("applying");
+    // daysToExact ≈ orb / |orbVelocity| = 2 / 1.
+    expect(k.daysToExact).toBeCloseTo(2, 6);
+    expect(k.relativeAngularVelocity).toBeCloseTo(1.0, 9);
+  });
+
+  test("applying: fast partner ahead closing a trine from below", () => {
+    // Separation 110° growing toward the exact 120° trine at 12°/day
+    // (13 − 1); the 10° orb closes in 10/12 days.
+    const k = computeAspectKinematics(100, 210, 120, 1, 13);
+
+    expect(k.orbVelocity).toBeCloseTo(-12, 6);
+    expect(k.state).toBe("applying");
+    expect(k.applying).toBe(true);
+    expect(k.daysToExact).toBeCloseTo(10 / 12, 6);
+    expect(k.relativeAngularVelocity).toBeCloseTo(-12, 9);
+  });
+
+  test("applying across the 0° Aries wrap", () => {
+    // 355° chasing 5° into a conjunction: 10° orb closing at 1°/day.
+    const k = computeAspectKinematics(355, 5, 0, 1.0, 0);
+
+    expect(k.orbVelocity).toBeCloseTo(-1.0, 6);
+    expect(k.state).toBe("applying");
+    expect(k.daysToExact).toBeCloseTo(10, 6);
+  });
+
+  test("separating: faster body moving past an 88° square", () => {
+    // Body 1 at 0° moving +1°/day away from body 2 at 88°: the separation
+    // shrinks below 88°, moving AWAY from the exact 90° square.
+    const k = computeAspectKinematics(0, 88, 90, 1.0, 0);
+
+    expect(k.orbVelocity).toBeCloseTo(+1.0, 6);
+    expect(k.applying).toBe(false);
+    expect(k.state).toBe("separating");
+    // daysToExact is positive on both sides: days SINCE exact here.
+    expect(k.daysToExact).toBeCloseTo(2, 6);
+  });
+
+  test("stationary: equal speeds hold the orb → 9999 days sentinel", () => {
+    // Both bodies advance at 0.7°/day, so the 2° orb never changes.
+    const k = computeAspectKinematics(10, 102, 90, 0.7, 0.7);
+
+    expect(Math.abs(k.orbVelocity)).toBeLessThan(STATIONARY_EPS);
+    expect(k.applying).toBe(false);
+    expect(k.state).toBe("stationary");
+    expect(k.daysToExact).toBe(9999);
+    expect(k.relativeAngularVelocity).toBeCloseTo(0, 9);
+  });
+
+  test("retrograde speeds are honored (negative daily motion)", () => {
+    // Body 1 at 94° retrograding −1°/day toward the 90° square with a body
+    // held at 0°: separation 94 → 90, orb closing at 1°/day.
+    const k = computeAspectKinematics(94, 0, 90, -1.0, 0);
+
+    expect(k.orbVelocity).toBeCloseTo(-1.0, 6);
+    expect(k.state).toBe("applying");
+    expect(k.daysToExact).toBeCloseTo(4, 6);
+    expect(k.relativeAngularVelocity).toBeCloseTo(-1.0, 9);
+  });
+});

--- a/src/app/(alchm)/birth-chart/page.tsx
+++ b/src/app/(alchm)/birth-chart/page.tsx
@@ -1,12 +1,49 @@
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
+import { buildFreeBodyDiagrams, type FBDPositionInput, type PlanetFBD } from '@/calculations/planetaryFBD';
 import { NatalTransitChart } from '@/components/dashboard/NatalTransitChart';
 import { AlchemicalConstitutionPanel } from '@/components/profile/AlchemicalConstitutionPanel';
 import { CosmicAlignmentCard } from '@/components/profile/CosmicAlignmentCard';
 import { ElementalWheel } from '@/components/profile/ElementalWheel';
+import PlanetFBDCard from '@/components/ui/alchm/PlanetFBDCard';
 import { auth } from '@/lib/auth/auth';
 import { withTimeout } from '@/lib/performance/withTimeout';
 import { userDatabase } from '@/services/userDatabaseService';
+import type { NatalChart } from '@/types/natalChart';
+import { isSectDiurnalForBirth } from '@/utils/planetaryAlchemyMapping';
+
+/**
+ * Natal free-body diagrams from the stored chart. Only planets carrying a
+ * real absolute longitude participate (position 0 means unknown/legacy) — a
+ * fabricated degree would produce confidently wrong aspects. Stored charts
+ * carry no daily motions, so cards degrade honestly (no applying/separating,
+ * no momentum).
+ */
+function buildNatalFBDs(natalChart: NatalChart): PlanetFBD[] | null {
+  const fbdPositions: Record<string, FBDPositionInput> = {};
+  for (const planet of natalChart.planets ?? []) {
+    if (!planet?.name || !planet.sign) continue;
+    if (typeof planet.position !== 'number' || planet.position <= 0) continue;
+    const degreeInSign = planet.position % 30;
+    fbdPositions[planet.name] = {
+      sign: planet.sign,
+      // `degree` is sign-relative and already carries the fractional
+      // arc-minutes; passing `minute` as well would double-count them on the
+      // fallback path that reconstructs a longitude from sign + degree.
+      degree: degreeInSign,
+      exactLongitude: planet.position,
+    };
+  }
+  if (Object.keys(fbdPositions).length < 2) return null;
+
+  const birthDate = natalChart.birthData?.dateTime
+    ? new Date(natalChart.birthData.dateTime)
+    : new Date(natalChart.calculatedAt);
+  return buildFreeBodyDiagrams({
+    positions: fbdPositions,
+    diurnal: isSectDiurnalForBirth(birthDate),
+  }).cards;
+}
 
 
 export default async function BirthChartPage() {
@@ -30,7 +67,8 @@ export default async function BirthChartPage() {
   }
 
   const { natalChart } = profile.profile;
-  
+  const natalFBDs = buildNatalFBDs(natalChart);
+
   // Format the birth date string if available
   const chartDate = natalChart.birthData?.dateTime
     ? new Date(natalChart.birthData.dateTime).toLocaleDateString('en-US', {
@@ -85,12 +123,38 @@ export default async function BirthChartPage() {
              <div className="mb-6">
                <h3 className="text-lg font-bold text-white uppercase tracking-widest">Natal &amp; Transit Cartography</h3>
                <p className="text-white/40 text-sm mt-1">
-                 This overlay renders your exact natal planetary positions against real-time celestial weather.
+                 Your exact natal positions against real-time celestial weather — now with aspect
+                 chords (teal harmony, ember tension) and elemental sign vectors at each planet.
                </p>
              </div>
              <div className="bg-black/50 p-4 rounded-2xl border border-white/[0.02]">
                <NatalTransitChart natalChart={natalChart} />
              </div>
+          </div>
+
+          {/* Natal free-body diagrams (alchm-root scope provides the design tokens) */}
+          <div className="alchm-root bg-gray-950 rounded-3xl p-6 border border-white/5 shadow-2xl mt-8">
+            <div className="mb-6">
+              <h3 className="text-lg font-bold text-white uppercase tracking-widest">Natal Free-Body Diagrams</h3>
+              <p className="text-white/40 text-sm mt-1">
+                The forces frozen into each planet at your birth moment — aspects at true ecliptic
+                bearings, sign and sect pulls on the element compass, dignity boosts and drags, and
+                the violet ESMS resultant. A stored chart carries no daily motions, so
+                applying/separating dynamics and momentum are shown only on the live sky
+                (<Link href="/planetary-chart" className="underline decoration-white/20 hover:text-white/70">planetary ecosystem</Link>).
+              </p>
+            </div>
+            {natalFBDs ? (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {natalFBDs.map((fbd) => (
+                  <PlanetFBDCard key={fbd.planet} fbd={fbd} />
+                ))}
+              </div>
+            ) : (
+              <p className="text-white/40 text-sm font-mono uppercase tracking-wider">
+                Awaiting exact natal longitudes — re-run ignite to compute degree-precise positions.
+              </p>
+            )}
           </div>
         </div>
       </main>

--- a/src/app/(alchm)/planetary-chart/PlanetaryChartClient.tsx
+++ b/src/app/(alchm)/planetary-chart/PlanetaryChartClient.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+/**
+ * Interactive half of the planetary-chart page: the chart wheel with
+ * date/location controls, live positions table, and alchemical/kinetics
+ * displays. The page shell (server) renders the free-body-diagram grid from
+ * per-request data; this component keeps the exploratory tooling.
+ */
+
+import dynamic from "next/dynamic";
+import React, { useState } from "react";
+import AlchemicalDisplay from "@/components/AlchemicalDisplay";
+import KineticsDisplay from "@/components/KineticsDisplay";
+import PlanetaryChartControls from "@/components/PlanetaryChartControls";
+import { useChartData } from "@/hooks/useChartData";
+
+const PlanetaryChart = dynamic(() => import("@/components/PlanetaryChart"), {
+  ssr: false,
+});
+
+export default function PlanetaryChartClient() {
+  const [dateTime, setDateTime] = useState<Date | undefined>(undefined);
+  const [location, setLocation] = useState({
+    latitude: 40.7128,
+    longitude: -74.006,
+  });
+  const [zodiacSystem, setZodiacSystem] = useState<"tropical" | "sidereal">(
+    "tropical",
+  );
+  const [showAspects, setShowAspects] = useState(true);
+  const [showDegrees, setShowDegrees] = useState(true);
+
+  const chartData = useChartData({
+    dateTime,
+    location,
+    zodiacSystem,
+    autoRefresh: !dateTime, // Auto-refresh only when using current moment
+    refreshInterval: 60000, // 1 minute
+  });
+
+  const {
+    positions,
+    aspects,
+    alchemical,
+    kinetics,
+    timestamp,
+    isLoading,
+    error,
+    refetch,
+  } = chartData;
+
+  return (
+    <div className="max-w-7xl mx-auto">
+      {timestamp && (
+        <p className="text-sm text-gray-400 mb-4 text-center">
+          Interactive chart calculated for: {new Date(timestamp).toLocaleString()}
+        </p>
+      )}
+
+      {/* Error Display */}
+      {error && (
+        <div className="mb-6 p-4 bg-red-900/30 border border-red-500/50 rounded-lg">
+          <p className="text-red-300">
+            <strong>Error:</strong> {error}
+          </p>
+        </div>
+      )}
+
+      {/* Main Content Grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Left Column: Controls */}
+        <div className="lg:col-span-1 space-y-6">
+          <PlanetaryChartControls
+            onDateTimeChange={setDateTime}
+            onLocationChange={setLocation}
+            onZodiacSystemChange={setZodiacSystem}
+            onRefresh={refetch}
+            currentDateTime={dateTime}
+            currentLocation={location}
+            currentZodiacSystem={zodiacSystem}
+            isLoading={isLoading}
+          />
+
+          {/* Chart Options */}
+          <div className="p-4 bg-gradient-to-br from-blue-900/20 to-purple-900/20 rounded-lg border border-blue-500/30">
+            <h3 className="text-lg font-semibold text-blue-300 mb-3">
+              Chart Options
+            </h3>
+
+            <div className="space-y-2">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={showAspects}
+                  onChange={(e) => setShowAspects(e.target.checked)}
+                  className="w-4 h-4 rounded border-blue-500/50 bg-blue-900/30 text-blue-500 focus:ring-blue-500"
+                />
+                <span className="text-sm text-gray-300">Show Aspects</span>
+              </label>
+
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={showDegrees}
+                  onChange={(e) => setShowDegrees(e.target.checked)}
+                  className="w-4 h-4 rounded border-blue-500/50 bg-blue-900/30 text-blue-500 focus:ring-blue-500"
+                />
+                <span className="text-sm text-gray-300">Show Degrees</span>
+              </label>
+            </div>
+          </div>
+
+          {/* Aspect Legend */}
+          {showAspects && aspects && aspects.length > 0 && (
+            <div className="p-4 bg-gradient-to-br from-green-900/20 to-teal-900/20 rounded-lg border border-green-500/30">
+              <h3 className="text-lg font-semibold text-green-300 mb-3">
+                Active Aspects ({aspects.length})
+              </h3>
+
+              <div className="space-y-1 max-h-64 overflow-y-auto">
+                {aspects.map((aspect, index) => (
+                  <div
+                    key={index}
+                    className="text-xs text-gray-300 py-1 px-2 bg-green-900/20 rounded"
+                  >
+                    <span className="font-semibold">{aspect.planet1}</span>{" "}
+                    <span className="text-green-400">{aspect.type}</span>{" "}
+                    <span className="font-semibold">{aspect.planet2}</span>
+                    {aspect.orb !== undefined && (
+                      <span className="text-gray-500 ml-2">
+                        ({aspect.orb.toFixed(2)}°)
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Center Column: Chart Visualization */}
+        <div className="lg:col-span-2 space-y-6">
+          <div className="p-6 bg-gradient-to-br from-indigo-900/20 to-purple-900/20 rounded-lg border border-indigo-500/30">
+            {isLoading && !positions ? (
+              <div className="flex items-center justify-center h-96">
+                <div className="text-center">
+                  <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-purple-500 mx-auto mb-4" />
+                  <p className="text-gray-300">
+                    Calculating planetary positions...
+                  </p>
+                </div>
+              </div>
+            ) : positions ? (
+              <div className="flex justify-center">
+                <PlanetaryChart
+                  positions={positions}
+                  aspects={showAspects ? aspects : []}
+                  size={600}
+                  showAspects={showAspects}
+                  showDegrees={showDegrees}
+                />
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-96">
+                <p className="text-gray-400 italic">
+                  No chart data available
+                </p>
+              </div>
+            )}
+          </div>
+
+          {/* Planetary Positions Table */}
+          {positions && (
+            <div className="p-6 bg-gradient-to-br from-cyan-900/20 to-blue-900/20 rounded-lg border border-cyan-500/30">
+              <h3 className="text-2xl font-bold text-cyan-300 mb-4">
+                Planetary Positions
+              </h3>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {Object.entries(positions).map(([planet, position]) => (
+                  <div
+                    key={planet}
+                    className="p-3 bg-cyan-900/20 border border-cyan-500/30 rounded-lg"
+                  >
+                    <div className="flex justify-between items-center">
+                      <span className="font-semibold text-cyan-300">
+                        {planet}
+                      </span>
+                      {position.isRetrograde && (
+                        <span className="text-xs text-red-400 font-bold">
+                          ℞
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-sm text-gray-300 capitalize">
+                      {position.degree.toFixed(0)}° {position.sign}
+                    </div>
+                    <div className="text-xs text-gray-500">
+                      Exact: {(position.exactLongitude ?? 0).toFixed(2)}°
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Alchemical Display */}
+          <AlchemicalDisplay alchemical={alchemical} isLoading={isLoading} />
+
+          {/* Kinetics Display */}
+          <KineticsDisplay kinetics={kinetics} isLoading={isLoading} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(alchm)/planetary-chart/page.tsx
+++ b/src/app/(alchm)/planetary-chart/page.tsx
@@ -1,296 +1,235 @@
 /**
- * Planetary Chart Page
+ * Planetary Chart — the planetary ecosystem surface.
  *
- * Interactive visualization of current planetary positions with alchemical analysis.
- * Uses /api/astrologize and /api/alchemize endpoints.
+ * Public (no premium gate): the current sky is the same for everyone. The
+ * server computes positions (arc-minute precise, with daily motions), the
+ * per-planet alchemical decomposition, and a free-body diagram for each of
+ * the ten planets once per request; the interactive wheel below keeps its
+ * client-side exploratory tooling (date/location controls).
  */
 
-"use client";
+import type { Metadata } from "next";
+import {
+  buildFreeBodyDiagrams,
+  type FBDPositionInput,
+} from "@/calculations/planetaryFBD";
+import PlanetFBDCard from "@/components/ui/alchm/PlanetFBDCard";
+import {
+  alchemizeDetailed,
+  type PlanetaryPosition,
+} from "@/services/RealAlchemizeService";
+import { calculatePlanetaryPositionsWithMeta } from "@/utils/serverPlanetaryCalculations";
+import PlanetaryChartClient from "./PlanetaryChartClient";
 
-import dynamic from "next/dynamic";
-import React, { useState } from "react";
-import AlchemicalDisplay from "@/components/AlchemicalDisplay";
-import KineticsDisplay from "@/components/KineticsDisplay";
-import PlanetaryChartControls from "@/components/PlanetaryChartControls";
-import { PremiumGate } from "@/components/PremiumGate";
-import { useChartData } from "@/hooks/useChartData";
+export const dynamic = "force-dynamic";
 
-const PlanetaryChart = dynamic(() => import("@/components/PlanetaryChart"), {
-  ssr: false,
-});
+export const metadata: Metadata = {
+  title: "Planetary Ecosystem — Free-Body Diagrams of the Current Sky",
+  description:
+    "Every force acting on every planet right now — aspects, elemental pulls, dignities, and momentum — drawn as physics-style free-body diagrams at arc-minute precision.",
+};
 
-export default function PlanetaryChartPage() {
-  const [dateTime, setDateTime] = useState<Date | undefined>(undefined);
-  const [location, setLocation] = useState({
-    latitude: 40.7128,
-    longitude: -74.006,
+async function computeEcosystem() {
+  const now = new Date();
+  const { positions, degraded } = await calculatePlanetaryPositionsWithMeta(now);
+
+  const alchemizeInput: Record<string, PlanetaryPosition> = {};
+  const fbdPositions: Record<string, FBDPositionInput> = {};
+  for (const [name, pos] of Object.entries(positions)) {
+    // The Ascendant depends entirely on the observer's latitude/longitude and
+    // advances ~1° every 4 minutes. This page is location-less and public —
+    // "the sky is the same for everyone" is only true of the planets — so a
+    // backend default-location Ascendant must not become force vectors here.
+    // The ESMS engine still injects its own sign-only grounding vessel, which
+    // contributes no aspects.
+    if (name === "Ascendant") continue;
+    alchemizeInput[name] = {
+      sign: pos.sign,
+      degree: pos.degree,
+      minute: pos.minute,
+      isRetrograde: pos.isRetrograde,
+      exactLongitude: pos.exactLongitude,
+    };
+    fbdPositions[name] = {
+      sign: pos.sign,
+      degree: pos.degree,
+      minute: pos.minute,
+      exactLongitude: pos.exactLongitude,
+      isRetrograde: pos.isRetrograde,
+      longitudeSpeed: pos.longitudeSpeed,
+    };
+  }
+
+  const detailed = alchemizeDetailed(alchemizeInput, null, now, {
+    incomingDegraded: degraded,
   });
-  const [zodiacSystem, setZodiacSystem] = useState<"tropical" | "sidereal">(
-    "tropical",
-  );
-  const [showAspects, setShowAspects] = useState(true);
-  const [showDegrees, setShowDegrees] = useState(true);
-
-  const chartData = useChartData({
-    dateTime,
-    location,
-    zodiacSystem,
-    autoRefresh: !dateTime, // Auto-refresh only when using current moment
-    refreshInterval: 60000, // 1 minute
+  const { cards: fbds, totals } = buildFreeBodyDiagrams({
+    positions: fbdPositions,
+    diurnal: detailed.metadata.isDiurnal,
   });
 
-  const {
-    positions,
-    aspects,
-    alchemical,
-    kinetics,
-    timestamp,
-    isLoading,
-    error,
-    refetch,
-  } = chartData;
+  return {
+    fbds,
+    totals,
+    thermo: detailed.thermodynamicProperties,
+    kalchm: detailed.kalchm,
+    monica: detailed.monica,
+    isDiurnal: detailed.metadata.isDiurnal,
+    degradedReasons: detailed.degraded?.reasons ?? null,
+    timestamp: now.toISOString(),
+  };
+}
+
+const fmtStat = (value: number) =>
+  Math.abs(value) >= 1000 || (Math.abs(value) < 0.001 && value !== 0)
+    ? value.toExponential(2)
+    : Number(value.toPrecision(3)).toString();
+
+export default async function PlanetaryChartPage() {
+  const sky = await computeEcosystem();
+
+  const u = sky.totals.unattributed;
+  const unattributedTotal = u.Spirit + u.Essence + u.Matter + u.Substance;
+
+  const stats: Array<[string, number]> = [
+    ["HEAT", sky.thermo.heat],
+    ["ENTROPY", sky.thermo.entropy],
+    ["REACTIVITY", sky.thermo.reactivity],
+    ["GREGS ENERGY", sky.thermo.gregsEnergy],
+    ["KALCHM", sky.kalchm],
+    ["MONICA", sky.monica],
+  ];
 
   return (
-    <PremiumGate feature="advancedPlanetaryCharts">
-    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-purple-900 to-blue-900 py-8 px-4">
-      <div className="max-w-7xl mx-auto">
+    <div
+      className="alchm-root min-h-screen py-8 px-4"
+      style={{ background: "var(--bg)", color: "var(--fg)" }}
+    >
+      <div className="max-w-7xl mx-auto space-y-8">
         {/* Header */}
-        <div className="text-center mb-8">
-          <h1 className="text-4xl md:text-5xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-pink-400 mb-3">
-            Planetary Chart
+        <header className="text-center space-y-3">
+          <h1
+            className="t-display"
+            style={{ fontSize: "clamp(28px, 5vw, 44px)", lineHeight: 1.1 }}
+          >
+            Planetary Ecosystem
           </h1>
-          <p className="text-gray-300 text-lg">
-            Real-time astronomical positions with alchemical and kinetic
-            analysis
+          <p style={{ color: "var(--fg-dim)", maxWidth: 640, margin: "0 auto" }}>
+            Every force acting on every planet, drawn as a free-body diagram at
+            the exact arc minute it occupies — aspects arriving and departing,
+            elemental pulls, dignities, and momentum.
           </p>
-          {timestamp && (
-            <p className="text-sm text-gray-400 mt-2">
-              Chart calculated for: {new Date(timestamp).toLocaleString()}
-            </p>
-          )}
-        </div>
-
-        {/* Error Display */}
-        {error && (
-          <div className="mb-6 p-4 bg-red-900/30 border border-red-500/50 rounded-lg">
-            <p className="text-red-300">
-              <strong>Error:</strong> {error}
-            </p>
-          </div>
-        )}
-
-        {/* Main Content Grid */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Left Column: Controls */}
-          <div className="lg:col-span-1 space-y-6">
-            <PlanetaryChartControls
-              onDateTimeChange={setDateTime}
-              onLocationChange={setLocation}
-              onZodiacSystemChange={setZodiacSystem}
-              onRefresh={refetch}
-              currentDateTime={dateTime}
-              currentLocation={location}
-              currentZodiacSystem={zodiacSystem}
-              isLoading={isLoading}
-            />
-
-            {/* Chart Options */}
-            <div className="p-4 bg-gradient-to-br from-blue-900/20 to-purple-900/20 rounded-lg border border-blue-500/30">
-              <h3 className="text-lg font-semibold text-blue-300 mb-3">
-                Chart Options
-              </h3>
-
-              <div className="space-y-2">
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={showAspects}
-                    onChange={(e) => setShowAspects(e.target.checked)}
-                    className="w-4 h-4 rounded border-blue-500/50 bg-blue-900/30 text-blue-500 focus:ring-blue-500"
-                  />
-                  <span className="text-sm text-gray-300">Show Aspects</span>
-                </label>
-
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={showDegrees}
-                    onChange={(e) => setShowDegrees(e.target.checked)}
-                    className="w-4 h-4 rounded border-blue-500/50 bg-blue-900/30 text-blue-500 focus:ring-blue-500"
-                  />
-                  <span className="text-sm text-gray-300">Show Degrees</span>
-                </label>
-              </div>
-            </div>
-
-            {/* Aspect Legend */}
-            {showAspects && aspects && aspects.length > 0 && (
-              <div className="p-4 bg-gradient-to-br from-green-900/20 to-teal-900/20 rounded-lg border border-green-500/30">
-                <h3 className="text-lg font-semibold text-green-300 mb-3">
-                  Active Aspects ({aspects.length})
-                </h3>
-
-                <div className="space-y-1 max-h-64 overflow-y-auto">
-                  {aspects.map((aspect, index) => (
-                    <div
-                      key={index}
-                      className="text-xs text-gray-300 py-1 px-2 bg-green-900/20 rounded"
-                    >
-                      <span className="font-semibold">{aspect.planet1}</span>{" "}
-                      <span className="text-green-400">{aspect.type}</span>{" "}
-                      <span className="font-semibold">{aspect.planet2}</span>
-                      {aspect.orb !== undefined && (
-                        <span className="text-gray-500 ml-2">
-                          ({aspect.orb.toFixed(2)}°)
-                        </span>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </div>
+          <p className="t-mono" style={{ fontSize: 10, color: "var(--fg-mute)", letterSpacing: "0.14em" }}>
+            COMPUTED {new Date(sky.timestamp).toUTCString().toUpperCase()} ·{" "}
+            {sky.isDiurnal ? "DIURNAL SECT" : "NOCTURNAL SECT"}
+            {sky.degradedReasons && (
+              <span style={{ color: "var(--accent-2)" }}>
+                {" "}· DEGRADED: {sky.degradedReasons.join(", ").toUpperCase()}
+              </span>
             )}
-          </div>
+          </p>
+        </header>
 
-          {/* Center Column: Chart Visualization */}
-          <div className="lg:col-span-2 space-y-6">
-            <div className="p-6 bg-gradient-to-br from-indigo-900/20 to-purple-900/20 rounded-lg border border-indigo-500/30">
-              {isLoading && !positions ? (
-                <div className="flex items-center justify-center h-96">
-                  <div className="text-center">
-                    <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-purple-500 mx-auto mb-4" />
-                    <p className="text-gray-300">
-                      Calculating planetary positions...
-                    </p>
-                  </div>
-                </div>
-              ) : positions ? (
-                <div className="flex justify-center">
-                  <PlanetaryChart
-                    positions={positions}
-                    aspects={showAspects ? aspects : []}
-                    size={600}
-                    showAspects={showAspects}
-                    showDegrees={showDegrees}
-                  />
-                </div>
-              ) : (
-                <div className="flex items-center justify-center h-96">
-                  <p className="text-gray-400 italic">
-                    No chart data available
-                  </p>
-                </div>
-              )}
-            </div>
-
-            {/* Planetary Positions Table */}
-            {positions && (
-              <div className="p-6 bg-gradient-to-br from-cyan-900/20 to-blue-900/20 rounded-lg border border-cyan-500/30">
-                <h3 className="text-2xl font-bold text-cyan-300 mb-4">
-                  Planetary Positions
-                </h3>
-
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  {Object.entries(positions).map(([planet, position]) => (
-                    <div
-                      key={planet}
-                      className="p-3 bg-cyan-900/20 border border-cyan-500/30 rounded-lg"
-                    >
-                      <div className="flex justify-between items-center">
-                        <span className="font-semibold text-cyan-300">
-                          {planet}
-                        </span>
-                        {position.isRetrograde && (
-                          <span className="text-xs text-red-400 font-bold">
-                            ℞
-                          </span>
-                        )}
-                      </div>
-                      <div className="text-sm text-gray-300 capitalize">
-                        {position.degree.toFixed(0)}° {position.sign}
-                      </div>
-                      <div className="text-xs text-gray-500">
-                        Exact: {(position.exactLongitude ?? 0).toFixed(2)}°
-                      </div>
-                    </div>
-                  ))}
-                </div>
+        {/* Sky telemetry strip */}
+        <section
+          aria-label="Sky thermodynamics"
+          className="grid grid-cols-3 md:grid-cols-6 gap-2"
+        >
+          {stats.map(([label, value]) => (
+            <div
+              key={label}
+              className="alchm-panel"
+              style={{ padding: "10px 12px", textAlign: "center" }}
+            >
+              <div className="t-tag">{label}</div>
+              <div
+                className="t-num t-mono"
+                style={{ fontSize: 15, color: "var(--fg)", marginTop: 4 }}
+              >
+                {fmtStat(value)}
               </div>
-            )}
+            </div>
+          ))}
+        </section>
 
-            {/* Alchemical Display */}
-            <AlchemicalDisplay alchemical={alchemical} isLoading={isLoading} />
-
-            {/* Kinetics Display */}
-            <KineticsDisplay kinetics={kinetics} isLoading={isLoading} />
+        {/* How to read */}
+        <section className="alchm-panel" style={{ padding: 16 }}>
+          <div className="t-tag" style={{ marginBottom: 8 }}>
+            HOW TO READ A FREE-BODY DIAGRAM
           </div>
-        </div>
-
-        {/* Info Footer */}
-        <div className="mt-8 p-6 bg-gradient-to-br from-gray-800/40 to-gray-900/40 rounded-lg border border-gray-700/50">
-          <h3 className="text-lg font-semibold text-gray-300 mb-3">
-            About This Chart
-          </h3>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 text-sm text-gray-400">
-            <div>
-              <h4 className="font-semibold text-gray-300 mb-2">
-                Planetary Positions
-              </h4>
-              <p>
-                Calculated using the astronomy-engine library with real-time
-                astronomical data. Positions are accurate to within 0.01
-                degrees.
-              </p>
-            </div>
-            <div>
-              <h4 className="font-semibold text-gray-300 mb-2">
-                Alchemical Properties
-              </h4>
-              <p>
-                ESMS (Spirit, Essence, Matter, Substance) values are calculated
-                from planetary positions using the authoritative planetary
-                alchemy mapping system.
-              </p>
-            </div>
-            <div>
-              <h4 className="font-semibold text-gray-300 mb-2">
-                Planetary Kinetics
-              </h4>
-              <p>
-                P=IV circuit model calculates Power, Current, and Voltage from
-                alchemical and elemental properties. Includes velocity,
-                momentum, and force dynamics.
-              </p>
-            </div>
-            <div>
-              <h4 className="font-semibold text-gray-300 mb-2">Aspects</h4>
-              <p>
-                Aspects represent geometric relationships between planets. Major
-                aspects include conjunction (0°), sextile (60°), square (90°),
-                trine (120°), and opposition (180°).
-              </p>
-            </div>
-            <div>
-              <h4 className="font-semibold text-gray-300 mb-2">Live Updates</h4>
-              <p>
-                When using &quot;current moment&quot; mode, the chart
-                automatically refreshes every minute to reflect the latest
-                planetary positions.
-              </p>
-            </div>
-            <div>
-              <h4 className="font-semibold text-gray-300 mb-2">
-                Force Classification
-              </h4>
-              <p>
-                Kinetic force is classified as accelerating, balanced, or
-                decelerating based on magnitude. Thermal direction indicates
-                heating, cooling, or stable states.
-              </p>
-            </div>
+          <div
+            className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-1"
+            style={{ color: "var(--fg-dim)", fontSize: 12.5, lineHeight: 1.65 }}
+          >
+            <p>
+              Each card centers a planet on the exact arc minute it occupies —
+              the curved ruler behind it is the surrounding slice of the
+              zodiac. Aspect vectors point along the true ecliptic bearing of
+              the other planet (0° = ahead along the zodiac).
+            </p>
+            <p>
+              A <strong style={{ color: "#4ecdc4" }}>solid arrowhead at the planet</strong>{" "}
+              is an applying force still closing in (with days to exact); an{" "}
+              <strong style={{ color: "var(--fg)" }}>open arrowhead angled away</strong>{" "}
+              is separating. Teal = harmonious, ember = challenging.
+            </p>
+            <p>
+              Sign, sect, and dignity forces read on the fixed element compass
+              (Fire ↑, Air →, Water ↓, Earth ←); the violet resultant reads on
+              the ESMS compass (Spirit ↑, Essence →, Matter ↓, Substance ←) —
+              the planet&apos;s net alchemical tendency.
+            </p>
+            <p>
+              Vector lengths are real engine magnitudes normalized within each
+              card; hover or tap any vector for its raw numbers. Momentum is
+              dashed violet along the planet&apos;s direction of motion (℞ flips
+              it).
+            </p>
           </div>
-        </div>
+        </section>
+
+        {/* Free-body diagram grid */}
+        <section aria-label="Planet free-body diagrams">
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              alignItems: "baseline",
+              gap: 10,
+              marginBottom: 10,
+            }}
+          >
+            <span className="t-tag">
+              FREE-BODY DIAGRAMS · {sky.fbds.length} PLANETS
+            </span>
+            <span
+              className="t-mono"
+              style={{ fontSize: 9, color: "var(--fg-mute)", letterSpacing: "0.1em" }}
+              title="The Ascendant is not a planet and gets no card, and aspects to it keep half their effect off-card — so the ten cards intentionally do not sum to the sky totals above."
+            >
+              + {unattributedTotal.toFixed(2)} ESMS OFF-CARD
+              {sky.totals.groundingVessel
+                ? ` (ASCENDANT GROUNDING VESSEL${
+                    sky.totals.groundingVessel.injected ? ", INJECTED" : ""
+                  })`
+                : ""}
+            </span>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+            {sky.fbds.map((fbd) => (
+              <PlanetFBDCard key={fbd.planet} fbd={fbd} />
+            ))}
+          </div>
+        </section>
+
+        {/* Interactive wheel + alchemical/kinetic tooling */}
+        <section aria-label="Interactive chart">
+          <div className="t-tag" style={{ margin: "8px 0 10px" }}>
+            INTERACTIVE CHART
+          </div>
+          <PlanetaryChartClient />
+        </section>
       </div>
     </div>
-    </PremiumGate>
   );
 }

--- a/src/app/api/alchm-quantities/aspects/route.ts
+++ b/src/app/api/alchm-quantities/aspects/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { rateLimit } from "@/lib/rateLimit";
 import { calculateComprehensiveAspects } from "@/utils/aspectCalculator";
+import { computeAspectKinematics, computeOrb } from "@/utils/aspectKinematics";
 import type { PlanetPosition } from "@/utils/astrologyUtils";
 import { createLogger } from "@/utils/logger";
 import { AVERAGE_DAILY_MOTION } from "@/utils/planetaryTransitions";
@@ -23,16 +24,6 @@ function toLongitude(pos: { sign: string; degree: number; minute?: number; exact
   const SIGNS = ["aries","taurus","gemini","cancer","leo","virgo","libra","scorpio","sagittarius","capricorn","aquarius","pisces"];
   const idx = SIGNS.indexOf(String(pos.sign).toLowerCase());
   return Math.max(0, idx) * 30 + (pos.degree ?? 0) + (pos.minute ?? 0) / 60;
-}
-
-/**
- * Compute the minimal angular separation from the aspect's ideal angle.
- * Returns a value in [0, maxOrb].
- */
-function computeOrb(long1: number, long2: number, aspectAngle: number): number {
-  let diff = Math.abs(long1 - long2) % 360;
-  if (diff > 180) diff = 360 - diff;
-  return Math.abs(diff - aspectAngle);
 }
 
 export interface AspectEntry {
@@ -141,10 +132,6 @@ export async function GET(request: Request) {
       return { speed: base * sign, source: "average-fallback" };
     };
 
-    // dt for finite-difference orb velocity — small enough to be ~instantaneous
-    // for the slowest planets, large enough to dodge floating-point noise.
-    const DT_DAYS = 1 / 24; // 1 hour
-
     for (const aspect of rawAspects) {
       if (!MAJOR_ASPECTS.has(aspect.type)) continue;
 
@@ -164,28 +151,9 @@ export async function GET(request: Request) {
           ? "ephemeris"
           : "average-fallback";
 
-      // Orb at t and t+dt → finite-difference velocity.
       const currentOrb = computeOrb(L1, L2, aspectAngle);
-      const L1next = (L1 + m1 * DT_DAYS + 360) % 360;
-      const L2next = (L2 + m2 * DT_DAYS + 360) % 360;
-      const nextOrb = computeOrb(L1next, L2next, aspectAngle);
-
-      // Signed orb velocity in deg/day. Negative ⇒ orb shrinking ⇒ applying.
-      const orbVelocity = (nextOrb - currentOrb) / DT_DAYS;
-      const STATIONARY_EPS = 1e-4; // deg/day
-      const applying = orbVelocity < -STATIONARY_EPS;
-      const state: "applying" | "separating" | "stationary" =
-        Math.abs(orbVelocity) < STATIONARY_EPS
-          ? "stationary"
-          : applying
-            ? "applying"
-            : "separating";
-
-      // Days to exact (signed by state semantics: positive = future, also positive for
-      // separating to indicate days since exact, matching prior contract).
-      const daysToExact = Math.abs(orbVelocity) > 1e-6
-        ? currentOrb / Math.abs(orbVelocity)
-        : 9999;
+      const { orbVelocity, applying, state, daysToExact } =
+        computeAspectKinematics(L1, L2, aspectAngle, m1, m2);
 
       const strength = Math.max(0, 1 - currentOrb / maxOrb);
 

--- a/src/calculations/planetaryFBD.ts
+++ b/src/calculations/planetaryFBD.ts
@@ -1,0 +1,803 @@
+/**
+ * Planetary free-body diagrams.
+ *
+ * For each planet, decompose everything the engine already knows about it into
+ * force vectors suitable for a free-body-diagram card:
+ *
+ *   - one vector per ASPECT from another body (true-bearing, strength-weighted,
+ *     with applying/separating kinematics when daily motions are available)
+ *   - a SIGN pull along the occupied sign's element axis (the engine's 0.6
+ *     sign-element weight)
+ *   - a SECT pull along the planet's sectarian element axis (the 0.4 weight)
+ *   - a DIGNITY boost/drag along (or against) the sign's element axis
+ *   - a MOMENTUM vector along the planet's direction of motion
+ *
+ * plus a RESULTANT in ESMS space — the planet's alchemical tendency — and an
+ * honest physics readout. Every magnitude is an engine-native quantity (no
+ * invented constants); per-card normalization is applied for display with the
+ * raw value preserved.
+ *
+ * Card space convention (renderers translate to SVG):
+ *   polar angle in degrees, 0° = direction of INCREASING ecliptic longitude
+ *   ("ahead" along the zodiac), increasing counterclockwise.
+ *   SVG mapping: x = cos(θ), y = −sin(θ).
+ *
+ * Element compass (fixed axes, matches ElementalWheel):
+ *   Fire ↑ 90°, Air → 0°, Water ↓ 270°, Earth ← 180°.
+ * ESMS compass (fixed axes, same rose):
+ *   Spirit ↑ 90°, Essence → 0°, Matter ↓ 270°, Substance ← 180°.
+ *
+ * This module is deliberately free of Node-only imports so both server pages
+ * and client components can use it.
+ */
+
+import type { AspectType } from "@/types/alchemy";
+import {
+  calculateComprehensiveAspects,
+  signDegreeToLongitude,
+  type AspectData,
+} from "@/utils/aspectCalculator";
+import { getAspectESMSEffect } from "@/utils/aspectESMSEffects";
+import {
+  computeAspectKinematics,
+  type AspectKinematics,
+} from "@/utils/aspectKinematics";
+import {
+  calculateEnhancedAlchemicalFromPlanetsDetailed,
+  getPlanetarySectElement,
+  type EnhancedPlanetContribution,
+} from "@/utils/planetaryAlchemyMapping";
+import type { DignityType } from "@/types/alchemy";
+
+// ---------------------------------------------------------------------------
+// Inputs
+// ---------------------------------------------------------------------------
+
+export interface FBDPositionInput {
+  sign: string;
+  /** Degree within the sign (0–29.999…). */
+  degree: number;
+  minute?: number;
+  /** Absolute ecliptic longitude 0–360; preferred (sub-arcminute precision). */
+  exactLongitude?: number;
+  isRetrograde?: boolean;
+  /**
+   * Signed daily motion in deg/day (negative while retrograde). When absent —
+   * e.g. a stored natal chart — kinematics and momentum degrade honestly:
+   * no applying/separating verdicts, no momentum vector.
+   */
+  longitudeSpeed?: number;
+}
+
+export interface BuildFBDInput {
+  positions: Record<string, FBDPositionInput>;
+  /**
+   * Sect for the moment — day charts map every planet to Spirit/Essence, so
+   * this flips which ESMS axes a planet can even contribute to.
+   */
+  diurnal: boolean;
+  /** Bodies to build cards for; defaults to the ten planets present. */
+  planets?: string[];
+}
+
+/** What a card's numbers reconcile against — see {@link FBDSkyTotals}. */
+export interface FBDSkyTotals {
+  /** The engine's ESMS totals for this moment. */
+  esms: { Spirit: number; Essence: number; Matter: number; Substance: number };
+  /** Layer-3 aspect total, already included in `esms`. */
+  aspectModifications: {
+    Spirit: number;
+    Essence: number;
+    Matter: number;
+    Substance: number;
+  };
+  /**
+   * ESMS inside `esms` that no card carries, so the parts always add up:
+   *
+   *   Σ cards[].esms + unattributed === esms   (exactly)
+   *
+   * Two things land here. The Ascendant's Physical-Vessel grounding term (it
+   * is not a planet and gets no card), and the far half of any aspect whose
+   * partner has no card — pair effects are split evenly between the two
+   * bodies, so an Ascendant–Mars square puts Mars's half on Mars's card and
+   * the Ascendant's half here. Surfaces must disclose this rather than
+   * implying the ten cards are the whole sky.
+   */
+  unattributed: {
+    Spirit: number;
+    Essence: number;
+    Matter: number;
+    Substance: number;
+  };
+  /** The grounding vessel's own Layer-1×2 term, part of `unattributed`. */
+  groundingVessel: {
+    esms: { Spirit: number; Essence: number; Matter: number; Substance: number };
+    injected: boolean;
+  } | null;
+}
+
+// ---------------------------------------------------------------------------
+// Outputs
+// ---------------------------------------------------------------------------
+
+export type FBDForceKind = "aspect" | "sign" | "sect" | "dignity" | "momentum";
+export type FBDPolarity = "harmonious" | "challenging" | "neutral";
+
+export interface FBDAspectDetail {
+  otherPlanet: string;
+  type: AspectType;
+  /** Orb in degrees (distance from exact). */
+  orb: number;
+  /** Cosine-bell strength 0–1 (1 = exact). */
+  strength: number;
+  /** Type importance = the engine's own orb budget, maxOrb/8 (0.25–1). */
+  baseWeight: number;
+  /** Signed ecliptic offset to the other body, −180…180 (positive = ahead). */
+  offsetDeg: number;
+  /** null when either body lacks a daily motion (e.g. natal charts). */
+  kinematics: AspectKinematics | null;
+  /** Pair-archetype ESMS delta, already scaled by strength. */
+  esmsDelta: { Spirit: number; Essence: number; Matter: number; Substance: number };
+  /** Archetypal description of the pair effect. */
+  description: string;
+}
+
+export interface FBDVector {
+  id: string;
+  kind: FBDForceKind;
+  /** What exerts the force: a planet name, a sign, an element, or "motion". */
+  source: string;
+  /** Short display label, e.g. "△ VENUS" or "LEO → FIRE". */
+  label: string;
+  /** Card-space polar angle (0° = ahead along the zodiac, CCW). */
+  angleDeg: number;
+  /** Raw engine-native magnitude (unitless). */
+  magnitude: number;
+  /** Display length 0–1, per-card normalized with a visibility floor. */
+  normalized: number;
+  polarity: FBDPolarity;
+  /** One-line tooltip detail with the raw numbers. */
+  detail: string;
+  aspect?: FBDAspectDetail;
+}
+
+export interface FBDResultant {
+  /** ESMS-space tendency angle on the Spirit/Essence/Matter/Substance rose. */
+  angleDeg: number;
+  /** |(Essence−Substance, Spirit−Matter)| — raw ESMS-space magnitude. */
+  magnitude: number;
+  /** Display length 0–1 (magnitude / RESULTANT_DISPLAY_SCALE, clamped). */
+  normalized: number;
+  /**
+   * The planet's ESMS involvement: its base contribution plus HALF of each of
+   * its aspects' pair deltas (each pair effect is shared by two planets, so
+   * summing every card's aspect share reproduces the engine's Layer-3 total).
+   */
+  esms: { Spirit: number; Essence: number; Matter: number; Substance: number };
+  dominant: "Spirit" | "Essence" | "Matter" | "Substance";
+  /** The planet's elemental push (sign + sect blend) and its dominant axis. */
+  elementalPush: {
+    Fire: number;
+    Water: number;
+    Earth: number;
+    Air: number;
+    dominant: "Fire" | "Water" | "Earth" | "Air";
+  };
+  /** Σ signed aspect influence (+harmonious −challenging, strength-weighted). */
+  netHarmony: number;
+}
+
+export interface FBDPhysics {
+  /** Q = Matter + Substance of this planet's ESMS contribution. */
+  charge: number;
+  /** p = daily motion × alchemical weight (deg/day-weighted); null w/o speed. */
+  momentum: number | null;
+  /** Signed daily motion, deg/day. */
+  speedDegPerDay: number | null;
+  /** Signed daily motion, arc-minutes/day — the card's arc-minute tie-in. */
+  arcminutesPerDay: number | null;
+  /** Orbital-period alchemical weight (log-normalized, Moon≈0.17 Pluto≈1). */
+  alchmWeight: number;
+}
+
+export interface PlanetFBD {
+  planet: string;
+  sign: string;
+  signElement: string;
+  /** Integer degree within sign. */
+  degree: number;
+  /** Integer arc-minute within degree. */
+  minute: number;
+  /** Absolute ecliptic longitude (sub-arcminute precision when available). */
+  exactLongitude: number;
+  isRetrograde: boolean;
+  dignity: {
+    /** ESMS-scale points (+10 domicile … −10 fall) — the scale the engine applies. */
+    esmsScale: number;
+    type: DignityType;
+    /** The multiplier the engine actually applied: 1 + esmsScale/100. */
+    multiplier: number;
+  };
+  vectors: FBDVector[];
+  resultant: FBDResultant;
+  physics: FBDPhysics;
+  esms: { Spirit: number; Essence: number; Matter: number; Substance: number };
+  elements: { Fire: number; Water: number; Earth: number; Air: number };
+  /** false when the source chart carries no daily motions (stored natal). */
+  kinematicsAvailable: boolean;
+  /** Raw magnitude that maps to normalized = 1 on this card. */
+  normalizationScale: number;
+  /** This planet's half of its aspects' pair deltas — the Layer-3 part of `esms`. */
+  aspectShare: { Spirit: number; Essence: number; Matter: number; Substance: number };
+}
+
+export interface FBDResult {
+  cards: PlanetFBD[];
+  /** The sky-level ESMS the cards decompose. See {@link FBDSkyTotals}. */
+  totals: FBDSkyTotals;
+}
+
+// ---------------------------------------------------------------------------
+// Constants (engine-native — no invented tuning knobs)
+// ---------------------------------------------------------------------------
+
+export const TEN_PLANETS = [
+  "Sun",
+  "Moon",
+  "Mercury",
+  "Venus",
+  "Mars",
+  "Jupiter",
+  "Saturn",
+  "Uranus",
+  "Neptune",
+  "Pluto",
+] as const;
+
+/** Fixed element compass, matches ElementalWheel (Fire up, Air right…). */
+export const ELEMENT_ANGLES: Record<string, number> = {
+  Fire: 90,
+  Air: 0,
+  Water: 270,
+  Earth: 180,
+};
+
+/** Fixed ESMS compass on the same rose (Spirit up, Essence right…). */
+export const ESMS_ANGLES: Record<string, number> = {
+  Spirit: 90,
+  Essence: 0,
+  Matter: 270,
+  Substance: 180,
+};
+
+/** Mirrors RealAlchemizeService's elemental blending weights. */
+const SIGN_WEIGHT = 0.6;
+const SECT_WEIGHT = 0.4;
+
+/** Ideal angles per aspect type (matches aspectCalculator's definitions). */
+const ASPECT_ANGLES: Record<AspectType, number> = {
+  conjunction: 0,
+  opposition: 180,
+  trine: 120,
+  square: 90,
+  sextile: 60,
+  quincunx: 150,
+  inconjunct: 150,
+  "semi-sextile": 30,
+  sesquisquare: 135,
+  semisquare: 45,
+  quintile: 72,
+  biquintile: 144,
+};
+
+/**
+ * Max orbs per aspect type (matches aspectCalculator). The type's importance
+ * weight is derived from the engine's own orb budget — maxOrb/8 — rather than
+ * a new hand-tuned table: conjunction/opposition/trine 1.0 … quintile 0.25.
+ */
+const ASPECT_MAX_ORBS: Record<AspectType, number> = {
+  conjunction: 8,
+  opposition: 8,
+  trine: 8,
+  square: 7,
+  sextile: 6,
+  quincunx: 5,
+  inconjunct: 5,
+  "semi-sextile": 4,
+  sesquisquare: 3,
+  semisquare: 3,
+  quintile: 2,
+  biquintile: 2,
+};
+
+const ASPECT_GLYPHS: Partial<Record<AspectType, string>> = {
+  conjunction: "☌",
+  opposition: "☍",
+  trine: "△",
+  square: "□",
+  sextile: "⚹",
+  quincunx: "⚻",
+  inconjunct: "⚻",
+  "semi-sextile": "⚺",
+};
+
+/** Vectors shorter than this fraction of the card max stay visible. */
+const MIN_VISUAL_NORM = 0.12;
+
+/**
+ * Raw ESMS-space magnitude that renders as a full-length resultant. Planet
+ * ESMS contributions live in roughly 0–1.3 (alchmWeight × dignity), so the
+ * axis differences rarely exceed ~1.5.
+ */
+const RESULTANT_DISPLAY_SCALE = 1.5;
+
+// ---------------------------------------------------------------------------
+// Small helpers (exported for tests + renderers)
+// ---------------------------------------------------------------------------
+
+/** Signed shortest angular offset from `from` to `to`, in (−180, 180]. */
+export function signedDeltaDeg(from: number, to: number): number {
+  let delta = (to - from) % 360;
+  if (delta > 180) delta -= 360;
+  if (delta <= -180) delta += 360;
+  return delta;
+}
+
+/** Normalize an angle to [0, 360). */
+export function normalizeAngle(angle: number): number {
+  return ((angle % 360) + 360) % 360;
+}
+
+/** "18°42′" from a sign-relative degree + minute. */
+export function formatDegMin(degree: number, minute: number): string {
+  return `${Math.floor(degree)}°${String(Math.floor(minute)).padStart(2, "0")}′`;
+}
+
+function harmonyOf(type: AspectType): FBDPolarity {
+  if (type === "conjunction" || type === "trine" || type === "sextile") {
+    return "harmonious";
+  }
+  if (type === "opposition" || type === "square") return "challenging";
+  return "neutral";
+}
+
+function resolveLongitude(pos: FBDPositionInput): number | null {
+  if (typeof pos.exactLongitude === "number" && Number.isFinite(pos.exactLongitude)) {
+    return normalizeAngle(pos.exactLongitude);
+  }
+  return signDegreeToLongitude(pos.sign, pos.degree, pos.minute ?? 0);
+}
+
+/**
+ * Bodies the ESMS engine excludes from its aspect universe (mirrors the
+ * positionData filter in RealAlchemizeService.alchemize). The FBD cards must
+ * draw the same aspect set Layer 3 actually consumes — a node aspect the
+ * engine never sees would be a phantom force. Ascendant stays: the engine
+ * includes it when a position is provided.
+ */
+const EXCLUDED_ASPECT_BODIES = new Set([
+  "NorthNode",
+  "SouthNode",
+  "True Node",
+  // The Swiss-Ephemeris backend spells the nodes with a space — the engine's
+  // own inline list misses "North Node", which is a known gap being fixed
+  // separately; the cards draw the intended (node-free) aspect universe.
+  "North Node",
+  "South Node",
+  "Chiron",
+  "Lilith",
+  "Vertex",
+  "Pars Fortune",
+  "Mean Node",
+  "MC",
+]);
+
+const SIGN_ELEMENT: Record<string, "Fire" | "Water" | "Earth" | "Air"> = {
+  aries: "Fire",
+  leo: "Fire",
+  sagittarius: "Fire",
+  taurus: "Earth",
+  virgo: "Earth",
+  capricorn: "Earth",
+  gemini: "Air",
+  libra: "Air",
+  aquarius: "Air",
+  cancer: "Water",
+  scorpio: "Water",
+  pisces: "Water",
+};
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a free-body diagram for every requested planet.
+ *
+ * All bodies present in `positions` participate as aspect sources (an
+ * Ascendant can pull on a card's planet), but cards are produced only for the
+ * requested planets (default: the ten planets).
+ */
+export function buildFreeBodyDiagrams(input: BuildFBDInput): FBDResult {
+  const { positions, diurnal } = input;
+
+  const longitudes: Record<string, number> = {};
+  for (const [name, pos] of Object.entries(positions)) {
+    const lon = resolveLongitude(pos);
+    if (lon !== null) longitudes[name] = lon;
+  }
+
+  // One aspect pass for the whole sky (cosine-bell strengths, majors+minors).
+  const aspects: AspectData[] = calculateComprehensiveAspects(
+    Object.fromEntries(
+      Object.entries(positions)
+        .filter(
+          ([name]) =>
+            longitudes[name] !== undefined && !EXCLUDED_ASPECT_BODIES.has(name),
+        )
+        .map(([name, pos]) => [
+          name,
+          {
+            sign: String(pos.sign).toLowerCase(),
+            degree: pos.degree,
+            exactLongitude: longitudes[name],
+            isRetrograde: pos.isRetrograde,
+          },
+        ]),
+    ),
+  );
+
+  // The ESMS numbers on every card come from the engine's OWN three-layer
+  // decomposition, so a card's Spirit/Essence/Matter/Substance is literally
+  // that planet's term in the totals — not a lookalike recomputation.
+  const signMap: Record<string, string> = {};
+  for (const [name, pos] of Object.entries(positions)) {
+    if (EXCLUDED_ASPECT_BODIES.has(name)) continue;
+    signMap[name] = String(pos.sign).toLowerCase();
+  }
+  const engine = calculateEnhancedAlchemicalFromPlanetsDetailed(
+    signMap,
+    diurnal,
+    aspects.map((a) => ({
+      planet1: a.planet1,
+      planet2: a.planet2,
+      type: a.type,
+      strength: a.strength,
+    })),
+  );
+
+  const cardPlanets =
+    input.planets ??
+    TEN_PLANETS.filter((planet) => positions[planet] !== undefined);
+
+  const cards = cardPlanets
+    .map((planet) => {
+      const pos = positions[planet];
+      const contribution = engine.perPlanet[planet];
+      const lon = longitudes[planet];
+      if (!pos || !contribution || lon === undefined) return null;
+      return buildCard(
+        planet,
+        pos,
+        lon,
+        contribution,
+        diurnal,
+        aspects,
+        longitudes,
+        positions,
+      );
+    })
+    .filter((card): card is PlanetFBD => card !== null);
+
+  // Momentum normalizes across the whole sky rather than per card, so arrow
+  // length stays comparable between planets (the Moon really does carry ~200×
+  // Pluto's) instead of every card rendering its own momentum at full length.
+  const maxMomentum = Math.max(
+    ...cards.flatMap((card) =>
+      card.vectors.filter((v) => v.kind === "momentum").map((v) => v.magnitude),
+    ),
+    1e-9,
+  );
+  for (const card of cards) {
+    for (const vector of card.vectors) {
+      if (vector.kind !== "momentum") continue;
+      vector.normalized = Math.min(
+        1,
+        Math.max(MIN_VISUAL_NORM, vector.magnitude / maxMomentum),
+      );
+    }
+  }
+
+  const vessel = engine.perPlanet.Ascendant;
+  // Whatever the cards don't carry — the vessel's own term plus the far half
+  // of any aspect whose partner has no card — is reported, never dropped.
+  const unattributed = { Spirit: 0, Essence: 0, Matter: 0, Substance: 0 };
+  for (const axis of ["Spirit", "Essence", "Matter", "Substance"] as const) {
+    const carried = cards.reduce((sum, card) => sum + card.esms[axis], 0);
+    unattributed[axis] = engine.totals[axis] - carried;
+  }
+
+  return {
+    cards,
+    totals: {
+      esms: engine.totals,
+      aspectModifications: engine.aspectModifications,
+      unattributed,
+      groundingVessel: vessel
+        ? { esms: vessel.esms, injected: engine.ascendantInjected }
+        : null,
+    },
+  };
+}
+
+function buildCard(
+  planet: string,
+  pos: FBDPositionInput,
+  lon: number,
+  contribution: EnhancedPlanetContribution,
+  diurnal: boolean,
+  allAspects: AspectData[],
+  longitudes: Record<string, number>,
+  positions: Record<string, FBDPositionInput>,
+): PlanetFBD {
+  const sign = String(pos.sign).toLowerCase();
+  const signElement = SIGN_ELEMENT[sign] ?? "Air";
+  const degreeInSign = lon % 30;
+  const degree = Math.floor(degreeInSign);
+  const minute = Math.floor((degreeInSign - degree) * 60);
+
+  // Elemental blend mirrors the engine's own 60/40 sign-vs-sect weighting.
+  const sectElement = getPlanetarySectElement(planet, diurnal);
+  const elements = { Fire: 0, Water: 0, Earth: 0, Air: 0 };
+  if (signElement in elements) {
+    elements[signElement as keyof typeof elements] += SIGN_WEIGHT;
+  }
+  if (sectElement in elements) {
+    elements[sectElement as keyof typeof elements] += SECT_WEIGHT;
+  }
+
+  const dignityEsmsScale = contribution.dignityEsmsScale;
+  const multiplier = contribution.dignityMultiplier;
+  // A speed of exactly 0 is astronomy-engine's "no motion computed" sentinel
+  // (serverPlanetaryCalculations initializes longitudeSpeed = 0 and only
+  // overwrites it on success), not a real standstill — treat it as unknown so
+  // the card degrades honestly instead of drawing a zero-length momentum arrow
+  // and claiming kinematics it does not have.
+  const speed =
+    typeof pos.longitudeSpeed === "number" &&
+    Number.isFinite(pos.longitudeSpeed) &&
+    pos.longitudeSpeed !== 0
+      ? pos.longitudeSpeed
+      : null;
+
+  const vectors: FBDVector[] = [];
+  const aspectEsmsShare = { Spirit: 0, Essence: 0, Matter: 0, Substance: 0 };
+  let netHarmony = 0;
+  // Card-level flag: does THIS planet carry a daily motion? Individual aspects
+  // additionally need the partner's motion and carry their own kinematics|null.
+  const kinematicsAvailable = speed !== null;
+
+  // --- Aspect force vectors ------------------------------------------------
+  for (const aspect of allAspects) {
+    const isP1 = aspect.planet1 === planet;
+    const isP2 = aspect.planet2 === planet;
+    if (!isP1 && !isP2) continue;
+    const other = isP1 ? aspect.planet2 : aspect.planet1;
+    const otherLon = longitudes[other];
+    if (otherLon === undefined) continue;
+
+    const offsetDeg = signedDeltaDeg(lon, otherLon);
+    const baseWeight = (ASPECT_MAX_ORBS[aspect.type] ?? 2) / 8;
+    const magnitude = aspect.strength * baseWeight;
+    const polarity = harmonyOf(aspect.type);
+    if (polarity === "harmonious") netHarmony += aspect.strength;
+    if (polarity === "challenging") netHarmony -= aspect.strength;
+
+    const otherSpeed = positions[other]?.longitudeSpeed;
+    const kinematics =
+      speed !== null && typeof otherSpeed === "number" && Number.isFinite(otherSpeed)
+        ? computeAspectKinematics(
+            lon,
+            otherLon,
+            ASPECT_ANGLES[aspect.type] ?? 0,
+            speed,
+            otherSpeed,
+          )
+        : null;
+
+    const rawEffect = getAspectESMSEffect(aspect.planet1, aspect.planet2, aspect.type);
+    const esmsDelta = {
+      Spirit: rawEffect.Spirit * aspect.strength,
+      Essence: rawEffect.Essence * aspect.strength,
+      Matter: rawEffect.Matter * aspect.strength,
+      Substance: rawEffect.Substance * aspect.strength,
+    };
+    // Half of the pair effect belongs to this card (see FBDResultant.esms).
+    aspectEsmsShare.Spirit += esmsDelta.Spirit / 2;
+    aspectEsmsShare.Essence += esmsDelta.Essence / 2;
+    aspectEsmsShare.Matter += esmsDelta.Matter / 2;
+    aspectEsmsShare.Substance += esmsDelta.Substance / 2;
+
+    // Round to whole arc-minutes FIRST, then split — rounding the minutes
+    // independently of a floored degree renders 2.999° as "2°60′".
+    const orbTotalMin = Math.round(aspect.orb * 60);
+    const orbDeg = Math.floor(orbTotalMin / 60);
+    const orbMin = orbTotalMin % 60;
+    const kinematicsNote = kinematics
+      ? kinematics.state === "stationary"
+        ? "stationary"
+        : kinematics.state === "applying"
+          ? `applying · ${kinematics.daysToExact.toFixed(1)}d to exact`
+          : `separating · ${kinematics.daysToExact.toFixed(1)}d since exact`
+      : "motion unavailable";
+
+    vectors.push({
+      id: `aspect-${other}-${aspect.type}`,
+      kind: "aspect",
+      source: other,
+      label: `${ASPECT_GLYPHS[aspect.type] ?? aspect.type.toUpperCase()} ${other.toUpperCase()}`,
+      angleDeg: normalizeAngle(offsetDeg),
+      magnitude,
+      normalized: 0, // filled after per-card normalization
+      polarity,
+      detail: `${aspect.type} · orb ${orbDeg}°${String(orbMin).padStart(2, "0")}′ · strength ${(aspect.strength * 100).toFixed(0)}% × weight ${baseWeight.toFixed(2)} · ${kinematicsNote}`,
+      aspect: {
+        otherPlanet: other,
+        type: aspect.type,
+        orb: aspect.orb,
+        strength: aspect.strength,
+        baseWeight,
+        offsetDeg,
+        kinematics,
+        esmsDelta,
+        description: rawEffect.description,
+      },
+    });
+  }
+
+  // --- Sign pull (engine's 0.6 sign-element weight) -------------------------
+  vectors.push({
+    id: "sign-pull",
+    kind: "sign",
+    source: sign,
+    label: `${sign.toUpperCase()} → ${signElement.toUpperCase()}`,
+    angleDeg: ELEMENT_ANGLES[signElement],
+    magnitude: SIGN_WEIGHT,
+    normalized: 0,
+    polarity: "neutral",
+    detail: `sign pull · ${signElement} · engine sign-element weight ${SIGN_WEIGHT.toFixed(2)}`,
+  });
+
+  // --- Sect pull (engine's 0.4 sectarian-element weight) --------------------
+  if (ELEMENT_ANGLES[sectElement] !== undefined) {
+    vectors.push({
+      id: "sect-pull",
+      kind: "sect",
+      source: sectElement,
+      label: `SECT → ${sectElement.toUpperCase()}`,
+      angleDeg: ELEMENT_ANGLES[sectElement],
+      magnitude: SECT_WEIGHT,
+      normalized: 0,
+      polarity: "neutral",
+      detail: `sectarian pull · ${sectElement} · engine sect-element weight ${SECT_WEIGHT.toFixed(2)}`,
+    });
+  }
+
+  // --- Dignity boost/drag along the sign's element axis ---------------------
+  //
+  // Magnitude and label both come from the ESMS-scale multiplier the engine
+  // actually applied (1 + esmsScale/100 → ±7% exaltation/detriment, ±10%
+  // domicile/fall). The ±15%-per-level food scale is a different system and
+  // would have the card claim a boost the ESMS totals never received.
+  if (dignityEsmsScale !== 0) {
+    const boosting = dignityEsmsScale > 0;
+    const label = contribution.dignityType.toUpperCase();
+    vectors.push({
+      id: "dignity",
+      kind: "dignity",
+      source: contribution.dignityType,
+      label: `${label} ${boosting ? "+" : "−"}${Math.abs(dignityEsmsScale)}%`,
+      angleDeg: boosting
+        ? ELEMENT_ANGLES[signElement]
+        : normalizeAngle(ELEMENT_ANGLES[signElement] + 180),
+      magnitude: Math.abs(multiplier - 1),
+      normalized: 0,
+      polarity: boosting ? "harmonious" : "challenging",
+      detail: `dignity · ${contribution.dignityType} in ${sign} · ESMS multiplier ×${multiplier.toFixed(2)}`,
+    });
+  }
+
+  // --- Momentum along the direction of motion -------------------------------
+  const momentum = speed !== null ? speed * contribution.alchmWeight : null;
+  if (speed !== null && momentum !== null) {
+    vectors.push({
+      id: "momentum",
+      kind: "momentum",
+      source: "motion",
+      label: pos.isRetrograde ? "℞ MOMENTUM" : "MOMENTUM",
+      angleDeg: speed >= 0 ? 0 : 180,
+      magnitude: Math.abs(momentum),
+      normalized: 0,
+      polarity: "neutral",
+      detail: `momentum · ${speed.toFixed(3)}°/day (${(speed * 60).toFixed(1)}′/day) × alchemical weight ${contribution.alchmWeight.toFixed(2)}`,
+    });
+  }
+
+  // --- Per-card normalization (raw values preserved) -------------------------
+  //
+  // Momentum is deliberately excluded from the force scale: it is |deg/day ×
+  // weight| while every other magnitude is a dimensionless 0–1 engine weight.
+  // Letting the two share a scale means the Moon's momentum (~3.7) sets the
+  // card max and squashes a strength-1.00 trine into the same 12px band as a
+  // trivial one — destroying exactly the comparison the card exists to make.
+  // Momentum is normalized separately, across cards, in buildFreeBodyDiagrams.
+  const scale = Math.max(
+    ...vectors.filter((v) => v.kind !== "momentum").map((v) => v.magnitude),
+    1e-9,
+  );
+  for (const vector of vectors) {
+    if (vector.kind === "momentum") continue;
+    vector.normalized = Math.min(
+      1,
+      Math.max(MIN_VISUAL_NORM, vector.magnitude / scale),
+    );
+  }
+
+  // --- Resultant: ESMS tendency ---------------------------------------------
+  const esms = {
+    Spirit: contribution.esms.Spirit + aspectEsmsShare.Spirit,
+    Essence: contribution.esms.Essence + aspectEsmsShare.Essence,
+    Matter: contribution.esms.Matter + aspectEsmsShare.Matter,
+    Substance: contribution.esms.Substance + aspectEsmsShare.Substance,
+  };
+  const rx = esms.Essence - esms.Substance;
+  const ry = esms.Spirit - esms.Matter;
+  const resultantMagnitude = Math.hypot(rx, ry);
+  const resultantAngle = normalizeAngle((Math.atan2(ry, rx) * 180) / Math.PI);
+  const dominant = (
+    Object.entries(esms) as Array<[FBDResultant["dominant"], number]>
+  ).sort((a, b) => b[1] - a[1])[0][0];
+
+  const elementalEntries = Object.entries(elements) as Array<
+    ["Fire" | "Water" | "Earth" | "Air", number]
+  >;
+  const dominantElement = elementalEntries.sort((a, b) => b[1] - a[1])[0][0];
+
+  return {
+    planet,
+    sign,
+    signElement,
+    degree,
+    minute,
+    exactLongitude: lon,
+    isRetrograde: Boolean(pos.isRetrograde),
+    dignity: {
+      esmsScale: dignityEsmsScale,
+      type: contribution.dignityType,
+      multiplier,
+    },
+    vectors,
+    resultant: {
+      angleDeg: resultantAngle,
+      magnitude: resultantMagnitude,
+      normalized: Math.min(1, resultantMagnitude / RESULTANT_DISPLAY_SCALE),
+      esms,
+      dominant,
+      elementalPush: { ...elements, dominant: dominantElement },
+      netHarmony,
+    },
+    physics: {
+      // Charge and the ESMS row must agree: both are aspect-inclusive.
+      charge: esms.Matter + esms.Substance,
+      momentum,
+      speedDegPerDay: speed,
+      arcminutesPerDay: speed !== null ? speed * 60 : null,
+      alchmWeight: contribution.alchmWeight,
+    },
+    esms,
+    elements,
+    kinematicsAvailable,
+    normalizationScale: scale,
+    aspectShare: aspectEsmsShare,
+  };
+}

--- a/src/components/dashboard/NatalTransitChart.tsx
+++ b/src/components/dashboard/NatalTransitChart.tsx
@@ -1,14 +1,20 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useAlchemical } from '@/contexts/AlchemicalContext/hooks';
 import { useActiveTransits } from '@/hooks/useActiveTransits';
 import { useTransitGroupChat } from '@/hooks/useTransitGroupChat';
 import type { NatalChart, Planet, ZodiacSignType } from '@/types/natalChart';
+import { buildAspectsFromChartPlanets } from '@/utils/aspectCalculator';
 import { extractPlanetaryPositions } from '@/utils/astrology/chartDataUtils';
+import { getDignityScore } from '@/utils/dignityScales';
 
 interface NatalTransitChartProps {
   natalChart: NatalChart;
+  /** Draw natal-to-natal major-aspect chords on the wheel (default true). */
+  showAspectLines?: boolean;
+  /** Draw per-planet element/dignity pull arrows outside the natal ring (default true). */
+  showSignVectors?: boolean;
 }
 
 const ZODIAC_SIGNS: ZodiacSignType[] = [
@@ -49,7 +55,22 @@ interface TransitData {
   isRetrograde?: boolean;
 }
 
-export const NatalTransitChart: React.FC<NatalTransitChartProps> = ({ natalChart }) => {
+/** Majors only on the wheel — minors would hairball; they live on the FBD cards instead. */
+const MAJOR_ASPECTS = new Set(['conjunction', 'opposition', 'trine', 'square', 'sextile']);
+const HARMONIOUS_ASPECTS = new Set(['conjunction', 'trine', 'sextile']);
+const ASPECT_DASH: Record<string, string | undefined> = {
+  conjunction: undefined,
+  trine: undefined,
+  square: '3,3',
+  opposition: '5,5',
+  sextile: '2,2',
+};
+
+export const NatalTransitChart: React.FC<NatalTransitChartProps> = ({
+  natalChart,
+  showAspectLines = true,
+  showSignVectors = true,
+}) => {
   const { planetaryPositions: currentPositionsRaw } = useAlchemical();
   const [transitData, setTransitData] = useState<Record<string, TransitData>>({});
   const { groupForPlanet } = useActiveTransits();
@@ -153,6 +174,19 @@ export const NatalTransitChart: React.FC<NatalTransitChartProps> = ({ natalChart
   const spreadNatal = spreadPositions(natalPositions, 8);
   const spreadTransit = spreadPositions(transitPositions, 8);
 
+  // Natal-to-natal major aspects for the wheel chords (minors live on the FBD cards).
+  const natalAspects = useMemo(
+    () =>
+      buildAspectsFromChartPlanets(natalChart.planets).filter(
+        (a) => MAJOR_ASPECTS.has(a.type) && a.strength >= 0.2,
+      ),
+    [natalChart.planets],
+  );
+
+  const spreadNatalByPlanet = new Map<string, { absAngle: number; sign: string }>(
+    spreadNatal.map((pos) => [pos.planet as string, pos as { absAngle: number; sign: string }]),
+  );
+
   return (
     <div className="space-y-4">
       <div className="flex justify-center">
@@ -202,6 +236,83 @@ export const NatalTransitChart: React.FC<NatalTransitChartProps> = ({ natalChart
               </g>
             );
           })}
+
+          {/* Natal-to-natal aspect chords (under the planet markers) */}
+          {showAspectLines &&
+            natalAspects.map((aspect) => {
+              const p1 = spreadNatalByPlanet.get(aspect.planet1);
+              const p2 = spreadNatalByPlanet.get(aspect.planet2);
+              if (!p1 || !p2) return null;
+              const pt1 = polarToXY(toSvgAngle(p1.absAngle), natalR);
+              const pt2 = polarToXY(toSvgAngle(p2.absAngle), natalR);
+              const chordLength = Math.hypot(pt2.x - pt1.x, pt2.y - pt1.y);
+              // Conjunction chords collapse to dots — skip the near-zero ones.
+              if (aspect.type === 'conjunction' && chordLength < 6) return null;
+              const alpha = 0.25 + 0.45 * aspect.strength;
+              const stroke = HARMONIOUS_ASPECTS.has(aspect.type)
+                ? `rgba(78,205,196,${alpha.toFixed(3)})`
+                : `rgba(239,68,68,${alpha.toFixed(3)})`;
+              return (
+                <line
+                  key={`aspect-${aspect.planet1}-${aspect.planet2}-${aspect.type}`}
+                  x1={pt1.x}
+                  y1={pt1.y}
+                  x2={pt2.x}
+                  y2={pt2.y}
+                  stroke={stroke}
+                  strokeWidth={0.6 + 1.6 * aspect.strength}
+                  strokeDasharray={ASPECT_DASH[aspect.type]}
+                  strokeLinecap="round"
+                >
+                  <title>{`${aspect.planet1} ${aspect.type} ${aspect.planet2} · strength ${aspect.strength.toFixed(2)}`}</title>
+                </line>
+              );
+            })}
+
+          {/* Sign-element pull vectors: radial arrows scaled by dignity */}
+          {showSignVectors &&
+            spreadNatal.map((pos) => {
+              const signStr = typeof pos.sign === 'string' ? pos.sign.toLowerCase() : '';
+              const element = SIGN_ELEMENTS[signStr];
+              if (!element) return null;
+              const color = ELEMENT_COLORS[element];
+              // ESMS-scale dignity — the same multiplier the alchemical engine
+              // applies, so the arrow length means what the FBD cards mean.
+              const dignity = getDignityScore(pos.planet, signStr);
+              const multiplier = 1 + dignity.esmsScale / 100;
+              const length = 10 * multiplier;
+              const angle = toSvgAngle(pos.absAngle);
+              const rad = (angle * Math.PI) / 180;
+              const ux = Math.cos(rad);
+              const uy = Math.sin(rad);
+              const start = polarToXY(angle, 144);
+              const tip = polarToXY(angle, 144 + length);
+              const headLen = 3.5;
+              const headHalfWidth = 2.2;
+              const baseX = tip.x - ux * headLen;
+              const baseY = tip.y - uy * headLen;
+              const perpX = -uy;
+              const perpY = ux;
+              const signLabel = signStr ? signStr.charAt(0).toUpperCase() + signStr.slice(1) : signStr;
+              return (
+                <g key={`sign-vector-${pos.planet}`} opacity="0.8">
+                  <title>{`${signLabel} → ${element} · ${dignity.type} ×${multiplier.toFixed(2)}`}</title>
+                  <line
+                    x1={start.x}
+                    y1={start.y}
+                    x2={baseX}
+                    y2={baseY}
+                    stroke={color}
+                    strokeWidth="1.2"
+                    strokeLinecap="round"
+                  />
+                  <polygon
+                    points={`${tip.x},${tip.y} ${baseX + perpX * headHalfWidth},${baseY + perpY * headHalfWidth} ${baseX - perpX * headHalfWidth},${baseY - perpY * headHalfWidth}`}
+                    fill={color}
+                  />
+                </g>
+              );
+            })}
 
           {/* Natal planet markers (outer ring) */}
           {spreadNatal.map((pos) => {
@@ -289,7 +400,7 @@ export const NatalTransitChart: React.FC<NatalTransitChartProps> = ({ natalChart
       </div>
 
       {/* Legend */}
-      <div className="flex justify-center gap-6 text-xs">
+      <div className="flex flex-wrap justify-center gap-x-6 gap-y-2 text-xs">
         <div className="flex items-center gap-1.5">
           <span className="w-2.5 h-2.5 rounded-full inline-block" style={{ backgroundColor: '#a78bfa', boxShadow: '0 0 6px rgba(167,139,250,0.4)' }} />
           <span className="text-white/40">Natal</span>
@@ -298,6 +409,29 @@ export const NatalTransitChart: React.FC<NatalTransitChartProps> = ({ natalChart
           <span className="w-2.5 h-2.5 rounded-full inline-block" style={{ backgroundColor: '#fb923c', boxShadow: '0 0 6px rgba(251,146,60,0.4)' }} />
           <span className="text-white/40">Transit</span>
         </div>
+        {/* Keyed off what was actually drawn: charts stored sign-only carry no
+            longitudes, so no chords exist to explain. */}
+        {showAspectLines && natalAspects.length > 0 && (
+          <>
+            <div className="flex items-center gap-1.5">
+              <span className="w-2.5 h-0.5 inline-block rounded-full" style={{ backgroundColor: 'rgba(78,205,196,0.8)', boxShadow: '0 0 6px rgba(78,205,196,0.4)' }} />
+              <span className="text-white/40">Harmony</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="w-2.5 h-0.5 inline-block rounded-full" style={{ backgroundColor: 'rgba(239,68,68,0.8)', boxShadow: '0 0 6px rgba(239,68,68,0.4)' }} />
+              <span className="text-white/40">Tension</span>
+            </div>
+          </>
+        )}
+        {showSignVectors && spreadNatal.length > 0 && (
+          <div className="flex items-center gap-1.5">
+            <span
+              className="w-2.5 h-2.5 rounded-full inline-block"
+              style={{ background: 'conic-gradient(#ef4444, #a78bfa, #34d399, #60a5fa, #ef4444)', opacity: 0.8 }}
+            />
+            <span className="text-white/40">Element pull</span>
+          </div>
+        )}
       </div>
 
       {/* Natal Placements Table */}

--- a/src/components/ui/alchm/PlanetFBDCard.tsx
+++ b/src/components/ui/alchm/PlanetFBDCard.tsx
@@ -1,0 +1,525 @@
+"use client";
+
+/**
+ * Planet free-body-diagram card.
+ *
+ * Renders one planet's PlanetFBD (from src/calculations/planetaryFBD) as a
+ * physics-style vector diagram:
+ *   - backdrop: a zoomed slice of the zodiac — a gently curved arc-minute
+ *     ruler centered on the planet's exact degree°minute′
+ *   - one vector per force (aspects at true ecliptic bearings; sign/sect/
+ *     dignity on the fixed element compass; momentum along the motion axis)
+ *   - applying aspects: solid arrowhead pointing IN at the planet, with a
+ *     days-to-exact countdown; separating: open arrowhead angled away
+ *   - the ESMS resultant (alchemical tendency) drawn prominently
+ *   - hover/tap a vector to see its raw values in the readout strip
+ *
+ * Requires an `.alchm-root` (or `.lab`) ancestor for the design-token CSS
+ * variables. Data is fully serializable — compute server-side, render here.
+ */
+
+import { useState } from "react";
+import type { FBDVector, PlanetFBD } from "@/calculations/planetaryFBD";
+import { getZodiacGlyph } from "@/utils/chartRendering";
+import type { ZodiacSignType } from "@/types/celestial";
+import { planetColor, planetGlyph } from "./planetColors";
+
+const ESMS_GLYPHS: Record<string, string> = {
+  Spirit: "🜀",
+  Essence: "🜁",
+  Matter: "🜃",
+  Substance: "🜄",
+};
+
+const ELEMENT_VAR: Record<string, string> = {
+  Fire: "var(--el-fire)",
+  Water: "var(--el-water)",
+  Earth: "var(--el-earth)",
+  Air: "var(--el-air)",
+};
+
+const POLARITY_COLORS: Record<FBDVector["polarity"], string> = {
+  harmonious: "#4ecdc4",
+  challenging: "#ef6a5a",
+  neutral: "var(--fg-dim)",
+};
+
+function vectorColor(vector: FBDVector, signElement: string): string {
+  if (vector.kind === "sign") return ELEMENT_VAR[signElement] ?? "var(--fg-dim)";
+  if (vector.kind === "sect") return ELEMENT_VAR[vector.source] ?? "var(--fg-dim)";
+  if (vector.kind === "dignity") {
+    return vector.polarity === "harmonious" ? "var(--accent-2)" : "#ef6a5a";
+  }
+  if (vector.kind === "momentum") return "var(--accent)";
+  return POLARITY_COLORS[vector.polarity];
+}
+
+// Diagram geometry ----------------------------------------------------------
+const W = 320;
+const H = 300;
+const CX = W / 2;
+const CY = 152;
+const R_MAX = 108; // max vector length from center
+const R_MIN = 26; // vector length at the visibility floor
+const NODE_R = 11;
+
+// Arc-minute ruler: a circle of huge radius through the planet node, so the
+// zodiac slice reads as a gently bowed ruler. 4px per arc-minute.
+const RULER_R = 1200;
+const PX_PER_ARCMIN = 4;
+const RULER_HALF_WINDOW = 40; // ± arc-minutes shown
+
+function rulerY(x: number): number {
+  const dx = x - CX;
+  return CY + RULER_R - Math.sqrt(RULER_R * RULER_R - dx * dx);
+}
+
+/** Card-space polar angle → SVG point at radius r from the planet node. */
+function polar(angleDeg: number, r: number): { x: number; y: number } {
+  const rad = (angleDeg * Math.PI) / 180;
+  return { x: CX + r * Math.cos(rad), y: CY - r * Math.sin(rad) };
+}
+
+function vectorLength(normalized: number): number {
+  return R_MIN + normalized * (R_MAX - R_MIN);
+}
+
+interface ArrowheadProps {
+  tip: { x: number; y: number };
+  angleDeg: number; // direction the head points (card space)
+  color: string;
+  open?: boolean;
+  size?: number;
+}
+
+function Arrowhead({ tip, angleDeg, color, open = false, size = 7 }: ArrowheadProps) {
+  const rad = (angleDeg * Math.PI) / 180;
+  const back = { x: Math.cos(rad), y: -Math.sin(rad) };
+  const side = { x: -back.y, y: back.x };
+  const b1 = {
+    x: tip.x - back.x * size + side.x * (size * 0.55),
+    y: tip.y - back.y * size + side.y * (size * 0.55),
+  };
+  const b2 = {
+    x: tip.x - back.x * size - side.x * (size * 0.55),
+    y: tip.y - back.y * size - side.y * (size * 0.55),
+  };
+  return (
+    <polygon
+      points={`${tip.x},${tip.y} ${b1.x},${b1.y} ${b2.x},${b2.y}`}
+      fill={open ? "none" : color}
+      stroke={color}
+      strokeWidth={open ? 1.1 : 0}
+    />
+  );
+}
+
+export interface PlanetFBDCardProps {
+  fbd: PlanetFBD;
+}
+
+export function PlanetFBDCard({ fbd }: PlanetFBDCardProps) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const color = planetColor(fbd.planet);
+  const signGlyph = getZodiacGlyph(fbd.sign as ZodiacSignType);
+  const active = fbd.vectors.find((v) => v.id === activeId) ?? null;
+
+  // Ruler ticks over the ± window around the planet's exact position.
+  //
+  // The planet sits at its true sub-arc-minute longitude BETWEEN ticks, rather
+  // than snapping to the nearest whole arc minute: snapping would let the ruler
+  // disagree with the header's degree°minute′ at a degree boundary (26°59.99′
+  // rounds to a 27°00′ tick drawn dead-center under a card reading 26°59′).
+  const exactArcmin = fbd.exactLongitude * 60;
+  const firstTick = Math.ceil(exactArcmin - RULER_HALF_WINDOW);
+  const lastTick = Math.floor(exactArcmin + RULER_HALF_WINDOW);
+  const ticks: Array<{
+    x: number;
+    h: number;
+    opacity: number;
+    label?: string;
+    signBoundary?: boolean;
+  }> = [];
+  for (let T = firstTick; T <= lastTick; T++) {
+    const x = CX + (T - exactArcmin) * PX_PER_ARCMIN;
+    if (x < 8 || x > W - 8) continue;
+    const isSignBoundary = ((T % 1800) + 1800) % 1800 === 0;
+    const isDegree = ((T % 60) + 60) % 60 === 0;
+    const isQuarter = ((T % 15) + 15) % 15 === 0;
+    const isFive = ((T % 5) + 5) % 5 === 0;
+    if (isSignBoundary) {
+      ticks.push({ x, h: 30, opacity: 0.55, signBoundary: true });
+    } else if (isDegree) {
+      const deg = ((Math.round(T / 60) % 30) + 30) % 30;
+      ticks.push({ x, h: 14, opacity: 0.5, label: `${deg}°` });
+    } else if (isQuarter) {
+      ticks.push({ x, h: 9, opacity: 0.4 });
+    } else if (isFive) {
+      ticks.push({ x, h: 6, opacity: 0.3 });
+    } else {
+      ticks.push({ x, h: 3, opacity: 0.16 });
+    }
+  }
+
+  const resultantLen = R_MIN + fbd.resultant.normalized * (R_MAX - R_MIN);
+  const resultantTip = polar(fbd.resultant.angleDeg, resultantLen);
+
+  const fmt = (n: number) => (Math.abs(n) < 10 ? n.toFixed(2) : n.toFixed(1));
+
+  return (
+    <div className="alchm-panel" style={{ padding: 14, display: "flex", flexDirection: "column", gap: 10 }}>
+      {/* Header ------------------------------------------------------------ */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+        <span
+          aria-hidden
+          style={{
+            width: 30,
+            height: 30,
+            borderRadius: "50%",
+            flexShrink: 0,
+            background: `radial-gradient(circle at 30% 30%, ${color}, color-mix(in oklch, ${color}, black 55%))`,
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 15,
+            color: "rgba(0,0,0,0.75)",
+          }}
+        >
+          {planetGlyph(fbd.planet)}
+        </span>
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div className="t-mono" style={{ fontSize: 11, letterSpacing: "0.16em", color: "var(--fg)" }}>
+            {fbd.planet.toUpperCase()}
+            {fbd.isRetrograde && (
+              <span style={{ color: "#ef6a5a", marginLeft: 6 }}>℞</span>
+            )}
+          </div>
+          <div className="t-mono" style={{ fontSize: 10, color: "var(--fg-mute)", letterSpacing: "0.1em" }}>
+            {signGlyph} {fbd.sign.toUpperCase()} · {fbd.degree}°{String(fbd.minute).padStart(2, "0")}′
+          </div>
+        </div>
+        <span
+          className="t-mono"
+          title={`ESMS dignity multiplier ×${fbd.dignity.multiplier.toFixed(2)}`}
+          style={{
+            fontSize: 8.5,
+            letterSpacing: "0.14em",
+            padding: "3px 7px",
+            borderRadius: 999,
+            border: "1px solid var(--line)",
+            color:
+              fbd.dignity.esmsScale > 0
+                ? "var(--accent-2)"
+                : fbd.dignity.esmsScale < 0
+                  ? "#ef6a5a"
+                  : "var(--fg-mute)",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {fbd.dignity.type.toUpperCase()}
+        </span>
+      </div>
+
+      {/* Diagram ------------------------------------------------------------ */}
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        style={{ width: "100%", height: "auto", overflow: "visible" }}
+        role="img"
+        aria-label={`Free-body diagram for ${fbd.planet}: ${fbd.vectors.length} force vectors, resultant toward ${fbd.resultant.dominant}`}
+      >
+        {/* Sign watermark */}
+        <text
+          x={CX}
+          y={CY + 8}
+          textAnchor="middle"
+          fontSize={110}
+          fill={ELEMENT_VAR[fbd.signElement] ?? "var(--fg-faint)"}
+          opacity={0.07}
+          style={{ userSelect: "none" }}
+        >
+          {signGlyph}
+        </text>
+
+        {/* Arc-minute ruler backdrop */}
+        <path
+          d={`M 8 ${rulerY(8)} A ${RULER_R} ${RULER_R} 0 0 1 ${W - 8} ${rulerY(W - 8)}`}
+          fill="none"
+          stroke="var(--line)"
+          strokeWidth={1}
+        />
+        {ticks.map((tick, i) => {
+          const y = rulerY(tick.x);
+          return (
+            <g key={i}>
+              <line
+                x1={tick.x}
+                y1={y - tick.h / 2}
+                x2={tick.x}
+                y2={y + tick.h / 2}
+                stroke={tick.signBoundary ? "var(--accent-2)" : "var(--fg-mute)"}
+                strokeWidth={tick.signBoundary ? 1.2 : 0.8}
+                opacity={tick.opacity}
+              />
+              {tick.label && (
+                <text
+                  x={tick.x}
+                  y={y + 22}
+                  textAnchor="middle"
+                  fontSize={8}
+                  fill="var(--fg-mute)"
+                  style={{ fontFamily: "var(--f-mono)" }}
+                >
+                  {tick.label}
+                </text>
+              )}
+            </g>
+          );
+        })}
+
+        {/* Force vectors */}
+        {fbd.vectors.map((vector) => {
+          const len = vectorLength(vector.normalized);
+          const tip = polar(vector.angleDeg, len);
+          const base = polar(vector.angleDeg, NODE_R + 3);
+          const vColor = vectorColor(vector, fbd.signElement);
+          const applying = vector.aspect?.kinematics?.applying === true;
+          const separating = vector.aspect?.kinematics?.state === "separating";
+          const isActive = activeId === vector.id;
+          // Applying: head sits AT the planet, pointing inward (force arriving).
+          // Separating (and every non-aspect force): head at the outer end.
+          const headAtCenter = applying;
+          const headTip = headAtCenter ? base : tip;
+          const headAngle = headAtCenter
+            ? vector.angleDeg + 180
+            : vector.angleDeg;
+          const labelPos = polar(vector.angleDeg, len + 12);
+          return (
+            <g
+              key={vector.id}
+              tabIndex={0}
+              role="button"
+              aria-label={`${vector.label}: ${vector.detail}`}
+              style={{ cursor: "pointer", outline: "none" }}
+              opacity={activeId && !isActive ? 0.35 : 1}
+              onMouseEnter={() => setActiveId(vector.id)}
+              onMouseLeave={() => setActiveId((id) => (id === vector.id ? null : id))}
+              onFocus={() => setActiveId(vector.id)}
+              onBlur={() => setActiveId((id) => (id === vector.id ? null : id))}
+              onClick={() => setActiveId((id) => (id === vector.id ? null : vector.id))}
+            >
+              <line
+                x1={base.x}
+                y1={base.y}
+                x2={tip.x}
+                y2={tip.y}
+                stroke={vColor}
+                strokeWidth={isActive ? 2.2 : 1.4}
+                strokeDasharray={vector.kind === "momentum" ? "4,3" : undefined}
+                opacity={0.9}
+              />
+              <Arrowhead
+                tip={headTip}
+                angleDeg={headAngle}
+                color={vColor}
+                open={separating}
+              />
+              <text
+                x={labelPos.x}
+                y={labelPos.y}
+                textAnchor={
+                  Math.cos((vector.angleDeg * Math.PI) / 180) > 0.35
+                    ? "start"
+                    : Math.cos((vector.angleDeg * Math.PI) / 180) < -0.35
+                      ? "end"
+                      : "middle"
+                }
+                dominantBaseline="central"
+                fontSize={7.5}
+                fill={vColor}
+                opacity={isActive ? 1 : 0.75}
+                style={{ fontFamily: "var(--f-mono)", letterSpacing: "0.08em", userSelect: "none" }}
+              >
+                {vector.label}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* ESMS resultant */}
+        <g>
+          <line
+            x1={CX}
+            y1={CY}
+            x2={resultantTip.x}
+            y2={resultantTip.y}
+            stroke="var(--accent)"
+            strokeWidth={3}
+            opacity={0.95}
+            style={{ filter: "drop-shadow(0 0 5px color-mix(in oklch, var(--accent), transparent 40%))" }}
+          />
+          <Arrowhead tip={resultantTip} angleDeg={fbd.resultant.angleDeg} color="var(--accent)" size={9} />
+          <text
+            x={polar(fbd.resultant.angleDeg, resultantLen + 16).x}
+            y={polar(fbd.resultant.angleDeg, resultantLen + 16).y}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fontSize={8}
+            fill="var(--accent)"
+            style={{ fontFamily: "var(--f-mono)", letterSpacing: "0.1em", fontWeight: 700 }}
+          >
+            {ESMS_GLYPHS[fbd.resultant.dominant]} {fbd.resultant.dominant.toUpperCase()}
+          </text>
+        </g>
+
+        {/* Planet node (on its exact arc-minute) */}
+        <circle
+          cx={CX}
+          cy={CY}
+          r={NODE_R + 3}
+          fill="none"
+          stroke={color}
+          strokeWidth={0.7}
+          opacity={0.4}
+        />
+        <circle cx={CX} cy={CY} r={NODE_R} fill={`color-mix(in oklch, ${color}, black 55%)`} stroke={color} strokeWidth={1.2} />
+        <text
+          x={CX}
+          y={CY}
+          textAnchor="middle"
+          dominantBaseline="central"
+          fontSize={11}
+          fill={color}
+          style={{ userSelect: "none" }}
+        >
+          {planetGlyph(fbd.planet)}
+        </text>
+
+        {/* Compass roses */}
+        <g opacity={0.75}>
+          {(
+            [
+              ["F", 90, "var(--el-fire)"],
+              ["A", 0, "var(--el-air)"],
+              ["W", 270, "var(--el-water)"],
+              ["E", 180, "var(--el-earth)"],
+            ] as const
+          ).map(([letter, angle, c]) => {
+            const rad = (angle * Math.PI) / 180;
+            return (
+              <text
+                key={letter}
+                x={30 + 13 * Math.cos(rad)}
+                y={H - 26 - 13 * Math.sin(rad)}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize={7}
+                fill={c}
+                style={{ fontFamily: "var(--f-mono)" }}
+              >
+                {letter}
+              </text>
+            );
+          })}
+          <circle cx={30} cy={H - 26} r={6} fill="none" stroke="var(--line)" strokeWidth={0.6} />
+          <text x={30} y={H - 8} textAnchor="middle" fontSize={6} fill="var(--fg-faint)" style={{ fontFamily: "var(--f-mono)", letterSpacing: "0.12em" }}>
+            ELEMENT
+          </text>
+        </g>
+        <g opacity={0.75}>
+          {(
+            [
+              ["S", 90],
+              ["E", 0],
+              ["M", 270],
+              ["Sb", 180],
+            ] as const
+          ).map(([letter, angle]) => {
+            const rad = (angle * Math.PI) / 180;
+            return (
+              <text
+                key={letter}
+                x={W - 30 + 13 * Math.cos(rad)}
+                y={H - 26 - 13 * Math.sin(rad)}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize={7}
+                fill="var(--accent)"
+                style={{ fontFamily: "var(--f-mono)" }}
+              >
+                {letter}
+              </text>
+            );
+          })}
+          <circle cx={W - 30} cy={H - 26} r={6} fill="none" stroke="var(--line)" strokeWidth={0.6} />
+          <text x={W - 30} y={H - 8} textAnchor="middle" fontSize={6} fill="var(--fg-faint)" style={{ fontFamily: "var(--f-mono)", letterSpacing: "0.12em" }}>
+            ESMS
+          </text>
+        </g>
+      </svg>
+
+      {/* Readout strip ------------------------------------------------------ */}
+      <div
+        className="t-mono"
+        style={{
+          minHeight: 30,
+          fontSize: 9,
+          lineHeight: 1.45,
+          letterSpacing: "0.06em",
+          color: active ? "var(--fg-dim)" : "var(--fg-mute)",
+          borderTop: "1px solid var(--line)",
+          paddingTop: 8,
+        }}
+      >
+        {active ? (
+          <>
+            <span style={{ color: vectorColor(active, fbd.signElement) }}>{active.label}</span> · {active.detail}
+            {active.aspect && (
+              <div style={{ color: "var(--fg-mute)", marginTop: 2 }}>{active.aspect.description}</div>
+            )}
+          </>
+        ) : (
+          <>
+            RESULTANT → {fbd.resultant.dominant.toUpperCase()} · |R| {fbd.resultant.magnitude.toFixed(2)} · net harmony{" "}
+            {fbd.resultant.netHarmony >= 0 ? "+" : ""}
+            {fbd.resultant.netHarmony.toFixed(2)} · push {fbd.resultant.elementalPush.dominant}
+          </>
+        )}
+      </div>
+
+      {/* Telemetry footer ----------------------------------------------------- */}
+      <div
+        className="t-mono"
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "4px 12px",
+          fontSize: 8.5,
+          letterSpacing: "0.08em",
+          color: "var(--fg-mute)",
+        }}
+      >
+        {(Object.entries(fbd.esms) as Array<[string, number]>).map(([key, value]) => (
+          <span key={key} title={`${key} (planet contribution incl. aspect share)`}>
+            <span style={{ color: "var(--accent)" }}>{ESMS_GLYPHS[key]}</span> {fmt(value)}
+          </span>
+        ))}
+        <span title="charge Q = Matter + Substance">Q {fmt(fbd.physics.charge)}</span>
+        <span title="momentum = daily motion × alchemical weight">
+          p {fbd.physics.momentum === null ? "—" : fmt(fbd.physics.momentum)}
+        </span>
+        <span title="daily motion in arc-minutes/day">
+          ω {fbd.physics.arcminutesPerDay === null ? "—" : `${fbd.physics.arcminutesPerDay.toFixed(1)}′/d`}
+        </span>
+        <span title="alchemical weight (orbital-period, log scale)">m {fbd.physics.alchmWeight.toFixed(2)}</span>
+        {!fbd.kinematicsAvailable && (
+          <span style={{ color: "var(--accent-2)" }} title="stored chart carries no daily motions">
+            STATIC CHART · MOTION N/A
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default PlanetFBDCard;

--- a/src/components/ui/alchm/planetColors.ts
+++ b/src/components/ui/alchm/planetColors.ts
@@ -1,0 +1,58 @@
+/**
+ * Per-planet colors + glyphs for the alchm design system.
+ *
+ * Intended as the convention new alchm-kit surfaces adopt. It is NOT yet the
+ * repo's single source of truth: several older per-planet color/glyph maps
+ * still exist and are still in use — `chartRendering.getPlanetColor`,
+ * `PlanetaryChip`'s sect-element orbs, `PlanetaryClock`'s per-body hexes, the
+ * admin dashboard's `sky.tsx` accents, and assorted component-local
+ * `PLANET_SYMBOLS` tables (they disagree with each other, notably on
+ * Venus/Mars). Migrating them is deliberately out of scope here; until that
+ * happens, do not describe this module as canonical in user-facing docs.
+ *
+ * Colors are chosen against the dark "Modern Alchemist" palette: the two
+ * luminaries take the brand accents (Sun = copper, Moon = the pale violet
+ * foreground family), the classical planets take warm mineral tones, and the
+ * outer planets take cool deep tones, so a ten-card grid reads as one system.
+ *
+ * The planet inventory itself lives in `@/calculations/planetaryFBD`
+ * (TEN_PLANETS) — kept there so the data contract owns it, not the palette.
+ */
+
+export const PLANET_COLORS: Record<string, string> = {
+  Sun: "var(--accent-2)", // copper — the solar brand accent
+  Moon: "#d6cfe8", // pale lavender-silver
+  Mercury: "oklch(0.85 0.07 90)", // airy pale gold (matches --el-air)
+  Venus: "oklch(0.8 0.09 25)", // warm rose
+  Mars: "oklch(0.68 0.19 30)", // ember red
+  Jupiter: "oklch(0.8 0.12 75)", // amber
+  Saturn: "oklch(0.62 0.03 290)", // lead gray-violet
+  Uranus: "oklch(0.78 0.11 200)", // electric cyan
+  Neptune: "oklch(0.68 0.12 265)", // deep indigo
+  Pluto: "oklch(0.62 0.14 340)", // dark magenta
+  Ascendant: "var(--fg-dim)",
+};
+
+export const PLANET_GLYPHS: Record<string, string> = {
+  Sun: "☉",
+  Moon: "☽",
+  Mercury: "☿",
+  Venus: "♀",
+  Mars: "♂",
+  Jupiter: "♃",
+  Saturn: "♄",
+  Uranus: "♅",
+  Neptune: "♆",
+  Pluto: "♇",
+  Ascendant: "AC",
+};
+
+/** Color for a planet, with a neutral fallback for unknown bodies. */
+export function planetColor(planet: string): string {
+  return PLANET_COLORS[planet] ?? "var(--fg-mute)";
+}
+
+/** Unicode glyph for a planet, falling back to its first letter. */
+export function planetGlyph(planet: string): string {
+  return PLANET_GLYPHS[planet] ?? planet.charAt(0).toUpperCase();
+}

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -109,7 +109,7 @@ export const NAV_IA: NavIA = {
       { label: "Recommendation Engine", path: "/lab", glyph: "orbital", hint: "Live signal flow · weights · overrides" },
       { label: "Lab Book", path: "/lab-book", glyph: "bookmark", hint: "Scan or paste recipes into your cookbook" },
       { label: "Grimoire", path: "/grimoire", glyph: "bookmark", hint: "The practices · today's resonance · your feats" },
-      { label: "Planetary Chart", path: "/planetary-chart", glyph: "ring", hint: "Current transit · zoomable", premium: true },
+      { label: "Planetary Chart", path: "/planetary-chart", glyph: "ring", hint: "Free-body diagrams of the current sky" },
       { label: "Current Chart", path: "/current-chart", glyph: "wave", hint: "Live sky × your natal" },
       { label: "Alchm Quantities", path: "/quantities", glyph: "crosshair", hint: "ESMS · Monica constants · P=IV" },
       { label: "Standing Chart", path: "/birth-chart", glyph: "diamond", hint: "Your natal · stored encrypted" },

--- a/src/lib/auth/auth.config.ts
+++ b/src/lib/auth/auth.config.ts
@@ -150,9 +150,11 @@ export const authConfig = {
 
       // Routes that require premium tier (authenticated users without premium
       // get redirected to /upgrade instead of seeing errors)
+      // /planetary-chart is deliberately absent: the planetary-ecosystem
+      // surface is public (the current sky is the same for everyone), and its
+      // middleware matcher entry was removed alongside this.
       const isPremiumRoute =
         pathname.startsWith("/recipe-generator") ||
-        pathname.startsWith("/planetary-chart") ||
         pathname.startsWith("/restaurant-creator") ||
         pathname.startsWith("/premium-table");
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -61,7 +61,8 @@ export const config = {
     "/birth-chart/:path*",
     "/current-chart/:path*",
     "/recipe-generator/:path*",
-    "/planetary-chart/:path*",
+    // /planetary-chart is deliberately absent: the planetary-ecosystem surface
+    // is fully public (the current sky is the same for everyone).
     "/restaurant-creator/:path*",
     "/premium-table/:path*",
   ],

--- a/src/utils/aspectESMSEffects.ts
+++ b/src/utils/aspectESMSEffects.ts
@@ -418,8 +418,13 @@ export function calculateAspectESMSModifications(
       continue;
     }
 
-    // Scale effect by aspect strength (0-1, where 1 = exact aspect)
-    const scaledEffect = aspect.strength || 1.0;
+    // Scale effect by aspect strength (0-1, where 1 = exact aspect).
+    // `??` not `||`: a pair sitting exactly at an aspect's maximum orb has a
+    // cosine-bell strength of exactly 0, and `||` would read that legitimate
+    // zero as "missing" and apply the FULL archetypal effect — the widest
+    // possible aspect hitting hardest, and disagreeing with every other
+    // consumer of the same `strength` field.
+    const scaledEffect = aspect.strength ?? 1.0;
 
     totalEffect.Spirit += effect.Spirit * scaledEffect;
     totalEffect.Essence += effect.Essence * scaledEffect;

--- a/src/utils/aspectKinematics.ts
+++ b/src/utils/aspectKinematics.ts
@@ -1,0 +1,106 @@
+/**
+ * Aspect kinematics — applying/separating dynamics for a planet pair.
+ *
+ * Extracted from /api/alchm-quantities/aspects so any surface (that route,
+ * the free-body-diagram builder, future forecast views) derives the same
+ * applying/separating verdicts from the same finite-difference model.
+ */
+
+/** Below this |orb velocity| (deg/day) the pair is treated as stationary. */
+export const STATIONARY_EPS = 1e-4;
+
+/**
+ * Finite-difference step in days. One minute: small enough that even the Moon
+ * (~13°/day) moves under 0.01°, so the step can't jump a feature of the curve.
+ */
+const DT_DAYS = 1 / 1440;
+
+/**
+ * Minimal angular separation from an aspect's ideal angle.
+ * Returns a value in [0, 180].
+ */
+export function computeOrb(
+  long1: number,
+  long2: number,
+  aspectAngle: number,
+): number {
+  return Math.abs(signedOrb(long1, long2, aspectAngle));
+}
+
+/**
+ * Orb WITH a sign: negative before the ideal angle, positive past it.
+ *
+ * Differencing the unsigned orb is what makes a near-exact aspect read as
+ * separating: |orb| reflects at exact, so any step that crosses exact comes
+ * back larger and the verdict flips at peak strength — worst for the Moon,
+ * which is the body most likely to be near exact. The signed value passes
+ * smoothly through zero, so its derivative stays meaningful there.
+ */
+export function signedOrb(
+  long1: number,
+  long2: number,
+  aspectAngle: number,
+): number {
+  let diff = Math.abs(long1 - long2) % 360;
+  if (diff > 180) diff = 360 - diff;
+  return diff - aspectAngle;
+}
+
+export interface AspectKinematics {
+  /** Signed rate of change of orb in degrees/day (negative = applying). */
+  orbVelocity: number;
+  /** true = approaching exact, false = moving away or stationary. */
+  applying: boolean;
+  /** Coupling state — applying stores energy, separating discharges. */
+  state: "applying" | "separating" | "stationary";
+  /** Days until (applying) or since (separating) exact. 9999 when stationary. */
+  daysToExact: number;
+  /** Relative angular velocity speed1 − speed2 in degrees/day (signed). */
+  relativeAngularVelocity: number;
+}
+
+/**
+ * Compute the kinematic state of an aspect from both bodies' longitudes and
+ * signed daily motions (deg/day, negative while retrograde).
+ */
+export function computeAspectKinematics(
+  long1: number,
+  long2: number,
+  aspectAngle: number,
+  speed1: number,
+  speed2: number,
+): AspectKinematics {
+  // Differentiate the SIGNED orb (smooth through exact), then convert to the
+  // rate of change of the unsigned orb the callers report.
+  const signedNow = signedOrb(long1, long2, aspectAngle);
+  const long1Next = (long1 + speed1 * DT_DAYS + 360) % 360;
+  const long2Next = (long2 + speed2 * DT_DAYS + 360) % 360;
+  const signedNext = signedOrb(long1Next, long2Next, aspectAngle);
+
+  const currentOrb = Math.abs(signedNow);
+  const signedRate = (signedNext - signedNow) / DT_DAYS;
+  // d|s|/dt = sign(s) · ds/dt. Exactly at exact (s = 0) the orb can only grow,
+  // so report the outbound rate rather than a spurious "applying".
+  const orbVelocity =
+    signedNow === 0 ? Math.abs(signedRate) : Math.sign(signedNow) * signedRate;
+  const applying = orbVelocity < -STATIONARY_EPS;
+  const state: AspectKinematics["state"] =
+    Math.abs(orbVelocity) < STATIONARY_EPS
+      ? "stationary"
+      : applying
+        ? "applying"
+        : "separating";
+
+  // Days to exact (positive both ways: time until exact when applying, time
+  // since exact when separating — matches the aspects API contract).
+  const daysToExact =
+    Math.abs(orbVelocity) > 1e-6 ? currentOrb / Math.abs(orbVelocity) : 9999;
+
+  return {
+    orbVelocity,
+    applying,
+    state,
+    daysToExact,
+    relativeAngularVelocity: speed1 - speed2,
+  };
+}

--- a/src/utils/planetaryAlchemyMapping.ts
+++ b/src/utils/planetaryAlchemyMapping.ts
@@ -16,7 +16,7 @@
  */
 
 import { PLANET_WEIGHTS, normalizePlanetWeight, PLANET_ALCHM_PERIODS, normalizeAlchmWeight } from "@/data/planets";
-import type { ElementalProperties } from "@/types/alchemy";
+import type { DignityType, ElementalProperties } from "@/types/alchemy";
 import type { AlchemicalProperties } from "@/types/celestial";
 import { calculateAspectESMSModifications, type AspectWithStrength } from "./aspectESMSEffects";
 import { getDignityScore } from "./dignityScales";
@@ -415,12 +415,67 @@ export function calculateEnhancedAlchemicalFromPlanets(
   diurnal: boolean = true,
   aspects?: AspectWithStrength[],
 ): AlchemicalProperties {
+  return calculateEnhancedAlchemicalFromPlanetsDetailed(
+    planetaryPositions,
+    diurnal,
+    aspects,
+  ).totals;
+}
+
+/** One body's Layer-1 × Layer-2 contribution to the ESMS totals. */
+export interface EnhancedPlanetContribution {
+  /** baseESMS(sect) × alchmWeight × dignityMultiplier — this body's share. */
+  esms: AlchemicalProperties;
+  /** The sign fed in (as provided). */
+  sign: string;
+  /** Orbital-period weight (log-normalized; Ascendant pinned to 1.0). */
+  alchmWeight: number;
+  /** Classical dignity type from the authoritative dual-scale table. */
+  dignityType: DignityType;
+  /** ESMS-scale points (+10 domicile … −10 fall) — NOT the food scale. */
+  dignityEsmsScale: number;
+  /** The multiplier actually applied: 1 + esmsScale/100. */
+  dignityMultiplier: number;
+  /** True for the Physical-Vessel Ascendant grounding constant. */
+  isGroundingVessel: boolean;
+}
+
+export interface EnhancedAlchemicalDetail {
+  /** Identical to what {@link calculateEnhancedAlchemicalFromPlanets} returns. */
+  totals: AlchemicalProperties;
+  /** Per-body Layer 1×2 contributions. Guaranteed: Σ perPlanet + aspectModifications = totals. */
+  perPlanet: Record<string, EnhancedPlanetContribution>;
+  /** Layer-3 total (0 when no aspects were supplied). */
+  aspectModifications: AlchemicalProperties;
+  /** True when the grounding Ascendant was injected rather than supplied. */
+  ascendantInjected: boolean;
+}
+
+/**
+ * The three-layer ESMS calculation, exposing its per-body decomposition.
+ *
+ * {@link calculateEnhancedAlchemicalFromPlanets} is a thin wrapper over this,
+ * so the parts provably reconcile with the whole:
+ *   Σ perPlanet[*].esms + aspectModifications === totals
+ *
+ * Surfaces that attribute ESMS to individual planets (the free-body-diagram
+ * cards) MUST read this rather than recomputing a parallel decomposition —
+ * a lookalike loop that misses the Ascendant grounding constant or uses the
+ * food-scale dignity table silently reports Matter/Substance of 0 for every
+ * planet in a day chart.
+ */
+export function calculateEnhancedAlchemicalFromPlanetsDetailed(
+  planetaryPositions: { [planet: string]: string },
+  diurnal: boolean = true,
+  aspects?: AspectWithStrength[],
+): EnhancedAlchemicalDetail {
   const totals: AlchemicalProperties = {
     Spirit: 0,
     Essence: 0,
     Matter: 0,
     Substance: 0,
   };
+  const perPlanet: Record<string, EnhancedPlanetContribution> = {};
 
   // Physical-Vessel grounding: in the diurnal sect every planet maps to
   // Spirit/Essence, so Matter & Substance collapse to 0 in any day chart lacking
@@ -473,15 +528,42 @@ export function calculateEnhancedAlchemicalFromPlanets(
     // Examples: +10 → 1.10 (10% boost), -10 → 0.90 (10% reduction)
 
     // Apply weighted ESMS with both alchm-period and dignity modifiers
-    totals.Spirit    += baseESMS.Spirit    * alchmWeight * dignityMultiplier;
-    totals.Essence   += baseESMS.Essence   * alchmWeight * dignityMultiplier;
-    totals.Matter    += baseESMS.Matter    * alchmWeight * dignityMultiplier;
-    totals.Substance += baseESMS.Substance * alchmWeight * dignityMultiplier;
+    const contribution: AlchemicalProperties = {
+      Spirit:    baseESMS.Spirit    * alchmWeight * dignityMultiplier,
+      Essence:   baseESMS.Essence   * alchmWeight * dignityMultiplier,
+      Matter:    baseESMS.Matter    * alchmWeight * dignityMultiplier,
+      Substance: baseESMS.Substance * alchmWeight * dignityMultiplier,
+    };
+    totals.Spirit    += contribution.Spirit;
+    totals.Essence   += contribution.Essence;
+    totals.Matter    += contribution.Matter;
+    totals.Substance += contribution.Substance;
+
+    perPlanet[planet] = {
+      esms: contribution,
+      sign,
+      alchmWeight,
+      dignityType: dignityScore.type,
+      dignityEsmsScale: dignityScore.esmsScale,
+      dignityMultiplier,
+      isGroundingVessel: planet === "Ascendant",
+    };
   }
 
   // LAYER 3: Apply aspect modifications
+  const aspectModifications: AlchemicalProperties = {
+    Spirit: 0,
+    Essence: 0,
+    Matter: 0,
+    Substance: 0,
+  };
   if (aspects && aspects.length > 0) {
     const aspectMods = calculateAspectESMSModifications(aspects);
+
+    aspectModifications.Spirit = aspectMods.Spirit;
+    aspectModifications.Essence = aspectMods.Essence;
+    aspectModifications.Matter = aspectMods.Matter;
+    aspectModifications.Substance = aspectMods.Substance;
 
     totals.Spirit += aspectMods.Spirit;
     totals.Essence += aspectMods.Essence;
@@ -489,7 +571,12 @@ export function calculateEnhancedAlchemicalFromPlanets(
     totals.Substance += aspectMods.Substance;
   }
 
-  return totals;
+  return {
+    totals,
+    perPlanet,
+    aspectModifications,
+    ascendantInjected: !planetaryPositions.Ascendant,
+  };
 }
 
 /**


### PR DESCRIPTION
Per-planet **free-body diagram cards**: a physics-style vector diagram of every force the alchemical engine knows about a planet, centered on the exact arc minute it occupies. The goal is to make the schema legible to someone who has never seen a credible astrological ecosystem — you can *see* what is pulling on each planet, how hard, from where, and whether it is arriving or leaving.

## What a card shows

| Force | Direction | Magnitude |
|---|---|---|
| Aspects (majors + minors) | true ecliptic bearing of the other body | cosine-bell strength × the engine's own orb budget (maxOrb/8) |
| Sign pull | occupied sign's element axis | 0.60 (the engine's sign-element weight) |
| Sect pull | sectarian element axis | 0.40 |
| Dignity | along/against the sign's element axis | \|multiplier − 1\| on the **ESMS** scale (±7/±10%) |
| Momentum | direction of motion (℞ flips it) | \|daily motion × alchemical weight\| |

**Applying** aspects get a solid arrowhead arriving at the planet with a days-to-exact countdown; **separating** ones an open arrowhead angled away. The violet resultant reads on the ESMS compass as the planet's net alchemical tendency, next to elemental push, net harmony, and physics telemetry (charge, momentum, arcmin/day, weight). Hover or tap any vector for its raw numbers. The backdrop is a zoomed arc-minute ruler of the surrounding zodiac.

## Surfaces

- **`/planetary-chart` → the public planetary ecosystem.** The current sky is the same for everyone, so the premium gate is removed — in all three places that gated it (middleware matcher, `auth.config` `isPremiumRoute`, and the nav's `premium: true` badge; missing any one still bounces guests to `/login`). Server-computed once per request; the interactive wheel moved to `PlanetaryChartClient`.
- **Birth chart → natal cards + wheel overlays.** Aspect chords (teal harmony / ember tension, width ∝ strength) and elemental sign vectors now render on the natal wheel. Stored charts carry no daily motions, so those cards degrade honestly: no applying/separating, no momentum, and a `STATIC CHART · MOTION N/A` chip.

## Engine changes this required

These came out of an adversarial review pass and are the reason the diff touches shared code.

**1. Per-planet ESMS didn't reconcile with the engine's own totals.** The cards read `alchemizeDetailed().perPlanet`, which looks authoritative but is a second, drifted loop in the same file: it applies the ±15% *food-scale* dignity and never sees the injected Ascendant. In a **diurnal** chart it summed to `Matter=0, Substance=0` while the same function's totals were `1.45` / `1.01`. Every card rendered `Q 0.00`, and every resultant could only ever point at Spirit or Essence.

`calculateEnhancedAlchemicalFromPlanetsDetailed` now exposes the three-layer calculation's per-body decomposition, with `calculateEnhancedAlchemicalFromPlanets` delegating to it — one implementation, so the parts cannot drift from the whole. Invariant, tested in **both sects**: `Σ cards + unattributed === totals`. The Ascendant gets no card (it isn't a planet) and aspects to it keep half their effect off-card, so that residual is **surfaced on the page** (`+ 4.00 ESMS OFF-CARD`) rather than silently dropped.

**2. Applying/separating inverted near exact — worst exactly when it matters.** `computeOrb` returns an unsigned distance that reflects at exact, and a 1-hour finite-difference step jumps the reflection for fast bodies. A Moon trine 0.2° from exact and closing reported `separating · 0.1d since exact`; truth was applying with 24 minutes to go. Now differentiates a **signed** orb (smooth through zero) at a 1-minute step. This bug was already live in `GET /api/alchm-quantities/aspects`, which now shares the extracted module — response contract verified unchanged (all 17 keys).

**3. Zero-strength aspects got *full* weight.** `aspect.strength || 1.0` read a legitimate cosine-bell zero at maximum orb as "missing", so the widest possible aspect hit hardest and disagreed with every other consumer of the same field. Now `??`.

Plus: dignity reads the authoritative ESMS scale instead of the food scale (a "FALL −30%" the engine never applied is now the true −10%); the arc-minute ruler places planets at their true sub-arcminute position so it can't disagree with the header at a degree boundary; momentum normalizes across the sky instead of sharing a scale with dimensionless force weights (the Moon's momentum was crushing every real force on its card into a 12px band); the location-dependent Ascendant is excluded from the location-less public sky.

## Verification

- `bun run typecheck` clean; **full suite green — 150 suites, 1235 passing, 0 failures**
- 60 unit tests for the new math, including the reconciliation invariant in both sects, near-exact applying/separating, the natal degrade path, and dignity on the ESMS scale
- Browser-verified on desktop + mobile: rendering, hover readouts (caught a live Moon ☍ Neptune at orb 0°02′), and the natal surfaces via a throwaway fixture route (deleted)

## Design

`docs/design/planet-fbd-stitch-prompt.md` — the Stitch prompt for the visual pass, with the locked decisions, the hard data-model constraints, and three screen prompts. The engine contract is settled, so Stitch can only restyle what is already true.

## Follow-ups (flagged, not fixed here)

- `aspectCalculator`'s Sun/Moon 1.2× orb widening compares lowercase names while every caller passes capitalized — the luminary bonus has never applied.
- `alchemize`'s inline aspect-exclusion list misses `"North Node"` (the backend's spelling), so node aspects leak into Layer 3 with backend positions. The cards exclude it deliberately; the engine fix shifts ESMS platform-wide and deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)