### PR TITLE
fix(agents): a natal chart's sect belongs to the birth moment and birthplace

### DIFF
--- a/src/__tests__/natalSect.test.ts
+++ b/src/__tests__/natalSect.test.ts
@@ -1,0 +1,101 @@
+/**
+ * A natal chart's sect belongs to the birth moment at the birthplace.
+ *
+ * The bug these pin: `agents/unified` called `alchemize(chartPositions)` with
+ * neither a date nor a sect, so `date` defaulted to `new Date()` and sect was
+ * resolved at the site's New York reference observer. A birth chart therefore
+ * inherited "is it daytime in New York right now" — creating the same agent
+ * twelve hours apart produced two different monicas, and the chart was not a
+ * function of the chart at all.
+ */
+import { alchemize, type PlanetaryPosition } from "@/services/RealAlchemizeService";
+import { isCurrentSkyDiurnal, isDiurnalAt } from "@/utils/astrology/positions";
+
+/** A fixed, arbitrary natal chart. Values never change, so any difference in
+ *  output can only come from sect. */
+const CHART: Record<string, PlanetaryPosition> = {
+  Sun: { sign: "leo", degree: 15, minute: 0, exactLongitude: 135 },
+  Moon: { sign: "taurus", degree: 3, minute: 0, exactLongitude: 33 },
+  Mercury: { sign: "virgo", degree: 2, minute: 0, exactLongitude: 152 },
+  Venus: { sign: "cancer", degree: 20, minute: 0, exactLongitude: 110 },
+  Mars: { sign: "aries", degree: 8, minute: 0, exactLongitude: 8 },
+  Jupiter: { sign: "sagittarius", degree: 25, minute: 0, exactLongitude: 265 },
+  Saturn: { sign: "capricorn", degree: 11, minute: 0, exactLongitude: 281 },
+};
+
+// Noon and midnight UTC on the same day — one is unambiguously day in New York,
+// the other unambiguously night.
+const NOON_UTC = new Date("2026-03-15T17:00:00Z"); // ~13:00 in New York
+const MIDNIGHT_UTC = new Date("2026-03-15T05:00:00Z"); // ~01:00 in New York
+
+describe("isDiurnalAt — sect at an arbitrary place and moment", () => {
+  it("disagrees between two places at the SAME instant", () => {
+    // Same moment: daytime in Tokyo, night in New York. If sect ignored
+    // location these would be equal.
+    const instant = new Date("2026-03-15T03:00:00Z"); // 12:00 Tokyo, 23:00 NY
+    const tokyo = isDiurnalAt(instant, 35.68, 139.65);
+    const newYork = isDiurnalAt(instant, 40.71, -74.01);
+
+    expect(tokyo).toBe(true);
+    expect(newYork).toBe(false);
+    expect(tokyo).not.toBe(newYork);
+  });
+
+  it("disagrees between two moments at the SAME place", () => {
+    expect(isDiurnalAt(NOON_UTC, 40.71, -74.01)).toBe(true);
+    expect(isDiurnalAt(MIDNIGHT_UTC, 40.71, -74.01)).toBe(false);
+  });
+
+  it("isCurrentSkyDiurnal is exactly isDiurnalAt at the New York observer", () => {
+    for (const d of [NOON_UTC, MIDNIGHT_UTC]) {
+      expect(isCurrentSkyDiurnal(d)).toBe(isDiurnalAt(d, 40.7128, -74.006));
+    }
+  });
+});
+
+describe("alchemize — the diurnal override", () => {
+  it("sect actually changes the result (non-vacuity guard)", () => {
+    const day = alchemize(CHART, null, NOON_UTC, { diurnal: true });
+    const night = alchemize(CHART, null, NOON_UTC, { diurnal: false });
+
+    // If these were equal, every other assertion here would be meaningless.
+    expect(day.monica).not.toBeCloseTo(night.monica, 6);
+  });
+
+  it("a natal chart is INDEPENDENT of when it is computed, once sect is pinned", () => {
+    // The same birth chart, with its own sect supplied, evaluated under two
+    // wildly different "now"s. This is the property the bug violated.
+    const a = alchemize(CHART, null, NOON_UTC, { diurnal: true });
+    const b = alchemize(CHART, null, MIDNIGHT_UTC, { diurnal: true });
+
+    expect(a.monica).toBeCloseTo(b.monica, 12);
+  });
+
+  it("WITHOUT the override, the same chart yields different monicas by clock", () => {
+    // Demonstrates the defect directly: no override → sect follows the date,
+    // so the identical natal chart reads differently at noon vs midnight.
+    const noon = alchemize(CHART, null, NOON_UTC);
+    const midnight = alchemize(CHART, null, MIDNIGHT_UTC);
+
+    expect(noon.monica).not.toBeCloseTo(midnight.monica, 6);
+  });
+
+  it("the override wins over the date", () => {
+    // NOON_UTC is diurnal in NY, but an explicit nocturnal override must win.
+    const forced = alchemize(CHART, null, NOON_UTC, { diurnal: false });
+    const natural = alchemize(CHART, null, MIDNIGHT_UTC); // genuinely nocturnal
+
+    expect(forced.monica).toBeCloseTo(natural.monica, 12);
+  });
+
+  it("omitting the override preserves the previous behaviour exactly", () => {
+    // Back-compat: every existing live-sky caller must be untouched.
+    for (const d of [NOON_UTC, MIDNIGHT_UTC]) {
+      const implicit = alchemize(CHART, null, d);
+      const explicit = alchemize(CHART, null, d, {
+        diurnal: isCurrentSkyDiurnal(d),
+      });
+      expect(implicit.monica).toBeCloseTo(explicit.monica, 12);
+    }
+  });
+});

--- a/src/app/api/agents/unified/route.ts
+++ b/src/app/api/agents/unified/route.ts
@@ -7,6 +7,7 @@ import { rateLimit } from "@/lib/rateLimit";
 import { getServiceUrlSafe } from "@/lib/serviceUrls";
 import { calculateNatalChart } from "@/services/natalChartService";
 import { alchemize, type PlanetaryPosition } from "@/services/RealAlchemizeService";
+import { isDiurnalAt } from "@/utils/astrology/positions";
 import type { NextRequest} from "next/server";
 
 export const dynamic = "force-dynamic";
@@ -174,7 +175,7 @@ export async function POST(request: NextRequest) {
         // (((sun + moon + asc) / 3 / 360) * 10), which shared nothing with the
         // monica formula but its name. Agents created here carry real birth
         // data, so they get the FULL-CHART monica of §18d, not the single-body
-        // calc; the chart already fixes the sect, so the monica_diurnal /
+        // calc; the chart fixes the sect, so the monica_diurnal /
         // monica_nocturnal columns stay NULL for these rows.
         const chartPositions: Record<string, PlanetaryPosition> = {};
         serverChart.planets.forEach((p) => {
@@ -185,7 +186,19 @@ export async function POST(request: NextRequest) {
             exactLongitude: p.position,
           };
         });
-        const monicaConstant = alchemize(chartPositions).monica;
+
+        // ⚠️ Sect MUST come from the birth moment at the BIRTHPLACE.
+        // This previously called `alchemize(chartPositions)` with neither, so
+        // `date` defaulted to `new Date()` and sect was resolved at the site's
+        // New York reference observer — i.e. a natal chart inherited "is it
+        // daytime in New York right now, as this agent is being created".
+        // Sect drives the whole day/night ESMS split, so the chart was not a
+        // function of the chart at all: creating the same agent twelve hours
+        // apart produced two different monicas.
+        const birthMoment = new Date(birthData.dateTime);
+        const monicaConstant = alchemize(chartPositions, null, birthMoment, {
+          diurnal: isDiurnalAt(birthMoment, latitude, longitude),
+        }).monica;
 
         const agentId = randomUUID();
         const email = `agent-${name.toLowerCase().replace(/[^a-z0-9]/g, "-")}-${randomUUID().slice(0, 8)}@agentic.alchm.kitchen`;

--- a/src/services/RealAlchemizeService.ts
+++ b/src/services/RealAlchemizeService.ts
@@ -267,12 +267,17 @@ function getPlanetaryDignity(planet: string, sign: string): number {
  * @param planetaryPositions - CURRENT planetary positions
  * @param historicalPositions - PREVIOUS planetary positions (for momentum calculation)
  * @param date - The moment being calculated
+ * @param options.diurnal - Override the computed sect. Sect is otherwise derived
+ *   from `date` at the site's NEW YORK reference observer, which is right for
+ *   the live sky and WRONG for a natal chart: a birth chart's sect belongs to
+ *   the birth moment at the BIRTHPLACE. Natal callers should compute it with
+ *   `isDiurnalAt(birthMoment, lat, lon)` and pass it here.
  */
 export function alchemize(
   planetaryPositions: Record<string, PlanetaryPosition>,
   historicalPositions: Record<string, PlanetaryPosition> | null = null,
   date: Date = new Date(),
-  options: { incomingDegraded?: DegradedInfo | null } = {},
+  options: { incomingDegraded?: DegradedInfo | null; diurnal?: boolean } = {},
 ): StandardizedAlchemicalResult {
   // Initialize totals
   const totals = {
@@ -304,11 +309,15 @@ export function alchemize(
     Ascendant: { Spirit: 1, Essence: 1, Matter: 1, Substance: 1 },
   };
   // Determine sect (diurnal / nocturnal) for the moment being calculated.
-  // This shifts at every sunrise (~06:00 UTC) and sunset (~18:00 UTC).
   // Using the provided `date` parameter ensures historical/forecast
   // calculations use the correct sect for that point in time.
-  const diurnal = isCurrentSkyDiurnal(date);
-  
+  //
+  // `options.diurnal` overrides it entirely. Required for NATAL charts: the
+  // default resolves sect at the site's New York reference observer, so a
+  // birth chart would otherwise inherit the sect of whoever's sky it was
+  // computed under rather than its own. See the @param note above.
+  const diurnal = options.diurnal ?? isCurrentSkyDiurnal(date);
+
   // Momentum Tracking
   const planetaryMomentum: Record<string, number> = {};
   // Elemental blending weights:

--- a/src/utils/astrology/positions.ts
+++ b/src/utils/astrology/positions.ts
@@ -256,6 +256,34 @@ function calculateLunarNodesInternal(date: Date): {
 export const NEW_YORK_OBSERVER = { latitude: 40.7128, longitude: -74.006 } as const;
 
 /**
+ * Diurnal/nocturnal sect at an ARBITRARY moment and place — the Sun's true
+ * altitude above that observer's horizon.
+ *
+ * This is the primitive the other sect helpers are built from. Use it directly
+ * whenever the moment and the place are both known — above all for **natal
+ * charts**, where sect must be evaluated at the birth time and birthplace.
+ * Getting either wrong flips the entire day/night ESMS split (day →
+ * Spirit/Essence, night → Matter/Substance) and therefore the whole chart.
+ *
+ * Degrades to the UTC-hour heuristic only if astronomy-engine throws.
+ */
+export function isDiurnalAt(
+  date: Date,
+  latitude: number,
+  longitude: number,
+): boolean {
+  try {
+    const observer = new Astronomy.Observer(latitude, longitude, 0);
+    const equ = Astronomy.Equator(Astronomy.Body.Sun, date, observer, true, true);
+    const hor = Astronomy.Horizon(date, observer, equ.ra, equ.dec, "normal");
+    return hor.altitude > 0;
+  } catch {
+    const hour = date.getUTCHours();
+    return hour >= 6 && hour < 18;
+  }
+}
+
+/**
  * Diurnal/nocturnal sect for the *current sky*, observed from New York.
  *
  * Sect drives the entire day/night ESMS split (day → Spirit/Essence, night →
@@ -265,23 +293,16 @@ export const NEW_YORK_OBSERVER = { latitude: 40.7128, longitude: -74.006 } as co
  * This computes the Sun's true altitude at NY for `date`; if astronomy-engine
  * throws (it shouldn't at this latitude) it degrades to the UTC-hour heuristic.
  *
- * Use this for any "now"/live-sky sect; keep `isSectDiurnal(birthDate)` for natal
- * charts, which should be evaluated at the birthplace, not New York.
+ * Use this for any "now"/live-sky sect. For a natal chart use
+ * {@link isDiurnalAt} with the birth moment AND the birthplace — New York is
+ * the site's reference observer, not the subject's.
  */
 export function isCurrentSkyDiurnal(date: Date = new Date()): boolean {
-  try {
-    const observer = new Astronomy.Observer(
-      NEW_YORK_OBSERVER.latitude,
-      NEW_YORK_OBSERVER.longitude,
-      0,
-    );
-    const equ = Astronomy.Equator(Astronomy.Body.Sun, date, observer, true, true);
-    const hor = Astronomy.Horizon(date, observer, equ.ra, equ.dec, "normal");
-    return hor.altitude > 0;
-  } catch {
-    const hour = date.getUTCHours();
-    return hour >= 6 && hour < 18;
-  }
+  return isDiurnalAt(
+    date,
+    NEW_YORK_OBSERVER.latitude,
+    NEW_YORK_OBSERVER.longitude,
+  );
 }
 
 /**


### PR DESCRIPTION
`agents/unified` computed every new agent's full-chart monica with:

```ts
alchemize(chartPositions)
```

No date, no sect. So `date` defaulted to `new Date()`, and sect resolved via `isCurrentSkyDiurnal(date)` — which observes from a **hardcoded New York observer**.

A natal chart therefore inherited *"is it daytime in New York right now, at the instant this agent happens to be created."*

Sect drives the entire day/night ESMS split (day → Spirit/Essence, night → Matter/Substance), so the stored monica **was not a function of the chart at all**. Creating the same agent twelve hours apart produced two different values.

The route's own comment asserted "the chart already fixes the sect". It didn't — and both the birth time and the birth location were sitting in scope, already validated.

## The fix

**1. `isDiurnalAt(date, latitude, longitude)`** — the Sun's true altitude at an arbitrary place and moment. This is the primitive the module's *own docstring already asked for*:

> keep `isSectDiurnal(birthDate)` for natal charts, which should be evaluated at the birthplace, not New York

…except `isSectDiurnal` is the crude UTC 06:00–18:00 heuristic, so the birthplace-aware version simply never existed. `isCurrentSkyDiurnal` is now a thin wrapper over it at the New York observer, making live-sky behaviour unchanged *by construction* rather than by inspection.

**2. `alchemize(..., options.diurnal?)`** — an explicit sect override, because a natal caller knows its own sect and must not inherit the server's. Omitting it preserves previous behaviour exactly (pinned by test), so every existing live-sky caller is untouched.

**3. The call site** passes both the birth moment and the birthplace.

## Tests (8)

Two are load-bearing:

- **non-vacuity**: sect genuinely changes the result — without this, every other assertion could be measuring nothing
- **the actual property**: the same chart with sect pinned is now independent of *when* it's computed

One test deliberately demonstrates the defect itself — without the override, the identical natal chart yields different monicas at noon vs. midnight.

Also covered: `isDiurnalAt` disagrees between two *places* at the same instant (Tokyo day / New York night), and between two *moments* at the same place.

161 suites / 1385 tests green on the source branch; 159/1321 on this one standalone. Typecheck and lint clean.

## Scope

This fixes **new writes only**. It deliberately does not backfill existing full-chart rows, because those values are separately unsafe to trust — full-chart monica measures ~12–43× *smaller* than single-body, monica is the only non-scale-invariant quantity in the engine, and the 71 "real person" rows are historical-figure agents holding hand-authored literals (Einstein 6.15 vs computed 0.018).

Correcting the sect does not make a raw full-chart monica writable. That decision is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)