### PR TITLE
fix(agents): the fabricated 3.5 was still live for 123 agents, and 0 was next

### DIFF
--- a/.github/workflows/monica-integrity.yml
+++ b/.github/workflows/monica-integrity.yml
@@ -1,0 +1,107 @@
+# Agent-monica integrity gate (§18).
+#
+# TWO jobs, because the two failure modes need different witnesses and only one
+# of them needs a database:
+#
+#   fabricated-fallback-scan   every push/PR, NO secrets. Static. Catches the
+#                              CODE defect: a reader that invents a monica.
+#   agent-monica-data          master + daily cron, needs the DB. Catches the
+#                              DATA defect: values that drift from the engine.
+#
+# Neither can substitute for the other. On 2026-07-22 an integrity audit reported
+# "ALL CLEAR — 22 checks, 0 failures" while 584 agents were being served a
+# fabricated 3.5, because the data was correct and only the readers were wrong.
+# Checking data alone cannot detect a reader pointed at the wrong column.
+
+name: Monica Integrity
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+  schedule:
+    # 07:15 UTC daily. The agent population grows continuously (4822 -> 5006 in
+    # under three days) and new arrivals land unclassified, so drift appears
+    # between deploys, not only at them. A deploy-triggered check alone is blind
+    # to that.
+    - cron: "15 7 * * *"
+
+concurrency:
+  group: monica-integrity-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Static. Runs everywhere, including forks — no secrets, so nothing to leak.
+  # ---------------------------------------------------------------------------
+  fabricated-fallback-scan:
+    name: No fabricated monica fallbacks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Scan for invented monica fallbacks
+        # Exits non-zero if any reader on the AGENT monica path falls back to a
+        # numeric literal, or tests a monica for truthiness (falsy at a real 0,
+        # which 284 agents have). Recipe-engine defaults are reported, not fatal.
+        run: bun scripts/checkNoFabricatedMonicaFallback.ts
+
+  # ---------------------------------------------------------------------------
+  # Data. master + cron only: it needs production credentials, so it must never
+  # run on a pull_request from a fork.
+  # ---------------------------------------------------------------------------
+  agent-monica-data:
+    name: Agent monica drift + integrity
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Setup safe directory
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Require the database secret
+        # FAIL, do not skip. A skipped job renders as a green check, and a green
+        # check that verified nothing is the exact failure this gate exists to
+        # prevent. If this step fails, the gate is not operational — add the
+        # DATABASE_PUBLIC_URL repository secret.
+        env:
+          DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
+        run: |
+          if [ -z "$DATABASE_PUBLIC_URL" ]; then
+            echo "::error::DATABASE_PUBLIC_URL secret is not set — this gate is NOT operational."
+            echo "Add it under Settings > Secrets and variables > Actions."
+            exit 1
+          fi
+          echo "database secret present"
+
+      - name: Drift check (recomputes every value from the engine)
+        env:
+          DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
+        run: bun scripts/checkAgentMonicaDrift.ts
+
+      # A second, INDEPENDENT witness (scripts/auditAgentDataIntegrity.ts) is
+      # added here by PR #636, which is where that script lands. It is not
+      # referenced yet because it does not exist on master, and a workflow step
+      # that runs a missing file is a failure, not a gate.
+      #
+      # It matters that there are two: the drift check re-derives values from the
+      # engine, the audit asserts structure directly in SQL without reusing any
+      # backfill's classification. A mis-classifying script passes its own
+      # re-run, which nearly happened twice on 2026-07-22, so neither tool is
+      # allowed to be the only witness.

--- a/scripts/checkNoFabricatedMonicaFallback.ts
+++ b/scripts/checkNoFabricatedMonicaFallback.ts
@@ -1,0 +1,176 @@
+/**
+ * Static guard against the defect that produced every monica incident in §18:
+ * a read of a monica field whose fallback is an INVENTED NUMBER.
+ *
+ * Needs no database and no secrets, so it runs on every PR. That matters,
+ * because the data-side tools (checkAgentMonicaDrift, auditAgentDataIntegrity)
+ * structurally CANNOT catch this class: the data was correct in every one of
+ * these incidents. An integrity audit reported "ALL CLEAR — 22 checks" while
+ * 584 agents were being served a fabricated 3.5.
+ *
+ *   bun scripts/checkNoFabricatedMonicaFallback.ts
+ *
+ * Exits non-zero on any finding. Two patterns are rejected:
+ *
+ *   1. NUMERIC FALLBACK   `x.monica_constant ? f(x) : 3.5`   `monica ?? 0`
+ *      A NULL becomes a plausible-looking number. Worse than a crash, because
+ *      nothing reports it and the value is in-range.
+ *
+ *   2. TRUTHINESS TEST    `row.monica_constant ? ... : ...`
+ *      Rejected even when the fallback is honest, because monica is legitimately
+ *      0 for 284 single-body agents and 0 is falsy. Whether this bites depends
+ *      on whether pg hands NUMERIC back as a string — i.e. on a driver detail,
+ *      not on anything the code states. Use an explicit `=== null` test.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = "src";
+const EXTS = [".ts", ".tsx"];
+const SKIP_DIRS = new Set(["node_modules", ".next", "__tests__", "__mocks__"]);
+
+/** Fields whose fallback must never be a literal. */
+const MONICA_FIELD = /monica(_constant|_single|_two_body|_full_chart|Constant|Score)?/i;
+
+interface Finding {
+  file: string;
+  line: number;
+  kind: "numeric-fallback" | "truthiness-test";
+  text: string;
+  why: string;
+}
+
+/**
+ * Only the AGENT monica read path FAILS the build.
+ *
+ * That is where every §18 incident happened, and there the correct fallback is
+ * unambiguous: an agent either has a stored monica or it does not.
+ *
+ * The recipe/cuisine/cooking-method engine also defaults monica — to 1.0, in
+ * ~15 places — but there `1.0` is the multiplicative identity, so in a multiplier
+ * it may be exactly right and in an average it is fabrication. Deciding that
+ * needs a domain ruling per site, and failing CI on all of them today would just
+ * get this check disabled. They are REPORTED, loudly, and left to the recipes
+ * pass.
+ */
+const AGENT_READ_PATH = /monica(_constant|_single|_two_body|_full_chart|Constant)\b/;
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const p = join(dir, entry);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, out);
+    else if (EXTS.some((e) => p.endsWith(e))) out.push(p);
+  }
+  return out;
+}
+
+const findings: Finding[] = [];
+const files = walk(ROOT);
+
+for (const file of files) {
+  const lines = readFileSync(file, "utf8").split("\n");
+
+  lines.forEach((raw, i) => {
+    const line = raw.trim();
+    if (line.startsWith("//") || line.startsWith("*")) return;
+    if (!MONICA_FIELD.test(line)) return;
+
+    // ── 1. `?? <number>` or `: <number>` used as a monica fallback ───────────
+    //    Excludes `?? null` and `: null`, which are the correct forms.
+    const nullish = /\?\?\s*(-?\d+(\.\d+)?)\b/.exec(line);
+    if (nullish) {
+      findings.push({
+        file,
+        line: i + 1,
+        kind: "numeric-fallback",
+        text: line,
+        why: `\`?? ${nullish[1]}\` invents a monica when the real one is absent. Use \`?? null\`.`,
+      });
+    }
+
+    const ternaryLiteral = /\?[^?:]*:\s*(-?\d+(\.\d+)?)\s*[,;)]/.exec(line);
+    if (ternaryLiteral) {
+      findings.push({
+        file,
+        line: i + 1,
+        kind: "numeric-fallback",
+        text: line,
+        why: `ternary falls back to the literal ${ternaryLiteral[1]}. Use null.`,
+      });
+    }
+
+    // ── 2. truthiness test on a monica field ────────────────────────────────
+    //    `row.monica_constant ? a : b` — falsy for a real 0.
+    //
+    //    `(?![.:])` is what keeps this precise. Two constructs look identical to
+    //    a naive `monica...\?` pattern and are both CORRECT:
+    //      `monicaConstant?: number`      optional PROPERTY in a type — `?:`
+    //      `monicaConstant?.toFixed(2)`   optional CHAINING — `?.`
+    //    Without the lookahead this reported 31 false positives against 2 real
+    //    ones, which is the kind of noise that gets a check switched off.
+    //    `(?![.:?])` — the third exclusion is `??`. A nullish coalesce is not a
+    //    truthiness test: `monicaConstant ?? null` is the CORRECT form, and
+    //    flagging it told me to "fix" a line that was already right.
+    const truthy = /\b(\w+\.)?monica(_constant|_single|_two_body|_full_chart|Constant)\s*\?(?![.:?])/.exec(
+      line,
+    );
+    if (truthy) {
+      findings.push({
+        file,
+        line: i + 1,
+        kind: "truthiness-test",
+        text: line,
+        why: "truthiness test is false for a real monica of 0 (284 agents). Use `=== null`.",
+      });
+    }
+  });
+}
+
+// ---------------------------------------------------------------- report ----
+console.log(`fabricated-monica-fallback scan: ${files.length} files under ${ROOT}/`);
+
+if (findings.length === 0) {
+  // A zero result is a claim. Prove the scanner can still fire, so a silent
+  // regression in the scanner itself cannot read as a clean bill of health.
+  const CONTROL = `monicaConstant: row.monica_constant ? parseFloat(row.monica_constant) : 3.5,`;
+  const controlFires =
+    /\?\?\s*(-?\d+(\.\d+)?)\b/.test(CONTROL) ||
+    /\?[^?:]*:\s*(-?\d+(\.\d+)?)\s*[,;)]/.test(CONTROL);
+  if (!controlFires) {
+    console.error(
+      "\nFATAL: the scanner did not flag its own control case.\n" +
+        "The 0 findings above mean nothing. Fix the patterns before trusting this.",
+    );
+    process.exit(1);
+  }
+  console.log("control case (the real 3.5 regression) IS flagged — scanner is live");
+  console.log("\nno fabricated monica fallbacks found");
+  process.exit(0);
+}
+
+const blocking = findings.filter((f) => AGENT_READ_PATH.test(f.text));
+const reported = findings.filter((f) => !AGENT_READ_PATH.test(f.text));
+
+if (reported.length) {
+  console.log(`\n${reported.length} finding(s) OUTSIDE the agent read path — reported, not blocking:`);
+  console.log(`(the recipe/cuisine engine's monica defaults — see the note in this file)\n`);
+  for (const f of reported) console.log(`  ${f.file}:${f.line}  ${f.text}`);
+}
+
+if (blocking.length === 0) {
+  console.log(`\nno fabricated fallbacks on the AGENT monica read path`);
+  process.exit(0);
+}
+
+console.error(`\n${blocking.length} BLOCKING finding(s) on the agent monica read path:\n`);
+for (const f of blocking) {
+  console.error(`  ${f.file}:${f.line}  [${f.kind}]`);
+  console.error(`    ${f.text}`);
+  console.error(`    -> ${f.why}\n`);
+}
+console.error(
+  "An agent monica that is absent must read as null, not as a number. See §18 and PR #637.",
+);
+process.exit(1);

--- a/src/__tests__/sacred7MonicaMapping.test.ts
+++ b/src/__tests__/sacred7MonicaMapping.test.ts
@@ -63,19 +63,49 @@ describe("normalizeMonicaForStats", () => {
     );
   });
 
-  it("falls back to the single-body scale for an unmeasured population", () => {
-    // full-chart values are not in production yet, so no scale is authored for
-    // them — §11: do not invent a constant. It must degrade, not throw.
-    expect(normalizeMonicaForStats(1, "full-chart")).toBeCloseTo(
+  it("gives full-chart its OWN measured scale, not single-body's", () => {
+    // This test previously asserted the OPPOSITE — that full-chart fell back to
+    // single-body — because those values were not yet in production and §11
+    // forbids inventing a constant. They are now in production (n=71) and the
+    // scale is measured, so the fallback it pinned is gone on purpose.
+    expect(normalizeMonicaForStats(1, "full-chart")).not.toBeCloseTo(
       normalizeMonicaForStats(1, "single-body"),
-      12,
+      6,
     );
+  });
+
+  it("spreads the real full-chart range instead of flattening it to ~0.50", () => {
+    // The measured production range. Under single-body's 1.9875 these all mapped
+    // into a 0.008-wide band, making 71 agents indistinguishable in the UI.
+    const lo = normalizeMonicaForStats(0.0018, "full-chart");
+    const hi = normalizeMonicaForStats(0.033702, "full-chart");
+    expect(hi - lo).toBeGreaterThan(0.3);
+
+    // Control: prove the old behaviour really was degenerate, so this test
+    // cannot quietly pass for the wrong reason.
+    const loOld = normalizeMonicaForStats(0.0018, "single-body");
+    const hiOld = normalizeMonicaForStats(0.033702, "single-body");
+    expect(hiOld - loOld).toBeLessThan(0.01);
   });
 
   it("returns the neutral 0.5 for non-finite input, never NaN", () => {
     for (const v of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
       expect(normalizeMonicaForStats(v, "single-body")).toBe(0.5);
     }
+  });
+
+  it("maps a NULL monica to the neutral 0.5 — and NOT via a coercion to 0", () => {
+    // An agent with no monica yet (unclassified new arrival) must not be given a
+    // number. 0 would ALSO map to 0.5 here, so this assertion alone is weak —
+    // the guard below is what makes it meaningful.
+    expect(normalizeMonicaForStats(null, "single-body")).toBe(0.5);
+
+    // Guard: 0 is a real monica for 284 single-body agents. Confirm that a real
+    // 0 and a null are treated as the same NUMBER here only because tanh(0)=0,
+    // not because null was silently coerced — the distinction has to survive
+    // upstream, where the type is `number | null`.
+    expect(normalizeMonicaForStats(0, "single-body")).toBe(0.5);
+    expect(Object.is(normalizeMonicaForStats(null, "two-body"), 0.5)).toBe(true);
   });
 });
 

--- a/src/app/api/agents/unified/route.ts
+++ b/src/app/api/agents/unified/route.ts
@@ -50,7 +50,12 @@ export async function POST(request: NextRequest) {
           name: row.name || row.email.split("@")[0],
           title: row.bio || "Custom Agent",
           dominantElement: row.dominant_element,
-          monicaConstant: row.monica_constant ? parseFloat(row.monica_constant) : null
+          // Explicit null test, not truthiness: a real monica of 0 (284 agents)
+          // is falsy, so `? :` would report those agents as having no monica.
+          monicaConstant:
+            row.monica_constant === null || row.monica_constant === undefined
+              ? null
+              : parseFloat(row.monica_constant)
         }));
         return NextResponse.json({ success: true, data: agents, timestamp });
       }

--- a/src/lib/agent-types.ts
+++ b/src/lib/agent-types.ts
@@ -356,7 +356,19 @@ export interface CraftedAgent {
   // Crafted Consciousness
   consciousness: {
     natalChart: NatalChart
-    monicaConstant: number
+    /**
+     * The agent's real thermodynamic monica, or null when it genuinely has none
+     * yet — a newly-arrived agent the backfill has not classified, or one whose
+     * chart has too few resolvable bodies.
+     *
+     * NULLABLE ON PURPOSE. It used to be `number`, which forced every read path
+     * to invent a value when the column was NULL; one of them invented 3.5 and
+     * served it to 584 agents. `null` is the honest answer, and 0 is NOT a
+     * substitute for it — 0 is a real, algebraically-proven monica for 284
+     * single-body agents, so collapsing unknown into 0 makes the two
+     * indistinguishable.
+     */
+    monicaConstant: number | null
     level?: ConsciousnessLevel
     metrics?: ConsciousnessMetrics
     strength?: string

--- a/src/lib/agents/persona/build-agent-context.ts
+++ b/src/lib/agents/persona/build-agent-context.ts
@@ -72,7 +72,19 @@ export async function findAgent(agentId: string): Promise<CraftedAgent | undefin
         },
         consciousness: {
           natalChart: chart,
-          monicaConstant: row.monica_constant ? parseFloat(row.monica_constant) : 3.5,
+          // No `: 3.5` fallback, and no `? :` truthiness test.
+          //
+          // The truthiness test was wrong twice over. It fabricated 3.5 whenever
+          // the COALESCE above found nothing — which is still the case for the
+          // ~123 agents that arrive faster than the backfill classifies them —
+          // and it would ALSO have fabricated 3.5 for the 284 agents whose real
+          // monica is exactly 0, had pg not happened to hand NUMERIC back as the
+          // truthy string "0.000000". That second bug was live and invisible,
+          // waiting for someone to switch the column to double precision.
+          monicaConstant:
+            row.monica_constant === null || row.monica_constant === undefined
+              ? null
+              : parseFloat(row.monica_constant),
           dominantElement: row.dominant_element || 'Fire',
           dominantModality: 'Mutable',
           signature: `DYNAMIC-AGENT-${row.user_id}`

--- a/src/lib/agents/persona/derive-sacred-stats.ts
+++ b/src/lib/agents/persona/derive-sacred-stats.ts
@@ -41,7 +41,10 @@ export function deriveSacredStats(agent: CraftedAgent): Sacred7Stats {
   const ascendant = agent.consciousness?.natalChart?.ascendant ?? 0
 
   return deriveStatsFromChart({
-    monicaConstant: agent.consciousness?.monicaConstant ?? 0,
+    // `?? null`, never `?? 0`. 0 is a real, algebraically-proven monica for 284
+    // single-body agents, so defaulting to it made "this agent has no monica"
+    // and "this agent's monica is zero" the same value.
+    monicaConstant: agent.consciousness?.monicaConstant ?? null,
     sunLongitude: planetLongitude(planets, 'Sun', 120),
     moonLongitude: planetLongitude(planets, 'Moon', 90),
     mercuryLongitude: planetLongitude(planets, 'Mercury', 150),

--- a/src/lib/sacred-7-stats.ts
+++ b/src/lib/sacred-7-stats.ts
@@ -276,15 +276,21 @@ export type MonicaMethod = 'single-body' | 'two-body' | 'full-chart'
  * degenerate-case sentinel piling up, not a feature of either distribution.
  * Scaling by it would be reading a sentinel as data.
  *
- * `full-chart` is deliberately ABSENT: those values are not in production yet
- * (§18n is triple-blocked), so its real spread is unmeasured. Authoring a
- * placeholder is exactly the unmeasured constant §11 exists to prevent. Callers
- * passing 'full-chart' fall back to single-body and must be revisited when
- * §18n lands.
+ * `full-chart` is now MEASURED too. It was absent while those values were not in
+ * production; they are (71 rows), so the placeholder objection no longer applies.
+ *
+ * Its scale is ~118x smaller than single-body's, which is not a rounding
+ * difference — it is the §18o point that these are different OBJECTS, not one
+ * quantity at three scales. Leaving full-chart to fall back to single-body's
+ * 1.9875 mapped the entire measured range [0.0018, 0.0337] into
+ * **[0.5004, 0.5085]** — a 0.008-wide band out of [0,1], so all 71 agents
+ * received a visually identical Sacred-7 contribution. That is a silently
+ * wrong number in a user-visible display, not a harmless default.
  */
 const MONICA_POPULATION_SCALE: Partial<Record<MonicaMethod, number>> = {
   'single-body': 1.9875, // |max| 3.9751 / 2
   'two-body': 2.7095, // |max| 5.4191 / 2
+  'full-chart': 0.016851, // |max| 0.033702 / 2  [MEASURED 2026-07-24, n=71]
 }
 
 const DEFAULT_MONICA_SCALE = MONICA_POPULATION_SCALE['single-body'] as number
@@ -308,16 +314,22 @@ const DEFAULT_MONICA_SCALE = MONICA_POPULATION_SCALE['single-body'] as number
  * reads as "up to N points of bonus".
  */
 export function normalizeMonicaForStats(
-  monicaConstant: number,
+  monicaConstant: number | null,
   method: MonicaMethod = 'single-body',
 ): number {
-  if (!Number.isFinite(monicaConstant)) return 0.5
+  // null = the agent genuinely has no monica yet (unclassified new arrival, or a
+  // chart with too few bodies). It maps to the same neutral 0.5 as a non-finite
+  // value. It must NOT be coerced to 0 first: 0 is a real monica for 284
+  // single-body agents, and tanh(0/scale) is also 0.5 — so the two would look
+  // identical here while meaning completely different things upstream.
+  if (monicaConstant === null || !Number.isFinite(monicaConstant)) return 0.5
   const scale = MONICA_POPULATION_SCALE[method] ?? DEFAULT_MONICA_SCALE
   return (Math.tanh(monicaConstant / scale) + 1) / 2
 }
 
 export function deriveStatsFromChart(chartData: {
-  monicaConstant: number
+  /** null when the agent has no monica yet — see normalizeMonicaForStats. */
+  monicaConstant: number | null
   /** Which construction produced `monicaConstant` (§18o). Defaults to
    *  single-body, which is what `monica_constant` holds. */
   monicaMethod?: MonicaMethod


### PR DESCRIPTION
## What #635 missed

#635 pointed the six readers at the right columns. It did not remove the fabrication, and **two paths were still serving invented numbers.**

### 1. `: 3.5` still fires — for 123 agents, right now

`COALESCE` only helps an agent that has a monica *somewhere*. Measured against production today:

```
total user_profiles                 5006   (prior sessions saw 4822 / 4865 / 4869)
agents with NO monica_method         125
  of those, classifiable by backfill 123
  of those, charts too sparse to use   2
```

Those agents hit `COALESCE(...) IS NULL` → the truthiness test fails → they get `3.5`.

This is **not** a leftover that a backfill closes permanently. The population grows continuously, so the set is never empty for long. The fabrication had to be removed in code.

### 2. The same expression breaks on zero

```ts
row.monica_constant ? parseFloat(row.monica_constant) : 3.5
```

**284 single-body agents have an algebraically-proven monica of exactly `0`** — and `0` is falsy.

It works today only because `monica_constant` is `NUMERIC(12,6)` and node-postgres returns NUMERIC as the *string* `"0.000000"`, which is truthy. Change the column to `double precision`, or register a NUMERIC type parser, and 284 agents silently begin reporting 3.5. Correct by accident is not correct.

### 3. `?? 0` in `derive-sacred-stats.ts`

Same class. Since `0` is a real monica, this made *"has no monica"* and *"monica is zero"* indistinguishable.

## The fix

`monicaConstant` becomes `number | null`. Null reaches the **already-documented neutral `0.5`** in `normalizeMonicaForStats` explicitly, instead of being coerced to a number first.

Typecheck: **0 errors** — verified with a control (a deliberate `number | null` misuse *is* caught), so the clean result isn't a vacuous pass. Nothing broke because consumers already guarded with `?.` and `!== null`.

## Also: the full-chart Sacred-7 scale

Now measurable, because those values are in production:

| population | scale | derivation |
|---|---|---|
| single-body | 1.9875 | \|max\| 3.9751 / 2 |
| two-body | 2.7095 | \|max\| 5.4191 / 2 |
| **full-chart** | **0.016851** | \|max\| 0.033702 / 2, n=71 |

It had been falling back to single-body's 1.9875, which mapped the entire real range `[0.0018, 0.033702]` into **`[0.5004, 0.5085]`** — a 0.008-wide band out of [0,1]. All 71 agents rendered an identical Sacred-7 contribution. A silently wrong number in a user-visible display, not a harmless default.

## Test note

One existing test asserted the **opposite** of the new behaviour — that full-chart falls back to single-body. That was correct while the values were unmeasured (§11: don't invent a constant). It's updated, with a **control assertion** proving the old mapping really was degenerate, so it cannot pass for the wrong reason.

`23 tests pass.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)