### PR TITLE
fix(astro): excluded bodies polluted elemental totals and momentum

### DIFF
--- a/src/__tests__/realAlchemizeExcludedBodies.test.ts
+++ b/src/__tests__/realAlchemizeExcludedBodies.test.ts
@@ -44,18 +44,14 @@ const NODE_SPELLINGS: Record<string, { sign: string; degree: number; minute: num
 describe('excluded aspect bodies', () => {
   const baseline = alchemize(REAL_PLANETS, null, new Date('2026-07-19T19:22:00Z'));
 
-  // Scope note: `esms` and `kalchm` are driven entirely by `signMap` +
-  // aspects, both of which route through the exclusion check this PR fixes
-  // — so they are the correct signal for "does this body participate in
-  // Layer 3". `thermodynamicProperties`/`monica` additionally depend on
-  // elemental totals (Fire/Water/Earth/Air), which are accumulated in a
-  // SEPARATE loop that has never been gated by the exclusion check for ANY
-  // body (not even the correctly-spelled "South Node"/"MC") — a real,
-  // broader, pre-existing gap, but a different one from what this PR fixes.
-  // Asserting elemental equality here would therefore fail even after this
-  // fix, for a reason unrelated to the bug under test.
+  // An excluded body must be a COMPLETE no-op: it may not touch ESMS (the
+  // aspect/signMap loop) nor the elemental totals (the per-body loop). Both
+  // loops are now gated. Elemental equality is the stronger assertion — it
+  // catches the pollution path where getPlanetarySectElement() silently
+  // returns "Air" for a body it does not recognize, so an unrecognized key
+  // pushed 0.4 of phantom Air into every chart that carried one.
   test.each(Object.entries(NODE_SPELLINGS))(
-    'adding %s does not change ESMS or kalchm',
+    'adding %s changes nothing at all',
     (name, position) => {
       const withBody = alchemize(
         { ...REAL_PLANETS, [name]: position },
@@ -64,6 +60,14 @@ describe('excluded aspect bodies', () => {
       );
       expect(withBody.esms).toEqual(baseline.esms);
       expect(withBody.kalchm).toBe(baseline.kalchm);
+      expect(withBody.elementalProperties).toEqual(baseline.elementalProperties);
+      expect(withBody.thermodynamicProperties).toEqual(
+        baseline.thermodynamicProperties,
+      );
+      expect(withBody.monica).toBe(baseline.monica);
+      // Not a planet, so it earns no momentum entry — its alchmWeight would
+      // otherwise fall back to 1.0, i.e. Pluto's mass.
+      expect(withBody.planetaryMomentum).not.toHaveProperty(name);
     },
   );
 
@@ -85,22 +89,47 @@ describe('excluded aspect bodies', () => {
     expect(withSouth.esms).toEqual(baseline.esms);
   });
 
-  test('alchemizeDetailed: North Node contributes zero ESMS, symmetric with South Node', () => {
-    // perPlanet still gets AN ENTRY for excluded bodies (that part of the
-    // per-body loop is the separate, pre-existing gap noted above), but its
-    // esms must be all-zero — the aspect/ESMS-relevant half of the fix.
+  test('alchemizeDetailed gives excluded bodies no perPlanet entry at all', () => {
+    // perPlanet keys are consumed as "the real planets in this chart" (the
+    // free-body-diagram builder reconciles against them), so an MC or node
+    // entry — populated `elements` beside all-zero `esms` — was misleading.
     const detailed = alchemizeDetailed(
-      { ...REAL_PLANETS, 'North Node': NODE_SPELLINGS['North Node'] },
+      {
+        ...REAL_PLANETS,
+        'North Node': NODE_SPELLINGS['North Node'],
+        MC: NODE_SPELLINGS.MC,
+      },
       null,
       new Date('2026-07-19T19:22:00Z'),
     );
-    expect(detailed.perPlanet['North Node'].esms).toEqual({
-      Spirit: 0,
-      Essence: 0,
-      Matter: 0,
-      Substance: 0,
-    });
+    expect(detailed.perPlanet['North Node']).toBeUndefined();
+    expect(detailed.perPlanet.MC).toBeUndefined();
+    expect(Object.keys(detailed.perPlanet).sort()).toEqual(
+      Object.keys(REAL_PLANETS).sort(),
+    );
     expect(detailed.esms).toEqual(baseline.esms);
+    expect(detailed.elementalProperties).toEqual(baseline.elementalProperties);
+  });
+
+  test('several excluded bodies at once are still a complete no-op', () => {
+    // The live sky carries MC and BOTH nodes simultaneously — the real-world
+    // shape of this bug, where three phantom bodies each pushed 0.4 Air.
+    const liveSkyShape = alchemize(
+      {
+        ...REAL_PLANETS,
+        'North Node': NODE_SPELLINGS['North Node'],
+        'South Node': NODE_SPELLINGS['South Node'],
+        MC: NODE_SPELLINGS.MC,
+      },
+      null,
+      new Date('2026-07-19T19:22:00Z'),
+    );
+    expect(liveSkyShape.elementalProperties).toEqual(baseline.elementalProperties);
+    expect(liveSkyShape.thermodynamicProperties).toEqual(
+      baseline.thermodynamicProperties,
+    );
+    expect(liveSkyShape.monica).toBe(baseline.monica);
+    expect(liveSkyShape.esms).toEqual(baseline.esms);
   });
 
   test('real planets still participate (the exclusion is not over-broad)', () => {

--- a/src/services/RealAlchemizeService.ts
+++ b/src/services/RealAlchemizeService.ts
@@ -314,6 +314,21 @@ export function alchemize(
   const SECT_WEIGHT = 0.4;
   // Process each planet
   for (const [planet, position] of Object.entries(planetaryPositions)) {
+    // Non-planets (nodes, MC, Chiron, Lilith, Vertex, Pars Fortune) contribute
+    // nothing here either — same rule as the aspect pass below.
+    //
+    // Without this gate they still reached the elemental blend: 60% from
+    // getZodiacElement(sign), which is real, plus 40% from
+    // getPlanetarySectElement(), which silently returns "Air" for any body it
+    // does not know. A live sky carrying MC and both nodes therefore had three
+    // phantom bodies each pushing 0.4 of pure Air into the totals, skewing
+    // elementalProperties and everything derived from it (thermodynamics,
+    // monica). Their momentum was fabricated too: alchmWeight falls back to
+    // PLANET_ALCHM_PERIODS[planet] ?? 1.0, and 1.0 is Pluto's weight, so MC
+    // was being handed the heaviest alchemical mass in the system.
+    if (isExcludedAspectBody(planet)) {
+      continue;
+    }
     // Get planetary alchemical properties
     const alchemy = planetaryAlchemy[planet];
     // Alchm weighting: orbital period (slower = deeper alchemical tide)
@@ -599,6 +614,13 @@ export function alchemizeDetailed(
   const SECT_WEIGHT = 0.4;
 
   for (const [planet, position] of Object.entries(planetaryPositions)) {
+    // Same exclusion as alchemize() above and the aspect pass below — see the
+    // comment there. Additionally keeps non-planets out of `perPlanet`, whose
+    // consumers reasonably assume its keys are real planets (an MC entry
+    // carried populated `elements` beside all-zero `esms`).
+    if (isExcludedAspectBody(planet)) {
+      continue;
+    }
     const alchemy = planetaryAlchemy[planet];
     const period = PLANET_ALCHM_PERIODS[planet] ?? 1.0;
     const alchmWeight = planet === "Ascendant" ? 1.0 : normalizeAlchmWeight(period);


### PR DESCRIPTION
> **Stacked on #615** — targets `fix/north-node-exclusion-gap`, not `master`, because it uses the `isExcludedAspectBody()` helper that PR introduces. Merge #615 first; this will retarget to master automatically.

## The bug

`alchemize` and `alchemizeDetailed` each have **two** per-body loops. #615 gated the second one (`positionData`/`signMap`, feeding aspects). The **first** loop — building elemental totals, `planetaryMomentum`, and `alchemizeDetailed`'s `perPlanet` entries — was never gated for *any* body, not even correctly-spelled ones like `"South Node"` or `"MC"`.

So every non-planet still blended into the elemental totals:

```ts
const signElement = getZodiacElement(position.sign);          // 60% — real
const sectElement = getPlanetarySectElement(planet, diurnal); // 40% — "Air" for unknown bodies
```

`getPlanetarySectElement` silently returns `"Air"` for anything it doesn't recognize (`planetaryAlchemyMapping.ts:292`). The live sky carries **MC and both lunar nodes**, so three phantom bodies were each pushing 0.4 of pure Air into every calculation.

Their momentum was fabricated too: `alchmWeight` falls back to `PLANET_ALCHM_PERIODS[planet] ?? 1.0` — and **1.0 is Pluto's weight**, so MC was being handed the heaviest alchemical mass in the system.

## The fix

Both first loops now use the same gate as the aspect pass, so an excluded body is a complete no-op everywhere — rather than a no-op in one loop and a full participant in the other.

## Blast radius

Real sky, 2026-07-19T21:00 UTC, backend positions carrying MC + both nodes:

| | Before | After | Δ |
|---|---|---|---|
| Fire | 0.228571 | 0.236364 | +3.41% |
| Water | 0.285714 | 0.309091 | +8.18% |
| **Earth** | 0.114286 | 0.090909 | **−20.45%** |
| Air | 0.371429 | 0.363636 | −2.10% |
| heat | 0.073187 | 0.083229 | +13.72% |
| entropy | 0.343637 | 0.306734 | −10.74% |
| **reactivity** | 66.488496 | 52.606023 | **−20.88%** |
| **gregsEnergy** | −22.774697 | −16.052846 | **+29.51%** |
| monica | 0.025046 | 0.022313 | −10.91% |

**`esms` and `kalchm` are byte-identical before and after.** That's the expected signal, and a good cross-check: those derive from the aspect/`signMap` path #615 already fixed, so this bug was purely elemental. The two bugs are cleanly separable.

Only live calculations pick this up — no stored or historical alchemical values are recomputed.

## Behavior changes beyond the numbers

- **`planetaryMomentum`** no longer contains entries for non-planets. This is serialized by `/api/alchm-quantities` and rendered per-key by the quantities page's "Celestial Momentum (Tides)" grid, so those tiles lose their MC/node entries. Verified at the API level:
  ```
  momentum keys served: Sun, Moon, Mercury, Venus, Mars, Jupiter, Saturn, Uranus, Neptune, Pluto, Ascendant
  excluded bodies still present: NONE
  ```
  (The grid itself doesn't currently render on `/quantities` — `alchData.planetaryMomentum` is undefined on that page, which is pre-existing and unrelated to this change — so there's no visual diff to show there.)
- **`alchemizeDetailed().perPlanet`** no longer contains non-planet keys. Consumers treat these as "the real planets in this chart" (the free-body-diagram builder reconciles against them), so an MC entry carrying populated `elements` beside all-zero `esms` was misleading.

## Tests

Strengthens the sibling regression test rather than adding a parallel one. Assertions now cover `elementalProperties`, `thermodynamicProperties`, `monica`, and momentum-key absence in addition to `esms`/`kalchm` — **which retires the scope caveat #615 had to add**. Adds a case for several excluded bodies at once, the real live-sky shape.

15/15 passing. Full suite green: **152 suites, 1253 passing, 0 failures**. `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)