### PR TITLE
fix(physics): kalchm exact at a zero axis, and every constant it cascades into

### DIFF
--- a/scripts/evaluateTwoBodyBandOptions.ts
+++ b/scripts/evaluateTwoBodyBandOptions.ts
@@ -1,0 +1,95 @@
+/**
+ * The two-body band has no derivable gap after the kalchm exact-zero fix.
+ * This measures the three candidate replacements so the choice is made on numbers.
+ *
+ * A. STRUCTURAL   — band exactly the cells whose vessel Essence is 0 (the CAUSE),
+ *                   instead of thresholding |ln kalchm| (a PROXY for it).
+ * B. BOUND        — pick the threshold that caps two-body monica at the
+ *                   single-body envelope (3.8977146920667267).
+ * C. NONE         — no band; accept whatever the formula gives.
+ *
+ * No DB. The two-body grid is deterministic.
+ */
+import { twoBodyState, twoBodyMonicaForSect } from "@/utils/agentMonicaTwoBody";
+import { ZODIAC_ELEMENTS } from "@/utils/planetaryAlchemyMapping";
+import { MONICA_EQUILIBRIUM } from "@/data/unified/alchemicalCalculations";
+
+const SIGNS = Object.keys(ZODIAC_ELEMENTS);
+const PHASES = [
+  "new moon", "waxing crescent", "first quarter", "waxing gibbous", "full moon",
+  "waning gibbous", "last quarter", "waning crescent", "dark moon",
+];
+const SECTS = ["diurnal", "nocturnal"] as const;
+const SINGLE_BODY_ENVELOPE = 3.8977146920667267;
+
+interface Cell {
+  phase: string; sign: string; degree: number; sect: string;
+  essence: number; absLn: number; monica: number;
+}
+
+const cells: Cell[] = [];
+for (const sign of SIGNS) {
+  for (let degree = 0; degree < 30; degree++) {
+    for (const sect of SECTS) {
+      for (const phase of PHASES) {
+        const st = twoBodyState(phase, sign, degree, sect);
+        const absLn = Math.abs((st.lnKalchm as number) ?? NaN);
+        const monica = twoBodyMonicaForSect(phase, sign, degree, sect);
+        if (!Number.isFinite(absLn) || !Number.isFinite(monica)) continue;
+        cells.push({ phase, sign, degree, sect, essence: st.esms?.Essence ?? NaN, absLn, monica });
+      }
+    }
+  }
+}
+
+const absMax = (xs: number[]) => Math.max(...xs.map(Math.abs));
+console.log(`two-body cells: ${cells.length}`);
+console.log(`single-body envelope: ${SINGLE_BODY_ENVELOPE}`);
+console.log("=".repeat(78));
+
+// ── which degrees actually have vessel Essence === 0? ───────────────────────
+const zeroEssDegrees = [...new Set(cells.filter((c) => c.essence === 0).map((c) => c.degree))].sort((a, b) => a - b);
+const comixion = [8, 22];
+console.log("");
+console.log("A. STRUCTURAL — cells with vessel Essence exactly 0");
+console.log(`   degrees with Essence 0 : [${zeroEssDegrees.join(", ")}]`);
+console.log(`   Comixion (as coded)    : [${comixion.join(", ")}]`);
+console.log(`   MATCH? ${JSON.stringify(zeroEssDegrees) === JSON.stringify(comixion) ? "yes" : "NO — the Essence-0 set is NOT the Comixion set"}`);
+const zeroEss = cells.filter((c) => c.essence === 0);
+const nonZeroEss = cells.filter((c) => c.essence !== 0);
+console.log(`   Essence-0 cells        : ${zeroEss.length}   |ln k| [${Math.min(...zeroEss.map(c=>c.absLn)).toPrecision(6)}, ${Math.max(...zeroEss.map(c=>c.absLn)).toPrecision(6)}]`);
+console.log(`   Essence-nonzero cells  : ${nonZeroEss.length}  |ln k| [${Math.min(...nonZeroEss.map(c=>c.absLn)).toPrecision(6)}, ${Math.max(...nonZeroEss.map(c=>c.absLn)).toPrecision(6)}]`);
+console.log(`   => banding by Essence===0 gives monica max ${absMax(nonZeroEss.map(c=>c.monica)).toPrecision(6)} on the REST`);
+console.log(`      within the single-body envelope? ${absMax(nonZeroEss.map(c=>c.monica)) <= SINGLE_BODY_ENVELOPE ? "YES" : "no"}`);
+
+// ── B. what threshold caps monica at the envelope? ─────────────────────────
+console.log("");
+console.log("B. BOUND — smallest |ln k| threshold that caps monica at the envelope");
+const sortedByLn = [...cells].sort((a, b) => a.absLn - b.absLn);
+let needed = 0;
+for (const c of sortedByLn) {
+  if (Math.abs(c.monica) > SINGLE_BODY_ENVELOPE) needed = Math.max(needed, c.absLn);
+}
+console.log(`   largest |ln k| among cells exceeding the envelope: ${needed.toPrecision(17)}`);
+const banded = cells.filter((c) => c.absLn < needed);
+console.log(`   a band at that value captures ${banded.length} of ${cells.length} cells (${((banded.length/cells.length)*100).toFixed(1)}%)`);
+const keptB = cells.filter((c) => c.absLn >= needed);
+console.log(`   monica max on the REST: ${absMax(keptB.map(c=>c.monica)).toPrecision(6)}`);
+const collateralB = banded.filter((c) => c.essence !== 0);
+console.log(`   HEALTHY cells (Essence != 0) swallowed: ${collateralB.length}  <- collateral damage`);
+
+// ── C. no band at all ──────────────────────────────────────────────────────
+console.log("");
+console.log("C. NONE — no band");
+console.log(`   monica max: ${absMax(cells.map(c=>c.monica)).toPrecision(6)}`);
+console.log(`   cells beyond the single-body envelope: ${cells.filter(c=>Math.abs(c.monica)>SINGLE_BODY_ENVELOPE).length}`);
+const beyond = cells.filter(c=>Math.abs(c.monica)>SINGLE_BODY_ENVELOPE);
+if (beyond.length) {
+  const degs = [...new Set(beyond.map(c=>c.degree))].sort((a,b)=>a-b);
+  console.log(`   they sit at degrees: [${degs.join(", ")}]`);
+  console.log(`   all Essence-0? ${beyond.every(c=>c.essence===0) ? "YES — the overshoot is exactly the degenerate family" : "no"}`);
+}
+
+console.log("");
+console.log("=".repeat(78));
+console.log(`for reference, phi = ${MONICA_EQUILIBRIUM}`);

--- a/scripts/remeasureAfterKalchmFix.ts
+++ b/scripts/remeasureAfterKalchmFix.ts
@@ -1,0 +1,118 @@
+/**
+ * Re-measure every constant derived from kalchm, AFTER the exact-zero fix.
+ *
+ * No DB. Both grids are deterministic, so these are censuses.
+ * Run from the branch that HAS the fix, or the numbers are the old ones.
+ */
+import {
+  calculateKalchm,
+  MONICA_LN_EPSILON,
+} from "@/data/unified/alchemicalCalculations";
+import { getDignityScore } from "@/utils/dignityScales";
+import { PLANETARY_SECTARIAN_ESMS, ZODIAC_ELEMENTS } from "@/utils/planetaryAlchemyMapping";
+import { groundingVessel, agentMonicaForSect, type ESMS } from "@/utils/agentMonica";
+import { twoBodyState, twoBodyMonicaForSect } from "@/utils/agentMonicaTwoBody";
+import type { AlchemicalProperties } from "@/types/celestial";
+
+const ZERO: ESMS = { Spirit: 0, Essence: 0, Matter: 0, Substance: 0 };
+const SIGNS = Object.keys(ZODIAC_ELEMENTS);
+const PLANETS = Object.keys(PLANETARY_SECTARIAN_ESMS);
+const SECTS = ["diurnal", "nocturnal"] as const;
+const p = (n: number) => n.toPrecision(17);
+
+function widestGap(sorted: number[], below = 0.5) {
+  let best = { lo: 0, hi: 0, width: 0 };
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i] >= below) break;
+    const w = sorted[i] - sorted[i - 1];
+    if (w > best.width) best = { lo: sorted[i - 1], hi: sorted[i], width: w };
+  }
+  return best;
+}
+
+// ─────────────────────────────────────────── 1. single-body |ln kalchm| gap ──
+const singleLn: number[] = [];
+const singleMonica: number[] = [];
+for (const planet of PLANETS) {
+  const table = PLANETARY_SECTARIAN_ESMS[planet as keyof typeof PLANETARY_SECTARIAN_ESMS];
+  for (const sign of SIGNS) {
+    const ds = getDignityScore(planet, sign as never).esmsScale;
+    for (let degree = 0; degree < 30; degree++) {
+      const v = groundingVessel(degree, ds);
+      for (const sect of SECTS) {
+        const base: ESMS = table ? { ...ZERO, ...table[sect] } : ZERO;
+        const esms: ESMS = {
+          Spirit: base.Spirit + v.Spirit,
+          Essence: base.Essence + v.Essence,
+          Matter: base.Matter + v.Matter,
+          Substance: base.Substance + v.Substance,
+        };
+        const k = calculateKalchm(esms as AlchemicalProperties);
+        if (Number.isFinite(k) && k > 0) singleLn.push(Math.abs(Math.log(k)));
+        singleMonica.push(agentMonicaForSect(planet, sign, degree, sect));
+      }
+    }
+  }
+}
+singleLn.sort((a, b) => a - b);
+const sg = widestGap(singleLn);
+const sMid = (sg.lo + sg.hi) / 2;
+
+console.log("=".repeat(76));
+console.log("1. SINGLE-BODY |ln kalchm| GAP");
+console.log("=".repeat(76));
+console.log(`  n                    ${singleLn.length}`);
+console.log(`  degenerate ceiling   ${p(sg.lo)}`);
+console.log(`  healthy floor        ${p(sg.hi)}`);
+console.log(`  gap width            ${p(sg.width)}`);
+console.log(`  MIDPOINT (epsilon)   ${p(sMid)}`);
+console.log(`  band captures        ${singleLn.filter((x) => x < sMid).length} / ${singleLn.length}`);
+console.log(`  current constant     ${p(MONICA_LN_EPSILON)}  ${Math.abs(MONICA_LN_EPSILON - sMid) < 1e-12 ? "MATCHES" : "*** STALE ***"}`);
+
+// ───────────────────────────────────────────── 2. two-body |ln kalchm| gap ──
+// Comixion degrees (8/22) are the degenerate family — vessel Essence is 0 there.
+const isComixion = (d: number) => d === 8 || d === 22;
+const twoLnDegen: number[] = [];
+const twoLnHealthy: number[] = [];
+const twoMonica: number[] = [];
+for (const sign of SIGNS) {
+  for (let degree = 0; degree < 30; degree++) {
+    for (const sect of SECTS) {
+      for (const phase of ["waxing gibbous", "full moon", "new moon", "waning crescent"]) {
+        const st = twoBodyState(phase, sign, degree, sect);
+        const ln = Math.abs((st.lnKalchm as number) ?? NaN);
+        if (Number.isFinite(ln)) (isComixion(degree) ? twoLnDegen : twoLnHealthy).push(ln);
+        const m = twoBodyMonicaForSect(phase, sign, degree, sect);
+        if (Number.isFinite(m)) twoMonica.push(m);
+      }
+    }
+  }
+}
+twoLnDegen.sort((a, b) => a - b);
+twoLnHealthy.sort((a, b) => a - b);
+
+console.log("");
+console.log("=".repeat(76));
+console.log("2. TWO-BODY |ln kalchm| GAP  (degenerate = Comixion degrees 8/22)");
+console.log("=".repeat(76));
+console.log(`  degenerate n         ${twoLnDegen.length}   max |ln k|  ${p(twoLnDegen[twoLnDegen.length - 1])}`);
+console.log(`  healthy n            ${twoLnHealthy.length}   min |ln k|  ${p(twoLnHealthy[0])}`);
+const separable = twoLnDegen[twoLnDegen.length - 1] < twoLnHealthy[0];
+console.log(`  cleanly separable    ${separable ? "YES" : "NO — they OVERLAP, midpoint derivation invalid"}`);
+if (separable) {
+  const mid = (twoLnDegen[twoLnDegen.length - 1] + twoLnHealthy[0]) / 2;
+  console.log(`  MIDPOINT (epsilon)   ${p(mid)}`);
+  console.log(`  collateral (healthy below midpoint): ${twoLnHealthy.filter((x) => x < mid).length}  (must be 0)`);
+} else {
+  console.log(`  degenerate max ${p(twoLnDegen[twoLnDegen.length - 1])} >= healthy min ${p(twoLnHealthy[0])}`);
+}
+
+// ───────────────────────────────────────────────── 3. Sacred-7 |max|/2 ──────
+const absMax = (xs: number[]) => Math.max(...xs.map(Math.abs));
+console.log("");
+console.log("=".repeat(76));
+console.log("3. SACRED-7 SCALES  (|max| / 2)");
+console.log("=".repeat(76));
+console.log(`  single-body  |max| ${p(absMax(singleMonica))}  -> scale ${p(absMax(singleMonica) / 2)}   (was 1.9875)`);
+console.log(`  two-body     |max| ${p(absMax(twoMonica))}  -> scale ${p(absMax(twoMonica) / 2)}   (was 2.7095)`);
+console.log(`  full-chart   needs the DB (71 stored rows) — measure separately`);

--- a/src/__tests__/monicaLnEpsilonDerivation.test.ts
+++ b/src/__tests__/monicaLnEpsilonDerivation.test.ts
@@ -104,7 +104,21 @@ describe("MONICA_LN_EPSILON is derived from a measured gap", () => {
 
   it("the epsilon is exactly the midpoint of those endpoints", () => {
     expect(MONICA_LN_EPSILON).toBeCloseTo((GAP.lo + GAP.hi) / 2, 15);
-    expect(MONICA_LN_EPSILON).toBeCloseTo(0.13241878500631321, 15);
+    // 0.10939293407637272 — was 0.13241878500631321 while calculateKalchm floored
+    // each axis at 0.01. The floor smeared the degenerate ceiling up to 0.046; with
+    // it removed a degenerate chart's kalchm is exactly 1, so the ceiling is exactly
+    // 0 and the midpoint dropped. Classification is unchanged (660, asserted below).
+    expect(MONICA_LN_EPSILON).toBeCloseTo(0.10939293407637272, 15);
+  });
+
+  it("the degenerate ceiling is EXACTLY zero, not merely small", () => {
+    // The strongest consequence of removing the floor: the degenerate set stops
+    // being an empirical cluster and becomes an exact algebraic condition.
+    // kalchm === 1 <=> ln kalchm === 0, for every chart with a zeroed axis.
+    expect(GAP.lo).toBe(0);
+    expect(GRID.filter((v) => v === 0).length).toBeGreaterThan(0);
+    // And nothing sits between 0 and the healthy floor — that IS the gap.
+    expect(GRID.filter((v) => v > 0 && v < GAP.hi).length).toBe(0);
   });
 
   it("sits strictly inside the gap, with real margin on both sides", () => {

--- a/src/__tests__/monicaPopulationScaleDerivation.test.ts
+++ b/src/__tests__/monicaPopulationScaleDerivation.test.ts
@@ -1,0 +1,228 @@
+/**
+ * The Sacred-7 monica scales are DERIVED, and this is where the derivation is checked.
+ *
+ * Each scale is `|max| / 2` over its own population, so `tanh(monica / scale)`
+ * puts the population extremum at tanh(2) ≈ 0.964 rather than clamping. That
+ * makes every scale hostage to a single row — and one already shipped 3.6x wrong
+ * because the row holding the maximum was a DUPLICATED chart (Jung/Kahlo).
+ *
+ * Two of the three populations are exhaustive deterministic grids, so their
+ * maxima can be re-derived here on every run: if the vessel, the dignity table,
+ * the phase geometry, the degeneracy band or `calculateKalchm` moves, the maximum
+ * moves and THIS FAILS. That is the point — without it the scales are comments
+ * asserting a measurement nobody re-checks.
+ *
+ * The third (full-chart) is NOT a grid. It comes from 71 authored charts in the
+ * production database, so it cannot be re-derived in-process. It is guarded
+ * differently: by the structural invariants it must satisfy, plus an explicit
+ * measured-pending marker. See the `full-chart` block below.
+ *
+ * Companion to monicaLnEpsilonDerivation.test.ts, which guards the epsilons.
+ */
+import {
+  MONICA_POPULATION_SCALE,
+  normalizeMonicaForStats,
+  type MonicaMethod,
+} from "@/lib/sacred-7-stats";
+import { agentMonicaForSect } from "@/utils/agentMonica";
+import { twoBodyMonicaForSect, PHASE_GEOMETRY } from "@/utils/agentMonicaTwoBody";
+import { PLANETARY_SECTARIAN_ESMS, ZODIAC_ELEMENTS } from "@/utils/planetaryAlchemyMapping";
+
+const SIGNS = Object.keys(ZODIAC_ELEMENTS);
+const SECTS = ["diurnal", "nocturnal"] as const;
+
+interface GridMeasurement {
+  n: number;
+  absMax: number;
+  /** Human-readable coordinates of the extremum, for when this test fails. */
+  argMax: string;
+}
+
+/** Every monica the single-body population can produce: planet x sign x degree x sect. */
+function measureSingleBody(): GridMeasurement {
+  let n = 0;
+  let absMax = 0;
+  let argMax = "";
+  for (const planet of Object.keys(PLANETARY_SECTARIAN_ESMS)) {
+    for (const sign of SIGNS) {
+      for (let degree = 0; degree < 30; degree++) {
+        for (const sect of SECTS) {
+          const m = agentMonicaForSect(planet, sign as never, degree, sect);
+          if (!Number.isFinite(m)) continue;
+          n++;
+          if (Math.abs(m) > absMax) {
+            absMax = Math.abs(m);
+            argMax = `${planet} ${sign} ${degree}° ${sect} -> ${m}`;
+          }
+        }
+      }
+    }
+  }
+  return { n, absMax, argMax };
+}
+
+/** Every monica the two-body population can produce: phase x sign x degree x sect. */
+function measureTwoBody(phases: string[]): GridMeasurement {
+  let n = 0;
+  let absMax = 0;
+  let argMax = "";
+  for (const phase of phases) {
+    for (const sign of SIGNS) {
+      for (let degree = 0; degree < 30; degree++) {
+        for (const sect of SECTS) {
+          const m = twoBodyMonicaForSect(phase, sign as never, degree, sect);
+          if (!Number.isFinite(m)) continue;
+          n++;
+          if (Math.abs(m) > absMax) {
+            absMax = Math.abs(m);
+            argMax = `${phase} ${sign} ${degree}° ${sect} -> ${m}`;
+          }
+        }
+      }
+    }
+  }
+  return { n, absMax, argMax };
+}
+
+/**
+ * The canonical phase enumeration is PHASE_GEOMETRY's own keys — NOT a list
+ * written out here, which is how a stale 9-entry list once put the wrong `n` in
+ * the scale's docstring. "dark moon" is an ALIAS of new moon at elongation 0,
+ * so it must not appear in the grid twice.
+ */
+const CANONICAL_PHASES = Object.keys(PHASE_GEOMETRY);
+
+const SINGLE = measureSingleBody();
+const TWO = measureTwoBody(CANONICAL_PHASES);
+
+describe("the Sacred-7 monica scales are derived from their populations", () => {
+  describe("single-body", () => {
+    it("enumerates the full deterministic grid", () => {
+      // 11 planets x 12 signs x 30 degrees x 2 sects
+      expect(SINGLE.n).toBe(7920);
+    });
+
+    it("re-derives the stated scale as |max| / 2, EXACTLY", () => {
+      // `===`, not toBeCloseTo. Dividing by 2 only changes a double's exponent, so
+      // the scale is exactly representable and the derivation is reproducible to
+      // the last bit. toBeCloseTo(…, 15) passed here while the constant was
+      // 1.9488573460333634 and the truth was ...638 — a lossy round-trip through a
+      // script's printed digits. Emit constants with String(x), never toPrecision.
+      expect(MONICA_POPULATION_SCALE["single-body"]).toBe(SINGLE.absMax / 2);
+    });
+
+    it("holds the measurement recorded in the source", () => {
+      // 3.8977146920667276 / 2. Was 1.9875 (|max| 3.9751) while calculateKalchm
+      // floored each axis at 0.01.
+      expect(SINGLE.absMax).toBe(3.8977146920667276);
+      expect(MONICA_POPULATION_SCALE["single-body"]).toBe(1.9488573460333638);
+    });
+  });
+
+  describe("two-body", () => {
+    it("uses PHASE_GEOMETRY's own keys, and dark moon is an alias not a 9th phase", () => {
+      expect(CANONICAL_PHASES).toHaveLength(8);
+      expect(CANONICAL_PHASES).not.toContain("dark moon");
+      // Folding the alias in must add cells WITHOUT moving the extremum — that is
+      // what makes it an alias rather than a distinct phase.
+      const withAlias = measureTwoBody([...CANONICAL_PHASES, "dark moon"]);
+      expect(withAlias.n).toBe(TWO.n + 720); // 12 signs x 30 degrees x 2 sects
+      // Exactly equal, not merely close: an alias must resolve down the identical
+      // code path, so the extra 720 cells are bit-for-bit duplicates.
+      expect(withAlias.absMax).toBe(TWO.absMax);
+    });
+
+    it("enumerates the full deterministic grid", () => {
+      // 8 phases x 12 signs x 30 degrees x 2 sects
+      expect(TWO.n).toBe(5760);
+    });
+
+    it("re-derives the stated scale as |max| / 2, EXACTLY", () => {
+      expect(MONICA_POPULATION_SCALE["two-body"]).toBe(TWO.absMax / 2);
+    });
+
+    it("holds the measurement recorded in the source", () => {
+      // 2.8107786459098314 / 2. Was 2.7095 (|max| 5.4191) while the degeneracy
+      // band was an |ln kalchm| threshold instead of `esms.Essence === 0` — that
+      // threshold left 442 genuinely degenerate charts unbanded, and those were
+      // the ones producing the extremes.
+      expect(TWO.absMax).toBe(2.810778645909833);
+      expect(MONICA_POPULATION_SCALE["two-body"]).toBe(1.4053893229549166);
+    });
+
+    it("sits inside the single-body envelope", () => {
+      // A two-body chart is a single-body chart plus one more body, so it should
+      // not reach further than the single-body population can. It DID before the
+      // structural degeneracy test (5.4191 > 3.8977) — that violation is what
+      // exposed the mis-banding, so this is a real regression guard, not a truism.
+      expect(TWO.absMax).toBeLessThanOrEqual(SINGLE.absMax);
+    });
+  });
+
+  describe("full-chart — measured from the DB, so guarded by invariant", () => {
+    /**
+     * ⚠️ This one cannot be re-derived in-process: its population is 71 authored
+     * charts in production, not a grid. Re-measure with
+     * scripts/measureThreeOpenNumbers.ts after ANY change to kalchm, monica, or
+     * the chart data itself.
+     *
+     * MEASURED-PENDING as of 2026-07-25: the current value excludes 10 rows whose
+     * natal_positions are duplicates of another row's — 8 ancients sharing one
+     * fallback blob, plus Jung/Kahlo. Those 10 are being re-based, and this number
+     * must be re-measured when they are.
+     */
+    const FULL_CHART_POPULATION_MAX = 0.009441;
+
+    it("is EXACTLY half its stated population max", () => {
+      // The one part of this scale that CAN be checked in-process: the arithmetic
+      // between the stated basis and the constant. monica_full_chart is NUMERIC(_,6)
+      // so 0.009441 is the stored value in full, not a rounded print — its half is
+      // exact. The first shipped value, 0.004720, was that half rounded to 4 dp and
+      // so failed this check by 5e-7.
+      expect(MONICA_POPULATION_SCALE["full-chart"]).toBe(FULL_CHART_POPULATION_MAX / 2);
+      expect(MONICA_POPULATION_SCALE["full-chart"]).toBe(0.0047205);
+    });
+
+    it("is the smallest of the three scales, by orders of magnitude", () => {
+      // A full chart sums ~10 bodies, so its ESMS axes are large and its kalchm
+      // sits far from the degenerate region — monica comes out 2-3 orders of
+      // magnitude smaller than a single body's. If this ever inverts, the value
+      // was measured from the wrong column (the failure mode that produced the
+      // "full-chart monica is 200x LARGER" claim, which was 12-43x SMALLER).
+      const full = MONICA_POPULATION_SCALE["full-chart"] as number;
+      expect(full).toBeLessThan(MONICA_POPULATION_SCALE["two-body"] as number);
+      expect(full).toBeLessThan(MONICA_POPULATION_SCALE["single-body"] as number);
+      expect(full * 100).toBeLessThan(MONICA_POPULATION_SCALE["single-body"] as number);
+    });
+  });
+
+  describe("the scales are load-bearing", () => {
+    it("every method a row can carry has a scale", () => {
+      // Without this, a new monica_method would silently fall back to the
+      // single-body scale and mis-map an entire population.
+      const methods: MonicaMethod[] = ["single-body", "two-body", "full-chart"];
+      for (const m of methods) {
+        expect(typeof MONICA_POPULATION_SCALE[m]).toBe("number");
+        expect(MONICA_POPULATION_SCALE[m]).toBeGreaterThan(0);
+      }
+      expect(Object.keys(MONICA_POPULATION_SCALE).sort()).toEqual([...methods].sort());
+    });
+
+    it("each population's extremum maps near the top of the range without clamping", () => {
+      // This is WHY the scale is |max|/2: tanh(2) = 0.964. If a scale drifts too
+      // small the extremum saturates at 1.0 and the top of the population stops
+      // being distinguishable.
+      expect(normalizeMonicaForStats(SINGLE.absMax, "single-body")).toBeCloseTo(0.982, 3);
+      expect(normalizeMonicaForStats(TWO.absMax, "two-body")).toBeCloseTo(0.982, 3);
+      expect(normalizeMonicaForStats(SINGLE.absMax, "single-body")).toBeLessThan(1);
+      expect(normalizeMonicaForStats(TWO.absMax, "two-body")).toBeLessThan(1);
+    });
+
+    it("a scale from the WRONG population visibly mis-maps", () => {
+      // Non-vacuity: if any scale were interchangeable the guards above would be
+      // decorative. A single-body extremum read against the full-chart scale
+      // saturates completely.
+      expect(normalizeMonicaForStats(SINGLE.absMax, "full-chart")).toBeCloseTo(1, 10);
+    });
+  });
+});

--- a/src/__tests__/utils/agentMonicaTwoBody.test.ts
+++ b/src/__tests__/utils/agentMonicaTwoBody.test.ts
@@ -18,13 +18,10 @@ import {
   ASPECT_DIGNITY_REFERENCE_ORB,
   ASPECT_ORB_BUDGET,
   ASPECT_POLARITY,
-  DEGENERATE_LN_KALCHM,
   EXACT_DIGNITY_MULTIPLIER,
-  HEALTHY_LN_KALCHM_FLOOR,
   MOTION_DIGNITY_MULTIPLIER,
   PHASE_GEOMETRY,
   SEPARATING_DIGNITY_MULTIPLIER,
-  TWO_BODY_LN_EPSILON,
   UnknownMoonPhaseError,
   VESSEL_DIGNITY_NEUTRAL,
   derivedSunPosition,
@@ -346,9 +343,9 @@ describe("twoBodyMonica — the totality contract", () => {
 
   // The Comixion pillar (Essence effect −1, so the vessel's Essence axis is 0)
   // sits at degrees 8 and 22. There, ln(kalchm) lands near 0 and −G/(R·ln k)
-  // amplifies. TWO_BODY_LN_EPSILON absorbs the degenerate core of that; a skirt
-  // survives, because some Comixion cells land at |ln k| ABOVE the healthy floor
-  // and cannot be absorbed without converting real values to φ.
+  // amplifies. This is now absorbed COMPLETELY by testing esms.Essence === 0
+  // directly, so no skirt survives — the old |ln kalchm| threshold left 442
+  // degenerate cells unbanded, which is where the extreme values came from.
   //
   // ⚠️ OPEN, deliberately pinned rather than clamped: flooring the vessel at
   // KALCHM_EPSILON does NOT fix this — tried both before normalisation (the
@@ -358,7 +355,7 @@ describe("twoBodyMonica — the totality contract", () => {
   //
   // These assertions describe the CURRENT measured behaviour so a change to it
   // is caught, not a bound we wish were true.
-  it("confines the amplified tail to the two Comixion degrees", () => {
+  it("has NO amplified tail left — the structural band removed it entirely", () => {
     const outlierDegrees = new Set<number>();
     let maxOutsideComixion = 0;
     let maxOverall = 0;
@@ -380,88 +377,101 @@ describe("twoBodyMonica — the totality contract", () => {
       }
     }
 
-    // Only the Comixion degrees amplify.
-    expect([...outlierDegrees].sort((a, b) => a - b)).toEqual([8, 22]);
-    // Everywhere else is comfortably INSIDE the single-body envelope (3.9751).
+    // NOTHING amplifies now. This previously asserted [8, 22] — that the two
+    // Comixion degrees exceeded |4| while everything else stayed under 2. Both
+    // halves of that were consequences of the kalchm epsilon floor: it kept 442
+    // degenerate cells OUTSIDE the old |ln kalchm| band, and those were the cells
+    // producing the amplification. Testing esms.Essence === 0 catches all of them.
+    expect([...outlierDegrees]).toEqual([]);
     expect(maxOutsideComixion).toBeLessThan(2);
-    // Bounded, and materially tighter than the 21.45 of the pre-band build.
-    expect(maxOverall).toBeLessThan(13);
+    // Was < 13 (measured 12.6756 on the pre-fix grid). Now the whole grid sits
+    // inside the single-body envelope, which it never did before.
+    expect(maxOverall).toBeLessThan(3.8977146920667267);
   });
 
-  // ── the band itself ──────────────────────────────────────────────────────
-  // TWO_BODY_LN_EPSILON is derived from two MEASURED bounds. These pin both, so
-  // that a retune which starts swallowing real values fails loudly rather than
-  // quietly flattening the distribution.
-  describe("TWO_BODY_LN_EPSILON — the two-body-local equilibrium band", () => {
-    /** Every grid cell's |ln kalchm|, partitioned by the STRUCTURAL cause. */
+  // ── degeneracy, tested by its CAUSE ──────────────────────────────────────
+  // Not an |ln kalchm| threshold: that proxy only worked while the kalchm floor
+  // kept the degenerate and healthy sets separable. These pin the predicate,
+  // its completeness, and that it does not over-absorb.
+  describe("degeneracy is tested STRUCTURALLY, not by an |ln kalchm| threshold", () => {
+    /** Every grid cell, tagged with the structural cause and its |ln kalchm|. */
     const cells = (() => {
-      const out: { degree: number; absLnK: number }[] = [];
+      const out: { degree: number; absLnK: number; essenceZero: boolean; monica: number }[] = [];
       for (const phase of ALL_PHASES)
         for (const sign of SIGNS)
           for (let degree = 0; degree < 30; degree++)
             for (const sect of ["diurnal", "nocturnal"] as const) {
               const s = twoBodyState(phase, sign, degree, sect);
-              out.push({ degree, absLnK: Math.abs(s.lnKalchm as number) });
+              out.push({
+                degree,
+                absLnK: Math.abs(s.lnKalchm as number),
+                essenceZero: s.esms?.Essence === 0,
+                monica: twoBodyMonicaForSect(phase, sign, degree, sect),
+              });
             }
       return out;
     })();
-    const isComixion = (d: number) => d === 8 || d === 22;
 
-    it("sits strictly between the two measured bounds", () => {
-      expect(TWO_BODY_LN_EPSILON).toBeGreaterThan(DEGENERATE_LN_KALCHM);
-      expect(TWO_BODY_LN_EPSILON).toBeLessThan(HEALTHY_LN_KALCHM_FLOOR);
-    });
-
-    it("[MEASURED] the degenerate bound really is the zero-Essence chart", () => {
-      // Comixion nocturnal: the vessel's Essence axis is exactly 0.
-      const s = twoBodyState("waxing gibbous", "Leo", 8, "nocturnal");
-      expect(s.esms?.Essence).toBe(0);
-      expect(Math.abs(s.lnKalchm as number)).toBeCloseTo(DEGENERATE_LN_KALCHM, 6);
-    });
-
-    it("[MEASURED] the healthy floor really is the smallest non-Comixion |ln k|", () => {
-      const floor = Math.min(
-        ...cells.filter((c) => !isComixion(c.degree)).map((c) => c.absLnK),
+    it("the zero-Essence family is SIX degrees, not the two 'Comixion' named", () => {
+      // The bug this replaces: `isComixion` was `d === 8 || d === 22`, but TWO
+      // vessel shapes have zero Essence. The band therefore missed four degrees.
+      const degrees = [...new Set(cells.filter((c) => c.essenceZero).map((c) => c.degree))].sort(
+        (a, b) => a - b,
       );
-      expect(floor).toBeCloseTo(HEALTHY_LN_KALCHM_FLOOR, 6);
+      expect(degrees).toEqual([8, 10, 12, 22, 24, 26]);
     });
 
-    it("absorbs with ZERO collateral — no healthy cell is converted to φ", () => {
-      const collateral = cells.filter(
-        (c) => !isComixion(c.degree) && c.absLnK < TWO_BODY_LN_EPSILON,
+    it("a threshold CANNOT separate degenerate from healthy any more", () => {
+      // This is why the old TWO_BODY_LN_EPSILON was removed rather than re-derived.
+      // Its derivation assumed the two sets were separable; with kalchm exact they
+      // overlap, so no single number can partition them.
+      const degen = cells.filter((c) => c.essenceZero).map((c) => c.absLnK);
+      const healthy = cells.filter((c) => !c.essenceZero).map((c) => c.absLnK);
+      expect(Math.max(...degen)).toBeGreaterThan(Math.min(...healthy));
+    });
+
+    it("EVERY zero-Essence cell returns φ — no degenerate chart is missed", () => {
+      const missed = cells.filter((c) => c.essenceZero && c.monica !== MONICA_EQUILIBRIUM);
+      expect(missed).toEqual([]);
+    });
+
+    it("the structural test itself has ZERO collateral", () => {
+      // A cell is banded by THIS module iff it is degenerate. Healthy cells may
+      // still receive φ from the CANONICAL band (the shared §17c equilibrium
+      // statement, |ln kalchm| < MONICA_LN_EPSILON) — that is the engine-wide
+      // contract applying uniformly, not a local miscalibration. Measured: 261
+      // such cells, all with |ln kalchm| genuinely below the canonical band.
+      const localCollateral = cells.filter(
+        (c) => !c.essenceZero && c.monica === MONICA_EQUILIBRIUM && c.absLnK >= MONICA_LN_EPSILON,
       );
-      expect(collateral).toEqual([]);
+      expect(localCollateral).toEqual([]);
     });
 
-    it("does absorb a real share of the degenerate cases", () => {
-      const tail = cells.filter((c) => isComixion(c.degree));
-      const absorbed = tail.filter((c) => c.absLnK < TWO_BODY_LN_EPSILON);
-      // Measured 304/384. Pinned as a floor so a silent narrowing is caught.
-      expect(absorbed.length).toBeGreaterThanOrEqual(304);
-      expect(absorbed.length).toBeLessThan(tail.length); // the skirt is real
+    it("brings the two-body range INSIDE the single-body envelope", () => {
+      // Previously two-body reached 5.4191 against a single-body 3.9751, because
+      // 442 degenerate charts went unbanded and produced the extremes.
+      const finite = cells.map((c) => c.monica).filter((m) => Number.isFinite(m));
+      expect(finite.length).toBe(cells.length);
+      const absMax = Math.max(...finite.map(Math.abs));
+      expect(absMax).toBeCloseTo(2.8107786459098314, 10);
+      expect(absMax).toBeLessThan(3.8977146920667267); // single-body envelope
     });
 
-    it("stays INDEPENDENT of the canonical engine's own band", () => {
-      // This used to assert `MONICA_LN_EPSILON === 0.05` and
-      // `TWO_BODY_LN_EPSILON > MONICA_LN_EPSILON`. Both were pinning incidental
-      // facts rather than the property that matters.
-      //
-      // The canonical band has since been DERIVED (midpoint of the measured
-      // single-body |ln kalchm| gap = 0.1324188, replacing a chosen 0.05), which
-      // made it slightly WIDER than the two-body band — so the old ordering
-      // inverted. That ordering was never meaningful: the two bands are derived
-      // from different populations by different mechanisms, so neither has to be
-      // larger.
-      //
-      // What actually matters is that they are SEPARATE constants, so a change to
-      // one cannot silently move the other's population.
-      expect(TWO_BODY_LN_EPSILON).not.toBeCloseTo(MONICA_LN_EPSILON, 6);
-
-      // And the two-body band must remain correct for ITS population — that is
-      // what the preceding tests in this block verify (zero collateral, real
-      // absorption), independent of whatever the canonical value is.
-      expect(TWO_BODY_LN_EPSILON).toBeGreaterThan(DEGENERATE_LN_KALCHM);
-      expect(TWO_BODY_LN_EPSILON).toBeLessThan(HEALTHY_LN_KALCHM_FLOOR);
+    it("still absorbs a real share of the grid (guard: not a no-op band)", () => {
+      // Derived from THIS test's own enumeration, deliberately not a hardcoded
+      // count. A literal here was briefly 909 — measured over 9 phases including
+      // "dark moon", while ALL_PHASES has 8 because Dark Moon folds into New at 0°.
+      // Same enumeration mismatch that made an earlier max-monica reading wrong.
+      const phi = cells.filter((c) => c.monica === MONICA_EQUILIBRIUM);
+      const structural = cells.filter((c) => c.essenceZero);
+      const canonicalOnly = cells.filter(
+        (c) => !c.essenceZero && c.absLnK < MONICA_LN_EPSILON,
+      );
+      // Every φ cell is explained by exactly one of the two bands.
+      expect(phi.length).toBe(structural.length + canonicalOnly.length);
+      expect(structural.length).toBeGreaterThan(0);
+      expect(canonicalOnly.length).toBeGreaterThan(0);
+      expect(phi.length).toBeLessThan(cells.length / 2); // not swallowing everything
     });
   });
 

--- a/src/data/unified/alchemicalCalculations.ts
+++ b/src/data/unified/alchemicalCalculations.ts
@@ -52,8 +52,22 @@ export interface AlchemicalIngredient {
 //   monica                                    → φ   (MONICA_EQUILIBRIUM, the
 //                                                    harmonic ideal — kalchm=1 is
 //                                                    perfect balance, not "dead")
-/** Floor applied to each ESMS axis before exponentiation, so 0^0 / division by
- *  zero cannot occur. Load-bearing for sparse/single-body charts (§18). */
+/**
+ * Minimum magnitude for REACTIVITY in the monica denominator, so a reactivity of
+ * 0 cannot divide. That is now its only job — see `calculateMonica` below.
+ *
+ * ⚠️ It used to ALSO floor each ESMS axis inside `calculateKalchm`, described as
+ * preventing "0^0 / division by zero". Both hazards were imaginary: `0 ** 0` is
+ * already exactly 1 in JS (the true limit), and x^x bottoms out at 0.692201, so
+ * the denominator can never be 0. The floor only cost accuracy — 0.01^0.01 =
+ * 0.954993 instead of 1, a ~4.5% understatement on the 68.2% of the single-body
+ * grid that has a zero axis. Removed; kalchm now clamps only negatives.
+ *
+ * This value is NOT derived. Unlike MONICA_LN_EPSILON there is no measured gap to
+ * place it in — reactivity has no bimodal structure to exploit, it is simply a
+ * divide-by-zero guard. Its only requirement is being small relative to real
+ * reactivities, and it is: see the sensitivity note in the monica docstring.
+ */
 export const KALCHM_EPSILON = 0.01;
 
 // ── The monica degenerate band, DERIVED ─────────────────────────────────────
@@ -112,22 +126,49 @@ const THERMO_DEN_FLOOR = 0.01;
  * Calculate Kalchm (K_alchm) - Baseline alchemical equilibrium
  * Formula: K_alchm = (Spirit^Spirit * Essence^Essence) / (Matter^Matter * Substance^Substance)
  *
- * TOTAL: always finite and > 0. Each axis is floored at KALCHM_EPSILON, so an
- * all-zero input yields exactly 1.0 (the equilibrium value).
+ * TOTAL: always finite and > 0. An all-zero input yields exactly 1.0.
+ *
+ * ── Why there is no longer an epsilon floor ─────────────────────────────────
+ *
+ * Each axis used to be floored at KALCHM_EPSILON = 0.01, justified in a comment
+ * as "so 0^0 and division-by-zero cannot occur". BOTH of those hazards are
+ * imaginary in JavaScript, and the floor cost real accuracy:
+ *
+ *   1. `0 ** 0 === 1` in JS — and 1 is exactly lim(x->0) x^x. The language
+ *      already returns the mathematically correct value for a zero axis. There
+ *      was nothing to protect against.
+ *   2. Division by zero is impossible: x^x has a global minimum of 0.692201 at
+ *      x = 1/e, so it never reaches 0. The denominator
+ *      (Matter^Matter * Substance^Substance) cannot be 0 for any real input.
+ *
+ * Meanwhile 0.01^0.01 = 0.954993, not 1 — so flooring a zero axis understated
+ * its contribution by ~4.5%. Measured over the exhaustive single-body grid
+ * (7920 points), the floor perturbed 4200 of them: median 2.21%, max 4.17%.
+ * 68.2% of that grid has at least one axis exactly 0, so this was not an edge
+ * case; it was the common case.
+ *
+ * ── What the guard IS for ───────────────────────────────────────────────────
+ *
+ * A NEGATIVE axis. `Math.pow(-0.5, -0.5)` is NaN — a negative base with a
+ * fractional exponent has no real value. Dignity scores can be negative, so
+ * rather than prove no construction ever yields a negative axis, clamp only
+ * negatives. They land on 0, which then yields exactly 1 like any other zero.
+ *
+ * So: exact for zero, NaN-proof for negatives, no distortion anywhere.
  */
 export function calculateKalchm(alchemicalProps: AlchemicalProperties): number {
   const { Spirit, Essence, Matter, Substance } = alchemicalProps;
 
-  // Floor each axis so 0^0 and division-by-zero cannot occur.
-  const safespirit = Math.max(Spirit, KALCHM_EPSILON);
-  const safeessence = Math.max(Essence, KALCHM_EPSILON);
-  const safematter = Math.max(Matter, KALCHM_EPSILON);
-  const safesubstance = Math.max(Substance, KALCHM_EPSILON);
+  // Clamp NEGATIVES only — see the note above. Zero passes through untouched
+  // because 0**0 is already exactly 1.
+  const nonNeg = (x: number) => (x > 0 ? x : 0);
+  const s = nonNeg(Spirit);
+  const e = nonNeg(Essence);
+  const m = nonNeg(Matter);
+  const sub = nonNeg(Substance);
 
-  const numerator =
-    Math.pow(safespirit, safespirit) * Math.pow(safeessence, safeessence);
-  const denominator =
-    Math.pow(safematter, safematter) * Math.pow(safesubstance, safesubstance);
+  const numerator = Math.pow(s, s) * Math.pow(e, e);
+  const denominator = Math.pow(m, m) * Math.pow(sub, sub);
 
   const kalchm = numerator / denominator;
   return Number.isFinite(kalchm) && kalchm > 0 ? kalchm : 1.0;

--- a/src/data/unified/alchemicalCalculations.ts
+++ b/src/data/unified/alchemicalCalculations.ts
@@ -101,17 +101,32 @@ export const KALCHM_EPSILON = 0.01;
 // re-derives both endpoints and FAILS if the grid moves. So the derivation is
 // checked on every test run; it is not a comment asserting a stale measurement.
 
-/** Largest |ln(kalchm)| in the degenerate cluster. [MEASURED 2026-07-25, n=7920] */
-export const SINGLE_BODY_DEGENERATE_LN_CEILING = 0.046051701859880986;
+/**
+ * Largest |ln(kalchm)| in the degenerate cluster. [MEASURED 2026-07-25, n=7920]
+ *
+ * EXACTLY ZERO now. Before the epsilon floor was removed from `calculateKalchm`
+ * this was 0.046051701859880986 — the floor smeared the degenerate cluster across
+ * [0, 0.046] by contributing 0.954993 instead of 1 for a zeroed axis. With `0**0`
+ * left alone, a degenerate chart's kalchm is exactly 1, so |ln kalchm| is exactly
+ * 0 and the degenerate set is defined EXACTLY rather than empirically.
+ */
+export const SINGLE_BODY_DEGENERATE_LN_CEILING = 0;
 
-/** Smallest |ln(kalchm)| among non-degenerate points. [MEASURED 2026-07-25, n=7920] */
+/**
+ * Smallest |ln(kalchm)| among non-degenerate points. [MEASURED 2026-07-25, n=7920]
+ * Unchanged by the floor removal — the floor only ever touched zeroed axes.
+ */
 export const SINGLE_BODY_HEALTHY_LN_FLOOR = 0.21878586815274545;
 
 /** Half-width of the monica degenerate band. When |ln(kalchm)| < this, kalchm is
  *  treated as the equilibrium point (perfect balance) and monica returns
  *  MONICA_EQUILIBRIUM instead of diverging toward ±∞.
  *
- *  DERIVED as the midpoint of the measured gap above = 0.13241878500631321. */
+ *  DERIVED as the midpoint of the measured gap above = 0.10939293407637272.
+ *  (It was 0.13241878500631321 while the kalchm floor smeared the degenerate
+ *  ceiling up to 0.046. Removing the floor moved the ceiling to exactly 0, so the
+ *  midpoint moved down. The band still captures the SAME 660 of 7920 grid points
+ *  — the classification is unchanged, only its derivation is now exact.) */
 export const MONICA_LN_EPSILON =
   (SINGLE_BODY_DEGENERATE_LN_CEILING + SINGLE_BODY_HEALTHY_LN_FLOOR) / 2;
 

--- a/src/lib/sacred-7-stats.ts
+++ b/src/lib/sacred-7-stats.ts
@@ -298,20 +298,31 @@ export type MonicaMethod = 'single-body' | 'two-body' | 'full-chart'
 // function of kalchm. Removing the epsilon floor moved every one. Re-measure with
 // scripts/remeasureAfterKalchmFix.ts (grids) and measureThreeOpenNumbers.ts
 // (full-chart, needs the DB) after any kalchm change — do not assume they hold.
-const MONICA_POPULATION_SCALE: Partial<Record<MonicaMethod, number>> = {
-  // |max| 3.8977146920667267 / 2  [MEASURED 2026-07-25, exhaustive grid n=7920,
+// Exported for src/__tests__/monicaPopulationScaleDerivation.test.ts, which
+// re-derives the two grid-backed entries from their populations on every run.
+export const MONICA_POPULATION_SCALE: Partial<Record<MonicaMethod, number>> = {
+  // |max| 3.8977146920667276 / 2  [MEASURED 2026-07-25, exhaustive grid n=7920,
   // AFTER the exact-zero kalchm fix]. Was 1.9875 from |max| 3.9751 under the floor.
-  'single-body': 1.9488573460333634,
-  // |max| 2.8107786459098314 / 2  [MEASURED 2026-07-25, exhaustive two-body grid
-  // n=6480, AFTER the exact-zero kalchm fix AND the switch to a structural
+  // Extremum at Neptune / Aquarius / 2° / nocturnal (monica -3.8977146920667276).
+  'single-body': 1.9488573460333638,
+  // |max| 2.810778645909833 / 2  [MEASURED 2026-07-25, exhaustive two-body grid
+  // n=5760, AFTER the exact-zero kalchm fix AND the switch to a structural
   // degeneracy test]. Was 2.7095 from |max| 5.4191.
+  // Extremum at waxing gibbous / Gemini / 20° / nocturnal, tied with three other
+  // cells (Gemini 28°, Libra 20°, Libra 28° — the vessel repeats).
+  //
+  // n is 8 phases x 12 signs x 30 degrees x 2 sects. The measuring script listed
+  // NINE phases (n=6480) because it wrote the list out by hand and included
+  // "dark moon", which is an ALIAS of new moon at elongation 0 — so 720 of those
+  // cells were duplicates. The maximum is identical either way, and the guard
+  // test asserts that (it enumerates PHASE_GEOMETRY's own keys, never a list).
   //
   // The |max| nearly HALVED because the old local |ln kalchm| threshold was
   // leaving 442 genuinely degenerate charts unbanded, and those were the ones
   // producing the extreme values. Testing `esms.Essence === 0` instead catches all
   // of them, so the surviving range is [-0.292735, 2.81078] — now comfortably
   // inside the single-body envelope of 3.8977, which it previously exceeded.
-  'two-body': 1.4053893229549157,
+  'two-body': 1.4053893229549166,
   // ⚠️ RE-DERIVED. The first value shipped here was 0.016851, taken from
   // |max| 0.033702 / 2 across all 71 rows. That maximum was NOT a real agent's
   // monica: Carl Jung and Frida Kahlo share a byte-identical natal_positions
@@ -326,7 +337,13 @@ const MONICA_POPULATION_SCALE: Partial<Record<MonicaMethod, number>> = {
   // blob, Jung/Kahlo share another). If a real chart is authored for any of
   // them, re-run scripts/measureThreeOpenNumbers.ts and update this line —
   // do not assume it still holds.
-  'full-chart': 0.004720, // |max| 0.009441 / 2  [MEASURED 2026-07-25, n=61, clones excluded]
+  //
+  // The stated max is the exact stored value: monica_full_chart is NUMERIC(_,6),
+  // so 0.009441 is the whole number, not a rounded print of it. The scale is
+  // therefore its exact half — 0.0047205, NOT the 0.004720 that shipped first.
+  // That earlier value was a 4-dp rounding of an exact half, so it could not be
+  // reproduced from its own stated basis (off by 5e-7, relative 1e-4).
+  'full-chart': 0.0047205, // |max| 0.009441 / 2  [MEASURED 2026-07-25, n=61, clones excluded]
 }
 
 const DEFAULT_MONICA_SCALE = MONICA_POPULATION_SCALE['single-body'] as number

--- a/src/lib/sacred-7-stats.ts
+++ b/src/lib/sacred-7-stats.ts
@@ -294,9 +294,20 @@ export type MonicaMethod = 'single-body' | 'two-body' | 'full-chart'
  * single least-trustworthy row — so audit the extremum's provenance before
  * trusting any |max|-derived scale, here or in the other two populations.
  */
+// ⚠️ ALL THREE of these shift when calculateKalchm changes, because monica is a
+// function of kalchm. Removing the epsilon floor moved every one. Re-measure with
+// scripts/remeasureAfterKalchmFix.ts (grids) and measureThreeOpenNumbers.ts
+// (full-chart, needs the DB) after any kalchm change — do not assume they hold.
 const MONICA_POPULATION_SCALE: Partial<Record<MonicaMethod, number>> = {
-  'single-body': 1.9875, // |max| 3.9751 / 2
-  'two-body': 2.7095, // |max| 5.4191 / 2
+  // |max| 3.8977146920667267 / 2  [MEASURED 2026-07-25, exhaustive grid n=7920,
+  // AFTER the exact-zero kalchm fix]. Was 1.9875 from |max| 3.9751 under the floor.
+  'single-body': 1.9488573460333634,
+  // ⚠️ PENDING: two-body's |max| depends on the equilibrium band, and the band's
+  // derivation no longer holds — after the kalchm fix the Comixion (degenerate)
+  // and non-Comixion sets OVERLAP in |ln kalchm| ([0.0102, 0.1537] vs
+  // [0.0921, 4.354]), so there is no gap to derive a threshold from. Left at the
+  // pre-fix value until that is resolved; it is KNOWN STALE, not verified.
+  'two-body': 2.7095, // |max| 5.4191 / 2  [STALE — see above]
   // ⚠️ RE-DERIVED. The first value shipped here was 0.016851, taken from
   // |max| 0.033702 / 2 across all 71 rows. That maximum was NOT a real agent's
   // monica: Carl Jung and Frida Kahlo share a byte-identical natal_positions

--- a/src/lib/sacred-7-stats.ts
+++ b/src/lib/sacred-7-stats.ts
@@ -302,12 +302,16 @@ const MONICA_POPULATION_SCALE: Partial<Record<MonicaMethod, number>> = {
   // |max| 3.8977146920667267 / 2  [MEASURED 2026-07-25, exhaustive grid n=7920,
   // AFTER the exact-zero kalchm fix]. Was 1.9875 from |max| 3.9751 under the floor.
   'single-body': 1.9488573460333634,
-  // ⚠️ PENDING: two-body's |max| depends on the equilibrium band, and the band's
-  // derivation no longer holds — after the kalchm fix the Comixion (degenerate)
-  // and non-Comixion sets OVERLAP in |ln kalchm| ([0.0102, 0.1537] vs
-  // [0.0921, 4.354]), so there is no gap to derive a threshold from. Left at the
-  // pre-fix value until that is resolved; it is KNOWN STALE, not verified.
-  'two-body': 2.7095, // |max| 5.4191 / 2  [STALE — see above]
+  // |max| 2.8107786459098314 / 2  [MEASURED 2026-07-25, exhaustive two-body grid
+  // n=6480, AFTER the exact-zero kalchm fix AND the switch to a structural
+  // degeneracy test]. Was 2.7095 from |max| 5.4191.
+  //
+  // The |max| nearly HALVED because the old local |ln kalchm| threshold was
+  // leaving 442 genuinely degenerate charts unbanded, and those were the ones
+  // producing the extreme values. Testing `esms.Essence === 0` instead catches all
+  // of them, so the surviving range is [-0.292735, 2.81078] — now comfortably
+  // inside the single-body envelope of 3.8977, which it previously exceeded.
+  'two-body': 1.4053893229549157,
   // ⚠️ RE-DERIVED. The first value shipped here was 0.016851, taken from
   // |max| 0.033702 / 2 across all 71 rows. That maximum was NOT a real agent's
   // monica: Carl Jung and Frida Kahlo share a byte-identical natal_positions

--- a/src/utils/agentMonicaTwoBody.ts
+++ b/src/utils/agentMonicaTwoBody.ts
@@ -505,7 +505,12 @@ export const VESSEL_DIGNITY_NEUTRAL = 0;
 /**
  * `[MEASURED 2026-07-21]` `|ln kalchm|` of the **exactly-degenerate** two-body
  * chart: Comixion (degree 8/22), nocturnal, where the vessel's Essence is
- * literally `0.000` and only `KALCHM_EPSILON` keeps `calculateKalchm` finite.
+ * literally `0.000`.
+ *
+ * ⚠️ This used to read "and only `KALCHM_EPSILON` keeps `calculateKalchm` finite".
+ * That was never true: `0 ** 0` is exactly 1 in JS, so a zero axis was always
+ * finite on its own. The floor has been removed, which means the measured value
+ * below CHANGES — see the recomputation note on TWO_BODY_LN_EPSILON.
  *
  *     nocturnal deg 8/22 → S 1.824  E 0.000  M 1.618  Su 1.333   ln k = −0.110698
  *

--- a/src/utils/agentMonicaTwoBody.ts
+++ b/src/utils/agentMonicaTwoBody.ts
@@ -518,7 +518,9 @@ export const VESSEL_DIGNITY_NEUTRAL = 0;
  * threshold. This is the LOWER bound on the band: any width at or below it
  * leaves a genuinely degenerate chart being divided by ~0.
  */
-export const DEGENERATE_LN_KALCHM = 0.110698;
+// REMOVED: DEGENERATE_LN_KALCHM was 0.110698. Measured WITH the kalchm epsilon
+// floor; with kalchm exact the same chart gives 0.06464620715111077. It existed
+// only to derive TWO_BODY_LN_EPSILON, which is itself removed — see below.
 
 /**
  * `[MEASURED 2026-07-21]` The smallest `|ln kalchm|` produced by any NON-Comixion
@@ -526,7 +528,9 @@ export const DEGENERATE_LN_KALCHM = 0.110698;
  * UPPER bound on the band: at or above it, the band starts converting cases that
  * computed a perfectly sane monica into φ.
  */
-export const HEALTHY_LN_KALCHM_FLOOR = 0.138173;
+// REMOVED: HEALTHY_LN_KALCHM_FLOOR was 0.138173. Also floor-dependent; the
+// non-degenerate minimum is now 0.0921214, BELOW the old degenerate bound, which
+// is precisely why a threshold can no longer separate the two sets.
 
 /**
  * `[DERIVED]` The two-body-local half-width of the monica equilibrium band, on
@@ -559,11 +563,36 @@ export const HEALTHY_LN_KALCHM_FLOOR = 0.138173;
  * signed and real; they are the honest reading of a nearly-balanced two-body
  * chart. The residual is quantified in the module docstring and pinned by test.
  *
- * `agentMonicaTwoBody.test.ts` pins BOTH bounds and the zero-collateral property,
- * so a future retune that widens this into real values fails loudly.
+ * ── ⚠️ REMOVED 2026-07-25 — the threshold was a proxy, and the proxy broke ──
+ *
+ * `TWO_BODY_LN_EPSILON` (0.1244355) and the two constants it was derived from
+ * (`DEGENERATE_LN_KALCHM` 0.110698, `HEALTHY_LN_KALCHM_FLOOR` 0.138173) are GONE.
+ * The reasoning above is preserved because it is still correct about the PHYSICS —
+ * Comixion zeroes vessel Essence, and near-perfect balance should return φ rather
+ * than divide by ~0. What was wrong was testing that condition with an
+ * |ln kalchm| threshold.
+ *
+ * The derivation depended on the degenerate and healthy |ln kalchm| sets being
+ * separable. They were separable only because `calculateKalchm` floored each axis
+ * at 0.01, which inflated degenerate charts away from healthy ones. With kalchm
+ * exact (`0**0 === 1`), the sets OVERLAP:
+ *
+ *     Comixion      n=432   |ln k| ∈ [0.0101671, 0.153707]
+ *     non-Comixion  n=6048  |ln k| ∈ [0.0921214, 4.35396]
+ *
+ * No threshold separates 0.1537 from 0.0921. Measured over all 6480 cells, the
+ * old threshold was wrong in BOTH directions: it handed φ to 286 healthy charts
+ * and missed 442 degenerate ones, getting 206 of 648 right — 32%.
+ *
+ * It is replaced by the exact structural test `esms.Essence === 0` at the point of
+ * use (see `twoBodyState`). That is the CAUSE the threshold was approximating, it
+ * has zero collateral by construction, and it needs no constant — so there is
+ * nothing left here to keep calibrated.
+ *
+ * It also corrects a latent error: the zero-Essence family is degrees
+ * [8, 10, 12, 22, 24, 26] — TWO vessel shapes — not just the [8, 22] that
+ * "Comixion" named.
  */
-export const TWO_BODY_LN_EPSILON =
-  (DEGENERATE_LN_KALCHM + HEALTHY_LN_KALCHM_FLOOR) / 2; // 0.1244355
 
 /** A body's sect-resolved, alchm-weighted, dignity-scaled ESMS contribution. */
 function bodyContribution(
@@ -691,13 +720,36 @@ export function twoBodyState(
   const kalchm = calculateKalchm(esms as AlchemicalProperties);
   const lnKalchm = Math.log(kalchm);
 
-  // ── the two-body-local equilibrium band (§18i-quater) ────────────────────
-  // Wider than the canonical MONICA_LN_EPSILON, and applied ONLY here. See the
-  // constant's own note for why it is local and how the width was measured.
-  const inBand =
-    !Number.isFinite(kalchm) ||
-    kalchm <= 0 ||
-    Math.abs(lnKalchm) < TWO_BODY_LN_EPSILON;
+  // ── degeneracy is now tested STRUCTURALLY, not by an |ln kalchm| threshold ──
+  //
+  // This used to be `Math.abs(lnKalchm) < TWO_BODY_LN_EPSILON`, a threshold
+  // derived from a gap between the degenerate and healthy |ln kalchm| sets. That
+  // gap was PARTLY AN ARTIFACT of the kalchm epsilon floor. With kalchm exact, the
+  // two sets overlap — Comixion spans [0.0102, 0.1537] and non-Comixion starts at
+  // 0.0921 — so no threshold separates them and the derivation is invalid.
+  //
+  // Measured over all 6480 cells, the old threshold was wrong in BOTH directions:
+  //     both agree                206
+  //     only the threshold bands   286   healthy charts handed phi (fabrication)
+  //     only Essence===0 bands     442   degenerate charts left unbanded
+  // It identified 206 of 648 degenerate charts — 32%.
+  //
+  // So test the CAUSE instead of a proxy for it. This module already states the
+  // principle: "a chart with a hard zero on an axis is degenerate by inspection".
+  // Essence === 0 IS that condition, it is exact, and it has zero collateral by
+  // construction — a cell is banded if and only if it is degenerate.
+  //
+  // Bonus: it removes a derived constant rather than re-deriving one, and it fixes
+  // a latent bug. The zero-Essence family is degrees [8, 10, 12, 22, 24, 26] —
+  // TWO vessel shapes — while `isComixion` in the tests only knows [8, 22].
+  //
+  // Non-degenerate monica then tops out at 2.81078, inside the single-body
+  // envelope of 3.8977. Under no band at all it reaches 9.46124, and every cell
+  // that overshoots is Essence===0 — independent confirmation of the predicate.
+  const degenerate =
+    !Number.isFinite(kalchm) || kalchm <= 0 || esms.Essence === 0;
+
+  const inBand = degenerate;
 
   const monica = inBand
     ? MONICA_EQUILIBRIUM


### PR DESCRIPTION
> **On the `DO NOT MERGE` warning in the first commit:** it belongs to `b9199bab`
> ("NOT READY, 6 tests fail BY DESIGN") and is **superseded**. Those 6 failures were
> the #641 derivation guards correctly detecting that removing the kalchm floor
> invalidates every constant downstream — which is exactly what commits 2-4 then
> fixed, by re-deriving each one. At the branch tip: **168 suites / 1445 tests /
> 0 failures**, typecheck clean, and all CI checks green (Build, Test, Verify,
> fabricated-fallback scan, Vercel). The stack is intentionally ordered
> break-then-repair so the guards' detection is visible in the history; squash-merging
> collapses it.

## kalchm is exact at a zero axis

`calculateKalchm` floored every ESMS axis at `KALCHM_EPSILON = 0.01` before exponentiating. The floor existed to avoid `0 ** 0`, but **`0 ** 0 === 1` in JavaScript already — and it is exactly `lim(x→0) x^x`.** So the floor was not protecting against anything; it was perturbing a value that was already correct.

```ts
// before: Math.max(0.01, x) on all four axes
// after:  clamp NEGATIVES only — 0**0 is already exactly 1
const nonNeg = (x: number) => (x > 0 ? x : 0);
```

`x^x` has a global minimum of `0.692201` at `1/e`, so it never reaches 0 and the denominator cannot vanish. The negative clamp stays: `Math.pow(-0.5, -0.5)` is `NaN`.

### What it cascaded into

monica is a function of kalchm, so every derived constant moved. Each one is re-derived here, not re-guessed.

| constant | before | after |
|---|---|---|
| `SINGLE_BODY_DEGENERATE_LN_CEILING` | 0.046051701859880986 | **0** (exactly) |
| `MONICA_LN_EPSILON` | 0.13241878500631321 | 0.10939293407637272 |
| `TWO_BODY_LN_EPSILON` | 0.1244355 | **removed** |
| `DEGENERATE_LN_KALCHM` | 0.110698 | **removed** |
| `HEALTHY_LN_KALCHM_FLOOR` | 0.138173 | **removed** |
| Sacred-7 `single-body` | 1.9875 | 1.9488573460333638 |
| Sacred-7 `two-body` | 2.7095 | 1.4053893229549166 |
| Sacred-7 `full-chart` | 0.016851 | 0.0047205 |

The degenerate ceiling becoming **exactly 0** is the strongest consequence: with the floor gone, a chart with a zeroed axis has `kalchm === 1` identically, so the degenerate set stops being an empirical cluster and becomes an exact algebraic condition. Single-body classification is unchanged — 660 cells either side.

### The two-body band: a constant removed, not re-derived

Three two-body constants had no derivable gap left. Measuring the candidates showed the threshold was approximating `esms.Essence === 0` — and doing it badly:

```
current band (|ln k| < 0.1244355)   492 cells → φ
structural  (vessel Essence === 0)  648 cells → φ
  both agree                206
  only the THRESHOLD bands   286   ← healthy charts getting φ (fabrication)
  only STRUCTURAL bands      442   ← degenerate charts NOT banded (missed)
```

**206 of 648 correct — 32%.** Testing the cause directly needs no calibration, so all three constants are gone.

```
two-body range        [−5.4191, 1.8004]  →  [−0.292735, 2.81078]
two-body |max|                   5.4191  →  2.810778645909833
amplified-tail degrees          [8, 22]  →  []
inside single-body envelope?         no  →  YES
```

The `|max|` nearly halved because those 442 unbanded degenerate charts were exactly where the extremes came from. Two-body now sits inside the single-body envelope — it never did before.

**A latent bug fell out:** the zero-Essence family is degrees `[8, 10, 12, 22, 24, 26]` (two vessel shapes), while `isComixion` only ever named `[8, 22]`. Four degrees of degenerate charts were never eligible for banding.

### Guards

- `monicaLnEpsilonDerivation.test.ts` — re-derives both epsilon endpoints from the 7920-cell grid each run, and asserts the ceiling is `=== 0` rather than merely small.
- `monicaPopulationScaleDerivation.test.ts` (new) — re-derives the two grid-backed Sacred-7 scales, asserting `===` rather than `toBeCloseTo`.

Writing that second guard found that **none of the three scale constants could be reproduced from its own stated basis**: two were copied from a script's `toPrecision()` output (lossy round-trip, last bits lost), and `full-chart` was an exact half rounded to 4 dp. All three are numerically irrelevant — `tanh` moves by ~1e-16 — and all three are disqualifying under the reproducibility standard. `toBeCloseTo(…, 15)` passed against every wrong value, which is exactly why they survived; halving is exact in binary FP, so the guard uses `===`.

The docstring's two-body grid size was also wrong: **n=5760, not 6480**. The measuring script hand-wrote its phase list and included `"dark moon"`, an alias of new moon at elongation 0 — 720 duplicate cells. The guard now enumerates `PHASE_GEOMETRY`'s own keys and asserts the alias adds exactly 720 cells while leaving the maximum bit-for-bit identical.

## Blast radius on persisted data: one row

Swept all 16 files holding a persisted kalchm (1166 values):

```
CHANGES under this fix                             1   (russian.ts:480, Substance=0)
hand-authored 1-dp placeholders, match no formula  203
unverifiable — inputs never persisted             423
reproducible from stored inputs                   540  (all hsca.ts)
```

**`hsca.ts` needs no regeneration** — all 540 values are byte-identical under both formulas (min axis 0.14, so the 0.01 floor never bit).

The single changed row is `russian.ts:480` (`Substance: 0`, `0.6761 → 0.6457`), whose stored value is `0.5` — matching *neither* formula. It is a pre-existing data defect, not a cascade of this fix, so it is filed as a follow-up rather than bundled here.

The 203 placeholders and 423 unverifiable values are also pre-existing and independent of this change; both are queued as separate work.

## Verification

- `168` suites, `1445` tests, `9` skipped, **0 failures**
- `bun run typecheck` clean
- No production write in this PR. The prod backfill runs after merge and deploy, snapshot-first, aborting on any φ-band crossing or drift ≠ 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

