### PR TITLE
fix(agents): snapshots missed 3 columns — 694 rows were unrecoverable

### DIFF
--- a/scripts/backfillMonicaPerConstruction.ts
+++ b/scripts/backfillMonicaPerConstruction.ts
@@ -252,9 +252,16 @@ console.log(`\nsnapshotting to ${snapshot}, then migrating in one transaction...
 await client.query("BEGIN");
 try {
   await client.query(
+    // ⚠️ ALL SEVEN value columns. This SELECT captured only the pre-§18o set
+    // (constant/diurnal/nocturnal/method) until 2026-07-25, which made every
+    // snapshot it took unable to restore the 623 two-body and 71 full-chart rows
+    // — the exact populations this script rewrites. It looked fine: right row
+    // count, joinable on user_id, monica_constant matching.
     `CREATE TABLE ${snapshot} AS
-       SELECT up.user_id, up.name, up.monica_constant, up.monica_diurnal,
-              up.monica_nocturnal, up.monica_method, now() AS snapshotted_at
+       SELECT up.user_id, up.name,
+              up.monica_constant, up.monica_single, up.monica_two_body,
+              up.monica_full_chart, up.monica_diurnal, up.monica_nocturnal,
+              up.monica_method, now() AS snapshotted_at
          FROM user_profiles up JOIN users u ON u.id = up.user_id
         WHERE u.is_agent`,
   );
@@ -340,6 +347,7 @@ const check = await client.query<Record<string, string>>(
 console.log("\npost-write verification (monica_constant must be 0 for two-body/full-chart):");
 console.table(check.rows);
 console.log(`\nTo reverse: restore from ${snapshot} (it holds the pre-migration`);
-console.log(`monica_constant/diurnal/nocturnal/method for every agent row).`);
+console.log(`monica_constant/single/two_body/full_chart/diurnal/nocturnal/method`);
+console.log(`for every agent row — all seven value columns).`);
 
 await client.end();

--- a/scripts/snapshotAgentMonica.ts
+++ b/scripts/snapshotAgentMonica.ts
@@ -8,12 +8,28 @@
  *
  *   railway run --service Postgres -- bun scripts/snapshotAgentMonica.ts
  *
- * To restore a row from a snapshot:
+ * ⚠️ THIS SCRIPT WAS SILENTLY INCOMPLETE FROM §18o UNTIL 2026-07-25. It captured
+ * only monica_constant / monica_diurnal / monica_nocturnal / monica_method — the
+ * pre-split column set. §18o moved each construction into its own column, so
+ * every snapshot taken in between could not restore **623 two-body and 71
+ * full-chart rows**: their values simply were not in the table. The snapshots
+ * looked healthy (correct row count, joinable on user_id, monica_constant
+ * matching), which is why this went unnoticed across two of them.
+ *
+ * The lesson generalises: a snapshot is only a safety net for the columns it
+ * actually contains, and "the row is present" is not the same as "the value is
+ * recoverable". After ANY schema change that adds or splits a column, re-check
+ * this SELECT against `information_schema.columns` for user_profiles.
+ *
+ * To restore a row from a snapshot (all seven value columns):
  *   UPDATE user_profiles up SET
- *     monica_constant = s.monica_constant,
- *     monica_diurnal = s.monica_diurnal,
- *     monica_nocturnal = s.monica_nocturnal,
- *     monica_method = s.monica_method
+ *     monica_constant   = s.monica_constant,
+ *     monica_single     = s.monica_single,
+ *     monica_two_body   = s.monica_two_body,
+ *     monica_full_chart = s.monica_full_chart,
+ *     monica_diurnal    = s.monica_diurnal,
+ *     monica_nocturnal  = s.monica_nocturnal,
+ *     monica_method     = s.monica_method
  *   FROM agent_monica_snapshot_<timestamp> s
  *   WHERE up.user_id = s.user_id;
  */
@@ -41,10 +57,52 @@ console.log(`Creating ${tableName}...`);
 await client.query(`
   CREATE TABLE ${tableName} AS
   SELECT up.user_id, up.name, u.is_agent,
-         up.monica_constant, up.monica_diurnal, up.monica_nocturnal, up.monica_method,
+         -- ALL SEVEN value columns. monica_single / monica_two_body /
+         -- monica_full_chart were added by the §18o split and were missing here
+         -- until 2026-07-25; without them a snapshot cannot restore the two-body
+         -- or full-chart populations at all. Asserted below against
+         -- information_schema, so a future column cannot go missing silently.
+         up.monica_constant, up.monica_single, up.monica_two_body, up.monica_full_chart,
+         up.monica_diurnal, up.monica_nocturnal, up.monica_method,
          now() AS snapshotted_at
     FROM user_profiles up JOIN users u ON u.id = up.user_id
 `);
+
+/**
+ * COMPLETENESS GATE. Compare the snapshot's monica_* columns against the live
+ * table's. A snapshot missing a column looks perfectly healthy — right row count,
+ * joinable on user_id, monica_constant matching — while being unable to restore
+ * an entire population. That is exactly how two prior snapshots passed review.
+ *
+ * This throws AFTER the table is created, deliberately: the incomplete table is
+ * left behind as evidence rather than silently dropped, and no backfill should
+ * proceed on the strength of it.
+ */
+const { rows: colDiff } = await client.query<{ missing: string[] }>(
+  // ::text is load-bearing. information_schema.columns.column_name is
+  // `sql_identifier`, and node-postgres has no parser for sql_identifier[], so it
+  // hands back the raw string "{}" instead of an array — whose .length is 2, which
+  // made this gate fire on a COMPLETE snapshot and then crash on .join.
+  `SELECT coalesce(array_agg(live.column_name::text ORDER BY live.column_name), '{}') AS missing
+     FROM information_schema.columns live
+    WHERE live.table_name = 'user_profiles'
+      AND live.column_name LIKE 'monica%'
+      AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns snap
+         WHERE snap.table_name = $1 AND snap.column_name = live.column_name
+      )`,
+  [tableName],
+);
+if (colDiff[0].missing.length > 0) {
+  throw new Error(
+    `INCOMPLETE SNAPSHOT ${tableName}: user_profiles has monica columns this ` +
+      `snapshot does not capture: ${colDiff[0].missing.join(", ")}.\n` +
+      `Rows in those populations would be UNRECOVERABLE. Add them to the SELECT ` +
+      `above before running any backfill. The incomplete table has been left in ` +
+      `place as evidence — drop it manually once the fix is in.`,
+  );
+}
+console.log(`Column completeness: every monica_* column on user_profiles is captured.`);
 
 const { rows } = await client.query<{ n: string; agents: string; with_monica: string }>(
   `SELECT count(*)::text AS n,


### PR DESCRIPTION
Found while taking the pre-backfill snapshot for the #642 reconciliation — by actually **testing** that the snapshot could restore, rather than assuming it.

## Both snapshot writers were pre-§18o

They captured only `monica_constant` / `monica_diurnal` / `monica_nocturnal` / `monica_method`. §18o split each construction into its own column, so every snapshot taken since could not restore **623 two-body and 71 full-chart rows** — their values were never in the table.

The failure was invisible to every check that had been applied to it:

```
rows joinable back to user_profiles   5033   <- correct
differing monica_constant                0   <- correct
differing monica_method                  0   <- correct
monica_two_body captured                 0   <- nobody looked
monica_full_chart captured               0   <- nobody looked
```

**"The row is present" is not "the value is recoverable."** My notes already recorded that two of the three existing snapshot tables restore nothing; this is the cause, not just the symptom.

## The fix

Both writers now capture all seven value columns, and `snapshotAgentMonica.ts` carries a **completeness gate**: it diffs its own columns against `information_schema` for `user_profiles` and throws if any `monica_*` column is uncaptured, naming it. The gate runs *after* `CREATE` on purpose, so an incomplete table is left behind as evidence rather than vanishing.

⚠️ **The gate was wrong on my first attempt**, in a way worth recording. `information_schema.columns.column_name` is type `sql_identifier`, and node-postgres has no parser for `sql_identifier[]` — so `array_agg(...)` came back as the raw string `"{}"`, whose `.length` is `2`. The gate fired on a *complete* snapshot and then crashed on `.join`. The `::text` cast in the aggregate is load-bearing.

## Verified against production

Read-only apart from one transaction that was rolled back:

```
new snapshot captures all 7 value columns; gate reports complete
two-body restore proof:
  original   0.234595
  corrupted  999.999999
  restored   0.234595   MATCHES
  after ROLLBACK        prod untouched
recoverable rows: two_body 0 -> 623, full_chart 0 -> 71
```

`bun run verify` exits 0.

## Context

This landed mid-flight: the complete snapshot `agent_monica_snapshot_20260725_221953` was used as the real safety net for the #642 backfill, which then ran clean — drift 0 / missing 0 / wrong-method 0 across 5020 rows, and 23 integrity checks with 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
