### PR TITLE
fix(natal-wheel): make sign-vector dignity actually visible

### DIFF
--- a/src/components/dashboard/NatalTransitChart.tsx
+++ b/src/components/dashboard/NatalTransitChart.tsx
@@ -55,6 +55,15 @@ interface TransitData {
   isRetrograde?: boolean;
 }
 
+/**
+ * Sign-vector length = BASE + (dignityMultiplier − 1) × GAIN, in SVG units.
+ * Yields ~6px at Fall (×0.90) and ~24px at Domicile (×1.10), a spread a
+ * reader can actually see, versus ~2px if the multiplier scaled the length
+ * directly. Neutral sits at BASE.
+ */
+const SIGN_VECTOR_BASE = 15;
+const SIGN_VECTOR_GAIN = 90;
+
 /** Majors only on the wheel — minors would hairball; they live on the FBD cards instead. */
 const MAJOR_ASPECTS = new Set(['conjunction', 'opposition', 'trine', 'square', 'sextile']);
 const HARMONIOUS_ASPECTS = new Set(['conjunction', 'trine', 'sextile']);
@@ -280,15 +289,25 @@ export const NatalTransitChart: React.FC<NatalTransitChartProps> = ({
               // applies, so the arrow length means what the FBD cards mean.
               const dignity = getDignityScore(pos.planet, signStr);
               const multiplier = 1 + dignity.esmsScale / 100;
-              const length = 10 * multiplier;
+              // Amplify the dignity deviation so it is actually visible.
+              //
+              // The ESMS dignity scale spans only ±7/±10% (Detriment 0.93 →
+              // Domicile 1.10), so drawing `10 × multiplier` put the entire
+              // range inside 2px — measured 5.8px to 7.5px on a real chart,
+              // which no reader can distinguish. Anchoring at a base length
+              // and scaling the *deviation* keeps the encoding monotonic and
+              // proportional while spreading it across ~6–24px. The exact
+              // multiplier stays in the <title> tooltip, so the precise value
+              // is never lost — only the scale is chosen for legibility.
+              const length = SIGN_VECTOR_BASE + (multiplier - 1) * SIGN_VECTOR_GAIN;
               const angle = toSvgAngle(pos.absAngle);
               const rad = (angle * Math.PI) / 180;
               const ux = Math.cos(rad);
               const uy = Math.sin(rad);
               const start = polarToXY(angle, 144);
               const tip = polarToXY(angle, 144 + length);
-              const headLen = 3.5;
-              const headHalfWidth = 2.2;
+              const headLen = 4.5;
+              const headHalfWidth = 2.8;
               const baseX = tip.x - ux * headLen;
               const baseY = tip.y - uy * headLen;
               const perpX = -uy;
@@ -303,7 +322,7 @@ export const NatalTransitChart: React.FC<NatalTransitChartProps> = ({
                     x2={baseX}
                     y2={baseY}
                     stroke={color}
-                    strokeWidth="1.2"
+                    strokeWidth="1.6"
                     strokeLinecap="round"
                   />
                   <polygon


### PR DESCRIPTION
## The problem

The natal wheel's element-pull arrows scale their length by the planet's dignity — but the ESMS dignity scale spans only **±7/±10%** (Detriment ×0.93 → Domicile ×1.10). Drawing `10 × multiplier` put the entire range inside **two pixels**.

Measured on a real chart, before:

```
Detriment ×0.93 → shaft 5.8px
Neutral   ×1.00 → shaft 6.5px
Exaltation ×1.07 → shaft 7.2px
Domicile  ×1.10 → shaft 7.5px
```

An exalted planet and a fallen one were indistinguishable. The encoding was decorative, not informative — and the goal for this surface is explicitly "**clear** sign vectors that a user can see."

This was a side-effect of an earlier *correctness* fix. The wheel previously read the ±15%-per-level **food** dignity scale, which happened to spread further; moving it to the authoritative **ESMS** scale was right (the arrow claims to show alchemical dignity) but collapsed the visual range.

## The fix

Anchor at a base length and scale the **deviation**:

```ts
length = SIGN_VECTOR_BASE + (multiplier − 1) × SIGN_VECTOR_GAIN   // 15 + d×90
```

After:

```
Detriment ×0.93 → 4.2px
Neutral   ×1.00 → 10.5px
Exaltation ×1.07 → 16.8px
Domicile  ×1.10 → 19.5px
```

A **4.6× spread** instead of 1.3×. The encoding stays monotonic and proportional to the true value, and the exact multiplier remains in the `<title>` tooltip — only the *scale* is chosen for legibility. Nothing is fabricated.

Also nudges stroke `1.2 → 1.6` and arrowhead `3.5 → 4.5`: the aspect chords added alongside these vectors visually swamped them at the old weight.

## Verified in-browser

Rendered `NatalTransitChart` exactly as `/birth-chart` mounts it, for two chart shapes side by side (throwaway fixture route, deleted before commit — `/birth-chart` itself is auth-gated).

Confirmed in the same pass, on the real component rather than a unit test:

| | chords | sign vectors |
|---|---|---|
| Degree-precise chart | 21 | 10 |
| **Legacy sign-only** (`position === 0`) | **0** | 10 |

So the phantom-conjunction fix (`869cbaae`) holds on the rendered component — a legacy chart drew **45** full-strength phantom conjunctions before it. Sign vectors still render for legacy charts, which is correct: the sign is known even when the degree is not.

`bun run typecheck` clean; `src/__tests__` 36 suites / 355 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)