### PR TITLE
fix(agents): app code lost 584 agents' monica after the §18o column split

### DIFF
--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -166,7 +166,9 @@ export async function GET(request: NextRequest) {
          up.onboarding_completed,
          COALESCE(up.dominant_element, up.natal_chart->>'dominantElement') AS dominant_element,
          up.bio,
-         up.monica_constant::text AS monica_constant,
+         -- §18o: monica_constant is single-body only; COALESCE the other two
+         -- constructions so the admin panel shows an agent's real value.
+         COALESCE(up.monica_constant, up.monica_two_body, up.monica_full_chart)::text AS monica_constant,
          s.tier::text AS subscription_tier,
          s.status::text AS subscription_status,
          ds.active_sessions,

--- a/src/app/api/agents/unified/route.ts
+++ b/src/app/api/agents/unified/route.ts
@@ -36,7 +36,10 @@ export async function POST(request: NextRequest) {
     switch (action) {
       case "list": {
         const result = await executeQuery<any>(
-          `SELECT u.id AS user_id, u.email, up.name, up.bio, up.dominant_element, up.monica_constant
+          // §18o: monica_constant is single-body only; COALESCE the other two
+          // constructions so the list still shows a value for those agents.
+          `SELECT u.id AS user_id, u.email, up.name, up.bio, up.dominant_element,
+                  COALESCE(up.monica_constant, up.monica_two_body, up.monica_full_chart) AS monica_constant
            FROM users u
            JOIN user_profiles up ON up.user_id = u.id
            WHERE u.is_agent = true AND u.is_active = true

--- a/src/app/api/commensal/companions/route.ts
+++ b/src/app/api/commensal/companions/route.ts
@@ -108,13 +108,15 @@ export async function GET(_req: NextRequest) {
       },
     ),
     executeQuery<LocalAgentRow>(
+      // §18o: monica_constant is single-body only; COALESCE the other two
+      // constructions so an agent of any kind still surfaces its real value.
       `SELECT u.id AS user_id,
               u.email,
               u.profile,
               up.name,
               up.bio,
               up.dominant_element,
-              up.monica_constant,
+              COALESCE(up.monica_constant, up.monica_two_body, up.monica_full_chart) AS monica_constant,
               up.birth_data,
               up.natal_chart
          FROM users u

--- a/src/app/api/community/agents/route.ts
+++ b/src/app/api/community/agents/route.ts
@@ -40,12 +40,14 @@ export async function GET(req: NextRequest) {
       AGENTS_CACHE_TTL_SECONDS,
       async () => {
         const result = await executeQuery<AgentRow>(
+          // §18o: monica_constant is single-body only; COALESCE the other two
+          // constructions so an agent of any kind still surfaces its real value.
           `SELECT u.id AS user_id,
                   u.email,
                   up.name,
                   up.bio,
                   up.dominant_element,
-                  up.monica_constant,
+                  COALESCE(up.monica_constant, up.monica_two_body, up.monica_full_chart) AS monica_constant,
                   MAX(f.created_at) AS last_action_at,
                   COUNT(f.id) AS action_count
              FROM users u
@@ -53,7 +55,8 @@ export async function GET(req: NextRequest) {
              LEFT JOIN feed_events f ON f.actor_id = u.id
             WHERE COALESCE(u.is_agent, false) = true
               AND u.is_active = true
-            GROUP BY u.id, u.email, up.name, up.bio, up.dominant_element, up.monica_constant
+            GROUP BY u.id, u.email, up.name, up.bio, up.dominant_element,
+                     up.monica_constant, up.monica_two_body, up.monica_full_chart
             ORDER BY MAX(f.created_at) DESC NULLS LAST
             LIMIT $1`,
           [limit],

--- a/src/lib/agents/persona/build-agent-context.ts
+++ b/src/lib/agents/persona/build-agent-context.ts
@@ -26,7 +26,14 @@ export async function findAgent(agentId: string): Promise<CraftedAgent | undefin
     let queryResult;
     if (isUuid) {
       queryResult = await executeQuery<any>(
-        `SELECT u.id AS user_id, u.email, u.profile, up.name, up.bio, up.birth_data, up.natal_chart, up.monica_constant, up.dominant_element
+        // §18o: monica_constant is single-body ONLY now. COALESCE across the
+        // per-construction columns so two-body/full-chart agents (584 rows)
+        // still surface their real value here instead of falling through to
+        // the hardcoded 3.5 fallback below — a fabricated number is exactly
+        // what this whole line of work exists to eliminate.
+        `SELECT u.id AS user_id, u.email, u.profile, up.name, up.bio, up.birth_data, up.natal_chart,
+                COALESCE(up.monica_constant, up.monica_two_body, up.monica_full_chart) AS monica_constant,
+                up.dominant_element
          FROM users u
          JOIN user_profiles up ON up.user_id = u.id
          WHERE u.id = $1::uuid AND u.is_agent = true LIMIT 1`,
@@ -34,7 +41,9 @@ export async function findAgent(agentId: string): Promise<CraftedAgent | undefin
       )
     } else {
       queryResult = await executeQuery<any>(
-        `SELECT u.id AS user_id, u.email, u.profile, up.name, up.bio, up.birth_data, up.natal_chart, up.monica_constant, up.dominant_element
+        `SELECT u.id AS user_id, u.email, u.profile, up.name, up.bio, up.birth_data, up.natal_chart,
+                COALESCE(up.monica_constant, up.monica_two_body, up.monica_full_chart) AS monica_constant,
+                up.dominant_element
          FROM users u
          JOIN user_profiles up ON up.user_id = u.id
          WHERE (u.email = $1 OR up.name ILIKE $2) AND u.is_agent = true LIMIT 1`,

--- a/src/services/userTimelineService.ts
+++ b/src/services/userTimelineService.ts
@@ -163,7 +163,9 @@ async function readIdentity(
          u.login_count,
          COALESCE(up.dominant_element, up.natal_chart->>'dominantElement') AS dominant_element,
          up.bio,
-         up.monica_constant::text AS monica_constant,
+         -- §18o: monica_constant is single-body only; COALESCE the other two
+         -- constructions so this view shows an agent's real value.
+         COALESCE(up.monica_constant, up.monica_two_body, up.monica_full_chart)::text AS monica_constant,
          up.onboarding_completed,
          up.onboarding_completed_at,
          (up.birth_data IS NOT NULL AND up.birth_data <> '{}'::jsonb) AS has_birth_data,


### PR DESCRIPTION
**Live data regression.** The §18o migration moved two-body and full-chart values out of `monica_constant` into their own columns and shipped to production **before** the application readers were updated to match. Six readers still selected `monica_constant` alone, so for **584 agents** (513 two-body + 71 full-chart) they saw `NULL`.

## Why this is a fix, not a tidy-up

`build-agent-context.ts:66` reads:

```ts
monicaConstant: row.monica_constant ? parseFloat(row.monica_constant) : 3.5
```

So every one of those 584 agents was being served a **fabricated 3.5** — the exact defect class this entire line of work exists to eliminate. The other five readers degraded to blank/null instead: wrong, but honest.

## The fix

`COALESCE` across the three per-construction columns in:

| file | surface |
|---|---|
| `build-agent-context.ts` | agent persona (both query branches) |
| `agents/unified/route.ts` | agent list |
| `commensal/companions/route.ts` | companion roster |
| `community/agents/route.ts` | public agent feed |
| `admin/users/route.ts` | admin panel |
| `userTimelineService.ts` | user timeline |

## Verified against live production, not just by reading code

```
rows where bare monica_constant is NULL but a real value exists : 584
rows where the COALESCE still returns NULL for a classified row :   0
```

Spot-checked per construction — **Edgar Allan Poe** (full-chart) now resolves `0.004611` where the bare column returns `NULL`; **Moon Phase Waxing Gibbous 184** (two-body) resolves `0.672136`.

## ⚠️ How this happened

The DB migration and the code that reads it were separated in time. That's the same shape as the earlier deploy gap (prod running fake-writing code over corrected data) — just **inverted**: corrected data under code that couldn't see it.

**A schema change that relocates a column's meaning is not complete until every reader moves with it.**

Worth noting why the earlier integrity audit reported "all clear" while the app was still wrong: the audit checked the **data**, and the data was correct. Checking data alone cannot catch a reader looking in the wrong place. A follow-up PR adds an app-code-parity assertion for exactly this.

165 suites / 1407 tests green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)