### PR TITLE
feat(menu-planner): mobile redesign, real weekly insights, public agent weeks

### DIFF
--- a/docs/design/menu-planner-stitch-prompt.md
+++ b/docs/design/menu-planner-stitch-prompt.md
@@ -1,0 +1,381 @@
+# Weekly Meal Planner — Stitch Redesign Prompt
+
+Ready-to-paste prompts for **Google Stitch** to generate a modern redesign of the
+`/menu-planner` weekly calendar. Built from a 20-question design interview + a full
+audit of the current page, data model, and design system.
+
+**How to use:** Paste the **Global Style Block** first, then paste each **Screen prompt**
+as its own generation (Stitch generates one screen per prompt; keep the style block at
+the top of each so every screen stays on-brand). Generate the **Mobile** screens first
+(this is a mobile-first design), then the desktop variants.
+
+---
+
+## Design decisions locked in (the 20 answers)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| Platform | Form factor | **Mobile-first, responsive** to desktop |
+| Goal | Optimize for | **Fast, effortless weekly fill** |
+| Theme | Aesthetic | **Clean & modern** (elemental cues as small accents) — rendered in the app's dark theme |
+| Density | Main screen | **Balanced** — calendar + one insights rail |
+| Layout | Calendar | **7-column grid (desktop) / swipeable day-stack (mobile)** |
+| Slots | Meals/day | **3 mains (Breakfast/Lunch/Dinner)** shown; **snack is an optional add** |
+| Today | Emphasis | **Prominent "Today" hero card** |
+| Nav | Week change | **Prev/next arrows + swipe + "Jump to today"** |
+| Balance | Elemental/ESMS | **Compact weekly balance meter in the insights rail** |
+| Nutrition | Macros | **Per-day, shown on the cards (data-forward)** |
+| AI | Generation | **Secondary / subtle** (fast-fill leans on templates, agent menus, copy-week, quick add) |
+| Agent menus | Entry point | **Living updating fixture on the agent's profile; interactive user-week fixture on the user's profile** |
+| Add recipe | Interaction | **Tap-to-add everywhere (no drag-and-drop)** |
+| Grocery | Shopping | **Prominent "Shop the week" → grocery list → Amazon Fresh cart** |
+| Planetary | Astro layer | **Keep the transit ribbon + planetary day rulers visible** |
+| Cards | Visual richness | **Data-forward** (macros + estimated cost on each card) |
+| Rail | Insights content | **Elemental balance + smart suggestions + budget/cost + variety & missing-meals** |
+| Empty state | Fast start | **Guided quick setup, then prefill an editable week** |
+| Tracking | "I ate this" | **Lives in a separate tracking view** (not on calendar slots) |
+| Deliverable | Scope | **Everything:** main week (mobile + desktop), empty state, add-recipe sheet, shop-the-week, insights, profile week-fixture |
+
+### Hard data-model constraints the design MUST respect
+- **7 days, Sunday → Saturday.** The ribbon and columns run Sun…Sat.
+- Underlying grid is **7 days × 4 meal types** (breakfast, lunch, dinner, snack). We
+  **show 3 mains by default** and expose snack as an "**+ add snack**" affordance — do
+  not invent custom meal types.
+- Each meal slot holds: one recipe, a **servings** number, an optional single **sauce**,
+  and a **lock** toggle (a locked meal survives "regenerate / balance / reshuffle").
+- The week is one unit keyed by its Sunday start date; users move week-to-week.
+
+---
+
+## GLOBAL STYLE BLOCK  *(prepend to every screen prompt)*
+
+```
+STYLE: Modern, clean, food-first meal-planning app in a refined DARK theme (dark mode
+only — never white/light surfaces). Think a premium, decluttered planner (Notion-calm
+meets a cooking app) with a subtle cosmic/alchemical signature — NOT a busy dashboard or
+sci-fi console. Generous whitespace, clear visual hierarchy, one primary action per area.
+
+COLOR PALETTE (dark, use these exact hex):
+- Backgrounds (darkest→lightest surfaces): #07060B, #0E0C16, #15121F, #1C1829, #241F33
+- Text: #F2EDFF (primary), #B5ADCC (secondary/labels), #6E6884 (muted)
+- Primary accent (violet): #B85AF0
+- Secondary accent (copper-gold): #DEA54B
+- Error/over-target: #F87171
+- Element accents (small dots/bars only): Fire #EF7A5A, Water #58A6E8, Earth #76B266, Air #D9CD9F
+- Signature gradient: 135° copper→violet (#DEA54B → #B85AF0), used sparingly on hero/CTA.
+
+SURFACES: Translucent "glass" cards — subtle white 4–8% fill, 1px hairline border, soft
+backdrop blur, rounded corners (14–16px). Hero cards get a faint violet glow. Keep it
+airy; avoid heavy borders, avoid neon, avoid terminal/monospace-console styling.
+
+TYPOGRAPHY:
+- Headings: an elegant serif (Cormorant Garamond), medium weight, tight letter-spacing.
+- Body: a clean humanist sans (Manrope).
+- Small labels, numbers, metadata, kcal/cost/servings: a monospace (JetBrains Mono),
+  UPPERCASE, wide letter-spacing (~0.12em), tabular figures. This mono-caps micro-label
+  treatment is the brand signature — use it for all tiny data readouts.
+
+ICONOGRAPHY: Minimal line icons. Preserve two signature astro touches only:
+(1) planetary day glyphs ☉ ☽ ♂ ☿ ♃ ♀ ♄, (2) small elemental dots. No heavy occult
+ornament, no fake telemetry, no crosshair gauges.
+
+MOOD: calm, confident, effortless. The user should feel a full week can be planned in
+under a minute.
+```
+
+---
+
+## SCREEN 1 — Weekly Planner (MOBILE, primary)
+
+```
+[PREPEND GLOBAL STYLE BLOCK]
+
+SCREEN: "Weekly Meal Planner" — mobile (390px wide). This is the primary screen.
+
+TOP APP BAR: Left: screen title "This Week" in serif. Below it, a small mono-caps
+date range label "SUN JUL 12 – SAT JUL 18". Right: a compact "⌄ Jump to today" pill and
+a settings/kebab icon. A left/right chevron pair for previous/next week; the whole day
+area is also horizontally swipeable between weeks.
+
+TRANSIT RIBBON (signature, keep subtle): A slim horizontal strip of 7 small circular
+"day medallions" (Sun→Sat), each showing the day's ruling-planet glyph (☉☽♂☿♃♀♄) and a
+one-letter day initial. Today's medallion glows copper-gold; the selected day glows
+violet. This is a lightweight week-navigator, not a big banner.
+
+TODAY HERO CARD (prominent, pinned near top): A larger glass card with a faint violet
+glow for the current day. Header row: planet glyph + "TODAY · SUNDAY" mono-caps + a short
+one-line cosmic tip (e.g. "A Sun day — favor warming, celebratory dishes"). Then a compact
+"3 of 3 planned" progress read-out. Body: the 3 main meals (Breakfast, Lunch, Dinner) as
+data-forward meal cards (see MEAL CARD spec). A subtle "+ add snack" ghost row at the
+bottom. Primary action on the card: "Fill this day" (subtle, secondary-styled) and a small
+lock icon per meal.
+
+WEEK LIST (below the hero): The rest of the week as a vertical stack of DAY CARDS you
+scroll through (day-stack layout on mobile). Each day card: a header with planet glyph +
+day name (serif) + short date (mono-caps) + a tiny per-day macro chip "560 KCAL · $6.20".
+Under it, the 3 main meal slots. Collapsed days can show just filled/empty meal chips.
+
+MEAL CARD spec (data-forward): a horizontal card = small recipe thumbnail (or an "+ Add"
+placeholder if empty) · recipe name (serif, 1 line) · a row of mono-caps data:
+"420 KCAL · P32 C40 F14 · $4.10 · x2" (calories, macros, est. cost, servings) · one small
+element dot showing the dish's dominant element · a lock icon (outline = unlocked, filled
+copper = locked). Tapping an EMPTY slot opens the Add-Recipe sheet (Screen 4). Tapping a
+FILLED card opens its detail/quick-actions (swap, servings, lock, remove).
+
+INSIGHTS RAIL (mobile = a collapsible panel or bottom section, not a permanent sidebar):
+A single "Week Insights" section with four compact modules, in this order:
+1. ELEMENTAL BALANCE — a small horizontal 4-segment meter (Fire/Water/Earth/Air) with a
+   plain-language verdict line "Balanced week" or "A little fire-heavy". Signature metric.
+2. SMART SUGGESTIONS — 2–3 recipe chips to fill gaps or improve balance ("Add a Water dish").
+3. BUDGET — "$41 / $60 this week" with a thin progress bar.
+4. VARIETY & GAPS — "2 slots empty · 9 unique ingredients" with a "Fill remaining" button.
+
+BOTTOM: Respect the app's existing global bottom tab bar — leave room for it; do NOT add a
+second fixed bottom bar. A single floating "✦ Shop the week" button sits above the tab bar.
+
+STATES: show the filled state (most days planned, 1–2 empty slots visible as dashed "+ Add"
+placeholders).
+```
+
+---
+
+## SCREEN 2 — Weekly Planner (DESKTOP)
+
+```
+[PREPEND GLOBAL STYLE BLOCK]
+
+SCREEN: "Weekly Meal Planner" — desktop (1440px). Same content as mobile, reflowed into a
+two-region layout: a wide 7-column calendar grid on the left (~70%) and a persistent
+INSIGHTS RAIL on the right (~30%).
+
+HEADER: serif title "This Week", mono-caps date range, prev/next week chevrons, a
+"Jump to today" button, and a subtle secondary "✦ Auto-plan" button (AI is intentionally
+low-key). Primary CTA (copper→violet gradient): "Shop the week".
+
+TRANSIT RIBBON: full-width slim strip of 7 planet-glyph day medallions (Sun→Sat) directly
+under the header; today = copper glow, selected = violet glow.
+
+CALENDAR GRID: 7 columns (Sun→Sat). Each column = a day. Column header: planet glyph +
+day name (serif) + date (mono-caps) + tiny per-day macro chip. TODAY'S COLUMN is visually
+elevated (violet-glow border, slightly wider) — this is the "Today hero" in grid form.
+Each column body stacks the 3 main meal slots as compact data-forward MEAL CARDS (same spec
+as mobile: thumbnail, name, "KCAL · P/C/F · $cost · xservings", element dot, lock icon),
+plus a subtle "+ add snack" ghost slot and a "Fill day" affordance on hover. Empty slots
+render as dashed "+ Add" placeholders. Tap a slot to add (no drag-and-drop).
+
+INSIGHTS RAIL (right, always visible): stacked cards in this order —
+1. ELEMENTAL BALANCE (hero of the rail): a clean 4-bar or small radial Fire/Water/Earth/Air
+   meter + verdict line + a "harmony 78%" mono readout. This is the platform's signature.
+2. WEEKLY MACROS: total kcal + P/C/F vs goals, a slim compliance ring.
+3. SMART SUGGESTIONS: 3 recipe suggestion rows with quick "+ add to <day>".
+4. BUDGET: est. weekly cost vs budget, progress bar, per-day mini-breakdown.
+5. VARIETY & MISSING MEALS: unique ingredients/cuisines + a list of empty slots with
+   one-click "fill".
+
+FOOTER: a slim link row "Templates · Copy last week · Save as template · Tracking".
+```
+
+---
+
+## SCREEN 3 — Empty State / Fast Start (guided quick setup)
+
+```
+[PREPEND GLOBAL STYLE BLOCK]
+
+SCREEN: "Plan your week" — the empty state for a brand-new/empty week. Mobile-first,
+centered, welcoming. Goal: get from zero to a full editable week in under a minute.
+
+HERO: a serif headline "Let's plan your week" + one-line subhead "Answer 3 quick things and
+we'll draft a balanced week you can tweak."
+
+A short GUIDED QUICK-SETUP card with 3 compact steps (segmented pickers, not a long form):
+1. WHO / SERVINGS — a stepper "Cooking for [2] people".
+2. DIET & PREFERENCES — chips: Balanced (default), High-protein, Vegetarian, Vegan,
+   Pescatarian, Low-carb + a "cuisines" multiselect row.
+3. BUDGET — a slider "$ per week" with a mono-caps value, plus "No budget" toggle.
+Primary CTA (gradient): "Draft my week ✦".
+
+Below the setup, three SECONDARY start options as cards (fast-fill, AI kept subtle):
+- "Start from a template" (your saved weeks)
+- "Adopt an agent's menu" (browse Planetary Agent-authored weeks — small preview cards
+  showing the agent avatar, week title, planetary focus, and a "Use this week" button)
+- "Copy last week"
+
+Keep it calm and uncluttered; one clear primary path (the guided draft) with the others as
+quieter alternatives.
+```
+
+---
+
+## SCREEN 4 — Add-Recipe Sheet (tap-to-add)
+
+```
+[PREPEND GLOBAL STYLE BLOCK]
+
+COMPONENT: A bottom sheet (mobile) / centered modal (desktop) that opens when the user taps
+an empty meal slot. Title mono-caps: "ADD TO · MONDAY · LUNCH".
+
+TOP: a search field "Search recipes…" with a mono-caps placeholder. Below it, quick filter
+chips: All · Suggested for balance · Quick (<30 min) · High-protein · Fire/Water/Earth/Air
+(as small element dots). A subtle "✦ Suggest for me" pill (AI, secondary).
+
+RESULTS: a scrollable list of data-forward recipe rows — thumbnail · name (serif) ·
+mono-caps data "420 KCAL · P32 C40 F14 · $4.10 · 25 MIN" · a small dominant-element dot ·
+a right-side "Add" button. A "SUGGESTED FOR THIS SLOT" section at the top shows 2–3 picks
+that improve the week's elemental balance or fill a macro gap, each with a tiny reason
+tag ("+ adds Water", "+ protein").
+
+FOOTER (when a recipe is chosen): a compact confirm row — servings stepper (default from
+setup), an optional "add a sauce" link, and a "Add to Monday · Lunch" primary button.
+
+Keep it fast: one tap to add, sheet dismisses back to the calendar with the slot now filled.
+```
+
+---
+
+## SCREEN 5 — Shop the Week (grocery list → Amazon Fresh)
+
+```
+[PREPEND GLOBAL STYLE BLOCK]
+
+SCREEN: "Shop the week" — a consolidated grocery list generated from the planned meals,
+with an Amazon Fresh handoff. (Do NOT reference Instacart.)
+
+HEADER: serif "Grocery List" + mono-caps subline "FROM 7 DAYS · 18 MEALS" + a total
+"EST. $52.40". Primary CTA (gradient): "Send to Amazon Fresh cart".
+
+LIST: items grouped by category sections (Produce, Proteins, Dairy, Grains, Spices,
+Condiments, Canned, Frozen, Bakery, Beverages, Other). Each item row: a checkbox, item name,
+mono-caps quantity+unit "2 LBS", a small "used in 3 meals" tag, and an "in pantry" toggle
+(dims/strikes the row when on). A top toolbar: "Check all", "Hide pantry items",
+"Add item".
+
+RIGHT/BELOW: a small summary card — item count, est. total, and a note "Pantry items
+excluded from cart". Keep it clean and scannable; category headers in mono-caps.
+```
+
+---
+
+## SCREEN 6 — Weekly Insights (expanded)
+
+```
+[PREPEND GLOBAL STYLE BLOCK]
+
+SCREEN: "Week Insights" — the full view behind the rail's balance/nutrition/variety modules.
+
+TOP HERO: ELEMENTAL BALANCE — a large but clean visualization of the week's Fire/Water/
+Earth/Air distribution (a radial 4-axis meter or 4 elegant bars) with a plain-language
+verdict ("Balanced, leaning warm"), a "harmony 78%" mono readout, and a one-line
+"this week trends heating →" thermal note. Small element dots as the only ornament.
+
+NUTRITION: weekly totals vs goals for Calories/Protein/Carbs/Fat as macro pills + a
+compliance ring (0–100). A short "below target: fiber, iron" list.
+
+VARIETY: unique ingredients, unique recipes, cuisine diversity, and color diversity as
+four small 0–100 bars.
+
+BUDGET: est. weekly cost vs budget with a per-day bar chart.
+
+SUGGESTIONS: a list of specific improvements each with a one-tap action
+("Swap Tue dinner for a Water dish to balance the week").
+
+Everything in calm glass cards; no console/terminal styling.
+```
+
+---
+
+## SCREEN 7 — Profile "Week Fixture" (embeddable) — agent & user variants
+
+```
+[PREPEND GLOBAL STYLE BLOCK]
+
+COMPONENT: A compact, embeddable "this week" fixture that lives on an alchm.kitchen PROFILE
+page (not the full planner). Two variants, same visual language:
+
+(A) AGENT PROFILE — a living, auto-updating fixture titled "[Agent]'s week" with a small
+mono-caps "UPDATED 2H AGO" stamp and a planetary-focus tag. Shows a condensed 7-day row
+(Sun→Sat) of small day tiles; each tile shows the planet glyph and up to 3 tiny meal chips
+(dominant-element dot + short name). A quiet "Adopt this week" button lets a viewer copy the
+agent's menu into their own planner. Read-only, elegant, feed-friendly.
+
+(B) USER PROFILE — the signed-in user's own week as an INTERACTIVE fixture: same condensed
+7-day row, but tiles are tappable — tapping a day expands its meals inline, tapping a meal
+opens quick actions (swap / lock / remove) or the add sheet for empty slots. A small
+"Open planner →" link jumps to the full /menu-planner screen. Include a compact elemental
+balance mini-meter and a "12/21 planned" mono progress read-out in the fixture header.
+
+Both variants must be small enough to sit inside a profile page card (max ~2 rows tall on
+mobile) and match the surrounding profile styling.
+```
+
+---
+
+## CONDENSED ONE-SHOT PROMPT  *(single paragraph, for Stitch quick mode)*
+
+Use this when you want one block instead of the per-screen set (attach the structured
+prompt above as extra context for finer detail).
+
+```
+Design a modern, clean, mobile-first Weekly Meal Planner screen for a premium cooking app,
+in a refined DARK theme only (never white surfaces) — calm and decluttered, like
+Notion-meets-a-cooking-app with a subtle cosmic/alchemical signature, NOT a busy dashboard
+or sci-fi console. Palette: backgrounds #07060B→#241F33, text #F2EDFF/#B5ADCC/#6E6884,
+violet accent #B85AF0, copper-gold #DEA54B, error #F87171, tiny element dots Fire #EF7A5A /
+Water #58A6E8 / Earth #76B266 / Air #D9CD9F, and a sparing 135° copper→violet gradient on the
+main CTA. Translucent glass cards with 1px hairline borders, soft blur, 14–16px radius; the
+hero card gets a faint violet glow. Type: elegant serif headings (Cormorant Garamond), clean
+sans body (Manrope), and UPPERCASE wide-tracked monospace (JetBrains Mono) for all small
+labels/numbers/kcal/cost — the brand signature. Layout top to bottom: a top bar with serif
+title "This Week", a mono-caps date range "SUN JUL 12 – SAT JUL 18", prev/next week chevrons
+and a "Jump to today" pill (the week also swipes); a slim signature transit ribbon of 7 small
+circular day-medallions Sun→Sat, each with a planetary glyph (☉☽♂☿♃♀♄), today glowing
+copper and the selected day glowing violet; a prominent glowing "TODAY · SUNDAY" hero card
+with a one-line cosmic tip, a "3 of 3 planned" readout, and its three main meals
+(Breakfast/Lunch/Dinner) plus a ghost "+ add snack" row; below it the rest of the week as a
+vertical stack of day cards (planet glyph + serif day name + mono-caps date + a tiny
+"560 KCAL · $6.20" chip), each holding its three meal slots. Every meal card is data-forward:
+a recipe thumbnail (or a dashed "+ Add" placeholder if empty), the recipe name in serif, a
+mono-caps data row "420 KCAL · P32 C40 F14 · $4.10 · x2", one dominant-element dot, and a
+small lock icon; tapping an empty slot adds a recipe (tap-to-add, no drag-and-drop). Include
+one collapsible "Week Insights" section with four compact modules in order: a
+Fire/Water/Earth/Air elemental balance meter with a plain verdict ("Balanced week"), 2–3
+smart recipe suggestions, a budget bar "$41 / $60", and a variety/gaps line
+"2 slots empty · 9 unique ingredients". Leave room for a global bottom tab bar and float a
+single "✦ Shop the week" button above it. Keep it airy and effortless. No terminal/console
+styling, no gauges, no occult ornament beyond the planet glyphs and element dots.
+```
+
+**Retarget trick:** keep everything through the typography sentence, then swap the layout
+description to aim the one-shot at another screen (empty state, add-recipe sheet, shop-the-week,
+insights, or the profile week-fixture).
+
+---
+
+## After Stitch generates — wiring notes (for the follow-up implementation)
+
+When the Stitch output comes back, we wire it into the codebase against these anchors:
+
+- **Route:** rebuild `src/app/menu-planner/page.tsx` (the `/meal-plan` redirect stays).
+- **Core grid:** replace/refactor `src/components/menu-planner/WeeklyCalendar.tsx`
+  (`DayColumn`, `MealSlot`, `TodayHeroCard`, `StitchTransitRibbon`).
+- **Consolidate toolbars:** collapse `QuickActionsToolbar.tsx` + the second "Tools Bar"
+  into one command surface; **re-skin the off-brand light-mode toolbar** (currently
+  `bg-white`/gray/blue — the worst clash) to alchm tokens.
+- **Insights rail:** wire the balance meter to the real `weeklyCircuitCalculations.ts`
+  circuit metrics (harmony/thermal/efficiency) via `CircuitMetricsPanel`, not the
+  hardcoded "Cycle Telemetry" placeholders (`☽ 14°`, `natalResonance = 92`, 65%/82%).
+- **Per-slot lock:** surface `isLocked` (`setMealPlanSlotLocked`) directly on the grid
+  meal card (today it's buried in `FocusedDayView`).
+- **Fast-start:** guided setup → prefill via `generateMealsForDay` loop / templates /
+  `/api/menu-planner/agent-weekly-menu` (agent menus) / copy-last-week.
+- **Shop the week:** `regenerateGroceryList` → `GroceryListModal` → Amazon Fresh cart
+  (`src/data/amazon`). **Do not** wire the deprecated Instacart route.
+- **Profile fixture:** new embeddable component reading the same `WeeklyMenu`
+  (`MenuPlannerProvider`), mounted on agent + user profile pages; agent variant reads the
+  agent's persisted menu (GET `/api/menu-planner/agent-weekly-menu`).
+- **One denominator:** standardize the "how full is my week" signal (pick 21 mains, or
+  28 incl. snack — currently /21, /6, /4 all appear).
+- **Persistence unchanged:** primary store = `WeeklyMenu` at `/api/menu-planner/menus`
+  (keyed by `weekStartDate`); live overlay = SpacetimeDB `meal_plan_slot`
+  (`NEXT_PUBLIC_SPACETIME_LIVE_PLANNER`). Keep 7 days Sun→Sat, 4 meal types (show 3 + snack).
+```

--- a/src/app/(alchm)/profile/[userId]/page.tsx
+++ b/src/app/(alchm)/profile/[userId]/page.tsx
@@ -6,6 +6,7 @@ import { useParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import React, { useEffect, useState } from "react";
 import Header from "@/components/Header";
+import AgentProfileWeekCard from "@/components/menu-planner/redesign/AgentProfileWeekCard";
 import { CustomizeDrawer } from "@/components/profile/CustomizeDrawer";
 import { LiveAgentFeed } from "@/components/profile/LiveAgentFeed";
 import { PROFILE_BLOCKS, type ProfileTab } from "@/components/profile/ProfileBlockRegistry";
@@ -154,6 +155,17 @@ export default function PublicProfilePage() {
             </button>
           )}
         </div>
+
+        {/* Living weekly-menu fixture for agent profiles (self-hides when the
+            agent hasn't published a week). */}
+        {!loading && profile?.isAgent && (
+          <div className="mb-6">
+            <AgentProfileWeekCard
+              userId={profile.userId}
+              agentName={profile.name}
+            />
+          </div>
+        )}
 
         {loading ? (
           <div className="glass-card-premium rounded-3xl p-12 border-white/8 text-center">

--- a/src/app/(alchm)/profile/page.tsx
+++ b/src/app/(alchm)/profile/page.tsx
@@ -29,6 +29,9 @@ const AgentsPane = dynamic(() => import('@/components/profile/AgentsPane').then(
 const CosmicAlignmentCard = dynamic(() =>
   import('@/components/profile/CosmicAlignmentCard').then((m) => m.CosmicAlignmentCard),
 );
+const ProfileWeekCard = dynamic(
+  () => import('@/components/menu-planner/redesign/ProfileWeekCard'),
+);
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -183,6 +186,9 @@ function PremiumDashboard({
                   onEditProfile={onEditBirthData}
                   onOpenSettings={() => setActiveTab('settings')}
                 />
+
+                {/* This week — interactive weekly-menu fixture */}
+                <ProfileWeekCard />
 
                 {/* Core data: constitution + elemental wheel */}
                 <div className="grid md:grid-cols-2 gap-7">

--- a/src/app/api/menu-planner/public-week/route.ts
+++ b/src/app/api/menu-planner/public-week/route.ts
@@ -1,0 +1,113 @@
+/**
+ * Public weekly-menu read for AGENT profiles.
+ *
+ * Planetary Agents (@agentic.alchm.kitchen users) author weekly menus that are
+ * published to the shared feed — public content. This read-only endpoint
+ * surfaces an agent's current-week menu so it can appear as a living fixture on
+ * the agent's alchm.kitchen profile page.
+ *
+ * Safety: resolves an EXISTING user by id (never creates one — unlike the
+ * internal ensureAgent bridge) and serves ONLY agent-domain users. A
+ * non-agent's plan is private and returns 403. No secrets or auth required —
+ * this is public agent content, and only meals/servings/planetary data are
+ * returned (never budgets, grocery lists, or owner identity beyond display
+ * name).
+ */
+
+import { NextResponse } from "next/server";
+import { menuPersistenceService } from "@/services/menuPersistenceService";
+import { userDatabase } from "@/services/userDatabaseService";
+import { getWeekStartDate } from "@/types/menuPlanner";
+import type { MealSlot } from "@/types/menuPlanner";
+import type { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const AGENTIC_EMAIL_DOMAIN = "@agentic.alchm.kitchen";
+
+/** Strip a persisted MealSlot down to the public, display-only fields. */
+function toPublicMeal(meal: MealSlot) {
+  return {
+    dayOfWeek: meal.dayOfWeek,
+    mealType: meal.mealType,
+    servings: meal.servings,
+    isLocked: meal.isLocked ?? false,
+    recipe: meal.recipe
+      ? {
+          id: (meal.recipe as any).id,
+          name: (meal.recipe as any).name,
+          elementalProperties: (meal.recipe as any).elementalProperties ?? null,
+        }
+      : undefined,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const userId = searchParams.get("userId");
+  if (!userId) {
+    return NextResponse.json(
+      { success: false, message: "userId is required" },
+      { status: 400 },
+    );
+  }
+
+  const weekParam = searchParams.get("weekStartDate");
+  const weekStartDate = weekParam
+    ? new Date(weekParam)
+    : getWeekStartDate(new Date());
+  if (Number.isNaN(weekStartDate.getTime())) {
+    return NextResponse.json(
+      { success: false, message: "Invalid weekStartDate" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const user = await userDatabase.getUserById(userId);
+    if (!user) {
+      return NextResponse.json(
+        { success: false, message: "User not found" },
+        { status: 404 },
+      );
+    }
+
+    // Only PLANETARY AGENTS' weekly menus are public, identified STRICTLY by the
+    // @agentic.alchm.kitchen domain — the same rule the internal authoring
+    // bridge enforces (normalizeAgentEmail), so only menus written by that
+    // bridge can ever be served here.
+    //
+    // Deliberately NOT using the users.is_agent flag: it is far broader
+    // (~4.7k rows, incl. accounts with non-agentic emails), and every weekly_menu
+    // that exists today is owned by an is_agent=false human. Trusting that flag
+    // would publicly expose a real person's meal plan the moment such an account
+    // planned a week.
+    const isPublishingAgent = (user.email ?? "")
+      .toLowerCase()
+      .endsWith(AGENTIC_EMAIL_DOMAIN);
+    if (!isPublishingAgent) {
+      return NextResponse.json(
+        { success: false, message: "This user's plan is private" },
+        { status: 403 },
+      );
+    }
+
+    const menu = await menuPersistenceService.getMenu(user.id, weekStartDate);
+    return NextResponse.json({
+      success: true,
+      userId: user.id,
+      // NB: the display name lives on the nested profile, not top-level.
+      displayName: user.profile?.name ?? null,
+      weekStartDate: weekStartDate.toISOString(),
+      updatedAt: menu?.updatedAt ?? null,
+      meals: (menu?.meals ?? []).map(toPublicMeal),
+    });
+  } catch (error) {
+    console.error("[public-week GET]", error);
+    return NextResponse.json(
+      { success: false, message: "Failed to load agent week" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/menu-planner/page.tsx
+++ b/src/app/menu-planner/page.tsx
@@ -14,6 +14,7 @@ import { useSession } from "next-auth/react";
 import { useEffect, useMemo, useState } from "react";
 import { useToast } from "@/components/common/Toast";
 import QuickActionsToolbar from "@/components/menu-builder/QuickActionsToolbar";
+import WeeklyInsights from "@/components/menu-planner/redesign/WeeklyInsights";
 import WeeklyCalendar from "@/components/menu-planner/WeeklyCalendar";
 import {
     MenuPlannerProvider,
@@ -252,79 +253,9 @@ function MenuPlannerContent() {
     }
   };
 
-  const energyPct = useMemo(() => {
-    return weeklyNutrition?.weeklyTotals?.calories && weeklyNutrition?.weeklyGoals?.calories
-      ? Math.round((weeklyNutrition.weeklyTotals.calories / weeklyNutrition.weeklyGoals.calories) * 100)
-      : 65;
-  }, [weeklyNutrition]);
-
-  const proteinPct = useMemo(() => {
-    return weeklyNutrition?.weeklyTotals?.protein && weeklyNutrition?.weeklyGoals?.protein
-      ? Math.round((weeklyNutrition.weeklyTotals.protein / weeklyNutrition.weeklyGoals.protein) * 100)
-      : 82;
-  }, [weeklyNutrition]);
-
-  const elementalTotals = useMemo(() => {
-    const totals = { fire: 0, water: 0, earth: 0, air: 0 };
-    if (!currentMenu) return { fire: 25, water: 25, earth: 25, air: 25 };
-    const mealsWithRecipe = currentMenu.meals.filter((m) => m.recipe);
-    if (mealsWithRecipe.length === 0) return { fire: 25, water: 25, earth: 25, air: 25 };
-    
-    mealsWithRecipe.forEach((m) => {
-      // ElementalProperties uses capitalized keys (Fire/Water/Earth/Air);
-      // accept lowercase too for recipes hydrated from older snapshots.
-      const props = m.recipe?.elementalProperties as
-        | Record<string, number>
-        | undefined;
-      if (props) {
-        totals.fire += props.Fire ?? props.fire ?? 0;
-        totals.water += props.Water ?? props.water ?? 0;
-        totals.earth += props.Earth ?? props.earth ?? 0;
-        totals.air += props.Air ?? props.air ?? 0;
-      }
-    });
-    
-    const sum = totals.fire + totals.water + totals.earth + totals.air || 1;
-    return {
-      fire: Math.round((totals.fire / sum) * 100),
-      water: Math.round((totals.water / sum) * 100),
-      earth: Math.round((totals.earth / sum) * 100),
-      air: Math.round((totals.air / sum) * 100),
-    };
-  }, [currentMenu]);
-
-  const qualities = useMemo(() => {
-    const fire = elementalTotals.fire;
-    const water = elementalTotals.water;
-    const earth = elementalTotals.earth;
-    const air = elementalTotals.air;
-    
-    const heat = (fire + air) - (water + earth); 
-    const moisture = (air + water) - (fire + earth);
-    
-    const x = 50 + (moisture * 0.4); 
-    const y = 50 - (heat * 0.4); 
-    
-    return {
-      x: Math.max(10, Math.min(90, x)),
-      y: Math.max(10, Math.min(90, y)),
-    };
-  }, [elementalTotals]);
-
-  const getElementalLabel = (pct: number) => {
-    if (pct === 0) return "Zero";
-    if (pct > 30) return "High";
-    if (pct < 15) return "Low";
-    if (pct >= 22 && pct <= 28) return "Opt";
-    return "Bal";
-  };
-
-  const natalResonance = useMemo(() => {
-    if (selectedChartIds.size > 0) {
-      return Math.min(100, 80 + (selectedChartIds.size * 4));
-    }
-    return 92;
-  }, [selectedChartIds.size]);
+  // The legacy "Cycle Telemetry" derived values (energyPct/proteinPct/
+  // elementalTotals/qualities/natalResonance) were removed with that panel;
+  // the desktop left column now renders the real <WeeklyInsights /> instead.
 
   const [activeElementFilter, setActiveElementFilter] = useState<"fire" | "water" | "earth" | "air" | null>(null);
 
@@ -408,17 +339,23 @@ function MenuPlannerContent() {
           </div>
         )}
 
-        {/* Quick Actions Toolbar - Generate, Balance, Variety, Clear */}
-        <QuickActionsToolbar onTogglePreferences={() => setShowPreferencesPanel((p) => !p)} />
+        {/* Quick Actions Toolbar + Generation Preferences — desktop/tablet only.
+            On mobile the redesigned calendar leads; whole-week generation returns
+            via the guided empty-state (next slice). */}
+        <div className="hidden md:block">
+          {/* Quick Actions Toolbar - Generate, Balance, Variety, Clear */}
+          <QuickActionsToolbar onTogglePreferences={() => setShowPreferencesPanel((p) => !p)} />
 
-        {/* Generation Preferences Panel */}
-        <GenerationPreferencesPanel
-          isOpen={showPreferencesPanel}
-          onToggle={() => setShowPreferencesPanel((p) => !p)}
-        />
+          {/* Generation Preferences Panel */}
+          <GenerationPreferencesPanel
+            isOpen={showPreferencesPanel}
+            onToggle={() => setShowPreferencesPanel((p) => !p)}
+          />
+        </div>
 
-        {/* Tools Bar */}
-        <div className="alchm-panel p-4 mt-3 rounded-xl">
+        {/* Tools Bar — desktop/tablet only (secondary tools; mobile uses the
+            redesigned calendar's inline actions + Shop the week) */}
+        <div className="hidden md:block alchm-panel p-4 mt-3 rounded-xl">
           <div className="flex flex-wrap gap-3">
             <button
               onClick={() => setShowRecipeQueue(!showRecipeQueue)}
@@ -585,89 +522,24 @@ function MenuPlannerContent() {
             hardcoded placeholders, not computed from the planned meals. The real
             nutrition totals live in the Nutrition Dashboard panel below. */}
         
-        {/* Posso Widget Panel (collapsible) */}
+        {/* Posso Widget Panel (collapsible) — desktop/tablet only */}
         {showPosso && (
-          <div className="mb-6 h-[500px]">
+          <div className="hidden md:block mb-6 h-[500px]">
             <PossoWidget onClose={() => setShowPosso(false)} />
           </div>
         )}
 
-        {/* Main Dashboard Grid */}
-        <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 mb-8 mt-6">
-          {/* Week Progress (Left Column) */}
-          <div className="lg:col-span-4 alchm-panel p-6 rounded-xl flex flex-col gap-6">
-            <div className="flex justify-between items-center border-b border-muted pb-2">
-              <h3 className="font-headline-md text-headline-md text-primary">Cycle Telemetry</h3>
-              <span className="text-on-surface-variant font-telemetry-md text-telemetry-md">☽ 14°</span>
-            </div>
-            
-            <div className="space-y-4">
-              <div>
-                <div className="flex justify-between font-telemetry-md text-telemetry-md mb-1">
-                  <span className="text-on-surface-variant">Energy (KCAL)</span>
-                  <span className="text-active-violet">{energyPct}%</span>
-                </div>
-                <div className="h-1 bg-surface-container-high rounded-full overflow-hidden">
-                  <div className="h-full bg-active-violet" style={{ width: `${Math.min(100, energyPct)}%` }} />
-                </div>
-              </div>
-              <div>
-                <div className="flex justify-between font-telemetry-md text-telemetry-md mb-1">
-                  <span className="text-on-surface-variant">Protein</span>
-                  <span className="text-fire-spirit">{proteinPct}%</span>
-                </div>
-                <div className="h-1 bg-surface-container-high rounded-full overflow-hidden">
-                  <div className="h-full bg-fire-spirit" style={{ width: `${Math.min(100, proteinPct)}%` }} />
-                </div>
-              </div>
-            </div>
-
-            {/* Dual Axis Gauge */}
-            <div className="flex flex-col gap-2 mt-2 border-t border-muted pt-4">
-              <div className="text-xs text-on-surface-variant font-label-caps text-center">Alchemical Qualities</div>
-              <div className="relative w-full h-24 bg-surface-container-lowest border border-muted rounded gauge-crosshair flex items-center justify-center overflow-hidden">
-                <span className="absolute top-1 text-[10px] text-on-surface-variant">HOT</span>
-                <span className="absolute bottom-1 text-[10px] text-on-surface-variant">COLD</span>
-                <span className="absolute left-1 text-[10px] text-on-surface-variant">DRY</span>
-                <span className="absolute right-1 text-[10px] text-on-surface-variant">MOIST</span>
-                {/* Indicator Dot */}
-                <div
-                  className="w-3 h-3 rounded-full bg-gold-accent absolute shadow-[0_0_8px_rgba(201,162,39,0.8)] transition-all duration-500 ease-out"
-                  style={{ top: `${qualities.y}%`, left: `${qualities.x}%`, transform: "translate(-50%, -50%)" }}
-                />
-              </div>
-            </div>
-
-            {/* Elemental breakdown */}
-            <div className="grid grid-cols-2 gap-4 mt-2 border-t border-muted pt-4">
-              <div className="bg-surface-container-low p-3 rounded border border-muted text-center">
-                <div className="text-[10px] text-on-surface-variant mb-1 font-label-caps">Fire 🜂 ({elementalTotals.fire}%)</div>
-                <div className={`font-telemetry-lg text-telemetry-lg ${elementalTotals.fire > 25 ? 'text-fire-spirit' : 'text-on-surface-variant'}`}>{getElementalLabel(elementalTotals.fire)}</div>
-              </div>
-              <div className="bg-surface-container-low p-3 rounded border border-muted text-center">
-                <div className="text-[10px] text-on-surface-variant mb-1 font-label-caps">Water 🜄 ({elementalTotals.water}%)</div>
-                <div className={`font-telemetry-lg text-telemetry-lg ${elementalTotals.water > 25 ? 'text-water-essence' : 'text-on-surface-variant'}`}>{getElementalLabel(elementalTotals.water)}</div>
-              </div>
-              <div className="bg-surface-container-low p-3 rounded border border-muted text-center">
-                <div className="text-[10px] text-on-surface-variant mb-1 font-label-caps">Earth 🜃 ({elementalTotals.earth}%)</div>
-                <div className={`font-telemetry-lg text-telemetry-lg ${elementalTotals.earth > 25 ? 'text-earth-matter' : 'text-on-surface-variant'}`}>{getElementalLabel(elementalTotals.earth)}</div>
-              </div>
-              <div className="bg-surface-container-low p-3 rounded border border-muted text-center">
-                <div className="text-[10px] text-on-surface-variant mb-1 font-label-caps">Air 🜁 ({elementalTotals.air}%)</div>
-                <div className={`font-telemetry-lg text-telemetry-lg ${elementalTotals.air > 25 ? 'text-air-substance' : 'text-on-surface-variant'}`}>{getElementalLabel(elementalTotals.air)}</div>
-              </div>
-            </div>
-
-            {/* Terminals */}
-            <div className="mt-4 flex flex-col gap-2">
-              <div className="font-telemetry-md text-[10px] bg-surface-container-lowest p-2 border border-muted text-active-violet h-16 overflow-y-auto leading-relaxed font-mono">
-                &gt; SYNCING DEGREE AFFINITIES...<br/>
-                &gt; NATAL RESONANCE: {natalResonance}%<br/>
-                &gt; OPTIMIZING MACROS...
-              </div>
-              {/* Fake "MERCURY RETROGRADE" warning terminal removed — it was a
-                  hardcoded decorative error, not a real transit alert. */}
-            </div>
+        {/* Main Dashboard Grid — desktop/tablet only. The left "Cycle Telemetry"
+            panel is legacy/placeholder; on mobile the redesigned Week Insights
+            rail (real elemental balance + budget) replaces it, and the Today
+            hero replaces TodaysMealsWidget. */}
+        <div className="hidden md:grid grid-cols-1 lg:grid-cols-12 gap-6 mb-8 mt-6">
+          {/* Week Balance (Left Column) — real insights (elemental balance,
+              budget, variety/suggestions). Replaces the legacy placeholder
+              "Cycle Telemetry" (hardcoded ☽14°, 65/82 fallbacks, natal-resonance
+              terminal) with values computed from the planned meals. */}
+          <div className="lg:col-span-4">
+            <WeeklyInsights />
           </div>
 
           {/* Today's Meals (Middle/Right) */}
@@ -686,9 +558,9 @@ function MenuPlannerContent() {
           </div>
         </div>
 
-        {/* Recipe Browser Panel (collapsible) */}
+        {/* Recipe Browser Panel (collapsible) — desktop/tablet only */}
         {showRecipeBrowser && (
-          <div className="mb-6" style={{ maxHeight: "500px" }}>
+          <div className="hidden md:block mb-6" style={{ maxHeight: "500px" }}>
             <RecipeBrowserPanel
               activeElementFilter={activeElementFilter}
               onSelectRecipe={(recipe) => {
@@ -703,14 +575,22 @@ function MenuPlannerContent() {
 
         {/* Main Content - Full-width Calendar */}
         <div className="w-full">
-          <WeeklyCalendar />
+          <WeeklyCalendar
+            onShopWeek={() => {
+              regenerateGroceryList();
+              setShowGroceryList(true);
+              setIsWeeklyDashboardExpanded(false);
+              setShowPosso(false);
+            }}
+          />
         </div>
 
         {/* Sidebars row - below calendar for better readability */}
         <div className="flex flex-col lg:flex-row gap-4 mt-6">
-          {/* Recipe Queue */}
+          {/* Recipe Queue — desktop/tablet only (drag-oriented; mobile uses
+              tap-to-add on the calendar) */}
           {showRecipeQueue && (
-            <div className="w-full lg:w-96 flex-shrink-0">
+            <div className="hidden md:block w-full lg:w-96 flex-shrink-0">
               <RecipeQueue
                 onSelectRecipe={() => {
                   showInfo(
@@ -732,8 +612,10 @@ function MenuPlannerContent() {
           </div>
         </div>
 
-        {/* Mobile: Suggestions Bottom Sheet */}
-        <div className="lg:hidden fixed bottom-0 left-0 right-0 bg-surface border-t-2 border-active-violet/30 shadow-xl z-40">
+        {/* Tablet: Suggestions Bottom Sheet — hidden on mobile to avoid a second
+            fixed bottom layer over the global tab bar (redesigned insights rail
+            already surfaces suggestions on mobile) */}
+        <div className="hidden md:block lg:hidden fixed bottom-0 left-0 right-0 bg-surface border-t-2 border-active-violet/30 shadow-xl z-40">
           <button
             onClick={() => setShowMobileSuggestions(!showMobileSuggestions)}
             className="w-full flex items-center justify-between px-4 py-3 focus:outline-none bg-surface-container-low"

--- a/src/components/menu-builder/QuickActionsToolbar.tsx
+++ b/src/components/menu-builder/QuickActionsToolbar.tsx
@@ -631,20 +631,20 @@ export default function QuickActionsToolbar({ onTogglePreferences }: QuickAction
       {/* Loading Overlay */}
       {isAnyLoading && (
         <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 shadow-xl animate-fade-in">
+          <div className="alchm-panel rounded-lg p-6 animate-fade-in">
             <LoadingSpinner size="lg" message={loadingMessage} />
           </div>
         </div>
       )}
 
-      <div className="bg-white rounded-xl shadow-md p-4 border border-gray-200">
+      <div className="alchm-panel rounded-xl p-4">
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
-            <span className="text-sm font-semibold text-gray-700">
+            <span className="text-sm font-semibold text-on-surface">
               Quick Actions
             </span>
             {totalMeals > 0 && (
-              <span className="text-xs text-gray-500">
+              <span className="text-xs text-on-surface-variant">
                 ({totalMeals}/21 meals planned)
               </span>
             )}
@@ -652,18 +652,18 @@ export default function QuickActionsToolbar({ onTogglePreferences }: QuickAction
 
           {/* Personalization Status */}
           {hasNatalChart ? (
-            <div className="flex items-center gap-1.5 px-2 py-1 bg-purple-50 rounded-lg">
-              <span className="w-2 h-2 bg-purple-500 rounded-full animate-pulse" />
-              <span className="text-xs text-purple-700 font-medium">
+            <div className="flex items-center gap-1.5 px-2 py-1 bg-active-violet/10 rounded-lg">
+              <span className="w-2 h-2 bg-active-violet/100 rounded-full animate-pulse" />
+              <span className="text-xs text-active-violet font-medium">
                 Personalized for you
               </span>
             </div>
           ) : (
             <Link
               href="/onboarding"
-              className="flex items-center gap-1.5 px-2 py-1 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
+              className="flex items-center gap-1.5 px-2 py-1 bg-surface-container-low rounded-lg hover:bg-surface-container-low transition-colors"
             >
-              <span className="text-xs text-gray-600">
+              <span className="text-xs text-on-surface-variant">
                 Add birth data for personalized recipes
               </span>
             </Link>
@@ -752,7 +752,7 @@ export default function QuickActionsToolbar({ onTogglePreferences }: QuickAction
               }
             }}
             disabled={totalMeals === 0}
-            className="flex items-center gap-2 px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 disabled:opacity-50 transition-all font-medium text-sm focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
+            className="flex items-center gap-2 px-4 py-2 bg-surface-container-low text-on-surface rounded-lg hover:bg-surface-container-high disabled:opacity-50 transition-all font-medium text-sm focus:outline-none focus:ring-2 focus:ring-active-violet/40 focus:ring-offset-2"
           >
             <span>🗑️</span>
             Clear Week
@@ -764,7 +764,7 @@ export default function QuickActionsToolbar({ onTogglePreferences }: QuickAction
             className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-all font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 ${
               weeklyBudget
                 ? "bg-gradient-to-r from-emerald-600 to-teal-600 text-white hover:from-emerald-700 hover:to-teal-700 focus:ring-emerald-500"
-                : "bg-gray-100 text-gray-700 hover:bg-gray-200 focus:ring-gray-400"
+                : "bg-surface-container-low text-on-surface hover:bg-surface-container-high focus:ring-active-violet/40"
             }`}
             title="Set a weekly grocery budget"
           >
@@ -779,14 +779,14 @@ export default function QuickActionsToolbar({ onTogglePreferences }: QuickAction
               className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-all font-medium text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 relative ${
                 prefsActiveCount > 0
                   ? "bg-gradient-to-r from-purple-500 to-indigo-600 text-white hover:from-purple-600 hover:to-indigo-700 focus:ring-purple-500"
-                  : "bg-gray-100 text-gray-700 hover:bg-gray-200 focus:ring-gray-400"
+                  : "bg-surface-container-low text-on-surface hover:bg-surface-container-high focus:ring-active-violet/40"
               }`}
               title="Customize generation preferences"
             >
               <span>🎯</span>
               Preferences
               {prefsActiveCount > 0 && (
-                <span className="ml-1 px-1.5 py-0.5 text-[10px] font-bold rounded-full bg-white text-purple-700">
+                <span className="ml-1 px-1.5 py-0.5 text-[10px] font-bold rounded-full bg-active-violet/20 text-active-violet">
                   {prefsActiveCount}
                 </span>
               )}
@@ -796,10 +796,10 @@ export default function QuickActionsToolbar({ onTogglePreferences }: QuickAction
 
         {/* Active Preferences Summary */}
         {prefsActiveCount > 0 && (
-          <div className="mt-2 flex items-center gap-2 text-xs text-gray-500">
-            <span className="font-medium text-gray-600">Generating with:</span>
+          <div className="mt-2 flex items-center gap-2 text-xs text-on-surface-variant">
+            <span className="font-medium text-on-surface-variant">Generating with:</span>
             {generationPreferences.preferredCuisines.length > 0 && (
-              <span className="px-2 py-0.5 bg-purple-50 text-purple-700 rounded-full">
+              <span className="px-2 py-0.5 bg-active-violet/10 text-active-violet rounded-full">
                 {generationPreferences.preferredCuisines.slice(0, 3).join(", ")}
                 {generationPreferences.preferredCuisines.length > 3 && ` +${generationPreferences.preferredCuisines.length - 3}`}
               </span>
@@ -834,7 +834,7 @@ export default function QuickActionsToolbar({ onTogglePreferences }: QuickAction
 
         {/* Budget Control Panel */}
         {budgetInputVisible && (
-          <div className="mt-3 p-3 bg-gradient-to-br from-emerald-50 to-teal-50 rounded-xl border border-emerald-200">
+          <div className="mt-3 p-3 bg-surface-container-low rounded-xl border border-earth-matter/20">
             <div className="flex items-center justify-between gap-4 flex-wrap">
               <div className="flex items-center gap-3">
                 <label htmlFor="budget-input" className="text-sm font-semibold text-emerald-800">
@@ -864,7 +864,7 @@ export default function QuickActionsToolbar({ onTogglePreferences }: QuickAction
                         if (!isNaN(val) && val >= 20) setWeeklyBudget(val);
                       }
                     }}
-                    className="w-20 px-2 py-1 text-sm rounded-md border border-emerald-300 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 bg-white text-gray-800"
+                    className="w-20 px-2 py-1 text-sm rounded-md border border-muted focus:border-active-violet focus:ring-1 focus:ring-active-violet bg-surface-container-lowest text-primary"
                     placeholder="100"
                   />
                 </div>
@@ -892,41 +892,41 @@ export default function QuickActionsToolbar({ onTogglePreferences }: QuickAction
                         costConfidence === 'high' ? 'bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.5)]' : 
                         costConfidence === 'medium' ? 'bg-amber-500' : 'bg-red-400'
                       }`} />
-                      <span className="text-[10px] uppercase tracking-tighter text-gray-400 font-bold">
+                      <span className="text-[10px] uppercase tracking-tighter text-on-surface-variant/60 font-bold">
                         {costConfidence === 'high' ? 'Live Match' : 'Estimated'}
                       </span>
                     </div>
                     <div className="flex flex-col items-end">
-                      <span className="text-xs text-gray-500">Est. Cost</span>
-                      <span className="font-semibold text-gray-900 drop-shadow-sm">
+                      <span className="text-xs text-on-surface-variant">Est. Cost</span>
+                      <span className="font-semibold text-primary drop-shadow-sm">
                         ${estimatedWeeklyCost.toFixed(2)}
                       </span>
                     </div>
 
                     {/* Tooltip Popup (Hidden by default, shown on group-hover) */}
-                    <div className="absolute top-10 right-0 z-50 w-72 p-3 bg-white/95 backdrop-blur-md rounded-xl shadow-2xl border border-gray-100 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 translate-y-2 group-hover:translate-y-0">
-                      <h4 className="text-xs font-bold text-gray-800 mb-2 border-b pb-1">Grocery Breakdown ({costBreakdown.length} items)</h4>
+                    <div className="absolute top-10 right-0 z-50 w-72 p-3 bg-surface-container-high/95 backdrop-blur-md rounded-xl shadow-2xl border border-muted opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 translate-y-2 group-hover:translate-y-0">
+                      <h4 className="text-xs font-bold text-primary mb-2 border-b pb-1">Grocery Breakdown ({costBreakdown.length} items)</h4>
                       <div className="max-h-48 overflow-y-auto space-y-1 pr-1 custom-scrollbar">
                         {costBreakdown.slice(0, 15).map((item, idx) => (
                           <div key={idx} className="flex justify-between items-center text-[10px]">
-                            <span className="text-gray-600 truncate max-w-[180px]">{item.ingredient}</span>
-                            <span className="font-mono text-gray-800">${item.estimatedCost.toFixed(2)}</span>
+                            <span className="text-on-surface-variant truncate max-w-[180px]">{item.ingredient}</span>
+                            <span className="font-mono text-primary">${item.estimatedCost.toFixed(2)}</span>
                           </div>
                         ))}
                         {costBreakdown.length > 15 && (
-                          <div className="text-[9px] text-gray-400 text-center pt-1 italic">
+                          <div className="text-[9px] text-on-surface-variant/60 text-center pt-1 italic">
                             + {costBreakdown.length - 15} more items...
                           </div>
                         )}
                       </div>
                       <div className="mt-2 pt-2 border-t flex justify-between items-center">
-                        <span className="text-[10px] text-gray-400">Confidence: {costConfidence.toUpperCase()}</span>
+                        <span className="text-[10px] text-on-surface-variant/60">Confidence: {costConfidence.toUpperCase()}</span>
                         <span className="text-[10px] font-bold text-emerald-600">${estimatedWeeklyCost.toFixed(2)}</span>
                       </div>
                     </div>
                   </div>
                   <div className="flex flex-col items-end">
-                    <span className="text-xs text-gray-500">Remaining</span>
+                    <span className="text-xs text-on-surface-variant">Remaining</span>
                     <span
                       className={`font-semibold ${
                         weeklyBudget - estimatedWeeklyCost >= 0
@@ -939,8 +939,8 @@ export default function QuickActionsToolbar({ onTogglePreferences }: QuickAction
                   </div>
                   {budgetPerMeal && (
                     <div className="flex flex-col items-end">
-                      <span className="text-xs text-gray-500">Per Meal</span>
-                      <span className="font-semibold text-gray-700">
+                      <span className="text-xs text-on-surface-variant">Per Meal</span>
+                      <span className="font-semibold text-on-surface">
                         ${budgetPerMeal.toFixed(2)}
                       </span>
                     </div>
@@ -952,7 +952,7 @@ export default function QuickActionsToolbar({ onTogglePreferences }: QuickAction
             {/* Budget progress bar */}
             {weeklyBudget && totalMeals > 0 && (
               <div className="mt-2">
-                <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+                <div className="w-full h-2 bg-surface-container-high rounded-full overflow-hidden">
                   <div
                     className={`h-full rounded-full transition-all duration-500 ${
                       estimatedWeeklyCost / weeklyBudget > 1
@@ -967,8 +967,8 @@ export default function QuickActionsToolbar({ onTogglePreferences }: QuickAction
                   />
                 </div>
                 <div className="flex justify-between mt-1">
-                  <span className="text-[10px] text-gray-400">$0</span>
-                  <span className="text-[10px] text-gray-400">
+                  <span className="text-[10px] text-on-surface-variant/60">$0</span>
+                  <span className="text-[10px] text-on-surface-variant/60">
                     ${weeklyBudget}
                   </span>
                 </div>

--- a/src/components/menu-planner/GenerationPreferencesPanel.tsx
+++ b/src/components/menu-planner/GenerationPreferencesPanel.tsx
@@ -188,35 +188,35 @@ export default function GenerationPreferencesPanel({
   }
 
   return (
-    <div className="bg-white rounded-xl shadow-md border border-gray-200 mt-3 overflow-hidden">
+    <div className="alchm-panel rounded-xl mt-3 overflow-hidden">
       {/* Collapsed Header Bar */}
       <button
         onClick={onToggle}
-        className="w-full flex items-center justify-between px-4 py-3 hover:bg-gray-50 transition-colors focus:outline-none"
+        className="w-full flex items-center justify-between px-4 py-3 hover:bg-surface-container-low transition-colors focus:outline-none"
       >
         <div className="flex items-center gap-2">
           <span className="text-base">🎯</span>
-          <span className="text-sm font-semibold text-gray-700">
+          <span className="text-sm font-semibold text-on-surface">
             Generation Preferences
           </span>
           {activeCount > 0 && (
-            <span className="px-2 py-0.5 text-xs font-bold rounded-full bg-purple-100 text-purple-700">
+            <span className="px-2 py-0.5 text-xs font-bold rounded-full bg-active-violet/15 text-active-violet">
               {activeCount} active
             </span>
           )}
           {nutritionActiveCount > 0 && (
-            <span className="px-2 py-0.5 text-xs font-bold rounded-full bg-emerald-100 text-emerald-700">
+            <span className="px-2 py-0.5 text-xs font-bold rounded-full bg-earth-matter/15 text-earth-matter">
               Nutrition
             </span>
           )}
         </div>
         <div className="flex items-center gap-3">
           {!isOpen && activeCount > 0 && summaryParts.length > 0 && (
-            <span className="text-xs text-gray-500 hidden sm:inline truncate max-w-xs">
+            <span className="text-xs text-on-surface-variant hidden sm:inline truncate max-w-xs">
               {summaryParts.join(" | ")}
             </span>
           )}
-          <span className={`text-gray-400 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}>
+          <span className={`text-on-surface-variant/60 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}>
             ▼
           </span>
         </div>
@@ -224,7 +224,7 @@ export default function GenerationPreferencesPanel({
 
       {/* Expanded Panel */}
       {isOpen && (
-        <div className="px-4 pb-4 border-t border-gray-100">
+        <div className="px-4 pb-4 border-t border-muted">
           {/* Reset Button */}
           {activeCount > 0 && (
             <div className="flex justify-end pt-3">
@@ -239,12 +239,12 @@ export default function GenerationPreferencesPanel({
 
           {/* ─── NUTRITIONAL GOALS ─── */}
           <div className="pt-3">
-            <div className="p-4 rounded-xl bg-gradient-to-br from-emerald-50 to-teal-50 border border-emerald-200">
-              <h4 className="text-xs font-bold text-emerald-800 uppercase tracking-wider mb-3 flex items-center gap-2">
+            <div className="p-4 rounded-xl bg-surface-container-low border border-earth-matter/20">
+              <h4 className="text-xs font-bold text-earth-matter uppercase tracking-wider mb-3 flex items-center gap-2">
                 <span className="w-5 h-5 rounded-full bg-emerald-600 text-white flex items-center justify-center text-[10px] font-bold">N</span>
                 Daily Nutritional Goals
                 {nutritionActiveCount > 0 && (
-                  <span className="px-1.5 py-0.5 text-[10px] font-bold rounded-full bg-emerald-200 text-emerald-800">
+                  <span className="px-1.5 py-0.5 text-[10px] font-bold rounded-full bg-earth-matter/20 text-earth-matter">
                     {nutritionActiveCount} set
                   </span>
                 )}
@@ -252,7 +252,7 @@ export default function GenerationPreferencesPanel({
 
               {/* Calorie Target */}
               <div className="mb-3">
-                <span className="text-[11px] font-semibold text-emerald-700 mb-1.5 block">
+                <span className="text-[11px] font-semibold text-earth-matter mb-1.5 block">
                   Daily Calories
                 </span>
                 <div className="flex flex-wrap gap-1.5">
@@ -271,7 +271,7 @@ export default function GenerationPreferencesPanel({
                         className={`px-2.5 py-1 rounded-lg text-xs font-medium transition-all ${
                           isSelected
                             ? "bg-emerald-600 text-white shadow-sm"
-                            : "bg-white text-emerald-700 hover:bg-emerald-100 border border-emerald-200"
+                            : "bg-surface-container-lowest text-earth-matter hover:bg-earth-matter/10 border border-earth-matter/20"
                         }`}
                       >
                         {preset.label}
@@ -300,9 +300,9 @@ export default function GenerationPreferencesPanel({
                       updateNutTarget("dailyCalories", val && val >= 800 ? val : null);
                     }}
                     placeholder="e.g. 2000"
-                    className="w-24 px-2 py-1 text-xs border border-emerald-300 rounded-lg focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 bg-white text-gray-800"
+                    className="w-24 px-2 py-1 text-xs border border-muted rounded-lg focus:border-active-violet focus:ring-1 focus:ring-active-violet bg-surface-container-lowest text-primary"
                   />
-                  <span className="text-[10px] text-emerald-600">kcal/day</span>
+                  <span className="text-[10px] text-earth-matter/80">kcal/day</span>
                 </div>
               </div>
 
@@ -369,7 +369,7 @@ export default function GenerationPreferencesPanel({
 
           {/* ─── CUISINE PREFERENCES ─── */}
           <div className="pt-4">
-            <h4 className="text-xs font-semibold text-gray-600 uppercase tracking-wider mb-2">
+            <h4 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wider mb-2">
               Preferred Cuisines
             </h4>
             <div className="flex flex-wrap gap-2">
@@ -382,7 +382,7 @@ export default function GenerationPreferencesPanel({
                     className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all ${
                       isSelected
                         ? "bg-purple-600 text-white shadow-sm"
-                        : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                        : "bg-surface-container-low text-on-surface-variant hover:bg-surface-container-high"
                     }`}
                   >
                     {cuisine}
@@ -394,7 +394,7 @@ export default function GenerationPreferencesPanel({
 
           {/* ─── DIETARY RESTRICTIONS ─── */}
           <div className="pt-4">
-            <h4 className="text-xs font-semibold text-gray-600 uppercase tracking-wider mb-2">
+            <h4 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wider mb-2">
               Dietary Restrictions
             </h4>
             <div className="flex flex-wrap gap-2">
@@ -407,7 +407,7 @@ export default function GenerationPreferencesPanel({
                     className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all ${
                       isSelected
                         ? "bg-green-600 text-white shadow-sm"
-                        : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                        : "bg-surface-container-low text-on-surface-variant hover:bg-surface-container-high"
                     }`}
                   >
                     {option.label}
@@ -421,7 +421,7 @@ export default function GenerationPreferencesPanel({
           <div className="pt-4 grid grid-cols-1 lg:grid-cols-2 gap-4">
             {/* Cooking Methods */}
             <div>
-              <h4 className="text-xs font-semibold text-gray-600 uppercase tracking-wider mb-2">
+              <h4 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wider mb-2">
                 Cooking Methods
               </h4>
               <div className="flex flex-wrap gap-1.5">
@@ -434,7 +434,7 @@ export default function GenerationPreferencesPanel({
                       className={`px-2.5 py-1 rounded-full text-xs font-medium transition-all ${
                         isSelected
                           ? "bg-amber-600 text-white shadow-sm"
-                          : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                          : "bg-surface-container-low text-on-surface-variant hover:bg-surface-container-high"
                       }`}
                     >
                       {method}
@@ -446,7 +446,7 @@ export default function GenerationPreferencesPanel({
 
             {/* Flavor Profile */}
             <div>
-              <h4 className="text-xs font-semibold text-gray-600 uppercase tracking-wider mb-2">
+              <h4 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wider mb-2">
                 Flavor Profile
               </h4>
               <div className="flex flex-wrap gap-1.5">
@@ -459,7 +459,7 @@ export default function GenerationPreferencesPanel({
                       className={`px-2.5 py-1 rounded-full text-xs font-medium transition-all ${
                         isSelected
                           ? "bg-pink-600 text-white shadow-sm"
-                          : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                          : "bg-surface-container-low text-on-surface-variant hover:bg-surface-container-high"
                       }`}
                     >
                       {flavor.label}
@@ -469,7 +469,7 @@ export default function GenerationPreferencesPanel({
               </div>
 
               {/* Prep Time */}
-              <h4 className="text-xs font-semibold text-gray-600 uppercase tracking-wider mb-2 mt-3">
+              <h4 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wider mb-2 mt-3">
                 Max Prep Time
               </h4>
               <div className="flex flex-wrap gap-1.5">
@@ -482,7 +482,7 @@ export default function GenerationPreferencesPanel({
                       className={`px-2.5 py-1 rounded-full text-xs font-medium transition-all ${
                         isSelected
                           ? "bg-indigo-600 text-white shadow-sm"
-                          : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                          : "bg-surface-container-low text-on-surface-variant hover:bg-surface-container-high"
                       }`}
                     >
                       {option.label}
@@ -497,7 +497,7 @@ export default function GenerationPreferencesPanel({
           <div className="pt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
             {/* Must Include */}
             <div>
-              <h4 className="text-xs font-semibold text-gray-600 uppercase tracking-wider mb-2">
+              <h4 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wider mb-2">
                 Must Include Ingredients
               </h4>
               <div className="flex flex-wrap gap-1.5 mb-2">
@@ -528,13 +528,13 @@ export default function GenerationPreferencesPanel({
                   }
                 }}
                 placeholder="Type ingredient, press Enter"
-                className="w-full px-3 py-1.5 text-xs border border-gray-300 rounded-lg focus:border-blue-500 focus:ring-1 focus:ring-blue-500 bg-white"
+                className="w-full px-3 py-1.5 text-xs border border-muted rounded-lg focus:border-active-violet focus:ring-1 focus:ring-active-violet bg-surface-container-lowest"
               />
             </div>
 
             {/* Exclude */}
             <div>
-              <h4 className="text-xs font-semibold text-gray-600 uppercase tracking-wider mb-2">
+              <h4 className="text-xs font-semibold text-on-surface-variant uppercase tracking-wider mb-2">
                 Exclude Ingredients
               </h4>
               <div className="flex flex-wrap gap-1.5 mb-2">
@@ -565,7 +565,7 @@ export default function GenerationPreferencesPanel({
                   }
                 }}
                 placeholder="Type ingredient, press Enter"
-                className="w-full px-3 py-1.5 text-xs border border-gray-300 rounded-lg focus:border-red-500 focus:ring-1 focus:ring-red-500 bg-white"
+                className="w-full px-3 py-1.5 text-xs border border-muted rounded-lg focus:border-red-500 focus:ring-1 focus:ring-red-500 bg-surface-container-lowest"
               />
             </div>
           </div>
@@ -593,7 +593,7 @@ function MacroInput({
   color: "blue" | "amber" | "orange" | "green";
 }) {
   const colorMap = {
-    blue: { bg: "bg-blue-50", border: "border-blue-200", focus: "focus:border-blue-500 focus:ring-blue-500", text: "text-blue-700", label: "text-blue-800" },
+    blue: { bg: "bg-blue-50", border: "border-blue-200", focus: "focus:border-active-violet focus:ring-active-violet", text: "text-blue-700", label: "text-blue-800" },
     amber: { bg: "bg-amber-50", border: "border-amber-200", focus: "focus:border-amber-500 focus:ring-amber-500", text: "text-amber-700", label: "text-amber-800" },
     orange: { bg: "bg-orange-50", border: "border-orange-200", focus: "focus:border-orange-500 focus:ring-orange-500", text: "text-orange-700", label: "text-orange-800" },
     green: { bg: "bg-green-50", border: "border-green-200", focus: "focus:border-green-500 focus:ring-green-500", text: "text-green-700", label: "text-green-800" },
@@ -617,7 +617,7 @@ function MacroInput({
             onChange(v && v > 0 ? v : null);
           }}
           placeholder={placeholder}
-          className={`w-full px-2 py-1 text-xs border ${c.border} rounded-md ${c.focus} focus:ring-1 bg-white text-gray-800`}
+          className={`w-full px-2 py-1 text-xs border ${c.border} rounded-md ${c.focus} focus:ring-1 bg-surface-container-lowest text-primary`}
         />
         <span className={`text-[10px] ${c.text} font-medium whitespace-nowrap`}>{unit}</span>
       </div>
@@ -643,14 +643,14 @@ function MacroSummaryBar({ targets }: { targets: NutritionalTargets }) {
   return (
     <div className="mt-2">
       <div className="flex items-center gap-1 mb-1">
-        <span className="text-[10px] text-gray-500 font-medium">Macro split:</span>
+        <span className="text-[10px] text-on-surface-variant font-medium">Macro split:</span>
         {totalMacroCal > cal * 1.05 && (
           <span className="text-[10px] text-amber-600 font-medium">
             (macros exceed calorie target by {Math.round(totalMacroCal - cal)} cal)
           </span>
         )}
       </div>
-      <div className="w-full h-2.5 rounded-full overflow-hidden flex bg-gray-200">
+      <div className="w-full h-2.5 rounded-full overflow-hidden flex bg-surface-container-high">
         {proteinCal > 0 && (
           <div
             className="h-full bg-blue-500 transition-all duration-300"
@@ -704,7 +704,7 @@ function PriorityToggle({
   const activeClasses = color === "blue"
     ? "bg-blue-600 text-white border-blue-700"
     : "bg-green-600 text-white border-green-700";
-  const inactiveClasses = "bg-white text-gray-600 border-gray-200 hover:bg-gray-50";
+  const inactiveClasses = "bg-surface-container-lowest text-on-surface-variant border-muted hover:bg-surface-container-low";
 
   return (
     <button
@@ -716,8 +716,8 @@ function PriorityToggle({
     >
       <span className={`w-3 h-3 rounded-full border-2 flex items-center justify-center ${
         active
-          ? "border-white bg-white"
-          : "border-gray-400"
+          ? "border-white bg-surface-container-lowest"
+          : "border-muted"
       }`}>
         {active && <span className={`w-1.5 h-1.5 rounded-full ${color === "blue" ? "bg-blue-600" : "bg-green-600"}`} />}
       </span>

--- a/src/components/menu-planner/GroceryListModal.tsx
+++ b/src/components/menu-planner/GroceryListModal.tsx
@@ -31,37 +31,37 @@ const CATEGORY_INFO: Record<
   GroceryCategory,
   { name: string; icon: string; color: string }
 > = {
-  produce: { name: "Produce", icon: "🥬", color: "bg-green-50 text-green-700" },
-  proteins: { name: "Proteins", icon: "🥩", color: "bg-red-50 text-red-700" },
-  dairy: { name: "Dairy", icon: "🥛", color: "bg-blue-50 text-blue-700" },
+  produce: { name: "Produce", icon: "🥬", color: "bg-earth-matter/10 text-earth-matter" },
+  proteins: { name: "Proteins", icon: "🥩", color: "bg-fire-spirit/10 text-fire-spirit" },
+  dairy: { name: "Dairy", icon: "🥛", color: "bg-water-essence/10 text-water-essence" },
   grains: {
     name: "Grains & Breads",
     icon: "🌾",
-    color: "bg-yellow-50 text-yellow-700",
+    color: "bg-gold-accent/10 text-gold-accent",
   },
   spices: {
     name: "Spices & Herbs",
     icon: "🌿",
-    color: "bg-purple-50 text-purple-700",
+    color: "bg-active-violet/10 text-active-violet",
   },
   condiments: {
     name: "Condiments & Sauces",
     icon: "🍯",
-    color: "bg-orange-50 text-orange-700",
+    color: "bg-fire-spirit/10 text-fire-spirit",
   },
   canned: {
     name: "Canned & Packaged",
     icon: "🥫",
-    color: "bg-gray-50 text-gray-700",
+    color: "bg-surface-container-low text-on-surface",
   },
-  frozen: { name: "Frozen", icon: "❄️", color: "bg-cyan-50 text-cyan-700" },
-  bakery: { name: "Bakery", icon: "🥐", color: "bg-pink-50 text-pink-700" },
+  frozen: { name: "Frozen", icon: "❄️", color: "bg-water-essence/10 text-water-essence" },
+  bakery: { name: "Bakery", icon: "🥐", color: "bg-active-violet/10 text-active-violet" },
   beverages: {
     name: "Beverages",
     icon: "☕",
-    color: "bg-brown-50 text-brown-700",
+    color: "bg-earth-matter/10 text-earth-matter",
   },
-  other: { name: "Other", icon: "📦", color: "bg-gray-50 text-gray-700" },
+  other: { name: "Other", icon: "📦", color: "bg-surface-container-low text-on-surface" },
 };
 
 /**
@@ -585,7 +585,7 @@ export default function GroceryListModal({
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-2xl shadow-2xl max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col">
+      <div className="alchm-panel rounded-2xl max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col">
         {/* Header */}
         <div className="bg-gradient-to-br from-indigo-900 via-purple-800 to-pink-800 text-white p-8 relative overflow-hidden shadow-inner">
           {/* Decorative background circles */}
@@ -630,7 +630,7 @@ export default function GroceryListModal({
         </div>
 
         {/* Actions */}
-        <div className="p-4 border-b bg-gray-50 flex gap-2 flex-wrap">
+        <div className="p-4 border-b border-muted bg-surface-container-low flex gap-2 flex-wrap">
           <button
             onClick={() => { void handleExport("clipboard"); }}
             className="px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm"
@@ -651,7 +651,7 @@ export default function GroceryListModal({
           </button>
           <button
             onClick={regenerateGroceryList}
-            className="px-3 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 text-sm"
+            className="px-3 py-2 bg-surface-container-high text-on-surface rounded-lg hover:bg-surface-container-highest text-sm"
           >
             🔄 Rebuild List
           </button>
@@ -694,7 +694,7 @@ export default function GroceryListModal({
             onChange={(e) =>
               setGroupBy(e.target.value as "category" | "recipe")
             }
-            className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-purple-500"
+            className="px-3 py-2 border border-muted rounded-lg text-sm focus:ring-2 focus:ring-purple-500"
           >
             <option value="category">Group by Aisle</option>
             <option value="recipe">Group by Recipe</option>
@@ -708,7 +708,7 @@ export default function GroceryListModal({
         </div>
 
         {amazonError && (
-          <div className="px-4 py-2 bg-red-50 border-b border-red-200 flex items-center justify-between text-sm text-red-700">
+          <div className="px-4 py-2 bg-fire-spirit/10 border-b border-fire-spirit/20 flex items-center justify-between text-sm text-fire-spirit">
             <span>⚠️ {amazonError}</span>
             <button
               onClick={() => setAmazonError(null)}
@@ -753,7 +753,7 @@ export default function GroceryListModal({
                             e.stopPropagation();
                             markCategoryPurchased(categoryKey);
                           }}
-                          className="px-2 py-1 bg-white bg-opacity-50 rounded text-xs hover:bg-opacity-70"
+                          className="px-2 py-1 bg-surface-container-high bg-opacity-50 rounded text-xs hover:bg-opacity-70"
                         >
                           ✓ Mark All
                         </button>
@@ -799,7 +799,7 @@ export default function GroceryListModal({
           )}
 
           {groceryList.length === 0 && (
-            <div className="text-center text-gray-500 py-12">
+            <div className="text-center text-on-surface-variant py-12">
               <div className="text-4xl mb-2">🛒</div>
               <p>No items in grocery list yet.</p>
               <p className="text-sm mt-2">
@@ -818,7 +818,7 @@ export default function GroceryListModal({
       {/* Amazon Handoff Preview Modal */}
       {showAmazonPreview && (
         <div className="absolute inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl shadow-xl max-w-lg w-full overflow-hidden animate-fade-in flex flex-col">
+          <div className="alchm-panel rounded-xl max-w-lg w-full overflow-hidden animate-fade-in flex flex-col">
             <div className="bg-[#FF9900] p-5 text-black flex justify-between items-center">
               <h3 className="text-xl font-bold flex items-center gap-2">
                 <span>🛒</span> Send to Amazon
@@ -832,7 +832,7 @@ export default function GroceryListModal({
             </div>
 
             <div className="p-6">
-              <p className="text-gray-700 mb-6 font-medium">
+              <p className="text-on-surface mb-6 font-medium">
                 Here is your current cart status. We&apos;ll only send grocery items that can be confidently matched to Amazon products.
               </p>
 
@@ -848,7 +848,7 @@ export default function GroceryListModal({
                   <span className="text-2xl font-black text-emerald-600">{stats.inPantry}</span>
                 </div>
 
-                <div className="bg-blue-50 border border-blue-100 rounded-lg p-4 flex items-center justify-between">
+                <div className="bg-water-essence/10 border border-water-essence/20 rounded-lg p-4 flex items-center justify-between">
                   <div className="flex items-center gap-3">
                     <span className="text-2xl">📦</span>
                     <div>
@@ -960,23 +960,23 @@ export default function GroceryListModal({
               </div>
 
               {amazonError && (
-                <div className="mt-4 p-3 bg-red-50 text-red-700 text-sm rounded-lg border border-red-200">
+                <div className="mt-4 p-3 bg-fire-spirit/10 text-fire-spirit text-sm rounded-lg border border-red-200">
                   {amazonError}
                 </div>
               )}
             </div>
 
-            <div className="p-4 bg-gray-50 border-t flex flex-wrap justify-end gap-3">
+            <div className="p-4 bg-surface-container-low border-t flex flex-wrap justify-end gap-3">
               <button
                 onClick={() => setShowAmazonPreview(false)}
-                className="px-4 py-2 text-gray-600 font-medium hover:bg-gray-200 rounded-lg transition-colors"
+                className="px-4 py-2 text-on-surface-variant font-medium hover:bg-surface-container-high rounded-lg transition-colors"
               >
                 Cancel
               </button>
               {amazonLoading ? (
                 <button
                   disabled
-                  className="px-6 py-2 bg-gray-400 text-white font-bold rounded-lg transition-all flex items-center gap-2"
+                  className="px-6 py-2 bg-surface-container-high text-on-surface-variant font-bold rounded-lg transition-all flex items-center gap-2"
                 >
                   Processing...
                 </button>
@@ -1039,11 +1039,11 @@ function GroceryItemRow({
 }) {
   return (
     <div
-      className={`bg-white border rounded-lg p-3 ${item.purchased
-          ? "opacity-50 border-green-300 bg-green-50"
+      className={`bg-surface-container-low border border-muted rounded-lg p-3 ${item.purchased
+          ? "opacity-50 border-earth-matter/30 bg-earth-matter/10"
           : isInPantry
-            ? "border-orange-300 bg-orange-50"
-            : "border-gray-200"
+            ? "border-gold-accent/30 bg-gold-accent/10"
+            : "border-muted"
         }`}
     >
       <div className="flex items-center justify-between">
@@ -1151,7 +1151,7 @@ function RecipeGroupedView({
 
         return (
           <div key={recipeId} className="mb-4">
-            <div className="bg-purple-50 text-purple-700 rounded-lg p-3 flex items-center gap-2 font-bold">
+            <div className="bg-active-violet/10 text-active-violet rounded-lg p-3 flex items-center gap-2 font-bold">
               <span className="text-lg">🍽️</span>
               <span>{recipeName}</span>
               <span className="text-sm font-normal">
@@ -1190,13 +1190,13 @@ function PantryModalSimple({ onClose }: { onClose: () => void }) {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-2xl shadow-2xl max-w-2xl w-full max-h-[80vh] overflow-hidden flex flex-col">
+      <div className="alchm-panel rounded-2xl max-w-2xl w-full max-h-[80vh] overflow-hidden flex flex-col">
         <div className="bg-gradient-to-r from-orange-600 to-yellow-600 text-white p-6">
           <div className="flex items-center justify-between">
             <h2 className="text-2xl font-bold">🏺 Pantry Items</h2>
             <button
               onClick={onClose}
-              className="text-white hover:text-gray-200 text-2xl font-bold"
+              className="text-on-surface hover:text-on-surface-variant text-2xl font-bold"
             >
               ×
             </button>
@@ -1205,7 +1205,7 @@ function PantryModalSimple({ onClose }: { onClose: () => void }) {
 
         <div className="flex-1 overflow-y-auto p-6">
           {pantryItems.length === 0 ? (
-            <div className="text-center text-gray-500 py-12">
+            <div className="text-center text-on-surface-variant py-12">
               <div className="text-4xl mb-2">🏺</div>
               <p>Your pantry is empty.</p>
               <p className="text-sm mt-2">
@@ -1217,13 +1217,13 @@ function PantryModalSimple({ onClose }: { onClose: () => void }) {
               {pantryItems.map((item, index) => (
                 <div
                   key={index}
-                  className="bg-gray-50 border border-gray-200 rounded-lg p-3 flex items-center justify-between"
+                  className="bg-surface-container-low border border-muted rounded-lg p-3 flex items-center justify-between"
                 >
                   <div>
                     <div className="font-medium">
                       {item.quantity} {item.unit} {item.name}
                     </div>
-                    <div className="text-xs text-gray-600">
+                    <div className="text-xs text-on-surface-variant">
                       Category: {item.category}
                     </div>
                   </div>

--- a/src/components/menu-planner/MealSlot.tsx
+++ b/src/components/menu-planner/MealSlot.tsx
@@ -64,27 +64,30 @@ function getMealTypeColors(mealType: MealType): {
   border: string;
   text: string;
 } {
+  // On-brand element-aligned tokens (was off-brand amber/emerald/purple/cyan
+  // marketing gradients). Breakfast→Fire, Lunch→Earth, Dinner→Air/violet,
+  // Snack→Water, keeping text on the neutral surface ramp for legibility.
   const colors: Record<MealType, { bg: string; border: string; text: string }> =
     {
       breakfast: {
-        bg: "bg-gradient-to-br from-amber-400/15 to-yellow-500/5",
-        border: "border-amber-300/30",
-        text: "text-amber-200",
+        bg: "bg-fire-spirit/5",
+        border: "border-fire-spirit/20",
+        text: "text-on-surface",
       },
       lunch: {
-        bg: "bg-gradient-to-br from-emerald-400/15 to-teal-500/5",
-        border: "border-emerald-300/30",
-        text: "text-emerald-200",
+        bg: "bg-earth-matter/5",
+        border: "border-earth-matter/20",
+        text: "text-on-surface",
       },
       dinner: {
-        bg: "bg-gradient-to-br from-purple-400/20 to-indigo-500/10",
-        border: "border-purple-300/40",
-        text: "text-purple-200",
+        bg: "bg-active-violet/5",
+        border: "border-active-violet/20",
+        text: "text-on-surface",
       },
       snack: {
-        bg: "bg-gradient-to-br from-cyan-400/15 to-sky-500/5",
-        border: "border-cyan-300/30",
-        text: "text-cyan-200",
+        bg: "bg-water-essence/5",
+        border: "border-water-essence/20",
+        text: "text-on-surface",
       },
     };
   return colors[mealType];

--- a/src/components/menu-planner/WeeklyCalendar.tsx
+++ b/src/components/menu-planner/WeeklyCalendar.tsx
@@ -30,6 +30,7 @@ import type { DailyNutritionResult } from "@/types/nutrition";
 import CopyMealModal from "./CopyMealModal";
 import FocusedDayView from "./FocusedDayView";
 import MealSlot from "./MealSlot";
+import RedesignedMobilePlanner from "./redesign/RedesignedMobilePlanner";
 import StitchTransitRibbon, { PLANET_GLYPHS } from "./StitchTransitRibbon";
 
 /**
@@ -95,6 +96,8 @@ function DayNutritionStrip({
 
 interface WeeklyCalendarProps {
   onMealClick?: (mealSlot: MealSlotType) => void;
+  /** Fires the "Shop the week" flow (build grocery list + open it). Mobile redesign. */
+  onShopWeek?: () => void;
 }
 
 /**
@@ -489,7 +492,7 @@ function TodayHeroCard({
 /**
  * Main Weekly Calendar Component
  */
-export default function WeeklyCalendar({ onMealClick }: WeeklyCalendarProps) {
+export default function WeeklyCalendar({ onMealClick, onShopWeek }: WeeklyCalendarProps) {
   const {
     currentMenu,
     navigation,
@@ -691,13 +694,13 @@ export default function WeeklyCalendar({ onMealClick }: WeeklyCalendarProps) {
               <div className="flex items-center gap-2">
                 <span className="text-gold-accent">☉</span>
                 <span>
-                  Click &quot;Generate&quot; on any day for planetary-aligned suggestions
+                  Tap &quot;+ Add&quot; on any meal to choose a recipe
                 </span>
               </div>
               <div className="hidden sm:block text-on-surface-variant/40">•</div>
               <div className="flex items-center gap-2">
                 <span className="text-active-violet">🜂</span>
-                <span>Search recipes below and drag to calendar</span>
+                <span>Or tap ✦ for a planetary-aligned suggestion</span>
               </div>
             </div>
           </div>
@@ -738,17 +741,19 @@ export default function WeeklyCalendar({ onMealClick }: WeeklyCalendarProps) {
         </div>
       )}
 
-      {/* Today Hero Card — always on top when today is within the viewed week */}
+      {/* Today Hero Card — desktop/tablet only; mobile uses the redesigned hero */}
       {todayDayOfWeek !== null && (
-        <TodayHeroCard
-          dayOfWeek={todayDayOfWeek}
-          date={weekDates[todayDayOfWeek]}
-          meals={mealsByDay[todayDayOfWeek] || []}
-          onCopyMealClick={handleCopyMealClick}
-          onFocusDay={() => handleOpenFocusedDay(todayDayOfWeek)}
-          currentPlanetaryHour={currentPlanetaryHour}
-          dailyNutrition={weeklyNutrition?.days?.[todayDayOfWeek]}
-        />
+        <div className="hidden md:block">
+          <TodayHeroCard
+            dayOfWeek={todayDayOfWeek}
+            date={weekDates[todayDayOfWeek]}
+            meals={mealsByDay[todayDayOfWeek] || []}
+            onCopyMealClick={handleCopyMealClick}
+            onFocusDay={() => handleOpenFocusedDay(todayDayOfWeek)}
+            currentPlanetaryHour={currentPlanetaryHour}
+            dailyNutrition={weeklyNutrition?.days?.[todayDayOfWeek]}
+          />
+        </div>
       )}
 
       {/* Calendar Grid - Desktop (7 columns, clickable to expand) */}
@@ -840,28 +845,20 @@ export default function WeeklyCalendar({ onMealClick }: WeeklyCalendarProps) {
         )}
       </div>
 
-      {/* Calendar Grid - Mobile (1 column) */}
-      <div className="md:hidden space-y-3">
-        {([0, 1, 2, 3, 4, 5, 6] as DayOfWeek[]).map((day) => (
-          <DayColumn
-            key={day}
-            dayOfWeek={day}
-            date={weekDates[day]}
-            meals={mealsByDay[day] || []}
-            onMealClick={onMealClick}
-            onCopyMealClick={handleCopyMealClick}
-            onFocusDay={() => handleOpenFocusedDay(day)}
-            onToggleExpand={() => toggleExpandDay(day)}
-            isExpanded={expandedDay === day}
-            currentPlanetaryHour={currentPlanetaryHour}
-            dailyNutrition={weeklyNutrition?.days?.[day]}
-            isSelectedForHero={day === todayDayOfWeek}
-          />
-        ))}
+      {/* Redesigned Mobile Planner — data-forward day cards + insights rail */}
+      <div className="md:hidden">
+        <RedesignedMobilePlanner
+          weekDates={weekDates}
+          mealsByDay={mealsByDay}
+          todayDayOfWeek={todayDayOfWeek}
+          weeklyNutrition={weeklyNutrition}
+          currentPlanetaryHour={currentPlanetaryHour}
+          onShopWeek={onShopWeek}
+        />
       </div>
 
-      {/* Helper Text */}
-      <div className="text-center text-xs text-on-surface-variant font-mono uppercase tracking-wider mt-6">
+      {/* Helper Text (desktop/tablet) */}
+      <div className="hidden md:block text-center text-xs text-on-surface-variant font-mono uppercase tracking-wider mt-6">
         <p>
           Click a day header to expand it inline • Click &quot;+ Add Recipe&quot;
           to add meals • Click 📋 to copy/move to multiple slots.

--- a/src/components/menu-planner/redesign/AgentProfileWeekCard.tsx
+++ b/src/components/menu-planner/redesign/AgentProfileWeekCard.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+/**
+ * AgentProfileWeekCard — the living weekly-menu fixture for a Planetary Agent's
+ * alchm.kitchen profile. Fetches the agent's published current-week menu from
+ * the public read endpoint and renders the read-only ProfileWeekFixture with an
+ * "Adopt this week" action. Renders nothing until the agent has published a
+ * week (no empty shells on real profiles).
+ *
+ * @file src/components/menu-planner/redesign/AgentProfileWeekCard.tsx
+ */
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import type { DayOfWeek, MealSlot as MealSlotType } from "@/types/menuPlanner";
+import ProfileWeekFixture from "./ProfileWeekFixture";
+
+/** Coarse "updated N ago" label from an ISO timestamp. */
+function relativeStamp(iso: string | null): string | undefined {
+  if (!iso) return undefined;
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return undefined;
+  const diffH = Math.floor((Date.now() - then) / 3_600_000);
+  if (diffH < 1) return "Updated just now";
+  if (diffH < 24) return `Updated ${diffH}h ago`;
+  return `Updated ${Math.floor(diffH / 24)}d ago`;
+}
+
+export default function AgentProfileWeekCard({
+  userId,
+  agentName,
+}: {
+  userId: string;
+  agentName?: string | null;
+}) {
+  const router = useRouter();
+  const [meals, setMeals] = useState<MealSlotType[] | null>(null);
+  const [updatedLabel, setUpdatedLabel] = useState<string | undefined>();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const res = await fetch(
+          `/api/menu-planner/public-week?userId=${encodeURIComponent(userId)}`,
+        );
+        if (!res.ok) {
+          if (!cancelled) setMeals([]);
+          return;
+        }
+        const json = (await res.json()) as {
+          success: boolean;
+          meals?: MealSlotType[];
+          updatedAt?: string | null;
+        };
+        if (!cancelled) {
+          setMeals((json?.meals ?? []));
+          setUpdatedLabel(relativeStamp(json?.updatedAt ?? null));
+        }
+      } catch {
+        if (!cancelled) setMeals([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  const todayDayOfWeek = new Date().getDay() as DayOfWeek;
+
+  if (loading) {
+    return <div className="alchm-panel rounded-xl p-4 h-28 animate-pulse" />;
+  }
+
+  // Don't render an empty shell on agents who haven't published a week.
+  if (!(meals ?? []).some((m) => m.recipe)) return null;
+
+  return (
+    <ProfileWeekFixture
+      variant="agent"
+      title={`${agentName ?? "Agent"}'s week`}
+      meals={meals ?? []}
+      updatedLabel={updatedLabel}
+      planetaryFocus="Planetary menu"
+      todayDayOfWeek={todayDayOfWeek}
+      onAdopt={() => router.push("/menu-planner")}
+    />
+  );
+}

--- a/src/components/menu-planner/redesign/FastStartCard.tsx
+++ b/src/components/menu-planner/redesign/FastStartCard.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+/**
+ * FastStartCard — the guided empty-state for the redesigned planner.
+ * Ask three quick things (diet, budget, portions), then draft a full week by
+ * looping the planetary-aligned day generator. This restores whole-week
+ * auto-plan on mobile after the legacy QuickActionsToolbar was hidden.
+ *
+ * @file src/components/menu-planner/redesign/FastStartCard.tsx
+ */
+
+import { Loader2, Sparkles } from "lucide-react";
+import { useState } from "react";
+import { useMenuPlanner } from "@/contexts/MenuPlannerContext";
+import type { DayOfWeek, MealType } from "@/types/menuPlanner";
+
+const MAIN_TYPES: MealType[] = ["breakfast", "lunch", "dinner"];
+const ALL_DAYS: DayOfWeek[] = [0, 1, 2, 3, 4, 5, 6];
+
+type DietKey =
+  | "balanced"
+  | "vegetarian"
+  | "vegan"
+  | "pescatarian"
+  | "high-protein";
+
+const DIETS: Array<{ key: DietKey; label: string }> = [
+  { key: "balanced", label: "Balanced" },
+  { key: "high-protein", label: "High-protein" },
+  { key: "vegetarian", label: "Vegetarian" },
+  { key: "vegan", label: "Vegan" },
+  { key: "pescatarian", label: "Pescatarian" },
+];
+
+export default function FastStartCard() {
+  const {
+    generateMealsForDay,
+    updateGenerationPreference,
+    setWeeklyBudget,
+    generationPreferences,
+  } = useMenuPlanner();
+
+  const [diet, setDiet] = useState<DietKey>("balanced");
+  const [budget, setBudget] = useState<number>(60);
+  const [noBudget, setNoBudget] = useState(false);
+  const [drafting, setDrafting] = useState(false);
+  const [progress, setProgress] = useState(0);
+
+  const applyPreferences = () => {
+    // Map the diet chip onto the real generation-preference model.
+    if (diet === "high-protein") {
+      updateGenerationPreference("dietaryRestrictions", []);
+      updateGenerationPreference("nutritionalTargets", {
+        ...generationPreferences.nutritionalTargets,
+        prioritizeProtein: true,
+      });
+    } else if (diet === "balanced") {
+      updateGenerationPreference("dietaryRestrictions", []);
+    } else {
+      updateGenerationPreference("dietaryRestrictions", [diet]);
+    }
+    setWeeklyBudget(noBudget ? null : budget);
+  };
+
+  const draftWeek = async () => {
+    if (drafting) return;
+    setDrafting(true);
+    setProgress(0);
+    applyPreferences();
+    try {
+      for (const day of ALL_DAYS) {
+         
+        await generateMealsForDay(day, { mealTypes: MAIN_TYPES });
+        setProgress((p) => p + 1);
+      }
+    } finally {
+      setDrafting(false);
+    }
+  };
+
+  return (
+    <section className="alchm-panel alchm-panel-glow regmarks rounded-2xl p-5 relative overflow-hidden">
+      <div className="absolute -top-12 -right-12 w-40 h-40 bg-active-violet/10 rounded-full blur-2xl pointer-events-none" />
+
+      <div className="relative z-10">
+        <h2 className="font-headline-md text-headline-md font-bold text-primary">
+          Let&apos;s plan your week
+        </h2>
+        <p className="mt-1 font-body-md text-[13px] text-on-surface-variant">
+          Answer 3 quick things and we&apos;ll draft a balanced week you can tweak.
+        </p>
+
+        {/* Diet */}
+        <div className="mt-4">
+          <p className="font-mono text-[10px] uppercase tracking-wider text-on-surface-variant mb-2">
+            Diet &amp; preferences
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {DIETS.map((d) => {
+              const active = diet === d.key;
+              return (
+                <button
+                  key={d.key}
+                  type="button"
+                  onClick={() => setDiet(d.key)}
+                  className={`px-3 py-1.5 rounded-full font-mono text-[11px] uppercase tracking-wide transition-all ${
+                    active
+                      ? "bg-active-violet/15 border border-active-violet/50 text-active-violet"
+                      : "bg-surface-container-low border border-muted text-on-surface-variant hover:text-on-surface hover:border-active-violet/30"
+                  }`}
+                >
+                  {d.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Budget */}
+        <div className="mt-4">
+          <div className="flex items-center justify-between mb-2">
+            <p className="font-mono text-[10px] uppercase tracking-wider text-on-surface-variant">
+              Weekly budget
+            </p>
+            <label className="flex items-center gap-1.5 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={noBudget}
+                onChange={(e) => setNoBudget(e.target.checked)}
+                className="h-3.5 w-3.5 rounded border-muted bg-surface-container-lowest text-active-violet focus:ring-active-violet focus:ring-offset-0"
+              />
+              <span className="font-mono text-[10px] uppercase tracking-wide text-on-surface-variant">
+                No budget
+              </span>
+            </label>
+          </div>
+          <div className="flex items-center gap-3">
+            <input
+              type="range"
+              min={20}
+              max={200}
+              step={5}
+              value={budget}
+              disabled={noBudget}
+              onChange={(e) => setBudget(Number(e.target.value))}
+              className="flex-1 accent-gold-accent disabled:opacity-40"
+            />
+            <span
+              className={`font-mono text-sm tabular-nums w-14 text-right ${noBudget ? "text-on-surface-variant/40" : "text-gold-accent"}`}
+            >
+              {noBudget ? "—" : `$${budget}`}
+            </span>
+          </div>
+        </div>
+
+        {/* Draft CTA */}
+        <button
+          type="button"
+          onClick={() => {
+            void draftWeek();
+          }}
+          disabled={drafting}
+          className="mt-5 w-full flex items-center justify-center gap-2 py-3 rounded-full bg-gradient-to-r from-gold-accent to-active-violet text-background font-mono text-[12px] uppercase tracking-wider font-bold shadow-[0_0_20px_rgba(184,90,240,0.25)] active:scale-[0.98] transition-transform disabled:opacity-70"
+        >
+          {drafting ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Drafting… {progress}/7 days
+            </>
+          ) : (
+            <>
+              <Sparkles className="h-4 w-4" />
+              Draft my week
+            </>
+          )}
+        </button>
+        <p className="mt-2 text-center font-mono text-[10px] uppercase tracking-wide text-on-surface-variant/50">
+          Planetary-aligned · fully editable after
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/menu-planner/redesign/MealRowCard.tsx
+++ b/src/components/menu-planner/redesign/MealRowCard.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+/**
+ * MealRowCard — the redesigned, data-forward meal row for the weekly planner.
+ * A compact tap-to-add row (no drag-and-drop): thumbnail · name · macro
+ * read-out · dominant-element dot · lock toggle. Empty slots render a dashed
+ * "Add {meal}" affordance that opens the recipe selector, plus a subtle
+ * planetary-aligned "suggest" action.
+ *
+ * @file src/components/menu-planner/redesign/MealRowCard.tsx
+ */
+
+import { Lock, LockOpen, Plus, Sparkles, Utensils, X } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { useMenuPlanner } from "@/contexts/MenuPlannerContext";
+import type { MonicaOptimizedRecipe } from "@/data/unified/recipeBuilding";
+import type { MealSlot as MealSlotType, MealType } from "@/types/menuPlanner";
+import type { Recipe } from "@/types/recipe";
+import RecipeSelector from "../RecipeSelector";
+import { dominantElement, ELEMENT_DOT } from "./elementUtils";
+
+const MEAL_LABEL: Record<MealType, string> = {
+  breakfast: "Breakfast",
+  lunch: "Lunch",
+  dinner: "Dinner",
+  snack: "Snack",
+};
+
+function recipeImage(r: any): string | null {
+  return r?.image ?? r?.imageUrl ?? r?.image_url ?? null;
+}
+
+/** Per-serving nutrition scaled to the slot's servings, as a mono read-out. */
+function macroLine(r: any, servings: number): string {
+  const n = r?.nutrition;
+  const kcal = Math.round((n?.calories ?? 0) * servings);
+  if (!kcal) return servings > 1 ? `x${servings} servings` : "";
+  const p = Math.round((n?.protein ?? 0) * servings);
+  const c = Math.round((n?.carbs ?? 0) * servings);
+  const f = Math.round((n?.fat ?? 0) * servings);
+  return `${kcal} KCAL · P${p} C${c} F${f}${servings > 1 ? ` · x${servings}` : ""}`;
+}
+
+export default function MealRowCard({
+  mealSlot,
+  ghost = false,
+}: {
+  mealSlot: MealSlotType;
+  /** Render an empty snack slot as a slim ghost affordance instead of a full row. */
+  ghost?: boolean;
+}) {
+  const {
+    addMealToSlot,
+    removeMealFromSlot,
+    generateMealsForDay,
+    lockMeal,
+    unlockMeal,
+  } = useMenuPlanner();
+  const [showSelector, setShowSelector] = useState(false);
+
+  const recipe = mealSlot.recipe as any;
+  const label = MEAL_LABEL[mealSlot.mealType];
+  const locked = mealSlot.isLocked ?? false;
+  const el = dominantElement(recipe?.elementalProperties);
+  const img = recipeImage(recipe);
+
+  const selector = (
+    <RecipeSelector
+      isOpen={showSelector}
+      onClose={() => setShowSelector(false)}
+      onSelectRecipe={(r: Recipe) => {
+        void addMealToSlot(
+          mealSlot.dayOfWeek,
+          mealSlot.mealType,
+          r as unknown as MonicaOptimizedRecipe,
+        );
+        setShowSelector(false);
+      }}
+      filters={{
+        mealType: mealSlot.mealType,
+        dayOfWeek: mealSlot.dayOfWeek,
+        planetarySnapshot: mealSlot.planetarySnapshot,
+      }}
+    />
+  );
+
+  // Empty snack → slim ghost affordance
+  if (!recipe && ghost) {
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => setShowSelector(true)}
+          className="w-full flex items-center justify-center gap-1 py-2 text-on-surface-variant/50 hover:text-on-surface-variant transition-colors"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          <span className="font-mono text-[10px] uppercase tracking-wider">
+            add {mealSlot.mealType}
+          </span>
+        </button>
+        {selector}
+      </>
+    );
+  }
+
+  // Empty main slot → dashed add + subtle suggest
+  if (!recipe) {
+    return (
+      <>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setShowSelector(true)}
+            className="group flex-1 flex items-center justify-center gap-2 p-3 rounded-lg border border-dashed border-on-surface-variant/25 text-on-surface-variant hover:border-active-violet/50 hover:bg-active-violet/5 hover:text-active-violet transition-all"
+          >
+            <Plus className="h-4 w-4" />
+            <span className="font-mono text-[11px] uppercase tracking-wider">
+              Add {label}
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              void generateMealsForDay(mealSlot.dayOfWeek, {
+                mealTypes: [mealSlot.mealType],
+              });
+            }}
+            title={`Suggest a planetary-aligned ${label.toLowerCase()}`}
+            className="shrink-0 p-3 rounded-lg border border-gold-accent/20 text-gold-accent/80 hover:bg-gold-accent/10 transition-all"
+          >
+            <Sparkles className="h-4 w-4" />
+          </button>
+        </div>
+        {selector}
+      </>
+    );
+  }
+
+  // Filled slot → data-forward row
+  return (
+    <>
+      <div className="flex items-center gap-3 p-2 rounded-lg hover:bg-white/[0.03] transition-colors group">
+        <div className="w-12 h-12 rounded-lg bg-surface-container overflow-hidden shrink-0 border border-on-surface/10 flex items-center justify-center">
+          {img ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={img}
+              alt={recipe.name}
+              className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+            />
+          ) : (
+            <Utensils className="h-5 w-5 text-on-surface-variant/40" />
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2">
+            <Link
+              href={`/recipes/${recipe.id || encodeURIComponent(recipe.name)}`}
+              className="font-body-md text-[15px] font-medium text-primary truncate hover:underline"
+            >
+              {recipe.name}
+            </Link>
+            <button
+              type="button"
+              onClick={() =>
+                locked ? unlockMeal(mealSlot.id) : lockMeal(mealSlot.id)
+              }
+              title={locked ? "Unlock meal" : "Lock meal (protect from regenerate)"}
+              aria-pressed={locked}
+              className={`shrink-0 transition-colors ${
+                locked
+                  ? "text-gold-accent"
+                  : "text-on-surface-variant/40 hover:text-on-surface-variant"
+              }`}
+            >
+              {locked ? (
+                <Lock className="h-3.5 w-3.5" />
+              ) : (
+                <LockOpen className="h-3.5 w-3.5" />
+              )}
+            </button>
+          </div>
+          <div className="flex items-center gap-2 mt-1">
+            {el && (
+              <span
+                className={`w-1.5 h-1.5 rounded-full shrink-0 ${ELEMENT_DOT[el]}`}
+                title={`${el}-dominant`}
+              />
+            )}
+            <span className="font-mono text-[10px] uppercase tracking-wide text-on-surface-variant truncate">
+              {macroLine(recipe, mealSlot.servings) || label}
+            </span>
+            <button
+              type="button"
+              onClick={() => {
+                void removeMealFromSlot(mealSlot.id);
+              }}
+              title="Remove meal"
+              className="ml-auto shrink-0 text-on-surface-variant/40 hover:text-error transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/menu-planner/redesign/ProfileWeekCard.tsx
+++ b/src/components/menu-planner/redesign/ProfileWeekCard.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+/**
+ * ProfileWeekCard — self-contained "This Week" fixture for the user's own
+ * alchm.kitchen profile. Fetches the signed-in user's current-week menu
+ * (owner-scoped GET /api/menu-planner/menus) and renders the interactive
+ * ProfileWeekFixture. Degrades to an honest "plan your week" CTA when there's
+ * no menu yet or the user isn't signed in.
+ *
+ * @file src/components/menu-planner/redesign/ProfileWeekCard.tsx
+ */
+
+import { CalendarDays } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import type { DayOfWeek, MealSlot as MealSlotType } from "@/types/menuPlanner";
+import { getWeekStartDate } from "@/types/menuPlanner";
+import ProfileWeekFixture from "./ProfileWeekFixture";
+
+export default function ProfileWeekCard() {
+  const [meals, setMeals] = useState<MealSlotType[] | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const weekStart = getWeekStartDate(new Date());
+        const iso = weekStart.toISOString();
+        const res = await fetch(
+          `/api/menu-planner/menus?weekStartDate=${encodeURIComponent(iso)}`,
+        );
+        if (!res.ok) {
+          if (!cancelled) setMeals([]);
+          return;
+        }
+        const json = (await res.json()) as {
+          success: boolean;
+          menu?: { meals?: MealSlotType[] } | null;
+        };
+        if (!cancelled) setMeals(json?.menu?.meals ?? []);
+      } catch {
+        if (!cancelled) setMeals([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const todayDayOfWeek = new Date().getDay() as DayOfWeek;
+
+  if (loading) {
+    return (
+      <div className="alchm-panel rounded-xl p-4 animate-pulse">
+        <div className="h-4 w-28 bg-surface-container-high rounded mb-4" />
+        <div className="grid grid-cols-7 gap-1">
+          {Array.from({ length: 7 }).map((_, i) => (
+            <div key={i} className="h-16 bg-surface-container-high/60 rounded" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const hasPlanned = (meals ?? []).some((m) => m.recipe);
+
+  if (!hasPlanned) {
+    return (
+      <Link
+        href="/menu-planner"
+        className="alchm-panel rounded-xl p-4 flex items-center justify-between gap-3 hover:bg-surface-container-low/40 transition-colors group"
+      >
+        <div className="flex items-center gap-3 min-w-0">
+          <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-active-violet/10 text-active-violet shrink-0">
+            <CalendarDays className="h-5 w-5" />
+          </span>
+          <div className="min-w-0">
+            <h3 className="font-headline-md text-[18px] font-bold text-primary">
+              Plan your week
+            </h3>
+            <p className="font-mono text-[10px] uppercase tracking-wider text-on-surface-variant/70">
+              Your weekly menu is empty
+            </p>
+          </div>
+        </div>
+        <span className="font-mono text-[10px] uppercase tracking-wider text-active-violet group-hover:text-primary transition-colors">
+          Open →
+        </span>
+      </Link>
+    );
+  }
+
+  return (
+    <ProfileWeekFixture
+      variant="user"
+      title="This Week"
+      meals={meals ?? []}
+      todayDayOfWeek={todayDayOfWeek}
+    />
+  );
+}

--- a/src/components/menu-planner/redesign/ProfileWeekFixture.tsx
+++ b/src/components/menu-planner/redesign/ProfileWeekFixture.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+/**
+ * ProfileWeekFixture — a compact, embeddable "this week" fixture for
+ * alchm.kitchen profile pages. Two variants share one visual language:
+ *  - "user":  the signed-in user's own week, interactive (day tiles link to
+ *             the full planner).
+ *  - "agent": a Planetary Agent's authored week, read-only, with an
+ *             "Adopt this week" action.
+ * Renders a condensed 7-day (Sun→Sat) row of tiles; each tile shows the day's
+ * ruling-planet glyph and three main-meal dots (filled + element-colored when
+ * planned, hollow when empty).
+ *
+ * @file src/components/menu-planner/redesign/ProfileWeekFixture.tsx
+ */
+
+import { ArrowRight, Sparkles } from "lucide-react";
+import Link from "next/link";
+import type { DayOfWeek, MealSlot as MealSlotType, MealType } from "@/types/menuPlanner";
+import {
+  getPlanetaryDayCharacteristics,
+  getShortDayName,
+} from "@/types/menuPlanner";
+import { PLANET_GLYPHS } from "../StitchTransitRibbon";
+import { dominantElement, ELEMENT_DOT } from "./elementUtils";
+
+const MAIN_TYPES: MealType[] = ["breakfast", "lunch", "dinner"];
+const ALL_DAYS: DayOfWeek[] = [0, 1, 2, 3, 4, 5, 6];
+
+function DayTile({
+  day,
+  meals,
+  isToday,
+}: {
+  day: DayOfWeek;
+  meals: MealSlotType[];
+  isToday: boolean;
+}) {
+  const glyph = PLANET_GLYPHS[getPlanetaryDayCharacteristics(day).planet] ?? "✶";
+  const mains = MAIN_TYPES.map((t) => meals.find((m) => m.mealType === t));
+
+  return (
+    <div className="flex flex-col items-center gap-1.5">
+      <span
+        className={`text-sm ${isToday ? "text-gold-accent" : "text-active-violet/60"}`}
+      >
+        {glyph}
+      </span>
+      <span
+        className={`font-mono text-[9px] uppercase tracking-wider ${
+          isToday ? "text-gold-accent" : "text-on-surface-variant/70"
+        }`}
+      >
+        {getShortDayName(day).slice(0, 1)}
+      </span>
+      <div className="flex flex-col gap-1 mt-0.5">
+        {mains.map((slot, i) => {
+          const el = dominantElement(slot?.recipe?.elementalProperties);
+          const planned = !!slot?.recipe;
+          return (
+            <span
+              key={i}
+              className={`w-1.5 h-1.5 rounded-full ${
+                planned
+                  ? el
+                    ? ELEMENT_DOT[el]
+                    : "bg-active-violet"
+                  : "border border-on-surface-variant/25"
+              }`}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default function ProfileWeekFixture({
+  meals,
+  variant,
+  title,
+  updatedLabel,
+  planetaryFocus,
+  onAdopt,
+  href = "/menu-planner",
+  todayDayOfWeek = null,
+}: {
+  meals: MealSlotType[];
+  variant: "user" | "agent";
+  title: string;
+  /** Agent variant: "UPDATED 2H AGO"-style freshness stamp. */
+  updatedLabel?: string;
+  /** Agent variant: e.g. "Saturn focus · grounding". */
+  planetaryFocus?: string;
+  /** Agent variant: adopt this week into the viewer's planner. */
+  onAdopt?: () => void;
+  /** User variant: where day tiles link (defaults to the planner). */
+  href?: string;
+  todayDayOfWeek?: DayOfWeek | null;
+}) {
+  const mealsByDay: Record<DayOfWeek, MealSlotType[]> = {
+    0: [], 1: [], 2: [], 3: [], 4: [], 5: [], 6: [],
+  };
+  meals.forEach((m) => {
+    if (mealsByDay[m.dayOfWeek]) mealsByDay[m.dayOfWeek].push(m);
+  });
+
+  const plannedMains = meals.filter(
+    (m) => m.recipe && m.mealType !== "snack",
+  ).length;
+
+  const grid = (
+    <div className="grid grid-cols-7 gap-1">
+      {ALL_DAYS.map((day) => (
+        <DayTile
+          key={day}
+          day={day}
+          meals={mealsByDay[day] ?? []}
+          isToday={day === todayDayOfWeek}
+        />
+      ))}
+    </div>
+  );
+
+  return (
+    <section className="alchm-panel rounded-xl p-4">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3 gap-2">
+        <div className="min-w-0">
+          <h3 className="font-headline-md text-[18px] font-bold text-primary truncate">
+            {title}
+          </h3>
+          {variant === "agent" && (updatedLabel || planetaryFocus) && (
+            <p className="font-mono text-[9px] uppercase tracking-wider text-on-surface-variant/70 truncate">
+              {[updatedLabel, planetaryFocus].filter(Boolean).join(" · ")}
+            </p>
+          )}
+        </div>
+        <span className="shrink-0 font-mono text-[10px] uppercase tracking-wider text-on-surface-variant">
+          {plannedMains}/21 planned
+        </span>
+      </div>
+
+      {/* 7-day tiles — interactive (link) for the user's own week */}
+      {variant === "user" ? (
+        <Link href={href} className="block group" aria-label="Open the weekly planner">
+          {grid}
+        </Link>
+      ) : (
+        grid
+      )}
+
+      {/* Footer action */}
+      <div className="mt-3 pt-3 border-t border-muted flex items-center justify-between">
+        {variant === "user" ? (
+          <Link
+            href={href}
+            className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-wider text-active-violet hover:text-primary transition-colors"
+          >
+            Open planner <ArrowRight className="h-3 w-3" />
+          </Link>
+        ) : (
+          <button
+            type="button"
+            onClick={onAdopt}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-gradient-to-r from-gold-accent to-active-violet text-background font-mono text-[10px] uppercase tracking-wider font-bold active:scale-[0.98] transition-transform"
+          >
+            <Sparkles className="h-3 w-3" /> Adopt this week
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/menu-planner/redesign/RedesignedDayCard.tsx
+++ b/src/components/menu-planner/redesign/RedesignedDayCard.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+/**
+ * RedesignedDayCard — one day in the redesigned mobile planner.
+ * Shows the 3 main meals (breakfast/lunch/dinner) as data-forward rows plus a
+ * ghost "+ add snack" affordance. The `hero` variant is the prominent, glowing
+ * "Today" card with a planetary cosmic tip and an N/3-planned read-out.
+ *
+ * @file src/components/menu-planner/redesign/RedesignedDayCard.tsx
+ */
+
+import type { DayOfWeek, MealSlot as MealSlotType, MealType } from "@/types/menuPlanner";
+import {
+  formatDateForDisplay,
+  getDayName,
+  getPlanetaryDayCharacteristics,
+} from "@/types/menuPlanner";
+import type { DailyNutritionResult } from "@/types/nutrition";
+import { PLANET_GLYPHS } from "../StitchTransitRibbon";
+import MealRowCard from "./MealRowCard";
+
+const MAIN_TYPES: MealType[] = ["breakfast", "lunch", "dinner"];
+
+export default function RedesignedDayCard({
+  dayOfWeek,
+  date,
+  meals,
+  dailyNutrition,
+  variant = "day",
+  currentPlanetaryHour,
+}: {
+  dayOfWeek: DayOfWeek;
+  date: Date;
+  meals: MealSlotType[];
+  dailyNutrition?: DailyNutritionResult;
+  variant?: "hero" | "day";
+  currentPlanetaryHour?: string | null;
+}) {
+  const characteristics = getPlanetaryDayCharacteristics(dayOfWeek);
+  const glyph = PLANET_GLYPHS[characteristics.planet] ?? "✶";
+
+  const byType = (t: MealType) => meals.find((m) => m.mealType === t);
+  const mains = MAIN_TYPES.map(byType).filter(Boolean) as MealSlotType[];
+  const snack = byType("snack");
+  const plannedMains = mains.filter((m) => m.recipe).length;
+
+  const kcal = dailyNutrition?.meals?.length
+    ? Math.round(dailyNutrition.totals.calories ?? 0)
+    : null;
+
+  const isHero = variant === "hero";
+
+  return (
+    <section
+      className={
+        isHero
+          ? "alchm-panel alchm-panel-glow regmarks rounded-2xl p-4 relative overflow-hidden"
+          : "alchm-panel rounded-xl p-4 relative overflow-hidden"
+      }
+    >
+      {isHero && (
+        <div className="absolute -top-10 -right-10 w-32 h-32 bg-active-violet/10 rounded-full blur-2xl pointer-events-none" />
+      )}
+
+      {/* Header */}
+      <header className="relative z-10 flex items-start justify-between gap-3 mb-4 border-b border-muted pb-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span
+              className={`text-xl ${isHero ? "text-gold-accent" : "text-active-violet/70"}`}
+            >
+              {glyph}
+            </span>
+            <div className="min-w-0">
+              <h3 className="font-headline-md text-headline-md font-bold text-primary truncate leading-tight">
+                {isHero ? "Today" : getDayName(dayOfWeek)}
+              </h3>
+              <p className="font-mono text-[10px] uppercase tracking-wider text-on-surface-variant truncate">
+                {isHero ? `${getDayName(dayOfWeek)} · ` : ""}
+                {formatDateForDisplay(date)}
+              </p>
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-col items-end gap-1 shrink-0">
+          <span className="px-2 py-0.5 rounded-full border border-muted bg-surface-container-low font-mono text-[10px] uppercase tracking-wider text-on-surface-variant">
+            {plannedMains}/3 planned
+          </span>
+          {kcal !== null && (
+            <span className="font-mono text-[10px] text-on-surface-variant/70">
+              {kcal} KCAL
+            </span>
+          )}
+        </div>
+      </header>
+
+      {/* Cosmic tip (hero only) */}
+      {isHero && (
+        <div className="relative z-10 mb-4 p-3 rounded-lg bg-surface-container-high/50 border border-on-surface/5">
+          <p className="font-body-md text-[13px] text-on-surface-variant italic">
+            {characteristics.mealGuidance}
+          </p>
+          {currentPlanetaryHour && (
+            <p className="mt-1.5 font-mono text-[10px] uppercase tracking-wider text-gold-accent/80">
+              ⏰ {currentPlanetaryHour} hour is weaving now
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Meal rows */}
+      <div className="relative z-10 space-y-1">
+        {mains.map((m) => (
+          <MealRowCard key={m.id} mealSlot={m} />
+        ))}
+        {snack && (snack.recipe ? (
+          <MealRowCard key={snack.id} mealSlot={snack} />
+        ) : (
+          <MealRowCard key={snack.id} mealSlot={snack} ghost />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/menu-planner/redesign/RedesignedMobilePlanner.tsx
+++ b/src/components/menu-planner/redesign/RedesignedMobilePlanner.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+/**
+ * RedesignedMobilePlanner — the mobile weekly-planner experience.
+ * Renders the prominent "Today" hero card, the rest of the week as
+ * data-forward day cards, a prominent "Shop the week" action, and the single
+ * Week Insights rail. Rendered inside WeeklyCalendar's mobile breakpoint; the
+ * shared transit ribbon + week nav sit above it.
+ *
+ * @file src/components/menu-planner/redesign/RedesignedMobilePlanner.tsx
+ */
+
+import { ShoppingBag } from "lucide-react";
+import type { DayOfWeek, MealSlot as MealSlotType } from "@/types/menuPlanner";
+import type { WeeklyNutritionResult } from "@/types/nutrition";
+import FastStartCard from "./FastStartCard";
+import RedesignedDayCard from "./RedesignedDayCard";
+import WeeklyInsights from "./WeeklyInsights";
+
+const ALL_DAYS: DayOfWeek[] = [0, 1, 2, 3, 4, 5, 6];
+
+export default function RedesignedMobilePlanner({
+  weekDates,
+  mealsByDay,
+  todayDayOfWeek,
+  weeklyNutrition,
+  currentPlanetaryHour,
+  onShopWeek,
+}: {
+  weekDates: Date[];
+  mealsByDay: Record<DayOfWeek, MealSlotType[]>;
+  todayDayOfWeek: DayOfWeek | null;
+  weeklyNutrition?: WeeklyNutritionResult | null;
+  currentPlanetaryHour?: string | null;
+  onShopWeek?: () => void;
+}) {
+  const otherDays = ALL_DAYS.filter((d) => d !== todayDayOfWeek);
+  const daysToRender = todayDayOfWeek !== null ? otherDays : ALL_DAYS;
+
+  const isEmptyWeek = !ALL_DAYS.some((d) =>
+    (mealsByDay[d] ?? []).some((m) => m.recipe),
+  );
+
+  return (
+    <div className="space-y-4">
+      {/* Guided fast-start — only when the whole week is empty */}
+      {isEmptyWeek && <FastStartCard />}
+
+      {/* Today hero */}
+      {todayDayOfWeek !== null && (
+        <RedesignedDayCard
+          variant="hero"
+          dayOfWeek={todayDayOfWeek}
+          date={weekDates[todayDayOfWeek]}
+          meals={mealsByDay[todayDayOfWeek] ?? []}
+          dailyNutrition={weeklyNutrition?.days?.[todayDayOfWeek]}
+          currentPlanetaryHour={currentPlanetaryHour}
+        />
+      )}
+
+      {/* Rest of the week */}
+      {daysToRender.map((day) => (
+        <RedesignedDayCard
+          key={day}
+          variant="day"
+          dayOfWeek={day}
+          date={weekDates[day]}
+          meals={mealsByDay[day] ?? []}
+          dailyNutrition={weeklyNutrition?.days?.[day]}
+        />
+      ))}
+
+      {/* Shop the week */}
+      {onShopWeek && (
+        <button
+          type="button"
+          onClick={onShopWeek}
+          className="w-full flex items-center justify-center gap-2 py-3 rounded-full bg-gradient-to-r from-gold-accent to-active-violet text-background font-mono text-[12px] uppercase tracking-wider font-bold shadow-[0_0_20px_rgba(184,90,240,0.25)] active:scale-[0.98] transition-transform"
+        >
+          <ShoppingBag className="h-4 w-4" />
+          Shop the week
+        </button>
+      )}
+
+      {/* Insights rail */}
+      <WeeklyInsights />
+    </div>
+  );
+}

--- a/src/components/menu-planner/redesign/WeeklyInsights.tsx
+++ b/src/components/menu-planner/redesign/WeeklyInsights.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+/**
+ * WeeklyInsights — the single insights rail for the redesigned planner.
+ * Modules (in order): weekly elemental balance meter (the signature metric),
+ * budget vs. estimated cost, and variety / missing-meals with smart
+ * suggestion chips. All values come from live MenuPlanner state; nothing is
+ * fabricated — modules degrade to honest empty copy when there's no data yet.
+ *
+ * @file src/components/menu-planner/redesign/WeeklyInsights.tsx
+ */
+
+import { useMemo } from "react";
+import { useMenuPlanner } from "@/contexts/MenuPlannerContext";
+import type { ElementName } from "./elementUtils";
+
+const ELEMENTS: Array<{ key: ElementName; bar: string; label: string }> = [
+  { key: "Fire", bar: "bg-fire-spirit", label: "Fire" },
+  { key: "Water", bar: "bg-water-essence", label: "Water" },
+  { key: "Earth", bar: "bg-earth-matter", label: "Earth" },
+  { key: "Air", bar: "bg-air-substance", label: "Air" },
+];
+
+function balanceVerdict(
+  dist: Record<ElementName, number> | null,
+  totalMeals: number,
+): string {
+  if (!dist || totalMeals === 0) return "Plan meals to see balance";
+  const entries = ELEMENTS.map((e) => ({ key: e.key, v: dist[e.key] ?? 0 }));
+  const max = entries.reduce((a, b) => (b.v > a.v ? b : a));
+  const min = entries.reduce((a, b) => (b.v < a.v ? b : a));
+  // Even distribution ≈ 0.25 each. Flag if the spread is wide.
+  if (max.v - min.v <= 0.14) return "Balanced week";
+  return `A little ${max.key.toLowerCase()}-heavy`;
+}
+
+export default function WeeklyInsights() {
+  const {
+    weeklyStats,
+    weeklyBudget,
+    estimatedWeeklyCost,
+    getSuggestions,
+  } = useMenuPlanner();
+
+  const dist =
+    (weeklyStats?.elementalDistribution as Record<ElementName, number> | null) ??
+    null;
+  const totalMeals = weeklyStats?.totalMeals ?? 0;
+  const totalRecipes = weeklyStats?.totalRecipes ?? 0;
+  const emptySlots = weeklyStats?.missingMeals?.length ?? 0;
+
+  const verdict = balanceVerdict(dist, totalMeals);
+
+  const suggestions = useMemo(
+    () => getSuggestions().slice(0, 2),
+    [getSuggestions],
+  );
+
+  const cost = Math.round(estimatedWeeklyCost ?? 0);
+  const hasBudget = typeof weeklyBudget === "number" && weeklyBudget > 0;
+  const budgetPct = hasBudget
+    ? Math.min(100, Math.round((cost / (weeklyBudget)) * 100))
+    : 0;
+
+  return (
+    <section className="alchm-panel rounded-xl p-4 space-y-5">
+      <h3 className="font-mono text-[11px] uppercase tracking-[0.15em] text-on-surface-variant text-center">
+        Week Insights
+      </h3>
+
+      {/* Elemental balance — the signature metric */}
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <span className="font-mono text-[10px] uppercase tracking-wider text-on-surface-variant">
+            Elemental Balance
+          </span>
+          <span className="font-mono text-[10px] uppercase tracking-wider text-primary">
+            {verdict}
+          </span>
+        </div>
+        <div className="flex w-full h-1.5 rounded-full overflow-hidden bg-surface-container-high">
+          {ELEMENTS.map((e) => {
+            const pct =
+              dist && totalMeals > 0
+                ? Math.max(2, Math.round((dist[e.key] ?? 0) * 100))
+                : 25;
+            return (
+              <div
+                key={e.key}
+                className={`${e.bar} h-full ${dist && totalMeals > 0 ? "" : "opacity-30"}`}
+                style={{ width: `${pct}%` }}
+                title={`${e.label}: ${dist ? Math.round((dist[e.key] ?? 0) * 100) : 0}%`}
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Budget */}
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <span className="font-mono text-[10px] uppercase tracking-wider text-on-surface-variant">
+            Budget
+          </span>
+          <span className="font-mono text-[10px] uppercase tracking-wider text-on-surface-variant">
+            {hasBudget
+              ? `$${cost} / $${Math.round(weeklyBudget)} this week`
+              : `$${cost} est. this week`}
+          </span>
+        </div>
+        <div className="w-full h-1.5 rounded-full bg-surface-container-high overflow-hidden">
+          <div
+            className={`h-full ${budgetPct > 100 || (hasBudget && cost > (weeklyBudget)) ? "bg-error" : "bg-gold-accent"}`}
+            style={{ width: `${hasBudget ? budgetPct : cost > 0 ? 100 : 0}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Variety & suggestions */}
+      <div className="pt-1 border-t border-on-surface/5">
+        <p className="font-mono text-[10px] uppercase tracking-wide text-on-surface-variant/70 text-center mb-3">
+          {emptySlots} slot{emptySlots === 1 ? "" : "s"} empty ·{" "}
+          {totalRecipes} recipe{totalRecipes === 1 ? "" : "s"} planned
+        </p>
+        {suggestions.length > 0 && (
+          <div className="flex flex-wrap gap-2 justify-center">
+            {suggestions.map((s, i) => (
+              <span
+                key={i}
+                className="px-3 py-1.5 rounded-full border border-active-violet/20 bg-active-violet/5 text-active-violet font-mono text-[10px] uppercase tracking-wide flex items-center gap-1"
+                title={s.reason}
+              >
+                <span className="text-[9px]">✦</span>
+                <span className="max-w-[10rem] truncate">{s.reason}</span>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/menu-planner/redesign/elementUtils.ts
+++ b/src/components/menu-planner/redesign/elementUtils.ts
@@ -1,0 +1,51 @@
+/**
+ * Elemental display helpers for the redesigned weekly planner.
+ * Maps recipe elemental properties onto the app's element tokens
+ * (fire-spirit / water-essence / earth-matter / air-substance).
+ *
+ * @file src/components/menu-planner/redesign/elementUtils.ts
+ */
+
+export type ElementName = "Fire" | "Water" | "Earth" | "Air";
+
+/** Tailwind background tokens for the small per-meal element dot. */
+export const ELEMENT_DOT: Record<ElementName, string> = {
+  Fire: "bg-fire-spirit",
+  Water: "bg-water-essence",
+  Earth: "bg-earth-matter",
+  Air: "bg-air-substance",
+};
+
+/** Tailwind text tokens for element labels. */
+export const ELEMENT_TEXT: Record<ElementName, string> = {
+  Fire: "text-fire-spirit",
+  Water: "text-water-essence",
+  Earth: "text-earth-matter",
+  Air: "text-air-substance",
+};
+
+/**
+ * Read a normalized elemental record, tolerating both capitalized
+ * (Fire/Water/…) and lowercase (fire/water/…) keys.
+ */
+export function readElemental(
+  ep?: Record<string, number> | null,
+): Record<ElementName, number> {
+  return {
+    Fire: ep?.Fire ?? ep?.fire ?? 0,
+    Water: ep?.Water ?? ep?.water ?? 0,
+    Earth: ep?.Earth ?? ep?.earth ?? 0,
+    Air: ep?.Air ?? ep?.air ?? 0,
+  };
+}
+
+/** The dominant element of a recipe, or null when no elemental data is present. */
+export function dominantElement(
+  ep?: Record<string, number> | null,
+): ElementName | null {
+  if (!ep) return null;
+  const vals = readElemental(ep);
+  const entries = Object.entries(vals) as Array<[ElementName, number]>;
+  const max = entries.reduce((a, b) => (b[1] > a[1] ? b : a));
+  return max[1] > 0 ? max[0] : null;
+}


### PR DESCRIPTION
Three changes that had been sitting uncommitted in the working tree across multiple sessions, on a branch with no commits of its own. Committing them was the point; the code itself is unchanged from what was already built and visually verified.

## What's here

**`FastStartCard`** — a guided mobile empty state (diet chip, budget slider, portions) that loops `generateMealsForDay` across all seven days with a `Drafting… n/7` progress readout. This restores whole-week auto-planning on mobile, which was lost when `QuickActionsToolbar` went behind `hidden md:block`.

**`WeeklyInsights`** — replaces the legacy "Cycle Telemetry" panel, which was hardcoded fiction: `energyPct` fell back to `65`, `proteinPct` to `82`, `natalResonance` to `92`, and the elemental split to a flat `25/25/25/25`. The new panel reads `weeklyStats`, `weeklyBudget`, `estimatedWeeklyCost` and `getSuggestions` off the live provider, and degrades to an honest "Plan meals to see balance" when there is nothing to show.

**This is a net removal of placeholder data, not an addition of a surface.**

**`api/menu-planner/public-week`** — read-only current-week menus for Planetary Agent profiles, so an agent's authored week renders on its public profile.

## Two things worth a reviewer's eyes

**The endpoint is a new unauthenticated public surface.** It is gated on the `@agentic.alchm.kitchen` email domain rather than `users.is_agent` — deliberately. That flag covers ~4.7k rows including non-agentic emails, and every `weekly_menu` in production today is owned by an `is_agent=false` human, so trusting it would have published a real person's meal plan. `toPublicMeal()` is an explicit allowlist: `dayOfWeek`, `mealType`, `servings`, `isLocked`, and `{id, name, elementalProperties}`. Budgets, grocery lists, inventory and email are dropped despite being on the persisted row. The gate reads correct, but it is worth a second pair of eyes given what it would expose if ever loosened.

**Mobile whole-week generation now depends entirely on `FastStartCard`.** With `QuickActionsToolbar` behind `hidden md:block`, there is no fallback path on a phone. Deserves a real device check before it reaches users.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (17 pre-existing warnings elsewhere in `src`, none in these files)
- Zero file overlap with the 23 commits master gained while this sat uncommitted — the entire planetary-FBD / unified-physics workstream touched different paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)