### PR TITLE
style(fbd-card): restyle PlanetFBDCard toward the Stitch card-anatomy mockup

### DIFF
--- a/src/components/ui/alchm/PlanetFBDCard.tsx
+++ b/src/components/ui/alchm/PlanetFBDCard.tsx
@@ -124,6 +124,12 @@ export function PlanetFBDCard({ fbd }: PlanetFBDCardProps) {
   const color = planetColor(fbd.planet);
   const signGlyph = getZodiacGlyph(fbd.sign as ZodiacSignType);
   const active = fbd.vectors.find((v) => v.id === activeId) ?? null;
+  const dignityColor =
+    fbd.dignity.esmsScale > 0
+      ? "var(--accent-2)"
+      : fbd.dignity.esmsScale < 0
+        ? "#ef6a5a"
+        : "var(--fg-mute)";
 
   // Ruler ticks over the ± window around the planet's exact position.
   //
@@ -178,12 +184,13 @@ export function PlanetFBDCard({ fbd }: PlanetFBDCardProps) {
             height: 30,
             borderRadius: "50%",
             flexShrink: 0,
-            background: `radial-gradient(circle at 30% 30%, ${color}, color-mix(in oklch, ${color}, black 55%))`,
+            background: `color-mix(in oklch, ${color}, transparent 80%)`,
+            border: `1px solid color-mix(in oklch, ${color}, transparent 50%)`,
             display: "inline-flex",
             alignItems: "center",
             justifyContent: "center",
             fontSize: 15,
-            color: "rgba(0,0,0,0.75)",
+            color,
           }}
         >
           {planetGlyph(fbd.planet)}
@@ -207,13 +214,9 @@ export function PlanetFBDCard({ fbd }: PlanetFBDCardProps) {
             letterSpacing: "0.14em",
             padding: "3px 7px",
             borderRadius: 999,
-            border: "1px solid var(--line)",
-            color:
-              fbd.dignity.esmsScale > 0
-                ? "var(--accent-2)"
-                : fbd.dignity.esmsScale < 0
-                  ? "#ef6a5a"
-                  : "var(--fg-mute)",
+            border: `1px solid color-mix(in oklch, ${dignityColor}, transparent 60%)`,
+            background: `color-mix(in oklch, ${dignityColor}, transparent 88%)`,
+            color: dignityColor,
             whiteSpace: "nowrap",
           }}
         >
@@ -294,6 +297,17 @@ export function PlanetFBDCard({ fbd }: PlanetFBDCardProps) {
             ? vector.angleDeg + 180
             : vector.angleDeg;
           const labelPos = polar(vector.angleDeg, len + 12);
+          const labelAnchor =
+            Math.cos((vector.angleDeg * Math.PI) / 180) > 0.35
+              ? "start"
+              : Math.cos((vector.angleDeg * Math.PI) / 180) < -0.35
+                ? "end"
+                : "middle";
+          const kinematics = vector.kind === "aspect" ? (vector.aspect?.kinematics ?? null) : null;
+          const countdown =
+            kinematics && kinematics.state !== "stationary"
+              ? `${kinematics.state} · ${kinematics.daysToExact.toFixed(1)}d`
+              : null;
           return (
             <g
               key={vector.id}
@@ -327,13 +341,7 @@ export function PlanetFBDCard({ fbd }: PlanetFBDCardProps) {
               <text
                 x={labelPos.x}
                 y={labelPos.y}
-                textAnchor={
-                  Math.cos((vector.angleDeg * Math.PI) / 180) > 0.35
-                    ? "start"
-                    : Math.cos((vector.angleDeg * Math.PI) / 180) < -0.35
-                      ? "end"
-                      : "middle"
-                }
+                textAnchor={labelAnchor}
                 dominantBaseline="central"
                 fontSize={7.5}
                 fill={vColor}
@@ -342,6 +350,20 @@ export function PlanetFBDCard({ fbd }: PlanetFBDCardProps) {
               >
                 {vector.label}
               </text>
+              {countdown && (
+                <text
+                  x={labelPos.x}
+                  y={labelPos.y + 8}
+                  textAnchor={labelAnchor}
+                  dominantBaseline="central"
+                  fontSize={4.5}
+                  fill="var(--fg-mute)"
+                  opacity={isActive ? 0.9 : 0.45}
+                  style={{ fontFamily: "var(--f-mono)", letterSpacing: "0.04em", userSelect: "none" }}
+                >
+                  {countdown}
+                </text>
+              )}
             </g>
           );
         })}


### PR DESCRIPTION
## Summary
Restyles `PlanetFBDCard.tsx` toward Google Stitch's Screen 2 ("card anatomy") output, reviewed against `docs/design/planet-fbd-stitch-prompt.md`:

- **Header planet badge**: flat color-tint circle + border (was a radial-gradient orb), glyph rendered in the planet's own color.
- **Dignity chip**: tinted background + border matching the polarity color (teal boosts / ember drags), not just colored text on a neutral border.
- **Aspect vectors**: a small muted second line under each aspect label showing the applying/separating countdown ("applying · 2.3d") at rest — matching both the Stitch mockup and the original spec's intent (raw numbers stay hover-only; the applying/separating state was meant to be visible at rest).

Two "bugs" initially found in Stitch's static mockup (wrong ESMS-resultant vector angle, incomplete compass roses) turned out not to apply to the real component — `fbd.resultant.angleDeg` is engine-computed, not hand-drawn, and both compass roses already render all four spokes correctly. No fix needed there.

**Known, accepted tradeoff**: the countdown line adds crowding on dense cards (Sun/Mercury/Mars/Neptune) on top of the pre-existing "vector labels overlap on dense cards" issue — tracked in a follow-up issue rather than fixed here.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run verify` exits 0 (0 errors, same pre-existing unrelated warnings)
- [x] Full FBD test suite: 50/50 passing (`planetaryFBD.test.ts`)
- [x] Visually confirmed live on `/planetary-chart` (dev server, worktree port 3011) — flat-tint badges, tinted dignity pills, and countdown labels all render correctly across all 10 planet cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)