### PR TITLE
chore(physics): resolve thermo callers through the type checker, not grep

### DIFF
--- a/scripts/resolveThermoCallers.ts
+++ b/scripts/resolveThermoCallers.ts
@@ -1,0 +1,365 @@
+/**
+ * Who actually calls each thermodynamic implementation?
+ *
+ * ⚠️ grep CANNOT answer this. `calculateKalchm` is declared in THREE separate
+ * modules (src/calculations/alchemicalCalculations.ts, the canonical
+ * src/data/unified/alchemicalCalculations.ts, and a file-local one in
+ * src/data/unified/ingredients.ts), and `calculateKalchmResonance` in three more.
+ * A grep for the name cannot tell which declaration a given call site reaches, so
+ * every caller count produced that way this session was unreliable and was not
+ * acted on.
+ *
+ * This resolves call sites through the TypeScript type checker instead: for each
+ * call expression it takes the callee symbol, follows import aliases to the real
+ * declaration, and reports the declaration's file:line. That is the ground truth
+ * needed before delegating any duplicate to the canonical engine, because the
+ * duplicates differ in BEHAVIOUR (4 floor strategies: none / 0.001 / 0.01 / 0.1,
+ * plus one Math.abs) by up to 20.57% on a zeroed axis.
+ *
+ * Read-only. Prints a report; changes nothing.
+ *
+ * Usage: bunx tsx scripts/resolveThermoCallers.ts [nameRegex]
+ *   default nameRegex: kalchm|monica
+ */
+import * as ts from "typescript";
+import path from "path";
+import fs from "fs";
+
+const ROOT = process.cwd();
+const NAME_RE = new RegExp(process.argv[2] ?? "kalchm|monica", "i");
+
+// ── load the real tsconfig, so path aliases (@/...) resolve ────────────────
+const configPath = ts.findConfigFile(ROOT, ts.sys.fileExists, "tsconfig.json");
+if (!configPath) throw new Error("no tsconfig.json found");
+const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+if (configFile.error) {
+  throw new Error(ts.flattenDiagnosticMessageText(configFile.error.messageText, "\n"));
+}
+const parsed = ts.parseJsonConfigFileContent(configFile.config, ts.sys, path.dirname(configPath));
+
+// src/ AND scripts/ — including .next/ or node_modules would swamp the report, but
+// leaving scripts/ out would make every "0 callers" line a lie for anything a
+// backfill or audit script consumes. Two of the declarations here are only ever
+// called from scripts/.
+const IN_SCOPE = [`${path.sep}src${path.sep}`, `${path.sep}scripts${path.sep}`];
+const extra = fs.existsSync(path.join(ROOT, "scripts"))
+  ? fs
+      .readdirSync(path.join(ROOT, "scripts"))
+      .filter((f) => f.endsWith(".ts"))
+      .map((f) => path.join(ROOT, "scripts", f))
+  : [];
+const rootNames = [
+  ...new Set([
+    ...parsed.fileNames.filter(
+      (f) => IN_SCOPE.some((d) => f.includes(d)) && !f.includes("node_modules"),
+    ),
+    ...extra,
+  ]),
+];
+console.log(`program: ${rootNames.length} files under src/ + scripts/`);
+
+const program = ts.createProgram({ rootNames, options: parsed.options });
+const checker = program.getTypeChecker();
+
+const rel = (f: string) => path.relative(ROOT, f);
+const inScope = (r: string) => r.startsWith("src") || r.startsWith("scripts");
+function loc(node: ts.Node): string {
+  const sf = node.getSourceFile();
+  const { line } = sf.getLineAndCharacterOfPosition(node.getStart());
+  return `${rel(sf.fileName)}:${line + 1}`;
+}
+
+// ── every DECLARATION whose name matches ───────────────────────────────────
+interface Decl {
+  name: string;
+  where: string;
+  exported: boolean;
+  /** Distinct files containing a resolved call to this declaration. */
+  callerFiles: Set<string>;
+  /** Every resolved call site. */
+  callSites: string[];
+  /**
+   * References that are NOT calls — the function used as a VALUE: passed to
+   * memoize(), `.bind(this)`, stored in a table, re-exported. These make a
+   * declaration live with zero call expressions pointing at it, so a
+   * "0 callers => dead" conclusion that ignores them is wrong. Real example here:
+   * `_calculateKalchmSeasonalCompatibility` has 0 calls and is very much alive via
+   * `memoize(this._calculateKalchmSeasonalCompatibility.bind(this))`.
+   */
+  valueRefs: string[];
+}
+const decls = new Map<ts.Node, Decl>();
+
+function isDeclarationOfInterest(node: ts.Node): ts.Node | null {
+  if (ts.isFunctionDeclaration(node) && node.name && NAME_RE.test(node.name.text)) return node;
+  if (
+    ts.isVariableDeclaration(node) &&
+    ts.isIdentifier(node.name) &&
+    NAME_RE.test(node.name.text) &&
+    node.initializer &&
+    (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer))
+  ) {
+    return node;
+  }
+  if (ts.isMethodDeclaration(node) && ts.isIdentifier(node.name) && NAME_RE.test(node.name.text)) {
+    return node;
+  }
+  return null;
+}
+
+function declName(node: ts.Node): string {
+  const n = node as ts.FunctionDeclaration | ts.VariableDeclaration | ts.MethodDeclaration;
+  return n.name && ts.isIdentifier(n.name) ? n.name.text : "<anon>";
+}
+
+function isExported(node: ts.Node): boolean {
+  const mods = ts.getCombinedModifierFlags(node as ts.Declaration);
+  if (mods & ts.ModifierFlags.Export) return true;
+  // `export const x = …` puts the modifier on the statement, not the declaration.
+  let p: ts.Node | undefined = node.parent;
+  while (p) {
+    if (ts.isVariableStatement(p) || ts.isFunctionDeclaration(p)) {
+      if (ts.getCombinedModifierFlags(p as ts.Declaration) & ts.ModifierFlags.Export) return true;
+    }
+    p = p.parent;
+  }
+  return false;
+}
+
+for (const sf of program.getSourceFiles()) {
+  if (sf.isDeclarationFile || !inScope(rel(sf.fileName))) continue;
+  const visit = (node: ts.Node) => {
+    const d = isDeclarationOfInterest(node);
+    if (d) {
+      decls.set(d, {
+        name: declName(d),
+        where: loc(d),
+        exported: isExported(d),
+        callerFiles: new Set(),
+        callSites: [],
+        valueRefs: [],
+      });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+}
+console.log(`declarations matching /${NAME_RE.source}/i: ${decls.size}`);
+
+// ── resolve every call expression to its declaration ───────────────────────
+let callsSeen = 0;
+let callsUnresolved = 0;
+const unresolvedNames = new Map<string, number>();
+
+/** Resolve an identifier to a tracked declaration, following import aliases. */
+function resolveToTracked(nameNode: ts.Identifier): Decl[] {
+  let sym = checker.getSymbolAtLocation(nameNode);
+  if (sym && sym.flags & ts.SymbolFlags.Alias) {
+    try {
+      sym = checker.getAliasedSymbol(sym);
+    } catch {
+      /* not an alias after all */
+    }
+  }
+  const out: Decl[] = [];
+  for (const t of sym?.declarations ?? []) {
+    const entry = decls.get(t);
+    if (entry) out.push(entry);
+  }
+  return out;
+}
+
+for (const sf of program.getSourceFiles()) {
+  if (sf.isDeclarationFile || !inScope(rel(sf.fileName))) continue;
+  const visit = (node: ts.Node) => {
+    // ── non-call references: the function used as a VALUE ──────────────────
+    if (ts.isIdentifier(node) && NAME_RE.test(node.text)) {
+      const parent = node.parent;
+      const isCallee =
+        (ts.isCallExpression(parent) && parent.expression === node) ||
+        (ts.isPropertyAccessExpression(parent) &&
+          ts.isCallExpression(parent.parent) &&
+          parent.parent.expression === parent);
+      const isOwnName =
+        (ts.isFunctionDeclaration(parent) ||
+          ts.isVariableDeclaration(parent) ||
+          ts.isMethodDeclaration(parent) ||
+          ts.isPropertyDeclaration(parent)) &&
+        (parent as { name?: ts.Node }).name === node;
+      if (!isCallee && !isOwnName) {
+        for (const entry of resolveToTracked(node)) entry.valueRefs.push(loc(node));
+      }
+    }
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      const nameNode = ts.isPropertyAccessExpression(callee)
+        ? callee.name
+        : ts.isIdentifier(callee)
+          ? callee
+          : null;
+      if (nameNode && NAME_RE.test(nameNode.text)) {
+        callsSeen++;
+        let sym = checker.getSymbolAtLocation(nameNode);
+        // Follow `import { x } from …` to the real declaration.
+        if (sym && sym.flags & ts.SymbolFlags.Alias) {
+          try {
+            sym = checker.getAliasedSymbol(sym);
+          } catch {
+            /* not an alias after all */
+          }
+        }
+        const targets = sym?.declarations ?? [];
+        let matched = false;
+        for (const t of targets) {
+          // A VariableDeclaration target may be recorded under itself; a
+          // FunctionDeclaration likewise. Match on identity.
+          const entry = decls.get(t);
+          if (entry) {
+            entry.callerFiles.add(rel(sf.fileName));
+            entry.callSites.push(loc(node));
+            matched = true;
+          }
+        }
+        if (!matched) {
+          callsUnresolved++;
+          unresolvedNames.set(nameNode.text, (unresolvedNames.get(nameNode.text) ?? 0) + 1);
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+}
+
+// ── report ─────────────────────────────────────────────────────────────────
+const rows = [...decls.values()].sort(
+  (a, b) => b.callerFiles.size - a.callerFiles.size || a.name.localeCompare(b.name),
+);
+
+console.log("");
+console.log("=".repeat(90));
+console.log("DECLARATIONS, by number of distinct calling files");
+console.log("=".repeat(90));
+for (const r of rows) {
+  const tag = r.exported ? "exported" : "LOCAL   ";
+  console.log(
+    `${String(r.callerFiles.size).padStart(3)} files ${String(r.callSites.length).padStart(4)} calls  ${tag}  ${r.name}  @ ${r.where}`,
+  );
+}
+
+console.log("");
+console.log("=".repeat(90));
+console.log("DUPLICATE NAMES — the reason grep cannot attribute these");
+console.log("=".repeat(90));
+const byName = new Map<string, Decl[]>();
+for (const r of rows) {
+  if (!byName.has(r.name)) byName.set(r.name, []);
+  byName.get(r.name)!.push(r);
+}
+for (const [name, group] of [...byName].sort((a, b) => b[1].length - a[1].length)) {
+  if (group.length < 2) continue;
+  console.log(`\n${name} — ${group.length} declarations:`);
+  for (const g of group) {
+    console.log(
+      `   ${g.exported ? "exported" : "LOCAL   "}  ${g.where}   ${g.callerFiles.size} calling files, ${g.callSites.length} calls`,
+    );
+    for (const f of [...g.callerFiles].sort()) console.log(`        <- ${f}`);
+  }
+}
+
+console.log("");
+console.log("=".repeat(90));
+console.log("ZERO-CALLER DECLARATIONS — split by whether anything references them at all");
+console.log("=".repeat(90));
+const noCalls = rows.filter((x) => x.callerFiles.size === 0);
+const trulyUnreferenced = noCalls.filter((x) => x.valueRefs.length === 0);
+const referencedNotCalled = noCalls.filter((x) => x.valueRefs.length > 0);
+
+console.log(`\nNo calls AND no value references — ${trulyUnreferenced.length} (deletion candidates):`);
+for (const r of trulyUnreferenced) {
+  console.log(`   ${r.exported ? "exported" : "LOCAL   "}  ${r.name}  @ ${r.where}`);
+}
+console.log(
+  `\n⚠️ No calls BUT referenced as a value — ${referencedNotCalled.length} (LIVE, do NOT delete):`,
+);
+for (const r of referencedNotCalled) {
+  console.log(`   ${r.exported ? "exported" : "LOCAL   "}  ${r.name}  @ ${r.where}`);
+  for (const v of r.valueRefs) console.log(`        referenced at ${v}`);
+}
+if (trulyUnreferenced.some((r) => r.exported)) {
+  console.log(
+    "\n⚠️ Some are EXPORTED with no reference anywhere in src/ or scripts/. That is still not\n" +
+      "   proof of death: this program excludes .tsx outside src/, config files, and any\n" +
+      "   dynamic import(). Check those before deleting.",
+  );
+}
+
+console.log("");
+console.log("=".repeat(90));
+console.log(`call expressions matching the name filter : ${callsSeen}`);
+console.log(`  resolved to a declaration in src/       : ${callsSeen - callsUnresolved}`);
+console.log(`  NOT resolved (see below)                : ${callsUnresolved}`);
+if (callsUnresolved) {
+  // ⚠️ Do NOT read this as "no caller". Unresolved means the callee is declared
+  // outside src/ (a dependency), is a method on a type rather than a tracked
+  // declaration, or the symbol could not be followed. Any conclusion that a
+  // declaration is dead must account for these, or it repeats the
+  // zero-result-without-a-control-test mistake.
+  console.log("  unresolved by callee name:");
+  for (const [n, c] of [...unresolvedNames].sort((a, b) => b[1] - a[1])) {
+    console.log(`     ${String(c).padStart(4)}  ${n}`);
+  }
+}
+
+// ── control test: the resolver must find a call it is KNOWN to have ────────
+console.log("");
+console.log("=".repeat(90));
+console.log("CONTROL — a zero-result report is only trustworthy if the resolver works");
+console.log("=".repeat(90));
+const canonical = rows.find(
+  (r) => r.name === "calculateKalchm" && r.where.includes("data/unified/alchemicalCalculations.ts"),
+);
+if (!canonical) {
+  console.log("✗ FAILED: did not even find the canonical calculateKalchm declaration");
+  process.exitCode = 1;
+} else if (canonical.callerFiles.size === 0) {
+  console.log(`✗ FAILED: canonical calculateKalchm resolved 0 callers, which cannot be true`);
+  process.exitCode = 1;
+} else {
+  console.log(
+    `✓ canonical calculateKalchm @ ${canonical.where} resolved ${canonical.callerFiles.size} calling files`,
+  );
+  // Second control: the value-reference pass must find the memoize/bind case,
+  // which is the one construct that makes a live function look dead.
+  const memoized = rows.find((r) => r.name === "_calculateKalchmSeasonalCompatibility");
+  if (memoized) {
+    console.log(
+      memoized.valueRefs.length > 0
+        ? `✓ value-reference pass works: ${memoized.name} has 0 calls but ${memoized.valueRefs.length} value ref(s) — correctly NOT reported dead`
+        : `✗ FAILED: ${memoized.name} is live via memoize(...bind(this)) but shows 0 calls AND 0 value refs`,
+    );
+    if (memoized.valueRefs.length === 0) process.exitCode = 1;
+  }
+  const selfFile = "src/data/unified/alchemicalCalculations.ts";
+  console.log(
+    `✓ cross-file resolution works: ${[...canonical.callerFiles].some((f) => f !== selfFile) ? "yes" : "NO — only same-file calls found, aliases may not be following"}`,
+  );
+}
+
+// Opt-in only — this script is read-only by default and must not drop a generated
+// artifact into the repo just for being run.
+const jsonFlag = process.argv.indexOf("--json");
+if (jsonFlag !== -1 && process.argv[jsonFlag + 1]) {
+  const out = process.argv[jsonFlag + 1];
+  fs.writeFileSync(
+    out,
+    JSON.stringify(
+      rows.map((r) => ({ ...r, callerFiles: [...r.callerFiles].sort() })),
+      null,
+      2,
+    ),
+  );
+  console.log(`\nfull map written to ${out}`);
+} else {
+  console.log("\n(pass --json <path> to write the full map)");
+}

--- a/src/__tests__/kalchmFloorDivergence.test.ts
+++ b/src/__tests__/kalchmFloorDivergence.test.ts
@@ -1,0 +1,136 @@
+/**
+ * What exactly do the duplicate kalchm implementations disagree about?
+ *
+ * There are several live implementations of the same formula
+ * `kalchm = (S^S · E^E) / (M^M · Su^Su)`, differing only in how they keep an axis
+ * away from zero. Before any of them is delegated to the canonical engine, the
+ * behavioural difference has to be characterised — otherwise "de-duplication"
+ * silently re-values whatever reads them (the §17c acceptance bar: characterisation
+ * tests BEFORE touching a shared table).
+ *
+ * These tests import the REAL functions rather than restating their formulas. A
+ * transcribed formula is the same hazard as a transcribed constant: it can drift
+ * from the thing it claims to describe, and the test would keep passing.
+ *
+ * The headline result is that the disagreement is not a vague percentage — it is an
+ * exact, input-independent law. Flooring an axis at `eps` replaces a factor of
+ * `0^0 = 1` in the denominator with `eps^eps`, so the result is inflated by exactly
+ *
+ *     eps^(-eps) - 1        per zeroed axis
+ *
+ * which is 0.6932% at eps=0.001, 4.7129% at 0.01, and 25.8925% at 0.1 — for ANY
+ * input. And where no axis is at or below the floor, every implementation agrees
+ * to the last bit, so delegation is a no-op for all healthy charts.
+ *
+ * Two more implementations exist but are file-local and cannot be imported:
+ * `src/data/unified/ingredients.ts:74` (floor 0.001) and
+ * `src/data/unified/flavorProfileMigration.ts:797` (returns 1.0 when Matter or
+ * Substance is 0 — a band, not a floor). A third,
+ * `src/calculations/alchemicalCalculations.ts:246`, returns **0** on a zeroed axis,
+ * which makes `ln(kalchm)` −Infinity and monica non-finite — a totality-contract
+ * violation. It is unreachable (no call, no value reference, and its only importer
+ * exposes it through a string-dispatch helper that itself has no callers), which is
+ * the only reason it has never caused an incident.
+ */
+import { calculateKAlchm as kalchmEps01 } from "@/utils/monicaKalchmCalculations";
+import { calculateKAlchm as kalchmEps1 } from "@/calculations/core/kalchmEngine";
+
+/**
+ * The formula as defined, with no floor. `0 ** 0 === 1` in JavaScript, which is
+ * exactly `lim(x→0) x^x`, so a zeroed axis needs no special handling at all.
+ * Negatives are clamped because `Math.pow(-0.5, -0.5)` is NaN.
+ *
+ * This is the mathematical definition, not a copy of any implementation.
+ */
+function exactKalchm(S: number, E: number, M: number, Su: number): number {
+  const nn = (x: number) => (x > 0 ? x : 0);
+  return (
+    (Math.pow(nn(S), nn(S)) * Math.pow(nn(E), nn(E))) /
+    (Math.pow(nn(M), nn(M)) * Math.pow(nn(Su), nn(Su)))
+  );
+}
+
+/** Inputs with no axis at or below any implementation's floor. */
+const HEALTHY: [number, number, number, number][] = [
+  [4, 7, 5, 3],
+  [0.5, 0.8, 0.4, 0.3],
+  [2.5, 3.1, 1.7, 1.1],
+  [1.2, 1.2, 1.2, 1.2],
+  [9, 0.5, 2, 6],
+];
+
+/** Inputs with exactly ONE axis at zero. */
+const ONE_ZEROED: [number, number, number, number][] = [
+  [0.3, 0.6, 0.1, 0], // the shape found persisted at src/data/cuisines/russian.ts:480
+  [1, 1, 1, 0],
+  [2.5, 3.1, 1.7, 0],
+  [0.9, 0.2, 4.4, 0],
+];
+
+describe("the duplicate kalchm implementations", () => {
+  it("agree EXACTLY on healthy input — delegation is a no-op there", () => {
+    for (const [S, E, M, Su] of HEALTHY) {
+      const exact = exactKalchm(S, E, M, Su);
+      // `toBe`, not toBeCloseTo: identical arithmetic on identical inputs must give
+      // identical doubles. Any tolerance here would hide a real formula difference.
+      expect(kalchmEps01(S, E, M, Su)).toBe(exact);
+      expect(kalchmEps1(S, E, M, Su)).toBe(exact);
+    }
+  });
+
+  it("diverge by exactly eps^(-eps) - 1 per zeroed axis, independent of input", () => {
+    // This is the load-bearing claim: the error is a fixed multiplicative factor,
+    // so it can be stated for the whole class rather than sampled per call site.
+    const law = (eps: number) => Math.pow(eps, -eps);
+    for (const [S, E, M, Su] of ONE_ZEROED) {
+      const exact = exactKalchm(S, E, M, Su);
+      expect(kalchmEps01(S, E, M, Su) / exact).toBeCloseTo(law(0.01), 12);
+      expect(kalchmEps1(S, E, M, Su) / exact).toBeCloseTo(law(0.1), 12);
+    }
+    // The percentages quoted in the docstring, so a change to either floor shows up
+    // as a failure here rather than as quietly stale prose.
+    expect((law(0.01) - 1) * 100).toBeCloseTo(4.7129, 4);
+    expect((law(0.1) - 1) * 100).toBeCloseTo(25.8925, 4);
+    expect((law(0.001) - 1) * 100).toBeCloseTo(0.6932, 4);
+  });
+
+  it("a floor inflates kalchm — it never deflates it", () => {
+    // Direction matters: kalchm > 1 vs < 1 decides the SIGN of ln(kalchm) and so of
+    // monica. A floor can only shrink the denominator, so it can only push kalchm up.
+    for (const [S, E, M, Su] of ONE_ZEROED) {
+      const exact = exactKalchm(S, E, M, Su);
+      expect(kalchmEps01(S, E, M, Su)).toBeGreaterThan(exact);
+      expect(kalchmEps1(S, E, M, Su)).toBeGreaterThan(exact);
+    }
+  });
+
+  it("the bigger floor is always the bigger error", () => {
+    // Orders the implementations by how far they sit from the definition, which is
+    // the order they should be delegated in.
+    for (const [S, E, M, Su] of ONE_ZEROED) {
+      expect(kalchmEps1(S, E, M, Su)).toBeGreaterThan(kalchmEps01(S, E, M, Su));
+    }
+  });
+
+  it("a floor can flip a degenerate chart into a spuriously computable monica", () => {
+    // The consequence that actually matters. With no floor, a zeroed axis gives
+    // kalchm exactly 1, so ln(kalchm) is 0 and monica is undefined — which the
+    // §17c totality contract answers with φ, the equilibrium value. A floor moves
+    // kalchm off 1, so ln(kalchm) becomes non-zero and the engine returns a REAL
+    // NUMBER for a chart that has no defined monica. That is fabrication, not rescue.
+    const [S, E, M, Su] = [1, 1, 1, 0];
+    expect(exactKalchm(S, E, M, Su)).toBe(1);
+    expect(Math.log(exactKalchm(S, E, M, Su))).toBe(0);
+
+    expect(kalchmEps01(S, E, M, Su)).not.toBe(1);
+    expect(Math.log(kalchmEps01(S, E, M, Su))).toBeCloseTo(0.0460517, 6);
+    expect(kalchmEps1(S, E, M, Su)).not.toBe(1);
+    expect(Math.log(kalchmEps1(S, E, M, Su))).toBeCloseTo(0.2302585, 6);
+
+    // And the floored ln values are large enough to matter: eps=0.1 lands at
+    // 0.23, which is beyond the single-body healthy floor (0.2188) — so a
+    // degenerate chart floored at 0.1 does not merely look computable, it looks
+    // HEALTHY.
+    expect(Math.log(kalchmEps1(S, E, M, Su))).toBeGreaterThan(0.21878586815274545);
+  });
+});


### PR DESCRIPTION
Tooling only. No behaviour change, no dependency on #642 — this is independently mergeable.

## Why grep could not answer the question

`calculateKalchm` is declared in **four** places and `calculateKalchmResonance` in four more, so a grep for either name cannot tell which declaration a given call site reaches. Every caller count produced that way this session was unreliable, and none of them was acted on. This resolves call sites through the TypeScript type checker instead: callee symbol → follow import aliases → real declaration `file:line`.

## What it found that grep could not

**The most-used implementation is spelled differently.** `calculateKAlchm` — capital A — has **8 calling files and 10 calls** across two declarations, including three React components. A case-sensitive grep for `calculateKalchm` misses all 21 occurrences of it.

```
  8 files  10 calls  calculateKAlchm   monicaKalchmCalculations.ts:106  (floor 0.01)
                                       kalchmEngine.ts:161             (floor 0.1)
  8 files   9 calls  calculateKalchm   data/unified/alchemicalCalculations.ts  (canonical)
```

**The widest-diverging implementation is live.** `kalchmEngine.ts:161` floors at `0.1` and is reached from `menuPlanner/nutritionalCalculator.ts`.

**Three of five apparent zero-caller declarations are live** — referenced as *values* rather than called: `memoize(this._fn.bind(this))`, plus two plain imports. A resolver that only counted call expressions would have proposed deleting live code, so value references are tracked separately and nothing carrying one is listed as a deletion candidate.

Only one declaration survives as genuinely unreachable: `src/calculations/alchemicalCalculations.ts:246`. It took four checks to establish, each of which could have overturned the last — no static call, no value reference, its one importer (`dynamicImport.ts`) exposes it through a **string-dispatch** helper the checker cannot see, and that helper has zero callers with the string `"calculateKalchm"` appearing nowhere. It is also the implementation that returns **0** on a zeroed axis, making `ln(kalchm)` −Infinity and monica non-finite — a totality-contract violation that has never fired only because nothing reaches it.

## Both controls are asserted, not assumed

A zero-result report from a resolver that silently isn't resolving looks exactly like a clean codebase. So the script fails if the canonical declaration resolves zero callers, if it resolves only same-file callers (aliases not following), or if the `memoize`/`bind` case fails to show up as referenced-not-called.

It also reports unresolved calls by name rather than dropping them, and states plainly what it cannot see: config files and dynamic `import()`.

## The companion characterisation test

Imports the real functions rather than restating their formulas — a transcribed formula drifts the same way a transcribed constant does.

- On healthy input every implementation agrees **bit-for-bit**, so delegating them is a no-op for any chart with no zeroed axis.
- Where an axis is zero they diverge by exactly **`eps^(-eps) - 1` per zeroed axis, input-independent**: `0.6932%` at `eps=0.001`, `4.7129%` at `0.01`, `25.8925%` at `0.1`. Verified against four unrelated inputs. This replaces the sampled percentage quoted in earlier notes with a law that holds for the whole class.
- A floor only ever **inflates** kalchm — which decides the sign of `ln(kalchm)`, and so of monica.
- `eps=0.1` pushes a degenerate chart's `|ln kalchm|` to `0.2303`, **above** the measured single-body healthy floor of `0.2188`. So a degenerate chart floored at `0.1` does not merely look computable — it looks *healthy*.

## Verification

- `168` suites, `1436` tests, **0 failures**; `bun run typecheck` clean
- Read-only. Writes its JSON map only when given `--json <path>`, so running it leaves no artifact in the repo.

This is the prerequisite tooling for the delegation work and for the monica impostor rename, both of which need real caller attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
