### PR TITLE
docs(fbd): correct stale weight comments + a sect table that disagreed with its own code

### DIFF
--- a/src/__tests__/sectElementDocSync.test.ts
+++ b/src/__tests__/sectElementDocSync.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { PLANETARY_SECTARIAN_ELEMENTS } from "@/utils/planetaryAlchemyMapping";
+
+/**
+ * The doc comment above PLANETARY_SECTARIAN_ELEMENTS lists each planet's
+ * diurnal/nocturnal element. It silently drifted out of sync with the code
+ * for FOUR of the ten planets (Venus, Jupiter, Uranus, Pluto) — the code was
+ * right, the comment was wrong.
+ *
+ * That matters more than a normal stale comment: the sect element drives the
+ * 0.4-weight sect pull on every FBD card, and the sibling repos (Pentacles,
+ * AlchmAgentsETH, PlanetaryAgents) are expected to hand-port this table. A
+ * porter reading the header would have encoded four wrong pairs.
+ *
+ * This test parses the comment back out of the source and asserts it matches
+ * the runtime table, so the two can never diverge again unnoticed.
+ */
+describe("PLANETARY_SECTARIAN_ELEMENTS doc comment", () => {
+  test("the header table matches the code for all ten planets", () => {
+    const src = readFileSync(
+      join(process.cwd(), "src/utils/planetaryAlchemyMapping.ts"),
+      "utf8",
+    );
+
+    // Lines shaped like: " *   Venus   Water / Earth"
+    const rowRe = /^\s*\*\s+([A-Z][a-z]+)\s+(Fire|Water|Earth|Air)\s*\/\s*(Fire|Water|Earth|Air)/gm;
+    const documented: Record<string, { diurnal: string; nocturnal: string }> = {};
+    for (const m of src.matchAll(rowRe)) {
+      documented[m[1]] = { diurnal: m[2], nocturnal: m[3] };
+    }
+
+    // Guard against the regex silently matching nothing and the test passing
+    // vacuously — the exact failure mode this test exists to prevent.
+    expect(Object.keys(documented).length).toBe(10);
+
+    for (const [planet, pair] of Object.entries(PLANETARY_SECTARIAN_ELEMENTS)) {
+      expect(documented[planet]).toBeDefined();
+      expect({ planet, ...documented[planet] }).toEqual({
+        planet,
+        diurnal: pair.diurnal,
+        nocturnal: pair.nocturnal,
+      });
+    }
+  });
+});

--- a/src/calculations/planetaryFBD.ts
+++ b/src/calculations/planetaryFBD.ts
@@ -195,7 +195,7 @@ export interface FBDPhysics {
   speedDegPerDay: number | null;
   /** Signed daily motion, arc-minutes/day — the card's arc-minute tie-in. */
   arcminutesPerDay: number | null;
-  /** Orbital-period alchemical weight (log-normalized, Moon≈0.17 Pluto≈1). */
+  /** Orbital-period alchemical weight (log-normalized, Moon≈0.28 Pluto=1). */
   alchmWeight: number;
 }
 

--- a/src/utils/planetaryAlchemyMapping.ts
+++ b/src/utils/planetaryAlchemyMapping.ts
@@ -166,17 +166,26 @@ export type ZodiacQuality = "Cardinal" | "Fixed" | "Mutable";
  * Night sect planets: Moon, Venus, Mars
  * Mercury is adaptable - it joins whichever sect it rises with
  *
- * Diurnal / Nocturnal element assignments (traditional authority):
+ * Diurnal / Nocturnal element assignments (traditional authority).
+ *
+ * ⚠️ This table is TRANSCRIBED FROM THE CODE BELOW, which is authoritative.
+ * It previously disagreed with its own code for FOUR of the ten planets
+ * (Venus, Jupiter, Uranus, Pluto had their pairs swapped or altered), so
+ * anyone hand-porting the engine from this header — as the sibling repos
+ * must — encoded four wrong sect elements. Sect drives the 0.4-weight pull
+ * vector on every FBD card, so a wrong pair silently tilts the elemental
+ * push. If you change the code, change this list in the same commit.
+ *
  *   Sun     Fire  / Fire    (luminary - always Fire)
  *   Moon    Water / Water   (luminary - always Water)
  *   Mercury Air   / Earth   (adapts to sect)
- *   Venus   Earth / Water
+ *   Venus   Water / Earth
  *   Mars    Fire  / Water
- *   Jupiter Fire  / Air
+ *   Jupiter Air   / Fire
  *   Saturn  Air   / Earth   ← key correction (was wrong before)
- *   Uranus  Air   / Air     (modern - airy by nature)
+ *   Uranus  Water / Air     (modern)
  *   Neptune Water / Water   (modern - watery by nature)
- *   Pluto   Water / Earth   (modern - transformative)
+ *   Pluto   Earth / Water   (modern - transformative)
  */
 export const PLANETARY_SECTARIAN_ELEMENTS = {
   Sun:     { diurnal: "Fire"  as AlchemicalElement, nocturnal: "Fire"  as AlchemicalElement },
@@ -514,7 +523,13 @@ export function calculateEnhancedAlchemicalFromPlanetsDetailed(
     const baseESMS = diurnal ? sectEntry.diurnal : sectEntry.nocturnal;
 
     // Alchm weight: orbital-period based (slower = higher alchemical volume)
-    // Pluto (P=248y) → weight ≈ 1.0; Moon (P=27d) → weight ≈ 0.17
+    // Pluto (P=248y) → weight = 1.0; Moon (P=27d) → weight ≈ 0.28
+    //
+    // NOTE: this is the ORBITAL-PERIOD scale (normalizeAlchmWeight), which is
+    // NOT the mass scale (normalizePlanetWeight) used a few hundred lines up.
+    // The two disagree per planet — e.g. Mercury is ≈0.39 here but ≈0.17 by
+    // mass. The stale "Moon ≈ 0.17" this line used to carry was Mercury's MASS
+    // weight copied across the two scales. Don't transcribe between them.
     //
     // SPECIAL CASE: The Ascendant is the "Physical Vessel" grounding constant.
     // It provides a fixed (+1) to all principles to anchor the system,


### PR DESCRIPTION
## Summary

Found while scoping the FBD port to the sibling repos (Pentacles, AlchmAgentsETH, PlanetaryAgents) — those repos are expected to **hand-transcribe these tables**, so a wrong comment here becomes a wrong engine there. Every claim below was verified by computing the real value, not by reading.

### 1. The sect-element doc comment disagreed with its own code for 4 of 10 planets

| Planet | Comment said | Code says |
|---|---|---|
| Venus | Earth / Water | **Water / Earth** |
| Jupiter | Fire / Air | **Air / Fire** |
| Uranus | Air / Air | **Water / Air** |
| Pluto | Water / Earth | **Earth / Water** |

The **code is authoritative** — PlanetaryAgents' independently-maintained sect table matches the code, not the comment. Sect drives the `SECT_WEIGHT = 0.4` pull vector on every FBD card, so a porter reading the header would have tilted the elemental push on four planets.

### 2. Two comments claimed the Moon's orbital-period weight is ≈0.17

Computed: `normalizeAlchmWeight(0.075) = 0.284`. Pluto = 1.0 is correct, but the lower bound is the **Ascendant** (0.003y), not the Moon.

**Root cause worth recording:** `0.17` is *Mercury's* **mass** weight (`normalizePlanetWeight` = 0.1709). Someone copied a number between the two weight scales, which are different functions over different data:

| Scale | Function | Moon | Mercury | Sun | Pluto |
|---|---|---|---|---|---|
| Orbital period | `normalizeAlchmWeight` | 0.284 | 0.387 | 0.513 | **1.000** |
| Mass | `normalizePlanetWeight` | 0.091 | **0.171** | **1.000** | 0.000 |

I checked the mass-scale comment at `planetaryAlchemyMapping.ts:366` ("Sun w=1.0, Mercury w≈0.17") before assuming it was wrong too — **it is correct** and was left alone. Added a note naming both scales so the next reader doesn't repeat the conflation.

## The new test

`src/__tests__/sectElementDocSync.test.ts` parses the header table back out of the source and asserts it matches the runtime table, so this class of drift can't recur silently.

**Proven non-vacuous** — reintroducing the historical Venus swap makes it fail with the exact diff:
```
✕ the header table matches the code for all ten planets
-   "diurnal": "Water",     -   "nocturnal": "Earth",
+   "diurnal": "Earth",     +   "nocturnal": "Water",
```
and it asserts the regex matched all 10 rows, so a broken pattern fails rather than passing vacuously.

## Test plan
- [x] Comments + one new test only — **no behaviour change**
- [x] `bun run verify` exits 0
- [x] New test passes, and provably fails when the historical bug is reintroduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)