### PR TITLE
feat(physics): derive MONICA_LN_EPSILON, and audit the two unchecked scale maxima

### DIFF
--- a/scripts/measureLnKalchmGap.ts
+++ b/scripts/measureLnKalchmGap.ts
@@ -1,0 +1,149 @@
+/**
+ * Is there a GAP in |ln(kalchm)| that MONICA_LN_EPSILON should sit in?
+ *
+ * No database needed. The single-body population is a deterministic grid
+ * (planet x sign x degree x sect), so this is exhaustive, not a sample.
+ *
+ * Why it matters: MONICA_LN_EPSILON = 0.05 is self-described as a "tunable knob".
+ * agentMonicaTwoBody instead DERIVES its band as the midpoint between two
+ * measured quantities:
+ *     DEGENERATE_LN_KALCHM   = 0.110698   (vessel Essence exactly 0)
+ *     HEALTHY_LN_KALCHM_FLOOR = 0.138173  (smallest non-degenerate |ln k|)
+ *     TWO_BODY_LN_EPSILON = (0.110698 + 0.138173) / 2 = 0.1244355
+ *
+ * That derivation only works if the distribution is BIMODAL — a cluster of
+ * degenerate values, a gap, then the healthy values. This measures whether the
+ * single-body population has the same shape, and where its gap is.
+ *
+ * If there is no gap, the band cannot be derived this way and any epsilon is a
+ * threshold on a continuum — which would be worth knowing before "deriving" one.
+ */
+import {
+  calculateKalchm,
+  MONICA_LN_EPSILON,
+} from "@/data/unified/alchemicalCalculations";
+import { getDignityScore } from "@/utils/dignityScales";
+import {
+  PLANETARY_SECTARIAN_ESMS,
+  ZODIAC_ELEMENTS,
+} from "@/utils/planetaryAlchemyMapping";
+import { groundingVessel, type ESMS } from "@/utils/agentMonica";
+import type { AlchemicalProperties } from "@/types/celestial";
+
+const ZERO: ESMS = { Spirit: 0, Essence: 0, Matter: 0, Substance: 0 };
+const SIGNS = Object.keys(ZODIAC_ELEMENTS);
+const PLANETS = Object.keys(PLANETARY_SECTARIAN_ESMS);
+const SECTS = ["diurnal", "nocturnal"] as const;
+
+interface Sample {
+  planet: string;
+  sign: string;
+  degree: number;
+  sect: string;
+  kalchm: number;
+  absLn: number;
+  essence: number;
+}
+
+const samples: Sample[] = [];
+
+for (const planet of PLANETS) {
+  const table = PLANETARY_SECTARIAN_ESMS[planet as keyof typeof PLANETARY_SECTARIAN_ESMS];
+  for (const sign of SIGNS) {
+    const dignityScale = getDignityScore(planet, sign as never).esmsScale;
+    const element = ZODIAC_ELEMENTS[sign as keyof typeof ZODIAC_ELEMENTS];
+    const elementalProps = {
+      Fire: element === "Fire" ? 1 : 0,
+      Water: element === "Water" ? 1 : 0,
+      Air: element === "Air" ? 1 : 0,
+      Earth: element === "Earth" ? 1 : 0,
+    };
+    for (let degree = 0; degree < 30; degree++) {
+      const v = groundingVessel(degree, dignityScale);
+      for (const sect of SECTS) {
+        const base: ESMS = table ? { ...ZERO, ...table[sect] } : ZERO;
+        const esms: ESMS = {
+          Spirit: base.Spirit + v.Spirit,
+          Essence: base.Essence + v.Essence,
+          Matter: base.Matter + v.Matter,
+          Substance: base.Substance + v.Substance,
+        };
+        const kalchm = calculateKalchm(esms as AlchemicalProperties);
+        if (!Number.isFinite(kalchm) || kalchm <= 0) continue;
+        const absLn = Math.abs(Math.log(kalchm));
+        samples.push({ planet, sign, degree, sect, kalchm, absLn, essence: esms.Essence });
+      }
+    }
+  }
+}
+
+console.log(`exhaustive single-body grid: ${samples.length} points`);
+console.log(`  ${PLANETS.length} planets x ${SIGNS.length} signs x 30 degrees x 2 sects`);
+console.log(`current MONICA_LN_EPSILON = ${MONICA_LN_EPSILON}`);
+console.log("=".repeat(74));
+
+// ── the low tail, where the band lives ──────────────────────────────────────
+const sorted = [...samples].sort((a, b) => a.absLn - b.absLn);
+console.log(`\nSMALLEST 25 |ln kalchm| values (the band's neighbourhood):`);
+console.log(`   #  |ln k|      kalchm     Essence  planet/sign/deg/sect`);
+sorted.slice(0, 25).forEach((s, i) => {
+  console.log(
+    `  ${String(i + 1).padStart(2)}  ${s.absLn.toFixed(6)}  ${s.kalchm.toFixed(6)}  ` +
+      `${s.essence.toFixed(3).padStart(7)}  ${s.planet} ${s.sign} ${s.degree} ${s.sect}`,
+  );
+});
+
+// ── is there a GAP? find the largest jump in the low tail ───────────────────
+console.log(`\nLARGEST GAPS in the low tail (|ln k| < 0.5):`);
+const lowTail = sorted.filter((s) => s.absLn < 0.5);
+const gaps: Array<{ lo: number; hi: number; width: number; idx: number }> = [];
+for (let i = 1; i < lowTail.length; i++) {
+  const lo = lowTail[i - 1].absLn;
+  const hi = lowTail[i].absLn;
+  if (hi - lo > 0) gaps.push({ lo, hi, width: hi - lo, idx: i });
+}
+gaps.sort((a, b) => b.width - a.width);
+console.log(`  width      between            midpoint    rows below`);
+for (const g of gaps.slice(0, 8)) {
+  const mid = (g.lo + g.hi) / 2;
+  const below = samples.filter((s) => s.absLn < mid).length;
+  console.log(
+    `  ${g.width.toFixed(6)}  ${g.lo.toFixed(6)} -> ${g.hi.toFixed(6)}  ` +
+      `${mid.toFixed(6)}  ${String(below).padStart(6)}`,
+  );
+}
+
+// ── how many points does each candidate epsilon capture? ────────────────────
+console.log(`\nHOW MANY GRID POINTS FALL INSIDE EACH CANDIDATE BAND:`);
+const CANDIDATES = [
+  ["0.05  (current, CHOSEN)", 0.05],
+  ["0.1244355 (two-body, DERIVED)", 0.1244355],
+] as const;
+for (const [label, eps] of CANDIDATES) {
+  const n = samples.filter((s) => s.absLn < eps).length;
+  console.log(`  ${label.padEnd(32)} ${String(n).padStart(6)} / ${samples.length}  (${((n / samples.length) * 100).toFixed(2)}%)`);
+}
+if (gaps.length) {
+  const best = gaps[0];
+  const mid = (best.lo + best.hi) / 2;
+  const n = samples.filter((s) => s.absLn < mid).length;
+  console.log(
+    `  ${`${mid.toFixed(7)} (widest gap, DERIVED)`.padEnd(32)} ${String(n).padStart(6)} / ${samples.length}  (${((n / samples.length) * 100).toFixed(2)}%)`,
+  );
+}
+
+// ── does Essence == 0 explain the degenerate cluster, as in two-body? ───────
+console.log(`\nIS THE DEGENERATE CLUSTER EXPLAINED BY Essence == 0?  (two-body's rule)`);
+const zeroEss = samples.filter((s) => s.essence === 0);
+console.log(`  grid points with Essence exactly 0 : ${zeroEss.length}`);
+if (zeroEss.length) {
+  const lns = zeroEss.map((s) => s.absLn).sort((a, b) => a - b);
+  console.log(`  their |ln k| range                 : [${lns[0].toFixed(6)}, ${lns[lns.length - 1].toFixed(6)}]`);
+  const nonZero = samples.filter((s) => s.essence !== 0).map((s) => s.absLn).sort((a, b) => a - b);
+  console.log(`  Essence != 0, smallest |ln k|       : ${nonZero[0].toFixed(6)}`);
+  const separable = lns[lns.length - 1] < nonZero[0];
+  console.log(`  cleanly separable?                 : ${separable ? "YES — a derivation exists" : "NO — the two overlap"}`);
+  if (separable) {
+    console.log(`  => derived epsilon = (${lns[lns.length - 1].toFixed(6)} + ${nonZero[0].toFixed(6)}) / 2 = ${((lns[lns.length - 1] + nonZero[0]) / 2).toFixed(7)}`);
+  }
+}

--- a/src/__tests__/monicaLnEpsilonDerivation.test.ts
+++ b/src/__tests__/monicaLnEpsilonDerivation.test.ts
@@ -1,0 +1,144 @@
+/**
+ * MONICA_LN_EPSILON is DERIVED, and this is where the derivation is checked.
+ *
+ * The constant is the midpoint of a measured gap in |ln(kalchm)|. Its two
+ * endpoints are stated in `alchemicalCalculations.ts` rather than computed
+ * there, because computing them needs `groundingVessel` from `@/utils/agentMonica`,
+ * which imports that module — a cycle. So the enumeration lives here.
+ *
+ * These tests re-derive both endpoints from the grid on every run. If the vessel,
+ * the dignity table, or the sectarian ESMS change, the gap moves and THIS FAILS —
+ * which is the point. Without it the constants would be a comment asserting a
+ * measurement nobody re-checks.
+ *
+ * The grid is exhaustive, not sampled: the single-body population is fully
+ * determined by planet x sign x degree x sect.
+ */
+import {
+  calculateKalchm,
+  MONICA_LN_EPSILON,
+  SINGLE_BODY_DEGENERATE_LN_CEILING,
+  SINGLE_BODY_HEALTHY_LN_FLOOR,
+} from "@/data/unified/alchemicalCalculations";
+import { getDignityScore } from "@/utils/dignityScales";
+import { PLANETARY_SECTARIAN_ESMS, ZODIAC_ELEMENTS } from "@/utils/planetaryAlchemyMapping";
+import { groundingVessel, type ESMS } from "@/utils/agentMonica";
+import type { AlchemicalProperties } from "@/types/celestial";
+
+const ZERO: ESMS = { Spirit: 0, Essence: 0, Matter: 0, Substance: 0 };
+
+/** Every |ln(kalchm)| the single-body population can produce. */
+function enumerateAbsLnKalchm(): number[] {
+  const out: number[] = [];
+  for (const planet of Object.keys(PLANETARY_SECTARIAN_ESMS)) {
+    const table = PLANETARY_SECTARIAN_ESMS[planet as keyof typeof PLANETARY_SECTARIAN_ESMS];
+    for (const sign of Object.keys(ZODIAC_ELEMENTS)) {
+      const dignityScale = getDignityScore(planet, sign as never).esmsScale;
+      for (let degree = 0; degree < 30; degree++) {
+        const v = groundingVessel(degree, dignityScale);
+        for (const sect of ["diurnal", "nocturnal"] as const) {
+          const base: ESMS = table ? { ...ZERO, ...table[sect] } : ZERO;
+          const esms: ESMS = {
+            Spirit: base.Spirit + v.Spirit,
+            Essence: base.Essence + v.Essence,
+            Matter: base.Matter + v.Matter,
+            Substance: base.Substance + v.Substance,
+          };
+          const kalchm = calculateKalchm(esms as AlchemicalProperties);
+          if (Number.isFinite(kalchm) && kalchm > 0) out.push(Math.abs(Math.log(kalchm)));
+        }
+      }
+    }
+  }
+  return out.sort((a, b) => a - b);
+}
+
+/** The widest gap below 0.5 — the band's home. */
+function widestLowGap(sorted: number[]): { lo: number; hi: number; width: number } {
+  let best = { lo: 0, hi: 0, width: 0 };
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i] >= 0.5) break;
+    const width = sorted[i] - sorted[i - 1];
+    if (width > best.width) best = { lo: sorted[i - 1], hi: sorted[i], width };
+  }
+  return best;
+}
+
+const GRID = enumerateAbsLnKalchm();
+const GAP = widestLowGap(GRID);
+
+describe("MONICA_LN_EPSILON is derived from a measured gap", () => {
+  it("enumerates the full deterministic grid", () => {
+    // 11 planets x 12 signs x 30 degrees x 2 sects
+    expect(GRID.length).toBe(7920);
+  });
+
+  it("the |ln kalchm| distribution really is bimodal with ONE dominant gap", () => {
+    // Without a gap there is nothing to derive and any epsilon would be an
+    // arbitrary threshold on a continuum. This is the load-bearing assumption.
+    expect(GAP.width).toBeGreaterThan(0.15);
+
+    // It must also DOMINATE — collect every gap in the low tail and compare the
+    // top two directly.
+    //
+    // ⚠️ Do NOT test this by filtering the winning endpoints out and re-running
+    // widestLowGap: removing them merges their neighbours into a single larger
+    // span (measured 0.2207 > 0.1727), so that version fails on correct data.
+    const widths: number[] = [];
+    for (let i = 1; i < GRID.length; i++) {
+      if (GRID[i] >= 0.5) break;
+      const w = GRID[i] - GRID[i - 1];
+      if (w > 0) widths.push(w);
+    }
+    widths.sort((a, b) => b - a);
+    expect(widths[0]).toBeCloseTo(GAP.width, 15);
+    // Widest is ~1.48x the runner-up (0.172734 vs 0.116838): a clear winner, so
+    // "the gap" is well defined rather than one of several similar candidates.
+    expect(widths[0] / widths[1]).toBeGreaterThan(1.3);
+  });
+
+  it("re-derives both stated endpoints from the grid", () => {
+    expect(GAP.lo).toBeCloseTo(SINGLE_BODY_DEGENERATE_LN_CEILING, 15);
+    expect(GAP.hi).toBeCloseTo(SINGLE_BODY_HEALTHY_LN_FLOOR, 15);
+  });
+
+  it("the epsilon is exactly the midpoint of those endpoints", () => {
+    expect(MONICA_LN_EPSILON).toBeCloseTo((GAP.lo + GAP.hi) / 2, 15);
+    expect(MONICA_LN_EPSILON).toBeCloseTo(0.13241878500631321, 15);
+  });
+
+  it("sits strictly inside the gap, with real margin on both sides", () => {
+    expect(MONICA_LN_EPSILON).toBeGreaterThan(GAP.lo);
+    expect(MONICA_LN_EPSILON).toBeLessThan(GAP.hi);
+    // The reason for the change: the old 0.05 had only 0.003948 of lower margin.
+    expect(MONICA_LN_EPSILON - GAP.lo).toBeGreaterThan(0.08);
+    expect(GAP.hi - MONICA_LN_EPSILON).toBeGreaterThan(0.08);
+  });
+
+  it("classifies EXACTLY as the old 0.05 did — a zero-behaviour-change edit", () => {
+    const withOld = GRID.filter((v) => v < 0.05).length;
+    const withNew = GRID.filter((v) => v < MONICA_LN_EPSILON).length;
+    expect(withNew).toBe(withOld);
+    expect(withNew).toBe(660);
+
+    // Non-vacuity: the band must actually exclude most of the grid, or "identical
+    // classification" would be trivially true.
+    expect(withNew).toBeLessThan(GRID.length / 2);
+    expect(withNew).toBeGreaterThan(0);
+  });
+
+  it("two-body's independently derived epsilon also lands in this gap", () => {
+    // agentMonicaTwoBody derives 0.1244355 from a DIFFERENT mechanism (vessel
+    // Essence exactly 0). That it falls inside the single-body gap is a genuine
+    // corroboration — two derivations, different routes, compatible answers.
+    //
+    // They are deliberately NOT unified (§18o: different populations). Note the
+    // mechanisms really do differ: single-body's degenerate cluster is NOT the
+    // Essence==0 set — those points sit at |ln k| in [1.06, 5.55], far from the
+    // band.
+    const TWO_BODY_LN_EPSILON = 0.1244355;
+    expect(TWO_BODY_LN_EPSILON).toBeGreaterThan(GAP.lo);
+    expect(TWO_BODY_LN_EPSILON).toBeLessThan(GAP.hi);
+    expect(GRID.filter((v) => v < TWO_BODY_LN_EPSILON).length).toBe(660);
+  });
+});

--- a/src/__tests__/utils/agentMonicaTwoBody.test.ts
+++ b/src/__tests__/utils/agentMonicaTwoBody.test.ts
@@ -441,11 +441,27 @@ describe("twoBodyMonica — the totality contract", () => {
       expect(absorbed.length).toBeLessThan(tail.length); // the skirt is real
     });
 
-    it("leaves the canonical engine's own band untouched", () => {
-      // The whole point of a LOCAL band: the shared §17c constant is unchanged,
-      // so the 4280 single-body rows in production keep their values.
-      expect(MONICA_LN_EPSILON).toBe(0.05);
-      expect(TWO_BODY_LN_EPSILON).toBeGreaterThan(MONICA_LN_EPSILON);
+    it("stays INDEPENDENT of the canonical engine's own band", () => {
+      // This used to assert `MONICA_LN_EPSILON === 0.05` and
+      // `TWO_BODY_LN_EPSILON > MONICA_LN_EPSILON`. Both were pinning incidental
+      // facts rather than the property that matters.
+      //
+      // The canonical band has since been DERIVED (midpoint of the measured
+      // single-body |ln kalchm| gap = 0.1324188, replacing a chosen 0.05), which
+      // made it slightly WIDER than the two-body band — so the old ordering
+      // inverted. That ordering was never meaningful: the two bands are derived
+      // from different populations by different mechanisms, so neither has to be
+      // larger.
+      //
+      // What actually matters is that they are SEPARATE constants, so a change to
+      // one cannot silently move the other's population.
+      expect(TWO_BODY_LN_EPSILON).not.toBeCloseTo(MONICA_LN_EPSILON, 6);
+
+      // And the two-body band must remain correct for ITS population — that is
+      // what the preceding tests in this block verify (zero collateral, real
+      // absorption), independent of whatever the canonical value is.
+      expect(TWO_BODY_LN_EPSILON).toBeGreaterThan(DEGENERATE_LN_KALCHM);
+      expect(TWO_BODY_LN_EPSILON).toBeLessThan(HEALTHY_LN_KALCHM_FLOOR);
     });
   });
 

--- a/src/data/unified/alchemicalCalculations.ts
+++ b/src/data/unified/alchemicalCalculations.ts
@@ -52,16 +52,54 @@ export interface AlchemicalIngredient {
 //   monica                                    → φ   (MONICA_EQUILIBRIUM, the
 //                                                    harmonic ideal — kalchm=1 is
 //                                                    perfect balance, not "dead")
-// The two floors below are the only tunable knobs.
-
 /** Floor applied to each ESMS axis before exponentiation, so 0^0 / division by
  *  zero cannot occur. Load-bearing for sparse/single-body charts (§18). */
 export const KALCHM_EPSILON = 0.01;
 
+// ── The monica degenerate band, DERIVED ─────────────────────────────────────
+//
+// This was `MONICA_LN_EPSILON = 0.05`, described in this file as a "tunable
+// knob" — an unmeasured constant on the hot path, which is what §11 forbids.
+//
+// Measured exhaustively over the single-body grid (11 planets x 12 signs x 30
+// degrees x 2 sects = 7920 points, deterministic, so this is a census not a
+// sample), |ln(kalchm)| is BIMODAL with one wide clean gap:
+//
+//     degenerate cluster ends   0.046051701859880986
+//                        GAP    width 0.17273416629286448
+//     healthy values begin      0.21878586815274545
+//
+// The band belongs at the midpoint, which is the same derivation
+// `agentMonicaTwoBody` already uses for TWO_BODY_LN_EPSILON.
+//
+// ── Why change a value that classified correctly? ───────────────────────────
+//
+// 0.05 and the midpoint capture the IDENTICAL 660 of 7920 points, so this is a
+// provably zero-behaviour-change edit. The reason to make it is MARGIN: 0.05 sat
+// only 0.003948 above the degenerate ceiling, while the midpoint sits 0.086367
+// from both edges — 22x more room. A constant 0.004 from a cliff is one grid
+// tweak away from silently reclassifying agents; one at the centre is not.
+//
+// ⚠️ The endpoints are stated here rather than computed from the grid at import,
+// because the grid needs `groundingVessel` from @/utils/agentMonica, which
+// imports THIS module — enumerating it here would be a dependency cycle. The
+// enumeration lives in `src/__tests__/monicaLnEpsilonDerivation.test.ts`, which
+// re-derives both endpoints and FAILS if the grid moves. So the derivation is
+// checked on every test run; it is not a comment asserting a stale measurement.
+
+/** Largest |ln(kalchm)| in the degenerate cluster. [MEASURED 2026-07-25, n=7920] */
+export const SINGLE_BODY_DEGENERATE_LN_CEILING = 0.046051701859880986;
+
+/** Smallest |ln(kalchm)| among non-degenerate points. [MEASURED 2026-07-25, n=7920] */
+export const SINGLE_BODY_HEALTHY_LN_FLOOR = 0.21878586815274545;
+
 /** Half-width of the monica degenerate band. When |ln(kalchm)| < this, kalchm is
  *  treated as the equilibrium point (perfect balance) and monica returns
- *  MONICA_EQUILIBRIUM instead of diverging toward ±∞. */
-export const MONICA_LN_EPSILON = 0.05;
+ *  MONICA_EQUILIBRIUM instead of diverging toward ±∞.
+ *
+ *  DERIVED as the midpoint of the measured gap above = 0.13241878500631321. */
+export const MONICA_LN_EPSILON =
+  (SINGLE_BODY_DEGENERATE_LN_CEILING + SINGLE_BODY_HEALTHY_LN_FLOOR) / 2;
 
 /** The harmonic-ideal monica (golden ratio). Returned for a perfectly balanced
  *  (degenerate) alchemical state. See §17c. */


### PR DESCRIPTION
`MONICA_LN_EPSILON` was `0.05`, described in the file itself as a *"tunable knob"* — an unmeasured constant on the hot path, which is what §11 forbids.

## The measurement

Exhaustive over the single-body grid (11 planets × 12 signs × 30 degrees × 2 sects = **7920 points**). Deterministic, so this is a census, not a sample. `|ln(kalchm)|` is **bimodal with one dominant gap**:

```
degenerate cluster ends   0.046051701859880986
                   GAP    width 0.17273416629286448   (1.48x the runner-up)
healthy values begin      0.21878586815274545
midpoint = DERIVED        0.13241878500631321
```

Both endpoints are now named `[MEASURED]` constants and the epsilon is their midpoint — the same derivation `agentMonicaTwoBody` already uses.

## Why change a value that classified correctly?

`0.05` and the midpoint capture the **identical 660 of 7920 points**, so this is provably zero-behaviour-change. Verified against production: **drift 0** across 4304 + 623 + 71.

The reason to make the change is **margin**:

| epsilon | margin below | margin above |
|---|---|---|
| `0.05` (old) | **0.003948** | 0.168786 |
| `0.1324188` (derived) | **0.086367** | 0.086367 |

`0.05` sat 0.004 from a cliff — one grid tweak away from silently reclassifying agents. The midpoint has **22× more room**, symmetric.

## How the derivation stays honest

The endpoints are *stated* in the engine rather than computed at import, because computing them needs `groundingVessel` from `@/utils/agentMonica`, which imports the engine — a **dependency cycle**.

So the enumeration lives in `src/__tests__/monicaLnEpsilonDerivation.test.ts`, which re-derives both endpoints on every run and **fails if the grid moves**. The derivation is checked, not asserted in a comment that nobody re-verifies.

## Corroboration from an independent derivation

Two-body's `TWO_BODY_LN_EPSILON = 0.1244355` is derived from a **different mechanism** (vessel `Essence` exactly 0), and it lands inside this gap and captures the same 660 points. Two derivations, different routes, compatible answers.

They stay separate per §18o. And the mechanisms really do differ — the single-body degenerate cluster is **not** the `Essence == 0` set, which sits at `|ln k| ∈ [1.06, 5.55]`, far from the band.

## Scale maxima audit — both sound

After the full-chart scale turned out to rest on a duplicated chart (#639), the other two `|max|/2` constants needed the same check. **Neither is affected:**

| scale | max | holder | verdict |
|---|---|---|---|
| single-body 1.9875 | 3.975066 | `Sun in Libra 8` **and** `22 Degree` | **function periodicity, not duplicated data** — the vessel has only **7 distinct shapes across 30 degrees**, and 8 & 22 share one. Different inputs, same output. |
| two-body 2.7095 | −5.419064 | single holder | no duplication |

Only the full-chart maximum was corrupt. `1.9875` and `2.7095` stand.

## Test correction

`agentMonicaTwoBody.test.ts` asserted `MONICA_LN_EPSILON === 0.05` and `TWO_BODY_LN_EPSILON > MONICA_LN_EPSILON`. Both pinned **incidental facts** rather than the property the test's own comment describes.

The derived canonical band is slightly *wider* than two-body's, so that ordering inverted — but it was never meaningful, since the two come from different populations by different mechanisms. It now asserts what matters: the constants are independent, and two-body's band still sits strictly inside its own measured gap.

---

`Typecheck 0 errors. 167 suites / 1435 tests pass. Production drift 0.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)