### PR TITLE
fix(lint): unbreak master — the stranded one-line fix from #645

### DIFF
--- a/src/services/userDatabaseService.ts
+++ b/src/services/userDatabaseService.ts
@@ -90,7 +90,9 @@ export const jsonbOrNull = (value: unknown): string | null => {
   if (value === null || value === undefined) return null;
   if (Array.isArray(value)) return value.length > 0 ? JSON.stringify(value) : null;
   if (typeof value === "object") {
-    return Object.keys(value as object).length > 0 ? JSON.stringify(value) : null;
+    // No `as object` needed — `typeof value === "object"` narrows unknown to
+    // `object | null`, and null was already returned above.
+    return Object.keys(value).length > 0 ? JSON.stringify(value) : null;
   }
   return JSON.stringify(value);
 };


### PR DESCRIPTION
**master is currently red.** `bun run verify` fails on it:

```
src/services/userDatabaseService.ts
  93:24  error  This assertion is unnecessary since it does not change the type
                of the expression  @typescript-eslint/no-unnecessary-type-assertion
```

This is the one-line fix, cherry-picked from the commit it was already verified in.

## How it got onto master

A merge raced a follow-up push:

```
21:09:27Z   3a64529c committed   introduces jsonbOrNull, with the redundant `as object`
21:11:59Z   #645 MERGED          squashed with only that commit
21:18:42Z   edcc5483 committed   the lint fix — 7 minutes too late to be included
```

I pushed the fix to #645's branch and confirmed all checks green on `edcc5483`, which was true — but the PR had already been squash-merged, so the fix never reached master. A squash merge takes whatever the head was **at merge time**; pushing to a merged PR's branch changes nothing.

## How it surfaced

PR #646 showed two `Verify` checks on one commit — one pass, one fail. The `push` run builds the branch tip (clean, since the branch predates #645) while the `pull_request` run builds `refs/pull/646/merge` — the branch merged with the **current** base tip, which now carries the error. So every open PR inherits the failure through its merge ref, and #646's failure was not #646's fault.

## Verification

- `bun run verify` exits **0** (`rm .eslintcache` first — the cache masks fixes in this repo)
- the 12 `jsonbOrNull` tests still pass
- no behaviour change: `typeof value === "object"` already narrows `unknown` to `object | null`, and `null` returns on the line above, so the assertion changed nothing at runtime or in the type

🤖 Generated with [Claude Code](https://claude.com/claude-code)
