### PR TITLE
feat(planetary-chart): positions table + aspect ledger

### DIFF
--- a/src/__tests__/calculations/planetaryFBD.test.ts
+++ b/src/__tests__/calculations/planetaryFBD.test.ts
@@ -13,6 +13,8 @@
  * expected geometry is obvious by inspection.
  */
 import {
+  ASPECT_GLYPHS,
+  ASPECT_MAX_ORBS,
   ELEMENT_ANGLES,
   buildFreeBodyDiagrams,
   formatDegMin,
@@ -693,6 +695,80 @@ describe("orb formatting", () => {
     for (const card of cards) {
       for (const vector of card.vectors) {
         expect(vector.detail).not.toContain("°60′");
+      }
+    }
+  });
+
+  // The two tests above only pin the `detail` STRING. The orb split is also
+  // exposed as `orbDeg`/`orbMin` precisely so other surfaces (the aspect
+  // ledger on /planetary-chart) never re-derive it — a consumer doing
+  // `floor(orb)` + `round(frac*60)` reintroduces "N°60′" while `detail`
+  // stays correct, so the two surfaces disagree about the same aspect.
+  test("the exposed orbDeg/orbMin never carry 60 arc-minutes either", () => {
+    const { cards } = buildFreeBodyDiagrams({
+      positions: RICH_SKY_POSITIONS,
+      diurnal: true,
+    });
+    for (const card of cards) {
+      for (const vector of card.vectors) {
+        if (!vector.aspect) continue;
+        expect(vector.aspect.orbMin).toBeGreaterThanOrEqual(0);
+        expect(vector.aspect.orbMin).toBeLessThan(60);
+        expect(Number.isInteger(vector.aspect.orbDeg)).toBe(true);
+        expect(Number.isInteger(vector.aspect.orbMin)).toBe(true);
+      }
+    }
+  });
+
+  test("orbDeg/orbMin agree with the detail string for the same aspect", () => {
+    // 2.9999° off an exact trine — the danger band. detail says 3°00′, so the
+    // structured fields must too, not 2°60′.
+    const { cards } = buildFreeBodyDiagrams({
+      positions: {
+        Mars: { sign: "cancer", degree: 10, exactLongitude: 100 },
+        Venus: { sign: "scorpio", degree: 12, exactLongitude: 222.9999 },
+      },
+      diurnal: true,
+    });
+    const vector = byPlanet(cards, "Mars").vectors.find((v) => v.kind === "aspect");
+    expect(vector?.aspect).toBeDefined();
+    expect(vector!.aspect!.orbDeg).toBe(3);
+    expect(vector!.aspect!.orbMin).toBe(0);
+    expect(vector!.detail).toContain(
+      `${vector!.aspect!.orbDeg}°${String(vector!.aspect!.orbMin).padStart(2, "0")}′`,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Aspect glyphs — every type the calculator can emit needs one, or a surface
+// that reads the glyph renders a whole uppercase word in a glyph-sized slot.
+// ---------------------------------------------------------------------------
+
+describe("aspect glyphs", () => {
+  test("every aspect type the engine scores has a glyph", () => {
+    for (const type of Object.keys(ASPECT_MAX_ORBS) as Array<keyof typeof ASPECT_MAX_ORBS>) {
+      expect(ASPECT_GLYPHS[type]).toBeDefined();
+      expect(ASPECT_GLYPHS[type].length).toBeGreaterThan(0);
+    }
+  });
+
+  test("no glyph is a whole word — they render in a glyph-sized column", () => {
+    for (const glyph of Object.values(ASPECT_GLYPHS)) {
+      expect(glyph.length).toBeLessThanOrEqual(2);
+    }
+  });
+
+  test("vector labels never start with an uppercased type name", () => {
+    const { cards } = buildFreeBodyDiagrams({
+      positions: RICH_SKY_POSITIONS,
+      diurnal: true,
+    });
+    for (const card of cards) {
+      for (const vector of card.vectors) {
+        if (vector.kind !== "aspect" || !vector.aspect) continue;
+        const first = vector.label.split(" ")[0];
+        expect(first).not.toBe(vector.aspect.type.toUpperCase());
       }
     }
   });

--- a/src/app/(alchm)/planetary-chart/page.tsx
+++ b/src/app/(alchm)/planetary-chart/page.tsx
@@ -12,15 +12,60 @@ import type { Metadata } from "next";
 import { unstable_cache } from "next/cache";
 import {
   buildFreeBodyDiagrams,
+  TEN_PLANETS,
   type FBDPositionInput,
+  type PlanetFBD,
 } from "@/calculations/planetaryFBD";
 import PlanetFBDCard from "@/components/ui/alchm/PlanetFBDCard";
+import { planetColor, planetGlyph } from "@/components/ui/alchm/planetColors";
 import {
   alchemizeDetailed,
   type PlanetaryPosition,
 } from "@/services/RealAlchemizeService";
+import { getZodiacGlyph } from "@/utils/chartRendering";
 import { calculatePlanetaryPositionsWithMeta } from "@/utils/serverPlanetaryCalculations";
 import PlanetaryChartClient from "./PlanetaryChartClient";
+
+/**
+ * Every aspecting pair appears on both planets' cards (each side's vector
+ * carries identical type/orb/strength/kinematics — only `otherPlanet` and
+ * the ESMS-delta sign convention differ). Dedupe to one row per pair for
+ * a ledger, keyed off the sorted planet pair + aspect type, ranked by
+ * strength.
+ */
+function buildAspectLedger(fbds: PlanetFBD[]) {
+  const seen = new Set<string>();
+  const rows: Array<{
+    planet1: string;
+    planet2: string;
+    glyph: string;
+    type: string;
+    orb: number;
+    strength: number;
+    polarity: "harmonious" | "challenging" | "neutral";
+    kinematics: { state: "applying" | "separating" | "stationary"; daysToExact: number } | null;
+  }> = [];
+  for (const card of fbds) {
+    for (const vector of card.vectors) {
+      if (vector.kind !== "aspect" || !vector.aspect) continue;
+      const other = vector.aspect.otherPlanet;
+      const key = [card.planet, other].sort().join("|") + "|" + vector.aspect.type;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      rows.push({
+        planet1: card.planet,
+        planet2: other,
+        glyph: vector.label.split(" ")[0] ?? "",
+        type: vector.aspect.type,
+        orb: vector.aspect.orb,
+        strength: vector.aspect.strength,
+        polarity: vector.polarity,
+        kinematics: vector.aspect.kinematics,
+      });
+    }
+  }
+  return rows.sort((a, b) => b.strength - a.strength);
+}
 
 // The (alchm) route group forces dynamic rendering for every route it wraps
 // (see layout.tsx — most siblings depend on per-request providers), so a
@@ -73,6 +118,20 @@ async function computeEcosystemUncached() {
     diurnal: detailed.metadata.isDiurnal,
   });
 
+  const positionRows = TEN_PLANETS.filter((planet) => positions[planet] !== undefined).map(
+    (planet) => {
+      const pos = positions[planet];
+      return {
+        planet,
+        sign: pos.sign,
+        degree: pos.degree,
+        minute: pos.minute,
+        isRetrograde: pos.isRetrograde ?? false,
+        arcminPerDay: pos.longitudeSpeed != null ? pos.longitudeSpeed * 60 : null,
+      };
+    },
+  );
+
   return {
     fbds,
     totals,
@@ -82,6 +141,8 @@ async function computeEcosystemUncached() {
     isDiurnal: detailed.metadata.isDiurnal,
     degradedReasons: detailed.degraded?.reasons ?? null,
     timestamp: now.toISOString(),
+    positionRows,
+    aspectLedger: buildAspectLedger(fbds),
   };
 }
 
@@ -166,6 +227,118 @@ export default async function PlanetaryChartPage() {
               </div>
             </div>
           ))}
+        </section>
+
+        {/* Positions & aspect ledger */}
+        <section
+          aria-label="Sky positions and aspect ledger"
+          className="grid grid-cols-1 md:grid-cols-2 gap-4"
+        >
+          <details open className="alchm-panel" style={{ overflow: "hidden" }}>
+            <summary className="t-tag" style={{ padding: "12px 14px", cursor: "pointer" }}>
+              POSITIONS
+            </summary>
+            <div style={{ padding: "0 14px 14px", overflowX: "auto" }}>
+              <table className="t-mono" style={{ width: "100%", borderCollapse: "collapse", fontSize: 11 }}>
+                <thead>
+                  <tr style={{ borderBottom: "1px solid var(--line)", color: "var(--fg-mute)" }}>
+                    <th style={{ textAlign: "left", padding: "4px 6px", fontWeight: 400 }}>PLANET</th>
+                    <th style={{ textAlign: "left", padding: "4px 6px", fontWeight: 400 }}>SIGN</th>
+                    <th style={{ textAlign: "left", padding: "4px 6px", fontWeight: 400 }}>DEG°MIN′</th>
+                    <th style={{ textAlign: "right", padding: "4px 6px", fontWeight: 400 }}>SPEED ′/D</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sky.positionRows.map((row) => (
+                    <tr key={row.planet} style={{ borderBottom: "1px solid var(--line)" }}>
+                      <td style={{ padding: "5px 6px", color: planetColor(row.planet) }}>
+                        {planetGlyph(row.planet)} {row.planet}
+                      </td>
+                      <td style={{ padding: "5px 6px", color: "var(--fg-dim)" }}>
+                        {getZodiacGlyph(row.sign)} {row.sign.toUpperCase().slice(0, 3)}
+                      </td>
+                      <td style={{ padding: "5px 6px", color: "var(--fg-dim)" }}>
+                        {row.degree}°{String(row.minute).padStart(2, "0")}′
+                      </td>
+                      <td
+                        style={{
+                          padding: "5px 6px",
+                          textAlign: "right",
+                          color: row.isRetrograde ? "var(--accent-2)" : "var(--fg-dim)",
+                        }}
+                      >
+                        {row.arcminPerDay == null ? "—" : row.arcminPerDay.toFixed(1)}
+                        {row.isRetrograde ? " ℞" : ""}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </details>
+
+          <details open className="alchm-panel" style={{ overflow: "hidden" }}>
+            <summary className="t-tag" style={{ padding: "12px 14px", cursor: "pointer" }}>
+              ASPECT LEDGER · {sky.aspectLedger.length}
+            </summary>
+            <div style={{ padding: "0 14px 14px", overflowX: "auto" }}>
+              <table className="t-mono" style={{ width: "100%", borderCollapse: "collapse", fontSize: 11 }}>
+                <thead>
+                  <tr style={{ borderBottom: "1px solid var(--line)", color: "var(--fg-mute)" }}>
+                    <th style={{ textAlign: "left", padding: "4px 6px", fontWeight: 400 }}>PAIR</th>
+                    <th style={{ textAlign: "left", padding: "4px 6px", fontWeight: 400 }}>TYPE</th>
+                    <th style={{ textAlign: "left", padding: "4px 6px", fontWeight: 400 }}>ORB</th>
+                    <th style={{ textAlign: "right", padding: "4px 6px", fontWeight: 400 }}>VERDICT</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sky.aspectLedger.map((row) => {
+                    const orbDeg = Math.floor(row.orb);
+                    const orbMin = Math.round((row.orb - orbDeg) * 60);
+                    const polarityColor =
+                      row.polarity === "harmonious"
+                        ? "#4ecdc4"
+                        : row.polarity === "challenging"
+                          ? "#ef6a5a"
+                          : "var(--fg-mute)";
+                    const verdict = !row.kinematics
+                      ? "—"
+                      : row.kinematics.state === "stationary"
+                        ? "STATIONARY"
+                        : `${row.kinematics.state === "applying" ? "APPLYING" : "SEPARATING"} ${row.kinematics.daysToExact.toFixed(1)}D`;
+                    return (
+                      <tr
+                        key={`${row.planet1}-${row.planet2}-${row.type}`}
+                        style={{ borderBottom: "1px solid var(--line)" }}
+                      >
+                        <td style={{ padding: "5px 6px", color: "var(--fg-dim)" }}>
+                          {row.planet1.slice(0, 3)}{" "}
+                          <span style={{ color: polarityColor }}>{row.glyph}</span>{" "}
+                          {row.planet2.slice(0, 3)}
+                        </td>
+                        <td style={{ padding: "5px 6px", color: polarityColor }}>
+                          {row.type.charAt(0).toUpperCase() + row.type.slice(1)}
+                        </td>
+                        <td style={{ padding: "5px 6px", color: "var(--fg-dim)" }}>
+                          {orbDeg}°{String(orbMin).padStart(2, "0")}′
+                        </td>
+                        <td
+                          style={{
+                            padding: "5px 6px",
+                            textAlign: "right",
+                            color: "var(--fg-mute)",
+                            fontSize: 9.5,
+                          }}
+                        >
+                          {verdict}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </details>
         </section>
 
         {/* How to read */}

--- a/src/app/(alchm)/planetary-chart/page.tsx
+++ b/src/app/(alchm)/planetary-chart/page.tsx
@@ -11,6 +11,7 @@
 import type { Metadata } from "next";
 import { unstable_cache } from "next/cache";
 import {
+  ASPECT_GLYPHS,
   buildFreeBodyDiagrams,
   TEN_PLANETS,
   type FBDPositionInput,
@@ -40,7 +41,8 @@ function buildAspectLedger(fbds: PlanetFBD[]) {
     planet2: string;
     glyph: string;
     type: string;
-    orb: number;
+    orbDeg: number;
+    orbMin: number;
     strength: number;
     polarity: "harmonious" | "challenging" | "neutral";
     kinematics: { state: "applying" | "separating" | "stationary"; daysToExact: number } | null;
@@ -55,9 +57,14 @@ function buildAspectLedger(fbds: PlanetFBD[]) {
       rows.push({
         planet1: card.planet,
         planet2: other,
-        glyph: vector.label.split(" ")[0] ?? "",
+        // Read the glyph and the orb split from the engine — never re-derive
+        // either. Parsing `label.split(" ")[0]` yields a whole uppercase word
+        // for the glyph-less minor types, and re-splitting the orb with
+        // floor+round reintroduces the "2°60′" bug the engine already guards.
+        glyph: ASPECT_GLYPHS[vector.aspect.type],
         type: vector.aspect.type,
-        orb: vector.aspect.orb,
+        orbDeg: vector.aspect.orbDeg,
+        orbMin: vector.aspect.orbMin,
         strength: vector.aspect.strength,
         polarity: vector.polarity,
         kinematics: vector.aspect.kinematics,
@@ -293,8 +300,6 @@ export default async function PlanetaryChartPage() {
                 </thead>
                 <tbody>
                   {sky.aspectLedger.map((row) => {
-                    const orbDeg = Math.floor(row.orb);
-                    const orbMin = Math.round((row.orb - orbDeg) * 60);
                     const polarityColor =
                       row.polarity === "harmonious"
                         ? "#4ecdc4"
@@ -320,7 +325,7 @@ export default async function PlanetaryChartPage() {
                           {row.type.charAt(0).toUpperCase() + row.type.slice(1)}
                         </td>
                         <td style={{ padding: "5px 6px", color: "var(--fg-dim)" }}>
-                          {orbDeg}°{String(orbMin).padStart(2, "0")}′
+                          {row.orbDeg}°{String(row.orbMin).padStart(2, "0")}′
                         </td>
                         <td
                           style={{

--- a/src/calculations/planetaryFBD.ts
+++ b/src/calculations/planetaryFBD.ts
@@ -127,6 +127,15 @@ export interface FBDAspectDetail {
   type: AspectType;
   /** Orb in degrees (distance from exact). */
   orb: number;
+  /**
+   * The orb pre-split into whole degrees + arc-minutes, rounded to whole
+   * arc-minutes FIRST so the pair can never read "2°60′". Exposed because
+   * every surface that shows an orb must use the SAME split — re-deriving it
+   * with `floor(orb)` + `round(frac*60)` reintroduces exactly that bug, and
+   * two surfaces on one page then disagree about the same aspect.
+   */
+  orbDeg: number;
+  orbMin: number;
   /** Cosine-bell strength 0–1 (1 = exact). */
   strength: number;
   /** Type importance = the engine's own orb budget, maxOrb/8 (0.25–1). */
@@ -294,7 +303,13 @@ const ASPECT_ANGLES: Record<AspectType, number> = {
  * weight is derived from the engine's own orb budget — maxOrb/8 — rather than
  * a new hand-tuned table: conjunction/opposition/trine 1.0 … quintile 0.25.
  */
-const ASPECT_MAX_ORBS: Record<AspectType, number> = {
+/**
+ * The engine's own orb budget per aspect type. Exported alongside
+ * {@link ASPECT_GLYPHS} so a consumer (or a port to another repo) can assert
+ * the two stay in step: every type that gets scored here must have a glyph.
+ * `baseWeight = maxOrb / 8` is load-bearing — it sets vector length.
+ */
+export const ASPECT_MAX_ORBS: Record<AspectType, number> = {
   conjunction: 8,
   opposition: 8,
   trine: 8,
@@ -309,7 +324,19 @@ const ASPECT_MAX_ORBS: Record<AspectType, number> = {
   biquintile: 2,
 };
 
-const ASPECT_GLYPHS: Partial<Record<AspectType, string>> = {
+/**
+ * Aspect glyphs, keyed by type. Exported so every surface that shows an aspect
+ * reads the SAME glyph rather than reverse-parsing it out of `vector.label`
+ * (`label.split(" ")[0]`), which silently yields a whole uppercase word for
+ * any type missing from this map.
+ *
+ * `aspectCalculator` emits — and `ASPECT_ANGLES`/`ASPECT_MAX_ORBS` below treat
+ * as first-class — four minor types that have no standard single glyph:
+ * semisquare, sesquisquare, quintile and biquintile. They get short mono
+ * abbreviations rather than being omitted, because a `Partial` map here is
+ * what produced "Mar SESQUISQUARE Sat" in a glyph-sized column.
+ */
+export const ASPECT_GLYPHS: Record<AspectType, string> = {
   conjunction: "☌",
   opposition: "☍",
   trine: "△",
@@ -318,6 +345,10 @@ const ASPECT_GLYPHS: Partial<Record<AspectType, string>> = {
   quincunx: "⚻",
   inconjunct: "⚻",
   "semi-sextile": "⚺",
+  semisquare: "∠",
+  sesquisquare: "⚼",
+  quintile: "Q",
+  biquintile: "bQ",
 };
 
 /** Vectors shorter than this fraction of the card max stay visible. */
@@ -593,8 +624,16 @@ function buildCard(
     if (polarity === "challenging") netHarmony -= aspect.strength;
 
     const otherSpeed = positions[other]?.longitudeSpeed;
+    // The `!== 0` test mirrors the planet's own speed guard above: exactly 0 is
+    // the "no motion computed" sentinel, not a real standstill. Both sides of a
+    // pair must apply it, or a partner whose speed failed to compute would be
+    // read as stationary and yield a confident, wrong applying/separating
+    // verdict instead of an honest "motion unavailable".
     const kinematics =
-      speed !== null && typeof otherSpeed === "number" && Number.isFinite(otherSpeed)
+      speed !== null &&
+      typeof otherSpeed === "number" &&
+      Number.isFinite(otherSpeed) &&
+      otherSpeed !== 0
         ? computeAspectKinematics(
             lon,
             otherLon,
@@ -634,7 +673,7 @@ function buildCard(
       id: `aspect-${other}-${aspect.type}`,
       kind: "aspect",
       source: other,
-      label: `${ASPECT_GLYPHS[aspect.type] ?? aspect.type.toUpperCase()} ${other.toUpperCase()}`,
+      label: `${ASPECT_GLYPHS[aspect.type]} ${other.toUpperCase()}`,
       angleDeg: normalizeAngle(offsetDeg),
       magnitude,
       normalized: 0, // filled after per-card normalization
@@ -644,6 +683,8 @@ function buildCard(
         otherPlanet: other,
         type: aspect.type,
         orb: aspect.orb,
+        orbDeg,
+        orbMin,
         strength: aspect.strength,
         baseWeight,
         offsetDeg,


### PR DESCRIPTION
## Summary

Screen 1 of the Stitch design pass called for a **position table** and an **aspect ledger** flanking the wheel on `/planetary-chart`. Investigation showed neither existed — `PlanetaryChart.tsx` is a pure SVG wheel renderer taking `positions`/`aspects` as props, with no surrounding tabular UI — so these are genuinely new, not restyles.

Both are built **server-side from the data the page already computes** (`alchemizeDetailed` → `buildFreeBodyDiagrams`), rather than from a second source that could drift out of agreement with the FBD cards.

**POSITIONS** — the ten planets in canonical `TEN_PLANETS` order: planet-colored glyph, sign glyph + abbreviation, `degree°minute′`, and daily motion in arc-minutes/day. Retrogrades marked `℞` and tinted, keyed off the real `isRetrograde` flag.

**ASPECT LEDGER** — one row per aspecting pair, ranked by strength, with polarity-colored type and the engine's own applying/separating verdict + days-to-exact.

### The dedup, and why it needed verifying

Every aspect appears on **both** planets' FBD cards (each side's vector carries identical type/orb/strength/kinematics — only `otherPlanet` differs). A naive ledger would double-count every row. Rows are deduped on sorted-planet-pair + aspect type, and I verified that against live positions rather than assuming:

```
raw aspect vectors across cards: 58
deduped ledger rows            : 29
ratio (expect ~2.0)            : 2.000
pairs w/ both cards not counted twice: 0
rows involving a non-card body       : 0
```

The rendered page header reads `ASPECT LEDGER · 29`, matching exactly.

### What was deliberately NOT carried over from the mockup

The Stitch output invented data this model doesn't have — a third `EXC` aspect verdict the engine never reports, and Newtonian `F_net: 4.2N` / `θ: 45°` footer metrics with units that have no counterpart in the ESMS engine. Verdicts here come only from `aspect.kinematics` (`applying`/`separating`/`stationary`), and degrade to `—` when kinematics are unavailable.

Minor aspects with no glyph in `ASPECT_GLYPHS` (semisquare, quintile, biquintile…) render their uppercase type name in the glyph slot — the same degrade the FBD card labels already use, so the two surfaces stay consistent.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run verify` exits 0 (0 errors)
- [x] Dedup verified against live Swiss-Ephemeris positions (numbers above)
- [x] Rendered live at `/planetary-chart` — both panels populated, retrogrades correctly marked, rows strength-sorted
- [x] `<details open>` so both panels collapse on mobile, per the design's mobile notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)