### PR TITLE
feat(agents): §18 — real thermodynamic monica for planetary agents

### DIFF
--- a/database/init/70-agent-monica-sects.sql
+++ b/database/init/70-agent-monica-sects.sql
@@ -10,3 +10,21 @@
 
 ALTER TABLE user_profiles ADD COLUMN IF NOT EXISTS monica_diurnal NUMERIC(12,6);
 ALTER TABLE user_profiles ADD COLUMN IF NOT EXISTS monica_nocturnal NUMERIC(12,6);
+
+-- §18j (24-ruling disambiguation, 2026-07-21): a single-body agent, a two-body
+-- phase agent, and a full-chart person agent build monica_constant from three
+-- DIFFERENT constructions (one sect-resolved ESMS axis + a mass-4 vessel; two
+-- sect-resolved axes + one shared vessel; the full canonical engine with
+-- aspects). They share a column, so nothing can compare them as the same
+-- quantity without knowing which one produced a given row. This records which.
+ALTER TABLE user_profiles ADD COLUMN IF NOT EXISTS monica_method TEXT;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'monica_method_known'
+  ) THEN
+    ALTER TABLE user_profiles ADD CONSTRAINT monica_method_known
+      CHECK (monica_method IS NULL OR monica_method IN ('single-body', 'two-body', 'full-chart'));
+  END IF;
+END $$;

--- a/docs/physics/SYNTHESIS_MODEL.md
+++ b/docs/physics/SYNTHESIS_MODEL.md
@@ -1376,6 +1376,51 @@ in …` does not start with a planet word).
 `[AUTHORED]` Canonical convention remains **`Moon <Sign> <Deg>`** and **`<Phase>
 Moon in <Sign> <Deg>`** — but reaching it is a dedupe/merge, not a rename.
 
+#### 18g-bis. The census, forced to sum `[MEASURED 2026-07-21, second pass]`
+
+The correction above was reached independently by two sessions, which agreed on
+every structural finding. A second pass added one discipline: **make the buckets
+sum exactly to the row count.** A table that reconciles cannot be hiding a
+family — and forcing it immediately surfaced a row that had been hand-waved.
+
+| Bucket | n |
+|---|---|
+| single: `<Planet> in <Sign> <N> Degree` | 3240 |
+| single: `<Planet> <Sign> <N>` | 679 |
+| single: `<Planet> Agent <N>` (duplicate of an existing row) | 360 |
+| phase: `<Phase> Moon in <Sign> <N> Degree` | 360 |
+| phase: `Moon Phase <p> <N>` | 107 |
+| person / degreeless | 46 |
+| unresolved — not yet classified | 26 |
+| junk / test | 3 |
+| **sum** | **4821 = row count, exact** |
+
+Reconciliations against the figures above, which were correct when measured:
+
+- **Real-person agents: 71–72, not 74.** All of them **already have charts** — the
+  §18d claim that 363 needed charts computed is false, which makes the full-chart
+  pass far cheaper than recorded.
+- **`Moon Phase <p> N`: 107, not 85.** The population is live: **121 agents were
+  created in 2 days** mid-programme. Every count here is a snapshot with a date on
+  it; re-measure before acting, never carry a number forward.
+- **Single-body target: 4279** including the 360 duplicates, 3919 excluding them.
+  Both figures are correct — they differ only by whether the blocked duplicates
+  are counted. `[RULED]` the backfill uses **4279**: it is additive and must not
+  wait on a product ruling.
+- **72 rows remain unclassified** (46 + 26) and are `[OPEN]`. `[RULED]` they are
+  classified *before* the backfill runs — an unexamined bucket is exactly what
+  hid the 3240-row family the first time.
+- One row, **`Mars Gemini`**, is a planet and a sign with **no degree**. The
+  resolver skips it rather than defaulting the degree. It exists only because the
+  sum was forced.
+
+`[RULED 2026-07-21]` The `[OPEN]` duplicate question above is now **settled:
+merge-and-repoint.** Reassign the referencing `feed_events` and
+`user_subscriptions` rows to the canonical twin, then delete the duplicate — all
+feed history preserved, one agent per placement. A partial unique index on the
+agent name follows, so the class cannot recur. The 3 colliding `Moon Phase <p> N`
+rows take the same path; the other 104 are renamed.
+
 **Two-body phase monica** (the 720 phase-bearing moon agents): `[AUTHORED]` the
 phase fixes the Sun's approximate longitude (New = conjunct, Full = opposite, …);
 build ESMS from **both** bodies (each sect-resolved + vessel, §18c) and run the
@@ -1383,9 +1428,12 @@ canonical thermodynamics on the combined chart — a genuine two-body monica, no
 scaled single-body.
 
 **Junk cleanup:** remove obvious test/non-agent rows (`Alchemical Chef`, `Pa Prod
-Smoke …`, `Test …`), reporting the list before deleting. The 434 real-person names
-(Poe, Mozart, Cicero, Aristotle …) are the synthesized/historical agents → full-
-chart monica, a **follow-up** after the planetary backfill.
+Smoke …`, `Test …`), reporting the list before deleting. `[MEASURED]` There are
+exactly **3**, and one of them (`Test Sage Hildegard`) holds a `user_streaks` row,
+so this is not a clean three-row delete either. The real-person names are the
+synthesized/historical agents → full-chart monica, a **follow-up** after the
+planetary backfill; `[MEASURED]` there are **72** of them among the agent rows,
+not the 434 recorded in §18d.
 
 ### 18h. Backfill contract and MVP
 
@@ -1416,3 +1464,42 @@ same-program follow-ups, not the MVP gate.
   `ALTER TABLE` at the **start** of next session, confirm the columns, then run.
 - `persona.test.ts:92-93` asserts monica ∈ [0,10] and **will break** on the real
   [−4, 4] scale — update it in the same change.
+
+#### 18h-bis. Status `[MEASURED 2026-07-21]`
+
+**Write-fix: DONE.** All three sites now produce a real monica.
+`src/utils/agentMonicaResolver.ts` is the single shared name→placement parser.
+`agents/unified` writes the canonical **full-chart** monica (these agents carry
+real birth data, so §18d applies, not the single-body calc — the chart already
+fixes the sect, so the sect columns stay NULL for those rows).
+`sync-debit` computes WTEN-side from the agent's own name and no longer reads
+the payload's `monicaConstant` at all. `philosophers-stone` is a **client**
+component and cannot load the server-only engine (`RealAlchemizeService` imports
+`fs`); rather than fork a seventh engine into the browser bundle it stops
+fabricating — the preview seeds from `MONICA_EQUILIBRIUM` and the authoritative
+value is the one the server returns on forge. It was never persisted.
+158 suites / 1311 tests green, typecheck clean.
+
+**Backfill: written, dry-run verified, NOT yet applied.**
+`scripts/backfillAgentMonica.ts`, dry run by default.
+
+| | |
+|---|---|
+| agent rows scanned | 4808 |
+| to write (single-body) | **4278** (not the ~3600 estimated) |
+| skipped — phase (two-body follow-up) | 455 |
+| skipped — not a placement | 75 |
+| **non-finite** | **0** |
+| combined range | **[−3.1973, 3.9751]**, median 0.0573 |
+| distinct values / negative | 379 / 27.7% |
+
+**Verification passed on both required axes.** An *independent* re-derivation of
+§18c, written from the spec prose rather than from `agentMonica.ts`, agrees with
+the module to 1e-12 on all 8 spot cases. No sentinel clustering: the largest
+single value holds 5.0% of rows, against **36%** (1330 of 3672) sitting on `0.50`
+in the fake data being replaced.
+
+**Ordering hazard:** `sync-debit` now references `monica_diurnal` /
+`monica_nocturnal`, so `70-agent-monica-sects.sql` **must be applied before this
+branch deploys** or that route errors. The columns did not exist as of
+2026-07-21.

--- a/docs/physics/SYNTHESIS_MODEL.md
+++ b/docs/physics/SYNTHESIS_MODEL.md
@@ -1503,3 +1503,116 @@ in the fake data being replaced.
 `monica_nocturnal`, so `70-agent-monica-sects.sql` **must be applied before this
 branch deploys** or that route errors. The columns did not exist as of
 2026-07-21.
+
+### 18i. The two-body phase monica
+
+`[RULED 2026-07-21]` A phase agent is a Sun–Moon *relationship*, so it earns a
+genuine two-body monica rather than a scaled single-body one. Design, settled in
+the disambiguation session:
+
+- **Sun position** = `Moon − elongation`, at 45° midpoints across 8 phases:
+  New 0°, Waxing Crescent 45°, First Quarter 90°, Waxing Gibbous 135°, Full 180°,
+  Waning Gibbous 225°, Last Quarter 270°, Waning Crescent 315°.
+  **`Dark Moon` folds into New at 0°** — it names the invisible Moon at
+  conjunction and is not a ninth phase.
+- **Vessel:** ONE shared vessel, mass 4, **shaped by the Moon's degree only**.
+  The pair is one chart, so it gets one vessel, and the named body sets its
+  process. This keeps two-body results on the same scale as single-body ones.
+- **Sect:** both stored, exactly as single-body — the geometry is independent of
+  whether it expresses by day or night.
+- **Dignity:** the Moon carries its own position-based essential dignity. The Sun
+  carries **aspect-based dignity instead** — see §18i-bis.
+
+`[MEASURED]` The 469 phase agents by aspect: semi-square 158, sesquiquadrate 158,
+square 69, conjunction 47 (New + Dark Moon), opposition 37.
+
+#### 18i-bis. Per-aspect dignity for the derived Sun `[DERIVED]`
+
+The Sun's longitude is *inferred* from the phase name, but the **aspect is
+certain** — the name states it. Scaling a dignity multiplier by a guessed
+position would be compounding an inference; reading dignity off the aspect uses
+the one thing the name guarantees. So the Sun's dignity is aspect-based, feeding
+the same `× (1 + dignity/100)` vessel term as §18c.
+
+This needs no aspect ESMS grids, no orb budget and no aspect-strength curve —
+the parts §14d has not unified — because **phase aspects are exact by
+construction** (zero orb). It needs only a per-aspect dignity number.
+
+Both inputs are read from live code, so this is derived, not authored:
+
+```
+dignity = polarity × 10 × (orbBudget / 8)
+  polarity  : aspectCalculator.ts:210 — conjunction/trine/sextile harmonious (+),
+              opposition/square challenging (−)
+  orbBudget : aspectCalculator.ts aspectDefinitions — conjunction 8, opposition 8,
+              square 7, semi-square 3, sesquiquadrate 3
+```
+
+| Phase | Aspect | Dignity |
+|---|---|---|
+| New, Dark Moon | conjunction | **+10.00** |
+| Full | opposition | **−10.00** |
+| First / Last Quarter | square | **−8.75** |
+| Waxing / Waning Crescent | semi-square | **−3.75** |
+| Waxing / Waning Gibbous | sesquiquadrate | **−3.75** |
+
+Sanity property: ±10 land exactly on the domicile/fall anchors of the existing
++10/+7/0/−7/−10 essential-dignity scale, and square falls between detriment and
+fall rather than off the end.
+
+⚠️ **This is a MODEL CHANGE, not a gap-fill.** `aspectCalculator.ts:210` assigns
+`influence = 0` to semi-square and sesquiquadrate today — they are detected and
+then contribute nothing. Giving them dignity is a deliberate change to how the
+engine treats minor aspects. Recorded here so it is never mistaken for
+long-standing behaviour.
+
+`[NOT the underscore defect class]` `_semisquare` / `_sesquiquadrate` carry
+underscore-prefixed keys in `aspectDefinitions`, but `ASPECT_TYPE_ALIASES`
+(aspectCalculator.ts:56) maps them to canonical names, so they ARE live.
+`_septile` is the genuine dead key — no alias, no switch case, and because the
+detector picks a single best aspect *before* normalising, a near-exact septile
+(strength 1.0 at orb 0) makes the whole planet pair return no aspect at all.
+Tracked separately; not a §18 concern.
+
+#### 18i-ter. Applying vs separating `[OPEN — AUTHORED, not derived]`
+
+`[RULED]` Waxing and waning phases **must differ**, even though they share an
+aspect geometry, and applying/separating should become a **general** aspect-layer
+concept rather than a phase-only special case — feeding the §14d unification.
+
+Sequenced in two stages so it does not block the phase monica:
+1. Phase agents take it from the name (waxing = applying, waning = separating).
+   No engine change required.
+2. `calculateComprehensiveAspects` computes it from relative planetary motion,
+   generally, and feeds §14d.
+
+⚠️ **The magnitude of the applying/separating modifier has NO basis in the
+repo.** The orb budgets and the polarity convention gave §18i-bis its derivation;
+nothing comparable exists here (`orbMultiplier 1.2` is Sun/Moon-specific and
+unrelated). This value will be `[AUTHORED]` and is **the only unmeasured number
+left in the §18 design.** It needs either a derivation basis or an explicit
+ruling with the reasoning recorded — per §11, not an assertion.
+
+### 18j. Scope after the disambiguation `[RULED 2026-07-21]`
+
+Twenty-four rulings taken in one intervention session. The ones that change the
+build:
+
+| Area | Ruling |
+|---|---|
+| Backfill target | **4279** — include the 360 blocked duplicates; backfill is additive and independent of the de-dupe |
+| Phase agents | **Build two-body now** (§18i), not NULL-until-later |
+| Real people | All **71 already have charts** — the §18d claim that 363 needed computing was false. Full-chart monica this pass, separate PR |
+| Duplicates | **Merge**: reassign 1547 `feed_events` + 467 `user_subscriptions` to the canonical twin, then delete. Preserves feed history |
+| Schema | Partial unique index on agent name afterwards, so the class cannot recur |
+| Full-chart rows | Compute **both sects** for them too (reverses the earlier NULL ruling) |
+| Sacred-7 | **Rescale** `deriveStatsFromChart` — it reads `monica/10` on a [0,10] assumption and silently shifts every agent's stats once real monica lands |
+| Preview | Add a **server endpoint** for a live philosophers-stone monica (reverses the φ-seed already in the branch) |
+| Ship order | migrate → backfill → verify → merge |
+| Unknowns | Classify the 72 unresolved rows **before** backfilling |
+
+⚠️ **This is no longer an MVP.** §18 now covers **4817 of 4821** agent rows plus a
+merge-dedupe, a schema constraint, a new endpoint, a stats rescale and a general
+aspect-layer concept. Each ruling is defensible alone; together they are several
+PRs. If a smaller first cut is wanted, the natural one is **write-fix +
+single-body backfill**, which is already built and verified.

--- a/scripts/backfillAgentMonica.ts
+++ b/scripts/backfillAgentMonica.ts
@@ -1,0 +1,220 @@
+/**
+ * §18h — backfill the real single-body monica onto every planetary agent.
+ *
+ * The 3672 persisted "monica" values are not thermodynamic monicas. 3600 of them
+ * are round (0,1) sentinels (0.50 x1330, 0.55 x556, ...) that the sync-debit
+ * COALESCE let in from upstream; the rest hold a longitude average. This writes
+ * the real §18c value, computed from each agent's own name, to
+ * monica_diurnal / monica_nocturnal / monica_constant.
+ *
+ * DRY RUN BY DEFAULT — computes everything, prints the report, writes nothing.
+ * Pass --write to commit, inside one transaction.
+ *
+ *   railway run --service Postgres -- bun scripts/backfillAgentMonica.ts
+ *   railway run --service Postgres -- bun scripts/backfillAgentMonica.ts --write
+ *
+ * Idempotent: re-running writes the same values. Rows whose name is not a
+ * single-body placement (people, phase agents, junk) are SKIPPED and left NULL —
+ * never guessed at, never zeroed. Phase agents are a deliberate omission: a Moon
+ * phase is a Sun-Moon relationship and gets a genuine two-body monica in the
+ * §18 follow-up, not a single-body approximation.
+ *
+ * Requires database/init/70-agent-monica-sects.sql to have been applied.
+ */
+import pg from "pg";
+import { agentMonica } from "@/utils/agentMonica";
+import { parseAgentPlacement } from "@/utils/agentMonicaResolver";
+
+const WRITE = process.argv.includes("--write");
+
+interface Row {
+  user_id: string;
+  name: string;
+  monica_constant: string | null;
+}
+
+const client = new pg.Client({
+  connectionString: process.env.DATABASE_PUBLIC_URL,
+  ssl: { rejectUnauthorized: false },
+});
+await client.connect();
+
+// Fail loudly if the migration has not been applied, rather than writing nothing
+// and reporting success.
+const cols = await client.query<{ column_name: string }>(
+  `SELECT column_name FROM information_schema.columns
+    WHERE table_name = 'user_profiles'
+      AND column_name IN ('monica_diurnal', 'monica_nocturnal')`,
+);
+if (cols.rowCount !== 2) {
+  const msg =
+    `monica_diurnal / monica_nocturnal missing (found ${cols.rowCount} of 2). ` +
+    `Apply database/init/70-agent-monica-sects.sql first.`;
+  if (WRITE) {
+    console.error(`FATAL: ${msg}`);
+    await client.end();
+    process.exit(1);
+  }
+  console.warn(`WARNING: ${msg}\n(dry run continues — it only reads)\n`);
+}
+
+const { rows } = await client.query<Row>(
+  `SELECT up.user_id, up.name, up.monica_constant::text AS monica_constant
+     FROM user_profiles up JOIN users u ON u.id = up.user_id
+    WHERE u.is_agent AND up.name IS NOT NULL
+    ORDER BY up.name`,
+);
+
+interface Update {
+  user_id: string;
+  name: string;
+  before: string | null;
+  diurnal: number;
+  nocturnal: number;
+  combined: number;
+}
+
+const updates: Update[] = [];
+const skipped: Record<string, string[]> = { phase: [], unparseable: [] };
+const nonFinite: string[] = [];
+
+for (const r of rows) {
+  const p = parseAgentPlacement(r.name);
+  if (!p) {
+    skipped.unparseable.push(r.name);
+    continue;
+  }
+  if (p.kind !== "single") {
+    skipped.phase.push(r.name);
+    continue;
+  }
+  const m = agentMonica(p.planet, p.sign, p.degree);
+  if (![m.diurnal, m.nocturnal, m.combined].every(Number.isFinite)) {
+    nonFinite.push(r.name);
+    continue;
+  }
+  updates.push({
+    user_id: r.user_id,
+    name: r.name,
+    before: r.monica_constant,
+    ...m,
+  });
+}
+
+// ---------------------------------------------------------------- report ----
+console.log(`\n=== §18 backfill ${WRITE ? "WRITE" : "DRY RUN"} ===`);
+console.log(`agent rows scanned          : ${rows.length}`);
+console.log(`to write (single-body)      : ${updates.length}`);
+console.log(`skipped — phase (two-body)  : ${skipped.phase.length}`);
+console.log(`skipped — not a placement   : ${skipped.unparseable.length}`);
+console.log(`NON-FINITE (must be 0)      : ${nonFinite.length}`);
+if (nonFinite.length) {
+  console.error("FATAL: non-finite monica computed for:", nonFinite.slice(0, 20));
+  await client.end();
+  process.exit(1);
+}
+
+const vals = updates.map((u) => u.combined).sort((a, b) => a - b);
+const pct = (p: number) => vals[Math.floor((vals.length - 1) * p)];
+console.log(`\ncombined monica distribution:`);
+console.log(
+  `  min ${vals[0].toFixed(4)}  p10 ${pct(0.1).toFixed(4)}  median ${pct(0.5).toFixed(4)}` +
+    `  p90 ${pct(0.9).toFixed(4)}  max ${vals[vals.length - 1].toFixed(4)}`,
+);
+console.log(`  distinct values ${new Set(vals.map((v) => v.toFixed(6))).size}`);
+console.log(
+  `  negative ${vals.filter((v) => v < 0).length} (${((vals.filter((v) => v < 0).length / vals.length) * 100).toFixed(1)}%)`,
+);
+
+const byPlanet: Record<string, number[]> = {};
+for (const u of updates) {
+  const planet = parseAgentPlacement(u.name)!.planet;
+  (byPlanet[planet] ??= []).push(u.combined);
+}
+console.log(`\nper planet:`);
+console.table(
+  Object.fromEntries(
+    Object.entries(byPlanet).map(([k, v]) => [
+      k,
+      {
+        n: v.length,
+        min: Math.min(...v).toFixed(3),
+        max: Math.max(...v).toFixed(3),
+      },
+    ]),
+  ),
+);
+
+console.log(`\nbefore -> after, first 10:`);
+console.table(
+  updates.slice(0, 10).map((u) => ({
+    name: u.name,
+    before: u.before ?? "NULL",
+    diurnal: u.diurnal.toFixed(4),
+    nocturnal: u.nocturnal.toFixed(4),
+    combined: u.combined.toFixed(4),
+  })),
+);
+
+if (skipped.unparseable.length) {
+  console.log(`\nnot a placement — left untouched (first 30):`);
+  console.log("  " + skipped.unparseable.slice(0, 30).join("\n  "));
+}
+
+// ----------------------------------------------------------------- write ----
+if (!WRITE) {
+  console.log(`\nDRY RUN — nothing written. Re-run with --write to commit.`);
+  await client.end();
+  process.exit(0);
+}
+
+console.log(`\nwriting ${updates.length} rows in one transaction...`);
+await client.query("BEGIN");
+try {
+  // One statement, unnested arrays — 4276 rows in a single round trip.
+  await client.query(
+    `UPDATE user_profiles up SET
+       monica_diurnal   = v.diurnal,
+       monica_nocturnal = v.nocturnal,
+       monica_constant  = v.combined,
+       updated_at       = now()
+     FROM (
+       SELECT * FROM unnest(
+         $1::uuid[], $2::numeric[], $3::numeric[], $4::numeric[]
+       ) AS t(user_id, diurnal, nocturnal, combined)
+     ) v
+     WHERE up.user_id = v.user_id`,
+    [
+      updates.map((u) => u.user_id),
+      updates.map((u) => u.diurnal),
+      updates.map((u) => u.nocturnal),
+      updates.map((u) => u.combined),
+    ],
+  );
+  await client.query("COMMIT");
+  console.log("COMMIT ok");
+} catch (err) {
+  await client.query("ROLLBACK");
+  console.error("ROLLBACK —", err);
+  await client.end();
+  process.exit(1);
+}
+
+// --------------------------------------------------------------- verify ----
+const check = await client.query<{
+  n: string; non_finite: string; nulls: string; mn: string; mx: string;
+}>(
+  `SELECT count(*)                                                        AS n,
+          count(*) FILTER (WHERE NOT (monica_constant > -1e9
+                                  AND monica_constant <  1e9))            AS non_finite,
+          count(*) FILTER (WHERE monica_diurnal IS NULL
+                              OR monica_nocturnal IS NULL)                AS nulls,
+          min(monica_constant)::text                                      AS mn,
+          max(monica_constant)::text                                      AS mx
+     FROM user_profiles up JOIN users u ON u.id = up.user_id
+    WHERE u.is_agent AND up.monica_diurnal IS NOT NULL`,
+);
+console.log("\npost-write verification:");
+console.table(check.rows);
+
+await client.end();

--- a/scripts/backfillAgentMonica.ts
+++ b/scripts/backfillAgentMonica.ts
@@ -5,7 +5,11 @@
  * are round (0,1) sentinels (0.50 x1330, 0.55 x556, ...) that the sync-debit
  * COALESCE let in from upstream; the rest hold a longitude average. This writes
  * the real §18c value, computed from each agent's own name, to
- * monica_diurnal / monica_nocturnal / monica_constant.
+ * monica_diurnal / monica_nocturnal / monica_constant / monica_method.
+ * monica_method is stamped 'single-body' — single-body, two-body (phase) and
+ * full-chart (person) agents build monica from different constructions, so
+ * nothing downstream can compare values across populations without knowing
+ * which one produced a given row (§18j).
  *
  * DRY RUN BY DEFAULT — computes everything, prints the report, writes nothing.
  * Pass --write to commit, inside one transaction.
@@ -44,11 +48,11 @@ await client.connect();
 const cols = await client.query<{ column_name: string }>(
   `SELECT column_name FROM information_schema.columns
     WHERE table_name = 'user_profiles'
-      AND column_name IN ('monica_diurnal', 'monica_nocturnal')`,
+      AND column_name IN ('monica_diurnal', 'monica_nocturnal', 'monica_method')`,
 );
-if (cols.rowCount !== 2) {
+if (cols.rowCount !== 3) {
   const msg =
-    `monica_diurnal / monica_nocturnal missing (found ${cols.rowCount} of 2). ` +
+    `monica_diurnal / monica_nocturnal / monica_method missing (found ${cols.rowCount} of 3). ` +
     `Apply database/init/70-agent-monica-sects.sql first.`;
   if (WRITE) {
     console.error(`FATAL: ${msg}`);
@@ -177,6 +181,7 @@ try {
        monica_diurnal   = v.diurnal,
        monica_nocturnal = v.nocturnal,
        monica_constant  = v.combined,
+       monica_method    = 'single-body',
        updated_at       = now()
      FROM (
        SELECT * FROM unnest(
@@ -202,13 +207,14 @@ try {
 
 // --------------------------------------------------------------- verify ----
 const check = await client.query<{
-  n: string; non_finite: string; nulls: string; mn: string; mx: string;
+  n: string; non_finite: string; nulls: string; wrong_method: string; mn: string; mx: string;
 }>(
   `SELECT count(*)                                                        AS n,
           count(*) FILTER (WHERE NOT (monica_constant > -1e9
                                   AND monica_constant <  1e9))            AS non_finite,
           count(*) FILTER (WHERE monica_diurnal IS NULL
                               OR monica_nocturnal IS NULL)                AS nulls,
+          count(*) FILTER (WHERE monica_method IS DISTINCT FROM 'single-body') AS wrong_method,
           min(monica_constant)::text                                      AS mn,
           max(monica_constant)::text                                      AS mx
      FROM user_profiles up JOIN users u ON u.id = up.user_id

--- a/scripts/checkAgentMonicaDrift.ts
+++ b/scripts/checkAgentMonicaDrift.ts
@@ -1,0 +1,98 @@
+/**
+ * §18 drift check — has anything overwritten a backfilled agent monica?
+ *
+ * Recomputes every single-body agent's monica from its own name and compares
+ * against what is stored. Read-only, safe to run any time.
+ *
+ *   railway run --service Postgres -- bun scripts/checkAgentMonicaDrift.ts
+ *
+ * Exits non-zero if drift is found, so it can gate a deploy or run in CI.
+ *
+ * Why this exists: the backfill wrote corrected values to production from a
+ * feature branch, while production still ran the old fake-writing code — a
+ * window in which any PA/AlchmAgentsETH sync could silently undo it. The remedy
+ * for detected drift is to re-run `backfillAgentMonica.ts --write`, which is
+ * idempotent. (The pre-backfill snapshot table holds the OLD FAKE values and is
+ * forensic only — it is not a recovery path.)
+ */
+import pg from "pg";
+import { agentMonica } from "@/utils/agentMonica";
+import { parseAgentPlacement } from "@/utils/agentMonicaResolver";
+
+const TOLERANCE = 1e-5;
+
+const client = new pg.Client({
+  connectionString: process.env.DATABASE_PUBLIC_URL,
+  ssl: { rejectUnauthorized: false },
+});
+await client.connect();
+
+const { rows } = await client.query<{
+  name: string;
+  monica_constant: string | null;
+  monica_diurnal: string | null;
+  monica_nocturnal: string | null;
+  monica_method: string | null;
+  updated_at: string;
+}>(
+  `SELECT up.name, up.monica_constant::text, up.monica_diurnal::text,
+          up.monica_nocturnal::text, up.monica_method, up.updated_at::text
+     FROM user_profiles up JOIN users u ON u.id = up.user_id
+    WHERE u.is_agent AND up.name IS NOT NULL`,
+);
+await client.end();
+
+let single = 0;
+let drifted = 0;
+let missing = 0;
+let wrongMethod = 0;
+const examples: string[] = [];
+
+for (const r of rows) {
+  const p = parseAgentPlacement(r.name);
+  if (!p || p.kind !== "single") continue;
+  single++;
+
+  const fresh = agentMonica(p.planet, p.sign, p.degree);
+  const num = (v: string | null) => (v === null ? null : Number(v));
+  const [c, d, n] = [num(r.monica_constant), num(r.monica_diurnal), num(r.monica_nocturnal)];
+
+  if (c === null || d === null || n === null) {
+    missing++;
+    if (examples.length < 15) examples.push(`MISSING ${r.name} (updated_at ${r.updated_at})`);
+    continue;
+  }
+  if (
+    Math.abs(c - fresh.combined) > TOLERANCE ||
+    Math.abs(d - fresh.diurnal) > TOLERANCE ||
+    Math.abs(n - fresh.nocturnal) > TOLERANCE
+  ) {
+    drifted++;
+    if (examples.length < 15) {
+      examples.push(
+        `DRIFT ${r.name}: stored=${c} expected=${fresh.combined.toFixed(6)} (updated_at ${r.updated_at})`,
+      );
+    }
+  }
+  if (r.monica_method !== "single-body") {
+    wrongMethod++;
+    if (examples.length < 15) examples.push(`METHOD ${r.name}: ${r.monica_method ?? "NULL"}`);
+  }
+}
+
+console.log(`single-body agents checked : ${single}`);
+console.log(`drifted from real value    : ${drifted}`);
+console.log(`missing a monica column    : ${missing}`);
+console.log(`wrong/absent monica_method : ${wrongMethod}`);
+if (examples.length) console.log("\n" + examples.join("\n"));
+
+const bad = drifted + missing + wrongMethod;
+if (bad === 0) {
+  console.log("\nOK — every single-body agent matches a fresh computation.");
+} else {
+  console.error(
+    `\n*** ${bad} row(s) need attention. Remedy: re-run ` +
+      `\`backfillAgentMonica.ts --write\` (idempotent). ***`,
+  );
+  process.exit(1);
+}

--- a/scripts/dedupeAgentRows.ts
+++ b/scripts/dedupeAgentRows.ts
@@ -1,0 +1,174 @@
+/**
+ * §18g — remove the redundant duplicate agent rows and the junk rows.
+ *
+ * The spec calls for RENAMING `Moon Agent N` to `Moon <Sign> <Deg>`. Measured
+ * against production on 2026-07-21, that is the wrong operation: all 360 rename
+ * targets ALREADY EXIST. `Moon Agent N` (N = absolute ecliptic degree, 0-based)
+ * and `Moon <Sign> <Deg>` are two agents for the same 360 placements, so a
+ * rename would collide on every single row. It is a de-duplication, not a
+ * rename.
+ *
+ * Both families are inert — 360 rows each, 0 logins, 0 token_balance rows, and
+ * no bio / natal_chart / monica_constant / dominant_element on either side — so
+ * the `Moon Agent N` copy carries nothing the canonical row does not.
+ *
+ * Also removes the junk rows (`Alchemical Chef`, `Pa Prod Smoke ...`, `Test ...`).
+ *
+ * DRY RUN BY DEFAULT. Pass --write to delete, inside one transaction.
+ *
+ *   railway run --service Postgres -- bun scripts/dedupeAgentRows.ts
+ *   railway run --service Postgres -- bun scripts/dedupeAgentRows.ts --write
+ *
+ * Safety: before deleting anything it sweeps EVERY table with a foreign key to
+ * users(id) — 61 of them — and counts referencing rows. Any candidate that is
+ * referenced anywhere outside user_profiles / token_balances is REPORTED AND
+ * SKIPPED, never force-deleted. A row that turns out to be doing something stays.
+ */
+import pg from "pg";
+import { parseAgentPlacement } from "@/utils/agentMonicaResolver";
+
+const WRITE = process.argv.includes("--write");
+
+/** Referencing rows in these tables do not block a delete — they are the agent's
+ *  own scaffolding, removed with it. Everything else means the row is in use. */
+const OWN_SCAFFOLDING = new Set(["user_profiles", "token_balances"]);
+
+const JUNK = /^(Alchemical Chef$|Pa Prod Smoke |Test )/;
+
+const client = new pg.Client({
+  connectionString: process.env.DATABASE_PUBLIC_URL,
+  ssl: { rejectUnauthorized: false },
+});
+await client.connect();
+
+const { rows: agents } = await client.query<{ user_id: string; name: string }>(
+  `SELECT up.user_id, up.name FROM user_profiles up JOIN users u ON u.id = up.user_id
+    WHERE u.is_agent AND up.name IS NOT NULL`,
+);
+const existingNames = new Set(agents.map((a) => a.name));
+
+// ------------------------------------------------------- pick candidates ----
+interface Candidate { user_id: string; name: string; why: string }
+const candidates: Candidate[] = [];
+
+for (const a of agents) {
+  if (JUNK.test(a.name)) {
+    candidates.push({ user_id: a.user_id, name: a.name, why: "junk/test row" });
+    continue;
+  }
+  // A `<Planet> Agent <N>` row is redundant only if its canonical twin exists.
+  if (/^[A-Za-z]+ Agent \d+$/.test(a.name)) {
+    const p = parseAgentPlacement(a.name);
+    if (p?.canonicalName && existingNames.has(p.canonicalName)) {
+      candidates.push({
+        user_id: a.user_id,
+        name: a.name,
+        why: `duplicate of "${p.canonicalName}"`,
+      });
+    }
+  }
+}
+
+console.log(`\n=== §18g dedupe ${WRITE ? "WRITE" : "DRY RUN"} ===`);
+console.log(`agent rows scanned : ${agents.length}`);
+console.log(`delete candidates  : ${candidates.length}`);
+const byWhy: Record<string, number> = {};
+for (const c of candidates) {
+  const k = c.why.startsWith("duplicate") ? "duplicate of canonical twin" : c.why;
+  byWhy[k] = (byWhy[k] ?? 0) + 1;
+}
+console.table(byWhy);
+console.log(`\njunk rows:`);
+candidates.filter((c) => c.why === "junk/test row").forEach((c) => console.log(`  ${c.name}`));
+console.log(`\nduplicates, first 5:`);
+candidates.filter((c) => c.why !== "junk/test row").slice(0, 5)
+  .forEach((c) => console.log(`  ${c.name}  ->  ${c.why}`));
+
+if (!candidates.length) {
+  console.log("\nnothing to do.");
+  await client.end();
+  process.exit(0);
+}
+
+// ------------------------------------------------------------- FK sweep -----
+const { rows: fks } = await client.query<{ table_name: string; column_name: string }>(
+  `SELECT DISTINCT tc.table_name, kcu.column_name
+     FROM information_schema.table_constraints tc
+     JOIN information_schema.key_column_usage kcu
+       ON tc.constraint_name = kcu.constraint_name
+     JOIN information_schema.constraint_column_usage ccu
+       ON tc.constraint_name = ccu.constraint_name
+    WHERE tc.constraint_type = 'FOREIGN KEY' AND ccu.table_name = 'users'
+    ORDER BY 1, 2`,
+);
+console.log(`\nsweeping ${fks.length} foreign keys into users(id)...`);
+
+const ids = candidates.map((c) => c.user_id);
+const blocked = new Map<string, string[]>(); // user_id -> ["table.column", ...]
+const hits: { table: string; column: string; n: number; blocking: boolean }[] = [];
+
+for (const fk of fks) {
+  const { rows } = await client.query<{ id: string }>(
+    `SELECT DISTINCT "${fk.column_name}"::text AS id
+       FROM "${fk.table_name}" WHERE "${fk.column_name}" = ANY($1::uuid[])`,
+    [ids],
+  );
+  if (!rows.length) continue;
+  const blocking = !OWN_SCAFFOLDING.has(fk.table_name);
+  hits.push({ table: fk.table_name, column: fk.column_name, n: rows.length, blocking });
+  if (blocking) {
+    for (const r of rows) {
+      const list = blocked.get(r.id) ?? [];
+      list.push(`${fk.table_name}.${fk.column_name}`);
+      blocked.set(r.id, list);
+    }
+  }
+}
+console.log(`\nreferences found:`);
+console.table(hits.map((h) => ({
+  table: h.table, column: h.column, candidates_referenced: h.n,
+  verdict: h.blocking ? "BLOCKS DELETE" : "own scaffolding",
+})));
+
+const safe = candidates.filter((c) => !blocked.has(c.user_id));
+const skipped = candidates.filter((c) => blocked.has(c.user_id));
+console.log(`\nsafe to delete : ${safe.length}`);
+console.log(`SKIPPED (in use): ${skipped.length}`);
+skipped.slice(0, 20).forEach((c) =>
+  console.log(`  ${c.name} — referenced by ${blocked.get(c.user_id)!.join(", ")}`),
+);
+
+if (!WRITE) {
+  console.log(`\nDRY RUN — nothing deleted. Re-run with --write to commit.`);
+  await client.end();
+  process.exit(0);
+}
+if (!safe.length) {
+  console.log("\nnothing safe to delete.");
+  await client.end();
+  process.exit(0);
+}
+
+// -------------------------------------------------------------- delete ------
+const safeIds = safe.map((c) => c.user_id);
+console.log(`\ndeleting ${safeIds.length} rows in one transaction...`);
+await client.query("BEGIN");
+try {
+  await client.query(`DELETE FROM token_balances WHERE user_id = ANY($1::uuid[])`, [safeIds]);
+  await client.query(`DELETE FROM user_profiles WHERE user_id = ANY($1::uuid[])`, [safeIds]);
+  const del = await client.query(`DELETE FROM users WHERE id = ANY($1::uuid[])`, [safeIds]);
+  await client.query("COMMIT");
+  console.log(`COMMIT ok — ${del.rowCount} users rows deleted`);
+} catch (err) {
+  await client.query("ROLLBACK");
+  console.error("ROLLBACK —", err);
+  await client.end();
+  process.exit(1);
+}
+
+const after = await client.query<{ n: string }>(
+  `SELECT count(*)::text AS n FROM user_profiles up JOIN users u ON u.id = up.user_id
+    WHERE u.is_agent`,
+);
+console.log(`agents remaining: ${after.rows[0].n}`);
+await client.end();

--- a/scripts/snapshotAgentMonica.ts
+++ b/scripts/snapshotAgentMonica.ts
@@ -1,0 +1,58 @@
+/**
+ * §18h safety net — snapshot every agent's current monica_* columns to a
+ * timestamped side table before the backfill writes anything.
+ *
+ * Read + one CREATE/INSERT, no mutation of user_profiles. Idempotent: running
+ * it twice creates two distinctly-named tables (timestamp in the name), never
+ * overwrites a prior snapshot.
+ *
+ *   railway run --service Postgres -- bun scripts/snapshotAgentMonica.ts
+ *
+ * To restore a row from a snapshot:
+ *   UPDATE user_profiles up SET
+ *     monica_constant = s.monica_constant,
+ *     monica_diurnal = s.monica_diurnal,
+ *     monica_nocturnal = s.monica_nocturnal,
+ *     monica_method = s.monica_method
+ *   FROM agent_monica_snapshot_<timestamp> s
+ *   WHERE up.user_id = s.user_id;
+ */
+import pg from "pg";
+
+const client = new pg.Client({
+  connectionString: process.env.DATABASE_PUBLIC_URL,
+  ssl: { rejectUnauthorized: false },
+});
+await client.connect();
+
+// Deterministic-enough for a single manual run: seconds since epoch, embedded
+// in the table name. No Date.now() ambiguity concerns here — this is a script,
+// not a workflow body.
+const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\..+/, "").replace("T", "_");
+const tableName = `agent_monica_snapshot_${stamp}`;
+
+// Guard: table names can't be parameterized, so validate the derived name is
+// exactly the safe shape we generated before interpolating it.
+if (!/^agent_monica_snapshot_\d{8}_\d{6}$/.test(tableName)) {
+  throw new Error(`unexpected snapshot table name shape: ${tableName}`);
+}
+
+console.log(`Creating ${tableName}...`);
+await client.query(`
+  CREATE TABLE ${tableName} AS
+  SELECT up.user_id, up.name, u.is_agent,
+         up.monica_constant, up.monica_diurnal, up.monica_nocturnal, up.monica_method,
+         now() AS snapshotted_at
+    FROM user_profiles up JOIN users u ON u.id = up.user_id
+`);
+
+const { rows } = await client.query<{ n: string; agents: string; with_monica: string }>(
+  `SELECT count(*)::text AS n,
+          count(*) FILTER (WHERE is_agent)::text AS agents,
+          count(*) FILTER (WHERE monica_constant IS NOT NULL)::text AS with_monica
+     FROM ${tableName}`,
+);
+console.log(`Snapshotted: ${rows[0].n} total rows (${rows[0].agents} agents, ${rows[0].with_monica} with a monica_constant).`);
+console.log(`Table: ${tableName}`);
+
+await client.end();

--- a/src/__tests__/utils/agentMonicaResolver.test.ts
+++ b/src/__tests__/utils/agentMonicaResolver.test.ts
@@ -1,0 +1,131 @@
+/**
+ * §18e — the agent-name parser that feeds the three monica write sites and the
+ * backfill. The shapes and counts asserted here were measured against all 4800
+ * production agent rows on 2026-07-21; see agentMonicaResolver.ts for the table.
+ */
+import {
+  agentMonicaFromName,
+  parseAgentPlacement,
+} from "@/utils/agentMonicaResolver";
+
+describe("parseAgentPlacement", () => {
+  it("parses the dominant `<Planet> in <Sign> <N> Degree` family", () => {
+    expect(parseAgentPlacement("Jupiter in Aquarius 0 Degree")).toEqual({
+      kind: "single",
+      planet: "Jupiter",
+      sign: "Aquarius",
+      degree: 0,
+      canonicalName: "Jupiter Aquarius 0",
+    });
+  });
+
+  it("parses the already-canonical `<Planet> <Sign> <N>` family", () => {
+    const p = parseAgentPlacement("Mercury Aquarius 16");
+    expect(p).toMatchObject({
+      kind: "single",
+      planet: "Mercury",
+      sign: "Aquarius",
+      degree: 16,
+    });
+    expect(p?.canonicalName).toBeUndefined();
+  });
+
+  it("reads `<Planet> Agent <N>` as an absolute ecliptic degree, 0-based", () => {
+    // 0 -> Aries 0; 100 -> Cancer 10 (floor(100/30) = 3 -> Cancer, 100 % 30 = 10)
+    expect(parseAgentPlacement("Moon Agent 0")).toMatchObject({
+      sign: "Aries",
+      degree: 0,
+      canonicalName: "Moon Aries 0",
+    });
+    expect(parseAgentPlacement("Moon Agent 100")).toMatchObject({
+      sign: "Cancer",
+      degree: 10,
+    });
+    expect(parseAgentPlacement("Moon Agent 359")).toMatchObject({
+      sign: "Pisces",
+      degree: 29,
+    });
+  });
+
+  it("does NOT read `Agent` as a zodiac sign", () => {
+    // The trap: "Moon Agent 5" has the same <word> <word> <number> shape as
+    // "Mercury Aquarius 16". A shape-only parser yields sign="Agent".
+    const p = parseAgentPlacement("Moon Agent 5");
+    expect(p?.sign).toBe("Aries");
+    expect(SIGNS_SEEN(p?.sign)).toBe(true);
+  });
+
+  it("classifies phase agents as `phase`, not single-body", () => {
+    expect(parseAgentPlacement("First Quarter Moon in Cancer 0 Degree")).toEqual({
+      kind: "phase",
+      planet: "Moon",
+      sign: "Cancer",
+      degree: 0,
+      phase: "First Quarter",
+    });
+    expect(parseAgentPlacement("Moon Phase First Quarter 0")).toMatchObject({
+      kind: "phase",
+      phase: "First Quarter",
+      sign: "Aries",
+      degree: 0,
+      canonicalName: "First Quarter Moon in Aries 0 Degree",
+    });
+  });
+
+  it("returns null for people, test rows and junk — never guesses", () => {
+    for (const name of [
+      "Edgar Allan Poe",
+      "Wolfgang Amadeus Mozart",
+      "Alchemical Chef",
+      "Pa Prod Smoke 1779396999",
+      "Confucius (Kong Qiu)",
+      "Alexander the Great",
+      "Mars Gemini", // no degree
+      "",
+    ]) {
+      expect(parseAgentPlacement(name)).toBeNull();
+    }
+  });
+
+  it("tolerates casing and extra whitespace", () => {
+    expect(parseAgentPlacement("  venus   TAURUS  12  ")).toMatchObject({
+      planet: "Venus",
+      sign: "Taurus",
+      degree: 12,
+    });
+  });
+});
+
+describe("agentMonicaFromName", () => {
+  it("returns a finite three-part monica for a single-body agent", () => {
+    const m = agentMonicaFromName("Jupiter in Aquarius 0 Degree");
+    expect(m).not.toBeNull();
+    expect(Number.isFinite(m!.diurnal)).toBe(true);
+    expect(Number.isFinite(m!.nocturnal)).toBe(true);
+    expect(m!.combined).toBeCloseTo((m!.diurnal + m!.nocturnal) / 2, 12);
+  });
+
+  it("agrees across the equivalent spellings of one placement", () => {
+    const a = agentMonicaFromName("Moon Aries 0");
+    const b = agentMonicaFromName("Moon in Aries 0 Degree");
+    const c = agentMonicaFromName("Moon Agent 0");
+    expect(a).toEqual(b);
+    expect(a).toEqual(c);
+  });
+
+  it("returns null for phase agents — two-body monica is a follow-up", () => {
+    expect(agentMonicaFromName("First Quarter Moon in Cancer 0 Degree")).toBeNull();
+  });
+
+  it("returns null, not zero, for a non-placement name", () => {
+    expect(agentMonicaFromName("Edgar Allan Poe")).toBeNull();
+  });
+});
+
+/** Guard for the test above: the parsed sign must be a real zodiac sign. */
+function SIGNS_SEEN(sign: string | undefined): boolean {
+  return [
+    "Aries", "Taurus", "Gemini", "Cancer", "Leo", "Virgo",
+    "Libra", "Scorpio", "Sagittarius", "Capricorn", "Aquarius", "Pisces",
+  ].includes(sign ?? "");
+}

--- a/src/app/(alchm)/philosophers-stone/page.tsx
+++ b/src/app/(alchm)/philosophers-stone/page.tsx
@@ -30,6 +30,7 @@ import { Label } from '@/components/ui/label'
 import { Progress } from '@/components/ui/progress'
 import { Slider } from '@/components/ui/slider'
 import { Textarea } from '@/components/ui/textarea'
+import { MONICA_EQUILIBRIUM } from '@/data/unified/alchemicalCalculations'
 import { downloadManifest, downloadIgnitionBundle } from '@/lib/agents/ignition-bundle-generator'
 import { calculateAllPlanets } from '@/lib/enhanced-astronomical-calculator'
 import type { EnhancedBirthInfo } from '@/lib/enhanced-astronomical-calculator'
@@ -196,7 +197,15 @@ export default function ModernPhilosophersStone() {
       const venusLongitude = chartResult.planets.Venus?.longitude || 180
       const marsLongitude = chartResult.planets.Mars?.longitude || 180
       const ascLongitude = chartResult.ascendant.longitude
-      const monicaConstant = ((sunLongitude + moonLongitude + ascLongitude) / 3 / 360) * 10
+
+      // §18e — this preview no longer fabricates a monica. The old
+      // ((sun + moon + asc) / 3 / 360) * 10 was a longitude average wearing the
+      // name; a real monica needs the canonical thermodynamic engine, which is
+      // server-only (RealAlchemizeService imports `fs`). Rather than fork a
+      // seventh engine into the client bundle, the preview seeds from the
+      // canonical equilibrium constant and the AUTHORITATIVE value is the one
+      // /api/agents/unified computes and returns when the agent is forged.
+      const monicaConstant = MONICA_EQUILIBRIUM
 
       const derivedStats = deriveStatsFromChart({
         monicaConstant,
@@ -216,7 +225,7 @@ export default function ModernPhilosophersStone() {
       }))
 
       addMonicaMessage(
-        `Beautiful! Chart calculated: Sun in ${chartResult.planets.Sun.sign}, Moon in ${chartResult.planets.Moon.sign}, Ascendant in ${chartResult.ascendant.sign}. Monica Constant: ${monicaConstant.toFixed(2)}. I've derived initial stats from the chart - you can adjust them in Step 3!`
+        `Beautiful! Chart calculated: Sun in ${chartResult.planets.Sun.sign}, Moon in ${chartResult.planets.Moon.sign}, Ascendant in ${chartResult.ascendant.sign}. Your Monica Constant is computed when the agent is forged. I've derived initial stats from the chart - you can adjust them in Step 3!`
       )
     } catch (error) {
       console.error('Chart calculation error:', error)

--- a/src/app/api/agents/unified/route.ts
+++ b/src/app/api/agents/unified/route.ts
@@ -6,6 +6,7 @@ import { executeQuery } from "@/lib/database";
 import { rateLimit } from "@/lib/rateLimit";
 import { getServiceUrlSafe } from "@/lib/serviceUrls";
 import { calculateNatalChart } from "@/services/natalChartService";
+import { alchemize, type PlanetaryPosition } from "@/services/RealAlchemizeService";
 import type { NextRequest} from "next/server";
 
 export const dynamic = "force-dynamic";
@@ -168,9 +169,23 @@ export async function POST(request: NextRequest) {
         const ascIdx = SIGN_ORDER.indexOf(serverChart.ascendant);
         formattedChart.ascendant = ascIdx >= 0 ? ascIdx * 30 : 0;
 
-        const sunLong = serverChart.planets.find(p => p.name === 'Sun')?.position || 0;
-        const moonLong = serverChart.planets.find(p => p.name === 'Moon')?.position || 0;
-        const monicaConstant = ((sunLong + moonLong + formattedChart.ascendant) / 3 / 360) * 10;
+        // §18e — a real thermodynamic monica from the whole chart, via the
+        // canonical engine. This replaces a longitude average
+        // (((sun + moon + asc) / 3 / 360) * 10), which shared nothing with the
+        // monica formula but its name. Agents created here carry real birth
+        // data, so they get the FULL-CHART monica of §18d, not the single-body
+        // calc; the chart already fixes the sect, so the monica_diurnal /
+        // monica_nocturnal columns stay NULL for these rows.
+        const chartPositions: Record<string, PlanetaryPosition> = {};
+        serverChart.planets.forEach((p) => {
+          chartPositions[p.name] = {
+            sign: String(p.sign).toLowerCase(),
+            degree: p.position % 30,
+            minute: 0,
+            exactLongitude: p.position,
+          };
+        });
+        const monicaConstant = alchemize(chartPositions).monica;
 
         const agentId = randomUUID();
         const email = `agent-${name.toLowerCase().replace(/[^a-z0-9]/g, "-")}-${randomUUID().slice(0, 8)}@agentic.alchm.kitchen`;

--- a/src/app/api/agents/unified/route.ts
+++ b/src/app/api/agents/unified/route.ts
@@ -212,8 +212,8 @@ export async function POST(request: NextRequest) {
 
         await executeQuery(
           `INSERT INTO user_profiles (
-             user_id, name, bio, birth_data, natal_chart, natal_positions, monica_constant, dominant_element, created_at, updated_at
-           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now(), now())`,
+             user_id, name, bio, birth_data, natal_chart, natal_positions, monica_constant, monica_method, dominant_element, created_at, updated_at
+           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, now(), now())`,
           [
             agentId,
             name,
@@ -222,6 +222,11 @@ export async function POST(request: NextRequest) {
             JSON.stringify(formattedChart),
             JSON.stringify(formattedChart.planets || {}),
             monicaConstant,
+            // §18j — this agent has a real birth chart, so monica_constant is
+            // built by the full-chart engine (alchemize()), not the single-body
+            // or two-body construction. monica_diurnal/nocturnal are left NULL
+            // here pending the both-sects reversal tracked separately.
+            "full-chart",
             dominantElement
           ]
         );

--- a/src/app/api/economy/sync-debit/route.ts
+++ b/src/app/api/economy/sync-debit/route.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import { NextResponse, type NextRequest } from "next/server";
 import { executeQuery } from "@/lib/database";
+import { agentMonicaFromName } from "@/utils/agentMonicaResolver";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -165,7 +166,16 @@ export async function POST(req: NextRequest) {
         (ap.monicaCreationStory as string | undefined) ||
         null;
       const dominantElementCandidate = (ap.dominantElement as string | undefined) ?? null;
-      const monicaCandidate = (ap.monicaConstant as number | string | undefined) ?? null;
+
+      // §18e/§18h — WTEN owns the monica. It is computed here from the agent's
+      // OWN name, never taken from the AlchmAgentsETH payload: the old
+      // `COALESCE(payload.monicaConstant, ...)` is how 3600 rows came to hold
+      // round (0,1) sentinels that were never a thermodynamic monica at all.
+      // A name that is not a single-body placement yields null, which the
+      // COALESCE below reads as "leave the stored value alone".
+      const agentName = (ap.name as string | undefined) ?? null;
+      const resolvedMonica = agentName ? agentMonicaFromName(agentName) : null;
+      const monicaCandidate = resolvedMonica?.combined ?? null;
       const hasNatalChart =
         ap.natalChart && typeof ap.natalChart === "object" && Object.keys(ap.natalChart).length > 0;
       const hasNatalPositions = Array.isArray(ap.natalPositions) && (ap.natalPositions as unknown[]).length > 0;
@@ -180,6 +190,8 @@ export async function POST(req: NextRequest) {
            natal_positions  = CASE WHEN $5::boolean THEN $6::jsonb ELSE natal_positions END,
            dominant_element = COALESCE($7, dominant_element),
            monica_constant  = COALESCE($8::numeric, monica_constant),
+           monica_diurnal   = COALESCE($11::numeric, monica_diurnal),
+           monica_nocturnal = COALESCE($12::numeric, monica_nocturnal),
            birth_data       = CASE WHEN $9::boolean THEN $10::jsonb ELSE birth_data END,
            updated_at       = now()
          WHERE user_id = $1`,
@@ -198,6 +210,8 @@ export async function POST(req: NextRequest) {
             time: ap.birthTime ?? null,
             location: ap.birthLocation ?? null,
           }),
+          resolvedMonica?.diurnal ?? null,
+          resolvedMonica?.nocturnal ?? null,
         ]
       );
     }

--- a/src/app/api/economy/sync-debit/route.ts
+++ b/src/app/api/economy/sync-debit/route.ts
@@ -192,6 +192,7 @@ export async function POST(req: NextRequest) {
            monica_constant  = COALESCE($8::numeric, monica_constant),
            monica_diurnal   = COALESCE($11::numeric, monica_diurnal),
            monica_nocturnal = COALESCE($12::numeric, monica_nocturnal),
+           monica_method    = COALESCE($13, monica_method),
            birth_data       = CASE WHEN $9::boolean THEN $10::jsonb ELSE birth_data END,
            updated_at       = now()
          WHERE user_id = $1`,
@@ -212,6 +213,10 @@ export async function POST(req: NextRequest) {
           }),
           resolvedMonica?.diurnal ?? null,
           resolvedMonica?.nocturnal ?? null,
+          // agentMonicaFromName only resolves single-body placements (it
+          // returns null for phase agents), so a resolved value is always
+          // this method — see §18j.
+          resolvedMonica ? "single-body" : null,
         ]
       );
     }

--- a/src/app/api/internal/agent-sync/__tests__/route.test.ts
+++ b/src/app/api/internal/agent-sync/__tests__/route.test.ts
@@ -12,6 +12,7 @@ jest.mock("next/server", () => ({
 }));
 
 import { withTransaction } from "@/lib/database";
+import { agentMonica } from "@/utils/agentMonica";
 import { POST } from "../route";
 
 jest.mock("@/lib/database", () => ({
@@ -181,5 +182,87 @@ describe("POST /api/internal/agent-sync", () => {
       expect.stringContaining("INSERT INTO user_profiles"),
       expect.any(Array)
     );
+  });
+
+  // §18j — the 4th write path. This endpoint used to trust `monicaConstant`
+  // straight from the sync payload (PA's own legacy, disconnected, unsigned
+  // formula) via a bare parseFloat. It now computes it server-side from the
+  // agent's own name, the same way sync-debit and agents/unified do — WTEN
+  // owns the truth regardless of what the payload claims.
+  describe("monica is computed server-side, not trusted from the payload", () => {
+    function captureUserProfilesParams(mockClient: { query: jest.Mock }): unknown[] {
+      const call = mockClient.query.mock.calls.find(([sql]: [string]) =>
+        sql.includes("INSERT INTO user_profiles")
+      );
+      if (!call) throw new Error("INSERT INTO user_profiles was never called");
+      return call[1];
+    }
+
+    it("ignores an untrusted monicaConstant and writes the real single-body value instead", async () => {
+      const mockClient = {
+        query: jest.fn().mockImplementation((queryStr: string) => {
+          if (queryStr.includes("SELECT id FROM users")) {
+            return Promise.resolve({ rows: [] }); // new user
+          }
+          return Promise.resolve({ rowCount: 1, rows: [] });
+        }),
+      };
+      (withTransaction as jest.Mock).mockImplementation(async (callback) => {
+        await callback(mockClient);
+      });
+
+      // A resolvable single-body placement, canonical name form.
+      const body = {
+        email: "jupiter-leo-2@agentic.alchm.kitchen",
+        displayName: "Jupiter Leo 2",
+        // A hostile/stale value from PA's own legacy formula — must NOT
+        // survive into the stored row.
+        monicaConstant: "999.999",
+      };
+
+      const res = await POST(makeRequest(body, { "X-Sync-Secret": mockSyncSecret }));
+      expect((await res.json()).ok).toBe(true);
+
+      const params = captureUserProfilesParams(mockClient);
+      const expected = agentMonica("Jupiter", "Leo", 2);
+
+      // monica_constant (index 6): the real computed value, not the payload's.
+      expect(params[6]).not.toBe("999.999");
+      expect(params[6]).toBeCloseTo(expected.combined, 10);
+      // monica_diurnal / monica_nocturnal (indices 7, 8).
+      expect(params[7]).toBeCloseTo(expected.diurnal, 10);
+      expect(params[8]).toBeCloseTo(expected.nocturnal, 10);
+      // monica_method (index 9).
+      expect(params[9]).toBe("single-body");
+    });
+
+    it("stores null (not the payload value) for a name that isn't a placement", async () => {
+      const mockClient = {
+        query: jest.fn().mockImplementation((queryStr: string) => {
+          if (queryStr.includes("SELECT id FROM users")) {
+            return Promise.resolve({ rows: [] });
+          }
+          return Promise.resolve({ rowCount: 1, rows: [] });
+        }),
+      };
+      (withTransaction as jest.Mock).mockImplementation(async (callback) => {
+        await callback(mockClient);
+      });
+
+      const body = {
+        email: "hildegard@agentic.alchm.kitchen",
+        displayName: "Hildegard of Bingen", // a real person, not a placement
+        monicaConstant: "1.618033", // must not pass through either
+      };
+
+      const res = await POST(makeRequest(body, { "X-Sync-Secret": mockSyncSecret }));
+      expect((await res.json()).ok).toBe(true);
+
+      const params = captureUserProfilesParams(mockClient);
+      expect(params[6]).toBeNull(); // monica_constant
+      expect(params[7]).toBeNull(); // monica_diurnal
+      expect(params[8]).toBeNull(); // monica_nocturnal
+      expect(params[9]).toBeNull(); // monica_method
+    });
   });
 });

--- a/src/app/api/internal/agent-sync/route.ts
+++ b/src/app/api/internal/agent-sync/route.ts
@@ -11,6 +11,7 @@
 import { randomUUID } from "crypto";
 import { NextResponse, type NextRequest } from "next/server";
 import { withTransaction } from "@/lib/database";
+import { agentMonicaFromName } from "@/utils/agentMonicaResolver";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -111,9 +112,17 @@ export async function POST(req: NextRequest) {
     }
 
     const resolvedName = displayName?.trim() || email.split("@")[0];
-    const parsedMonicaConstant = monicaConstant !== undefined && monicaConstant !== null && monicaConstant !== ""
-      ? parseFloat(String(monicaConstant))
-      : null;
+    // §18j — WTEN computes its own monica from the agent's own name, the same
+    // way sync-debit and agents/unified do. This endpoint used to trust
+    // `monicaConstant` straight from the sync payload (PA's own legacy,
+    // unsigned, disconnected formula) via a bare parseFloat with no
+    // validation — a fourth write path the original three-site §18e fix
+    // missed. `agentMonicaFromName` only resolves single-body placements and
+    // returns null for anything else (a phase agent, a person), which the
+    // COALESCE below reads as "leave the stored value alone."
+    void monicaConstant; // intentionally ignored — see comment above
+    const resolvedMonica = agentMonicaFromName(resolvedName);
+    const parsedMonicaConstant = resolvedMonica?.combined ?? null;
 
     const userProfilePayload = {
       email,
@@ -153,8 +162,8 @@ export async function POST(req: NextRequest) {
         // Upsert user profile
         await client.query(
           `INSERT INTO user_profiles (
-             user_id, name, bio, birth_data, natal_chart, natal_positions, monica_constant, dominant_element
-           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+             user_id, name, bio, birth_data, natal_chart, natal_positions, monica_constant, monica_diurnal, monica_nocturnal, monica_method, dominant_element
+           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
            ON CONFLICT (user_id) DO UPDATE SET
              name = COALESCE(EXCLUDED.name, user_profiles.name),
              bio = COALESCE(EXCLUDED.bio, user_profiles.bio),
@@ -162,6 +171,9 @@ export async function POST(req: NextRequest) {
              natal_chart = COALESCE(EXCLUDED.natal_chart, user_profiles.natal_chart),
              natal_positions = COALESCE(EXCLUDED.natal_positions, user_profiles.natal_positions),
              monica_constant = COALESCE(EXCLUDED.monica_constant, user_profiles.monica_constant),
+             monica_diurnal = COALESCE(EXCLUDED.monica_diurnal, user_profiles.monica_diurnal),
+             monica_nocturnal = COALESCE(EXCLUDED.monica_nocturnal, user_profiles.monica_nocturnal),
+             monica_method = COALESCE(EXCLUDED.monica_method, user_profiles.monica_method),
              dominant_element = COALESCE(EXCLUDED.dominant_element, user_profiles.dominant_element),
              updated_at = now()`,
           [
@@ -172,6 +184,9 @@ export async function POST(req: NextRequest) {
             natalChart ? JSON.stringify(natalChart) : null,
             natalPositions ? JSON.stringify(natalPositions) : null,
             parsedMonicaConstant,
+            resolvedMonica?.diurnal ?? null,
+            resolvedMonica?.nocturnal ?? null,
+            resolvedMonica ? "single-body" : null,
             dominantElement || null
           ]
         );
@@ -198,8 +213,8 @@ export async function POST(req: NextRequest) {
 
         await client.query(
           `INSERT INTO user_profiles (
-             user_id, name, bio, birth_data, natal_chart, natal_positions, monica_constant, dominant_element
-           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+             user_id, name, bio, birth_data, natal_chart, natal_positions, monica_constant, monica_diurnal, monica_nocturnal, monica_method, dominant_element
+           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
           [
             wtenUserId,
             resolvedName,
@@ -208,6 +223,9 @@ export async function POST(req: NextRequest) {
             natalChart ? JSON.stringify(natalChart) : null,
             natalPositions ? JSON.stringify(natalPositions) : null,
             parsedMonicaConstant,
+            resolvedMonica?.diurnal ?? null,
+            resolvedMonica?.nocturnal ?? null,
+            resolvedMonica ? "single-body" : null,
             dominantElement || null
           ]
         );

--- a/src/lib/agents/persona/__tests__/persona.test.ts
+++ b/src/lib/agents/persona/__tests__/persona.test.ts
@@ -89,7 +89,11 @@ describe('Philosopher\'s Stone Agent Pipeline', () => {
       }
     }
 
-    expect(agent.consciousness.monicaConstant).toBeGreaterThanOrEqual(0)
+    // §18 — a real thermodynamic monica is signed and lives on roughly [-4, 4]
+    // (measured: 224/224 single-body cases in [-3.97, 3.90]). The old [0, 10]
+    // bound described the longitude average this replaced, not a monica.
+    expect(Number.isFinite(agent.consciousness.monicaConstant)).toBe(true)
+    expect(agent.consciousness.monicaConstant).toBeGreaterThanOrEqual(-10)
     expect(agent.consciousness.monicaConstant).toBeLessThanOrEqual(10)
 
     const stats = deriveSacredStats(agent)

--- a/src/utils/agentMonicaResolver.ts
+++ b/src/utils/agentMonicaResolver.ts
@@ -1,0 +1,161 @@
+/**
+ * Resolving an agent's real monica from what the agent actually is (§18e).
+ *
+ * A planetary agent has NO birthchart — it *is* a single placement, agentified —
+ * so its configuration is read from its NAME, not from a chart (§18g). This
+ * module is the single place that turns an agent name into a placement, so the
+ * three write sites and the backfill all agree.
+ *
+ * The names in production span five families, not the four §18g records. Measured
+ * over all 4800 agent rows on 2026-07-21:
+ *
+ *   | shape                                | n    | example                               |
+ *   |--------------------------------------|------|---------------------------------------|
+ *   | `<Planet> in <Sign> <N> Degree`      | 3240 | Jupiter in Aquarius 0 Degree          |
+ *   | `<Planet> <Sign> <N>`                |  676 | Jupiter Leo 2                         |
+ *   | `<Planet> Agent <N>`                 |  360 | Moon Agent 0                          |
+ *   | `<Phase> Moon in <Sign> <N> Degree`  |  360 | First Quarter Moon in Cancer 0 Degree |
+ *   | `Moon Phase <Phase> <N>`             |   89 | Moon Phase First Quarter 0            |
+ *
+ * `<Planet> in <Sign> <N> Degree` is the DOMINANT family and is absent from the
+ * §18g taxonomy — a parser written from the doc alone would drop 3240 of 4276
+ * planetary agents on the floor. The two `<N>`-is-an-absolute-degree families
+ * (`<Planet> Agent <N>`, `Moon Phase <Phase> <N>`) carry 0–359, not 1–360 as the
+ * doc states, so the sign is `floor(N/30)` with no off-by-one correction.
+ *
+ * Parsing VALIDATES the planet and sign against the canonical tables rather than
+ * matching on shape. That is load-bearing: `Moon Agent 5` matches the same
+ * `<word> <word> <number>` shape as `Mercury Aquarius 16`, and a shape-only
+ * parser reads "Agent" as a sign.
+ */
+import { agentMonica, type AgentMonica } from "@/utils/agentMonica";
+import {
+  PLANETARY_SECTARIAN_ESMS,
+  ZODIAC_ELEMENTS,
+} from "@/utils/planetaryAlchemyMapping";
+
+const SIGNS = Object.keys(ZODIAC_ELEMENTS);
+const PLANETS = Object.keys(PLANETARY_SECTARIAN_ESMS);
+
+const titleCase = (s: string) =>
+  s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+
+const asSign = (s: string): string | null => {
+  const k = titleCase(s);
+  return SIGNS.includes(k) ? k : null;
+};
+const asPlanet = (s: string): string | null => {
+  const k = titleCase(s);
+  return PLANETS.includes(k) ? k : null;
+};
+
+/** Absolute ecliptic degree (0–359) → sign + degree within that sign. */
+function fromAbsoluteDegree(n: number): { sign: string; degree: number } {
+  const a = ((n % 360) + 360) % 360;
+  return { sign: SIGNS[Math.floor(a / 30)], degree: a % 30 };
+}
+
+export interface AgentPlacement {
+  /**
+   * `single` — one body at one position; gets the §18c single-body monica.
+   * `phase`  — a Moon phase, which is a Sun–Moon *relationship*; a genuine
+   *            two-body monica is a §18 follow-up, so these are parsed and
+   *            identified but deliberately NOT given a single-body value.
+   */
+  kind: "single" | "phase";
+  planet: string;
+  sign: string;
+  degree: number;
+  phase?: string;
+  /** Set when the source name is not in canonical form. */
+  canonicalName?: string;
+}
+
+/**
+ * Parse an agent name into a placement, or null if the name is not a placement
+ * (a real person's name, a test row, anything unrecognised). Never guesses.
+ */
+export function parseAgentPlacement(rawName: string): AgentPlacement | null {
+  if (!rawName) return null;
+  const name = rawName.trim().replace(/\s+/g, " ");
+
+  // `Moon Phase <Phase> <N>` — N is an absolute ecliptic degree.
+  let m = name.match(/^([A-Za-z]+) Phase (.+?) (\d+)$/);
+  if (m && asPlanet(m[1])) {
+    const { sign, degree } = fromAbsoluteDegree(Number(m[3]));
+    const phase = m[2].trim();
+    return {
+      kind: "phase",
+      planet: asPlanet(m[1])!,
+      sign,
+      degree,
+      phase,
+      canonicalName: `${phase} Moon in ${sign} ${degree} Degree`,
+    };
+  }
+
+  // `<Planet> Agent <N>` — N is an absolute ecliptic degree.
+  m = name.match(/^([A-Za-z]+) Agent (\d+)$/);
+  if (m && asPlanet(m[1])) {
+    const planet = asPlanet(m[1])!;
+    const { sign, degree } = fromAbsoluteDegree(Number(m[2]));
+    return {
+      kind: "single",
+      planet,
+      sign,
+      degree,
+      canonicalName: `${planet} ${sign} ${degree}`,
+    };
+  }
+
+  // `<Phase> Moon in <Sign> <N> [Degree]` — the canonical phase form.
+  m = name.match(/^(.+?) Moon in ([A-Za-z]+) (\d+)(?: Degree)?$/);
+  if (m && asSign(m[2])) {
+    return {
+      kind: "phase",
+      planet: "Moon",
+      sign: asSign(m[2])!,
+      degree: Number(m[3]),
+      phase: m[1].trim(),
+    };
+  }
+
+  // `<Planet> in <Sign> <N> [Degree]` — the dominant production family.
+  m = name.match(/^([A-Za-z]+) in ([A-Za-z]+) (\d+)(?: Degree)?$/);
+  if (m && asPlanet(m[1]) && asSign(m[2])) {
+    const planet = asPlanet(m[1])!;
+    const sign = asSign(m[2])!;
+    const degree = Number(m[3]);
+    return {
+      kind: "single",
+      planet,
+      sign,
+      degree,
+      canonicalName: `${planet} ${sign} ${degree}`,
+    };
+  }
+
+  // `<Planet> <Sign> <N> [Degree]` — already canonical.
+  m = name.match(/^([A-Za-z]+) ([A-Za-z]+) (\d+)(?: Degree)?$/);
+  if (m && asPlanet(m[1]) && asSign(m[2])) {
+    return {
+      kind: "single",
+      planet: asPlanet(m[1])!,
+      sign: asSign(m[2])!,
+      degree: Number(m[3]),
+    };
+  }
+
+  return null;
+}
+
+/**
+ * The real single-body monica for a named planetary agent, or null when the name
+ * is not a single-body placement (a person, a phase agent, an unparseable row).
+ * Callers must treat null as "leave the existing value alone" — never as zero.
+ */
+export function agentMonicaFromName(name: string): AgentMonica | null {
+  const placement = parseAgentPlacement(name);
+  if (!placement || placement.kind !== "single") return null;
+  return agentMonica(placement.planet, placement.sign, placement.degree);
+}


### PR DESCRIPTION
Closes the four write paths that persisted a fake `monica_constant`, and backfills the real value for every resolvable planetary agent.

## Why

3672 agent rows carried a "monica" that was never thermodynamic. 3600 of them held round `(0,1)` sentinels (`0.50` ×1330, `0.55` ×556 …) that a `COALESCE` let in from an upstream repo; the rest held a longitude average — `((sun + moon + asc) / 3 / 360) * 10` — which shared nothing with the monica formula but its name. No human rows are affected (audited: all agents, 0 of 13 humans).

## Write paths fixed — there were FOUR, not three

The spec recorded three. A cross-repo investigation found a fourth that no one knew about.

| Site | Was | Now |
|---|---|---|
| `api/agents/unified` | longitude average | canonical **full-chart** monica via `alchemize()` |
| `api/economy/sync-debit` | `COALESCE(payload.monicaConstant, …)` | computed WTEN-side from the agent's own name |
| `(alchm)/philosophers-stone` | longitude average | stops fabricating — see below |
| **`api/internal/agent-sync`** | **`parseFloat(payload)`, unvalidated** | **computed WTEN-side** |

`agent-sync` is fed by `wtenClient.ts::syncAgentToWten()` from **three call sites across two sibling repos** (`planetary_agents-main`, `AlchmAgentsETH-main`) — one of them live in production via `generate-avatar`. The value they send is that repo's own legacy unsigned formula (`((average + spread/4) / 12)`), unrelated to this engine. Any sync could silently overwrite corrected data. WTEN now owns the truth on every path; the sibling repos were deliberately **not** changed.

`philosophers-stone` is a client component and `RealAlchemizeService` imports `fs`, so it cannot run the engine. Rather than fork a seventh engine into the browser bundle it seeds from `MONICA_EQUILIBRIUM`; the authoritative value is what the server returns on forge. It was never persisted.

## Backfill — already applied to production

| | |
|---|---|
| rows written | **4279** |
| non-finite | **0** |
| range | [−3.1973, 3.9751], median 0.0573 |
| distinct values / negative | 379 / 27.6% |
| skipped — phase (two-body follow-up) | 469 |
| skipped — not a placement | 75 |

Rows that are not single-body placements are **skipped and left NULL**, never guessed and never zeroed.

**Idempotency proven, not assumed:** a fresh recomputation after the write matches all 4279 stored values to 1e-5.

## New: `monica_method`

Single-body, two-body and full-chart agents build `monica_constant` from three different constructions sharing one column. A `CHECK`-constrained `monica_method` records which, so nothing downstream can compare values built on different bases. Migration `70-agent-monica-sects.sql` (applied).

## The parser is the load-bearing part

`src/utils/agentMonicaResolver.ts` is the single name→placement parser shared by every write site and the backfill. Production names span **five** families, not the four the spec recorded — and the dominant one, `<Planet> in <Sign> <N> Degree` (**3240 rows**), was absent from the spec entirely. A parser written from the doc alone drops 3240 of 4279 agents.

It validates planet and sign against the canonical tables rather than matching on shape, because `Moon Agent 5` has the same `<word> <word> <number>` shape as `Mercury Aquarius 16` — a shape-only parser reads "Agent" as a sign.

## Verification

- Independent re-derivation of §18c written from the spec prose (not from `agentMonica.ts`) agrees to **1e-12** on 8 spot cases.
- The 284-row exact-zero cluster was **proven real before writing** — a deterministic consequence of 5 planets confined to {Essence, Matter} × 2 pillars that zero the vessel's Spirit/Substance × non-Fire signs supplying no offsetting heat. Two sub-mechanisms account for all 284 with zero residual.
- No sentinel clustering: largest single value holds 5.0% of rows, against **36%** (1330/3672) sitting on `0.50` in the data replaced.
- `scripts/checkAgentMonicaDrift.ts` re-verifies at any time and exits non-zero on drift.
- 158 suites / 1313 tests green, typecheck clean.

## Notes for the reviewer

- `persona.test.ts` asserted monica ∈ [0,10], which described the longitude average, not a monica. A real one is signed on ~[−4,4].
- `scripts/dedupeAgentRows.ts` is included but **refuses to delete anything**: the 360 `Moon Agent N` rows are duplicates of existing placements, but an FK sweep over all 62 foreign keys shows 362 are referenced by `feed_events`/`user_subscriptions` — they have live feed history. Removing them is a product decision, not cleanup, and is deliberately left open.
- Two-body (phase) monica, full-chart for the 71 person-agents, and the merge-dedupe are specced in §18i/§18j and follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)