### PR TITLE
fix(astro): Sun/Moon orb widening never applied due to name casing

### DIFF
--- a/src/__tests__/aspectOrbMultiplier.test.ts
+++ b/src/__tests__/aspectOrbMultiplier.test.ts
@@ -1,0 +1,76 @@
+import {
+  calculateComprehensiveAspects,
+  type PlanetaryPositionData,
+} from '../utils/aspectCalculator';
+
+/**
+ * The Sun/Moon 20%-wider-orb rule was checked against lowercase planet names
+ * ("sun"/"moon"), but every live caller keys positions by the canonical
+ * capitalized name ("Sun"/"Moon" — see RealAlchemizeService's planetaryAlchemy
+ * table and every position-source convention in the repo). The bonus was
+ * therefore dead: it never fired, and Sun/Moon aspects used the same orb
+ * budget as Pluto. These tests pin the fix and its symptom.
+ */
+
+// A Sun-Mars square just past the plain 7° orb but within the 8.4° a Sun
+// aspect should get (7 * 1.2 = 8.4).
+const CHART: Record<string, PlanetaryPositionData> = {
+  Sun: { sign: 'aries', degree: 0, exactLongitude: 0 },
+  Mars: { sign: 'cancer', degree: 7.8, exactLongitude: 97.8 }, // 97.8° away, orb 7.8° past the square
+  Mercury: { sign: 'aries', degree: 0, exactLongitude: 0.3 }, // near-conjunct Sun, unaffected either way
+};
+
+describe('Sun/Moon orb multiplier', () => {
+  test('a Sun aspect outside the plain orb but inside the widened one is found', () => {
+    const aspects = calculateComprehensiveAspects(CHART);
+    const sunMars = aspects.find(
+      (a) =>
+        (a.planet1 === 'Sun' && a.planet2 === 'Mars') ||
+        (a.planet1 === 'Mars' && a.planet2 === 'Sun'),
+    );
+    // Square's plain maxOrb is 7°; this pair sits at orb 7.8° — only visible
+    // with the Sun's 1.2× widening (7 * 1.2 = 8.4°).
+    expect(sunMars).toBeDefined();
+    expect(sunMars?.type).toBe('square');
+    expect(sunMars?.orb).toBeCloseTo(7.8, 5);
+  });
+
+  test('the same separation with no luminary involved gets no aspect', () => {
+    const noLuminary: Record<string, PlanetaryPositionData> = {
+      Mercury: { sign: 'aries', degree: 0, exactLongitude: 0 },
+      Mars: { sign: 'cancer', degree: 7.8, exactLongitude: 97.8 },
+    };
+    const aspects = calculateComprehensiveAspects(noLuminary);
+    const pair = aspects.find(
+      (a) =>
+        (a.planet1 === 'Mercury' && a.planet2 === 'Mars') ||
+        (a.planet1 === 'Mars' && a.planet2 === 'Mercury'),
+    );
+    // Same 7.8° separation, no Sun/Moon → outside the plain 7° square orb.
+    expect(pair).toBeUndefined();
+  });
+
+  test('strength at a given orb is higher for a luminary pair than a non-luminary pair', () => {
+    // Both pairs sit at the same 2° orb past an exact square (90°); only the
+    // Moon pair gets the widened orb budget, so its cosine-bell strength
+    // (computed against a larger maxOrb) must be higher.
+    const moonPair: Record<string, PlanetaryPositionData> = {
+      Moon: { sign: 'aries', degree: 0, exactLongitude: 0 },
+      Saturn: { sign: 'cancer', degree: 2, exactLongitude: 92 },
+    };
+    const plainPair: Record<string, PlanetaryPositionData> = {
+      Venus: { sign: 'aries', degree: 0, exactLongitude: 0 },
+      Saturn: { sign: 'cancer', degree: 2, exactLongitude: 92 },
+    };
+    const moonAspect = calculateComprehensiveAspects(moonPair).find(
+      (a) => a.type === 'square',
+    );
+    const plainAspect = calculateComprehensiveAspects(plainPair).find(
+      (a) => a.type === 'square',
+    );
+    expect(moonAspect).toBeDefined();
+    expect(plainAspect).toBeDefined();
+    expect(moonAspect!.orb).toBeCloseTo(plainAspect!.orb, 5);
+    expect(moonAspect!.strength).toBeGreaterThan(plainAspect!.strength);
+  });
+});

--- a/src/utils/aspectCalculator.ts
+++ b/src/utils/aspectCalculator.ts
@@ -157,13 +157,19 @@ export function calculateComprehensiveAspects(
       let diff = Math.abs(long1 - long2);
       if (diff > 180) diff = 360 - diff;
 
-      // Adjust orbs based on planetary importance (Sun/Moon have larger orbs)
+      // Adjust orbs based on planetary importance (Sun/Moon have larger orbs).
+      // Case-insensitive: every live caller keys positions by the canonical
+      // capitalized planet name ("Sun", "Moon" — see RealAlchemizeService's
+      // planetaryAlchemy table and every position-source convention in the
+      // repo), so a strict lowercase match here never fires in practice.
       let orbMultiplier = 1.0;
+      const p1Lower = planet1.toLowerCase();
+      const p2Lower = planet2.toLowerCase();
       if (
-        planet1 === "sun" ||
-        planet1 === "moon" ||
-        planet2 === "sun" ||
-        planet2 === "moon"
+        p1Lower === "sun" ||
+        p1Lower === "moon" ||
+        p2Lower === "sun" ||
+        p2Lower === "moon"
       ) {
         orbMultiplier = 1.2; // 20% larger orbs for aspects involving Sun or Moon
       }


### PR DESCRIPTION
## The bug

`calculateComprehensiveAspects`'s 20%-wider-orb rule for Sun/Moon aspects checked `planet1 === "sun"` against lowercase literals:

```ts
if (planet1 === "sun" || planet1 === "moon" || planet2 === "sun" || planet2 === "moon") {
  orbMultiplier = 1.2;
}
```

Every live caller keys positions by the canonical **capitalized** planet name — `"Sun"`, `"Moon"` — per `RealAlchemizeService`'s own `planetaryAlchemy` table and every position-source convention in the repo (`RealAlchemizeService.alchemize`/`alchemizeDetailed`, `buildAspectsWithStrength`, `/api/alchemize`, `/api/alchm-quantities/aspects`). The comparison never matched in practice, so luminary aspects silently used the same orb budget as Pluto.

## The fix

Lowercase both sides before comparing. One line of actual logic change (`src/utils/aspectCalculator.ts`).

## Regression test

`src/__tests__/aspectOrbMultiplier.test.ts` — three cases:
1. A Sun-Mars square at orb 7.8° (outside the plain 7° square budget, inside the widened 8.4°) is now found.
2. The identical 7.8° separation with no luminary involved finds nothing.
3. A luminary pair scores higher cosine-bell strength than a non-luminary pair at an identical orb.

## Blast radius

Measured against the real current sky (2026-07-19T19:15 UTC), before vs. after:

| | Before | After |
|---|---|---|
| Total aspects | 52 | 56 |
| Luminary-involving aspects | 13 | 17 |

Four previously-invisible Sun/Moon aspects appear (e.g. Moon trine Mars at orb 9.0°, only visible within the widened opposition/trine budget). Every existing Sun/Moon aspect strengthens, since a wider `maxOrb` shrinks the `orb/maxOrb` ratio feeding the cosine-bell strength curve:

- Sun square Ascendant: 0.253 → 0.416
- Sun semisquare Mars: 0.034 → 0.164
- Sun conjunction Jupiter: 0.022 → 0.141
- Sun trine Neptune: 0.014 → 0.124

This strengthens Layer-3 ESMS aspect effects specifically for Sun/Moon pairs (`aspectESMSEffects.ts`'s `SUN_MOON_ASPECTS` table, scaled by `strength`) and shifts any *future* live-position alchemical calculation. No stored or historical alchemical data is retroactively recomputed — only calculations run against live positions after this deploys pick up the change.

## Verification

- New regression test passes; full suite green (149 suites, 1178 passing, 0 failures)
- `bun run typecheck` clean
- `bun run lint` clean (0 errors, 12 pre-existing warnings unrelated to this file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)