### PR TITLE
feat(physics): §14d — one monica engine, three names (+ CI second witness)

### DIFF
--- a/.github/workflows/monica-integrity.yml
+++ b/.github/workflows/monica-integrity.yml
@@ -95,13 +95,17 @@ jobs:
           DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
         run: bun scripts/checkAgentMonicaDrift.ts
 
-      # A second, INDEPENDENT witness (scripts/auditAgentDataIntegrity.ts) is
-      # added here by PR #636, which is where that script lands. It is not
-      # referenced yet because it does not exist on master, and a workflow step
-      # that runs a missing file is a failure, not a gate.
-      #
-      # It matters that there are two: the drift check re-derives values from the
-      # engine, the audit asserts structure directly in SQL without reusing any
-      # backfill's classification. A mis-classifying script passes its own
-      # re-run, which nearly happened twice on 2026-07-22, so neither tool is
-      # allowed to be the only witness.
+      - name: Integrity audit (asserts structure directly in SQL)
+        # The SECOND, INDEPENDENT witness. It matters that there are two: the
+        # drift check re-derives values from the engine, while this asserts
+        # structure directly in SQL and reuses none of the backfill's
+        # classification logic.
+        #
+        # A mis-classifying script PASSES ITS OWN RE-RUN. That nearly shipped
+        # twice on 2026-07-22, which is why neither tool is allowed to be the
+        # only witness. It also identifies the true rollback snapshot BY CONTENT
+        # — there are three `monica_preconstruction_*` tables and only the first
+        # restores anything, so picking the newest by name is wrong.
+        env:
+          DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
+        run: bun scripts/auditAgentDataIntegrity.ts

--- a/scripts/backfillAgentMonica.ts
+++ b/scripts/backfillAgentMonica.ts
@@ -43,6 +43,33 @@ const client = new pg.Client({
 });
 await client.connect();
 
+// ── SUPERSEDED BY §18o ──────────────────────────────────────────────────────
+// Less obviously broken than backfillPhaseMonica, but broken. It sets
+// `monica_method = 'single-body'` and `monica_constant`, and NEVER sets
+// `monica_single`. The `monica_method_matches_column` CHECK requires
+// `monica_method = 'single-body' AND monica_single IS NOT NULL`, so for any row
+// whose monica_single is still NULL — i.e. every new arrival, which is exactly
+// what you would reach for this script to fix — the write is rejected.
+//
+// Refuse rather than fail mid-transaction. Dry runs still work.
+if (WRITE) {
+  const split = await client.query<{ n: string }>(
+    `SELECT count(*)::text AS n FROM information_schema.columns
+      WHERE table_name = 'user_profiles' AND column_name = 'monica_single'`,
+  );
+  if (Number(split.rows[0]?.n ?? 0) > 0) {
+    console.error(
+      "REFUSING TO WRITE: this script is superseded by §18o.\n" +
+        "  It sets monica_method='single-body' without setting monica_single,\n" +
+        "  which the monica_method_matches_column CHECK rejects.\n\n" +
+        "  Use instead:\n" +
+        "    railway run --service Postgres -- bun scripts/backfillMonicaPerConstruction.ts --write",
+    );
+    await client.end();
+    process.exit(1);
+  }
+}
+
 // Fail loudly if the migration has not been applied, rather than writing nothing
 // and reporting success.
 const cols = await client.query<{ column_name: string }>(

--- a/scripts/backfillPhaseMonica.ts
+++ b/scripts/backfillPhaseMonica.ts
@@ -61,6 +61,33 @@ const client = new pg.Client({
 });
 await client.connect();
 
+// ── SUPERSEDED BY §18o ──────────────────────────────────────────────────────
+// This script writes `monica_constant = combined` together with
+// `monica_method = 'two-body'`. §18o narrowed monica_constant to SINGLE-BODY
+// ONLY and added the `monica_constant_single_body_only` CHECK, so that write is
+// now rejected by the database.
+//
+// Refuse to run rather than let the operator discover it as a constraint
+// violation halfway through a transaction. Read paths are still allowed, so a
+// dry run remains useful for comparison.
+if (WRITE) {
+  const split = await client.query<{ n: string }>(
+    `SELECT count(*)::text AS n FROM information_schema.columns
+      WHERE table_name = 'user_profiles' AND column_name = 'monica_two_body'`,
+  );
+  if (Number(split.rows[0]?.n ?? 0) > 0) {
+    console.error(
+      "REFUSING TO WRITE: this script is superseded by §18o.\n" +
+        "  It writes monica_constant for two-body rows, which the\n" +
+        "  monica_constant_single_body_only CHECK now rejects.\n\n" +
+        "  Use instead:\n" +
+        "    railway run --service Postgres -- bun scripts/backfillMonicaPerConstruction.ts --write",
+    );
+    await client.end();
+    process.exit(1);
+  }
+}
+
 const cols = await client.query<{ column_name: string }>(
   `SELECT column_name FROM information_schema.columns
     WHERE table_name = 'user_profiles'

--- a/scripts/checkAgentMonicaDrift.ts
+++ b/scripts/checkAgentMonicaDrift.ts
@@ -226,10 +226,19 @@ if (bad === 0) {
       `match a fresh computation (tolerance ${TOLERANCE}).`,
   );
 } else {
+  // The remedy MUST name the post-§18o script. It previously pointed at
+  // `backfillAgentMonica.ts` / `backfillPhaseMonica.ts`, and following that
+  // advice now fails: both write `monica_constant = combined` alongside
+  // `monica_method = 'two-body'|'full-chart'`, which the
+  // `monica_constant_single_body_only` CHECK rejects. A gate that reports a
+  // problem and then names the wrong fix is worse than one that stays quiet.
   console.error(
-    `\n*** ${bad} row(s) need attention. Remedy: re-run the matching backfill ` +
-      `(\`backfillAgentMonica.ts\` / \`backfillPhaseMonica.ts\`) with --write; ` +
-      `both are idempotent. ***`,
+    `\n*** ${bad} row(s) need attention. Remedy:\n` +
+      `      railway run --service Postgres -- bun scripts/backfillMonicaPerConstruction.ts --write\n` +
+      `    It is idempotent, classifies by NAME, and handles all three constructions.\n` +
+      `    Do NOT use backfillAgentMonica.ts / backfillPhaseMonica.ts — they are\n` +
+      `    pre-§18o and write monica_constant for two-body/full-chart rows, which\n` +
+      `    the monica_constant_single_body_only constraint now rejects. ***`,
   );
   process.exit(1);
 }

--- a/src/__tests__/thermodynamicDegenerateCharacterisation.test.ts
+++ b/src/__tests__/thermodynamicDegenerateCharacterisation.test.ts
@@ -1,150 +1,137 @@
 /**
- * §14d / §17c CHARACTERISATION — the thermodynamic layer's degenerate-case
- * contract, as it behaves TODAY.
+ * §14d / §17c — the thermodynamic degenerate-case contract, NOW UNIFIED.
  *
- * ⚠️ THIS TEST PINS BUGS ON PURPOSE. It asserts current behaviour, including
- * behaviour that is wrong. Do not "fix" a failure here by editing the expected
- * value — a failure means an engine changed, which is the signal this file
- * exists to produce. When the modules are unified, these goldens converge, and
- * THAT diff is the deliverable.
+ * This file began as a pure characterisation test that pinned three
+ * implementations disagreeing. The two non-canonical ones now delegate to the
+ * canonical engine, so the goldens have CONVERGED — which is exactly the diff
+ * this file existed to produce. The pre-unification values are kept in the
+ * comments below, because they are the evidence that the change was safe.
  *
- * §17c states the problem as "the same undefined input returns 1.0 / NaN / 0 /
- * null across modules". Measured, it is sharper than that, in two ways that
- * matter for how the reconciliation should be sequenced.
+ * ── What the divergence WAS (measured 2026-07-24) ────────────────────────────
  *
- * ── 1. On HEALTHY input all three agree, exactly ─────────────────────────────
+ *   input                canonical      monicaKalchm     kalchmEngine
+ *   healthy              -2.705053      -2.705053        -2.705053   <- agreed
+ *   kalchm = 1           1.618 (φ)      1.0              NaN
+ *   kalchm = 1.0001      1.618          -18750.94        -18750.94
+ *   kalchm <= 0          1.618          1.0              NaN
+ *   reactivity = 0       -216.40        1.0              -Infinity
  *
- * Same formula, same result to the last digit. So this is NOT a case of three
- * rival physics models — it is one model with three different failure handlers.
- * Unification is therefore much lower-risk than the §14 framing suggests: no
- * healthy value moves.
+ * Two facts made the unification low-risk, and both are still asserted below:
  *
- * ── 2. The danger is NEAR-degenerate, not degenerate ─────────────────────────
+ *   1. ALL THREE AGREED EXACTLY ON HEALTHY INPUT. Not three rival physics
+ *      models — one model with three different failure handlers. So delegation
+ *      moves NO healthy value, and the first test here proves it.
  *
- * At kalchm = 1.0001 — ordinary production data, not an edge case — the
- * canonical engine returns φ (1.618) because it bands |ln kalchm| < 0.05, while
- * the other two return −18750.94. That is not a different convention, it is a
- * four-orders-of-magnitude disagreement on a realistic input, and it is invisible
- * because both answers are finite numbers a consumer will happily render.
+ *   2. THE DANGEROUS CASE WAS NEAR-DEGENERATE, NOT DEGENERATE. At
+ *      kalchm = 1.0001 — ordinary production data — the canonical engine bands
+ *      |ln kalchm| < MONICA_LN_EPSILON to φ while the others divided by
+ *      ln(1.0001) ~ 1e-4 and returned -18750.94. Both answers finite, so nothing
+ *      threw and no consumer could tell. That is what got fixed.
  *
- * The exactly-degenerate cases (kalchm = 1, kalchm <= 0) disagree too, but at
- * least NaN announces itself. The near-degenerate band does not.
+ * ⚠️ If a test here fails, an engine changed. Investigate the engine; do not
+ * edit the expected value to match.
  */
-import { calculateMonica, MONICA_EQUILIBRIUM } from "@/data/unified/alchemicalCalculations";
+import {
+  calculateMonica,
+  MONICA_EQUILIBRIUM,
+  MONICA_LN_EPSILON,
+} from "@/data/unified/alchemicalCalculations";
 import { calculateMonicaConstant as monicaKalchmImpl } from "@/utils/monicaKalchmCalculations";
 import { calculateMonicaConstant as kalchmEngineImpl } from "@/calculations/core/kalchmEngine";
 
-/** Fixed, arbitrary-but-healthy inputs. Only kalchm/reactivity vary per case. */
+/** Fixed, arbitrary-but-healthy. Only kalchm/reactivity vary per case. */
 const G = 1.5;
 const R = 0.8;
 
-describe("§17c — three implementations of monica(gregsEnergy, reactivity, kalchm)", () => {
-  it("AGREE exactly on healthy input (so unification moves no healthy value)", () => {
+/** Every implementation that must now agree. */
+const IMPLS: Array<[string, (g: number, r: number, k: number) => number]> = [
+  ["canonical", calculateMonica],
+  ["monicaKalchmCalculations", monicaKalchmImpl],
+  ["kalchmEngine", kalchmEngineImpl],
+];
+
+describe("§14d — the three monica implementations are unified", () => {
+  it("still agree exactly on healthy input (proves delegation moved nothing)", () => {
     const expected = -2.705053;
-    expect(calculateMonica(G, R, 2.0)).toBeCloseTo(expected, 6);
-    expect(monicaKalchmImpl(G, R, 2.0)).toBeCloseTo(expected, 6);
-    expect(kalchmEngineImpl(G, R, 2.0)).toBeCloseTo(expected, 6);
-
-    // Non-vacuity: the shared value must be a real computation, not all three
-    // hitting the same fallback. A fallback would be positive and small.
-    expect(expected).toBeLessThan(0);
+    for (const [name, fn] of IMPLS) {
+      expect(fn(G, R, 2.0)).toBeCloseTo(expected, 6);
+      // Guard the guard: an impl stubbed to return a constant would also
+      // "agree". Require the value to actually depend on its input.
+      expect(fn(G * 2, R, 2.0)).not.toBeCloseTo(fn(G, R, 2.0), 6);
+      expect(name).toBeTruthy();
+    }
   });
 
-  describe("kalchm EXACTLY 1 — ln(kalchm) is 0, the true degenerate case", () => {
-    it("canonical returns φ (the §17c totality contract)", () => {
-      expect(calculateMonica(G, R, 1.0)).toBe(MONICA_EQUILIBRIUM);
-      expect(MONICA_EQUILIBRIUM).toBe(1.618);
-    });
+  describe("degenerate inputs now produce ONE answer, not three", () => {
+    const CASES: Array<[string, number, number, number]> = [
+      ["kalchm exactly 1 (ln = 0)", G, R, 1.0],
+      ["kalchm 1.0001 (near-degenerate)", G, R, 1.0001],
+      ["kalchm 1.05 (inside the band)", G, R, 1.05],
+      ["kalchm 0 (log undefined)", G, R, 0],
+      ["kalchm negative", G, R, -2.0],
+      ["reactivity 0 (division by zero)", G, 0, 2.0],
+      ["reactivity 1e-9", G, 1e-9, 2.0],
+      ["all zero", 0, 0, 0],
+    ];
 
-    it("monicaKalchmCalculations returns 1.0 — an unmotivated 'neutral'", () => {
-      // Its own comment calls this a "Default neutral value". 1.0 is neither
-      // neutral (monica is signed and unbounded) nor derived from anything.
-      expect(monicaKalchmImpl(G, R, 1.0)).toBe(1.0);
-    });
-
-    it("kalchmEngine returns NaN — no totality contract at all", () => {
-      expect(Number.isNaN(kalchmEngineImpl(G, R, 1.0))).toBe(true);
-    });
-
-    it("=> three different answers to one input", () => {
-      const answers = new Set([
-        String(calculateMonica(G, R, 1.0)),
-        String(monicaKalchmImpl(G, R, 1.0)),
-        String(kalchmEngineImpl(G, R, 1.0)),
-      ]);
-      expect(answers.size).toBe(3);
+    it.each(CASES)("%s — all three return the same value", (_label, g, r, k) => {
+      const values = IMPLS.map(([, fn]) => fn(g, r, k));
+      const [first] = values;
+      for (const v of values) expect(v).toBe(first);
     });
   });
 
-  describe("kalchm NEAR 1 — the case that actually threatens production data", () => {
-    it("canonical bands |ln kalchm| < MONICA_LN_EPSILON to φ", () => {
-      expect(calculateMonica(G, R, 1.0001)).toBe(MONICA_EQUILIBRIUM);
-      expect(calculateMonica(G, R, 1.05)).toBe(MONICA_EQUILIBRIUM);
+  describe("the specific WRONG values are gone", () => {
+    it("no implementation returns the unmotivated 1.0 default any more", () => {
+      // monicaKalchmCalculations returned exactly 1.0 for kalchm <= 0,
+      // ln(kalchm) === 0, and reactivity === 0. Its own comment called that a
+      // "Default neutral value" — 1.0 is neither neutral (monica is signed and
+      // unbounded) nor derived from anything.
+      for (const [, fn] of IMPLS) {
+        expect(fn(G, R, 1.0)).not.toBe(1.0);
+        expect(fn(G, R, 0)).not.toBe(1.0);
+        expect(fn(G, R, -2.0)).not.toBe(1.0);
+        expect(fn(G, 0, 2.0)).not.toBe(1.0);
+      }
     });
 
-    it("the other two EXPLODE instead, on input that is not degenerate at all", () => {
-      // kalchm = 1.0001 is ordinary data. ln(1.0001) ~ 1e-4, so dividing by it
-      // yields ~-18750 where the canonical engine yields 1.618.
-      expect(monicaKalchmImpl(G, R, 1.0001)).toBeCloseTo(-18750.937484, 4);
-      expect(kalchmEngineImpl(G, R, 1.0001)).toBeCloseTo(-18750.937484, 4);
-
-      expect(monicaKalchmImpl(G, R, 1.05)).toBeCloseTo(-38.429877, 4);
-      expect(kalchmEngineImpl(G, R, 1.05)).toBeCloseTo(-38.429877, 4);
+    it("no implementation returns NaN or +/-Infinity any more", () => {
+      // kalchmEngine returned NaN (kalchm <= 0, ln === 0) and -Infinity
+      // (reactivity === 0, which it never checked). -Infinity is worse than NaN:
+      // NaN poisons comparisons visibly, while -Infinity silently wins every
+      // Math.min and sorts to the front of every list.
+      for (const [, fn] of IMPLS) {
+        for (const [g, r, k] of [
+          [G, R, 1.0],
+          [G, R, 0],
+          [G, R, -2.0],
+          [G, 0, 2.0],
+        ]) {
+          const v = fn(g, r, k);
+          expect(Number.isNaN(v)).toBe(false);
+          expect(v).not.toBe(Number.NEGATIVE_INFINITY);
+          expect(v).not.toBe(Number.POSITIVE_INFINITY);
+        }
+      }
     });
 
-    it("=> a 4-orders-of-magnitude disagreement, both answers finite", () => {
-      // This is why it is invisible: nothing throws, nothing is NaN, and a
-      // consumer renders -18750.94 as readily as 1.618.
-      const canonical = calculateMonica(G, R, 1.0001);
-      const other = monicaKalchmImpl(G, R, 1.0001);
-      expect(Number.isFinite(canonical)).toBe(true);
-      expect(Number.isFinite(other)).toBe(true);
-      expect(Math.abs(other / canonical)).toBeGreaterThan(10_000);
-    });
-  });
-
-  describe("kalchm <= 0 — undefined logarithm", () => {
-    it.each([
-      ["zero", 0],
-      ["negative", -2.0],
-    ])("canonical returns φ for %s", (_label, k) => {
-      expect(calculateMonica(G, R, k)).toBe(MONICA_EQUILIBRIUM);
-    });
-
-    it.each([
-      ["zero", 0],
-      ["negative", -2.0],
-    ])("monicaKalchmCalculations returns 1.0 for %s", (_label, k) => {
-      expect(monicaKalchmImpl(G, R, k)).toBe(1.0);
-    });
-
-    it.each([
-      ["zero", 0],
-      ["negative", -2.0],
-    ])("kalchmEngine returns NaN for %s", (_label, k) => {
-      expect(Number.isNaN(kalchmEngineImpl(G, R, k))).toBe(true);
-    });
-  });
-
-  describe("reactivity 0 — division by zero", () => {
-    it("canonical clamps reactivity to +/-KALCHM_EPSILON and stays finite", () => {
-      const v = calculateMonica(G, 0, 2.0);
-      expect(v).toBeCloseTo(-216.404256, 4);
-      expect(Number.isFinite(v)).toBe(true);
-    });
-
-    it("monicaKalchmCalculations returns its 1.0 default", () => {
-      expect(monicaKalchmImpl(G, 0, 2.0)).toBe(1.0);
-    });
-
-    it("kalchmEngine returns -Infinity, which nothing downstream guards", () => {
-      // Worse than NaN: NaN poisons comparisons visibly, while -Infinity
-      // silently wins every `Math.min` and sorts to the front of every list.
-      expect(kalchmEngineImpl(G, 0, 2.0)).toBe(Number.NEGATIVE_INFINITY);
+    it("the near-degenerate blowup is banded, not divided", () => {
+      // Was -18750.94 in two of three impls. Now phi everywhere.
+      for (const [, fn] of IMPLS) {
+        expect(fn(G, R, 1.0001)).toBe(MONICA_EQUILIBRIUM);
+        expect(fn(G, R, 1.05)).toBe(MONICA_EQUILIBRIUM);
+      }
+      // Non-vacuity: just outside the band it must compute normally again,
+      // otherwise "banded" is indistinguishable from "always phi".
+      const outside = Math.exp(MONICA_LN_EPSILON * 4);
+      for (const [, fn] of IMPLS) {
+        expect(fn(G, R, outside)).not.toBe(MONICA_EQUILIBRIUM);
+        expect(Number.isFinite(fn(G, R, outside))).toBe(true);
+      }
     });
   });
 
-  describe("the totality contract holds for the canonical engine ONLY", () => {
+  describe("§17c totality now holds for ALL THREE (was canonical only)", () => {
     const HOSTILE: Array<[number, number, number]> = [
       [G, R, 1.0],
       [G, R, 1.0001],
@@ -158,32 +145,24 @@ describe("§17c — three implementations of monica(gregsEnergy, reactivity, kal
       [G, R, Number.NaN],
     ];
 
-    it("canonical is ALWAYS finite (§17c totality)", () => {
-      for (const [g, r, k] of HOSTILE) {
-        const v = calculateMonica(g, r, k);
-        expect(Number.isFinite(v)).toBe(true);
+    it("every implementation is finite across all 10 hostile inputs", () => {
+      // Before delegation, 8 of these 10 produced a non-finite result in at least
+      // one of the two non-canonical impls. Now none do.
+      const nonFinite: string[] = [];
+      for (const [name, fn] of IMPLS) {
+        for (const [g, r, k] of HOSTILE) {
+          if (!Number.isFinite(fn(g, r, k))) nonFinite.push(`${name}(${g},${r},${k})`);
+        }
       }
+      expect(nonFinite).toEqual([]);
     });
 
-    it("the other two are NOT — pinned as the gap to close", () => {
-      const nonFinite = HOSTILE.filter(
-        ([g, r, k]) =>
-          !Number.isFinite(monicaKalchmImpl(g, r, k)) || !Number.isFinite(kalchmEngineImpl(g, r, k)),
-      );
-
-      // 8 of 10, MEASURED — not estimated. (My first guess here was 5, and
-      // writing it as a test is what caught that. The two that stay finite are
-      // the near-degenerate rows, kalchm=1.0001 and reactivity=1e-9, which
-      // return huge-but-finite numbers — the invisible failure mode above.)
-      expect(nonFinite.length).toBe(8);
-
-      // Name them, so a change in this count says WHICH case moved rather than
-      // just that the number is different.
-      const finiteCases = HOSTILE.filter(
-        ([g, r, k]) =>
-          Number.isFinite(monicaKalchmImpl(g, r, k)) && Number.isFinite(kalchmEngineImpl(g, r, k)),
-      ).map(([g, r, k]) => `g=${g} r=${r} k=${k}`);
-      expect(finiteCases).toEqual(["g=1.5 r=0.8 k=1.0001", "g=1.5 r=1e-9 k=2"]);
+    it("and all three AGREE on every hostile input, not merely stay finite", () => {
+      for (const [g, r, k] of HOSTILE) {
+        const values = IMPLS.map(([, fn]) => fn(g, r, k));
+        const [first] = values;
+        for (const v of values) expect(v).toBe(first);
+      }
     });
   });
 });

--- a/src/calculations/core/kalchmEngine.ts
+++ b/src/calculations/core/kalchmEngine.ts
@@ -5,6 +5,7 @@
  * for Kalchm (K_alchm) and Monica Constant (M) as specified in the system requirements.
  */
 
+import { calculateMonica } from "@/data/unified/alchemicalCalculations";
 import type { ElementalProperties, PlanetaryPosition } from "@/types/alchemy";
 import type { AlchemicalProperties } from "@/types/celestial";
 import { getCachedCalculation } from "../../utils/calculationCache";
@@ -180,21 +181,33 @@ export function calculateKAlchm(
 }
 
 /**
- * Calculate Monica Constant using the exact formula: * M = -Greg's Energy / (Reactivity × ln(K_alchm))
+ * Calculate Monica Constant: M = -Greg's Energy / (Reactivity × ln(K_alchm))
+ *
+ * §14d — DELEGATES to the canonical engine. Name and signature kept so no
+ * importer changes.
+ *
+ * It previously reimplemented the formula and agreed with the canonical engine
+ * EXACTLY on healthy input (−2.705053 to the last digit), so this moves no
+ * healthy value. It differed only in failure handling, and had no totality
+ * contract at all — it could return NaN (kalchm ≤ 0, or ln(kalchm) === 0) and
+ * **-Infinity** (reactivity === 0, which it never checked).
+ *
+ * -Infinity is worse than NaN: NaN poisons comparisons visibly, while -Infinity
+ * silently wins every Math.min and sorts to the front of every list. Nothing
+ * downstream guarded for either.
+ *
+ * It also had no near-degenerate band, so at kalchm = 1.0001 it returned
+ * −18750.94 where the canonical engine returns φ — both finite, so undetectable.
+ *
+ * Pinned before and after in
+ * `src/__tests__/thermodynamicDegenerateCharacterisation.test.ts`.
  */
 export function calculateMonicaConstant(
   gregsEnergy: number,
   reactivity: number,
   K_alchm: number,
 ): number {
-  // Check for valid K_alchm
-  if (K_alchm <= 0) return NaN;
-  const lnK = Math.log(K_alchm);
-
-  // Check for valid natural log
-  if (lnK === 0) return NaN;
-
-  return -gregsEnergy / (reactivity * lnK);
+  return calculateMonica(gregsEnergy, reactivity, K_alchm);
 }
 
 /**

--- a/src/utils/monicaKalchmCalculations.ts
+++ b/src/utils/monicaKalchmCalculations.ts
@@ -1,5 +1,6 @@
 import { calculateKinetics } from "@/calculations/kinetics";
 import { ALCHEMICAL_PILLARS, COOKING_METHOD_PILLAR_MAPPING } from "@/constants/alchemicalPillars";
+import { calculateMonica } from "@/data/unified/alchemicalCalculations";
 import type { ElementalProperties } from "@/types/alchemy";
 import type { AlchemicalProperties } from "@/types/celestial";
 import type { KineticMetrics } from "@/types/kinetics";
@@ -122,18 +123,32 @@ export function calculateKAlchm(
 /**
  * Calculate Monica Constant: Dynamic system constant relating energy to equilibrium
  * Formula: M = -Greg's Energy / (Reactivity × ln(K_alchm))
+ *
+ * §14d — DELEGATES to the canonical engine. The name and signature are kept so
+ * no importer changes.
+ *
+ * It previously reimplemented the formula. Measured, that reimplementation agreed
+ * with the canonical engine EXACTLY on healthy input (−2.705053 to the last
+ * digit), so this delegation moves no healthy value. It differed only in failure
+ * handling, in two ways that were both wrong:
+ *
+ *   1. It returned a hardcoded `1.0` for kalchm ≤ 0, ln(kalchm) === 0, or
+ *      reactivity === 0 — its own comment called that a "Default neutral value".
+ *      1.0 is neither neutral (monica is signed and unbounded) nor derived from
+ *      anything.
+ *   2. It had NO near-degenerate band, so at kalchm = 1.0001 — ordinary data, not
+ *      an edge case — it returned −18750.94 where the canonical engine returns φ.
+ *      Both values are finite, so nothing threw and no consumer could tell.
+ *
+ * Pinned before and after in
+ * `src/__tests__/thermodynamicDegenerateCharacterisation.test.ts`.
  */
 export function calculateMonicaConstant(
   gregsEnergy: number,
   reactivity: number,
   K_alchm: number,
 ): number {
-  const lnK = Math.log(K_alchm);
-  if (K_alchm > 0 && lnK !== 0 && reactivity !== 0) {
-    return -gregsEnergy / (reactivity * lnK);
-  } else {
-    return 1.0; // Default neutral value
-  }
+  return calculateMonica(gregsEnergy, reactivity, K_alchm);
 }
 // ========== HELPER FUNCTIONS ==========
 /**


### PR DESCRIPTION
Two things, both about making a gate actually work.

## 1. §14d — the three monica implementations are unified

`monicaKalchmCalculations.calculateMonicaConstant` and `kalchmEngine.calculateMonicaConstant` now **delegate** to the canonical `calculateMonica`. Exported names and signatures unchanged, so **no importer moves**.

### Why this was safe — verified, not argued

| check | result |
|---|---|
| All three agreed on healthy input *before* the change | `-2.705053` to the last digit (#638) |
| Drift check re-derived **all of production** against the delegated code | **0 drifted** across 4302 + 623 + 71 |
| Full suite | 166 suites / 1423 tests pass |
| Typecheck | 0 errors |

No real agent's monica moved. That's measured against the live database, not inferred.

### What the two implementations used to do wrong

| impl | failure behaviour |
|---|---|
| `monicaKalchmCalculations` | hardcoded **`1.0`** for `kalchm <= 0`, `ln(kalchm) === 0`, `reactivity === 0`. Its own comment called this a *"Default neutral value"* — 1.0 is neither neutral (monica is signed and unbounded) nor derived from anything. |
| `kalchmEngine` | **`NaN`**, and **`-Infinity`** for `reactivity === 0`, which it never checked. `-Infinity` is worse than NaN: NaN poisons comparisons visibly, while `-Infinity` silently wins every `Math.min` and sorts to the front of every list. |
| both | **no near-degenerate band** — at `kalchm = 1.0001`, ordinary data, they returned `-18750.94` where the canonical engine returns φ. Both finite, so nothing threw and no consumer could tell. |

#638's goldens are converted from *pinning the divergence* to *asserting convergence* — the diff that file existed to produce. The old values remain in its header as evidence. **Totality now holds for all three:** 0 non-finite across 10 hostile inputs, where 8 of 10 were non-finite before.

## 2. Two stale-pointer bugs found on the way

**The drift check's failure message named a remedy that cannot work.** It told the operator to run `backfillAgentMonica.ts` / `backfillPhaseMonica.ts`. Both are pre-§18o, and both are now rejected by the constraints:

| script | why it fails now |
|---|---|
| `backfillPhaseMonica` | writes `monica_constant` with `monica_method='two-body'` → rejected by `monica_constant_single_body_only` |
| `backfillAgentMonica` | sets `monica_method='single-body'` without setting `monica_single` → rejected by `monica_method_matches_column`, for exactly the new-arrival rows you'd reach for it to fix |

A gate that reports a problem and then names a fix that cannot work is worse than one that stays quiet. The message now names `backfillMonicaPerConstruction.ts`, and both superseded scripts **refuse to `--write`** (detecting the split by column existence) rather than failing mid-transaction. Dry runs still work — verified by control.

## 3. The CI gate's second witness

Adds the `auditAgentDataIntegrity.ts` step, deliberately omitted when the workflow shipped because the script landed in #636 while the workflow landed in #637.

The drift check re-derives from the engine; the audit asserts structure in SQL reusing **none** of the backfill's classification. **A mis-classifying script passes its own re-run** — that nearly shipped twice on 2026-07-22.

## ⚠️ Not fixed here

`MONICA_LN_EPSILON = 0.05` is **chosen, not derived** — the file calls it a *"tunable knob"*. Meanwhile `agentMonicaTwoBody` derives its own as `(0.110698 + 0.138173) / 2 = 0.1244355` from two **measured** quantities. Two modules in one repo, **2.5× apart**, one measured and one not. It doesn't block delegation, but it should be derived.

Also: the drift check now reports **4 missing** two-body rows — Moon Phase agents created at 03:01 today. Not caused by this change; it's the continuous-growth hazard, and the gate catching it is the gate working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)