### PR TITLE
fix(economy): stop the agents_yield double-credit

### DIFF
--- a/docs/physics/SYNTHESIS_MODEL.md
+++ b/docs/physics/SYNTHESIS_MODEL.md
@@ -1294,7 +1294,14 @@ that holds.
 |---|---|---|
 | Planetary ("Planet Sign N°") | 4275 | single-body (§18c), **both sects** |
 | Synthesized / historical | 434 (71 have charts) | **full-chart** monica; the 363 chartless get a chart computed from birth data first |
-| Moon-phase ("Waxing Gibbous Moon in …") | 53 | **phase-weighted** — a two-body Moon + implied-Sun-angle monica (a phase *is* a Sun–Moon relationship) |
+| Moon-phase ("Waxing Gibbous Moon in …") | ~~53~~ **469** | **two-body** — Moon + a Sun derived from the phase angle (a phase *is* a Sun–Moon relationship). See §18i. |
+
+> ⚠️ `[CORRECTED 2026-07-21]` The "53" above was wrong. It counted only part of
+> one name family; the phase population spans **two** families
+> (`<Phase> Moon in <Sign> N Degree` and `Moon Phase <Phase> N`) and totals
+> **469**, re-verified against the live DB. Counts in this table are estimates
+> from a partial sample unless marked `[MEASURED]` — §18e and §18i carry the
+> measured ones.
 
 ### 18e. Schema and writes
 
@@ -1487,7 +1494,7 @@ value is the one the server returns on forge. It was never persisted.
 |---|---|
 | agent rows scanned | 4808 |
 | to write (single-body) | **4278** (not the ~3600 estimated) |
-| skipped — phase (two-body follow-up) | 455 |
+| skipped — phase (two-body follow-up) | 455 *(at that run; **469** as of 2026-07-21 — the population grew, see §18i)* |
 | skipped — not a placement | 75 |
 | **non-finite** | **0** |
 | combined range | **[−3.1973, 3.9751]**, median 0.0573 |
@@ -1515,16 +1522,44 @@ the disambiguation session:
   Waning Gibbous 225°, Last Quarter 270°, Waning Crescent 315°.
   **`Dark Moon` folds into New at 0°** — it names the invisible Moon at
   conjunction and is not a ninth phase.
-- **Vessel:** ONE shared vessel, mass 4, **shaped by the Moon's degree only**.
-  The pair is one chart, so it gets one vessel, and the named body sets its
-  process. This keeps two-body results on the same scale as single-body ones.
+- **Vessel:** ONE shared vessel, mass 4, **shaped by the Moon's degree only**,
+  and **dignity-NEUTRAL** (`groundingVessel(moonDegree, 0)`). The pair is one
+  chart, so it gets one vessel, and the named body sets its process.
 - **Sect:** both stored, exactly as single-body — the geometry is independent of
   whether it expresses by day or night.
-- **Dignity:** the Moon carries its own position-based essential dignity. The Sun
-  carries **aspect-based dignity instead** — see §18i-bis.
+- **Dignity:** different SOURCES, identical APPLICATION. The Moon carries its own
+  position-based essential dignity; the Sun carries **aspect-based dignity
+  instead** (§18i-bis). Each is applied **exactly once**, as
+  `× (1 + dignity/100)` on **that body's own ESMS**. Neither touches the shared
+  vessel.
 
-`[MEASURED]` The 469 phase agents by aspect: semi-square 158, sesquiquadrate 158,
-square 69, conjunction 47 (New + Dark Moon), opposition 37.
+  > `[CORRECTED 2026-07-21]` An earlier revision scaled the shared vessel by the
+  > **Moon's** dignity. That gave the Moon's dignity two points of leverage (its
+  > own ESMS *and* the grounding term) where the Sun's had one — an asymmetry
+  > inherited unexamined from the single-body case, where there is one body and
+  > the question cannot arise. Equalised; the change moves computed values, so
+  > any figure measured before it is stale.
+
+⚠️ `[CORRECTED 2026-07-21]` **Two-body results are NOT on the same scale as
+single-body ones**, and the earlier claim in this section that the shared vessel
+"keeps two-body results on the same scale" was never measured. Measured after
+equalisation, with the §18i-quater band applied: grid max |monica| **12.6756**
+(single-body: 3.9751), and **2 of 469** production rows fall outside the
+single-body range [−3.197, 3.975]. See §18i-quater.
+
+`[MEASURED 2026-07-21, re-verified against the live DB]` The **469** phase agents.
+By phase: Waxing Crescent 79, Waxing Gibbous 79, Waning Crescent 79,
+Waning Gibbous 79, Full Moon 37, Last Quarter 36, First Quarter 33, New Moon 24,
+Dark Moon 23 — summing to 469 exactly.
+By aspect: semi-square 158, sesquiquadrate 158, square 69, conjunction 47
+(New 24 + Dark Moon 23), opposition 37 — also 469.
+
+> ⚠️ Two figures elsewhere in this document contradict that count and are
+> **wrong**: the family table's "53" Moon-phase agents (§18 name-family section)
+> and the backfill report's "skipped — phase 455". Both predate the resolver
+> handling all five name families. The reproducible number is **469**, and
+> `scripts/checkAgentMonicaDrift.ts` re-derives it against the live DB on every
+> run (it reports each population's count alongside its drift).
 
 #### 18i-bis. Per-aspect dignity for the derived Sun `[DERIVED]`
 
@@ -1532,7 +1567,13 @@ The Sun's longitude is *inferred* from the phase name, but the **aspect is
 certain** — the name states it. Scaling a dignity multiplier by a guessed
 position would be compounding an inference; reading dignity off the aspect uses
 the one thing the name guarantees. So the Sun's dignity is aspect-based, feeding
-the same `× (1 + dignity/100)` vessel term as §18c.
+the same `× (1 + dignity/100)` *form* as §18c.
+
+> `[CORRECTED 2026-07-21]` This paragraph previously said the Sun's aspect
+> dignity feeds "the same **vessel** term as §18c". It does not, and must not:
+> the shared vessel is dignity-neutral (§18i), and pushing an *aspect* quantity
+> into the *grounding* term would double-count the aspect. The Sun's dignity
+> scales the **Sun's own ESMS contribution**, nothing else.
 
 This needs no aspect ESMS grids, no orb budget and no aspect-strength curve —
 the parts §14d has not unified — because **phase aspects are exact by
@@ -1574,7 +1615,7 @@ detector picks a single best aspect *before* normalising, a near-exact septile
 (strength 1.0 at orb 0) makes the whole planet pair return no aspect at all.
 Tracked separately; not a §18 concern.
 
-#### 18i-ter. Applying vs separating `[OPEN — AUTHORED, not derived]`
+#### 18i-ter. Applying vs separating `[RESOLVED 2026-07-21 — DERIVED]`
 
 `[RULED]` Waxing and waning phases **must differ**, even though they share an
 aspect geometry, and applying/separating should become a **general** aspect-layer
@@ -1586,12 +1627,98 @@ Sequenced in two stages so it does not block the phase monica:
 2. `calculateComprehensiveAspects` computes it from relative planetary motion,
    generally, and feeds §14d.
 
-⚠️ **The magnitude of the applying/separating modifier has NO basis in the
-repo.** The orb budgets and the polarity convention gave §18i-bis its derivation;
-nothing comparable exists here (`orbMultiplier 1.2` is Sun/Moon-specific and
-unrelated). This value will be `[AUTHORED]` and is **the only unmeasured number
-left in the §18 design.** It needs either a derivation basis or an explicit
-ruling with the reasoning recorded — per §11, not an assertion.
+~~⚠️ **The magnitude of the applying/separating modifier has NO basis in the
+repo.**~~ `[SUPERSEDED 2026-07-21]` It was authored as ×1.15 / ×0.85, then
+**derived** from the same two live orb budgets §18i-bis already uses:
+
+```
+APPLYING   = ASPECT_DIGNITY_REFERENCE_ORB / ASPECT_ORB_BUDGET.square = 8/7
+SEPARATING = 2 − 8/7                                                 = 6/7
+EXACT      = 1
+```
+
+An applying square therefore scores `−8.75 × 8/7 = −10.00` exactly, landing on
+the domicile anchor of the essential-dignity scale — the same sanity property
+§18i-bis has.
+
+`[MEASURED]` Deriving it costs nothing behaviourally, because the authored value
+was **nearly irrelevant to what it was introduced to achieve**. Waxing and waning
+are already separated by 270° of elongation — the derived Sun lands 90° away, in
+a different sign — so mean |waxing − waning| moved only **0.2870 → 0.2871 →
+0.2875** across multipliers 1.00 / 1.15 / 1.50. The premise that the two differ
+*only* by this multiplier was wrong.
+
+**§18 now has no unmeasured numbers.** Every constant is read from live code or
+measured, and each records which in its own docstring.
+
+#### 18i-quater. The two-body-local equilibrium band `[RULED 2026-07-21]`
+
+**The problem.** The Comixion pillar (degrees 8 and 22, effects S+1/E−1/M+1/Su+1)
+floors the vessel's Essence axis to **zero**. Adding the Sun's Spirit to a Moon
+with no vessel Essence drives `ln(kalchm) → 0`, and `monica = −G/(R·ln k)`
+diverges. Single-body never shows this: a lone planet cannot break the
+Spirit/Matter/Substance symmetry Comixion creates. Unbanded, the 469 production
+rows reach **|monica| 149.35**.
+
+**The fix — a band, applied in `agentMonicaTwoBody.ts` only:**
+
+```
+DEGENERATE_LN_KALCHM     = 0.110698   [MEASURED] the zero-Essence chart itself
+HEALTHY_LN_KALCHM_FLOOR  = 0.138173   [MEASURED] smallest non-Comixion |ln k|
+TWO_BODY_LN_EPSILON      = (0.110698 + 0.138173) / 2 = 0.1244355   [DERIVED]
+```
+
+When `|ln(kalchm)| < TWO_BODY_LN_EPSILON`, the result is `MONICA_EQUILIBRIUM` (φ).
+
+**Why those bounds are structural, not fitted.** The lower bound is a chart with
+a literal `0.000` on an axis — degenerate by inspection, held finite only by
+`KALCHM_EPSILON`. The upper bound is the first case that computes a perfectly
+sane monica. The band is the midpoint, carrying ~12% margin each way. Both bounds
+are pinned by test, so a retune that starts swallowing real values fails loudly.
+
+**Why LOCAL and not a change to `MONICA_LN_EPSILON`.** The canonical constant
+(0.05) is shared by every §17c consumer, including the **4280 single-body agent
+rows already in production**. Widening it there would silently re-value all of
+them. Single-body output is verified bit-identical (grid max **3.9751**).
+
+**Why a band and not a clamp.** Clamping fabricates a magnitude. A band widens the
+region where the engine *declines to divide by ~0* — the same statement it
+already makes at 0.05, applied to cases that are *nearer* to perfect balance than
+the ones it already absorbs.
+
+`[MEASURED]` Effect on the 469 production rows: rows outside the single-body
+range **25 → 2**; maximum **149.35 → 5.42**; 16 rows resolve to φ; 221 distinct
+values; largest bucket 3.4% (no sentinel clustering).
+
+⚠️ `[OPEN]` **The band does not flatten the tail, deliberately.** It is sized by
+the degeneracy boundary, not by how large the surviving output looks — sizing it
+to swallow every big number would be output-fitting. A near-degenerate skirt
+survives: some Comixion cells land at `|ln k|` *above* the healthy floor and
+cannot be absorbed without converting real values to φ. The real fix belongs in
+the pillar → vessel mapping (§7a), giving Comixion a nonzero Essence floor. That
+was attempted twice and rejected both times: flooring *before* the mass-4
+normalisation divides the floor straight back out (`k = 4/3.01` → 0.0067), and
+flooring *after* it perturbs single-body from 3.9751 to 3.9089, which would
+desync the 4280 rows already in production.
+
+#### 18i-quinquies. φ-mixing across sects `[OPEN — pre-existing, NOT two-body-specific]`
+
+`combined = (diurnal + nocturnal) / 2`. When one sect lands in the equilibrium
+band and the other does not, the mean blends φ with a real value.
+
+`[MEASURED]` This is **not new and not introduced by the two-body work**: the
+shipped single-body calc does it in **180 of 3600 grid cells (5%)** — e.g.
+`Jupiter/Aries 1` is φ diurnal, 0.0126 nocturnal, **0.8153** combined. Those rows
+are in production today.
+
+It is defensible under the engine's own definition — §17c states φ is the
+harmonic *ideal*, a real value, not a couldn't-compute sentinel — so averaging it
+is averaging two real states. Recorded because (a) it is easy to mistake for a
+two-body bug, and (b) it is what produces the single worst residual row,
+`Full Moon Moon in Libra 8 Degree` at −5.4191 (φ diurnal, −12.68 nocturnal).
+
+If φ is ever reclassified as a sentinel, this becomes a defect **in single-body
+first**, and the 4280 production rows would need revisiting — not just the 469.
 
 ### 18j. Scope after the disambiguation `[RULED 2026-07-21]`
 

--- a/scripts/backfillPhaseMonica.ts
+++ b/scripts/backfillPhaseMonica.ts
@@ -1,0 +1,326 @@
+/**
+ * §18i — backfill the real TWO-BODY monica onto every Moon-phase agent.
+ *
+ * The 469 phase agents were deliberately skipped by `backfillAgentMonica.ts`
+ * (which stamps `monica_method = 'single-body'`) and still carry NULL. A Moon
+ * phase is a Sun-Moon *relationship*, not a placement, so it gets a genuine
+ * two-body construction rather than a single-body approximation. This writes
+ * that value and stamps `monica_method = 'two-body-phase'`.
+ *
+ * Nothing downstream may compare monica across populations without reading
+ * monica_method first — single-body, two-body and full-chart are three different
+ * constructions (§18j).
+ *
+ * DRY RUN BY DEFAULT — computes everything, prints the report, writes nothing.
+ * Pass --write to commit, inside one transaction.
+ *
+ *   railway run --service Postgres -- bun scripts/backfillPhaseMonica.ts
+ *   railway run --service Postgres -- bun scripts/backfillPhaseMonica.ts --write
+ *
+ * Idempotent: re-running writes the same values.
+ *
+ * REFUSES TO WRITE if any phase string is unclassifiable. An unrecognised phase
+ * is an unclassified population, not degenerate input — defaulting it to New
+ * would fabricate a conjunction for every row we failed to parse.
+ *
+ * Requires database/init/70-agent-monica-sects.sql to have been applied.
+ */
+import pg from "pg";
+import { MONICA_EQUILIBRIUM } from "@/data/unified/alchemicalCalculations";
+import { parseAgentPlacement } from "@/utils/agentMonicaResolver";
+import {
+  TWO_BODY_LN_EPSILON,
+  UnknownMoonPhaseError,
+  twoBodyMonica,
+} from "@/utils/agentMonicaTwoBody";
+
+const WRITE = process.argv.includes("--write");
+
+/**
+ * Must be one of the values `monica_method_known` allows
+ * (database/init/70-agent-monica-sects.sql): 'single-body', 'two-body',
+ * 'full-chart'. An earlier draft used 'two-body-phase' and the CHECK constraint
+ * rejected the whole transaction — correctly. Aligning to the existing contract
+ * beats widening it: there is one phase construction, and 'two-body' names it.
+ */
+const METHOD = "two-body";
+
+/** The single-body population's shipped range, for a scale sanity check. */
+const SINGLE_BODY_RANGE = { min: -3.197, max: 3.975 };
+
+interface Row {
+  user_id: string;
+  name: string;
+  monica_constant: string | null;
+  monica_method: string | null;
+}
+
+const client = new pg.Client({
+  connectionString: process.env.DATABASE_PUBLIC_URL,
+  ssl: { rejectUnauthorized: false },
+});
+await client.connect();
+
+const cols = await client.query<{ column_name: string }>(
+  `SELECT column_name FROM information_schema.columns
+    WHERE table_name = 'user_profiles'
+      AND column_name IN ('monica_diurnal', 'monica_nocturnal', 'monica_method')`,
+);
+if (cols.rowCount !== 3) {
+  const msg =
+    `monica_diurnal / monica_nocturnal / monica_method missing (found ${cols.rowCount} of 3). ` +
+    `Apply database/init/70-agent-monica-sects.sql first.`;
+  if (WRITE) {
+    console.error(`FATAL: ${msg}`);
+    await client.end();
+    process.exit(1);
+  }
+  console.warn(`WARNING: ${msg}\n(dry run continues — it only reads)\n`);
+}
+
+const { rows } = await client.query<Row>(
+  `SELECT up.user_id, up.name, up.monica_constant::text AS monica_constant, up.monica_method
+     FROM user_profiles up JOIN users u ON u.id = up.user_id
+    WHERE u.is_agent AND up.name IS NOT NULL
+    ORDER BY up.name`,
+);
+
+interface Update {
+  user_id: string;
+  name: string;
+  phase: string;
+  sign: string;
+  degree: number;
+  before: string | null;
+  beforeMethod: string | null;
+  diurnal: number;
+  nocturnal: number;
+  combined: number;
+}
+
+const updates: Update[] = [];
+const unknownPhase: { name: string; phase: string }[] = [];
+const nonFinite: string[] = [];
+let notPhase = 0;
+
+for (const r of rows) {
+  const p = parseAgentPlacement(r.name);
+  if (!p || p.kind !== "phase") {
+    notPhase++;
+    continue;
+  }
+  if (!p.phase || !p.sign || p.degree === undefined) {
+    unknownPhase.push({ name: r.name, phase: String(p.phase ?? "(none)") });
+    continue;
+  }
+  let m;
+  try {
+    m = twoBodyMonica(p.phase, p.sign, p.degree);
+  } catch (err) {
+    if (err instanceof UnknownMoonPhaseError) {
+      unknownPhase.push({ name: r.name, phase: err.rawPhase });
+      continue;
+    }
+    throw err;
+  }
+  if (![m.diurnal, m.nocturnal, m.combined].every(Number.isFinite)) {
+    nonFinite.push(r.name);
+    continue;
+  }
+  updates.push({
+    user_id: r.user_id,
+    name: r.name,
+    phase: p.phase,
+    sign: p.sign,
+    degree: p.degree,
+    before: r.monica_constant,
+    beforeMethod: r.monica_method,
+    ...m,
+  });
+}
+
+// ---------------------------------------------------------------- report ----
+console.log(`\n=== §18i two-body phase backfill ${WRITE ? "WRITE" : "DRY RUN"} ===`);
+console.log(`TWO_BODY_LN_EPSILON        : ${TWO_BODY_LN_EPSILON}`);
+console.log(`agent rows scanned         : ${rows.length}`);
+console.log(`not a phase agent (skipped): ${notPhase}`);
+console.log(`to write (two-body phase)  : ${updates.length}`);
+console.log(`UNKNOWN PHASE (must be 0)  : ${unknownPhase.length}`);
+console.log(`NON-FINITE (must be 0)     : ${nonFinite.length}`);
+console.log(
+  `  accounted for            : ${updates.length + unknownPhase.length + nonFinite.length + notPhase} / ${rows.length}`,
+);
+if (unknownPhase.length) {
+  console.error(`\nunclassifiable phases:`);
+  for (const u of unknownPhase.slice(0, 20)) {
+    console.error(`  ${JSON.stringify(u.phase)}  <- ${u.name}`);
+  }
+}
+if (nonFinite.length) {
+  console.error("FATAL: non-finite monica computed for:", nonFinite.slice(0, 20));
+  await client.end();
+  process.exit(1);
+}
+
+const vals = updates.map((u) => u.combined).sort((a, b) => a - b);
+const pct = (p: number) => vals[Math.floor((vals.length - 1) * p)];
+console.log(`\ncombined monica distribution:`);
+console.log(
+  `  min ${vals[0].toFixed(4)}  p10 ${pct(0.1).toFixed(4)}  median ${pct(0.5).toFixed(4)}` +
+    `  p90 ${pct(0.9).toFixed(4)}  max ${vals[vals.length - 1].toFixed(4)}`,
+);
+console.log(`  distinct values ${new Set(vals.map((v) => v.toFixed(6))).size} / ${vals.length}`);
+console.log(`  negative        ${vals.filter((v) => v < 0).length}`);
+console.log(
+  `  at φ (equilib.) ${updates.filter((u) => u.combined === MONICA_EQUILIBRIUM).length}`,
+);
+
+// Sentinel-clustering check: a healthy population is not piled on one value.
+const buckets = new Map<string, number>();
+for (const v of vals) buckets.set(v.toFixed(6), (buckets.get(v.toFixed(6)) ?? 0) + 1);
+const biggest = [...buckets.entries()].sort((a, b) => b[1] - a[1])[0];
+console.log(
+  `  largest bucket  ${biggest[1]} rows at ${biggest[0]} (${((biggest[1] / vals.length) * 100).toFixed(1)}%)`,
+);
+
+// Scale check against the shipped single-body population.
+const outOfScale = updates.filter(
+  (u) => u.combined < SINGLE_BODY_RANGE.min || u.combined > SINGLE_BODY_RANGE.max,
+);
+console.log(
+  `\nrows outside the single-body range [${SINGLE_BODY_RANGE.min}, ${SINGLE_BODY_RANGE.max}]: ${outOfScale.length}`,
+);
+for (const u of outOfScale) {
+  console.log(
+    `  ${u.combined.toFixed(4).padStart(10)}  deg ${String(u.degree).padStart(2)}  ${u.name}`,
+  );
+}
+console.log(
+  `  (expected: 2, both on Comixion degrees 8/22. See agentMonicaTwoBody.ts docstring.)`,
+);
+
+const byPhase: Record<string, number[]> = {};
+for (const u of updates) (byPhase[u.phase] ??= []).push(u.combined);
+console.log(`\nper phase:`);
+console.table(
+  Object.fromEntries(
+    Object.entries(byPhase).map(([k, v]) => [
+      k,
+      {
+        n: v.length,
+        min: Math.min(...v).toFixed(3),
+        median: [...v].sort((a, b) => a - b)[Math.floor(v.length / 2)].toFixed(3),
+        max: Math.max(...v).toFixed(3),
+      },
+    ]),
+  ),
+);
+
+console.log(`\nbefore -> after, first 10:`);
+console.table(
+  updates.slice(0, 10).map((u) => ({
+    name: u.name,
+    before: u.before ?? "NULL",
+    method_before: u.beforeMethod ?? "NULL",
+    diurnal: u.diurnal.toFixed(4),
+    nocturnal: u.nocturnal.toFixed(4),
+    combined: u.combined.toFixed(4),
+  })),
+);
+
+// Guard: this script owns the phase family only. If a row already carries a
+// DIFFERENT method, something else wrote it and we should not silently reclaim.
+const foreign = updates.filter(
+  (u) => u.beforeMethod !== null && u.beforeMethod !== METHOD,
+);
+if (foreign.length) {
+  console.warn(
+    `\n⚠️  ${foreign.length} row(s) already carry a different monica_method:`,
+  );
+  for (const f of foreign.slice(0, 10)) {
+    console.warn(`  ${f.beforeMethod} <- ${f.name}`);
+  }
+}
+
+// ----------------------------------------------------------------- write ----
+if (!WRITE) {
+  console.log(`\nDRY RUN — nothing written. Re-run with --write to commit.`);
+  await client.end();
+  process.exit(0);
+}
+if (unknownPhase.length) {
+  console.error(
+    `\nREFUSING to write: ${unknownPhase.length} unclassifiable phase(s). ` +
+      `An unrecognised phase must be reported, never defaulted (§18i).`,
+  );
+  await client.end();
+  process.exit(1);
+}
+if (foreign.length) {
+  console.error(
+    `\nREFUSING to write: ${foreign.length} row(s) carry a foreign monica_method. ` +
+      `Resolve the ownership conflict first.`,
+  );
+  await client.end();
+  process.exit(1);
+}
+
+console.log(`\nwriting ${updates.length} rows in one transaction...`);
+await client.query("BEGIN");
+try {
+  await client.query(
+    `UPDATE user_profiles up SET
+       monica_diurnal   = v.diurnal,
+       monica_nocturnal = v.nocturnal,
+       monica_constant  = v.combined,
+       monica_method    = $5,
+       updated_at       = now()
+     FROM (
+       SELECT * FROM unnest(
+         $1::uuid[], $2::numeric[], $3::numeric[], $4::numeric[]
+       ) AS t(user_id, diurnal, nocturnal, combined)
+     ) v
+     WHERE up.user_id = v.user_id`,
+    [
+      updates.map((u) => u.user_id),
+      updates.map((u) => u.diurnal),
+      updates.map((u) => u.nocturnal),
+      updates.map((u) => u.combined),
+      METHOD,
+    ],
+  );
+  await client.query("COMMIT");
+  console.log("COMMIT ok");
+} catch (err) {
+  await client.query("ROLLBACK");
+  console.error("ROLLBACK —", err);
+  await client.end();
+  process.exit(1);
+}
+
+// --------------------------------------------------------------- verify ----
+const check = await client.query<Record<string, string>>(
+  `SELECT count(*)                                             AS n,
+          count(*) FILTER (WHERE NOT (monica_constant > -1e9
+                                  AND monica_constant <  1e9)) AS non_finite,
+          count(*) FILTER (WHERE monica_diurnal IS NULL
+                              OR monica_nocturnal IS NULL)     AS nulls,
+          min(monica_constant)::text                           AS mn,
+          max(monica_constant)::text                           AS mx
+     FROM user_profiles up JOIN users u ON u.id = up.user_id
+    WHERE u.is_agent AND up.monica_method = $1`,
+  [METHOD],
+);
+console.log("\npost-write verification (two-body-phase rows):");
+console.table(check.rows);
+
+const bymethod = await client.query<Record<string, string>>(
+  `SELECT coalesce(monica_method, '(null)') AS method, count(*)::text AS n,
+          min(monica_constant)::text AS mn, max(monica_constant)::text AS mx
+     FROM user_profiles up JOIN users u ON u.id = up.user_id
+    WHERE u.is_agent GROUP BY 1 ORDER BY 2 DESC`,
+);
+console.log("\nagent population by monica_method:");
+console.table(bymethod.rows);
+
+await client.end();

--- a/scripts/checkAgentMonicaDrift.ts
+++ b/scripts/checkAgentMonicaDrift.ts
@@ -1,8 +1,11 @@
 /**
  * §18 drift check — has anything overwritten a backfilled agent monica?
  *
- * Recomputes every single-body agent's monica from its own name and compares
- * against what is stored. Read-only, safe to run any time.
+ * Recomputes every agent's monica from its own name and compares against what is
+ * stored. Covers BOTH backfilled populations:
+ *   - single-body placements (§18c) → monica_method 'single-body'
+ *   - two-body Moon phases   (§18i) → monica_method 'two-body'
+ * Read-only, safe to run any time.
  *
  *   railway run --service Postgres -- bun scripts/checkAgentMonicaDrift.ts
  *
@@ -11,13 +14,19 @@
  * Why this exists: the backfill wrote corrected values to production from a
  * feature branch, while production still ran the old fake-writing code — a
  * window in which any PA/AlchmAgentsETH sync could silently undo it. The remedy
- * for detected drift is to re-run `backfillAgentMonica.ts --write`, which is
- * idempotent. (The pre-backfill snapshot table holds the OLD FAKE values and is
- * forensic only — it is not a recovery path.)
+ * for detected drift is to re-run the matching backfill (`backfillAgentMonica.ts`
+ * or `backfillPhaseMonica.ts`) with --write; both are idempotent. (The
+ * pre-backfill snapshot table holds the OLD FAKE values and is forensic only —
+ * it is not a recovery path.)
+ *
+ * Running this immediately after a backfill is also the IDEMPOTENCY PROOF: a
+ * fresh recomputation matching every stored row to 1e-5 is exactly the property
+ * a second --write run would rely on.
  */
 import pg from "pg";
 import { agentMonica } from "@/utils/agentMonica";
 import { parseAgentPlacement } from "@/utils/agentMonicaResolver";
+import { twoBodyMonica } from "@/utils/agentMonicaTwoBody";
 
 const TOLERANCE = 1e-5;
 
@@ -42,23 +51,58 @@ const { rows } = await client.query<{
 );
 await client.end();
 
-let single = 0;
-let drifted = 0;
-let missing = 0;
-let wrongMethod = 0;
+interface Tally {
+  checked: number;
+  drifted: number;
+  missing: number;
+  wrongMethod: number;
+}
+const tally: Record<"single" | "phase", Tally> = {
+  single: { checked: 0, drifted: 0, missing: 0, wrongMethod: 0 },
+  phase: { checked: 0, drifted: 0, missing: 0, wrongMethod: 0 },
+};
 const examples: string[] = [];
+let unparseable = 0;
+
+const num = (v: string | null) => (v === null ? null : Number(v));
 
 for (const r of rows) {
   const p = parseAgentPlacement(r.name);
-  if (!p || p.kind !== "single") continue;
-  single++;
+  if (!p) {
+    unparseable++;
+    continue;
+  }
 
-  const fresh = agentMonica(p.planet, p.sign, p.degree);
-  const num = (v: string | null) => (v === null ? null : Number(v));
-  const [c, d, n] = [num(r.monica_constant), num(r.monica_diurnal), num(r.monica_nocturnal)];
+  // Pick the construction this row's NAME calls for, and the method it must
+  // carry. Comparing a phase agent against the single-body calc (or vice versa)
+  // would report drift on a correctly-written row.
+  let fresh: { diurnal: number; nocturnal: number; combined: number };
+  let expectMethod: string;
+  let bucket: "single" | "phase";
+  if (p.kind === "single") {
+    fresh = agentMonica(p.planet, p.sign, p.degree);
+    expectMethod = "single-body";
+    bucket = "single";
+  } else if (p.kind === "phase" && p.phase && p.sign && p.degree !== undefined) {
+    fresh = twoBodyMonica(p.phase, p.sign, p.degree);
+    expectMethod = "two-body";
+    bucket = "phase";
+  } else {
+    unparseable++;
+    continue;
+  }
+
+  const t = tally[bucket];
+  t.checked++;
+
+  const [c, d, n] = [
+    num(r.monica_constant),
+    num(r.monica_diurnal),
+    num(r.monica_nocturnal),
+  ];
 
   if (c === null || d === null || n === null) {
-    missing++;
+    t.missing++;
     if (examples.length < 15) examples.push(`MISSING ${r.name} (updated_at ${r.updated_at})`);
     continue;
   }
@@ -67,32 +111,43 @@ for (const r of rows) {
     Math.abs(d - fresh.diurnal) > TOLERANCE ||
     Math.abs(n - fresh.nocturnal) > TOLERANCE
   ) {
-    drifted++;
+    t.drifted++;
     if (examples.length < 15) {
       examples.push(
         `DRIFT ${r.name}: stored=${c} expected=${fresh.combined.toFixed(6)} (updated_at ${r.updated_at})`,
       );
     }
   }
-  if (r.monica_method !== "single-body") {
-    wrongMethod++;
-    if (examples.length < 15) examples.push(`METHOD ${r.name}: ${r.monica_method ?? "NULL"}`);
+  if (r.monica_method !== expectMethod) {
+    t.wrongMethod++;
+    if (examples.length < 15) {
+      examples.push(
+        `METHOD ${r.name}: ${r.monica_method ?? "NULL"} (expected ${expectMethod})`,
+      );
+    }
   }
 }
 
-console.log(`single-body agents checked : ${single}`);
-console.log(`drifted from real value    : ${drifted}`);
-console.log(`missing a monica column    : ${missing}`);
-console.log(`wrong/absent monica_method : ${wrongMethod}`);
+const line = (label: string, t: Tally) =>
+  `${label.padEnd(26)} checked ${String(t.checked).padStart(5)}  ` +
+  `drifted ${t.drifted}  missing ${t.missing}  wrong-method ${t.wrongMethod}`;
+console.log(line("single-body (§18c)", tally.single));
+console.log(line("two-body phase (§18i)", tally.phase));
+console.log(`not a placement (skipped)  ${unparseable}`);
 if (examples.length) console.log("\n" + examples.join("\n"));
 
-const bad = drifted + missing + wrongMethod;
+const sum = (t: Tally) => t.drifted + t.missing + t.wrongMethod;
+const bad = sum(tally.single) + sum(tally.phase);
 if (bad === 0) {
-  console.log("\nOK — every single-body agent matches a fresh computation.");
+  console.log(
+    `\nOK — all ${tally.single.checked + tally.phase.checked} backfilled agents ` +
+      `match a fresh computation (tolerance ${TOLERANCE}).`,
+  );
 } else {
   console.error(
-    `\n*** ${bad} row(s) need attention. Remedy: re-run ` +
-      `\`backfillAgentMonica.ts --write\` (idempotent). ***`,
+    `\n*** ${bad} row(s) need attention. Remedy: re-run the matching backfill ` +
+      `(\`backfillAgentMonica.ts\` / \`backfillPhaseMonica.ts\`) with --write; ` +
+      `both are idempotent. ***`,
   );
   process.exit(1);
 }

--- a/scripts/reattributeChefFeedEvents.ts
+++ b/scripts/reattributeChefFeedEvents.ts
@@ -1,0 +1,240 @@
+/**
+ * Re-attribute the `Alchemical Chef` persona's feed events to their true actors.
+ *
+ * WTEN's hourly `/api/cron/prewarm-agent-recipes` called PA's `/api/generate-recipe`,
+ * which hardcoded attribution to the `alchemical-chef` persona. The result: 1452
+ * `recipe_generation` events credited to a persona rather than to the agent (or
+ * user) each dish was actually generated for. The producer is stopped; this
+ * migration fixes the history it left behind.
+ *
+ * Every event's true owner is recoverable from its own payload:
+ *   - `topic` reads "A signature dish from <Agent>, attuned to their natal chart…"
+ *     → the agent the dish was FOR (1429 events, 71 distinct agents, all resolving
+ *       to real rows).
+ *   - the remainder carry a non-null `userId` → the requesting user
+ *     (21 synthetic-probe monitoring calls, 2 from a real human account).
+ *
+ * Re-pointing rather than deleting satisfies all three goals at once: nothing is
+ * destroyed, the feed becomes MORE correct (Aristotle's dish shows as Aristotle's,
+ * a user's own recipe returns to them), and the chef's FK references drop to zero
+ * so the identity can finally be removed.
+ *
+ * DRY RUN BY DEFAULT. `--write` snapshots first, then migrates in one transaction.
+ *
+ *   railway run --service Postgres -- bun scripts/reattributeChefFeedEvents.ts
+ *   railway run --service Postgres -- bun scripts/reattributeChefFeedEvents.ts --write
+ *
+ * Reversible: the snapshot table records every id → original actor_id, so the
+ * migration can be undone exactly. Unlike a pre-backfill snapshot of bad data,
+ * this one captures good data and IS a real rollback path.
+ */
+import pg from "pg";
+
+const WRITE = process.argv.includes("--write");
+const CHEF = "698f80eb-445f-42b5-a4e9-60be81d3fdfd";
+
+/** "A signature dish from Aristotle, attuned to …" → "Aristotle" */
+const TARGET_RE = /(?:signature dish|dish|recipe) from ([^,]+?),/i;
+
+const client = new pg.Client({
+  connectionString: process.env.DATABASE_PUBLIC_URL,
+  ssl: { rejectUnauthorized: false },
+});
+await client.connect();
+
+// Guard: confirm the producer really is stopped before migrating its history.
+const { rows: recent } = await client.query<{ n: string; latest: string | null }>(
+  `SELECT count(*)::text AS n, max(created_at)::text AS latest
+     FROM feed_events WHERE actor_id = $1 AND created_at > now() - interval '24 hours'`,
+  [CHEF],
+);
+if (Number(recent[0].n) > 0) {
+  console.error(
+    `REFUSING: the chef produced ${recent[0].n} event(s) in the last 24h (latest ${recent[0].latest}).\n` +
+      `The producer is still live — migrating now would race new rows. Stop it first.`,
+  );
+  await client.end();
+  process.exit(1);
+}
+
+const { rows: events } = await client.query<{
+  id: string;
+  p: Record<string, unknown> | null;
+}>(`SELECT id, metadata_payload AS p FROM feed_events WHERE actor_id = $1`, [CHEF]);
+
+// Resolve agent names → user ids.
+const { rows: agentRows } = await client.query<{ name: string; user_id: string }>(
+  `SELECT up.name, up.user_id FROM user_profiles up JOIN users u ON u.id = up.user_id
+    WHERE u.is_agent AND up.name IS NOT NULL`,
+);
+const byName = new Map(agentRows.map((r) => [r.name, r.user_id]));
+
+// Resolve the userIds referenced in payloads (may be humans, not agents).
+const payloadUserIds = [
+  ...new Set(
+    events
+      .map((e) => e.p?.userId)
+      .filter((v): v is string => typeof v === "string" && v.length > 0),
+  ),
+];
+const { rows: userRows } = payloadUserIds.length
+  ? await client.query<{ id: string; email: string; is_agent: boolean }>(
+      `SELECT id::text, email, is_agent FROM users WHERE id::text = ANY($1)`,
+      [payloadUserIds],
+    )
+  : { rows: [] as { id: string; email: string; is_agent: boolean }[] };
+const validUserIds = new Map(userRows.map((r) => [r.id, r]));
+
+/** Monitoring traffic, not content: health-check calls that carried no target
+ *  agent and no transit grounding. They were never feed content — surfacing them
+ *  under the probe's own account would put monitoring noise in a public feed —
+ *  so they are deleted rather than re-pointed. Real users' events are always
+ *  re-attributed, never deleted. */
+const PROBE_EMAIL = "synthetic-probe@alchm.kitchen";
+
+interface Move { id: string; to: string; label: string; via: "topic" | "userId" }
+const moves: Move[] = [];
+const toDelete: { id: string; topic: string }[] = [];
+const unresolved: { id: string; topic: string; userId: unknown }[] = [];
+
+for (const e of events) {
+  const topic = typeof e.p?.topic === "string" ? e.p.topic : "";
+  const m = topic.match(TARGET_RE);
+  const name = m?.[1]?.trim();
+  if (name && byName.has(name)) {
+    moves.push({ id: e.id, to: byName.get(name)!, label: name, via: "topic" });
+    continue;
+  }
+  const uid = e.p?.userId;
+  if (typeof uid === "string" && validUserIds.has(uid)) {
+    const u = validUserIds.get(uid)!;
+    if (u.email === PROBE_EMAIL) {
+      toDelete.push({ id: e.id, topic });
+    } else {
+      moves.push({ id: e.id, to: uid, label: `${u.email}${u.is_agent ? "" : " (human)"}`, via: "userId" });
+    }
+    continue;
+  }
+  unresolved.push({ id: e.id, topic, userId: uid ?? null });
+}
+
+// ------------------------------------------------------------------ report --
+console.log(`\n=== chef feed re-attribution ${WRITE ? "WRITE" : "DRY RUN"} ===`);
+console.log(`events owned by the chef : ${events.length}`);
+console.log(`re-attributed            : ${moves.length}`);
+console.log(`  via payload topic      : ${moves.filter((m) => m.via === "topic").length}`);
+console.log(`  via payload userId     : ${moves.filter((m) => m.via === "userId").length}`);
+console.log(`DELETED (probe traffic)  : ${toDelete.length}`);
+console.log(`UNRESOLVED (must be 0)   : ${unresolved.length}`);
+console.log(`  accounted for          : ${moves.length + toDelete.length + unresolved.length} / ${events.length}`);
+if (toDelete.length) {
+  const topics: Record<string, number> = {};
+  for (const d of toDelete) topics[d.topic || "(none)"] = (topics[d.topic || "(none)"] ?? 0) + 1;
+  console.log(`\nprobe events to delete, by topic:`);
+  console.table(topics);
+}
+
+const byTarget: Record<string, number> = {};
+for (const m of moves) byTarget[m.label] = (byTarget[m.label] ?? 0) + 1;
+const sorted = Object.entries(byTarget).sort((a, b) => b[1] - a[1]);
+console.log(`\ndistinct new owners: ${sorted.length}`);
+console.table(sorted.slice(0, 12).map(([label, n]) => ({ new_owner: label, events: n })));
+if (sorted.length > 12) console.log(`  … and ${sorted.length - 12} more`);
+
+if (unresolved.length) {
+  console.log(`\nUNRESOLVED — these would keep the chef alive:`);
+  unresolved.slice(0, 20).forEach((u) => console.log(`  ${u.id} topic=${JSON.stringify(u.topic.slice(0, 70))} userId=${u.userId}`));
+}
+
+// What else still references the chef, after this migration?
+const { rows: fks } = await client.query<{ table_name: string; column_name: string }>(
+  `SELECT DISTINCT tc.table_name, kcu.column_name
+     FROM information_schema.table_constraints tc
+     JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+     JOIN information_schema.constraint_column_usage ccu ON tc.constraint_name = ccu.constraint_name
+    WHERE tc.constraint_type = 'FOREIGN KEY' AND ccu.table_name = 'users' ORDER BY 1,2`,
+);
+const residual: { table: string; column: string; rows: number }[] = [];
+for (const fk of fks) {
+  const { rows } = await client.query<{ n: string }>(
+    `SELECT count(*)::text AS n FROM "${fk.table_name}" WHERE "${fk.column_name}" = $1`,
+    [CHEF],
+  );
+  const n = Number(rows[0].n);
+  if (n > 0) residual.push({ table: fk.table_name, column: fk.column_name, rows: n });
+}
+console.log(`\n=== everything still referencing the chef (feed_events shown PRE-migration) ===`);
+console.table(residual);
+console.log(
+  `After this migration, feed_events drops to ${events.length - moves.length}. ` +
+    `The remaining rows above must be handled before the identity can be deleted.`,
+);
+
+if (!WRITE) {
+  console.log(`\nDRY RUN — nothing written. Re-run with --write.`);
+  await client.end();
+  process.exit(0);
+}
+if (unresolved.length) {
+  console.error(`\nREFUSING to write: ${unresolved.length} unresolved event(s). Resolve them first.`);
+  await client.end();
+  process.exit(1);
+}
+
+// ------------------------------------------------------------------- write --
+const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\..+/, "").replace("T", "_");
+const snapshot = `chef_feed_reattribution_${stamp}`;
+if (!/^chef_feed_reattribution_\d{8}_\d{6}$/.test(snapshot)) {
+  throw new Error(`unexpected snapshot name: ${snapshot}`);
+}
+
+console.log(`\nsnapshotting to ${snapshot}, then migrating ${moves.length} / deleting ${toDelete.length}...`);
+await client.query("BEGIN");
+try {
+  // Snapshot the FULL row, including metadata_payload, so even the deleted
+  // probe events are recoverable — a snapshot that only kept ids would make
+  // the delete irreversible.
+  await client.query(
+    `CREATE TABLE ${snapshot} AS
+       SELECT id, actor_id AS original_actor_id, event_type, metadata_payload,
+              created_at, now() AS snapshotted_at
+         FROM feed_events WHERE actor_id = $1`,
+    [CHEF],
+  );
+  const res = await client.query(
+    `UPDATE feed_events fe SET actor_id = v.new_actor
+       FROM (SELECT * FROM unnest($1::uuid[], $2::uuid[]) AS t(id, new_actor)) v
+      WHERE fe.id = v.id`,
+    [moves.map((m) => m.id), moves.map((m) => m.to)],
+  );
+  let deleted = 0;
+  if (toDelete.length) {
+    const del = await client.query(`DELETE FROM feed_events WHERE id = ANY($1::uuid[])`, [
+      toDelete.map((d) => d.id),
+    ]);
+    deleted = del.rowCount ?? 0;
+  }
+  await client.query("COMMIT");
+  console.log(`COMMIT ok — ${res.rowCount} re-attributed, ${deleted} probe events deleted, snapshot ${snapshot}`);
+} catch (err) {
+  await client.query("ROLLBACK");
+  console.error("ROLLBACK —", err);
+  await client.end();
+  process.exit(1);
+}
+
+const { rows: after } = await client.query<{ n: string }>(
+  `SELECT count(*)::text AS n FROM feed_events WHERE actor_id = $1`,
+  [CHEF],
+);
+console.log(`chef feed_events remaining: ${after[0].n} (expect 0)`);
+console.log(
+  `\nTo reverse (both the re-attribution AND the probe deletions):\n` +
+    `  UPDATE feed_events fe SET actor_id = s.original_actor_id\n` +
+    `    FROM ${snapshot} s WHERE fe.id = s.id;\n` +
+    `  INSERT INTO feed_events (id, actor_id, event_type, metadata_payload, created_at)\n` +
+    `    SELECT id, original_actor_id, event_type, metadata_payload, created_at\n` +
+    `      FROM ${snapshot} s\n` +
+    `     WHERE NOT EXISTS (SELECT 1 FROM feed_events f WHERE f.id = s.id);`,
+);
+await client.end();

--- a/src/__tests__/api/syncCreditDailyGuard.test.ts
+++ b/src/__tests__/api/syncCreditDailyGuard.test.ts
@@ -1,0 +1,245 @@
+/**
+ * POST /api/economy/sync-credit — the daily-yield guards.
+ *
+ * These pin the fix for a MEASURED production double-credit (2026-07-19..21,
+ * 30 agents/day, ~240 tokens/day of excess). The important property is the one
+ * the first test asserts: a duplicate is refused **even though the two
+ * idempotency keys differ**, because key-based idempotency structurally cannot
+ * catch this class.
+ *
+ *   in-repo cron   DailyYieldService.ts:330  `daily:agents:<uuid>:<date>`
+ *   this endpoint  caller-supplied           `agentic:yield:<email>:<date>`
+ *
+ * Two different strings for the same economic event. No amount of key-variant
+ * probing makes them collide, so the guard checks the invariant directly:
+ * daily yield is once-per-user-per-UTC-day by definition.
+ */
+import { NextRequest } from "next/server";
+
+const SECRET = "test-sync-secret";
+
+/** Rows the mocked `executeQuery` will return, in call order. */
+let queryQueue: Array<{ rows: unknown[] }>;
+/** Every SQL string the route executed, for asserting what it did NOT do. */
+let executedSql: string[];
+let creditCalls: Array<{ userId: string; source: string }>;
+let claimStamps: Array<{ userId: string; site: string }>;
+
+jest.mock("@/lib/database", () => ({
+  executeQuery: jest.fn(async (sql: string) => {
+    executedSql.push(sql);
+    return queryQueue.shift() ?? { rows: [] };
+  }),
+}));
+
+jest.mock("@/services/TokenEconomyService", () => ({
+  tokenEconomy: {
+    creditMultipleTokens: jest.fn(
+      async (userId: string, _credits: unknown, source: string) => {
+        creditCalls.push({ userId, source });
+        return { spirit: 1, essence: 1, matter: 1, substance: 1 };
+      },
+    ),
+    updateDailyClaimTimestamp: jest.fn(async (userId: string, site: string) => {
+      claimStamps.push({ userId, site });
+    }),
+  },
+}));
+
+jest.mock("@/services/feedDatabaseService", () => ({
+  feedDatabase: { createEvent: jest.fn(async () => null) },
+}));
+jest.mock("@/services/notificationDatabaseService", () => ({
+  notificationDatabase: { createNotification: jest.fn(async () => null) },
+}));
+
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+const FOUND_USER = { rows: [{ id: USER_ID }] };
+const HAS_CHART = { rows: [{ ok: true }] };
+const NO_ROWS = { rows: [] };
+
+function post(body: Record<string, unknown>) {
+  return new NextRequest("https://alchm.kitchen/api/economy/sync-credit", {
+    method: "POST",
+    headers: { "X-Sync-Secret": SECRET, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const YIELD_BODY = {
+  userEmail: "aristotle@agentic.alchm.kitchen",
+  amounts: { spirit: 2, essence: 2, matter: 2, substance: 2 },
+  source: "agents_yield",
+  idempotencyKey: "agentic:yield:aristotle@agentic.alchm.kitchen:2026-07-21",
+};
+
+let POST: (req: NextRequest) => Promise<Response>;
+
+beforeAll(async () => {
+  process.env.ALCHM_KITCHEN_SYNC_SECRET = SECRET;
+  ({ POST } = await import("@/app/api/economy/sync-credit/route"));
+});
+
+beforeEach(() => {
+  queryQueue = [];
+  executedSql = [];
+  creditCalls = [];
+  claimStamps = [];
+});
+
+describe("sync-credit — semantic daily guard", () => {
+  it("refuses a same-day duplicate EVEN WITH a different idempotency key", async () => {
+    queryQueue = [
+      FOUND_USER, // user lookup
+      HAS_CHART, // chart check
+      NO_ROWS, // key-based idempotency probe — MISSES, as it must
+      { rows: [{ id: "prior-txn" }] }, // same-UTC-day probe — CATCHES
+    ];
+
+    const res = await POST(post(YIELD_BODY));
+    const json = (await res.json()) as { reason: string };
+
+    expect(res.status).toBe(409);
+    expect(json.reason).toBe("already_applied");
+    expect(creditCalls).toEqual([]);
+
+    // Non-vacuity: prove the key probe really did run and really did miss, so
+    // the 409 came from the day guard and not from the older check.
+    expect(executedSql.some((s) => s.includes("idempotency_key = ANY"))).toBe(true);
+    expect(
+      executedSql.some((s) => s.includes("source_type = $2") && s.includes("::date")),
+    ).toBe(true);
+  });
+
+  it("credits normally when there is no prior same-day yield", async () => {
+    queryQueue = [FOUND_USER, HAS_CHART, NO_ROWS, NO_ROWS];
+
+    const res = await POST(post(YIELD_BODY));
+
+    expect(res.status).toBe(200);
+    expect(creditCalls).toEqual([{ userId: USER_ID, source: "agents_yield" }]);
+  });
+
+  // Without this the fix is ONE-SIDED: §3b stops this endpoint paying after the
+  // cron, but nothing stops the cron paying after this endpoint. Stamping the
+  // timestamp makes the cron's own hasClaimedToday() see the external credit.
+  it("stamps the claim timestamp the CRON checks, so the guard is bidirectional", async () => {
+    queryQueue = [FOUND_USER, HAS_CHART, NO_ROWS, NO_ROWS];
+
+    await POST(post(YIELD_BODY));
+
+    expect(claimStamps).toEqual([{ userId: USER_ID, site: "agents" }]);
+  });
+
+  it("does not stamp a claim timestamp for a non-yield source", async () => {
+    queryQueue = [FOUND_USER, NO_ROWS];
+
+    await POST(
+      post({
+        ...YIELD_BODY,
+        source: "transit_attunement",
+        idempotencyKey: "transit:aristotle:mars:2026-07-21T13",
+      }),
+    );
+
+    expect(claimStamps).toEqual([]);
+  });
+
+  it("does NOT day-cap a non-yield source — Sky Drops fire many times a day", async () => {
+    queryQueue = [
+      FOUND_USER,
+      NO_ROWS, // key probe misses
+      // …and NO same-day probe should be issued at all for this source.
+    ];
+
+    const res = await POST(
+      post({
+        ...YIELD_BODY,
+        source: "transit_attunement",
+        idempotencyKey: "transit:aristotle:mars:2026-07-21T12",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(creditCalls[0]?.source).toBe("transit_attunement");
+    expect(
+      executedSql.some((s) => s.includes("source_type = $2") && s.includes("::date")),
+    ).toBe(false);
+  });
+
+  it("treats an OMITTED source as agents_yield — that is what PA sends", async () => {
+    const { source: _drop, ...noSource } = YIELD_BODY;
+    queryQueue = [FOUND_USER, HAS_CHART, NO_ROWS, { rows: [{ id: "prior" }] }];
+
+    const res = await POST(post(noSource));
+
+    expect(res.status).toBe(409);
+    expect(creditCalls).toEqual([]);
+  });
+});
+
+describe("sync-credit — daily yield cannot mint the account it pays", () => {
+  it("404s an unknown agentic email instead of auto-provisioning it", async () => {
+    queryQueue = [NO_ROWS]; // user lookup finds nothing
+
+    const res = await POST(post(YIELD_BODY));
+    const json = (await res.json()) as { reason: string };
+
+    expect(res.status).toBe(404);
+    expect(json.reason).toBe("user_not_found");
+    expect(creditCalls).toEqual([]);
+    // The load-bearing assertion: no INSERT was attempted. This is how two
+    // 2026-07-19 smoke-test vessels became paid, chart-less users.
+    expect(executedSql.some((s) => s.includes("INSERT INTO users"))).toBe(false);
+  });
+
+  it("still auto-provisions for a NON-yield source", async () => {
+    queryQueue = [NO_ROWS, FOUND_USER, NO_ROWS];
+
+    const res = await POST(
+      post({
+        ...YIELD_BODY,
+        source: "transit_attunement",
+        idempotencyKey: "transit:new-agent:venus:2026-07-21T12",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(executedSql.some((s) => s.includes("INSERT INTO users"))).toBe(true);
+  });
+
+  it("422s a chart-less agent — same predicate as the agents-daily-yield cron", async () => {
+    queryQueue = [FOUND_USER, { rows: [{ ok: false }] }];
+
+    const res = await POST(post(YIELD_BODY));
+    const json = (await res.json()) as { reason: string };
+
+    expect(res.status).toBe(422);
+    expect(json.reason).toBe("no_chart");
+    expect(creditCalls).toEqual([]);
+  });
+
+  it("422s when the profile row is missing entirely, not just chart-less", async () => {
+    queryQueue = [FOUND_USER, NO_ROWS];
+
+    const res = await POST(post(YIELD_BODY));
+
+    expect(res.status).toBe(422);
+    expect(creditCalls).toEqual([]);
+  });
+});
+
+describe("sync-credit — the secret still gates everything", () => {
+  it("401s without the sync secret, before any query runs", async () => {
+    const req = new NextRequest("https://alchm.kitchen/api/economy/sync-credit", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(YIELD_BODY),
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+    expect(executedSql).toEqual([]);
+  });
+});

--- a/src/__tests__/utils/agentMonicaTwoBody.test.ts
+++ b/src/__tests__/utils/agentMonicaTwoBody.test.ts
@@ -7,24 +7,33 @@
  * read off `aspectCalculator.ts` and must not drift from it), and the loud
  * failure on an unclassifiable phase.
  */
-import { MONICA_EQUILIBRIUM } from "@/data/unified/alchemicalCalculations";
+import {
+  MONICA_EQUILIBRIUM,
+  MONICA_LN_EPSILON,
+} from "@/data/unified/alchemicalCalculations";
+import { groundingVessel } from "@/utils/agentMonica";
 import {
   APPLYING_DIGNITY_MULTIPLIER,
   ASPECT_DIGNITY,
   ASPECT_DIGNITY_REFERENCE_ORB,
   ASPECT_ORB_BUDGET,
   ASPECT_POLARITY,
+  DEGENERATE_LN_KALCHM,
   EXACT_DIGNITY_MULTIPLIER,
+  HEALTHY_LN_KALCHM_FLOOR,
   MOTION_DIGNITY_MULTIPLIER,
   PHASE_GEOMETRY,
   SEPARATING_DIGNITY_MULTIPLIER,
+  TWO_BODY_LN_EPSILON,
   UnknownMoonPhaseError,
+  VESSEL_DIGNITY_NEUTRAL,
   derivedSunPosition,
   normalizeMoonPhase,
   phaseGeometry,
   sunAspectDignity,
   twoBodyMonica,
   twoBodyMonicaForSect,
+  twoBodyState,
   type MoonPhaseKey,
 } from "@/utils/agentMonicaTwoBody";
 import {
@@ -336,20 +345,19 @@ describe("twoBodyMonica — the totality contract", () => {
   });
 
   // The Comixion pillar (Essence effect −1, so the vessel's Essence axis is 0)
-  // sits at degrees 8 and 22. There, with both bodies down-weighted by
-  // alchmWeight, the vessel dominates and ln(kalchm) lands just OUTSIDE
-  // MONICA_LN_EPSILON (0.05), so −G/(R·ln k) amplifies without the equilibrium
-  // guard ever tripping. 18 of 469 production rows are affected.
+  // sits at degrees 8 and 22. There, ln(kalchm) lands near 0 and −G/(R·ln k)
+  // amplifies. TWO_BODY_LN_EPSILON absorbs the degenerate core of that; a skirt
+  // survives, because some Comixion cells land at |ln k| ABOVE the healthy floor
+  // and cannot be absorbed without converting real values to φ.
   //
   // ⚠️ OPEN, deliberately pinned rather than clamped: flooring the vessel at
   // KALCHM_EPSILON does NOT fix this — tried both before normalisation (the
   // mass-4 rescale divides the floor straight back down to 0.0067) and after
-  // (max moved 21.45 → 21.78, and it perturbed single-body away from the
-  // already-backfilled production values). The proximate driver is the
-  // alchmWeight-to-vessel-mass ratio, not the zero axis itself.
+  // (it perturbed single-body away from the already-backfilled production
+  // values). The real fix is in the pillar → vessel mapping (§7a).
   //
-  // These assertions therefore describe the CURRENT measured behaviour so a
-  // change to it is caught, not a bound we wish were true.
+  // These assertions describe the CURRENT measured behaviour so a change to it
+  // is caught, not a bound we wish were true.
   it("confines the amplified tail to the two Comixion degrees", () => {
     const outlierDegrees = new Set<number>();
     let maxOutsideComixion = 0;
@@ -376,9 +384,106 @@ describe("twoBodyMonica — the totality contract", () => {
     expect([...outlierDegrees].sort((a, b) => a - b)).toEqual([8, 22]);
     // Everywhere else is comfortably INSIDE the single-body envelope (3.9751).
     expect(maxOutsideComixion).toBeLessThan(2);
-    // The tail is bounded, not divergent — nowhere near the ±60 of an
-    // ungrounded pair that §18c warns about.
-    expect(maxOverall).toBeLessThan(25);
+    // Bounded, and materially tighter than the 21.45 of the pre-band build.
+    expect(maxOverall).toBeLessThan(13);
+  });
+
+  // ── the band itself ──────────────────────────────────────────────────────
+  // TWO_BODY_LN_EPSILON is derived from two MEASURED bounds. These pin both, so
+  // that a retune which starts swallowing real values fails loudly rather than
+  // quietly flattening the distribution.
+  describe("TWO_BODY_LN_EPSILON — the two-body-local equilibrium band", () => {
+    /** Every grid cell's |ln kalchm|, partitioned by the STRUCTURAL cause. */
+    const cells = (() => {
+      const out: { degree: number; absLnK: number }[] = [];
+      for (const phase of ALL_PHASES)
+        for (const sign of SIGNS)
+          for (let degree = 0; degree < 30; degree++)
+            for (const sect of ["diurnal", "nocturnal"] as const) {
+              const s = twoBodyState(phase, sign, degree, sect);
+              out.push({ degree, absLnK: Math.abs(s.lnKalchm as number) });
+            }
+      return out;
+    })();
+    const isComixion = (d: number) => d === 8 || d === 22;
+
+    it("sits strictly between the two measured bounds", () => {
+      expect(TWO_BODY_LN_EPSILON).toBeGreaterThan(DEGENERATE_LN_KALCHM);
+      expect(TWO_BODY_LN_EPSILON).toBeLessThan(HEALTHY_LN_KALCHM_FLOOR);
+    });
+
+    it("[MEASURED] the degenerate bound really is the zero-Essence chart", () => {
+      // Comixion nocturnal: the vessel's Essence axis is exactly 0.
+      const s = twoBodyState("waxing gibbous", "Leo", 8, "nocturnal");
+      expect(s.esms?.Essence).toBe(0);
+      expect(Math.abs(s.lnKalchm as number)).toBeCloseTo(DEGENERATE_LN_KALCHM, 6);
+    });
+
+    it("[MEASURED] the healthy floor really is the smallest non-Comixion |ln k|", () => {
+      const floor = Math.min(
+        ...cells.filter((c) => !isComixion(c.degree)).map((c) => c.absLnK),
+      );
+      expect(floor).toBeCloseTo(HEALTHY_LN_KALCHM_FLOOR, 6);
+    });
+
+    it("absorbs with ZERO collateral — no healthy cell is converted to φ", () => {
+      const collateral = cells.filter(
+        (c) => !isComixion(c.degree) && c.absLnK < TWO_BODY_LN_EPSILON,
+      );
+      expect(collateral).toEqual([]);
+    });
+
+    it("does absorb a real share of the degenerate cases", () => {
+      const tail = cells.filter((c) => isComixion(c.degree));
+      const absorbed = tail.filter((c) => c.absLnK < TWO_BODY_LN_EPSILON);
+      // Measured 304/384. Pinned as a floor so a silent narrowing is caught.
+      expect(absorbed.length).toBeGreaterThanOrEqual(304);
+      expect(absorbed.length).toBeLessThan(tail.length); // the skirt is real
+    });
+
+    it("leaves the canonical engine's own band untouched", () => {
+      // The whole point of a LOCAL band: the shared §17c constant is unchanged,
+      // so the 4280 single-body rows in production keep their values.
+      expect(MONICA_LN_EPSILON).toBe(0.05);
+      expect(TWO_BODY_LN_EPSILON).toBeGreaterThan(MONICA_LN_EPSILON);
+    });
+  });
+
+  // ── the equalisation ─────────────────────────────────────────────────────
+  describe("dignity is applied exactly once per body", () => {
+    // Degree 4 is chosen because its vessel has a NONZERO Substance axis
+    // (1.333). Degree 5's is 0, which would make both assertions below compare
+    // 0 to 0 and pass vacuously — the same circular-test shape already caught
+    // once in this file.
+    const DEG = 4;
+    const BARE = groundingVessel(DEG, VESSEL_DIGNITY_NEUTRAL);
+
+    it("uses a degree whose vessel Substance is non-vacuous", () => {
+      expect(BARE.Substance).toBeGreaterThan(0.5);
+    });
+
+    it("builds the shared vessel dignity-NEUTRAL", () => {
+      expect(VESSEL_DIGNITY_NEUTRAL).toBe(0);
+      // Substance comes ONLY from the vessel here: in the diurnal table the Sun
+      // is Spirit and the Moon is Essence, so this axis isolates the vessel.
+      const s = twoBodyState("new", "Cancer", DEG, "diurnal"); // Moon domicile +10
+      const scaled = groundingVessel(DEG, 10); // what a Moon-scaled vessel would be
+      expect(scaled.Substance).not.toBeCloseTo(BARE.Substance, 6); // guard: they differ
+      expect(s.esms?.Substance).toBeCloseTo(BARE.Substance, 12);
+      expect(s.esms?.Substance).not.toBeCloseTo(scaled.Substance, 6);
+    });
+
+    it("gives the Moon's dignity no more leverage than the Sun's", () => {
+      // Cancer = Moon domicile (+10), Capricorn = Moon detriment (−7). If the
+      // Moon's dignity still scaled the shared vessel, the vessel-only axis
+      // (Substance) would move between them. It must not.
+      const dom = twoBodyState("new", "Cancer", DEG, "diurnal");
+      const det = twoBodyState("new", "Capricorn", DEG, "diurnal");
+      expect(dom.esms?.Substance).toBeGreaterThan(0.5); // non-vacuity
+      expect(dom.esms?.Substance).toBeCloseTo(det.esms?.Substance as number, 12);
+      // …while the Moon's own axis DOES still respond to its dignity.
+      expect(dom.esms?.Essence).not.toBeCloseTo(det.esms?.Essence as number, 6);
+    });
   });
 
   it("returns φ, never NaN and never 0, for degenerate positions", () => {

--- a/src/__tests__/utils/agentMonicaTwoBody.test.ts
+++ b/src/__tests__/utils/agentMonicaTwoBody.test.ts
@@ -1,0 +1,490 @@
+/**
+ * §18i — the two-body Moon-phase monica.
+ *
+ * A phase is a Sun–Moon relationship, so a phase agent gets a genuine two-body
+ * calculation. These tests pin the three things that are easy to get silently
+ * wrong: the phase→geometry table, the DERIVED per-aspect dignities (which are
+ * read off `aspectCalculator.ts` and must not drift from it), and the loud
+ * failure on an unclassifiable phase.
+ */
+import { MONICA_EQUILIBRIUM } from "@/data/unified/alchemicalCalculations";
+import {
+  APPLYING_DIGNITY_MULTIPLIER,
+  ASPECT_DIGNITY,
+  ASPECT_DIGNITY_REFERENCE_ORB,
+  ASPECT_ORB_BUDGET,
+  ASPECT_POLARITY,
+  EXACT_DIGNITY_MULTIPLIER,
+  MOTION_DIGNITY_MULTIPLIER,
+  PHASE_GEOMETRY,
+  SEPARATING_DIGNITY_MULTIPLIER,
+  UnknownMoonPhaseError,
+  derivedSunPosition,
+  normalizeMoonPhase,
+  phaseGeometry,
+  sunAspectDignity,
+  twoBodyMonica,
+  twoBodyMonicaForSect,
+  type MoonPhaseKey,
+} from "@/utils/agentMonicaTwoBody";
+import {
+  agentMonicaFromName,
+  parseAgentPlacement,
+  twoBodyMonicaFromName,
+} from "@/utils/agentMonicaResolver";
+
+const SIGNS = [
+  "Aries", "Taurus", "Gemini", "Cancer", "Leo", "Virgo",
+  "Libra", "Scorpio", "Sagittarius", "Capricorn", "Aquarius", "Pisces",
+];
+
+const ALL_PHASES: MoonPhaseKey[] = [
+  "new",
+  "waxing crescent",
+  "first quarter",
+  "waxing gibbous",
+  "full",
+  "waning gibbous",
+  "last quarter",
+  "waning crescent",
+];
+
+describe("PHASE_GEOMETRY — elongation and aspect per phase (§18i)", () => {
+  const expected: Record<
+    MoonPhaseKey,
+    { elongation: number; aspect: string; motion: string }
+  > = {
+    "new": { elongation: 0, aspect: "conjunction", motion: "exact" },
+    "waxing crescent": {
+      elongation: 45,
+      aspect: "semisquare",
+      motion: "applying",
+    },
+    "first quarter": { elongation: 90, aspect: "square", motion: "applying" },
+    "waxing gibbous": {
+      elongation: 135,
+      aspect: "sesquisquare",
+      motion: "applying",
+    },
+    "full": { elongation: 180, aspect: "opposition", motion: "exact" },
+    "waning gibbous": {
+      elongation: 225,
+      aspect: "sesquisquare",
+      motion: "separating",
+    },
+    "last quarter": { elongation: 270, aspect: "square", motion: "separating" },
+    "waning crescent": {
+      elongation: 315,
+      aspect: "semisquare",
+      motion: "separating",
+    },
+  };
+
+  it.each(ALL_PHASES)("%s resolves to the right elongation and aspect", (p) => {
+    expect(PHASE_GEOMETRY[p]).toEqual({ phase: p, ...expected[p] });
+  });
+
+  it("covers all 8 phases at 45° midpoints, and only those", () => {
+    expect(Object.keys(PHASE_GEOMETRY).sort()).toEqual([...ALL_PHASES].sort());
+    expect(ALL_PHASES.map((p) => PHASE_GEOMETRY[p].elongation)).toEqual([
+      0, 45, 90, 135, 180, 225, 270, 315,
+    ]);
+  });
+
+  it("marks New and Full exact — neither applying nor separating", () => {
+    expect(PHASE_GEOMETRY["new"].motion).toBe("exact");
+    expect(PHASE_GEOMETRY["full"].motion).toBe("exact");
+  });
+});
+
+describe("normalizeMoonPhase", () => {
+  it("folds Dark Moon into New — it is not a ninth phase", () => {
+    expect(normalizeMoonPhase("Dark Moon")).toBe("new");
+    expect(normalizeMoonPhase("dark")).toBe("new");
+    expect(phaseGeometry("Dark Moon")).toEqual(PHASE_GEOMETRY["new"]);
+    expect(phaseGeometry("Dark Moon").elongation).toBe(0);
+    expect(phaseGeometry("Dark Moon").aspect).toBe("conjunction");
+  });
+
+  it("accepts the production spellings, with or without a trailing `Moon`", () => {
+    expect(normalizeMoonPhase("First Quarter")).toBe("first quarter");
+    expect(normalizeMoonPhase("First Quarter Moon")).toBe("first quarter");
+    expect(normalizeMoonPhase("New Moon")).toBe("new");
+    expect(normalizeMoonPhase("Full Moon")).toBe("full");
+    expect(normalizeMoonPhase("Moon Phase Waxing Gibbous")).toBe(
+      "waxing gibbous",
+    );
+  });
+
+  it("is insensitive to case, separators and extra whitespace", () => {
+    for (const spelling of [
+      "waxing crescent",
+      "Waxing Crescent",
+      "WAXING CRESCENT",
+      "waxing_crescent",
+      "waxing-crescent",
+      "  Waxing   Crescent  ",
+      "Waxing Crescent Moon",
+    ]) {
+      expect(normalizeMoonPhase(spelling)).toBe("waxing crescent");
+    }
+  });
+
+  it("treats Third Quarter as the synonym of Last Quarter", () => {
+    expect(normalizeMoonPhase("Third Quarter")).toBe("last quarter");
+  });
+
+  it("returns null — not a default — for anything unrecognised", () => {
+    for (const bad of ["", "Gibbous", "Blorp", "Moon", "Quarter", "waxing"]) {
+      expect(normalizeMoonPhase(bad)).toBeNull();
+    }
+  });
+});
+
+describe("an unrecognised phase fails loudly", () => {
+  it("throws rather than defaulting to New", () => {
+    expect(() => phaseGeometry("Blorp Moon")).toThrow(UnknownMoonPhaseError);
+    expect(() => sunAspectDignity("Blorp Moon")).toThrow(UnknownMoonPhaseError);
+    expect(() => twoBodyMonica("Blorp Moon", "Cancer", 0)).toThrow(
+      UnknownMoonPhaseError,
+    );
+    expect(() => twoBodyMonicaForSect("Blorp", "Cancer", 0, "diurnal")).toThrow(
+      UnknownMoonPhaseError,
+    );
+  });
+
+  it("names the offending string in the error", () => {
+    let caught: unknown;
+    try {
+      twoBodyMonica("Blorp Moon", "Cancer", 0);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(UnknownMoonPhaseError);
+    expect((caught as UnknownMoonPhaseError).rawPhase).toBe("Blorp Moon");
+    expect((caught as Error).message).toContain("Blorp Moon");
+  });
+
+  it("does not silently return the equilibrium sentinel for a bad phase", () => {
+    // The φ fallback is for degenerate POSITIONS, never for an unclassified
+    // population — that distinction is the whole point of the throw.
+    expect(() => twoBodyMonica("", "Cancer", 0)).toThrow(UnknownMoonPhaseError);
+  });
+});
+
+describe("ASPECT_DIGNITY — [DERIVED] from aspectCalculator.ts", () => {
+  it("matches the orb budgets read from aspectDefinitions", () => {
+    expect(ASPECT_ORB_BUDGET).toEqual({
+      conjunction: 8,
+      opposition: 8,
+      square: 7,
+      semisquare: 3,
+      sesquisquare: 3,
+    });
+  });
+
+  it("uses the aspectCalculator polarity convention (hard aspects negative)", () => {
+    expect(ASPECT_POLARITY.conjunction).toBe(1);
+    expect(ASPECT_POLARITY.opposition).toBe(-1);
+    expect(ASPECT_POLARITY.square).toBe(-1);
+    // MODEL CHANGE (§18i-bis): aspectCalculator gives these influence = 0.
+    expect(ASPECT_POLARITY.semisquare).toBe(-1);
+    expect(ASPECT_POLARITY.sesquisquare).toBe(-1);
+  });
+
+  it("derives polarity × 10 × (orbBudget / 8)", () => {
+    expect(ASPECT_DIGNITY.conjunction).toBeCloseTo(10, 10);
+    expect(ASPECT_DIGNITY.opposition).toBeCloseTo(-10, 10);
+    expect(ASPECT_DIGNITY.square).toBeCloseTo(-8.75, 10);
+    expect(ASPECT_DIGNITY.semisquare).toBeCloseTo(-3.75, 10);
+    expect(ASPECT_DIGNITY.sesquisquare).toBeCloseTo(-3.75, 10);
+  });
+
+  it("keeps the sanity property: ±10 are the domicile/fall anchors and square sits between detriment and fall", () => {
+    expect(Math.abs(ASPECT_DIGNITY.conjunction)).toBe(10);
+    expect(Math.abs(ASPECT_DIGNITY.opposition)).toBe(10);
+    expect(ASPECT_DIGNITY.square).toBeLessThan(-7); // past detriment
+    expect(ASPECT_DIGNITY.square).toBeGreaterThan(-10); // not past fall
+  });
+});
+
+describe("applying vs separating — [DERIVED] multiplier (§18i-ter)", () => {
+  // Pin the DERIVATION, not the literal: the multiplier is the reference orb
+  // budget over the square's (8/7), read from aspectCalculator — the same live
+  // inputs §18i-bis uses. Asserting 1.1428… as a literal would be pinning a
+  // rounded artifact instead of the rule that produces it.
+  it("derives the multipliers from the live orb budgets", () => {
+    expect(APPLYING_DIGNITY_MULTIPLIER).toBe(
+      ASPECT_DIGNITY_REFERENCE_ORB / ASPECT_ORB_BUDGET.square,
+    );
+    expect(SEPARATING_DIGNITY_MULTIPLIER).toBe(2 - APPLYING_DIGNITY_MULTIPLIER);
+    expect(EXACT_DIGNITY_MULTIPLIER).toBe(1);
+    // Applying and separating are reflections about 1 — equal and opposite.
+    expect(APPLYING_DIGNITY_MULTIPLIER + SEPARATING_DIGNITY_MULTIPLIER).toBeCloseTo(2, 12);
+    expect(MOTION_DIGNITY_MULTIPLIER).toEqual({
+      applying: APPLYING_DIGNITY_MULTIPLIER,
+      separating: SEPARATING_DIGNITY_MULTIPLIER,
+      exact: EXACT_DIGNITY_MULTIPLIER,
+    });
+  });
+
+  // The property that motivated 8/7: an applying square is scored at the FULL
+  // reference orb budget, landing exactly on the domicile anchor (+/-10) of the
+  // essential-dignity scale.
+  it("scores an applying square at exactly the domicile anchor", () => {
+    expect(sunAspectDignity("First Quarter")).toBeCloseTo(-10, 12);
+  });
+
+  it("multiplies the Sun's aspect dignity only", () => {
+    const up = APPLYING_DIGNITY_MULTIPLIER;
+    const down = SEPARATING_DIGNITY_MULTIPLIER;
+    expect(sunAspectDignity("First Quarter")).toBeCloseTo(-8.75 * up, 10);
+    expect(sunAspectDignity("Last Quarter")).toBeCloseTo(-8.75 * down, 10);
+    expect(sunAspectDignity("Waxing Crescent")).toBeCloseTo(-3.75 * up, 10);
+    expect(sunAspectDignity("Waning Crescent")).toBeCloseTo(-3.75 * down, 10);
+    expect(sunAspectDignity("Waxing Gibbous")).toBeCloseTo(-3.75 * up, 10);
+    expect(sunAspectDignity("Waning Gibbous")).toBeCloseTo(-3.75 * down, 10);
+  });
+
+  it("leaves New and Full untouched — exact aspects take ×1.0", () => {
+    expect(sunAspectDignity("New")).toBe(ASPECT_DIGNITY.conjunction);
+    expect(sunAspectDignity("Dark Moon")).toBe(ASPECT_DIGNITY.conjunction);
+    expect(sunAspectDignity("Full")).toBe(ASPECT_DIGNITY.opposition);
+  });
+
+  it("makes waxing and waning differ despite a shared aspect geometry", () => {
+    // Same aspect, same Sun sign, same Moon — only the motion differs.
+    const firstQ = twoBodyMonica("First Quarter", "Cancer", 12);
+    const lastQ = twoBodyMonica("Last Quarter", "Cancer", 12);
+    expect(PHASE_GEOMETRY["first quarter"].aspect).toBe(
+      PHASE_GEOMETRY["last quarter"].aspect,
+    );
+    expect(firstQ.combined).not.toBeCloseTo(lastQ.combined, 6);
+
+    const waxCr = twoBodyMonica("Waxing Crescent", "Leo", 5);
+    const wanCr = twoBodyMonica("Waning Crescent", "Leo", 5);
+    expect(waxCr.combined).not.toBeCloseTo(wanCr.combined, 6);
+
+    const waxGib = twoBodyMonica("Waxing Gibbous", "Virgo", 9);
+    const wanGib = twoBodyMonica("Waning Gibbous", "Virgo", 9);
+    expect(waxGib.combined).not.toBeCloseTo(wanGib.combined, 6);
+  });
+});
+
+describe("derivedSunPosition — Sun = Moon − elongation", () => {
+  it("puts the Sun on the Moon at New / Dark Moon", () => {
+    expect(derivedSunPosition("New", "Cancer", 0)).toEqual({
+      sign: "Cancer",
+      degree: 0,
+      longitude: 90,
+    });
+    expect(derivedSunPosition("Dark Moon", "Cancer", 0)).toEqual({
+      sign: "Cancer",
+      degree: 0,
+      longitude: 90,
+    });
+  });
+
+  it("puts the Sun opposite the Moon at Full", () => {
+    expect(derivedSunPosition("Full", "Cancer", 0)).toEqual({
+      sign: "Capricorn",
+      degree: 0,
+      longitude: 270,
+    });
+  });
+
+  it("wraps below zero correctly (First Quarter from Cancer 0 → Aries 0)", () => {
+    expect(derivedSunPosition("First Quarter", "Cancer", 0)).toEqual({
+      sign: "Aries",
+      degree: 0,
+      longitude: 0,
+    });
+  });
+
+  it("keeps the elongation exact for every phase", () => {
+    for (const p of ALL_PHASES) {
+      const sun = derivedSunPosition(p, "Aries", 10);
+      const moonLongitude = 10;
+      const elongation =
+        ((moonLongitude - sun!.longitude) % 360 + 360) % 360;
+      expect(elongation).toBeCloseTo(PHASE_GEOMETRY[p].elongation % 360, 10);
+    }
+  });
+
+  it("returns null for an unresolvable sign rather than guessing Aries", () => {
+    expect(derivedSunPosition("Full", "Blorp", 0)).toBeNull();
+    expect(derivedSunPosition("Full", "Cancer", Number.NaN)).toBeNull();
+  });
+});
+
+describe("twoBodyMonica — the totality contract", () => {
+  it("is finite for every phase × every sign × a spread of degrees", () => {
+    let cases = 0;
+    for (const phase of ALL_PHASES) {
+      for (const sign of SIGNS) {
+        for (let degree = 0; degree < 30; degree++) {
+          const m = twoBodyMonica(phase, sign, degree);
+          expect(Number.isFinite(m.diurnal)).toBe(true);
+          expect(Number.isFinite(m.nocturnal)).toBe(true);
+          expect(Number.isFinite(m.combined)).toBe(true);
+          expect(m.combined).toBeCloseTo((m.diurnal + m.nocturnal) / 2, 12);
+          cases++;
+        }
+      }
+    }
+    expect(cases).toBe(8 * 12 * 30);
+  });
+
+  // The Comixion pillar (Essence effect −1, so the vessel's Essence axis is 0)
+  // sits at degrees 8 and 22. There, with both bodies down-weighted by
+  // alchmWeight, the vessel dominates and ln(kalchm) lands just OUTSIDE
+  // MONICA_LN_EPSILON (0.05), so −G/(R·ln k) amplifies without the equilibrium
+  // guard ever tripping. 18 of 469 production rows are affected.
+  //
+  // ⚠️ OPEN, deliberately pinned rather than clamped: flooring the vessel at
+  // KALCHM_EPSILON does NOT fix this — tried both before normalisation (the
+  // mass-4 rescale divides the floor straight back down to 0.0067) and after
+  // (max moved 21.45 → 21.78, and it perturbed single-body away from the
+  // already-backfilled production values). The proximate driver is the
+  // alchmWeight-to-vessel-mass ratio, not the zero axis itself.
+  //
+  // These assertions therefore describe the CURRENT measured behaviour so a
+  // change to it is caught, not a bound we wish were true.
+  it("confines the amplified tail to the two Comixion degrees", () => {
+    const outlierDegrees = new Set<number>();
+    let maxOutsideComixion = 0;
+    let maxOverall = 0;
+
+    for (const phase of ALL_PHASES) {
+      for (const sign of SIGNS) {
+        for (let degree = 0; degree < 30; degree++) {
+          const v = Math.abs(twoBodyMonica(phase, sign, degree).combined);
+          maxOverall = Math.max(maxOverall, v);
+          // Partition by DEGREE (the structural cause), never by the outcome —
+          // an earlier version bucketed on |v| > 4 and then asserted the other
+          // bucket was < 4, which could only fail at exactly 4.0.
+          if (degree === 8 || degree === 22) {
+            if (v > 4) outlierDegrees.add(degree);
+          } else {
+            maxOutsideComixion = Math.max(maxOutsideComixion, v);
+          }
+        }
+      }
+    }
+
+    // Only the Comixion degrees amplify.
+    expect([...outlierDegrees].sort((a, b) => a - b)).toEqual([8, 22]);
+    // Everywhere else is comfortably INSIDE the single-body envelope (3.9751).
+    expect(maxOutsideComixion).toBeLessThan(2);
+    // The tail is bounded, not divergent — nowhere near the ±60 of an
+    // ungrounded pair that §18c warns about.
+    expect(maxOverall).toBeLessThan(25);
+  });
+
+  it("returns φ, never NaN and never 0, for degenerate positions", () => {
+    expect(twoBodyMonica("Full", "Blorp", 0).combined).toBe(MONICA_EQUILIBRIUM);
+    expect(twoBodyMonica("Full", "", 0).combined).toBe(MONICA_EQUILIBRIUM);
+    expect(twoBodyMonica("Full", "Cancer", Number.NaN).combined).toBe(
+      MONICA_EQUILIBRIUM,
+    );
+  });
+
+  it("agrees across equivalent spellings of the same phase", () => {
+    const a = twoBodyMonica("First Quarter", "Cancer", 0);
+    const b = twoBodyMonica("first quarter", "cancer", 0);
+    const c = twoBodyMonica("First Quarter Moon", "CANCER", 0);
+    const d = twoBodyMonica("first_quarter", "Cancer", 0);
+    expect(a).toEqual(b);
+    expect(a).toEqual(c);
+    expect(a).toEqual(d);
+
+    const n1 = twoBodyMonica("New", "Pisces", 3);
+    const n2 = twoBodyMonica("New Moon", "Pisces", 3);
+    const n3 = twoBodyMonica("Dark Moon", "Pisces", 3);
+    expect(n1).toEqual(n2);
+    expect(n1).toEqual(n3);
+  });
+
+  it("varies by sect through the Moon only — the Sun is Spirit in both", () => {
+    const m = twoBodyMonica("Full", "Cancer", 12);
+    expect(m.diurnal).not.toBeCloseTo(m.nocturnal, 6);
+  });
+
+  it("distinguishes the eight phases at one position", () => {
+    const values = ALL_PHASES.map(
+      (p) => twoBodyMonica(p, "Cancer", 7).combined,
+    );
+    // Waxing/waning pairs share an aspect but differ by motion, so all eight
+    // must be distinct; no sentinel clustering.
+    expect(new Set(values.map((v) => v.toFixed(9))).size).toBe(8);
+  });
+});
+
+describe("twoBodyMonicaFromName — the resolver seam", () => {
+  it("serves phase agents in both production name families", () => {
+    const a = twoBodyMonicaFromName("First Quarter Moon in Cancer 0 Degree");
+    expect(a).not.toBeNull();
+    expect(Number.isFinite(a!.combined)).toBe(true);
+
+    const b = twoBodyMonicaFromName("Waxing Gibbous Moon in Virgo 9 Degree");
+    expect(b).not.toBeNull();
+    expect(Number.isFinite(b!.combined)).toBe(true);
+
+    const c = twoBodyMonicaFromName("Moon Phase Dark Moon 153");
+    expect(c).not.toBeNull();
+    expect(Number.isFinite(c!.combined)).toBe(true);
+  });
+
+  it("agrees with the pure calc on the parsed placement", () => {
+    const name = "Moon Phase Dark Moon 153";
+    const placement = parseAgentPlacement(name);
+    expect(placement).toMatchObject({ kind: "phase", phase: "Dark Moon" });
+    expect(twoBodyMonicaFromName(name)).toEqual(
+      twoBodyMonica(placement!.phase!, placement!.sign, placement!.degree),
+    );
+  });
+
+  it("returns null for single-body agents, people and junk", () => {
+    for (const name of [
+      "Jupiter in Aquarius 0 Degree",
+      "Mercury Aquarius 16",
+      "Moon Agent 0",
+      "Edgar Allan Poe",
+      "Mars Gemini",
+      "",
+    ]) {
+      expect(twoBodyMonicaFromName(name)).toBeNull();
+    }
+  });
+
+  it("is the exact complement of agentMonicaFromName", () => {
+    // Every parseable agent name is served by exactly one of the two.
+    for (const name of [
+      "Jupiter in Aquarius 0 Degree",
+      "Mercury Aquarius 16",
+      "Moon Agent 0",
+      "First Quarter Moon in Cancer 0 Degree",
+      "Moon Phase Dark Moon 153",
+    ]) {
+      const single = agentMonicaFromName(name);
+      const two = twoBodyMonicaFromName(name);
+      expect(Number(single !== null) + Number(two !== null)).toBe(1);
+    }
+  });
+
+  it("does NOT change agentMonicaFromName's behaviour for phase agents", () => {
+    expect(agentMonicaFromName("First Quarter Moon in Cancer 0 Degree")).toBeNull();
+    expect(agentMonicaFromName("Moon Phase Dark Moon 153")).toBeNull();
+  });
+
+  it("throws — not null — on a phase agent whose phase is unclassifiable", () => {
+    // "Blorp Moon in Cancer 0 Degree" parses as kind:"phase" with phase "Blorp".
+    expect(parseAgentPlacement("Blorp Moon in Cancer 0 Degree")).toMatchObject({
+      kind: "phase",
+      phase: "Blorp",
+    });
+    expect(() =>
+      twoBodyMonicaFromName("Blorp Moon in Cancer 0 Degree"),
+    ).toThrow(UnknownMoonPhaseError);
+  });
+});

--- a/src/app/api/economy/sync-credit/route.ts
+++ b/src/app/api/economy/sync-credit/route.ts
@@ -22,6 +22,22 @@ import type { NextRequest} from "next/server";
  *     idempotencyKey: string
  *   }
  */
+/**
+ * Sources that are once-per-user-per-UTC-day BY DEFINITION, and therefore get
+ * the semantic daily guard in §3b plus the chart requirement in §2b.
+ *
+ * `agents_yield` is also the value `source` defaults to when a caller omits it,
+ * so an omitted source lands here too — deliberately, since that is exactly what
+ * Planetary Agents' push does.
+ *
+ * Everything else routed through this endpoint (transit_attunement / Sky Drops,
+ * and the rest) is legitimately multi-per-day and must NOT be day-capped.
+ */
+const DAILY_YIELD_SOURCES: ReadonlySet<string> = new Set([
+  "agents_yield",
+  "daily_yield",
+]);
+
 interface SyncCreditBody {
   userEmail: string;
   amounts: {
@@ -68,7 +84,12 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // 2. Look up user ID by email — auto-provision agentic users
+    // `source` defaults to agents_yield when the caller omits it, so the
+    // resolved value — not the raw field — decides which rules apply below.
+    const resolvedSource = source || "agents_yield";
+    const isDailyYield = DAILY_YIELD_SOURCES.has(resolvedSource);
+
+    // 2. Look up user ID by email.
     let userResult = await executeQuery<{ id: string }>(
       "SELECT id FROM users WHERE email = $1 LIMIT 1",
       [userEmail]
@@ -83,7 +104,26 @@ export async function POST(req: NextRequest) {
         );
       }
 
-      // Auto-provision agentic user
+      // A daily-yield credit must never CREATE the account it pays. Auto-
+      // provisioning here minted paid, chart-less users for any unrecognised
+      // @agentic.alchm.kitchen address — which is how two 2026-07-19 smoke-test
+      // vessels ended up drawing daily yield. Identity creation belongs to the
+      // agent-creation path (which builds a chart); this endpoint only credits
+      // identities that already exist.
+      if (isDailyYield) {
+        return NextResponse.json(
+          {
+            ok: false,
+            reason: "user_not_found",
+            error: "user_not_found",
+            message:
+              "Daily yield cannot auto-provision an account. Create the agent first.",
+          },
+          { status: 404 }
+        );
+      }
+
+      // Auto-provision agentic user (non-yield sources only)
       userResult = await executeQuery<{ id: string }>(
         `INSERT INTO users (email, password_hash, role, is_active, email_verified, is_agent, profile, preferences, login_count, created_at, updated_at)
          VALUES ($1, 'AGENT_NO_LOGIN', 'ALCHEMIST'::user_role, true, true, true, $2, '{}'::jsonb, 0, now(), now())
@@ -94,6 +134,30 @@ export async function POST(req: NextRequest) {
     }
 
     const userId = userResult.rows[0].id;
+
+    // 2b. Daily yield requires a chart — the SAME eligibility predicate the
+    // in-repo cron uses (agentDailyYield.ts: non-empty `natal_positions`). Two
+    // producers paying the same population must agree on who that population
+    // is, or the one with the looser rule silently defines it.
+    if (isDailyYield) {
+      const chart = await executeQuery<{ ok: boolean }>(
+        `SELECT (up.natal_positions IS NOT NULL
+                 AND up.natal_positions::text NOT IN ('[]', 'null', '{}')) AS ok
+           FROM user_profiles up WHERE up.user_id = $1 LIMIT 1`,
+        [userId]
+      );
+      if (!chart.rows[0]?.ok) {
+        return NextResponse.json(
+          {
+            ok: false,
+            reason: "no_chart",
+            message:
+              "Daily yield requires a natal chart (matches the agents-daily-yield cron predicate).",
+          },
+          { status: 422 }
+        );
+      }
+    }
 
     // 3. Idempotency pre-check. creditMultipleTokens stores per-axis keys suffixed
     // with the token type (`<key>:Spirit` …), so probing the raw key alone would
@@ -119,6 +183,41 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // 3b. SEMANTIC daily guard — the one that actually stops the double-credit.
+    //
+    // Key-based idempotency cannot catch this class of duplicate. Two producers
+    // pay the same daily yield under structurally non-colliding namespaces:
+    //   in-repo cron   DailyYieldService.ts:330  `daily:agents:<uuid>:<date>`
+    //   this endpoint  caller-supplied           `agentic:yield:<email>:<date>`
+    // Different strings for the same economic event, so §3 above can never
+    // return 409 no matter how many key variants it probes. Measured
+    // 2026-07-19..21: 30 agents/day paid twice, ~240 tokens/day of excess.
+    //
+    // Daily yield is once-per-user-per-UTC-day BY DEFINITION, so check that
+    // invariant directly instead of trying to make the key strings agree. This
+    // is deliberately scoped to the daily-yield sources — transit attunement,
+    // Sky Drops and the other sync sources are legitimately multi-per-day.
+    if (isDailyYield) {
+      const sameDay = await executeQuery<{ id: string }>(
+        `SELECT id FROM token_transactions
+          WHERE user_id = $1
+            AND source_type = $2
+            AND (created_at AT TIME ZONE 'UTC')::date = (now() AT TIME ZONE 'UTC')::date
+          LIMIT 1`,
+        [userId, resolvedSource]
+      );
+      if (sameDay.rows.length > 0) {
+        return NextResponse.json(
+          {
+            ok: false,
+            reason: "already_applied",
+            message: `${resolvedSource} already credited for this UTC day`,
+          },
+          { status: 409 }
+        );
+      }
+    }
+
     // 4. Transform amounts to Credit array
     const credits: Array<{ tokenType: TokenType; amount: number }> = [
       { tokenType: "Spirit" as const, amount: Math.max(0, Number(amounts.spirit) || 0) },
@@ -127,14 +226,16 @@ export async function POST(req: NextRequest) {
       { tokenType: "Substance" as const, amount: Math.max(0, Number(amounts.substance) || 0) },
     ].filter(c => c.amount > 0);
 
-    // 5. Apply credits
+    // 5. Apply credits. `resolvedSource` (not a third copy of the `source ||
+    // "agents_yield"` fallback) — the value that was GUARDED above must be the
+    // value that is WRITTEN, or a future edit to one can silently desync them.
     const result = await tokenEconomy.creditMultipleTokens(
       userId,
       credits,
-      source || "agents_yield",
+      resolvedSource,
       {
         idempotencyKey,
-        description: `Sync: ${source || 'agents_yield'}`,
+        description: `Sync: ${resolvedSource}`,
       }
     );
 
@@ -143,6 +244,20 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(
         { ok: false, reason: "already_applied" },
         { status: 409 }
+      );
+    }
+
+    // 5a. Stamp the daily-claim timestamp, so the guard works in BOTH
+    // directions. §3b stops this endpoint double-paying after the cron; this
+    // stops the CRON double-paying after this endpoint, by reusing the check it
+    // already performs (`tokenEconomy.hasClaimedToday`, which reads
+    // last_daily_claim_agents_at). Without it the fix would be one-sided and
+    // hold only by scheduling luck — the cron fires at 00:30 UTC and PA has so
+    // far trickled in later, but nothing guarantees that ordering.
+    if (isDailyYield) {
+      await tokenEconomy.updateDailyClaimTimestamp(
+        userId,
+        resolvedSource === "agents_yield" ? "agents" : "main",
       );
     }
 

--- a/src/utils/agentMonica.ts
+++ b/src/utils/agentMonica.ts
@@ -52,7 +52,7 @@ export type Sect = "diurnal" | "nocturnal";
  *  magnitude. See §18c. */
 export const VESSEL_MASS = 4;
 
-interface ESMS {
+export interface ESMS {
   Spirit: number;
   Essence: number;
   Matter: number;
@@ -74,8 +74,12 @@ function toSignKey(sign: string): SignKey | null {
 /**
  * The process-shaped, dignity-scaled grounding vessel for a given degree.
  * `dignityEsmsScale` is the +10/+7/0/-7/-10 essential-dignity score.
+ *
+ * Exported so the two-body phase calc (§18i) reuses this exact construction
+ * rather than forking a second one — the §17c lesson was that a forked formula
+ * is how six engines came to disagree.
  */
-function vessel(degree: number, dignityEsmsScale: number): ESMS {
+export function groundingVessel(degree: number, dignityEsmsScale: number): ESMS {
   // Degree 1..30 → one of the 14 alchemical processes (§7a). The array is
   // 0-indexed, so pillar id = index + 1.
   const idx = ((Math.floor(degree) - 1) % 14 + 14) % 14;
@@ -115,7 +119,7 @@ export function agentMonicaForSect(
 
   const signKey = toSignKey(sign);
   const dignityScale = signKey ? getDignityScore(planet, signKey).esmsScale : 0;
-  const v = vessel(degree, dignityScale);
+  const v = groundingVessel(degree, dignityScale);
 
   const esms: ESMS = {
     Spirit: base.Spirit + v.Spirit,

--- a/src/utils/agentMonicaResolver.ts
+++ b/src/utils/agentMonicaResolver.ts
@@ -29,6 +29,7 @@
  * parser reads "Agent" as a sign.
  */
 import { agentMonica, type AgentMonica } from "@/utils/agentMonica";
+import { twoBodyMonica } from "@/utils/agentMonicaTwoBody";
 import {
   PLANETARY_SECTARIAN_ESMS,
   ZODIAC_ELEMENTS,
@@ -57,10 +58,11 @@ function fromAbsoluteDegree(n: number): { sign: string; degree: number } {
 
 export interface AgentPlacement {
   /**
-   * `single` — one body at one position; gets the §18c single-body monica.
-   * `phase`  — a Moon phase, which is a Sun–Moon *relationship*; a genuine
-   *            two-body monica is a §18 follow-up, so these are parsed and
-   *            identified but deliberately NOT given a single-body value.
+   * `single` — one body at one position; gets the §18c single-body monica via
+   *            `agentMonicaFromName`.
+   * `phase`  — a Moon phase, which is a Sun–Moon *relationship*; it gets the
+   *            §18i genuine two-body monica via `twoBodyMonicaFromName`, and is
+   *            deliberately NEVER given a single-body value.
    */
   kind: "single" | "phase";
   planet: string;
@@ -158,4 +160,26 @@ export function agentMonicaFromName(name: string): AgentMonica | null {
   const placement = parseAgentPlacement(name);
   if (!placement || placement.kind !== "single") return null;
   return agentMonica(placement.planet, placement.sign, placement.degree);
+}
+
+/**
+ * The real TWO-BODY monica for a named Moon-phase agent (§18i), or null when the
+ * name is not a phase agent (a single-body placement, a person, an unparseable
+ * row). The mirror of `agentMonicaFromName`, which returns null for exactly the
+ * rows this one serves — between them they cover every parseable agent name.
+ *
+ * Callers must treat null as "not a phase agent — leave it to the single-body
+ * path", never as zero.
+ *
+ * ⚠️ A name that IS a phase agent but whose phase cannot be classified THROWS
+ * `UnknownMoonPhaseError` rather than returning null. The two outcomes mean
+ * different things — null is "not my population", the throw is "my population,
+ * unclassified" — and collapsing the second into the first would silently drop
+ * rows from the backfill. A backfill that wants to survive one bad row catches
+ * it and reports; it must not default the phase.
+ */
+export function twoBodyMonicaFromName(name: string): AgentMonica | null {
+  const placement = parseAgentPlacement(name);
+  if (!placement || placement.kind !== "phase") return null;
+  return twoBodyMonica(placement.phase ?? "", placement.sign, placement.degree);
 }

--- a/src/utils/agentMonicaTwoBody.ts
+++ b/src/utils/agentMonicaTwoBody.ts
@@ -5,7 +5,10 @@
  * A phase agent ("First Quarter Moon in Cancer 0 Degree", "Moon Phase Dark Moon
  * 153") is not a placement. A phase is a Sun–Moon *relationship*, so it earns a
  * genuine two-body calculation rather than a scaled single-body one. 469 agent
- * rows are in this family; they carry NULL monica until this lands.
+ * rows are in this family. Until this lands they carry NULL in
+ * `monica_diurnal` / `monica_nocturnal` (the single-body backfill skipped them)
+ * and the OLD FAKE `monica_constant` of 0.5 — not NULL. That fake sentinel is
+ * what this replaces.
  *
  * ── The construction ────────────────────────────────────────────────────────
  *
@@ -17,17 +20,30 @@
  *  2. **ONE shared grounding vessel, mass 4, shaped by the MOON's degree only.**
  *     Not one vessel per body: the pair is one chart, so it gets one vessel, and
  *     the NAMED body (the Moon) sets its process. Built by the very same
- *     `groundingVessel()` the single-body calc uses (§18c), so a two-body result
- *     lands on the same scale as a single-body one.
+ *     `groundingVessel()` the single-body calc uses (§18c) — one construction,
+ *     not a fork (the §17c lesson).
  *
- *     ► VESSEL-DIGNITY DECISION `[RULED here]`: the shared vessel is scaled by
- *       the **MOON's** essential dignity, `× (1 + moonDignity/100)`. The Moon is
- *       the body that shapes the vessel (its degree picks the process), so it is
- *       the body that strengthens or weakens it; and the Moon's dignity is the
- *       only *position-based* dignity in this chart that is actually stated by
- *       the name. The Sun's dignity is aspect-based (below) and is applied to
- *       the Sun's own ESMS contribution, never to the shared vessel — mixing an
- *       aspect quantity into the grounding term would double-count the aspect.
+ *     ⚠️ Sharing the vessel does NOT put the two scales on top of each other.
+ *     An earlier version of this note claimed it "lands on the same scale as a
+ *     single-body one"; that was never measured and is false. See the measured
+ *     behaviour section: the two-body grid reaches 12.6756 where single-body
+ *     reaches 3.9751.
+ *
+ *     ► VESSEL-DIGNITY DECISION `[RULED 2026-07-21, revised]`: the shared vessel
+ *       is **dignity-NEUTRAL** — `groundingVessel(moonDegree, 0)`. The Moon
+ *       still shapes it (its degree picks the process); it no longer scales it.
+ *
+ *       An earlier revision scaled the shared vessel by the Moon's dignity. That
+ *       gave the Moon's dignity **two** points of leverage on the result (its own
+ *       ESMS *and* the grounding term) while the Sun's had one — an asymmetry
+ *       that was never argued for, only inherited from the single-body case
+ *       where there is exactly one body and the question cannot arise. Equalised:
+ *       **each body's dignity is applied exactly once, to that body's own ESMS.**
+ *       The vessel grounds the pair rather than taking a side.
+ *
+ *       This also keeps the aspect quantity out of the grounding term, which the
+ *       previous note already required — now by construction rather than by an
+ *       asymmetric exception.
  *
  *  3. **Both sects are returned**, exactly as single-body. NOTE: the Sun is
  *     Spirit in BOTH sects (PLANETARY_SECTARIAN_ESMS), so for a phase agent
@@ -41,13 +57,17 @@
  *     planet and must never be transcribed between. This module uses the
  *     orbital-period one.
  *
- *  5. **Dignity — the two bodies are treated DIFFERENTLY, deliberately:**
+ *  5. **Dignity — the two bodies SOURCE it differently, but APPLY it identically.**
  *       • Moon → POSITION-based: its own essential dignity at its own sign,
  *         the +10/+7/0/−7/−10 scale (`getDignityScore`).
  *       • Sun  → ASPECT-based, NOT position-based. Its longitude is *inferred*
  *         from the phase name, but the *aspect* is stated by the name with
  *         certainty. Scaling by a guessed position would compound an inference;
  *         reading dignity off the aspect uses the one thing the name guarantees.
+ *
+ *     Different SOURCES, identical APPLICATION: each is a ±10-scale number and
+ *     each multiplies exactly one thing, `× (1 + dignity/100)` on its own body's
+ *     ESMS. Neither touches the shared vessel (see 2).
  *
  * ── Provenance of the numbers ───────────────────────────────────────────────
  *
@@ -76,12 +96,13 @@
  * `semisquare` / `sesquisquare` — this is NOT the dead-underscore-key defect
  * class; they are live.)
  *
- * `[AUTHORED]` **The applying/separating multiplier** — ×1.15 applying, ×0.85
- * separating, ×1.0 exact — is the ONE unmeasured number in the design (§18i-ter).
- * Waxing and waning phases must differ even though they share an aspect
- * geometry, and nothing in the repo supplies a magnitude for that difference.
- * It multiplies the SUN's aspect dignity only, and is exported as a named
- * constant pair so it is trivially tunable when §14d supplies a basis.
+ * `[DERIVED]` **The applying/separating multiplier** — 8/7 applying, 6/7
+ * separating, 1 exact (§18i-ter). Read from the same two live orb budgets
+ * §18i-bis uses, so an applying square scores exactly −10.00, the domicile
+ * anchor. It replaced an authored ×1.15/×0.85 pair; see the constant's own note
+ * for the measurement showing the authored value barely mattered. **§18 now has
+ * no unmeasured numbers** — every constant here is read from live code or
+ * measured, and each records which.
  *
  * ── Contract ────────────────────────────────────────────────────────────────
  *
@@ -96,38 +117,62 @@
  *
  * ── Measured behaviour ──────────────────────────────────────────────────────
  *
- * `[MEASURED 2026-07-21]` Over the full grid (8 phases × 12 signs × 30 degrees =
- * 2880): **2880/2880 finite**, median |monica| 0.25, p90 1.56.
+ * All figures below are `[MEASURED 2026-07-21]` **after** the dignity
+ * equalisation and **with** TWO_BODY_LN_EPSILON applied. Both changed the
+ * numbers, so any earlier figure quoted elsewhere is stale by construction.
  *
- * ⚠️ **There is a heavy tail, and it is entirely one pillar.** Every one of the
- * 133 cases with |monica| > 4 sits at **degree 8 or 22 — the Comixion process**
- * (`ALCHEMICAL_PILLARS[7]`, effects S+1/E−1/M+1/Su+1), whose vessel floors
- * Essence to **zero**: `{2,0,2,2} → mass-4 → {1.33, 0, 1.33, 1.33}`. With no
- * vessel Essence, the ESMS lands just outside the MONICA_LN_EPSILON equilibrium
- * band, `ln(kalchm) → 0⁺`, and `−G/(R·ln K)` grows; max |monica| 21.4.
- * **Excluding degrees 8 and 22, max |monica| is 3.857** — exactly the
- * single-body / full-chart scale of [−3.97, 3.90] (§18c).
+ * **Full grid** (8 phases × 12 signs × 30 degrees × 2 sects = 5760):
+ * 5760/5760 finite · median |monica| 0.2244 · p90 1.2434 · **max 12.6756** ·
+ * 304 cells (5.3%) resolve to φ via the local band.
  *
- * This is the canonical engine's documented band-edge behaviour, not a fork and
- * not a defect of this module: the values are finite, signed and real. It is
- * recorded (and pinned by a test) rather than clamped, because widening
- * MONICA_LN_EPSILON would retune the shared §17c engine for every consumer.
- * Single-body does not show it because a lone planet cannot break the
- * Spirit/Matter/Substance symmetry Comixion creates; adding the Sun's Spirit
- * does. `[OPEN]` if the tail is later judged unacceptable, the fix belongs in
- * the pillar → vessel mapping (§7a), not here.
+ * **All 469 production phase agents**: 0 unrecognised phase strings, 0
+ * non-finite, **range [−5.4191, 1.8004]**, 221 distinct values, 16 φ.
  *
- * `[MEASURED 2026-07-21]` Against all **469** production phase agents: 0
- * unrecognised phase strings, 0 non-finite, range [−19.74, 13.54], median
- * 0.1775, 234 distinct values, largest bucket 1.5% (no sentinel clustering).
+ * ⚠️ **The residual tail is one pillar, and it is not fully absorbed.**
+ * Comixion (degrees 8 and 22, `ALCHEMICAL_PILLARS[7]`, S+1/E−1/M+1/Su+1) floors
+ * vessel Essence to **zero**. Adding the Sun's Spirit to a Moon with no vessel
+ * Essence drives `ln(kalchm) → 0`, and `−G/(R·ln K)` grows. The local band
+ * absorbs the degenerate core, cutting production rows outside the single-body
+ * range from **25 to 2** and the maximum from **149.35 to 5.42** — but a skirt
+ * survives, because some Comixion cells land at `|ln k|` ABOVE the healthy floor
+ * and cannot be absorbed without converting real values to φ.
+ *
+ * **Exactly two production rows fall outside the single-body range**
+ * ([−3.197, 3.975]), both on Comixion degrees:
+ *   • `Full Moon Moon in Libra 8 Degree` at **−5.4191**
+ *   • `Waxing Crescent Moon in Taurus 22 Degree` at **−3.2711** (2.3% below the
+ *     single-body floor — marginal, but counted rather than rounded away)
+ * The first is a φ-MIXED row: its diurnal chart is degenerate and returns φ, its
+ * nocturnal chart is healthy and returns −12.68, and `combined` is their mean.
+ * Finite, signed, real — recorded and pinned, not clamped.
+ *
+ * ⚠️ Counting note: an earlier pass reported ONE such row because it filtered on
+ * `|monica| > 4`. The single-body range is ASYMMETRIC, so a magnitude threshold
+ * is not the same test as the range test and silently missed −3.2711.
+ *
+ * ► φ-MIXING IS NOT NEW AND NOT TWO-BODY-SPECIFIC. `[MEASURED]` The shipped
+ *   single-body calc does the same thing in **180 of 3600 cells (5%)** — e.g.
+ *   `Jupiter/Aries 1` is φ diurnal, 0.0126 nocturnal, 0.8153 combined. Those
+ *   rows are in production today. It is defensible under the engine's own
+ *   definition (§17c: φ is the harmonic *ideal*, a real value, not a
+ *   couldn't-compute sentinel), so averaging it is averaging two real states.
+ *   Flagged here because it is easy to mistake for a bug introduced by this
+ *   module, and because it is what makes the last row hard to remove.
+ *
+ * `[OPEN]` To flatten the residual, the fix belongs in the pillar → vessel
+ * mapping (§7a) — giving Comixion a nonzero Essence floor — NOT in a wider band
+ * and NOT in an output clamp. That was attempted twice and rejected both times:
+ * flooring before mass-4 normalisation divides the floor back out, and flooring
+ * after it perturbs single-body from 3.9751 to 3.9089, which would desync the
+ * 4280 rows already in production.
  */
+import { PLANET_ALCHM_PERIODS, normalizeAlchmWeight } from "@/data/planets";
 import {
   MONICA_EQUILIBRIUM,
   calculateKalchm,
   calculateMonica,
   calculateThermodynamics,
 } from "@/data/unified/alchemicalCalculations";
-import { PLANET_ALCHM_PERIODS, normalizeAlchmWeight } from "@/data/planets";
 import type { AlchemicalProperties } from "@/types/celestial";
 import {
   groundingVessel,
@@ -142,7 +187,7 @@ import {
 } from "@/utils/planetaryAlchemyMapping";
 
 /** Zodiac signs in ecliptic order — index × 30 is the sign's start longitude. */
-const SIGNS = Object.keys(ZODIAC_ELEMENTS) as (keyof typeof ZODIAC_ELEMENTS)[];
+const SIGNS = Object.keys(ZODIAC_ELEMENTS) as Array<keyof typeof ZODIAC_ELEMENTS>;
 
 const DEGREES_PER_SIGN = 30;
 const FULL_CIRCLE = 360;
@@ -449,6 +494,72 @@ function alchmWeightOf(planet: string): number {
  */
 export const ELEMENTAL_MASS = 1;
 
+/**
+ * The dignity scale passed to the SHARED grounding vessel: none. The vessel
+ * grounds the pair, it does not take a side — each body's dignity is applied
+ * exactly once, to that body's own ESMS. Named rather than a bare `0` so the
+ * equalisation is greppable and cannot be silently un-done.
+ */
+export const VESSEL_DIGNITY_NEUTRAL = 0;
+
+/**
+ * `[MEASURED 2026-07-21]` `|ln kalchm|` of the **exactly-degenerate** two-body
+ * chart: Comixion (degree 8/22), nocturnal, where the vessel's Essence is
+ * literally `0.000` and only `KALCHM_EPSILON` keeps `calculateKalchm` finite.
+ *
+ *     nocturnal deg 8/22 → S 1.824  E 0.000  M 1.618  Su 1.333   ln k = −0.110698
+ *
+ * A chart with a hard zero on an axis is degenerate by inspection, not by
+ * threshold. This is the LOWER bound on the band: any width at or below it
+ * leaves a genuinely degenerate chart being divided by ~0.
+ */
+export const DEGENERATE_LN_KALCHM = 0.110698;
+
+/**
+ * `[MEASURED 2026-07-21]` The smallest `|ln kalchm|` produced by any NON-Comixion
+ * cell across the full 8×12×30×2 grid — the healthiest-case floor. This is the
+ * UPPER bound on the band: at or above it, the band starts converting cases that
+ * computed a perfectly sane monica into φ.
+ */
+export const HEALTHY_LN_KALCHM_FLOOR = 0.138173;
+
+/**
+ * `[DERIVED]` The two-body-local half-width of the monica equilibrium band, on
+ * `|ln(kalchm)|` — the midpoint of the two measured bounds above, so it carries
+ * the maximum available margin on both sides (~12% each way).
+ *
+ * ── Why local, and not a change to MONICA_LN_EPSILON ────────────────────────
+ * The canonical `MONICA_LN_EPSILON` (0.05) is shared by every consumer of the
+ * §17c engine, including the **4280 single-body agent rows already written to
+ * production**. Widening it there would silently re-value all of them and every
+ * full-chart caller besides. This band is applied in this module only; the
+ * canonical engine is untouched and single-body output is bit-identical
+ * (grid max 3.9751, regression-pinned).
+ *
+ * ── Why a wider band is the right shape of fix ──────────────────────────────
+ * The two-body tail is not a scatter of unlucky inputs — it is one pillar.
+ * Comixion (degrees 8 and 22) floors vessel Essence to zero, and adding the
+ * Sun's Spirit to a Moon that has no vessel Essence lands the pair just OUTSIDE
+ * the canonical band, where `ln(kalchm) → 0⁺` makes `−G/(R·ln K)` diverge. Those
+ * cases are *nearer* to perfect balance than the ones the canonical band already
+ * absorbs, so returning φ for them is the same statement the engine already
+ * makes, not a new one. Clamping the output instead would fabricate a magnitude;
+ * this widens the region where the engine declines to divide by ~0.
+ *
+ * ── What it does NOT do `[MEASURED]` ────────────────────────────────────────
+ * It does not flatten the tail, and this is deliberate. The band is set by the
+ * degeneracy boundary, not by how large the surviving output looks — sizing it
+ * to swallow every big number would be output-fitting. A near-degenerate skirt
+ * survives with |monica| above the single-body scale. Those values are finite,
+ * signed and real; they are the honest reading of a nearly-balanced two-body
+ * chart. The residual is quantified in the module docstring and pinned by test.
+ *
+ * `agentMonicaTwoBody.test.ts` pins BOTH bounds and the zero-collateral property,
+ * so a future retune that widens this into real values fails loudly.
+ */
+export const TWO_BODY_LN_EPSILON =
+  (DEGENERATE_LN_KALCHM + HEALTHY_LN_KALCHM_FLOOR) / 2; // 0.1244355
+
 /** A body's sect-resolved, alchm-weighted, dignity-scaled ESMS contribution. */
 function bodyContribution(
   planet: "Sun" | "Moon",
@@ -466,19 +577,57 @@ function bodyContribution(
 }
 
 /**
- * The two-body phase monica for one sect. Always finite.
+ * Every intermediate of the two-body calc, for one sect. `twoBodyMonicaForSect`
+ * is a one-line wrapper over this.
+ *
+ * Exposed so tests and measurement scripts can read the real `kalchm` /
+ * `gregsEnergy` / `reactivity` this module actually used, instead of
+ * reconstructing the ESMS from the exported parts. A reconstruction is a second
+ * copy of the formula, and §17c is the record of what happens when copies drift.
+ */
+export interface TwoBodyState {
+  /** null when the input was degenerate and no chart could be built. */
+  esms: ESMS | null;
+  elemental: { Fire: number; Water: number; Air: number; Earth: number } | null;
+  kalchm: number | null;
+  /** `Math.log(kalchm)` — the quantity the equilibrium band is measured on. */
+  lnKalchm: number | null;
+  gregsEnergy: number | null;
+  reactivity: number | null;
+  /** Always finite. */
+  monica: number;
+  /** The local equilibrium band absorbed this case (§18i-quater). */
+  equilibrium: boolean;
+  /** The input could not be placed at all; monica is φ by the totality contract. */
+  degenerate: boolean;
+}
+
+const DEGENERATE_STATE: TwoBodyState = {
+  esms: null,
+  elemental: null,
+  kalchm: null,
+  lnKalchm: null,
+  gregsEnergy: null,
+  reactivity: null,
+  monica: MONICA_EQUILIBRIUM,
+  equilibrium: false,
+  degenerate: true,
+};
+
+/**
+ * The two-body phase monica for one sect, with every intermediate. Always finite.
  *
  * @param rawPhase  phase as it appears in the agent name ("First Quarter",
  *                  "Dark Moon", "waxing_gibbous"). Unrecognised → throws.
  * @param moonSign  the Moon's sign (the sign the agent is named for).
  * @param moonDegree the Moon's degree within that sign.
  */
-export function twoBodyMonicaForSect(
+export function twoBodyState(
   rawPhase: string,
   moonSign: string,
   moonDegree: number,
   sect: Sect,
-): number {
+): TwoBodyState {
   // Throws on an unrecognised phase — deliberately, before any defaulting.
   const geometry = phaseGeometry(rawPhase);
 
@@ -486,13 +635,13 @@ export function twoBodyMonicaForSect(
   if (!moonSignKey || !Number.isFinite(moonDegree)) {
     // Degenerate input: the pair cannot be placed at all. The canonical
     // totality constant, never NaN and never a 0 sentinel.
-    return MONICA_EQUILIBRIUM;
+    return DEGENERATE_STATE;
   }
 
   const sun = derivedSunPosition(rawPhase, moonSignKey, moonDegree);
-  if (!sun) return MONICA_EQUILIBRIUM;
+  if (!sun) return DEGENERATE_STATE;
   const sunSignKey = toSignKey(sun.sign);
-  if (!sunSignKey) return MONICA_EQUILIBRIUM;
+  if (!sunSignKey) return DEGENERATE_STATE;
 
   // Moon: position-based essential dignity at its own sign.
   const moonDignity = getDignityScore("Moon", moonSignKey).esmsScale;
@@ -504,9 +653,12 @@ export function twoBodyMonicaForSect(
   const moonEsms = bodyContribution("Moon", sect, moonDignity);
   const sunEsms = bodyContribution("Sun", sect, sunDignity);
 
-  // ONE shared vessel, mass 4, shaped by the MOON's degree and scaled by the
-  // MOON's dignity (see the vessel-dignity decision in the module docstring).
-  const vessel = groundingVessel(moonDegree, moonDignity);
+  // ONE shared vessel, mass 4, SHAPED by the Moon's degree and scaled by
+  // nobody's dignity. Each body's dignity has already been applied exactly once,
+  // to its own ESMS above; scaling the shared vessel too would give whichever
+  // body it belonged to a second point of leverage. See the vessel-dignity
+  // decision in the module docstring.
+  const vessel = groundingVessel(moonDegree, VESSEL_DIGNITY_NEUTRAL);
 
   const esms: ESMS = {
     Spirit: moonEsms.Spirit + sunEsms.Spirit + vessel.Spirit,
@@ -532,8 +684,44 @@ export function twoBodyMonicaForSect(
 
   const t = calculateThermodynamics(esms as AlchemicalProperties, elementalProps);
   const kalchm = calculateKalchm(esms as AlchemicalProperties);
-  const monica = calculateMonica(t.gregsEnergy, t.reactivity, kalchm);
-  return Number.isFinite(monica) ? monica : MONICA_EQUILIBRIUM;
+  const lnKalchm = Math.log(kalchm);
+
+  // ── the two-body-local equilibrium band (§18i-quater) ────────────────────
+  // Wider than the canonical MONICA_LN_EPSILON, and applied ONLY here. See the
+  // constant's own note for why it is local and how the width was measured.
+  const inBand =
+    !Number.isFinite(kalchm) ||
+    kalchm <= 0 ||
+    Math.abs(lnKalchm) < TWO_BODY_LN_EPSILON;
+
+  const monica = inBand
+    ? MONICA_EQUILIBRIUM
+    : calculateMonica(t.gregsEnergy, t.reactivity, kalchm);
+
+  return {
+    esms,
+    elemental: elementalProps,
+    kalchm,
+    lnKalchm,
+    gregsEnergy: t.gregsEnergy,
+    reactivity: t.reactivity,
+    monica: Number.isFinite(monica) ? monica : MONICA_EQUILIBRIUM,
+    equilibrium: inBand,
+    degenerate: false,
+  };
+}
+
+/**
+ * The two-body phase monica for one sect. Always finite. Thin wrapper over
+ * `twoBodyState` — there is exactly one construction.
+ */
+export function twoBodyMonicaForSect(
+  rawPhase: string,
+  moonSign: string,
+  moonDegree: number,
+  sect: Sect,
+): number {
+  return twoBodyState(rawPhase, moonSign, moonDegree, sect).monica;
 }
 
 /**

--- a/src/utils/agentMonicaTwoBody.ts
+++ b/src/utils/agentMonicaTwoBody.ts
@@ -1,0 +1,559 @@
+/**
+ * Two-body phase monica — a real thermodynamic monica for a Moon PHASE agent
+ * (§18i of docs/physics/SYNTHESIS_MODEL.md).
+ *
+ * A phase agent ("First Quarter Moon in Cancer 0 Degree", "Moon Phase Dark Moon
+ * 153") is not a placement. A phase is a Sun–Moon *relationship*, so it earns a
+ * genuine two-body calculation rather than a scaled single-body one. 469 agent
+ * rows are in this family; they carry NULL monica until this lands.
+ *
+ * ── The construction ────────────────────────────────────────────────────────
+ *
+ *  1. **The Sun's position is fixed by the phase.** Elongation = Moon − Sun, so
+ *     Sun = Moon − elongation, at the 45° midpoints of the 8 phases (see
+ *     PHASE_GEOMETRY). `Dark Moon` folds into New at 0° — it names the invisible
+ *     Moon at conjunction, it is not a ninth phase.
+ *
+ *  2. **ONE shared grounding vessel, mass 4, shaped by the MOON's degree only.**
+ *     Not one vessel per body: the pair is one chart, so it gets one vessel, and
+ *     the NAMED body (the Moon) sets its process. Built by the very same
+ *     `groundingVessel()` the single-body calc uses (§18c), so a two-body result
+ *     lands on the same scale as a single-body one.
+ *
+ *     ► VESSEL-DIGNITY DECISION `[RULED here]`: the shared vessel is scaled by
+ *       the **MOON's** essential dignity, `× (1 + moonDignity/100)`. The Moon is
+ *       the body that shapes the vessel (its degree picks the process), so it is
+ *       the body that strengthens or weakens it; and the Moon's dignity is the
+ *       only *position-based* dignity in this chart that is actually stated by
+ *       the name. The Sun's dignity is aspect-based (below) and is applied to
+ *       the Sun's own ESMS contribution, never to the shared vessel — mixing an
+ *       aspect quantity into the grounding term would double-count the aspect.
+ *
+ *  3. **Both sects are returned**, exactly as single-body. NOTE: the Sun is
+ *     Spirit in BOTH sects (PLANETARY_SECTARIAN_ESMS), so for a phase agent
+ *     *all* sect variation comes from the Moon (day = Essence, night = Matter).
+ *     That is expected, not a bug.
+ *
+ *  4. **Each body is weighted by `alchmWeight`** — the ORBITAL-PERIOD scale
+ *     (`normalizeAlchmWeight(PLANET_ALCHM_PERIODS[planet])`), canonical in this
+ *     engine. ⚠️ There is a second, mass-based scale (`normalizePlanetWeight`);
+ *     planetaryAlchemyMapping.ts:528-533 records that the two disagree per
+ *     planet and must never be transcribed between. This module uses the
+ *     orbital-period one.
+ *
+ *  5. **Dignity — the two bodies are treated DIFFERENTLY, deliberately:**
+ *       • Moon → POSITION-based: its own essential dignity at its own sign,
+ *         the +10/+7/0/−7/−10 scale (`getDignityScore`).
+ *       • Sun  → ASPECT-based, NOT position-based. Its longitude is *inferred*
+ *         from the phase name, but the *aspect* is stated by the name with
+ *         certainty. Scaling by a guessed position would compound an inference;
+ *         reading dignity off the aspect uses the one thing the name guarantees.
+ *
+ * ── Provenance of the numbers ───────────────────────────────────────────────
+ *
+ * `[DERIVED]` **Per-aspect dignity** (§18i-bis) — both inputs read from live
+ * code, not authored:
+ *
+ *     dignity = polarity × ASPECT_DIGNITY_MAGNITUDE × (orbBudget / 8)
+ *       polarity  : src/utils/aspectCalculator.ts:211-215 — conjunction/trine/
+ *                   sextile harmonious (+), opposition/square challenging (−)
+ *       orbBudget : src/utils/aspectCalculator.ts:104-112 `aspectDefinitions` —
+ *                   conjunction 8, opposition 8, square 7, _semisquare 3,
+ *                   _sesquiquadrate 3
+ *
+ * giving conjunction +10, opposition −10, square −8.75, semisquare −3.75,
+ * sesquisquare −3.75. Sanity property: ±10 land exactly on the domicile/fall
+ * anchors of the existing dignity scale, and square falls between detriment
+ * (−7) and fall (−10) rather than off the end.
+ *
+ * ⚠️ **Giving semisquare / sesquisquare a nonzero dignity is a MODEL CHANGE,
+ * not a gap-fill.** `aspectCalculator.ts:209-215` assigns `influence = 0` to
+ * both today — they are detected and then contribute nothing. Treating them as
+ * hard (negative-polarity) aspects here is a deliberate change to how the engine
+ * values minor aspects, recorded so it is never mistaken for long-standing
+ * behaviour. (The keys are `_semisquare` / `_sesquiquadrate` in
+ * `aspectDefinitions`, but `ASPECT_TYPE_ALIASES` maps them to the canonical
+ * `semisquare` / `sesquisquare` — this is NOT the dead-underscore-key defect
+ * class; they are live.)
+ *
+ * `[AUTHORED]` **The applying/separating multiplier** — ×1.15 applying, ×0.85
+ * separating, ×1.0 exact — is the ONE unmeasured number in the design (§18i-ter).
+ * Waxing and waning phases must differ even though they share an aspect
+ * geometry, and nothing in the repo supplies a magnitude for that difference.
+ * It multiplies the SUN's aspect dignity only, and is exported as a named
+ * constant pair so it is trivially tunable when §14d supplies a basis.
+ *
+ * ── Contract ────────────────────────────────────────────────────────────────
+ *
+ * TOTALITY: every returned number is finite. Degenerate input (an unresolvable
+ * sign, a non-finite degree) returns MONICA_EQUILIBRIUM (φ), never NaN and never
+ * 0-as-a-sentinel — the same convention as the canonical engine.
+ *
+ * LOUD FAILURE: an UNRECOGNISED PHASE throws `UnknownMoonPhaseError`. It is not
+ * degenerate input, it is an unclassified population — silently defaulting it to
+ * New would fabricate a conjunction for every row we failed to parse. Callers
+ * that want a non-throwing probe use `normalizeMoonPhase()`, which returns null.
+ *
+ * ── Measured behaviour ──────────────────────────────────────────────────────
+ *
+ * `[MEASURED 2026-07-21]` Over the full grid (8 phases × 12 signs × 30 degrees =
+ * 2880): **2880/2880 finite**, median |monica| 0.25, p90 1.56.
+ *
+ * ⚠️ **There is a heavy tail, and it is entirely one pillar.** Every one of the
+ * 133 cases with |monica| > 4 sits at **degree 8 or 22 — the Comixion process**
+ * (`ALCHEMICAL_PILLARS[7]`, effects S+1/E−1/M+1/Su+1), whose vessel floors
+ * Essence to **zero**: `{2,0,2,2} → mass-4 → {1.33, 0, 1.33, 1.33}`. With no
+ * vessel Essence, the ESMS lands just outside the MONICA_LN_EPSILON equilibrium
+ * band, `ln(kalchm) → 0⁺`, and `−G/(R·ln K)` grows; max |monica| 21.4.
+ * **Excluding degrees 8 and 22, max |monica| is 3.857** — exactly the
+ * single-body / full-chart scale of [−3.97, 3.90] (§18c).
+ *
+ * This is the canonical engine's documented band-edge behaviour, not a fork and
+ * not a defect of this module: the values are finite, signed and real. It is
+ * recorded (and pinned by a test) rather than clamped, because widening
+ * MONICA_LN_EPSILON would retune the shared §17c engine for every consumer.
+ * Single-body does not show it because a lone planet cannot break the
+ * Spirit/Matter/Substance symmetry Comixion creates; adding the Sun's Spirit
+ * does. `[OPEN]` if the tail is later judged unacceptable, the fix belongs in
+ * the pillar → vessel mapping (§7a), not here.
+ *
+ * `[MEASURED 2026-07-21]` Against all **469** production phase agents: 0
+ * unrecognised phase strings, 0 non-finite, range [−19.74, 13.54], median
+ * 0.1775, 234 distinct values, largest bucket 1.5% (no sentinel clustering).
+ */
+import {
+  MONICA_EQUILIBRIUM,
+  calculateKalchm,
+  calculateMonica,
+  calculateThermodynamics,
+} from "@/data/unified/alchemicalCalculations";
+import { PLANET_ALCHM_PERIODS, normalizeAlchmWeight } from "@/data/planets";
+import type { AlchemicalProperties } from "@/types/celestial";
+import {
+  groundingVessel,
+  type AgentMonica,
+  type ESMS,
+  type Sect,
+} from "@/utils/agentMonica";
+import { getDignityScore } from "@/utils/dignityScales";
+import {
+  PLANETARY_SECTARIAN_ESMS,
+  ZODIAC_ELEMENTS,
+} from "@/utils/planetaryAlchemyMapping";
+
+/** Zodiac signs in ecliptic order — index × 30 is the sign's start longitude. */
+const SIGNS = Object.keys(ZODIAC_ELEMENTS) as (keyof typeof ZODIAC_ELEMENTS)[];
+
+const DEGREES_PER_SIGN = 30;
+const FULL_CIRCLE = 360;
+
+// ───────────────────────────── phase geometry ─────────────────────────────
+
+/** The eight canonical phases. `Dark Moon` is NOT one — it folds into `new`. */
+export type MoonPhaseKey =
+  | "new"
+  | "waxing crescent"
+  | "first quarter"
+  | "waxing gibbous"
+  | "full"
+  | "waning gibbous"
+  | "last quarter"
+  | "waning crescent";
+
+/** The Sun–Moon aspects a phase can express. Names are the repo-canonical
+ *  `AspectType` spellings (`sesquisquare` is the doc's "sesquiquadrate"). */
+export type PhaseAspect =
+  | "conjunction"
+  | "opposition"
+  | "square"
+  | "semisquare"
+  | "sesquisquare";
+
+/**
+ * Whether the aspect is closing (applying), opening (separating), or exact.
+ * `[§18i-ter stage 1]` Phase agents take this from the NAME — waxing = applying,
+ * waning = separating — which needs no engine change. Stage 2 computes it from
+ * relative planetary motion generally and feeds §14d.
+ */
+export type AspectMotion = "applying" | "separating" | "exact";
+
+export interface PhaseGeometry {
+  phase: MoonPhaseKey;
+  /** Moon − Sun, in degrees. The Sun sits at `moonLongitude − elongation`. */
+  elongation: number;
+  aspect: PhaseAspect;
+  motion: AspectMotion;
+}
+
+/**
+ * The phase → elongation / aspect / motion table (§18i). 45° midpoints across
+ * the 8 phases. New and Full are exact aspects: neither applying nor separating.
+ */
+export const PHASE_GEOMETRY: Record<MoonPhaseKey, PhaseGeometry> = {
+  "new": { phase: "new", elongation: 0, aspect: "conjunction", motion: "exact" },
+  "waxing crescent": {
+    phase: "waxing crescent",
+    elongation: 45,
+    aspect: "semisquare",
+    motion: "applying",
+  },
+  "first quarter": {
+    phase: "first quarter",
+    elongation: 90,
+    aspect: "square",
+    motion: "applying",
+  },
+  "waxing gibbous": {
+    phase: "waxing gibbous",
+    elongation: 135,
+    aspect: "sesquisquare",
+    motion: "applying",
+  },
+  "full": { phase: "full", elongation: 180, aspect: "opposition", motion: "exact" },
+  "waning gibbous": {
+    phase: "waning gibbous",
+    elongation: 225,
+    aspect: "sesquisquare",
+    motion: "separating",
+  },
+  "last quarter": {
+    phase: "last quarter",
+    elongation: 270,
+    aspect: "square",
+    motion: "separating",
+  },
+  "waning crescent": {
+    phase: "waning crescent",
+    elongation: 315,
+    aspect: "semisquare",
+    motion: "separating",
+  },
+};
+
+/**
+ * Every spelling seen in production (and its obvious variants) → canonical key.
+ * `dark` folds into `new`: the Dark Moon is the invisible Moon at conjunction,
+ * not a ninth phase. `third quarter` is the astronomical synonym of
+ * `last quarter`.
+ */
+const PHASE_ALIASES: Record<string, MoonPhaseKey> = {
+  "new": "new",
+  "dark": "new",
+  "waxing crescent": "waxing crescent",
+  "first quarter": "first quarter",
+  "waxing gibbous": "waxing gibbous",
+  "full": "full",
+  "waning gibbous": "waning gibbous",
+  "last quarter": "last quarter",
+  "third quarter": "last quarter",
+  "waning crescent": "waning crescent",
+};
+
+/** Thrown when a phase string cannot be classified. Never defaulted away. */
+export class UnknownMoonPhaseError extends Error {
+  readonly rawPhase: string;
+  constructor(rawPhase: string) {
+    super(
+      `Unrecognised moon phase: ${JSON.stringify(rawPhase)}. ` +
+        `Known phases: ${Object.keys(PHASE_ALIASES).join(", ")}. ` +
+        `A phase agent whose phase cannot be classified must be reported, ` +
+        `never defaulted (§18i).`,
+    );
+    this.name = "UnknownMoonPhaseError";
+    this.rawPhase = rawPhase;
+  }
+}
+
+/**
+ * Normalise a raw phase string to a canonical key, or null if unrecognised.
+ *
+ * The parser (`parseAgentPlacement`) yields the phase with "Moon" possibly still
+ * attached — "Dark Moon" from `Moon Phase Dark Moon 153`, "First Quarter" from
+ * `First Quarter Moon in Cancer 0 Degree` — so a leading `Moon`/`Moon Phase` and
+ * a trailing `Moon` are both stripped defensively, along with case, separators
+ * and punctuation.
+ */
+export function normalizeMoonPhase(rawPhase: string): MoonPhaseKey | null {
+  if (!rawPhase) return null;
+  let s = rawPhase
+    .toLowerCase()
+    .replace(/[^a-z]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  s = s
+    .replace(/^moon phase\s+/, "")
+    .replace(/^moon\s+/, "")
+    .replace(/\s+moon$/, "")
+    .trim();
+  return PHASE_ALIASES[s] ?? null;
+}
+
+/** Geometry for a raw phase string. Throws `UnknownMoonPhaseError` if unknown. */
+export function phaseGeometry(rawPhase: string): PhaseGeometry {
+  const key = normalizeMoonPhase(rawPhase);
+  if (!key) throw new UnknownMoonPhaseError(rawPhase);
+  return PHASE_GEOMETRY[key];
+}
+
+// ─────────────────────── aspect dignity for the Sun ───────────────────────
+
+/**
+ * `[DERIVED]` Orb budgets, read from `aspectCalculator.ts` `aspectDefinitions`.
+ * The underscore-prefixed source keys (`_semisquare`, `_sesquiquadrate`) are
+ * live via `ASPECT_TYPE_ALIASES`; the canonical names are used here.
+ */
+export const ASPECT_ORB_BUDGET: Record<PhaseAspect, number> = {
+  conjunction: 8,
+  opposition: 8,
+  square: 7,
+  semisquare: 3,
+  sesquisquare: 3,
+};
+
+/**
+ * `[DERIVED / MODEL CHANGE]` Aspect polarity, read from `aspectCalculator.ts`:
+ * conjunction/trine/sextile harmonious (+1), opposition/square challenging (−1).
+ * ⚠️ semisquare and sesquisquare carry `influence = 0` there; classing them as
+ * hard aspects (−1) is the deliberate MODEL CHANGE recorded in §18i-bis.
+ */
+export const ASPECT_POLARITY: Record<PhaseAspect, 1 | -1> = {
+  conjunction: 1,
+  opposition: -1,
+  square: -1,
+  semisquare: -1,
+  sesquisquare: -1,
+};
+
+/** The dignity magnitude a full-orb-budget aspect earns — matches the
+ *  domicile/fall anchors (+10/−10) of the essential-dignity scale. */
+export const ASPECT_DIGNITY_MAGNITUDE = 10;
+
+/** The orb budget that scores the full magnitude (conjunction/opposition = 8). */
+export const ASPECT_DIGNITY_REFERENCE_ORB = 8;
+
+/**
+ * `[DERIVED]` Per-aspect dignity for the inferred Sun (§18i-bis):
+ * `polarity × 10 × (orbBudget / 8)`.
+ *
+ * conjunction +10, opposition −10, square −8.75, semisquare −3.75,
+ * sesquisquare −3.75.
+ */
+export const ASPECT_DIGNITY: Record<PhaseAspect, number> = Object.fromEntries(
+  (Object.keys(ASPECT_ORB_BUDGET) as PhaseAspect[]).map((aspect) => [
+    aspect,
+    (ASPECT_POLARITY[aspect] *
+      ASPECT_DIGNITY_MAGNITUDE *
+      ASPECT_ORB_BUDGET[aspect]) /
+      ASPECT_DIGNITY_REFERENCE_ORB,
+  ]),
+) as Record<PhaseAspect, number>;
+
+/**
+ * `[DERIVED]` Closing aspect — the relationship is intensifying.
+ *
+ * Read from the same two live orb budgets §18i-bis already uses: the reference
+ * budget (8, conjunction/opposition) over the square's (7). An APPLYING hard
+ * aspect is therefore scored at the FULL reference budget — `8.75 × 8/7 = 10.00`
+ * exactly, landing on the domicile anchor of the essential-dignity scale — and
+ * SEPARATING removes an equal amount (`2 − 8/7 = 6/7`).
+ *
+ * This replaced an authored ×1.15/×0.85. Measurement showed the authored value
+ * was nearly irrelevant to what it was introduced to achieve: waxing and waning
+ * are already separated by 270° of elongation (the derived Sun lands 90° apart,
+ * in a different sign), so mean |separation| moved only 0.2870 → 0.2871 → 0.2875
+ * across multipliers 1.00 / 1.15 / 1.50. Deriving it costs nothing behaviourally
+ * and leaves §18 with **no unmeasured numbers**.
+ */
+export const APPLYING_DIGNITY_MULTIPLIER =
+  ASPECT_DIGNITY_REFERENCE_ORB / ASPECT_ORB_BUDGET.square; // 8/7
+
+/** `[DERIVED]` Opening aspect — the relationship is releasing. The reflection of
+ *  the applying multiplier about 1: `2 − 8/7 = 6/7`. */
+export const SEPARATING_DIGNITY_MULTIPLIER = 2 - APPLYING_DIGNITY_MULTIPLIER; // 6/7
+
+/** Exact aspects (New, Full, Dark Moon) are neither applying nor separating. */
+export const EXACT_DIGNITY_MULTIPLIER = 1;
+
+/** `[DERIVED]` The motion → multiplier table. */
+export const MOTION_DIGNITY_MULTIPLIER: Record<AspectMotion, number> = {
+  applying: APPLYING_DIGNITY_MULTIPLIER,
+  separating: SEPARATING_DIGNITY_MULTIPLIER,
+  exact: EXACT_DIGNITY_MULTIPLIER,
+};
+
+/**
+ * The Sun's dignity for a phase: aspect dignity × the applying/separating
+ * multiplier. Throws `UnknownMoonPhaseError` on an unrecognised phase.
+ */
+export function sunAspectDignity(rawPhase: string): number {
+  const g = phaseGeometry(rawPhase);
+  return ASPECT_DIGNITY[g.aspect] * MOTION_DIGNITY_MULTIPLIER[g.motion];
+}
+
+// ───────────────────────────── body placement ─────────────────────────────
+
+export interface BodyPosition {
+  sign: string;
+  /** Degree within the sign, 0–29.999…  */
+  degree: number;
+  /** Absolute ecliptic longitude, 0–359.999…  */
+  longitude: number;
+}
+
+/** Normalise a sign to the Title-case key ZODIAC_ELEMENTS uses, or null. */
+function toSignKey(sign: string): keyof typeof ZODIAC_ELEMENTS | null {
+  if (!sign) return null;
+  const key = (sign.charAt(0).toUpperCase() +
+    sign.slice(1).toLowerCase()) as keyof typeof ZODIAC_ELEMENTS;
+  return key in ZODIAC_ELEMENTS ? key : null;
+}
+
+function fromLongitude(longitude: number): BodyPosition {
+  const lon = ((longitude % FULL_CIRCLE) + FULL_CIRCLE) % FULL_CIRCLE;
+  return {
+    sign: SIGNS[Math.floor(lon / DEGREES_PER_SIGN)],
+    degree: lon % DEGREES_PER_SIGN,
+    longitude: lon,
+  };
+}
+
+/**
+ * The Sun's position implied by the Moon's position and the phase:
+ * `Sun = Moon − elongation`. Returns null if the Moon's sign is unresolvable.
+ * Throws `UnknownMoonPhaseError` on an unrecognised phase.
+ */
+export function derivedSunPosition(
+  rawPhase: string,
+  moonSign: string,
+  moonDegree: number,
+): BodyPosition | null {
+  const g = phaseGeometry(rawPhase);
+  const signKey = toSignKey(moonSign);
+  if (!signKey || !Number.isFinite(moonDegree)) return null;
+  const moonLongitude = SIGNS.indexOf(signKey) * DEGREES_PER_SIGN + moonDegree;
+  return fromLongitude(moonLongitude - g.elongation);
+}
+
+// ─────────────────────────────── the calc ─────────────────────────────────
+
+/** Orbital-period ("alchm") weight for a body. NOT the mass scale. */
+function alchmWeightOf(planet: string): number {
+  return normalizeAlchmWeight(PLANET_ALCHM_PERIODS[planet] ?? 1.0);
+}
+
+/**
+ * Total elemental mass the two-body element vector is normalised to. Equal to
+ * the single-body vector's mass (one body → one unit of its sign's element), so
+ * the thermodynamic ratios stay on the same scale. A New Moon (both bodies in
+ * one sign) therefore reproduces the single-body unit vector exactly.
+ */
+export const ELEMENTAL_MASS = 1;
+
+/** A body's sect-resolved, alchm-weighted, dignity-scaled ESMS contribution. */
+function bodyContribution(
+  planet: "Sun" | "Moon",
+  sect: Sect,
+  dignityEsmsScale: number,
+): ESMS {
+  const base = PLANETARY_SECTARIAN_ESMS[planet][sect];
+  const k = alchmWeightOf(planet) * (1 + dignityEsmsScale / 100);
+  return {
+    Spirit: base.Spirit * k,
+    Essence: base.Essence * k,
+    Matter: base.Matter * k,
+    Substance: base.Substance * k,
+  };
+}
+
+/**
+ * The two-body phase monica for one sect. Always finite.
+ *
+ * @param rawPhase  phase as it appears in the agent name ("First Quarter",
+ *                  "Dark Moon", "waxing_gibbous"). Unrecognised → throws.
+ * @param moonSign  the Moon's sign (the sign the agent is named for).
+ * @param moonDegree the Moon's degree within that sign.
+ */
+export function twoBodyMonicaForSect(
+  rawPhase: string,
+  moonSign: string,
+  moonDegree: number,
+  sect: Sect,
+): number {
+  // Throws on an unrecognised phase — deliberately, before any defaulting.
+  const geometry = phaseGeometry(rawPhase);
+
+  const moonSignKey = toSignKey(moonSign);
+  if (!moonSignKey || !Number.isFinite(moonDegree)) {
+    // Degenerate input: the pair cannot be placed at all. The canonical
+    // totality constant, never NaN and never a 0 sentinel.
+    return MONICA_EQUILIBRIUM;
+  }
+
+  const sun = derivedSunPosition(rawPhase, moonSignKey, moonDegree);
+  if (!sun) return MONICA_EQUILIBRIUM;
+  const sunSignKey = toSignKey(sun.sign);
+  if (!sunSignKey) return MONICA_EQUILIBRIUM;
+
+  // Moon: position-based essential dignity at its own sign.
+  const moonDignity = getDignityScore("Moon", moonSignKey).esmsScale;
+  // Sun: aspect-based dignity, scaled by applying/separating.
+  const sunDignity =
+    ASPECT_DIGNITY[geometry.aspect] *
+    MOTION_DIGNITY_MULTIPLIER[geometry.motion];
+
+  const moonEsms = bodyContribution("Moon", sect, moonDignity);
+  const sunEsms = bodyContribution("Sun", sect, sunDignity);
+
+  // ONE shared vessel, mass 4, shaped by the MOON's degree and scaled by the
+  // MOON's dignity (see the vessel-dignity decision in the module docstring).
+  const vessel = groundingVessel(moonDegree, moonDignity);
+
+  const esms: ESMS = {
+    Spirit: moonEsms.Spirit + sunEsms.Spirit + vessel.Spirit,
+    Essence: moonEsms.Essence + sunEsms.Essence + vessel.Essence,
+    Matter: moonEsms.Matter + sunEsms.Matter + vessel.Matter,
+    Substance: moonEsms.Substance + sunEsms.Substance + vessel.Substance,
+  };
+
+  // Elements come from the SIGNS — both bodies contribute their own sign's
+  // element, weighted the same way their ESMS is, then normalised to the
+  // single-body elemental mass.
+  const moonWeight = alchmWeightOf("Moon");
+  const sunWeight = alchmWeightOf("Sun");
+  const elementalProps = { Fire: 0, Water: 0, Air: 0, Earth: 0 };
+  elementalProps[ZODIAC_ELEMENTS[moonSignKey]] += moonWeight;
+  elementalProps[ZODIAC_ELEMENTS[sunSignKey]] += sunWeight;
+  const elementalSum = moonWeight + sunWeight || 1;
+  const scale = ELEMENTAL_MASS / elementalSum;
+  elementalProps.Fire *= scale;
+  elementalProps.Water *= scale;
+  elementalProps.Air *= scale;
+  elementalProps.Earth *= scale;
+
+  const t = calculateThermodynamics(esms as AlchemicalProperties, elementalProps);
+  const kalchm = calculateKalchm(esms as AlchemicalProperties);
+  const monica = calculateMonica(t.gregsEnergy, t.reactivity, kalchm);
+  return Number.isFinite(monica) ? monica : MONICA_EQUILIBRIUM;
+}
+
+/**
+ * The two-body phase monica, both sects. `combined` is the mean — the value
+ * written to `monica_constant` (§18e).
+ *
+ * Throws `UnknownMoonPhaseError` on an unrecognised phase; every other input
+ * resolves to a finite number.
+ */
+export function twoBodyMonica(
+  rawPhase: string,
+  moonSign: string,
+  moonDegree: number,
+): AgentMonica {
+  const diurnal = twoBodyMonicaForSect(rawPhase, moonSign, moonDegree, "diurnal");
+  const nocturnal = twoBodyMonicaForSect(
+    rawPhase,
+    moonSign,
+    moonDegree,
+    "nocturnal",
+  );
+  return { diurnal, nocturnal, combined: (diurnal + nocturnal) / 2 };
+}


### PR DESCRIPTION
Two producers have been paying the same daily yield since **2026-07-19**. Measured against production with explicit UTC date bounds (no rolling window — that artifact has produced a wrong number in this program before):

| day | users | double-paid | cron only | PA only |
|---|---|---|---|---|
| 2026-07-14 … 07-18 | 30 | **0** | 30 | 0 |
| 2026-07-19 | 73 | **30** | 0 | 43 |
| 2026-07-20 | 73 | **30** | 0 | 43 |
| 2026-07-21 | 73 | **30** | 0 | 43 |

**91 double-paid user-days, 728.00 excess ESMS**, still accruing at ~240/day.

## Why key-based idempotency could never catch this

The two producers write into structurally non-colliding namespaces:

```
in-repo cron    DailyYieldService.ts:330   daily:agents:<uuid>:<date>
this endpoint   caller-supplied            agentic:yield:<email>:<date>
```

Different strings for the same economic event. The existing probe already tries five key variants and still returns nothing — no amount of variant-probing makes a uuid-keyed string collide with an email-keyed one.

So the guard checks the **invariant** instead: daily yield is once-per-user-per-UTC-day by definition.

## The guard is bidirectional

Blocking only this endpoint would have been one-sided, holding by scheduling luck alone — the cron fires at 00:30 UTC and PA has so far trickled in later, but nothing guarantees that ordering. A daily-yield credit here now also stamps `last_daily_claim_agents_at`, which makes the cron's **own pre-existing** `hasClaimedToday` check see the external credit. Whichever producer runs second is refused, either way round.

Scoped to `agents_yield` / `daily_yield` only. `transit_attunement` (Sky Drops) and the other sync sources are legitimately multi-per-day and are **not** day-capped — pinned by test.

⚠️ The 43 PA-only agents are unaffected: the cron's default limit is 30, so it never paid them, and the guard only refuses a *second* payment.

## Daily yield can no longer mint the account it pays

Auto-provisioning created a paid, chart-less user for **any** unrecognised `@agentic.alchm.kitchen` address — that is how two 2026-07-19 smoke-test vessels ended up drawing daily yield. Yield now requires the user to already exist **and** to have a chart, using the same eligibility predicate as the in-repo cron (non-empty `natal_positions`). Two producers paying one population must agree on who that population is, or the looser rule silently defines it. Auto-provisioning still works for non-yield sources.

## Not doing: no reversal of the 728 tokens

Those agents cannot spend, cannot mint and cannot rank publicly. A debit campaign against a live ledger would itself need the idempotency machinery that just failed. The excess is fully attributable (73 agents, exact keys, exact timestamps) and is recorded in the commit message so a later audit does not read it as signal.

## Tests

11 new. The load-bearing one asserts a duplicate is refused **even with a different idempotency key**, and proves non-vacuity by asserting the key probe really did run and really did miss — so the 409 provably comes from the new guard, not the old check.

Full suite 160 suites / 1377 tests green; typecheck and lint clean.

## Note on scope

An unrelated production **auth bypass** was found during the same investigation (`getUserIdFromRequest` has an unguarded `?userId=` fallback, confirmed live). It is deliberately **not** in this PR and is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)