### PR TITLE
fix(auth): remove unauthenticated ?userId= identity bypass

### DIFF
--- a/src/app/api/economy/purchase/__tests__/route.test.ts
+++ b/src/app/api/economy/purchase/__tests__/route.test.ts
@@ -1,0 +1,77 @@
+/**
+ * SECURITY REGRESSION: POST /api/economy/purchase must not accept an
+ * unauthenticated caller's own ?userId= as identity. It previously did
+ * (query-param fallback in getUserIdFromRequest -> getDatabaseUserFromRequest),
+ * which let anyone spend another user's ESMS balance just by knowing their UUID.
+ */
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body, init) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("jose", () => ({
+  jwtVerify: jest.fn(),
+  errors: {
+    JWTExpired: class extends Error {},
+    JWSInvalid: class extends Error {},
+    JWTInvalid: class extends Error {},
+  },
+}));
+
+jest.mock("@/lib/rateLimit", () => ({ rateLimit: jest.fn().mockResolvedValue({ allowed: true }) }));
+jest.mock("@/lib/economy/livePricing", () => ({
+  applyPersonalizedPricing: jest.fn(),
+  getPersonalizedPricingContext: jest.fn(),
+  applyLivePricing: jest.fn(),
+  getLivePricingContext: jest.fn(),
+}));
+jest.mock("@/services/TokenEconomyService", () => ({ tokenEconomy: {} }));
+jest.mock("@/utils/astrology/chartDataUtils", () => ({ getCapitalizedNatalPositions: jest.fn() }));
+
+import { __resetValidateRequestTestLoaders, __setValidateRequestTestLoaders } from "@/lib/auth/validateRequest";
+import { POST } from "../route";
+
+function makeRequest(url: string, body: unknown): any {
+  return {
+    url,
+    method: "POST",
+    nextUrl: { pathname: "/api/economy/purchase" },
+    headers: { get: () => null },
+    cookies: { get: () => undefined },
+    json: async () => body,
+  };
+}
+
+describe("POST /api/economy/purchase", () => {
+  const auth = jest.fn();
+  const userDb = { getUserById: jest.fn(), getUserByEmail: jest.fn() };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    auth.mockResolvedValue(null);
+    __setValidateRequestTestLoaders({
+      authLoader: async () => auth,
+      userDatabaseLoader: async () => userDb,
+    });
+  });
+
+  afterEach(() => {
+    __resetValidateRequestTestLoaders();
+  });
+
+  it("401s an unauthenticated request carrying only ?userId=, before any spend", async () => {
+    const res = await POST(
+      makeRequest(
+        "http://localhost/api/economy/purchase?userId=00000000-0000-4000-8000-000000000000",
+        { shopItemSlug: "some-item" },
+      ),
+    );
+
+    expect(res.status).toBe(401);
+    expect(userDb.getUserById).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/food-diary/__tests__/route.test.ts
+++ b/src/app/api/food-diary/__tests__/route.test.ts
@@ -1,0 +1,69 @@
+/**
+ * SECURITY REGRESSION: GET /api/food-diary must not accept an unauthenticated
+ * caller's own ?userId= as identity. It previously did (query-param fallback
+ * in getUserIdFromRequest, plus a second local fallback in this route), which
+ * let anyone read another user's food diary just by knowing their UUID.
+ */
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body, init) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+jest.mock("jose", () => ({
+  jwtVerify: jest.fn(),
+  errors: {
+    JWTExpired: class extends Error {},
+    JWSInvalid: class extends Error {},
+    JWTInvalid: class extends Error {},
+  },
+}));
+
+jest.mock("@/lib/rateLimit", () => ({ rateLimit: jest.fn().mockResolvedValue({ allowed: true }) }));
+jest.mock("@/services/FoodDiaryService", () => ({ foodDiaryService: {} }));
+jest.mock("@/services/questEventReporter", () => ({ reportQuestEventBestEffort: jest.fn() }));
+
+import { __resetValidateRequestTestLoaders, __setValidateRequestTestLoaders } from "@/lib/auth/validateRequest";
+import { GET } from "../route";
+
+function makeRequest(url: string): any {
+  return {
+    url,
+    method: "GET",
+    nextUrl: { pathname: "/api/food-diary" },
+    headers: { get: () => null },
+    cookies: { get: () => undefined },
+  };
+}
+
+describe("GET /api/food-diary", () => {
+  const auth = jest.fn();
+  const userDb = { getUserById: jest.fn(), getUserByEmail: jest.fn() };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    auth.mockResolvedValue(null);
+    __setValidateRequestTestLoaders({
+      authLoader: async () => auth,
+      userDatabaseLoader: async () => userDb,
+    });
+  });
+
+  afterEach(() => {
+    __resetValidateRequestTestLoaders();
+  });
+
+  it("401s an unauthenticated request carrying only ?userId=", async () => {
+    const res = await GET(
+      makeRequest(
+        "http://localhost/api/food-diary?userId=00000000-0000-4000-8000-000000000000",
+      ),
+    );
+
+    expect(res.status).toBe(401);
+    expect(userDb.getUserById).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/food-diary/route.ts
+++ b/src/app/api/food-diary/route.ts
@@ -26,17 +26,12 @@ export const runtime = "nodejs";
  * - date: ISO date string (YYYY-MM-DD) — if provided, returns only that day's entries
  * - startDate: ISO date string — range start (inclusive)
  * - endDate:   ISO date string — range end (inclusive)
- * - userId:    override (falls back to auth session)
  */
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
 
-    // Prefer session auth, fall back to explicit userId param for backwards compat
-    let userId = await getUserIdFromRequest(request);
-    if (!userId) {
-      userId = searchParams.get("userId");
-    }
+    const userId = await getUserIdFromRequest(request);
 
     if (!userId) {
       return NextResponse.json(
@@ -97,12 +92,11 @@ export async function GET(request: NextRequest) {
  * POST /api/food-diary
  * Create a new food diary entry for the authenticated user.
  *
- * Body: CreateFoodDiaryEntryInput (with optional userId override)
+ * Body: CreateFoodDiaryEntryInput
  */
 export async function POST(request: NextRequest) {
   try {
-    // Prefer session auth, fall back to body userId for backwards compat
-    let userId = await getUserIdFromRequest(request);
+    const userId = await getUserIdFromRequest(request);
 
     const rl = await rateLimit(request, { window: 60_000, max: 30, bucket: "food-diary-post", identifier: userId ?? undefined });
     if (!rl.allowed) return rl.response!;
@@ -127,10 +121,6 @@ export async function POST(request: NextRequest) {
     }
     
     const inputData = parsedBody.data;
-
-    if (!userId) {
-      userId = inputData.userId ?? null;
-    }
 
     if (!userId) {
       return NextResponse.json(

--- a/src/lib/auth/__tests__/validateRequest.test.ts
+++ b/src/lib/auth/__tests__/validateRequest.test.ts
@@ -130,4 +130,16 @@ describe("validateRequest: getUserIdFromRequest", () => {
     const userId = await getUserIdFromRequest(mockReq);
     expect(userId).toBeNull();
   });
+
+  it("SECURITY REGRESSION: must NOT trust a ?userId= query param as identity when there is no session, token, or agents-bridge cookie", async () => {
+    auth.mockResolvedValue(null);
+    const spoofedReq = new (jest.requireMock("next/server").NextRequest)(
+      "http://localhost:3000/api/test?userId=00000000-0000-4000-8000-000000000000",
+    );
+
+    const userId = await getUserIdFromRequest(spoofedReq);
+
+    expect(userId).toBeNull();
+    expect(userDb.getUserById).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/auth/validateRequest.ts
+++ b/src/lib/auth/validateRequest.ts
@@ -359,10 +359,7 @@ export async function getUserIdFromRequest(
     );
   }
 
-  // Fallback to query param (for development/testing)
-  const { searchParams } = new URL(request.url);
-  const queryUserId = searchParams.get("userId");
-  return queryUserId;
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

`getUserIdFromRequest` ended in an unguarded query-param fallback — no `NODE_ENV` check — that let an unauthenticated caller impersonate **any** account by appending `?userId=<uuid>`. No cookie, no `Authorization` header, nothing else required.

Confirmed exploitable in production prior to this fix:
```
curl "https://alchm.kitchen/api/economy/shop?userId=<real-user-uuid>"  ->  200 with that account's balances
```

Since `getDatabaseUserFromRequest` calls `getUserIdFromRequest` directly and passes the result straight into `userDb.getUserById()`, this was full impersonation, not just a read leak — it reached ~70 routes including mutating ones (`economy/purchase`, `economy/swap`, `economy/claim-onchain`, chat, tables, profile edits, etc.).

Two more instances of the same pattern were found and fixed in `food-diary/route.ts` while auditing this file:
- `GET` had its own duplicate `?userId=` fallback.
- `POST` fell back to a `userId` field in the request **body**, letting an unauthenticated caller write food-diary entries as any user.

**Incident window:** the fallback landed on `master` (auto-deploys to prod) around Apr 30–May 8, 2026 — roughly 11–12 weeks of exposure.

## Dependent-caller audit

Nothing legitimate relied on this fallback:
- The agents cross-site bridge (`resolveAgentsBridgeUser`) is a separate cookie-based mechanism, untouched by this change.
- Internal/PA server-to-server routes (`economy/balance`, `sync-credit`, `sync-debit`, `sync-event`, `internal/agent-sync`, `internal/agent-recipes`, `feed`, `feed/health`, `agents/unified`) already authenticate via `X-Sync-Secret` + `ALCHM_KITCHEN_SYNC_SECRET`, checked *before* ever falling through to `getUserIdFromRequest`.
- `/api/menu-planner/public-week` reads `?userId=` itself directly for its own, intentionally-public, agent-domain-gated purpose — it never calls `getUserIdFromRequest` and is unaffected.
- `useFoodDiary.ts`'s client-side `?userId=` query param is vestigial: it always sends `credentials: "include"`, so session auth (tried first) already resolves identity.

## What changed

- `src/lib/auth/validateRequest.ts`: `getUserIdFromRequest` now returns `null` instead of falling back to `searchParams.get("userId")`.
- `src/app/api/food-diary/route.ts`: removed the GET route's duplicate local fallback and the POST route's body-`userId` override.

## Test plan

- [x] New regression test in `validateRequest.test.ts`: an unauthenticated request carrying only `?userId=` resolves to `null`.
- [x] New route-level regression test for a **read** route (`food-diary` GET): 401s with only `?userId=`.
- [x] New route-level regression test for a **spend** route (`economy/purchase` POST): 401s with only `?userId=`, before any spend logic runs.
- [x] Verified all three new/updated tests **fail** against the pre-fix code (via `git stash`) and **pass** against the fix — confirmed as genuine regressions, not vacuous assertions.
- [x] `bun run typecheck` clean.
- [x] Existing `useFoodDiary` hook test suite (12 tests) still passes — client behavior unaffected since it already sends session credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)