### PR TITLE
fix(stats): the full-chart Sacred-7 scale I shipped came from a duplicated chart

### DIFF
--- a/scripts/auditFullChartPositions.ts
+++ b/scripts/auditFullChartPositions.ts
@@ -1,0 +1,190 @@
+/**
+ * Are the 71 full-chart agents' natal_positions REAL, or placeholders?
+ *
+ * READ-ONLY. Only SELECTs.
+ *
+ * Why this must run before any birth data is authored: a placeholder chart makes
+ * its monica fabricated no matter how accurate the birth time is. Authoring
+ * birth data for a placeholder chart just adds precision to an invented number.
+ *
+ * The trigger: Alexander the Great, Archimedes and Aristotle all produced
+ * monica_full_chart = 0.003160 with diurnal 0.009703 / nocturnal -0.003383 —
+ * byte-identical. Three different people cannot share a chart. And the backfill
+ * reported only 63 DISTINCT values across 71 rows, so there are at least 8
+ * collisions, not 3.
+ *
+ * Tests, in increasing strength:
+ *   1. Do any two agents share an identical positions BLOB? (exact clone)
+ *   2. Do any share an identical monica but differ in blob? (different route in)
+ *   3. Does any chart use suspiciously round longitudes (0, 15, 30...)?
+ *   4. How many bodies does each chart actually resolve?
+ *   5. Is any position list identical to a KNOWN default (all-zero, all-Aries)?
+ */
+import { Client } from "pg";
+import { createHash } from "node:crypto";
+
+const url = process.env.DATABASE_PUBLIC_URL || process.env.DATABASE_URL;
+if (!url) {
+  console.error("No DATABASE_PUBLIC_URL in env");
+  process.exit(1);
+}
+
+interface Row {
+  name: string;
+  positions: unknown;
+  full_chart: string | null;
+  diurnal: string | null;
+  nocturnal: string | null;
+}
+
+const hash = (v: unknown) =>
+  createHash("sha256").update(JSON.stringify(v ?? null)).digest("hex").slice(0, 12);
+
+const SIGNS = [
+  "Aries", "Taurus", "Gemini", "Cancer", "Leo", "Virgo",
+  "Libra", "Scorpio", "Sagittarius", "Capricorn", "Aquarius", "Pisces",
+];
+
+/**
+ * ⚠️ Longitude MUST be derived from sign + degree.
+ *
+ * The stored `longitude` field is **0 for every body in every one of the 71
+ * charts** — present in the JSON, never populated. Reading it directly reports
+ * all 71 charts as identical all-zero placeholders, which is false: the real
+ * data is in `sign` + `degree` (Adam Smith: Sun Gemini 25°, Mars Taurus 22°).
+ *
+ * A `p.position ?? p.longitude ?? ...` chain does NOT save you here, because
+ * `0` is not nullish — the chain stops at the zero and never reaches `degree`.
+ * That is how the first version of this script "found" 71 all-zero charts.
+ */
+function longitudes(positions: unknown): Array<{ body: string; lon: number }> {
+  if (!Array.isArray(positions)) return [];
+  const out: Array<{ body: string; lon: number }> = [];
+  for (const p of positions as Array<Record<string, unknown>>) {
+    if (!p || typeof p !== "object") continue;
+    const body = String(p.planet ?? p.name ?? p.body ?? "?");
+    const signIdx = SIGNS.indexOf(String(p.sign));
+    const degree = Number(p.degree);
+    if (signIdx < 0 || !Number.isFinite(degree)) continue;
+    out.push({ body, lon: signIdx * 30 + degree });
+  }
+  return out;
+}
+
+/** How many bodies carry a non-zero stored `longitude`? Expect 0 everywhere. */
+function storedLongitudeNonZero(positions: unknown): number {
+  if (!Array.isArray(positions)) return 0;
+  return (positions as Array<Record<string, unknown>>).filter(
+    (p) => p && typeof p === "object" && Number(p.longitude) !== 0,
+  ).length;
+}
+
+async function main() {
+  const c = new Client({ connectionString: url, ssl: { rejectUnauthorized: false } });
+  await c.connect();
+
+  const { rows } = await c.query<Row>(`
+    SELECT min(up.name) AS name,
+           up.natal_positions   AS positions,
+           up.monica_full_chart::text AS full_chart,
+           up.monica_diurnal::text    AS diurnal,
+           up.monica_nocturnal::text  AS nocturnal
+    FROM user_profiles up
+    WHERE up.monica_method = 'full-chart'
+    GROUP BY up.natal_positions, up.monica_full_chart, up.monica_diurnal, up.monica_nocturnal, up.user_id
+    ORDER BY min(up.name)
+  `);
+
+  console.log(`full-chart agents: ${rows.length}`);
+  console.log("=".repeat(74));
+
+  // ── 1. identical positions blobs ──────────────────────────────────────────
+  const byBlob = new Map<string, string[]>();
+  for (const r of rows) {
+    const h = hash(r.positions);
+    byBlob.set(h, [...(byBlob.get(h) ?? []), r.name]);
+  }
+  const clonedBlobs = [...byBlob.entries()].filter(([, names]) => names.length > 1);
+
+  console.log(`\n1. IDENTICAL natal_positions blobs: ${clonedBlobs.length} group(s)`);
+  let clonedRows = 0;
+  for (const [h, names] of clonedBlobs) {
+    clonedRows += names.length;
+    console.log(`   [${h}] x${names.length}: ${names.join(", ")}`);
+  }
+  console.log(`   rows involved: ${clonedRows} of ${rows.length}`);
+
+  // ── 2. identical monica, different blob ───────────────────────────────────
+  const byMonica = new Map<string, Array<{ name: string; blob: string }>>();
+  for (const r of rows) {
+    const k = String(r.full_chart);
+    byMonica.set(k, [...(byMonica.get(k) ?? []), { name: r.name, blob: hash(r.positions) }]);
+  }
+  const monicaCollisions = [...byMonica.entries()].filter(([, v]) => v.length > 1);
+  console.log(`\n2. IDENTICAL monica_full_chart: ${monicaCollisions.length} group(s)`);
+  for (const [val, members] of monicaCollisions) {
+    const distinctBlobs = new Set(members.map((m) => m.blob)).size;
+    const verdict = distinctBlobs === 1 ? "same chart (clone)" : `DIFFERENT charts, same monica (!)`;
+    console.log(`   ${val}  x${members.length}  ${verdict}`);
+    console.log(`      ${members.map((m) => m.name).join(", ")}`);
+  }
+
+  // ── 3. body count per chart ───────────────────────────────────────────────
+  const counts = rows.map((r) => longitudes(r.positions).length);
+  const byCount = new Map<number, number>();
+  for (const n of counts) byCount.set(n, (byCount.get(n) ?? 0) + 1);
+  console.log(`\n3. RESOLVABLE BODY COUNT (MIN_CHART_BODIES = 5)`);
+  for (const [n, freq] of [...byCount.entries()].sort((a, b) => a[0] - b[0])) {
+    console.log(`   ${String(n).padStart(2)} bodies: ${freq} chart(s)`);
+  }
+
+  // ── 4. the always-zero stored `longitude` field ──────────────────────────
+  const withRealLongitude = rows.filter((r) => storedLongitudeNonZero(r.positions) > 0);
+  console.log(`\n4. STORED \`longitude\` FIELD (separate defect)`);
+  console.log(`   charts with ANY non-zero stored longitude: ${withRealLongitude.length} / ${rows.length}`);
+  if (withRealLongitude.length === 0) {
+    console.log(`   => the field exists in every body object and is ALWAYS 0.`);
+    console.log(`      Any consumer reading .longitude instead of sign+degree gets 0 for`);
+    console.log(`      every planet in every chart. Derive it, or drop the field.`);
+  }
+
+  // ── 4b. suspiciously round degrees ───────────────────────────────────────
+  console.log(`\n4b. DEGREE GRANULARITY (whole degrees => low-precision source)`);
+  let allWhole = 0;
+  for (const r of rows) {
+    const ls = longitudes(r.positions);
+    if (ls.length && ls.every((x) => Number.isInteger(x.lon))) allWhole++;
+  }
+  console.log(`   charts whose every position is a whole degree: ${allWhole} / ${rows.length}`);
+  if (allWhole === rows.length) {
+    console.log(`   => all positions are whole degrees. Consistent with hand-authored or`);
+    console.log(`      low-precision ephemeris data, NOT a computed chart (which would`);
+    console.log(`      carry fractional degrees).`);
+  }
+  const suspicious = allWhole;
+
+  // ── 5. summary verdict ───────────────────────────────────────────────────
+  const distinctBlobs = byBlob.size;
+  const distinctMonica = new Set(rows.map((r) => String(r.full_chart))).size;
+  console.log("\n" + "=".repeat(74));
+  console.log(`distinct positions blobs : ${distinctBlobs} / ${rows.length}`);
+  console.log(`distinct monica values   : ${distinctMonica} / ${rows.length}`);
+  console.log(`rows sharing a blob      : ${clonedRows}`);
+  console.log(`suspicious longitudes    : ${suspicious}`);
+  console.log("");
+  if (clonedRows > 0) {
+    console.log(`VERDICT: ${clonedRows} rows do NOT have their own chart. Their full-chart`);
+    console.log(`monica is not derived from their own birth data, so authoring birth data`);
+    console.log(`for them would add precision to a value that is not theirs.`);
+  } else {
+    console.log(`VERDICT: every chart is distinct. Monica collisions (if any) come from the`);
+    console.log(`formula, not from shared positions.`);
+  }
+
+  await c.end();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/__tests__/sacred7MonicaMapping.test.ts
+++ b/src/__tests__/sacred7MonicaMapping.test.ts
@@ -75,17 +75,29 @@ describe("normalizeMonicaForStats", () => {
   });
 
   it("spreads the real full-chart range instead of flattening it to ~0.50", () => {
-    // The measured production range. Under single-body's 1.9875 these all mapped
-    // into a 0.008-wide band, making 71 agents indistinguishable in the UI.
+    // The measured range across the 61 agents with their OWN distinct chart.
+    // 0.009441 (Wangari Maathai), NOT 0.033702 — that larger value belongs to the
+    // Carl Jung / Frida Kahlo duplicated chart and is not a real agent's monica.
     const lo = normalizeMonicaForStats(0.0018, "full-chart");
-    const hi = normalizeMonicaForStats(0.033702, "full-chart");
-    expect(hi - lo).toBeGreaterThan(0.3);
+    const hi = normalizeMonicaForStats(0.009441, "full-chart");
+    expect(hi - lo).toBeGreaterThan(0.25);
 
     // Control: prove the old behaviour really was degenerate, so this test
     // cannot quietly pass for the wrong reason.
     const loOld = normalizeMonicaForStats(0.0018, "single-body");
-    const hiOld = normalizeMonicaForStats(0.033702, "single-body");
+    const hiOld = normalizeMonicaForStats(0.009441, "single-body");
     expect(hiOld - loOld).toBeLessThan(0.01);
+  });
+
+  it("saturates the duplicated-chart outlier instead of letting it set the scale", () => {
+    // 0.033702 comes from a chart shared by two different people. Under the
+    // corrected scale it saturates near 1.0, which is the right signal for an
+    // anomalous value — rather than compressing the other 61 agents to make room
+    // for it, which is what deriving the scale from it did.
+    expect(normalizeMonicaForStats(0.033702, "full-chart")).toBeGreaterThan(0.99);
+
+    // And the honest agents still occupy a usable spread below it.
+    expect(normalizeMonicaForStats(0.009441, "full-chart")).toBeLessThan(0.99);
   });
 
   it("returns the neutral 0.5 for non-finite input, never NaN", () => {

--- a/src/lib/sacred-7-stats.ts
+++ b/src/lib/sacred-7-stats.ts
@@ -279,18 +279,39 @@ export type MonicaMethod = 'single-body' | 'two-body' | 'full-chart'
  * `full-chart` is now MEASURED too. It was absent while those values were not in
  * production; they are (71 rows), so the placeholder objection no longer applies.
  *
- * Its scale is ~118x smaller than single-body's, which is not a rounding
+ * Its scale is ~420x smaller than single-body's, which is not a rounding
  * difference — it is the §18o point that these are different OBJECTS, not one
  * quantity at three scales. Leaving full-chart to fall back to single-body's
- * 1.9875 mapped the entire measured range [0.0018, 0.0337] into
- * **[0.5004, 0.5085]** — a 0.008-wide band out of [0,1], so all 71 agents
+ * 1.9875 mapped the entire measured range [0.0018, 0.0094] into
+ * **[0.5005, 0.5024]** — a 0.002-wide band out of [0,1], so all 71 agents
  * received a visually identical Sacred-7 contribution. That is a silently
  * wrong number in a user-visible display, not a harmless default.
+ *
+ * ⚠️ A SCALE IS ONLY AS GOOD AS ITS MAXIMUM. The first version of this constant
+ * was derived from |max| across all 71 rows, and that maximum turned out to be a
+ * DUPLICATED chart (see the note on the 'full-chart' entry below). Deriving a
+ * constant from an extremum makes the whole population's mapping hostage to the
+ * single least-trustworthy row — so audit the extremum's provenance before
+ * trusting any |max|-derived scale, here or in the other two populations.
  */
 const MONICA_POPULATION_SCALE: Partial<Record<MonicaMethod, number>> = {
   'single-body': 1.9875, // |max| 3.9751 / 2
   'two-body': 2.7095, // |max| 5.4191 / 2
-  'full-chart': 0.016851, // |max| 0.033702 / 2  [MEASURED 2026-07-24, n=71]
+  // ⚠️ RE-DERIVED. The first value shipped here was 0.016851, taken from
+  // |max| 0.033702 / 2 across all 71 rows. That maximum was NOT a real agent's
+  // monica: Carl Jung and Frida Kahlo share a byte-identical natal_positions
+  // blob, and it produced the only chart in the population where nocturnal
+  // (0.049297) exceeds diurnal (0.018108) with both positive. A duplicated,
+  // shape-anomalous row was setting the scale for the other 61.
+  //
+  // Re-measured over the 61 rows with their OWN distinct chart:
+  //   |max| 0.009441 / 2 = 0.004720   (3.6x smaller than the value it replaces)
+  //
+  // ⚠️ RE-DERIVE THIS when the 10 cloned charts are fixed (8 ancients share one
+  // blob, Jung/Kahlo share another). If a real chart is authored for any of
+  // them, re-run scripts/measureThreeOpenNumbers.ts and update this line —
+  // do not assume it still holds.
+  'full-chart': 0.004720, // |max| 0.009441 / 2  [MEASURED 2026-07-25, n=61, clones excluded]
 }
 
 const DEFAULT_MONICA_SCALE = MONICA_POPULATION_SCALE['single-body'] as number


### PR DESCRIPTION
The `full-chart` scale merged in #637 is **wrong**, and I introduced it. Reporting the correction rather than quietly amending it, because the reason it was wrong is the interesting part.

## What happened

The scale was `0.016851`, derived from `|max| 0.033702 / 2` across all 71 rows. **That maximum is not a real agent's monica.**

**Carl Jung and Frida Kahlo share a byte-identical `natal_positions` blob.** Two different people cannot have one chart. The row is anomalous in shape too — it's the *only* chart in the population where nocturnal (`0.049297`) exceeds diurnal (`0.018108`) with both positive. Every other chart has nocturnal at or below zero.

So a duplicated, shape-anomalous row was setting the mapping for the other 61 agents.

## The correction

| basis | \|max\| | scale |
|---|---|---|
| all 71 rows | 0.033702 | 0.016851 ← shipped in #637 |
| **61 distinct charts** | **0.009441** | **0.004720** ← correct, 3.6× smaller |

The real maximum belongs to Wangari Maathai. Under the corrected scale the duplicated value **saturates near 1.0** — the right signal for an anomaly — rather than compressing everyone else to make room for it.

## The general lesson (now recorded in the file)

**A scale derived from an extremum makes the entire population's mapping hostage to the single least-trustworthy row.**

Audit the extremum's provenance before trusting any `|max|`-derived constant. That applies equally to single-body's `1.9875` and two-body's `2.7095` — **neither maximum's provenance has been checked.**

## Full audit results

Adds `scripts/auditFullChartPositions.ts` (read-only), which found this:

```
identical natal_positions blobs : 2 groups, 10 of 71 rows
    x8  Alexander the Great, Archimedes, Aristotle, Herodotus, Homer,
        Julius Caesar, Marcus Tullius Cicero, Plato    (all pre-Common-Era)
    x2  Carl Jung, Frida Kahlo                         (both well documented)
distinct blobs / distinct monica: 63 / 63 of 71
resolvable bodies               : 10 in all 71 charts
whole-degree-only positions     : 43 of 71
```

`63 distinct blobs → 63 distinct monica values` is a clean 1:1, so monica is a faithful function of positions. **There are no formula collisions, only data ones.**

The **8-ancient clone is defensible** as a placeholder — no reliable birth date exists for Homer. The **Jung/Kahlo clone is not**: both have well-documented birth data, so one of those rows is simply wrong.

## ⚠️ Also found, deliberately NOT fixed here

**The stored `longitude` field is `0` for every body in all 71 charts.** The real data lives in `sign` + `degree`.

`fullChartMonica` is safe — it tests `typeof entry.position === "number"` before falling back to `signIndex * 30 + degree`, and never reads `longitude`. But any future consumer reading it gets 0 for every planet in every chart. It should be derived or dropped rather than left as a zero-valued trap.

This is also how the first version of my audit script "discovered" 71 all-zero charts: a `??` chain **stops at 0**, because `0` is not nullish. The all-zero result contradicted the 63 distinct monica values, which is what exposed the bug.

`16 tests pass. Typecheck 0 errors. Detector exit 0.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)