### PR TITLE
physics: one kalchm engine per runtime — and the Python one was live

### DIFF
--- a/.github/workflows/monica-integrity.yml
+++ b/.github/workflows/monica-integrity.yml
@@ -58,8 +58,10 @@ jobs:
 
       - name: No stray kalchm formula
         # Exits non-zero on any NEW self-exponentiation (x^x) outside the canonical
-        # engine. 18 copies already exist and are allowlisted BY LOCATION with a
-        # per-file count and a reason; the list is only allowed to shrink.
+        # engine. The allowlist is now at its TARGET END STATE: exactly ONE entry,
+        # the characterisation test's own restatement of the definition, which it
+        # needs in order to measure anything against it. The list may shrink; it
+        # must not grow.
         #
         # This is the CODE-STRUCTURE witness, distinct from the two above: the
         # fallback scan catches a reader that invents a value, the data job catches
@@ -126,3 +128,18 @@ jobs:
         env:
           DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
         run: bun scripts/auditAgentDataIntegrity.ts
+
+      - name: No new cloned natal charts
+        # A THIRD data witness, watching a defect the other two cannot see: a
+        # chart REUSED as a fallback across several agents. Drift-clean by
+        # construction (the value is correctly derived from the chart it has) and
+        # structurally valid in SQL, so both existing witnesses pass on it.
+        #
+        # It is a GROWTH detector, not a unique index — two people can legitimately
+        # share a birth moment. It fails when the cloned-row count rises above the
+        # recorded baseline of 10, and also when it FALLS without KNOWN_GROUPS being
+        # updated, because a resolved clone changes the |max| population that the
+        # Sacred-7 full-chart scale is derived from.
+        env:
+          DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
+        run: bun scripts/checkNoNewClonedCharts.ts

--- a/NEXT_SESSION_PROMPT.md
+++ b/NEXT_SESSION_PROMPT.md
@@ -152,8 +152,13 @@ This is a product decision — merge-and-repoint / keep-both / delete-with-casca
 ## 6. Opportunistic
 
 - **3 deferred dead-exports** — re-verify live/dead *at deletion time*:
-  `core-energy-rules.ts` `GregsEnergyCalculator` (the file is LIVE — `galileo-logger`
-  uses `ANumberCalculator`, so this is a per-symbol removal),
+  `core-energy-rules.ts` `GregsEnergyCalculator` (⚠️ **CORRECTED 2026-07-26**: the
+  claim that this file is LIVE via `galileo-logger` → `ANumberCalculator` is
+  **REFUTED**. Three independent sweeps, each with a positive control, found no
+  live caller for any of its exports. This wrong rationale had already deferred
+  the file from a dead-code sweep TWICE. Its kalchm/monica now delegate to the
+  canonical engine — see §18r r2 — so the remaining question is plain dead-code
+  removal, not a per-symbol carve-out),
   `alchemicalEnergyMapping.ts` (re-exported at `src/constants/index.ts:6`),
   `UnifiedRecommendationService.ts` (imported by
   `src/services/__tests__/realPlanetaryRecommendations.test.ts` — delete both).

--- a/backend/alchm_kitchen/main.py
+++ b/backend/alchm_kitchen/main.py
@@ -504,6 +504,16 @@ MONICA_EQUILIBRIUM = 1.618
 # reactivities, which it is.
 KALCHM_EPSILON = 0.01
 
+# Floor for the heat/entropy/reactivity denominators, matching
+# THERMO_DEN_FLOOR in src/data/unified/alchemicalCalculations.ts. Unlike the
+# kalchm denominator (which cannot reach 0 because x^x >= 0.6922), these three
+# ARE genuinely reachable at 0, so a guard is required. It must be a FLOOR and
+# not the truthiness fallback `(den or 1)` this file used: `or 1` substitutes
+# 1 for a zero denominator, which is 100x smaller than the floored value and
+# therefore understates the quantity by 100x at exactly the point where it
+# matters most.
+THERMO_DEN_FLOOR = 0.01
+
 
 def compute_kalchm_monica(
     spirit: float,
@@ -740,14 +750,26 @@ def calculate_local_alchemize(request: AlchemizeRequest) -> Dict[str, Any]:
 
     heat_num = spirit ** 2 + fire ** 2
     heat_den = (substance + essence + matter + water + air + earth) ** 2
-    heat = heat_num / (heat_den or 1)
+    heat = heat_num / max(heat_den, THERMO_DEN_FLOOR)
 
     entropy_num = spirit ** 2 + substance ** 2 + fire ** 2 + air ** 2
     entropy_den = (essence + matter + earth + water) ** 2
-    entropy = entropy_num / (entropy_den or 1)
+    entropy = entropy_num / max(entropy_den, THERMO_DEN_FLOOR)
 
     reactivity_num = spirit ** 2 + substance ** 2 + essence ** 2 + fire ** 2 + air ** 2 + water ** 2
-    reactivity = (reactivity_num / (matter or 1)) + earth ** 2
+    # Reactivity = (S² + Su² + E² + F² + A² + W²) / (Matter + Earth)²
+    #
+    # This read `(reactivity_num / (matter or 1)) + earth ** 2` — the same
+    # expression with the parentheses lost, so Earth moved out of the
+    # denominator and became an additive term. MEASURED on
+    # (S,Su,E,F,A,W,M,Ea) = (4,1,3,2,1.5,1,2,0.5): 16.875 here versus 5.320
+    # canonical, a 3.17x divergence, which propagated straight into
+    # monica = -gregsEnergy / (reactivity * ln kalchm).
+    #
+    # Not a judgement call: all NINE TypeScript implementations use
+    # (Matter + Earth)², and the two forms coincide only when Earth = 0 and
+    # Matter = 1 — which is why it survived this long.
+    reactivity = reactivity_num / max((matter + earth) ** 2, THERMO_DEN_FLOOR)
     gregs_energy = heat - entropy * reactivity
 
     kalchm, monica = compute_kalchm_monica(

--- a/backend/alchm_kitchen/main.py
+++ b/backend/alchm_kitchen/main.py
@@ -479,6 +479,96 @@ PLANET_ALCHM_PERIODS = {
 PERIOD_LOG_MIN = math.log10(0.003)
 PERIOD_LOG_MAX = math.log10(247.94)
 
+# ── The kalchm/monica engine constants, ported from TypeScript ───────────────
+#
+# This is the SECOND runtime that computes kalchm, so these must stay pinned to
+# src/data/unified/alchemicalCalculations.ts. The shared golden vectors in
+# backend/tests/test_kalchm_parity.py assert both runtimes agree bit-for-bit;
+# change a value here and that test fails.
+#
+# DERIVED, not tuned: the midpoint of a MEASURED bimodal gap in |ln kalchm| over
+# the single-body grid (11 planets x 12 signs x 30 degrees x 2 sects = 7920
+# points, a census not a sample). The degenerate cluster ends at exactly 0 and
+# the healthy values begin at 0.21878586815274545. The TS side re-derives both
+# endpoints in src/__tests__/monicaLnEpsilonDerivation.test.ts and FAILS if the
+# grid moves — update this literal in lockstep, never independently.
+MONICA_LN_EPSILON = 0.10939293407637272
+
+# The harmonic-ideal monica (golden ratio), returned for a perfectly balanced
+# (degenerate) alchemical state. monica is TOTAL: it is always finite, and this
+# engine never returns None or NaN.
+MONICA_EQUILIBRIUM = 1.618
+
+# Divide-by-zero guard for reactivity. Not derived — reactivity has no bimodal
+# structure to place it in; its only requirement is being small relative to real
+# reactivities, which it is.
+KALCHM_EPSILON = 0.01
+
+
+def compute_kalchm_monica(
+    spirit: float,
+    essence: float,
+    matter: float,
+    substance: float,
+    reactivity: float,
+    gregs_energy: float,
+) -> tuple:
+    """The ONE kalchm/monica implementation in the Python runtime.
+
+    kalchm = (S^S * E^E) / (M^M * Su^Su),  monica = -gregsEnergy / (reactivity * ln kalchm)
+
+    Mirrors ``calculateKalchm`` / ``calculateMonica`` in
+    ``src/data/unified/alchemicalCalculations.ts``. Every behaviour below was
+    measured against that module over shared golden vectors; see
+    ``backend/tests/test_kalchm_parity.py``.
+
+    Three defects this replaces, each verified before removal:
+
+    1. ``(kalchm_denominator or 1)`` — a truthiness fallback. It was unreachable
+       for real input (x^x has a global minimum of 0.6922006275556402 at x=1/e,
+       so the denominator is never 0 for non-negative axes) and actively WRONG
+       for a negative one, because a complex denominator of 0+0j is falsy.
+    2. Unclamped negatives. Python's ``**`` returns a COMPLEX number for a
+       negative base with a fractional exponent — ``(-0.5) ** (-0.5)`` is
+       ``8.66e-17-1.414j`` — where JS ``Math.pow`` returns NaN. That complex
+       value then raised ``TypeError: '>' not supported between instances of
+       'complex' and 'int'``, surfacing as an HTTP 500. Clamping negatives to 0
+       makes the two runtimes agree in TYPE as well as value.
+    3. ``monica = 1.0`` — a fabricated literal, neither the equilibrium constant
+       nor an honest absence. Worse, the guard was the bare ``ln_k != 0``, which
+       excludes only the single point ln_k == 0 and does nothing about ln_k
+       merely SMALL: at kalchm = 1.00002 it returned -49999.5 where canonical
+       returns phi, a ~31000x error that is finite and plausible-looking, so it
+       survives every downstream ``isfinite`` check and reaches the database.
+    """
+    # Clamp NEGATIVES only. Zero passes through untouched because 0**0 is
+    # exactly 1 — the true limit of x^x — so a zeroed axis needs no handling.
+    def non_neg(x: float) -> float:
+        return x if x > 0 else 0.0
+
+    s = non_neg(spirit)
+    e = non_neg(essence)
+    m = non_neg(matter)
+    sub = non_neg(substance)
+
+    kalchm = ((s ** s) * (e ** e)) / ((m ** m) * (sub ** sub))
+    if not math.isfinite(kalchm) or kalchm <= 0:
+        return 1.0, MONICA_EQUILIBRIUM
+
+    # A degenerate BAND, not a bare `!= 0`. Inside it the chart is at
+    # equilibrium and monica is the golden ratio rather than a divergence.
+    ln_k = math.log(kalchm)
+    if abs(ln_k) < MONICA_LN_EPSILON:
+        return kalchm, MONICA_EQUILIBRIUM
+
+    safe_reactivity = reactivity
+    if abs(reactivity) < KALCHM_EPSILON:
+        safe_reactivity = math.copysign(KALCHM_EPSILON, reactivity if reactivity else 1.0)
+
+    monica = -gregs_energy / (safe_reactivity * ln_k)
+    # Totality: never NaN, never None, never infinite.
+    return kalchm, (monica if math.isfinite(monica) else MONICA_EQUILIBRIUM)
+
 PLANETARY_ALCHEMY = {
     "Sun": {"Spirit": 1, "Essence": 0, "Matter": 0, "Substance": 0},
     "Moon": {"Spirit": 0, "Essence": 1, "Matter": 1, "Substance": 0},
@@ -660,13 +750,9 @@ def calculate_local_alchemize(request: AlchemizeRequest) -> Dict[str, Any]:
     reactivity = (reactivity_num / (matter or 1)) + earth ** 2
     gregs_energy = heat - entropy * reactivity
 
-    kalchm_denominator = (matter ** matter) * (substance ** substance)
-    kalchm = ((spirit ** spirit) * (essence ** essence)) / (kalchm_denominator or 1)
-    monica = 1.0
-    if kalchm > 0 and math.isfinite(kalchm):
-        ln_k = math.log(kalchm)
-        if ln_k != 0 and reactivity != 0:
-            monica = -gregs_energy / (reactivity * ln_k)
+    kalchm, monica = compute_kalchm_monica(
+        spirit, essence, matter, substance, reactivity, gregs_energy
+    )
 
     element_total = max(1.0, fire + water + air + earth)
     elemental_properties = {
@@ -869,9 +955,13 @@ async def calculate_token_rates_endpoint(request: TokenRatesRequest):
     except Exception:
         pass
         
+    # kalchm 1.0 is the true degenerate value for a unit ESMS vector, and monica
+    # at that kalchm is the equilibrium constant — NOT 1.0, which was a
+    # fabricated literal. The four unit axes remain a declared convention for
+    # this rate endpoint rather than a measurement.
     return TokenRatesResult(
         Spirit=1.0, Essence=1.0, Matter=1.0, Substance=1.0,
-        kalchm=1.0, monica=1.0,
+        kalchm=1.0, monica=MONICA_EQUILIBRIUM,
         planetaryHour=planetary_hour,
         isDaytime=is_day
     )
@@ -910,8 +1000,12 @@ async def alchemize_current_moment(request: AlchemizeRequest):
             elementalProperties=result.get('elementalProperties', {}),
             thermodynamicProperties=result.get('thermodynamicProperties', {}),
             esms=result.get('esms', {}),
-            kalchm=result.get('kalchm', 0),
-            monica=result.get('monica', 0),
+            # No defaults: kalchm is > 0 by the totality contract and monica is
+            # always finite, so 0 is IMPOSSIBLE for either. A default here would
+            # turn a future upstream shape change into silent corruption
+            # instead of a loud KeyError.
+            kalchm=result['kalchm'],
+            monica=result['monica'],
             score=result.get('score', 0),
             normalized=result.get('normalized', False),
             confidence=result.get('confidence', 0),

--- a/backend/tests/kalchm_golden_vectors.json
+++ b/backend/tests/kalchm_golden_vectors.json
@@ -1,0 +1,162 @@
+{
+  "_comment": [
+    "SHARED golden vectors for the kalchm/monica engine. Read by BOTH runtimes:",
+    "  Python     backend/tests/test_kalchm_parity.py",
+    "  TypeScript src/__tests__/kalchmCrossRuntimeParity.test.ts",
+    "",
+    "This file is the contract. There is one kalchm engine per runtime, and the",
+    "only thing that keeps them from drifting apart is that both must reproduce",
+    "every vector below EXACTLY. Expected values were computed from the canonical",
+    "TypeScript implementation (src/data/unified/alchemicalCalculations.ts) and",
+    "are written as full-precision decimal strings, never toPrecision output, so",
+    "they round-trip through both JSON parsers unchanged.",
+    "",
+    "The regimes are chosen because they are where implementations actually",
+    "diverged in practice, not to be exhaustive:",
+    "  healthy        - all implementations already agree bit-for-bit here",
+    "  zeroed axis    - where every epsilon floor showed up (eps^-eps - 1 per axis)",
+    "  negative axis  - JS gives NaN, Python gives a COMPLEX number; both must clamp",
+    "  near-degenerate- the ~31000x monica error a missing band produces",
+    "  tiny reactivity- divide-by-near-zero"
+  ],
+  "constants": {
+    "MONICA_LN_EPSILON": 0.10939293407637272,
+    "MONICA_EQUILIBRIUM": 1.618,
+    "KALCHM_EPSILON": 0.01,
+    "X_POW_X_GLOBAL_MINIMUM": 0.6922006275556402
+  },
+  "vectors": [
+    {
+      "name": "healthy - a REAL production ESMS vector from POST /alchemize",
+      "spirit": 3.2772289332979954,
+      "essence": 5.482048975845337,
+      "matter": 4.3549306100522225,
+      "substance": 2.351311954308986,
+      "reactivity": 6.326,
+      "gregsEnergy": -1.5018,
+      "expectedKalchm": 121.49817994831771,
+      "expectedMonica": 0.04945962142181648
+    },
+    {
+      "name": "healthy - second independent point",
+      "spirit": 4,
+      "essence": 3,
+      "matter": 2,
+      "substance": 1,
+      "reactivity": 5.32,
+      "gregsEnergy": -2.0403,
+      "expectedKalchm": 1728,
+      "expectedMonica": 0.05144593495114522
+    },
+    {
+      "name": "one zeroed axis (Matter) - 0**0 is exactly 1, no floor",
+      "spirit": 3.2772289332979954,
+      "essence": 5.482048975845337,
+      "matter": 0,
+      "substance": 2.351311954308986,
+      "reactivity": 6.326,
+      "gregsEnergy": -1.5018,
+      "expectedKalchm": 73669.6711736147,
+      "expectedMonica": 0.02118264139473428
+    },
+    {
+      "name": "one zeroed axis (Spirit) - numerator side",
+      "spirit": 0,
+      "essence": 5.482048975845337,
+      "matter": 4.3549306100522225,
+      "substance": 2.351311954308986,
+      "reactivity": 6.326,
+      "gregsEnergy": -1.5018,
+      "expectedKalchm": 2.4839110308381294,
+      "expectedMonica": 0.26092793956910537
+    },
+    {
+      "name": "two zeroed axes (Matter and Substance)",
+      "spirit": 3.2772289332979954,
+      "essence": 5.482048975845337,
+      "matter": 0,
+      "substance": 0,
+      "reactivity": 6.326,
+      "gregsEnergy": -1.5018,
+      "expectedKalchm": 549990.2180348035,
+      "expectedMonica": 0.01796091572456522
+    },
+    {
+      "name": "all four axes zero - kalchm exactly 1, DEGENERATE, monica is phi",
+      "spirit": 0,
+      "essence": 0,
+      "matter": 0,
+      "substance": 0,
+      "reactivity": 0,
+      "gregsEnergy": 0,
+      "expectedKalchm": 1,
+      "expectedMonica": 1.618
+    },
+    {
+      "name": "balanced non-zero axes - kalchm exactly 1, still DEGENERATE",
+      "spirit": 1.3,
+      "essence": 1.3,
+      "matter": 1.3,
+      "substance": 1.3,
+      "reactivity": 4,
+      "gregsEnergy": -1,
+      "expectedKalchm": 1,
+      "expectedMonica": 1.618
+    },
+    {
+      "name": "NEAR-degenerate - inside the band. A bare ln_k != 0 test returned -49999.5 here.",
+      "spirit": 1,
+      "essence": 1.00002,
+      "matter": 1,
+      "substance": 1,
+      "reactivity": 1,
+      "gregsEnergy": 1,
+      "expectedKalchm": 1.000020000400004,
+      "expectedMonica": 1.618
+    },
+    {
+      "name": "negative Spirit - JS gives NaN, Python gives complex; both must clamp to 0",
+      "spirit": -0.5,
+      "essence": 5.482048975845337,
+      "matter": 4.3549306100522225,
+      "substance": 2.351311954308986,
+      "reactivity": 6.326,
+      "gregsEnergy": -1.5018,
+      "expectedKalchm": 2.4839110308381294,
+      "expectedMonica": 0.26092793956910537
+    },
+    {
+      "name": "all four axes negative - clamps to the all-zero degenerate case",
+      "spirit": -0.5,
+      "essence": -2,
+      "matter": -1,
+      "substance": -0.5,
+      "reactivity": 3,
+      "gregsEnergy": -1,
+      "expectedKalchm": 1,
+      "expectedMonica": 1.618
+    },
+    {
+      "name": "healthy kalchm with near-zero reactivity - guarded by KALCHM_EPSILON",
+      "spirit": 4,
+      "essence": 3,
+      "matter": 2,
+      "substance": 1,
+      "reactivity": 0.000001,
+      "gregsEnergy": -2.0403,
+      "expectedKalchm": 1728,
+      "expectedMonica": 27.36923739400925
+    },
+    {
+      "name": "healthy kalchm with exactly zero reactivity",
+      "spirit": 4,
+      "essence": 3,
+      "matter": 2,
+      "substance": 1,
+      "reactivity": 0,
+      "gregsEnergy": -2.0403,
+      "expectedKalchm": 1728,
+      "expectedMonica": 27.36923739400925
+    }
+  ]
+}

--- a/backend/tests/kalchm_golden_vectors.json
+++ b/backend/tests/kalchm_golden_vectors.json
@@ -23,7 +23,8 @@
     "MONICA_LN_EPSILON": 0.10939293407637272,
     "MONICA_EQUILIBRIUM": 1.618,
     "KALCHM_EPSILON": 0.01,
-    "X_POW_X_GLOBAL_MINIMUM": 0.6922006275556402
+    "X_POW_X_GLOBAL_MINIMUM": 0.6922006275556402,
+    "THERMO_DEN_FLOOR": 0.01
   },
   "vectors": [
     {
@@ -157,6 +158,83 @@
       "gregsEnergy": -2.0403,
       "expectedKalchm": 1728,
       "expectedMonica": 27.36923739400925
+    }
+  ],
+  "thermoVectors": [
+    {
+      "name": "healthy, Earth non-zero — where the parens loss shows",
+      "Spirit": 4,
+      "Essence": 3,
+      "Matter": 2,
+      "Substance": 1,
+      "Fire": 2,
+      "Water": 1,
+      "Air": 1.5,
+      "Earth": 0.5,
+      "expectedHeat": 0.24691358024691357,
+      "expectedEntropy": 0.5502958579881657,
+      "expectedReactivity": 5.32,
+      "expectedGregsEnergy": -2.680660384250128
+    },
+    {
+      "name": "Earth = 0, Matter = 1 — the coincidence point",
+      "Spirit": 4,
+      "Essence": 3,
+      "Matter": 1,
+      "Substance": 1,
+      "Fire": 2,
+      "Water": 1,
+      "Air": 1.5,
+      "Earth": 0,
+      "expectedHeat": 0.35555555555555557,
+      "expectedEntropy": 0.93,
+      "expectedReactivity": 33.25,
+      "expectedGregsEnergy": -30.56694444444445
+    },
+    {
+      "name": "Matter + Earth = 0 — denominator floor is load-bearing",
+      "Spirit": 4,
+      "Essence": 3,
+      "Matter": 0,
+      "Substance": 1,
+      "Fire": 2,
+      "Water": 1,
+      "Air": 1.5,
+      "Earth": 0,
+      "expectedHeat": 0.47337278106508873,
+      "expectedEntropy": 1.453125,
+      "expectedReactivity": 3325,
+      "expectedGregsEnergy": -4831.167252218935
+    },
+    {
+      "name": "all axes zero — every denominator floored",
+      "Spirit": 0,
+      "Essence": 0,
+      "Matter": 0,
+      "Substance": 0,
+      "Fire": 0,
+      "Water": 0,
+      "Air": 0,
+      "Earth": 0,
+      "expectedHeat": 0,
+      "expectedEntropy": 0,
+      "expectedReactivity": 0,
+      "expectedGregsEnergy": 0
+    },
+    {
+      "name": "real production vector",
+      "Spirit": 3.2772289332979954,
+      "Essence": 5.482048975845337,
+      "Matter": 4.3549306100522225,
+      "Substance": 2.351311954308986,
+      "Fire": 2.1,
+      "Water": 1.4,
+      "Air": 1.9,
+      "Earth": 1.2,
+      "expectedHeat": 0.05439956849681729,
+      "expectedEntropy": 0.1570283101870952,
+      "expectedReactivity": 1.8245874441960752,
+      "expectedGregsEnergy": -0.2321123146538833
     }
   ]
 }

--- a/backend/tests/test_kalchm_parity.py
+++ b/backend/tests/test_kalchm_parity.py
@@ -1,0 +1,154 @@
+"""Cross-runtime parity for the kalchm/monica engine.
+
+There is ONE kalchm implementation per runtime. Nothing in the type system or the
+build stops the Python one from drifting away from the TypeScript one, so the
+only real defence is that both must reproduce the same golden vectors EXACTLY.
+The TypeScript half of this pair is src/__tests__/kalchmCrossRuntimeParity.test.ts,
+and both read the same file — backend/tests/kalchm_golden_vectors.json.
+
+Assertions here are `==` on floats, deliberately. `pytest.approx` would pass
+against a value that is wrong in the 4th decimal, which is precisely the class of
+error this suite exists to catch: an epsilon floor at 0.01 inflates kalchm by
+4.7129% and every "close enough" comparison waves it through.
+"""
+import json
+import math
+import os
+
+import pytest
+
+from backend.alchm_kitchen.main import (
+    KALCHM_EPSILON,
+    MONICA_EQUILIBRIUM,
+    MONICA_LN_EPSILON,
+    compute_kalchm_monica,
+)
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+with open(os.path.join(_HERE, "kalchm_golden_vectors.json"), encoding="utf-8") as fh:
+    GOLDEN = json.load(fh)
+
+VECTORS = GOLDEN["vectors"]
+
+
+def test_golden_vector_file_is_populated():
+    """CONTROL. A parametrised test over an empty list PASSES, which would make a
+    broken loader indistinguishable from a green suite."""
+    assert len(VECTORS) >= 10, f"expected the full vector set, got {len(VECTORS)}"
+    names = [v["name"] for v in VECTORS]
+    assert len(set(names)) == len(names), "duplicate vector names"
+    # The regimes that actually caught bugs must all be represented.
+    joined = " ".join(names).lower()
+    for regime in ("healthy", "zeroed axis", "degenerate", "negative", "reactivity"):
+        assert regime in joined, f"golden vectors no longer cover the {regime!r} regime"
+
+
+def test_constants_match_the_shared_contract():
+    """The constants are DERIVED. If Python and the JSON disagree, one of them was
+    edited without the other and the whole comparison below is meaningless."""
+    assert MONICA_LN_EPSILON == GOLDEN["constants"]["MONICA_LN_EPSILON"]
+    assert MONICA_EQUILIBRIUM == GOLDEN["constants"]["MONICA_EQUILIBRIUM"]
+    assert KALCHM_EPSILON == GOLDEN["constants"]["KALCHM_EPSILON"]
+
+
+def test_monica_ln_epsilon_is_the_derived_midpoint():
+    """Re-derive rather than re-type. The band is the midpoint of a measured gap
+    whose lower endpoint is exactly 0 and whose upper endpoint is the healthy
+    floor; if someone replaces it with a round number this fails."""
+    single_body_degenerate_ln_ceiling = 0.0
+    single_body_healthy_ln_floor = 0.21878586815274545
+    expected = (single_body_degenerate_ln_ceiling + single_body_healthy_ln_floor) / 2
+    assert MONICA_LN_EPSILON == expected
+
+
+def test_x_pow_x_never_reaches_zero():
+    """The reason the engine needs no epsilon floor and no divide-by-zero guard:
+    x**x has a global minimum well above 0, so the denominator cannot be 0."""
+    minimum = min((i / 100000) ** (i / 100000) for i in range(1, 100001))
+    assert minimum == GOLDEN["constants"]["X_POW_X_GLOBAL_MINIMUM"]
+    assert 0.0**0.0 == 1.0  # the true limit of x^x, not a special case
+
+
+@pytest.mark.parametrize("v", VECTORS, ids=[v["name"] for v in VECTORS])
+def test_matches_canonical_typescript_exactly(v):
+    kalchm, monica = compute_kalchm_monica(
+        v["spirit"], v["essence"], v["matter"], v["substance"],
+        v["reactivity"], v["gregsEnergy"],
+    )
+    assert kalchm == v["expectedKalchm"], (
+        f"kalchm drifted from canonical TypeScript for {v['name']!r}: "
+        f"python {kalchm!r} vs expected {v['expectedKalchm']!r}"
+    )
+    assert monica == v["expectedMonica"], (
+        f"monica drifted from canonical TypeScript for {v['name']!r}: "
+        f"python {monica!r} vs expected {v['expectedMonica']!r}"
+    )
+
+
+@pytest.mark.parametrize("v", VECTORS, ids=[v["name"] for v in VECTORS])
+def test_totality_holds_for_every_vector(v):
+    """monica is TOTAL: always a finite float. Never None, never NaN, never
+    complex — Python's ** returns a COMPLEX number for a negative base with a
+    fractional exponent, so this is a real hazard here and not a formality."""
+    kalchm, monica = compute_kalchm_monica(
+        v["spirit"], v["essence"], v["matter"], v["substance"],
+        v["reactivity"], v["gregsEnergy"],
+    )
+    assert isinstance(kalchm, float) and not isinstance(kalchm, complex)
+    assert isinstance(monica, float) and not isinstance(monica, complex)
+    assert math.isfinite(kalchm) and kalchm > 0
+    assert math.isfinite(monica)
+
+
+def test_negative_axis_never_produces_a_complex_number():
+    """Regression for the runtime-divergence defect. Before the clamp,
+    (-0.5) ** (-0.5) returned (8.66e-17-1.414j); `complex or 1` is truthy so the
+    old fallback did not fire, and `kalchm > 0` then raised
+    TypeError: '>' not supported between instances of 'complex' and 'int',
+    surfacing as an HTTP 500 from POST /alchemize."""
+    assert isinstance((-0.5) ** (-0.5), complex)  # the hazard is real
+    for axes in [(-0.5, 1, 1, 1), (1, -0.5, 1, 1), (1, 1, -0.5, 1), (1, 1, 1, -0.5)]:
+        kalchm, monica = compute_kalchm_monica(*axes, 1.0, 1.0)
+        assert isinstance(kalchm, float) and not isinstance(kalchm, complex)
+        assert math.isfinite(kalchm) and kalchm > 0
+        assert math.isfinite(monica)
+
+
+def test_a_negative_axis_is_clamped_not_absolute_valued():
+    """Clamping to 0 and taking abs() are different operations, and one repo copy
+    got this wrong: abs() feeds |−0.5|^|−0.5| = 0.707 into the numerator where the
+    true limit contributes exactly 1."""
+    clamped, _ = compute_kalchm_monica(-0.5, 2, 1, 0.5, 1.0, 1.0)
+    zeroed, _ = compute_kalchm_monica(0.0, 2, 1, 0.5, 1.0, 1.0)
+    assert clamped == zeroed
+
+
+def test_near_degenerate_returns_phi_not_a_divergence():
+    """The defect a bare `ln_k != 0` guard leaves behind. At kalchm = 1.00002 the
+    raw formula gives -49999.5 — finite and plausible, so it survives every
+    downstream isfinite() check and reaches the database."""
+    kalchm, monica = compute_kalchm_monica(1.0, 1.00002, 1.0, 1.0, 1.0, 1.0)
+    assert abs(math.log(kalchm)) < MONICA_LN_EPSILON
+    assert monica == MONICA_EQUILIBRIUM
+    raw = -1.0 / (1.0 * math.log(kalchm))
+    assert abs(raw) > 10000  # what the old code returned
+    assert math.isfinite(raw)  # ...and why nothing downstream caught it
+
+
+def test_zeroed_axis_does_not_imply_kalchm_is_one():
+    """A zeroed axis is NEITHER SUFFICIENT NOR NECESSARY for kalchm == 1. This
+    claim sat false inside a passing test for two days because no assertion ever
+    covered it — the prose beside a green test proves nothing."""
+    zeroed_but_not_one, _ = compute_kalchm_monica(3.0, 5.0, 0.0, 2.0, 1.0, 1.0)
+    assert zeroed_but_not_one != 1.0
+
+    one_without_any_zero, _ = compute_kalchm_monica(1.3, 1.3, 1.3, 1.3, 1.0, 1.0)
+    assert one_without_any_zero == 1.0
+
+
+def test_no_truthiness_fallback_survives_on_the_denominator():
+    """`(denominator or 1)` was unreachable for real input. Assert the premise
+    directly so a future edit cannot quietly reintroduce it as 'defensive'."""
+    for m in (0.0, 0.5, 1 / math.e, 1.0, 5.0):
+        for su in (0.0, 0.5, 1 / math.e, 1.0, 5.0):
+            assert (m**m) * (su**su) > 0.4  # 0.6922^2 = 0.4791, comfortably clear

--- a/backend/tests/test_kalchm_parity.py
+++ b/backend/tests/test_kalchm_parity.py
@@ -21,6 +21,7 @@ from backend.alchm_kitchen.main import (
     KALCHM_EPSILON,
     MONICA_EQUILIBRIUM,
     MONICA_LN_EPSILON,
+    THERMO_DEN_FLOOR,
     compute_kalchm_monica,
 )
 
@@ -152,3 +153,76 @@ def test_no_truthiness_fallback_survives_on_the_denominator():
     for m in (0.0, 0.5, 1 / math.e, 1.0, 5.0):
         for su in (0.0, 0.5, 1 / math.e, 1.0, 5.0):
             assert (m**m) * (su**su) > 0.4  # 0.6922^2 = 0.4791, comfortably clear
+
+
+# ── Thermodynamic parity ────────────────────────────────────────────────────
+#
+# Added after the kalchm work uncovered that REACTIVITY had also drifted. The
+# Python form was `(reactivity_num / (matter or 1)) + earth ** 2` — the canonical
+# expression with the parentheses lost, so Earth left the denominator and became
+# an additive term. 3.17x on a representative input, and the two forms coincide
+# only when Earth == 0 and Matter == 1, which is why it survived.
+#
+# monica = -gregsEnergy / (reactivity * ln kalchm), so an identical kalchm engine
+# is NOT sufficient for identical monica. These pin the rest.
+
+THERMO_VECTORS = GOLDEN["thermoVectors"]
+
+
+def test_thermo_vector_file_is_populated():
+    """CONTROL, same reasoning as above: a parametrised test over [] passes."""
+    assert len(THERMO_VECTORS) >= 5
+    joined = " ".join(v["name"] for v in THERMO_VECTORS).lower()
+    # The regimes that distinguish the two reactivity forms must be present, or
+    # the suite would pass against the defect it exists to catch.
+    assert "coincidence point" in joined
+    assert "earth non-zero" in joined
+    assert "floor" in joined
+
+
+def _thermo(v):
+    """Mirrors calculate_local_alchemize's thermodynamic block."""
+    s, e, m, su = v["Spirit"], v["Essence"], v["Matter"], v["Substance"]
+    f, w, a, ea = v["Fire"], v["Water"], v["Air"], v["Earth"]
+    heat = (s**2 + f**2) / max((su + e + m + w + a + ea) ** 2, THERMO_DEN_FLOOR)
+    entropy = (s**2 + su**2 + f**2 + a**2) / max((e + m + ea + w) ** 2, THERMO_DEN_FLOOR)
+    reactivity = (s**2 + su**2 + e**2 + f**2 + a**2 + w**2) / max(
+        (m + ea) ** 2, THERMO_DEN_FLOOR
+    )
+    return heat, entropy, reactivity, heat - entropy * reactivity
+
+
+@pytest.mark.parametrize("v", THERMO_VECTORS, ids=[v["name"] for v in THERMO_VECTORS])
+def test_thermodynamics_match_canonical_exactly(v):
+    heat, entropy, reactivity, gregs = _thermo(v)
+    assert heat == v["expectedHeat"], f"heat drifted for {v['name']!r}"
+    assert entropy == v["expectedEntropy"], f"entropy drifted for {v['name']!r}"
+    assert reactivity == v["expectedReactivity"], (
+        f"reactivity drifted for {v['name']!r}: {reactivity!r} vs "
+        f"{v['expectedReactivity']!r} — check for the lost-parentheses form "
+        f"(num/matter)+earth**2"
+    )
+    assert gregs == v["expectedGregsEnergy"], f"gregsEnergy drifted for {v['name']!r}"
+
+
+def test_reactivity_is_not_the_lost_parens_form():
+    """Regression guard naming the exact defect, so a re-introduction is obvious
+    rather than showing up as a mystery numeric drift."""
+    s, su, e, f, a, w, m, ea = 4, 1, 3, 2, 1.5, 1, 2, 0.5
+    num = s**2 + su**2 + e**2 + f**2 + a**2 + w**2
+    correct = num / max((m + ea) ** 2, THERMO_DEN_FLOOR)
+    lost_parens = (num / (m or 1)) + ea**2
+    assert correct == 5.32
+    assert lost_parens == 16.875
+    assert _thermo(
+        {"Spirit": s, "Essence": e, "Matter": m, "Substance": su,
+         "Fire": f, "Water": w, "Air": a, "Earth": ea}
+    )[2] == correct
+
+
+def test_denominator_guard_is_a_floor_not_a_truthiness_fallback():
+    """`(den or 1)` and `max(den, 0.01)` differ by 100x at a zero denominator,
+    in the direction of understating the quantity."""
+    num = 25.0
+    assert num / max(0.0, THERMO_DEN_FLOOR) == 2500.0
+    assert num / (0.0 or 1) == 25.0

--- a/docs/physics/ALCHM_AGENTS_ETH_BRIEF_ROUND2.md
+++ b/docs/physics/ALCHM_AGENTS_ETH_BRIEF_ROUND2.md
@@ -1,0 +1,153 @@
+# Thermodynamics alignment — brief for AlchmAgentsETH, round 2
+
+**Authored** 2026-07-26 · **From** WhatToEatNext
+
+> ## ⚠️ Read this line before anything else
+>
+> **Pinned reference: `f919172fc2bbf660caa07d18002b33bd869997e2`**
+> (branch `claude/wten-thermodynamics-completion-852fa3`, PR
+> [#651](https://github.com/gregcastro23/WhatToEatNext/pull/651))
+>
+> Every file path and line number below is relative to **that commit**. A bare
+> filesystem path is *not* a reference to a version, and the reader cannot tell
+> they got the wrong one.
+>
+> This is not a hypothetical. Round 1's audit reported our canonical engine as
+> "still containing the older epsilon-floor implementation". That was **true of
+> the checkout it read** — `~/Desktop/WhatToEatNext-master` sits on a stale
+> feature branch, many commits behind — and **false of the project**. Resolve
+> this brief with `git show <sha>:<path>`, or fetch and check out the SHA.
+
+---
+
+## 1. Two corrections you earned
+
+Round 1's brief was wrong on both of these. Your audit was right to push back.
+
+**1a. Single-body degeneracy is NOT structural.** The brief said it tests
+`esms.Essence === 0`. It does not. Single-body degeneracy uses the **derived
+`|ln kalchm|` band**, `MONICA_LN_EPSILON = 0.10939293407637272` — itself the
+midpoint of a *measured* bimodal gap whose lower endpoint is now exactly 0. The
+`Essence === 0` set sits at `|ln k| ∈ [1.06, 5.55]`, far outside that band. The
+structural test belongs to **two-body only**, where it was right 206 of 648 times
+(32%) as a threshold and so was replaced by its cause.
+
+**1b. A zeroed axis does NOT imply `kalchm === 1`.** It is neither sufficient nor
+necessary. Of 5400 zeroed-axis grid cells, **4980 have `kalchm ≠ 1`**; of 660
+degenerate cells, **240 have no zeroed axis**. The only real condition is
+`S^S·E^E === M^M·Su^Su`. This claim lived inside a *passing* WTEN test for two
+days because no assertion covered it — fixed in WTEN #649.
+
+---
+
+## 2. The finding that likely applies to you
+
+**A second runtime was implementing the formula, and our gate could not see it.**
+
+WTEN's `scripts/checkNoStrayKalchmFormula.ts` is a **TypeScript** AST gate. It
+proved "one engine" convincingly and completely — for TypeScript. A Python
+FastAPI module at `backend/alchm_kitchen/main.py` had been serving production
+traffic the whole time.
+
+If AlchmAgentsETH has **Solidity, Rust, SQL or a notebook** touching these
+quantities, the same blind spot applies. Enumerate your runtimes explicitly
+rather than assuming the gate's scope equals the project's scope.
+
+### The cross-runtime hazard worth knowing
+
+```python
+(-0.5) ** (-0.5)   # Python → (8.659560562354934e-17-1.4142135623730951j)  COMPLEX
+```
+```js
+Math.pow(-0.5, -0.5)   // JS → NaN
+```
+
+The runtimes differ in **TYPE**, not merely in value. In our case a complex
+denominator made `complex or 1` truthy (so the fallback never fired) and then
+`kalchm > 0` raised `TypeError`, surfacing as an HTTP 500. **Do not infer
+cross-runtime agreement from a shared formula — test it.**
+
+We now pin both runtimes with shared golden vectors that each suite reads from
+one file:
+
+| file | role |
+|---|---|
+| `backend/tests/kalchm_golden_vectors.json` | the contract — 12 kalchm/monica + 5 thermodynamic vectors |
+| `backend/tests/test_kalchm_parity.py` | Python half |
+| `src/__tests__/kalchmCrossRuntimeParity.test.ts` | TypeScript half, owns the expected values |
+
+You are welcome to copy that file wholesale; it is deliberately runtime-neutral
+JSON. **Generate your expected values from your canonical implementation — do not
+transcribe ours.** On our first pass 9 of 12 hand-written monica values were
+wrong.
+
+### The most dangerous defect we found, in case you share it
+
+A bare `if ln_k != 0` guard instead of a **band**. It excludes exactly one point
+and does nothing about `ln_k` merely *small*:
+
+| kalchm | bare `!= 0` guard | correct (band) |
+|---|---|---|
+| 1.00002 | **−49999.5** | φ = 1.618 |
+
+That value is **finite and plausible**, so it survives every downstream
+`isfinite` / `Number.isFinite` check and lands in the database. A NaN at least
+announces itself. **Test the band, never the point.**
+
+### And one to check by inspection
+
+Our Python reactivity read `(reactivity_num / (matter or 1)) + earth ** 2` —
+the canonical `num / (Matter + Earth)²` **with the parentheses lost**, so Earth
+left the denominator and became an additive term. Measured 16.875 vs 5.320
+(**3.17×**). The two forms agree **only when Earth = 0 and Matter = 1**, which is
+why nobody noticed. Since `monica = −G/(R·ln K)`, this made monica un-matchable
+across runtimes even with an identical kalchm engine.
+
+Worth grepping for in any port of the thermodynamics.
+
+---
+
+## 3. Carried authorisations
+
+**3a. The nullable Monica/Kalchm migration — APPROVED, in a dedicated session.**
+`kalchmConstant NOT NULL` and `user_profiles.monicaConstant NOT NULL` currently
+make **ABSENT unrepresentable**, which is why registration writes `0.5`. You were
+right to revert rather than work around it. A literal substituted for an absent
+value invents data; propagate `null` and handle absence at the display layer.
+
+**3b. Remove the two unreachable tier labels — RULED.** Exhaustive enumeration of
+all 286 compositions proves the heuristic can only produce `[2.50, 5.21]`, so
+"Advanced" and "Master" are unattainable. Delete them rather than widen the range.
+
+---
+
+## 4. Method notes that cost us the most
+
+1. **A zero result is a claim requiring a control test.** Every false all-clear in
+   this programme came from a broken search, not clean code: unquoted
+   `--include=*.ts` (the shell expands it → zero matches, always); TS generic call
+   syntax putting the type argument before the paren so `grep 'fn('` misses the
+   declaration; ugrep silently rejecting backreferences. **Prove a search works by
+   making it find something you know exists, and say so.**
+2. **grep cannot attribute symbols.** `calculateKalchm` is declared in several
+   modules and `calculateKAlchm` (capital A) is a further, differently-cased
+   family. Use the type checker.
+3. **Before deleting anything as dead, try to REFUTE that.** We were instructed to
+   delete a file as unreachable; three verifiers with different lenses returned
+   REACHABLE 3/3, and an `export *` in a barrel turned out to be publishing that
+   file's *worst-in-repo* implementation as the public `calculateKalchm`. Prefer
+   delegation — it is reversible and fixes behaviour either way.
+4. **A green test does not validate the prose beside it.** If a comment states a
+   measurable relationship, assert it.
+
+---
+
+## 5. Round 3
+
+Not scheduled. WTEN's remaining open items (a partial unique index for the
+daily-yield guard, a provenance column, chart authoring for 10 cloned rows) are
+internal and do not block you.
+
+Full detail: `docs/physics/SYNTHESIS_MODEL.md` §18k (25 rulings), §18q (the
+second runtime), §18r (three corrections), §18s (the ephemeris gate) at the
+pinned SHA above.

--- a/docs/physics/SYNTHESIS_MODEL.md
+++ b/docs/physics/SYNTHESIS_MODEL.md
@@ -2214,3 +2214,149 @@ exists precisely for the part that is not.
   Acceptance bar ruled: characterisation tests BEFORE touching any shared table,
   and run the drift check either side of any change, since those tables feed
   every value now in production.
+
+### 18q. The second runtime — Python was live all along `[MEASURED 2026-07-26]`
+
+§18k k7 ruled that the formula lives in "one module per runtime, enforced by an
+AST gate". The gate is a **TypeScript** AST gate, and it structurally cannot see
+a second runtime. There is one, and it serves production traffic.
+
+**Deployment, proven end to end.** `railway.json` declares
+`builder: DOCKERFILE, dockerfilePath: backend/Dockerfile`; that Dockerfile's CMD
+is `uvicorn backend.alchm_kitchen.main:app`. The Railway service **WhatToEatNext**
+is Online; `/health` returns `{"service":"alchm-backend"}`; `/openapi.json` serves
+34 routes from that module. `POST /alchemize` returned kalchm
+**121.49817994831771** for a live request, which round-trips **exactly** to the
+formula at `main.py:663`. It was not dead scaffolding.
+
+**Its kalchm was already correct.** There was no epsilon floor — Python's `0**0`
+is 1 exactly as JS's is, and `(kalchm_denominator or 1)` was unreachable for real
+input because x^x ≥ 0.6922006275556402. The defects were elsewhere:
+
+| # | Defect | Measured consequence |
+|---|---|---|
+| 1 | `monica = 1.0` at exact degeneracy | 1.0 where canonical returns φ = 1.618 |
+| 2 | Bare `ln_k != 0`, **no degenerate band** | kalchm 1.00002 → monica **−49999.5** vs φ. A **~31,000×** error that is *finite and plausible*, so it passes every downstream `isfinite` check and reaches the database |
+| 3 | Unclamped negative axis | `(-0.5) ** (-0.5)` is a **complex number** in Python where JS gives NaN. `complex or 1` is truthy so the fallback never fired; `kalchm > 0` then raised TypeError → HTTP 500 |
+| 4 | `reactivity = (num / (matter or 1)) + earth**2` | **3.17×** divergence — see below |
+| 5 | `TokenRatesResult(... kalchm=1.0, monica=1.0)` from a bare `except: pass` | fabricated ESMS tuple |
+| 6 | `result.get('kalchm', 0)` | 0 is IMPOSSIBLE for kalchm under the totality contract |
+
+**Defect 4 is the instructive one.** `reactivity` should be
+`(S² + Su² + E² + F² + A² + W²) / (Matter + Earth)²`. The Python form is that
+expression **with the parentheses lost**, so Earth left the denominator and
+became an additive term. This is not a judgement call between two candidate
+definitions: **all nine TypeScript implementations** use `(Matter + Earth)²`
+(`data/unified/alchemicalCalculations.ts:227`, `calculations/gregsEnergy.ts:164`,
+`calculations/core/alchemicalEngine.ts:258`, `services/UnifiedScoringService.ts:582`,
+`lib/core-energy-rules.ts:185`, `utils/recommendation/ingredientRecommendation.ts:1158`
+and `:1256`, `app/recipes/[recipeId]/RecipeClient.tsx:441`,
+`calculations/alchemicalCalculations.ts:191`). Measured on
+(S,Su,E,F,A,W,M,Ea) = (4,1,3,2,1.5,1,2,0.5): **16.875 vs 5.320**. The two forms
+coincide **only when Earth = 0 and Matter = 1**, which is why it survived.
+
+Python also used `(den or 1)` on the heat and entropy denominators where
+canonical floors at `THERMO_DEN_FLOOR = 0.01`. Those differ at a zero
+denominator by a factor of **100**, in the direction of understating the value.
+
+**Fixed** by one `compute_kalchm_monica`, plus aligned thermodynamic
+denominators. Both runtimes are now pinned by shared golden vectors in
+`backend/tests/kalchm_golden_vectors.json` — 12 kalchm/monica vectors and 5
+thermodynamic vectors × 4 quantities — read by
+`backend/tests/test_kalchm_parity.py` and
+`src/__tests__/kalchmCrossRuntimeParity.test.ts`. Expected values are
+**generated from canonical**, not transcribed: 9 of 12 hand-written monica values
+were wrong on the first pass, which is k10 reproducing itself exactly.
+
+#### Rulings
+
+| # | Ruling | Basis |
+|---|---|---|
+| q1 | The formula lives in one module **per runtime**, and "per runtime" must be **enumerated**, not assumed. A TypeScript gate proves nothing about Python, SQL, Rust or a notebook. | MEASURED |
+| q2 | Cross-runtime agreement must be **tested, never inferred from a shared formula**. `(-0.5) ** (-0.5)` differs between JS and Python in **TYPE**, not just value. | MEASURED |
+| q3 | ⚠️ **A near-degenerate divergence is more dangerous than a NaN.** NaN announces itself; −49999.5 is finite, plausible, and survives every `isfinite` guard to reach the database. Test the BAND, never the point. | MEASURED |
+| q4 | Where implementations disagree, **count them**. Nine-to-one with a visible mechanism (lost parentheses) settles a question that prose argument would not. | MEASURED |
+
+### 18r. Corrections to §18k `[MEASURED 2026-07-26]`
+
+Three claims this programme acted on did not survive re-measurement. Recording
+them because the reversals are the more instructive record (§18k precedent).
+
+**r1 — "`src/calculations/alchemicalCalculations.ts` is UNREACHABLE; DELETE it."
+FALSE.** Three adversarial verifiers, each with a different lens, returned
+REACHABLE at high confidence, with an empirical deletion test:
+`src/calculations/index.ts:459` does `export * from "./alchemicalCalculations"`,
+and removing the file yields exactly one
+`TS2307: Cannot find module './alchemicalCalculations'`. Worse — the neighbouring
+`export * from "./core/kalchmEngine"` exports `calculateKAlchm` (**capital A**), a
+*different identifier*, so no name collision shadowed it and
+`import { calculateKalchm } from "@/calculations"` bound to **this** file: the
+copy that returned **0** at a zeroed axis, making `ln(kalchm)` −Infinity. **The
+barrel was publicly exporting the worst implementation in the repo.** Delegated,
+not deleted. Deletion is a one-way door; delegation fixes the behaviour either
+way and is reversible.
+
+**r2 — "`src/lib/core-energy-rules.ts` is live via galileo-logger
+ANumberCalculator." FALSE.** Refuted by three independent sweeps, each with a
+positive control. It has no live callers at all. The claim had been used **twice**
+to defer the file from dead-code sweeps. Of its four alleged defects, three
+confirmed (sign destruction via `Math.abs`, a parity-based sign flip letting
+kalchm go negative, a `return NaN` violating totality); the fourth —
+`Math.log(Math.abs(k))` masking negativity — is **misdescribed**: the
+`kalchmConstant > 0` guard on the preceding line rejects a negative first, so that
+line is unreachable with a negative argument.
+
+**r3 — the persisted-value partition.** Measured by AST walk with an exact
+round-trip test at each value's own stored precision: **967 reproducible / 198
+placeholders**, not 540 / 203 / 423. The "423 unverifiable, inputs never
+persisted" population **does not exist** — those values reproduce exactly from
+ESMS stored beside them. The work item to persist their inputs is therefore
+unnecessary, the same way k13's 4940-row migration was cancelled.
+
+Also re-measured: `natal_positions` is an **empty array** (not a partial chart)
+for Mars Gemini and Moon Cancer; **285** agents hold monica_constant exactly 0,
+not 284; and the agent population moved **5028 → 5032 → 5057 within four hours**,
+which is k-level evidence for never quoting a count from a document.
+
+### 18s. The ephemeris gate — it passes, but not for the reason expected `[MEASURED 2026-07-26]`
+
+§18k k20 gated chart authoring on validating `astronomy-engine` outside its
+documented ~1700–2200 window. **Validated against JPL Horizons (DE441),
+56 body-date pairs across the 8 ancients × 7 bodies:**
+
+| | result |
+|---|---|
+| SIGN mismatches | **0 of 56** |
+| DEGREE mismatches | 4 of 56 (7.1%) |
+| worst deviation | **0.4533°** (Moon) |
+| controls (J2000, 1875) | ≤ 0.0011° |
+
+Since the ESMS vector is driven by **sign**, ancient charts are defensible at
+sign granularity. k20 is **cleared** — but two other things nearly produced a
+wrong answer, and one of them is the real blocker:
+
+1. **Horizons returns rows sorted by JD, not in TLIST order.** Zipping
+   positionally reported **26 sign mismatches** — entirely artefact. Caught only
+   because a control row mapped J2000 to 1875. Join on the echoed JD
+   (`CAL_FORMAT='JD'`), never on array position.
+2. **Calendar convention dwarfs ephemeris error by two orders of magnitude.**
+   JS `Date` is proleptic Gregorian; historical dates are quoted in the **Julian**
+   calendar. The same JD reads as May 21 (Gregorian) and May 26 (Julian) — a
+   5-day gap, which is ~4.9° of Sun and **~66° of Moon, more than two signs.**
+3. Outer-planet **body-centre** ephemerides (Horizons 499/599/699) do not exist
+   before **AD 1600**; ancient work needs the barycentres (4/5/6).
+
+**So the blocker for the 8 ancients is date ATTESTATION, not ephemeris
+accuracy.** A Sun-degree → date inversion (measured: exact round-trip,
+sub-arcsecond, at 750 BC) structurally removes hazard 2, because it never
+constructs a calendar date — but it cannot supply the year, and a 1° Sun window
+(±0.5 day) leaves the Moon spanning **14.28°**: degree unrecoverable, ~48% chance
+of straddling a sign boundary. Pairing it with an attested lunar-calendar day
+(Plato's traditional 7 Thargelion → Sun–Moon elongation) is what would pin the
+Moon.
+
+| # | Ruling |
+|---|---|
+| s1 | An external ephemeris comparison must **join on an explicit key**. Row order is not a contract, and a positional zip fails silently and spectacularly. |
+| s2 | For any pre-1582 date, state the **calendar** as explicitly as the timezone. Going longitude → JD avoids the question entirely and is preferred. |
+| s3 | Authoring a chart from a declared convention is acceptable **only if the convention is recorded as the basis**. The same guess inside a birth date reads as a fact; inside `basis=DERIVED` it reads as what it is. |

--- a/scripts/checkNoNewClonedCharts.ts
+++ b/scripts/checkNoNewClonedCharts.ts
@@ -1,0 +1,172 @@
+/**
+ * CI detector: does any NEW group of agents share one natal chart?
+ *
+ * ── Why this is a growth detector and not a unique index ─────────────────────
+ *
+ * Two people can legitimately share a birth moment, so identical
+ * `natal_positions` is not by itself an error and a UNIQUE constraint would be
+ * wrong. What IS an error is a chart being REUSED as a fallback — which is what
+ * produced the two groups this repo already carries:
+ *
+ *   8 agents (Alexander, Archimedes, Aristotle, Herodotus, Homer, Caesar,
+ *     Cicero, Plato) share ONE chart, monica_full_chart 0.003160
+ *   2 agents (Jung, Kahlo) share a chart in which ALL TEN bodies sit at
+ *     Aries 0°, degree 0 — degenerate, not merely duplicated
+ *
+ * So the gate asserts the known baseline and fails when the count GROWS.
+ *
+ * ── Why it matters beyond tidiness ──────────────────────────────────────────
+ *
+ * A |max|-derived constant is hostage to its least-trustworthy row. The
+ * Jung/Kahlo chart holds the full-chart population maximum (0.033702); including
+ * it would set the Sacred-7 full-chart scale to 0.0168, against 0.0047205 from
+ * the 61 rows with distinct charts — a 3.6× error of exactly the kind that has
+ * shipped before. A cloned chart is therefore a live hazard to a constant, not
+ * just duplicated data.
+ *
+ * ── Controls ────────────────────────────────────────────────────────────────
+ *
+ * A zero result here is a claim requiring a control test, because a broken query
+ * and a clean database are indistinguishable from the outside. This script
+ * therefore asserts that it can (a) reach a populated agent table at all,
+ * (b) see chart-bearing agents, and (c) still detect the two clone groups it
+ * already knows about. If any control fails it exits non-zero and says the scan
+ * was unsound — it never reports "clean".
+ *
+ * Read-only. Never writes.
+ *
+ *   railway run --service Postgres -- bun scripts/checkNoNewClonedCharts.ts
+ */
+import pg from "pg";
+
+/** The clone groups that exist as of 2026-07-26 and are tracked, not new. */
+const KNOWN_GROUPS: Array<{ size: number; note: string }> = [
+  { size: 8, note: "the 8 ancients sharing one fallback chart" },
+  { size: 2, note: "Jung + Kahlo, all ten bodies at Aries 0° (degenerate)" },
+];
+const KNOWN_CLONED_ROWS = KNOWN_GROUPS.reduce((n, g) => n + g.size, 0); // 10
+
+interface CloneRow {
+  chart_hash: string;
+  n_agents: string;
+  agents: string;
+  monica_full_chart: string | null;
+  distinct_positions: string;
+}
+
+const fail = (msg: string): never => {
+  console.error(`\n✗ ${msg}`);
+  process.exit(1);
+};
+
+const url = process.env.DATABASE_PUBLIC_URL ?? process.env.DATABASE_URL;
+if (!url) fail("no DATABASE_PUBLIC_URL / DATABASE_URL in the environment");
+
+const client = new pg.Client({
+  connectionString: url,
+  ssl: { rejectUnauthorized: false },
+});
+await client.connect();
+
+try {
+  // ── Control 1: the agent population is reachable and non-empty ────────────
+  const pop = await client.query<{ agents: string; with_chart: string }>(`
+    SELECT COUNT(*) AS agents,
+           COUNT(*) FILTER (
+             WHERE jsonb_typeof(up.natal_positions) = 'array'
+               AND jsonb_array_length(up.natal_positions) > 0
+           ) AS with_chart
+      FROM user_profiles up
+      JOIN users u ON u.id = up.user_id
+     WHERE u.is_agent = true
+  `);
+  const agents = Number(pop.rows[0]?.agents ?? 0);
+  const withChart = Number(pop.rows[0]?.with_chart ?? 0);
+
+  if (agents === 0) {
+    fail(
+      "CONTROL FAILED: zero agent rows. The scan cannot distinguish a clean " +
+        "database from a broken query, so this is not an all-clear.",
+    );
+  }
+  if (withChart === 0) {
+    fail(
+      `CONTROL FAILED: ${agents} agents but ZERO with a chart. Either the ` +
+        "natal_positions shape changed or the predicate is wrong — a clone " +
+        "scan over an empty set trivially finds nothing.",
+    );
+  }
+  console.log(`✓ control: ${agents} agents, ${withChart} carrying a chart`);
+
+  // ── The scan ──────────────────────────────────────────────────────────────
+  const dupes = await client.query<CloneRow>(`
+    SELECT md5(up.natal_positions::text)      AS chart_hash,
+           COUNT(*)                           AS n_agents,
+           MIN(up.monica_full_chart::text)    AS monica_full_chart,
+           string_agg(u.name, ' | ' ORDER BY u.name) AS agents,
+           MIN((
+             SELECT COUNT(DISTINCT (p->>'sign') || '@' || (p->>'degree'))
+               FROM jsonb_array_elements(up.natal_positions) p
+           ))::text                           AS distinct_positions
+      FROM user_profiles up
+      JOIN users u ON u.id = up.user_id
+     WHERE u.is_agent = true
+       AND jsonb_typeof(up.natal_positions) = 'array'
+       AND jsonb_array_length(up.natal_positions) > 0
+     GROUP BY md5(up.natal_positions::text)
+    HAVING COUNT(*) > 1
+     ORDER BY COUNT(*) DESC
+  `);
+
+  const clonedRows = dupes.rows.reduce((n, r) => n + Number(r.n_agents), 0);
+
+  // ── Control 2: the detector still finds what it is known to find ──────────
+  // If the known groups vanish, either they were legitimately fixed (in which
+  // case update KNOWN_GROUPS in the same commit) or the query silently broke.
+  // Both need a human, so neither may pass quietly.
+  if (clonedRows < KNOWN_CLONED_ROWS) {
+    console.log(
+      `\n⚠ Found ${clonedRows} cloned rows, FEWER than the ${KNOWN_CLONED_ROWS} ` +
+        "recorded baseline.",
+    );
+    console.log(
+      "  If clone groups were resolved, update KNOWN_GROUPS in this file in the " +
+        "same commit — and RE-MEASURE the Sacred-7 full-chart scale, because new " +
+        "distinct charts change the |max| population it is derived from.",
+    );
+    fail(
+      "baseline moved down without the constant being updated — treat as unsound, not clean",
+    );
+  }
+
+  for (const r of dupes.rows) {
+    const degenerate = Number(r.distinct_positions) === 1;
+    console.log(
+      `\n  ${r.n_agents} agents share chart ${r.chart_hash.slice(0, 12)}…` +
+        `  monica_full_chart=${r.monica_full_chart ?? "NULL"}` +
+        (degenerate ? "  ⚠ DEGENERATE (every body at one position)" : ""),
+    );
+    console.log(`     ${r.agents}`);
+  }
+
+  if (clonedRows > KNOWN_CLONED_ROWS) {
+    console.log(
+      `\n✗ ${clonedRows - KNOWN_CLONED_ROWS} NEW cloned chart row(s) since the ` +
+        `baseline of ${KNOWN_CLONED_ROWS}.`,
+    );
+    console.log(
+      "  A chart reused as a fallback is not a coincidence of birth moments. It " +
+        "also poisons any |max|-derived constant: the existing Jung/Kahlo clone " +
+        "holds the full-chart maximum, and including it would set the Sacred-7 " +
+        "scale 3.6× wrong.",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `\n✓ ${clonedRows} cloned row(s) in ${dupes.rows.length} group(s) — matches ` +
+      "the recorded baseline exactly, no new clones",
+  );
+} finally {
+  await client.end();
+}

--- a/scripts/checkNoStrayKalchmFormula.ts
+++ b/scripts/checkNoStrayKalchmFormula.ts
@@ -42,54 +42,12 @@ const CANONICAL = "src/data/unified/alchemicalCalculations.ts";
  * gate exists to prevent. Delegate to the canonical engine instead.
  */
 const ALLOWLIST: Record<string, { count: number; why: string }> = {
-  // ── characterised: floor strategy measured, divergence known ──────────────
-  "src/utils/monicaKalchmCalculations.ts": {
-    count: 4,
-    why: "calculateKAlchm, floor 0.01 (+4.7129% at a zeroed axis). 8 calling files incl. 3 React components — the most-used copy in the repo.",
-  },
-  "src/calculations/core/kalchmEngine.ts": {
-    count: 4,
-    why: "calculateKAlchm, floor 0.1 (+25.8925%). Its floored |ln kalchm| of 0.2303 exceeds the healthy floor 0.2188, so a degenerate chart reads as HEALTHY. Highest-priority delegation.",
-  },
-  "src/data/unified/ingredients.ts": {
-    count: 4,
-    why: "file-local calculateKalchm, floor 0.001 (+0.6932%). One caller, same file.",
-  },
-  "src/data/unified/flavorProfileMigration.ts": {
-    count: 4,
-    why: "file-local calculateKalchm. Not a floor — returns 1.0 when Matter or Substance is 0, which at least keeps monica defined at the equilibrium value.",
-  },
-  "src/calculations/alchemicalCalculations.ts": {
-    count: 4,
-    why: "UNREACHABLE (verified: no call, no value reference, no string dispatch). Returns 0 at a zeroed axis => ln(kalchm) -Infinity => monica non-finite, a totality-contract violation. DELETE rather than delegate.",
-  },
-
-  // ── found by this gate, NOT yet characterised ─────────────────────────────
-  // ⚠️ These were missed by the earlier grep-based audits that reported "8
-  // duplicates". Each still needs its zero-axis behaviour measured before it can
-  // be delegated. Do not assume they match any of the strategies above.
-  "src/calculations/core/alchemicalEngine.ts": { count: 4, why: "not yet characterised" },
-  "src/data/unified/recipeBuilding.ts": { count: 4, why: "not yet characterised" },
-  "src/lib/core-energy-rules.ts": {
-    count: 4,
-    why: "not yet characterised. Live via galileo-logger ANumberCalculator — previously deferred from a dead-code sweep for that reason.",
-  },
-  "src/services/RealAlchemizeService.ts": {
-    count: 8,
-    why: "TWO copies. The production ESMS path — treat any change here as behaviour-affecting for live surfaces.",
-  },
-  "src/services/UnifiedScoringService.ts": { count: 4, why: "not yet characterised" },
-  "src/utils/alchemy/derivedStats.ts": { count: 8, why: "TWO copies. Not yet characterised." },
-  "src/utils/astrologyUtils.ts": {
-    count: 4,
-    why: "not yet characterised. NO floor at all (Math.pow(Spirit, Spirit) on the raw axes), so post-#642 it may already agree with canonical exactly.",
-  },
-  "src/utils/recommendation/ingredientRecommendation.ts": {
-    count: 12,
-    why: "THREE copies in one file (:1109, :1182, :1280). The worst single concentration in the repo.",
-  },
-
   // ── legitimate restatements ───────────────────────────────────────────────
+  //
+  // This is the END STATE the gate was built for: ONE entry. Every other copy
+  // has been delegated to src/data/unified/alchemicalCalculations.ts.
+  //
+  // The list may SHRINK. It must not grow.
   "src/__tests__/kalchmFloorDivergence.test.ts": {
     count: 4,
     why: "the characterisation test's own reference implementation of the DEFINITION (no floor). It must restate the formula in order to measure the others against it.",

--- a/src/__tests__/kalchmCrossRuntimeParity.test.ts
+++ b/src/__tests__/kalchmCrossRuntimeParity.test.ts
@@ -24,6 +24,7 @@ import { readFileSync } from "fs";
 import { join } from "path";
 
 import {
+  calculateThermodynamics,
   KALCHM_EPSILON,
   MONICA_EQUILIBRIUM,
   MONICA_LN_EPSILON,
@@ -53,7 +54,18 @@ const GOLDEN = JSON.parse(
 ) as {
   constants: Record<string, number>;
   vectors: GoldenVector[];
+  thermoVectors: ThermoVector[];
 };
+
+interface ThermoVector {
+  name: string;
+  Spirit: number; Essence: number; Matter: number; Substance: number;
+  Fire: number; Water: number; Air: number; Earth: number;
+  expectedHeat: number;
+  expectedEntropy: number;
+  expectedReactivity: number;
+  expectedGregsEnergy: number;
+}
 
 describe("kalchm cross-runtime parity", () => {
   // CONTROL. `it.each([])` is a silent no-op, so an empty or unreadable vector
@@ -199,5 +211,59 @@ describe("kalchm cross-runtime parity", () => {
     const unguarded = -1 / (1 * Math.log(kalchm));
     expect(Math.abs(unguarded)).toBeGreaterThan(10000);
     expect(Number.isFinite(unguarded)).toBe(true);
+  });
+});
+
+describe("thermodynamic cross-runtime parity", () => {
+  // Added after the kalchm work uncovered that REACTIVITY had drifted too. The
+  // Python form was `(reactivity_num / (matter or 1)) + earth ** 2` — canonical
+  // with the parentheses lost, so Earth left the denominator and became an
+  // additive term. Since monica = -gregsEnergy / (reactivity · ln kalchm), an
+  // identical kalchm engine is NOT sufficient for identical monica.
+  it("loaded thermo vectors covering the regimes that separate the two forms", () => {
+    expect(GOLDEN.thermoVectors.length).toBeGreaterThanOrEqual(5);
+    const joined = GOLDEN.thermoVectors.map((v) => v.name).join(" ").toLowerCase();
+    expect(joined).toContain("coincidence point");
+    expect(joined).toContain("earth non-zero");
+    expect(joined).toContain("floor");
+  });
+
+  it.each(GOLDEN.thermoVectors.map((v) => [v.name, v] as const))(
+    "reproduces %s exactly",
+    (_name, v) => {
+      const t = calculateThermodynamics(
+        { Spirit: v.Spirit, Essence: v.Essence, Matter: v.Matter, Substance: v.Substance } as never,
+        { Fire: v.Fire, Water: v.Water, Air: v.Air, Earth: v.Earth } as never,
+      );
+      expect(t.heat).toBe(v.expectedHeat);
+      expect(t.entropy).toBe(v.expectedEntropy);
+      expect(t.reactivity).toBe(v.expectedReactivity);
+      expect(t.gregsEnergy).toBe(v.expectedGregsEnergy);
+    },
+  );
+
+  it("does not use the lost-parentheses reactivity form", () => {
+    // Named explicitly so a re-introduction reads as the known defect rather
+    // than as a mystery numeric drift.
+    const [S, Su, E, F, A, W, M, Ea] = [4, 1, 3, 2, 1.5, 1, 2, 0.5];
+    const num = S ** 2 + Su ** 2 + E ** 2 + F ** 2 + A ** 2 + W ** 2;
+    const correct = num / Math.max((M + Ea) ** 2, GOLDEN.constants.THERMO_DEN_FLOOR);
+    const lostParens = num / (M || 1) + Ea ** 2;
+    expect(correct).toBe(5.32);
+    expect(lostParens).toBe(16.875);
+
+    const t = calculateThermodynamics(
+      { Spirit: S, Essence: E, Matter: M, Substance: Su } as never,
+      { Fire: F, Water: W, Air: A, Earth: Ea } as never,
+    );
+    expect(t.reactivity).toBe(correct);
+  });
+
+  it("floors the thermo denominators rather than falling back to 1", () => {
+    // `(den || 1)` and `Math.max(den, 0.01)` differ by 100x at a zero
+    // denominator, understating the quantity exactly where it matters most.
+    const num = 25;
+    expect(num / Math.max(0, GOLDEN.constants.THERMO_DEN_FLOOR)).toBe(2500);
+    expect(num / (0 || 1)).toBe(25);
   });
 });

--- a/src/__tests__/kalchmCrossRuntimeParity.test.ts
+++ b/src/__tests__/kalchmCrossRuntimeParity.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Cross-runtime parity for the kalchm/monica engine — the TypeScript half.
+ *
+ * The formula is implemented ONCE PER RUNTIME: canonically in
+ * `src/data/unified/alchemicalCalculations.ts`, and in Python in
+ * `backend/alchm_kitchen/main.py` (`compute_kalchm_monica`), which is LIVE —
+ * railway.json builds backend/Dockerfile, whose CMD is
+ * `uvicorn backend.alchm_kitchen.main:app`, and POST /alchemize serves real
+ * computed values from it.
+ *
+ * Nothing in either build stops those two from drifting apart. The only defence
+ * is that both must reproduce the SAME golden vectors exactly, so both tests
+ * read the same file and this one owns the expected values.
+ *
+ * The Python half is `backend/tests/test_kalchm_parity.py`. If you change a
+ * vector here, that suite fails until Python agrees — which is the point.
+ *
+ * Assertions are `toBe` on numbers, deliberately. `toBeCloseTo(…, 15)` once
+ * passed against three separately WRONG constants, and an epsilon floor at 0.01
+ * inflates kalchm by 4.7129% — a difference any tolerant comparison waves
+ * through.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import {
+  KALCHM_EPSILON,
+  MONICA_EQUILIBRIUM,
+  MONICA_LN_EPSILON,
+  SINGLE_BODY_DEGENERATE_LN_CEILING,
+  SINGLE_BODY_HEALTHY_LN_FLOOR,
+  calculateKalchm,
+  calculateMonica,
+} from "@/data/unified/alchemicalCalculations";
+
+interface GoldenVector {
+  name: string;
+  spirit: number;
+  essence: number;
+  matter: number;
+  substance: number;
+  reactivity: number;
+  gregsEnergy: number;
+  expectedKalchm: number;
+  expectedMonica: number;
+}
+
+const GOLDEN = JSON.parse(
+  readFileSync(
+    join(process.cwd(), "backend/tests/kalchm_golden_vectors.json"),
+    "utf8",
+  ),
+) as {
+  constants: Record<string, number>;
+  vectors: GoldenVector[];
+};
+
+describe("kalchm cross-runtime parity", () => {
+  // CONTROL. `it.each([])` is a silent no-op, so an empty or unreadable vector
+  // file would leave this whole suite green while testing nothing.
+  it("loaded a populated vector set covering every divergence regime", () => {
+    expect(GOLDEN.vectors.length).toBeGreaterThanOrEqual(10);
+    const names = GOLDEN.vectors.map((v) => v.name);
+    expect(new Set(names).size).toBe(names.length);
+    const joined = names.join(" ").toLowerCase();
+    for (const regime of [
+      "healthy",
+      "zeroed axis",
+      "degenerate",
+      "negative",
+      "reactivity",
+    ]) {
+      expect(joined).toContain(regime);
+    }
+  });
+
+  it("pins the shared constants, so neither runtime can edit one alone", () => {
+    expect(MONICA_LN_EPSILON).toBe(GOLDEN.constants.MONICA_LN_EPSILON);
+    expect(MONICA_EQUILIBRIUM).toBe(GOLDEN.constants.MONICA_EQUILIBRIUM);
+    expect(KALCHM_EPSILON).toBe(GOLDEN.constants.KALCHM_EPSILON);
+  });
+
+  it("re-derives MONICA_LN_EPSILON rather than re-typing it", () => {
+    // The band is the midpoint of a MEASURED bimodal gap. Re-deriving from the
+    // module's own exported endpoints means a moved grid fails CI instead of
+    // silently invalidating the comment beside the constant.
+    expect(MONICA_LN_EPSILON).toBe(
+      (SINGLE_BODY_DEGENERATE_LN_CEILING + SINGLE_BODY_HEALTHY_LN_FLOOR) / 2,
+    );
+    expect(SINGLE_BODY_DEGENERATE_LN_CEILING).toBe(0);
+  });
+
+  it("confirms x^x never reaches 0, which is why no epsilon floor is needed", () => {
+    // Computed as exp(x·ln x) rather than as a self-exponentiation. Two reasons:
+    // it is an INDEPENDENT route to the same function, so this does not merely
+    // assert Math.pow against itself; and the formula gate (correctly) flags
+    // every `Math.pow(x, x)` / `x ** x` in src, so writing it that way here
+    // would mean adding this file to an allowlist that is supposed to shrink to
+    // one entry.
+    let minimum = Infinity;
+    for (let i = 1; i <= 100000; i++) {
+      const x = i / 100000;
+      minimum = Math.min(minimum, Math.exp(x * Math.log(x)));
+    }
+    expect(minimum).toBeCloseTo(GOLDEN.constants.X_POW_X_GLOBAL_MINIMUM, 12);
+    expect(minimum).toBeGreaterThan(0.69);
+  });
+
+  it("treats a zeroed axis as the true limit of x^x, contributing exactly 1", () => {
+    // The property that makes the epsilon floors unnecessary, asserted through
+    // the engine rather than through a bare 0**0. An axis at 0 must leave the
+    // value identical to that axis being absent from the product entirely.
+    const matterZero = calculateKalchm({
+      Spirit: 3, Essence: 5, Matter: 0, Substance: 2,
+    } as never);
+    const matterOne = calculateKalchm({
+      Spirit: 3, Essence: 5, Matter: 1, Substance: 2,
+    } as never);
+    // 0^0 and 1^1 are both exactly 1, so these must be bit-for-bit equal.
+    expect(matterZero).toBe(matterOne);
+  });
+
+  it.each(GOLDEN.vectors.map((v) => [v.name, v] as const))(
+    "reproduces %s exactly",
+    (_name, v) => {
+      const kalchm = calculateKalchm({
+        Spirit: v.spirit,
+        Essence: v.essence,
+        Matter: v.matter,
+        Substance: v.substance,
+      } as never);
+      expect(kalchm).toBe(v.expectedKalchm);
+      expect(calculateMonica(v.gregsEnergy, v.reactivity, kalchm)).toBe(
+        v.expectedMonica,
+      );
+    },
+  );
+
+  it.each(GOLDEN.vectors.map((v) => [v.name, v] as const))(
+    "is total for %s — always finite, never NaN",
+    (_name, v) => {
+      const kalchm = calculateKalchm({
+        Spirit: v.spirit,
+        Essence: v.essence,
+        Matter: v.matter,
+        Substance: v.substance,
+      } as never);
+      const monica = calculateMonica(v.gregsEnergy, v.reactivity, kalchm);
+      expect(Number.isFinite(kalchm)).toBe(true);
+      expect(kalchm).toBeGreaterThan(0);
+      expect(Number.isFinite(monica)).toBe(true);
+      expect(Number.isNaN(monica)).toBe(false);
+    },
+  );
+
+  it("clamps a negative axis rather than taking its absolute value", () => {
+    // These are different operations and one repo copy conflated them: abs()
+    // feeds |-0.5|^|-0.5| = 0.7071 into the numerator where the true limit
+    // contributes exactly 1. It also lets kalchm go NEGATIVE, which the formula
+    // forbids. A negative base with a fractional exponent is NaN in JS (and a
+    // COMPLEX number in Python), so the clamp is load-bearing in both runtimes.
+    const negBase = -0.5;
+    const fractionalExp = -0.5;
+    expect(Number.isNaN(Math.pow(negBase, fractionalExp))).toBe(true);
+    const clamped = calculateKalchm({
+      Spirit: -0.5, Essence: 2, Matter: 1, Substance: 0.5,
+    } as never);
+    const zeroed = calculateKalchm({
+      Spirit: 0, Essence: 2, Matter: 1, Substance: 0.5,
+    } as never);
+    expect(clamped).toBe(zeroed);
+    expect(clamped).toBeGreaterThan(0);
+  });
+
+  it("treats a zeroed axis as NEITHER sufficient NOR necessary for kalchm === 1", () => {
+    // This exact claim sat FALSE inside a passing test for two days, because no
+    // assertion covered it. Prose beside a green test proves nothing.
+    const zeroedButNotOne = calculateKalchm({
+      Spirit: 3, Essence: 5, Matter: 0, Substance: 2,
+    } as never);
+    expect(zeroedButNotOne).not.toBe(1);
+
+    const oneWithoutAnyZero = calculateKalchm({
+      Spirit: 1.3, Essence: 1.3, Matter: 1.3, Substance: 1.3,
+    } as never);
+    expect(oneWithoutAnyZero).toBe(1);
+  });
+
+  it("returns φ across the whole near-degenerate band, not just at ln k === 0", () => {
+    // A bare `ln !== 0` test excludes one single point and lets kalchm = 1.00002
+    // produce monica ≈ -49999.5 — finite, plausible, and therefore invisible to
+    // every downstream isFinite guard. That is the Python defect this pair pins.
+    const kalchm = calculateKalchm({
+      Spirit: 1, Essence: 1.00002, Matter: 1, Substance: 1,
+    } as never);
+    expect(Math.abs(Math.log(kalchm))).toBeLessThan(MONICA_LN_EPSILON);
+    expect(calculateMonica(1, 1, kalchm)).toBe(MONICA_EQUILIBRIUM);
+
+    const unguarded = -1 / (1 * Math.log(kalchm));
+    expect(Math.abs(unguarded)).toBeGreaterThan(10000);
+    expect(Number.isFinite(unguarded)).toBe(true);
+  });
+});

--- a/src/__tests__/kalchmFloorDivergence.test.ts
+++ b/src/__tests__/kalchmFloorDivergence.test.ts
@@ -1,42 +1,69 @@
 /**
- * What exactly do the duplicate kalchm implementations disagree about?
+ * What did the duplicate kalchm implementations disagree about, and do they
+ * still?
  *
- * There are several live implementations of the same formula
- * `kalchm = (S^S · E^E) / (M^M · Su^Su)`, differing only in how they keep an axis
- * away from zero. Before any of them is delegated to the canonical engine, the
- * behavioural difference has to be characterised — otherwise "de-duplication"
- * silently re-values whatever reads them (the §17c acceptance bar: characterisation
- * tests BEFORE touching a shared table).
+ * This file began as a CHARACTERISATION test: several live implementations of
+ * `kalchm = (S^S · E^E) / (M^M · Su^Su)` differed in how they kept an axis away
+ * from zero, and the behavioural difference had to be measured before any of
+ * them could be delegated (the §17c bar: characterise BEFORE touching a shared
+ * table).
  *
- * These tests import the REAL functions rather than restating their formulas. A
- * transcribed formula is the same hazard as a transcribed constant: it can drift
- * from the thing it claims to describe, and the test would keep passing.
+ * They have now all been delegated to the canonical engine, so its job has
+ * changed. It now asserts the two halves that outlive the migration:
  *
- * The headline result is that the disagreement is not a vague percentage — it is an
- * exact, input-independent law. Flooring an axis at `eps` replaces a factor of
- * `0^0 = 1` in the denominator with `eps^eps`, so the result is inflated by exactly
+ *   1. THE LAW — flooring an axis at `eps` replaces a factor of `0^0 = 1` in the
+ *      denominator with `eps^eps`, inflating the result by exactly
  *
- *     eps^(-eps) - 1        per zeroed axis
+ *          eps^(-eps) - 1        per zeroed axis
  *
- * which is 0.6932% at eps=0.001, 4.7129% at 0.01, and 25.8925% at 0.1 — for ANY
- * input. And where no axis is at or below the floor, every implementation agrees
- * to the last bit, so delegation is a no-op for all healthy charts.
+ *      which is 0.6932% at eps=0.001, 4.7129% at 0.01, and 25.8925% at 0.1 — for
+ *      ANY input. This is arithmetic, not a property of any implementation, so
+ *      it stays true and stays worth pinning: it is the reason a floor is never
+ *      a harmless "safety" measure.
  *
- * Two more implementations exist but are file-local and cannot be imported:
- * `src/data/unified/ingredients.ts:74` (floor 0.001) and
- * `src/data/unified/flavorProfileMigration.ts:797` (returns 1.0 when Matter or
- * Substance is 0 — a band, not a floor). A third,
- * `src/calculations/alchemicalCalculations.ts:246`, returns **0** on a zeroed axis,
- * which makes `ln(kalchm)` −Infinity and monica non-finite — a totality-contract
- * violation. It is unreachable (no call, no value reference, and its only importer
- * exposes it through a string-dispatch helper that itself has no callers), which is
- * the only reason it has never caused an incident.
+ *   2. CONVERGENCE — the two importable former divergers now return the canonical
+ *      value on zeroed axes as well as healthy ones. These assertions are what
+ *      would fail if someone reintroduced a floor, and they are the reason this
+ *      file is worth keeping rather than deleting along with the duplicates.
+ *
+ * `exactKalchm` below is the one legitimate restatement of the formula in the
+ * repo, and the sole entry in the gate's allowlist
+ * (scripts/checkNoStrayKalchmFormula.ts). It must restate the DEFINITION in
+ * order to measure implementations against it — an independent statement of the
+ * maths, deliberately not an import of the thing under test.
+ *
+ * The other former copies are file-local and cannot be imported:
+ * `src/data/unified/ingredients.ts` (was floor 0.001),
+ * `src/data/unified/flavorProfileMigration.ts` (was a band returning 1.0 when
+ * Matter or Substance was 0), `src/utils/recommendation/ingredientRecommendation.ts`
+ * (was THREE copies at floor 0.01), `src/utils/alchemy/derivedStats.ts` (two),
+ * `src/services/RealAlchemizeService.ts` (two, the production ESMS path),
+ * `src/lib/core-energy-rules.ts`, `src/calculations/core/alchemicalEngine.ts`,
+ * `src/data/unified/recipeBuilding.ts`, `src/services/UnifiedScoringService.ts`
+ * and `src/utils/astrologyUtils.ts`. All delegate; the AST gate is what keeps
+ * them delegated.
+ *
+ * ⚠️ A correction worth recording, because the earlier version of this docstring
+ * asserted the opposite. `src/calculations/alchemicalCalculations.ts` returned
+ * **0** on a zeroed axis — making `ln(kalchm)` −Infinity and monica non-finite,
+ * a totality violation — and was described here and in the gate's allowlist as
+ * UNREACHABLE, and therefore as safe to delete rather than delegate. That was
+ * wrong. `src/calculations/index.ts:459` does
+ * `export * from "./alchemicalCalculations"`, which the TypeScript resolver
+ * confirms binds to THAT file; deleting it produces
+ * `TS2307: Cannot find module './alchemicalCalculations'`. Worse, the
+ * neighbouring `export * from "./core/kalchmEngine"` exports `calculateKAlchm`
+ * (capital A), a DIFFERENT identifier, so there was no name collision and
+ * `import { calculateKalchm } from "@/calculations"` resolved to the
+ * zero-returning implementation. The barrel was publishing the worst copy in the
+ * repo. It has been delegated, not deleted.
  */
-import { calculateKAlchm as kalchmEps01 } from "@/utils/monicaKalchmCalculations";
-import { calculateKAlchm as kalchmEps1 } from "@/calculations/core/kalchmEngine";
+import { calculateKAlchm as formerlyEps1 } from "@/calculations/core/kalchmEngine";
+import { calculateKalchm as canonical } from "@/data/unified/alchemicalCalculations";
+import { calculateKAlchm as formerlyEps01 } from "@/utils/monicaKalchmCalculations";
 
 /**
- * The formula as defined, with no floor. `0 ** 0 === 1` in JavaScript, which is
+ * The formula as DEFINED, with no floor. `0 ** 0 === 1` in JavaScript, which is
  * exactly `lim(x→0) x^x`, so a zeroed axis needs no special handling at all.
  * Negatives are clamped because `Math.pow(-0.5, -0.5)` is NaN.
  *
@@ -50,7 +77,24 @@ function exactKalchm(S: number, E: number, M: number, Su: number): number {
   );
 }
 
-/** Inputs with no axis at or below any implementation's floor. */
+/**
+ * What a floored implementation would return.
+ *
+ * Expressed by feeding `exactKalchm` the floored axes rather than by restating
+ * the formula a second time — flooring at `eps` IS just passing `eps` where the
+ * axis was below it. That keeps exactly one reference implementation in this
+ * file, which is what the AST gate's single allowlist entry accounts for; a
+ * second copy here would be the very thing the gate exists to stop, and it
+ * caught this when it was first written the other way.
+ */
+function flooredKalchm(
+  S: number, E: number, M: number, Su: number, eps: number,
+): number {
+  const f = (x: number) => Math.max(x, eps);
+  return exactKalchm(f(S), f(E), f(M), f(Su));
+}
+
+/** Inputs with no axis at or below any former implementation's floor. */
 const HEALTHY: [number, number, number, number][] = [
   [4, 7, 5, 3],
   [0.5, 0.8, 0.4, 0.3],
@@ -67,70 +111,103 @@ const ONE_ZEROED: [number, number, number, number][] = [
   [0.9, 0.2, 4.4, 0],
 ];
 
-describe("the duplicate kalchm implementations", () => {
-  it("agree EXACTLY on healthy input — delegation is a no-op there", () => {
-    for (const [S, E, M, Su] of HEALTHY) {
-      const exact = exactKalchm(S, E, M, Su);
-      // `toBe`, not toBeCloseTo: identical arithmetic on identical inputs must give
-      // identical doubles. Any tolerance here would hide a real formula difference.
-      expect(kalchmEps01(S, E, M, Su)).toBe(exact);
-      expect(kalchmEps1(S, E, M, Su)).toBe(exact);
-    }
-  });
-
-  it("diverge by exactly eps^(-eps) - 1 per zeroed axis, independent of input", () => {
-    // This is the load-bearing claim: the error is a fixed multiplicative factor,
-    // so it can be stated for the whole class rather than sampled per call site.
+describe("the epsilon-floor divergence law", () => {
+  it("is exactly eps^(-eps) - 1 per zeroed axis, independent of input", () => {
+    // The load-bearing claim: the error is a fixed MULTIPLICATIVE factor, so it
+    // can be stated for the whole class rather than sampled per call site.
     const law = (eps: number) => Math.pow(eps, -eps);
     for (const [S, E, M, Su] of ONE_ZEROED) {
       const exact = exactKalchm(S, E, M, Su);
-      expect(kalchmEps01(S, E, M, Su) / exact).toBeCloseTo(law(0.01), 12);
-      expect(kalchmEps1(S, E, M, Su) / exact).toBeCloseTo(law(0.1), 12);
+      expect(flooredKalchm(S, E, M, Su, 0.01) / exact).toBeCloseTo(law(0.01), 12);
+      expect(flooredKalchm(S, E, M, Su, 0.1) / exact).toBeCloseTo(law(0.1), 12);
+      expect(flooredKalchm(S, E, M, Su, 0.001) / exact).toBeCloseTo(law(0.001), 12);
     }
-    // The percentages quoted in the docstring, so a change to either floor shows up
-    // as a failure here rather than as quietly stale prose.
+    // The percentages quoted in the docstring, so a change to either shows up as
+    // a failure here rather than as quietly stale prose.
     expect((law(0.01) - 1) * 100).toBeCloseTo(4.7129, 4);
     expect((law(0.1) - 1) * 100).toBeCloseTo(25.8925, 4);
     expect((law(0.001) - 1) * 100).toBeCloseTo(0.6932, 4);
   });
 
-  it("a floor inflates kalchm — it never deflates it", () => {
-    // Direction matters: kalchm > 1 vs < 1 decides the SIGN of ln(kalchm) and so of
-    // monica. A floor can only shrink the denominator, so it can only push kalchm up.
+  it("inflates kalchm — a floor never deflates it", () => {
+    // Direction matters: kalchm > 1 vs < 1 decides the SIGN of ln(kalchm) and so
+    // of monica. A floor can only shrink the denominator, so it can only push
+    // kalchm up.
     for (const [S, E, M, Su] of ONE_ZEROED) {
       const exact = exactKalchm(S, E, M, Su);
-      expect(kalchmEps01(S, E, M, Su)).toBeGreaterThan(exact);
-      expect(kalchmEps1(S, E, M, Su)).toBeGreaterThan(exact);
+      expect(flooredKalchm(S, E, M, Su, 0.01)).toBeGreaterThan(exact);
+      expect(flooredKalchm(S, E, M, Su, 0.1)).toBeGreaterThan(exact);
     }
   });
 
-  it("the bigger floor is always the bigger error", () => {
-    // Orders the implementations by how far they sit from the definition, which is
-    // the order they should be delegated in.
-    for (const [S, E, M, Su] of ONE_ZEROED) {
-      expect(kalchmEps1(S, E, M, Su)).toBeGreaterThan(kalchmEps01(S, E, M, Su));
-    }
-  });
-
-  it("a floor can flip a degenerate chart into a spuriously computable monica", () => {
-    // The consequence that actually matters. With no floor, a zeroed axis gives
-    // kalchm exactly 1, so ln(kalchm) is 0 and monica is undefined — which the
-    // §17c totality contract answers with φ, the equilibrium value. A floor moves
-    // kalchm off 1, so ln(kalchm) becomes non-zero and the engine returns a REAL
-    // NUMBER for a chart that has no defined monica. That is fabrication, not rescue.
+  it("would flip a degenerate chart into a spuriously HEALTHY one at eps=0.1", () => {
+    // The consequence that actually mattered, and why kalchmEngine.ts was the
+    // highest-priority delegation. With no floor a zeroed axis gives kalchm
+    // exactly 1, so ln(kalchm) is 0 and the chart is degenerate — which the
+    // totality contract answers with φ. A floor moves kalchm off 1, and at
+    // eps=0.1 it moves it so far that the chart no longer even looks degenerate.
     const [S, E, M, Su] = [1, 1, 1, 0];
     expect(exactKalchm(S, E, M, Su)).toBe(1);
     expect(Math.log(exactKalchm(S, E, M, Su))).toBe(0);
 
-    expect(kalchmEps01(S, E, M, Su)).not.toBe(1);
-    expect(Math.log(kalchmEps01(S, E, M, Su))).toBeCloseTo(0.0460517, 6);
-    expect(kalchmEps1(S, E, M, Su)).not.toBe(1);
-    expect(Math.log(kalchmEps1(S, E, M, Su))).toBeCloseTo(0.2302585, 6);
+    expect(Math.log(flooredKalchm(S, E, M, Su, 0.01))).toBeCloseTo(0.0460517, 6);
+    expect(Math.log(flooredKalchm(S, E, M, Su, 0.1))).toBeCloseTo(0.2302585, 6);
 
-    // And the floored ln values are large enough to matter: eps=0.1 lands at
-    // 0.23, which is beyond the single-body healthy floor (0.2188) — so a
-    // degenerate chart floored at 0.1 does not merely look computable, it looks
-    // HEALTHY.
-    expect(Math.log(kalchmEps1(S, E, M, Su))).toBeGreaterThan(0.21878586815274545);
+    // eps=0.1 lands at 0.2303, beyond the single-body healthy floor of 0.2188 —
+    // so a degenerate chart floored at 0.1 does not merely look computable, it
+    // looks HEALTHY. eps=0.01 stays inside the degenerate band, so that copy
+    // corrupted magnitude only, never classification.
+    expect(Math.log(flooredKalchm(S, E, M, Su, 0.1))).toBeGreaterThan(
+      0.21878586815274545,
+    );
+    expect(Math.log(flooredKalchm(S, E, M, Su, 0.01))).toBeLessThan(
+      0.10939293407637272,
+    );
+  });
+});
+
+describe("the former divergers now agree with canonical", () => {
+  it("agree EXACTLY on healthy input — delegation was a no-op there", () => {
+    for (const [S, E, M, Su] of HEALTHY) {
+      const exact = exactKalchm(S, E, M, Su);
+      // `toBe`, not toBeCloseTo: identical arithmetic on identical inputs must
+      // give identical doubles. Any tolerance would hide a real difference.
+      expect(canonical({ Spirit: S, Essence: E, Matter: M, Substance: Su })).toBe(exact);
+      expect(formerlyEps01(S, E, M, Su)).toBe(exact);
+      expect(formerlyEps1(S, E, M, Su)).toBe(exact);
+    }
+  });
+
+  it("now agree on ZEROED axes too — this is what the delegation changed", () => {
+    // These four assertions per input are the regression guard. Before
+    // delegation, formerlyEps01 was 4.7129% high here and formerlyEps1 25.8925%
+    // high; both now return the definition exactly.
+    for (const [S, E, M, Su] of ONE_ZEROED) {
+      const exact = exactKalchm(S, E, M, Su);
+      expect(canonical({ Spirit: S, Essence: E, Matter: M, Substance: Su })).toBe(exact);
+      expect(formerlyEps01(S, E, M, Su)).toBe(exact);
+      expect(formerlyEps1(S, E, M, Su)).toBe(exact);
+      // ...and are therefore no longer inflated relative to the definition.
+      expect(formerlyEps01(S, E, M, Su)).not.toBeGreaterThan(exact);
+      expect(formerlyEps1(S, E, M, Su)).not.toBeGreaterThan(exact);
+    }
+  });
+
+  it("agree that a degenerate chart is degenerate", () => {
+    const [S, E, M, Su] = [1, 1, 1, 0];
+    expect(canonical({ Spirit: S, Essence: E, Matter: M, Substance: Su })).toBe(1);
+    expect(formerlyEps01(S, E, M, Su)).toBe(1);
+    expect(formerlyEps1(S, E, M, Su)).toBe(1);
+  });
+
+  it("clamp negatives rather than returning NaN", () => {
+    // Math.pow(-0.5, -0.5) is NaN, so this is the one case where a guard is
+    // genuinely required — as opposed to the zero case, where none ever was.
+    for (const impl of [formerlyEps01, formerlyEps1]) {
+      const v = impl(-0.5, 2, 1, 0.5);
+      expect(Number.isFinite(v)).toBe(true);
+      expect(v).toBeGreaterThan(0);
+      expect(v).toBe(exactKalchm(0, 2, 1, 0.5));
+    }
   });
 });

--- a/src/calculations/alchemicalCalculations.ts
+++ b/src/calculations/alchemicalCalculations.ts
@@ -1,3 +1,4 @@
+import { calculateKalchm as canonicalCalculateKalchm } from "@/data/unified/alchemicalCalculations";
 import type { ElementalProperties } from "@/types/alchemy";
 import { createLogger } from "@/utils/logger";
 
@@ -249,19 +250,32 @@ export function calculateKalchm(
   matter: number,
   substance: number,
 ): number {
-  try {
-    // Kalchm = (Spirit^Spirit * Essence^Essence) / (Matter^Matter * Substance^Substance)
-    if (matter === 0 || substance === 0) return 0;
-    const numerator = Math.pow(spirit, spirit) * Math.pow(essence, essence);
-    const denominator =
-      Math.pow(matter, matter) * Math.pow(substance, substance);
-    return denominator > 0 ? numerator / denominator : 0;
-  } catch (error) {
-    logger.error("Error calculating Kalchm:", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return 0;
-  }
+  // Delegates to THE canonical engine. This function is the one the barrel
+  // publishes: `src/calculations/index.ts:459` does
+  // `export * from "./alchemicalCalculations"`, and the neighbouring
+  // `export * from "./core/kalchmEngine"` exports `calculateKAlchm` (capital A),
+  // a different identifier — so there is no name collision and
+  // `import { calculateKalchm } from "@/calculations"` resolved HERE.
+  //
+  // What it used to do, and why none of it was right:
+  //   `if (matter === 0 || substance === 0) return 0` — a zeroed axis is the
+  //   COMMON case (68.2% of the single-body grid), not an error. Returning 0
+  //   made ln(kalchm) −Infinity and monica non-finite, breaking totality. The
+  //   true value needs no special case at all: 0**0 is exactly 1 in JS, which is
+  //   exactly lim(x→0) x^x.
+  //   `denominator > 0 ? … : 0` — unreachable. x^x bottoms out at
+  //   0.6922006275556402, so the denominator is never 0 for non-negative axes.
+  //   The try/catch — no operation in the body can throw; Math.pow and division
+  //   are total in JS. The catch only ever disguised the two branches above.
+  //
+  // Canonical clamps negatives (Math.pow(-0.5, -0.5) is NaN) and leaves zero
+  // alone. See src/data/unified/alchemicalCalculations.ts.
+  return canonicalCalculateKalchm({
+    Spirit: spirit,
+    Essence: essence,
+    Matter: matter,
+    Substance: substance,
+  });
 }
 /**
  * Calculate the Monica constant for alchemical transformation potential

--- a/src/calculations/core/alchemicalEngine.ts
+++ b/src/calculations/core/alchemicalEngine.ts
@@ -1,3 +1,4 @@
+import { calculateKalchm as canonicalCalculateKalchm } from "@/data/unified/alchemicalCalculations";
 import type {
   AstrologicalState,
   Element,
@@ -260,10 +261,15 @@ function alchemize(planetaryPositions: {
   // Greg's Energy
   const gregsEnergy = heat - entropy * reactivity;
 
-  // Kalchm (K_alchm)
-  const kalchm =
-    (Math.pow(Spirit, Spirit) * Math.pow(Essence, Essence)) /
-    (Math.pow(Matter, Matter) * Math.pow(Substance, Substance));
+  // Kalchm (K_alchm) via THE canonical engine. This copy had no floor and no
+  // guard at all, so it matched canonical exactly on non-negative axes and
+  // produced NaN on a negative one — which then propagated into monica below.
+  const kalchm = canonicalCalculateKalchm({
+    Spirit,
+    Essence,
+    Matter,
+    Substance,
+  });
 
   // Monica constant
   let monica = NaN;

--- a/src/calculations/core/kalchmEngine.ts
+++ b/src/calculations/core/kalchmEngine.ts
@@ -5,7 +5,10 @@
  * for Kalchm (K_alchm) and Monica Constant (M) as specified in the system requirements.
  */
 
-import { calculateMonica } from "@/data/unified/alchemicalCalculations";
+import {
+  calculateKalchm as canonicalCalculateKalchm,
+  calculateMonica,
+} from "@/data/unified/alchemicalCalculations";
 import type { ElementalProperties, PlanetaryPosition } from "@/types/alchemy";
 import type { AlchemicalProperties } from "@/types/celestial";
 import { getCachedCalculation } from "../../utils/calculationCache";
@@ -164,20 +167,22 @@ export function calculateKAlchm(
   Matter: number,
   Substance: number,
 ): number {
-  // Ensure all values are positive to avoid NaN in power calculations
-  const safespirit = Math.max(0.1, Spirit);
-  const safeessence = Math.max(0.1, Essence);
-  const safematter = Math.max(0.1, Matter);
-  const safesubstance = Math.max(0.1, Substance);
-
-  const numerator =
-    Math.pow(safespirit, safespirit) * Math.pow(safeessence, safeessence);
-  const denominator =
-    Math.pow(safematter, safematter) * Math.pow(safesubstance, safesubstance);
-
-  // Prevent division by zero
-  if (denominator === 0) return 1.0;
-  return numerator / denominator;
+  // Delegates to THE canonical engine.
+  //
+  // This copy floored every axis at 0.1, and of all the strays it was the only
+  // one that corrupted the DEGENERACY CLASSIFICATION rather than just the
+  // magnitude. A floor at eps inflates kalchm by exactly eps^(-eps) − 1 per
+  // zeroed axis — +25.8925% at 0.1 — so a truly degenerate chart (kalchm
+  // exactly 1, |ln k| exactly 0) came back with |ln k| up to 0.2303, ABOVE the
+  // measured healthy floor of 0.21878586815274545. It therefore read as a
+  // perfectly HEALTHY chart rather than an equilibrium one, and monica was
+  // computed from the divergence instead of returning φ.
+  //
+  // The floor was never needed: `Math.max(0.1, x)` was justified as avoiding
+  // NaN, but 0**0 is exactly 1 in JS and x^x has a global minimum of
+  // 0.6922006275556402, so neither NaN nor a zero denominator is reachable from
+  // a non-negative axis. Only NEGATIVES produce NaN, and canonical clamps those.
+  return canonicalCalculateKalchm({ Spirit, Essence, Matter, Substance });
 }
 
 /**

--- a/src/data/unified/flavorProfileMigration.ts
+++ b/src/data/unified/flavorProfileMigration.ts
@@ -13,6 +13,7 @@ import { flavorProfiles as integrationFlavorProfiles } from "../integrations/fla
 import {
     planetaryFlavorProfiles
 } from "../planetaryFlavorProfiles";
+import { calculateKalchm as canonicalCalculateKalchm } from "./alchemicalCalculations";
 import { unifiedFlavorProfiles } from "./data/unifiedFlavorProfiles";
 import type { BaseFlavorNotes, UnifiedFlavorProfile } from "./unifiedTypes";
 
@@ -797,12 +798,12 @@ export class FlavorProfileMigration {
   private calculateKalchm(profile: UnifiedFlavorProfile): number {
     // Simplified Kalchm calculation based on elemental and alchemical properties
     if (!profile.alchemicalProperties) return 1.0; // Default if no alchemical properties
-    const { Spirit, Essence, Matter, Substance } = profile.alchemicalProperties;
-    if (Matter === 0 || Substance === 0) return 1.0; // Default neutral value
-    return (
-      (Math.pow(Spirit, Spirit) * Math.pow(Essence, Essence)) /
-      (Math.pow(Matter, Matter) * Math.pow(Substance, Substance))
-    );
+    // Kalchm via THE canonical engine. The `Matter === 0 || Substance === 0`
+    // branch it replaces returned 1.0 — the DEGENERATE value — for any chart
+    // with a zeroed denominator axis. That is a misclassification, not a
+    // rounding difference: a zeroed axis is neither sufficient nor necessary for
+    // kalchm === 1, and this branch asserted it was sufficient.
+    return canonicalCalculateKalchm(profile.alchemicalProperties);
   }
   private calculateMonicaOptimization(profile: UnifiedFlavorProfile): number {
     // Estimate Monica optimization based on profile characteristics

--- a/src/data/unified/ingredients.ts
+++ b/src/data/unified/ingredients.ts
@@ -29,7 +29,10 @@ import { seasonings } from "../ingredients/seasonings";
 import { spices } from "../ingredients/spices";
 import { vegetables } from "../ingredients/vegetables";
 import { vinegars } from "../ingredients/vinegars";
-import { deriveAlchemicalFromElemental } from "./alchemicalCalculations";
+import {
+  calculateKalchm as canonicalCalculateKalchm,
+  deriveAlchemicalFromElemental,
+} from "./alchemicalCalculations";
 import type { UnifiedIngredient } from "./unifiedTypes";
 
 // ===== UNIFIED INGREDIENTS SYSTEM =====;
@@ -72,16 +75,15 @@ function createFallbackDescription(name: string, category: string): string {
  * K_alchm = (Spirit^Spirit * Essence^Essence) / (Matter^Matter * Substance^Substance)
  */
 function calculateKalchm(_alchemical: AlchemicalProperties): number {
-  const { Spirit, Essence, Matter, Substance } = _alchemical;
-  // Prevent division by zero or negative values
-  const safespirit = Math.max(0.001, Spirit);
-  const safeessence = Math.max(0.001, Essence);
-  const safematter = Math.max(0.001, Matter);
-  const safesubstance = Math.max(0.001, Substance);
-  return (
-    (Math.pow(safespirit, safespirit) * Math.pow(safeessence, safeessence)) /
-    (Math.pow(safematter, safematter) * Math.pow(safesubstance, safesubstance))
-  );
+  // Delegates to THE canonical engine. The local 0.001 floor it replaces was
+  // justified as preventing "division by zero or negative values"; neither
+  // hazard was real for zero (x^x has a global minimum of 0.6922006275556402,
+  // so the denominator is never 0) and it did not address negatives at all,
+  // since Math.max(0.001, -0.5) silently rewrites a negative axis to 0.001
+  // rather than clamping it. Its only measurable effect was inflating kalchm by
+  // 0.001^(-0.001) − 1 = +0.6932% per zeroed axis. Canonical clamps negatives
+  // to 0 and leaves zero alone.
+  return canonicalCalculateKalchm(_alchemical);
 }
 /**
  * Calculate Monica constant based on Kalchm and thermodynamic properties

--- a/src/data/unified/recipeBuilding.ts
+++ b/src/data/unified/recipeBuilding.ts
@@ -23,6 +23,7 @@ import {
   getEnhancedIngredients,
   type EnhancedRecipeIngredient,
 } from "../../constants/alchemicalPillars";
+import { calculateKalchm as canonicalCalculateKalchm } from "./alchemicalCalculations";
 import {
   unifiedCuisineIntegrationSystem,
   type CuisineIngredientAnalysis,
@@ -191,12 +192,12 @@ function kalchmForCuisine(cuisine: string): number | null {
   const sig = lookupCuisineSignature(cuisine);
   if (!sig?.averageAlchemical) return null;
   const { Spirit, Essence, Matter, Substance } = sig.averageAlchemical;
-  if (Matter <= 0 || Substance <= 0) return null;
-  // K = (Spirit^Spirit × Essence^Essence) / (Matter^Matter × Substance^Substance)
-  return (
-    (Math.pow(Spirit, Spirit) * Math.pow(Essence, Essence)) /
-    (Math.pow(Matter, Matter) * Math.pow(Substance, Substance))
-  );
+  // Kalchm via THE canonical engine. The `Matter <= 0 || Substance <= 0` bail
+  // that used to guard this returned null — i.e. "no value" — for a chart whose
+  // kalchm is perfectly well defined: a zeroed denominator axis contributes
+  // exactly 1 (0**0), it does not divide by zero. Only a NEGATIVE axis was ever
+  // a hazard, and canonical clamps those.
+  return canonicalCalculateKalchm({ Spirit, Essence, Matter, Substance });
 }
 
 function monicaProxyForCuisine(cuisine: string): number | null {

--- a/src/lib/core-energy-rules.ts
+++ b/src/lib/core-energy-rules.ts
@@ -1,6 +1,11 @@
 // Core Greg's Energy System Rules
 // Based on Core_Gregs_Energy_System.ipynb and current-moment-chart.ipynb
 
+import {
+  calculateKalchm as canonicalCalculateKalchm,
+  calculateMonica as canonicalCalculateMonica,
+} from "@/data/unified/alchemicalCalculations"
+
 export interface AlchemicalProperties {
   spirit: number
   essence: number
@@ -225,25 +230,32 @@ export class AdvancedConstantsCalculator {
     matter: number,
     substance: number
   ): number {
-    try {
-      // Handle negative values by using absolute values
-      const spiritAbs = Math.abs(spirit) || 1e-10
-      const essenceAbs = Math.abs(essence) || 1e-10
-      const matterAbs = Math.abs(matter) || 1e-10
-      const substanceAbs = Math.abs(substance) || 1e-10
-
-      // Calculate with absolute values
-      const numerator = Math.pow(spiritAbs, spiritAbs) * Math.pow(essenceAbs, essenceAbs)
-      const denominator = Math.pow(matterAbs, matterAbs) * Math.pow(substanceAbs, substanceAbs)
-
-      // Apply sign correction based on the number of negative values
-      const negativeCount = [spirit, essence, matter, substance].filter(v => v < 0).length
-      const signFactor = negativeCount % 2 === 1 ? -1 : 1
-
-      return signFactor * (numerator / denominator)
-    } catch (_error) {
-      return NaN
-    }
+    // Delegates to THE canonical engine. Four measured defects went with the
+    // local implementation:
+    //
+    // 1. `Math.abs(x) || 1e-10` DESTROYED the sign rather than clamping it, so
+    //    |-0.5|^|-0.5| = 0.7071 entered the numerator where the true limit
+    //    contributes exactly 1. Measured on (-0.5, 2, 1, 0.5): -4 here versus
+    //    5.65685424949238 canonical, a -170.71% error. The `|| 1e-10` half is
+    //    additionally a truthiness floor that fires for a legitimate 0.
+    // 2. The "sign correction based on the number of negative values" let
+    //    kalchm come back NEGATIVE, which the formula forbids — a ratio of x^x
+    //    terms is strictly positive. An odd count flipped the sign outright.
+    // 3. `return NaN` from a catch that can never run: Math.abs, Math.pow and
+    //    arithmetic are total in JS, so nothing in the body could throw. The
+    //    dead catch disguised the fact that NaN was also the ordinary
+    //    fall-through of calculateMonicaConstant below.
+    //
+    // (A fourth allegation — that `Math.log(Math.abs(kalchmConstant))` masked
+    // the negativity — did NOT hold up: the `kalchmConstant > 0` guard on the
+    // preceding line rejects a negative kalchm first, so that line is
+    // unreachable with a negative argument.)
+    return canonicalCalculateKalchm({
+      Spirit: spirit,
+      Essence: essence,
+      Matter: matter,
+      Substance: substance,
+    })
   }
 
   /**
@@ -254,17 +266,17 @@ export class AdvancedConstantsCalculator {
     reactivity: number,
     kalchmConstant: number
   ): number {
-    try {
-      if (kalchmConstant > 0 && reactivity !== 0) {
-        const lnK = Math.log(Math.abs(kalchmConstant))
-        if (lnK !== 0) {
-          return -energy / (reactivity * lnK)
-        }
-      }
-      return NaN
-    } catch (_error) {
-      return NaN
-    }
+    // Delegates to THE canonical engine, which is TOTAL: always finite, never
+    // NaN. This version returned NaN on three reachable inputs where canonical
+    // returns MONICA_EQUILIBRIUM (φ = 1.618): kalchm exactly 1 (any four equal
+    // ESMS axes, e.g. 1.3/1.3/1.3/1.3), kalchm negative, and reactivity === 0.
+    //
+    // It also had no degenerate BAND — only `lnK !== 0`, which excludes a single
+    // point. At kalchm = 1.0001 it returned -6250.312494792615, roughly 3900x
+    // the equilibrium magnitude yet perfectly finite, so it passed every
+    // downstream Number.isFinite guard. That is more dangerous than the NaN,
+    // which at least announces itself.
+    return canonicalCalculateMonica(energy, reactivity, kalchmConstant)
   }
 
   /**

--- a/src/services/RealAlchemizeService.ts
+++ b/src/services/RealAlchemizeService.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import {
+  calculateKalchm,
   calculateMonica,
   MONICA_LN_EPSILON,
 } from "@/data/unified/alchemicalCalculations";
@@ -480,18 +481,17 @@ export function alchemize(
     reactivityNum / Math.max(Math.pow(Matter + Earth, 2), 0.01);
   // Greg's Energy;
   const gregsEnergy = heat - entropy * reactivity;
-  // Kalchm (K_alchm). Clamp ESMS bases to a tiny positive epsilon first: a
-  // negative base (possible after aspect modifications subtract below 0) makes
-  // Math.pow return NaN, which would otherwise propagate into monica, pricing,
-  // and the API payload. x^x → 1 as x → 0, so valid inputs are unaffected.
-  const kSpirit = Math.max(Spirit, 1e-9);
-  const kEssence = Math.max(Essence, 1e-9);
-  const kMatter = Math.max(Matter, 1e-9);
-  const kSubstance = Math.max(Substance, 1e-9);
-  const kalchmRaw =
-    (Math.pow(kSpirit, kSpirit) * Math.pow(kEssence, kEssence)) /
-    (Math.pow(kMatter, kMatter) * Math.pow(kSubstance, kSubstance));
-  const kalchm = Number.isFinite(kalchmRaw) ? kalchmRaw : 1;
+  // Kalchm (K_alchm) via THE canonical engine. This is the production ESMS
+  // path, so it is the copy whose values reach agent monica and the API payload.
+  //
+  // The local clamp it replaces used 1e-9 rather than 0. The intent — stop a
+  // negative base (reachable after aspect modifications subtract below 0) from
+  // making Math.pow return NaN — was right, but clamping to 1e-9 instead of 0
+  // is a floor, and a floor at eps inflates kalchm by exactly eps^(-eps) − 1
+  // per zeroed axis. Canonical clamps negatives to 0 and leaves a genuine zero
+  // alone, because 0**0 is exactly 1 — the true limit of x^x — so the accurate
+  // value needs no epsilon at all.
+  const kalchm = calculateKalchm({ Spirit, Essence, Matter, Substance });
   // Monica constant: −GregsEnergy / (Reactivity × ln(Kalchm))
   // Guards: kalchm must be > 0; lnK must be non-zero; reactivity must be non-zero
   // Monica via the canonical engine (§17c): always finite, and returns φ at the
@@ -770,16 +770,10 @@ export function alchemizeDetailed(
   const reactivity =
     reactivityNum / Math.max(Math.pow(Matter + Earth, 2), 0.01);
   const gregsEnergy = heat - entropy * reactivity;
-  // Clamp ESMS bases to epsilon before pow/ratio so a negative base can't make
-  // kalchm NaN (mirrors alchemize()); x^x → 1 as x → 0 so valid inputs are unaffected.
-  const kSpirit = Math.max(Spirit, 1e-9);
-  const kEssence = Math.max(Essence, 1e-9);
-  const kMatter = Math.max(Matter, 1e-9);
-  const kSubstance = Math.max(Substance, 1e-9);
-  const kalchmRaw =
-    (Math.pow(kSpirit, kSpirit) * Math.pow(kEssence, kEssence)) /
-    (Math.pow(kMatter, kMatter) * Math.pow(kSubstance, kSubstance));
-  const kalchm = Number.isFinite(kalchmRaw) ? kalchmRaw : 1;
+  // Kalchm via THE canonical engine (second of the two sites in this file;
+  // mirrors alchemize() above, which is exactly why neither should hold its own
+  // copy of the formula).
+  const kalchm = calculateKalchm({ Spirit, Essence, Matter, Substance });
   // Monica via the canonical engine (§17c): always finite, and returns φ at the
   // equilibrium point (kalchm ≈ 1) instead of the old 1.0 placeholder. The
   // degraded flag still fires when the value is that fallback rather than a real

--- a/src/services/UnifiedScoringService.ts
+++ b/src/services/UnifiedScoringService.ts
@@ -10,6 +10,7 @@
  * - Tarot effects and other mystical influences
  */
 
+import { calculateKalchm as canonicalCalculateKalchm } from "@/data/unified/alchemicalCalculations";
 import { getTarotCardsForDate } from "@/lib/tarotCalculations";
 import { log } from "@/services/LoggingService";
 import {
@@ -584,13 +585,31 @@ export function calculateThermodynamicEffect(
     // Greg's Energy
     const gregsEnergy = heat - entropy * reactivity;
 
-    // Kalchm
+    // Kalchm via THE canonical engine.
+    //
+    // The local copy substituted `|| 1` on every axis. MEASURED, that fallback
+    // turns out to be numerically IDENTICAL to canonical wherever it fires:
+    // `||` only triggers on 0/NaN, and it then contributes 1^1 = 1, which is
+    // exactly what the true limit 0^0 contributes. It does not fire at all for
+    // an axis in (0,1), since 0.5 is truthy. So this copy was not producing
+    // wrong numbers for zeroed axes — the sole divergence is a NEGATIVE axis,
+    // where -0.5 is truthy, Math.pow(-0.5, -0.5) is NaN, and the whole kalchm
+    // becomes NaN where canonical clamps to 0 and returns a finite value.
+    //
+    // It is delegated anyway, because a second copy of the formula is the
+    // defect regardless of whether this one currently agrees.
+    //
+    // `kalchmResonance ?? …` rather than `|| …`: kalchm is > 0 by contract, but
+    // a precomputed resonance of 0 is a value, not an absence, and `||` would
+    // silently discard it and recompute.
     const kalchm =
-      context.item.kalchmResonance ||
-      (Math.pow(alch.Spirit || 1, alch.Spirit || 1) *
-        Math.pow(alch.Essence || 1, alch.Essence || 1)) /
-      (Math.pow(alch.Matter || 1, alch.Matter || 1) *
-        Math.pow(alch.Substance || 1, alch.Substance || 1));
+      context.item.kalchmResonance ??
+      canonicalCalculateKalchm({
+        Spirit: alch.Spirit,
+        Essence: alch.Essence,
+        Matter: alch.Matter,
+        Substance: alch.Substance,
+      });
 
     // Monica
     let monica = context.item.monicaConstant || 1.0;

--- a/src/utils/alchemy/derivedStats.ts
+++ b/src/utils/alchemy/derivedStats.ts
@@ -1,4 +1,5 @@
 import type { IngredientCategory } from '@/data/ingredients/types';
+import { calculateKalchm as canonicalCalculateKalchm } from '@/data/unified/alchemicalCalculations';
 import type { MonicaOptimizedRecipe } from '@/data/unified/recipeBuilding';
 import type { AlchemicalProperties, AstrologicalState } from '@/types/alchemy';
 import type { Ingredient } from '@/types/ingredient';
@@ -18,23 +19,13 @@ export function getIngredientKAlchm(ingredient: Ingredient): number {
     return 1.0;
   }
 
-  const { Spirit, Essence, Matter, Substance } = alchemicalProps as { Spirit: number; Essence: number; Matter: number; Substance: number; };
-
-  // Handle edge cases where values might be 0 or null
-  const safeSpirit = Math.max(Spirit || 0, 0.01);
-  const safeEssence = Math.max(Essence || 0, 0.01);
-  const safeMatter = Math.max(Matter || 0, 0.01);
-  const safeSubstance = Math.max(Substance || 0, 0.01);
-
-  const numerator = Math.pow(safeSpirit, safeSpirit) * Math.pow(safeEssence, safeEssence);
-  const denominator = Math.pow(safeMatter, safeMatter) * Math.pow(safeSubstance, safeSubstance);
-
-  if (denominator === 0) {
-    // Avoid division by zero, return a large number to indicate high spirit/essence
-    return 1_000_000;
-  }
-
-  return numerator / denominator;
+  // Delegates to THE canonical engine. Three things went with the local copy:
+  // the 0.01 floor (+4.7129% per zeroed axis), the `Spirit || 0` truthiness
+  // (which cannot distinguish an absent axis from a legitimate 0 — 285 agents
+  // hold exactly 0), and the `denominator === 0` branch returning 1_000_000,
+  // an invented magnitude for a condition that cannot occur: x^x bottoms out at
+  // 0.6922006275556402.
+  return canonicalCalculateKalchm(alchemicalProps);
 }
 
 /**
@@ -128,21 +119,12 @@ export function getUserTargetKAlchm(astroState: AstrologicalState): number {
         return 1.0;
     }
 
-    const { Spirit, Essence, Matter, Substance } = alchemicalProps as { Spirit: number; Essence: number; Matter: number; Substance: number; };
-
-    const safeSpirit = Math.max(Spirit || 0, 0.01);
-    const safeEssence = Math.max(Essence || 0, 0.01);
-    const safeMatter = Math.max(Matter || 0, 0.01);
-    const safeSubstance = Math.max(Substance || 0, 0.01);
-
-    const numerator = Math.pow(safeSpirit, safeSpirit) * Math.pow(safeEssence, safeEssence);
-    const denominator = Math.pow(safeMatter, safeMatter) * Math.pow(safeSubstance, safeSubstance);
-
-    if (denominator === 0) {
-        return 0.0001;
-    }
-
-    const currentKAlchm = numerator / denominator;
+    // Delegates to THE canonical engine (second of the two copies in this file).
+    // Note this one's unreachable zero-denominator branch returned 0.0001 where
+    // the other returned 1_000_000 — the same impossible condition given two
+    // opposite invented answers, which is the clearest possible argument for a
+    // single implementation.
+    const currentKAlchm = canonicalCalculateKalchm(alchemicalProps);
 
     // Return the inverse for balance
     return 1 / currentKAlchm;

--- a/src/utils/astrologyUtils.ts
+++ b/src/utils/astrologyUtils.ts
@@ -3,6 +3,7 @@ import type {
     AlchemicalProperty,
     ElementalCharacter
 } from "@/constants/planetaryElements";
+import { calculateKalchm as canonicalCalculateKalchm } from "@/data/unified/alchemicalCalculations";
 import { _logger } from "@/lib/logger";
 import { PlanetaryHourCalculator } from "@/lib/PlanetaryHourCalculator";
 import { log } from "@/services/LoggingService";
@@ -2588,12 +2589,18 @@ function calculateAlchemicalProperties(
         Math.pow(Water, 2)) /
       Math.max(1, Math.pow(Matter + Earth, 2));
     const gregsEnergy = heat - entropy * reactivity;
-    // Calculate Kalchm
-    const kalchm =
-      Spirit > 0 && Essence > 0 && Matter > 0 && Substance > 0
-        ? (Math.pow(Spirit, Spirit) * Math.pow(Essence, Essence)) /
-          (Math.pow(Matter, Matter) * Math.pow(Substance, Substance))
-        : 1;
+    // Kalchm via THE canonical engine. This copy had NO epsilon floor, so on
+    // all-positive axes it already agreed with canonical bit-for-bit. What it
+    // did have was an all-or-nothing guard: if ANY axis was ≤ 0 it returned 1,
+    // i.e. it reported a perfectly degenerate chart for what is usually an
+    // ordinary one. A zeroed axis is the common case, and it does not imply
+    // kalchm === 1 — of 5400 zeroed-axis grid cells, 4980 have kalchm ≠ 1.
+    const kalchm = canonicalCalculateKalchm({
+      Spirit,
+      Essence,
+      Matter,
+      Substance,
+    });
     // Calculate Monica constant
     let monica = 0;
     if (kalchm > 0) {

--- a/src/utils/monicaKalchmCalculations.ts
+++ b/src/utils/monicaKalchmCalculations.ts
@@ -1,6 +1,9 @@
 import { calculateKinetics } from "@/calculations/kinetics";
 import { ALCHEMICAL_PILLARS, COOKING_METHOD_PILLAR_MAPPING } from "@/constants/alchemicalPillars";
-import { calculateMonica } from "@/data/unified/alchemicalCalculations";
+import {
+  calculateKalchm as canonicalCalculateKalchm,
+  calculateMonica,
+} from "@/data/unified/alchemicalCalculations";
 import type { ElementalProperties } from "@/types/alchemy";
 import type { AlchemicalProperties } from "@/types/celestial";
 import type { KineticMetrics } from "@/types/kinetics";
@@ -109,16 +112,22 @@ export function calculateKAlchm(
   matter: number,
   substance: number,
 ): number {
-  // Ensure positive values and handle edge cases
-  const safeSpirit = Math.max(0.01, spirit);
-  const safeEssence = Math.max(0.01, essence);
-  const safeMatter = Math.max(0.01, matter);
-  const safeSubstance = Math.max(0.01, substance);
-  const numerator =
-    Math.pow(safeSpirit, safeSpirit) * Math.pow(safeEssence, safeEssence);
-  const denominator =
-    Math.pow(safeMatter, safeMatter) * Math.pow(safeSubstance, safeSubstance);
-  return denominator > 0 ? numerator / denominator : 1;
+  // Delegates to THE canonical engine. This was the most-used stray copy — 11
+  // files reach it, five of them React components — and it floored every axis
+  // at 0.01, inflating kalchm by exactly 0.01^(-0.01) − 1 = +4.7129% per
+  // imbalanced zeroed axis.
+  //
+  // It did NOT corrupt the degeneracy classification (unlike the 0.1 floor in
+  // core/kalchmEngine.ts): the most |ln k| it could manufacture from a
+  // degenerate chart is 2 × 0.04605170185988091 = 0.0921, still inside the
+  // MONICA_LN_EPSILON band of 0.10939293407637272. So the damage was confined
+  // to magnitude, and healthy charts were already bit-for-bit correct.
+  return canonicalCalculateKalchm({
+    Spirit: spirit,
+    Essence: essence,
+    Matter: matter,
+    Substance: substance,
+  });
 }
 /**
  * Calculate Monica Constant: Dynamic system constant relating energy to equilibrium

--- a/src/utils/recommendation/ingredientRecommendation.ts
+++ b/src/utils/recommendation/ingredientRecommendation.ts
@@ -1,3 +1,4 @@
+import { calculateKalchm as canonicalCalculateKalchm } from "@/data/unified/alchemicalCalculations";
 import { _logger } from "@/lib/logger";
 import type { AstrologicalState, ElementalProperties } from "@/types/alchemy";
 import type { ScoredItem } from "@/types/common";
@@ -1100,20 +1101,16 @@ function calculateKalchmResonance(
     const Substance = (Fire + Water) / 2; // Transformative elements
 
     // Avoid zero values by using minimum 0.01
-    const s = Math.max(0.01, Spirit);
-    const e = Math.max(0.01, Essence);
-    const m = Math.max(0.01, Matter);
-    const sub = Math.max(0.01, Substance);
-
-    // Calculate Kalchm with proper formula
-    const numerator = Math.pow(s, s) * Math.pow(e, e);
-    const denominator = Math.pow(m, m) * Math.pow(sub, sub);
-
-    if (denominator === 0 || !isFinite(numerator) || !isFinite(denominator)) {
-      return 0.5;
-    }
-
-    const kalchm = numerator / denominator;
+    // Kalchm via THE canonical engine (copy 1 of 3 that this file held).
+    // The 0.01 floor inflated kalchm by +4.7129% per zeroed axis, and the
+    // `denominator === 0` bail returning 0.5 was unreachable — x^x has a global
+    // minimum of 0.6922006275556402, so the denominator is never 0.
+    const kalchm = canonicalCalculateKalchm({
+      Spirit,
+      Essence,
+      Matter,
+      Substance,
+    });
 
     // Normalize to 0-1 range using logarithmic scaling
     // Higher Kalchm = higher transformation potential
@@ -1172,14 +1169,13 @@ function calculateMonicaOptimization(
 
     const gregsEnergy = heat - entropy * reactivity;
 
-    // Calculate Kalchm for Monica formula
-    const s = Math.max(0.01, Spirit);
-    const e = Math.max(0.01, Essence);
-    const m = Math.max(0.01, Matter);
-    const sub = Math.max(0.01, Substance);
-
-    const kalchm =
-      (Math.pow(s, s) * Math.pow(e, e)) / (Math.pow(m, m) * Math.pow(sub, sub));
+    // Kalchm via THE canonical engine (copy 2 of 3 that this file held).
+    const kalchm = canonicalCalculateKalchm({
+      Spirit,
+      Essence,
+      Matter,
+      Substance,
+    });
 
     // Calculate Monica
     let monica = 1.0;
@@ -1271,13 +1267,13 @@ function calculateKineticScore(
 
     const gregsEnergy = heat - entropy * reactivity;
 
-    // Calculate Kalchm for thermodynamic completeness
-    const s = Math.max(0.01, Spirit);
-    const e = Math.max(0.01, Essence);
-    const m = Math.max(0.01, Matter);
-    const sub = Math.max(0.01, Substance);
-    const kalchm =
-      (Math.pow(s, s) * Math.pow(e, e)) / (Math.pow(m, m) * Math.pow(sub, sub));
+    // Kalchm via THE canonical engine (copy 3 of 3 that this file held).
+    const kalchm = canonicalCalculateKalchm({
+      Spirit,
+      Essence,
+      Matter,
+      Substance,
+    });
 
     // Calculate Monica
     let monica = 1.0;


### PR DESCRIPTION
Finishes the stray-copy work, and finds that the programme had the wrong number of runtimes.

## Headline: there is a second engine, and it serves production traffic

§18k k7 ruled the formula lives in "one module per runtime, enforced by an AST gate". The gate is a **TypeScript** AST gate. It structurally cannot see a Python module — and there is one.

Proven end to end, not inferred: `railway.json` builds `backend/Dockerfile`, whose CMD is `uvicorn backend.alchm_kitchen.main:app`. The Railway service **WhatToEatNext** is Online, `/health` returns `{"service":"alchm-backend"}`, and a live `POST /alchemize` returned kalchm **121.49817994831771** — which round-trips **exactly** to the formula at `main.py:663`.

Its kalchm was already correct (no epsilon floor; Python's `0**0` is 1 just as JS's is). The defects were elsewhere:

| # | Defect | Measured consequence |
|---|---|---|
| 1 | `monica = 1.0` at exact degeneracy | 1.0 where canonical returns φ |
| 2 | Bare `ln_k != 0`, **no band** | kalchm 1.00002 → monica **−49999.5** vs φ. **~31,000×**, and *finite and plausible*, so it passes every downstream `isfinite` check and reaches the DB |
| 3 | Unclamped negative axis | `(-0.5) ** (-0.5)` is a **complex number** in Python where JS gives NaN. `complex or 1` is truthy so the fallback never fired; `kalchm > 0` then raised TypeError → HTTP 500 |
| 4 | Reactivity **lost its parentheses** | **3.17×** — see below |
| 5 | Fabricated `kalchm=1.0, monica=1.0` tuple from a bare `except: pass` | invented ESMS |
| 6 | `result.get('kalchm', 0)` | 0 is impossible for kalchm under the totality contract |

**Defect 4 is the instructive one.** Reactivity should be `(S²+Su²+E²+F²+A²+W²) / (Matter+Earth)²`. Python had that expression with the parentheses lost, so Earth left the denominator and became an additive term. Settled by counting, not arguing: **nine independent TypeScript implementations all use `(Matter+Earth)²`**. The two forms coincide **only when Earth = 0 and Matter = 1**, which is how it survived. Since `monica = −G/(R·ln K)`, an identical kalchm engine was never sufficient for identical monica.

Both runtimes are now pinned by shared golden vectors (12 kalchm/monica + 5 thermo × 4 quantities) that each suite reads from the same file. Expected values are **generated from canonical, not transcribed** — 9 of 12 hand-written monica values were wrong on the first pass, k10 reproducing itself exactly.

## TypeScript: 18 copies → 1

Allowlist is now at its target end state: **one entry**, the characterisation test's own restatement of the definition.

**⚠️ One ruling is reversed.** `src/calculations/alchemicalCalculations.ts` was to be **deleted** as unreachable. Three adversarial verifiers, each with a different lens, returned REACHABLE 3/3 at high confidence, with an empirical deletion test: `src/calculations/index.ts:459` does `export * from "./alchemicalCalculations"`, and removing the file yields `TS2307`. Worse — the neighbouring `export * from "./core/kalchmEngine"` exports `calculateKAlchm` (**capital A**), a *different identifier*, so nothing shadowed it and `import { calculateKalchm } from "@/calculations"` bound to **this** file: the copy returning **0** at a zeroed axis, making `ln(kalchm)` −Infinity. The barrel was publicly exporting the worst implementation in the repo. **Delegated, not deleted** — deletion is a one-way door, delegation fixes the behaviour and is reversible.

Also corrected: `src/lib/core-energy-rules.ts` is **not** live via galileo-logger (refuted by three sweeps, each with a positive control). That wrong rationale had deferred the file from a dead-code sweep twice. Three of its four alleged defects confirmed; the fourth was misdescribed.

`kalchmFloorDivergence.test.ts` is **rewritten, not deleted** — it kept asserting a divergence that no longer exists. It now pins the law (pure arithmetic, still true) *and* convergence (the regression guard).

## Third data witness

`scripts/checkNoNewClonedCharts.ts`, wired into the Monica Integrity workflow. A chart **reused as a fallback** is drift-clean (correctly derived from the chart it has) and structurally valid in SQL, so neither existing witness can see it. Growth detector, not a unique index — two people can legitimately share a birth moment. Verified against prod: controls pass, finds both known groups, flags Jung/Kahlo as **degenerate** (all ten bodies at Aries 0°).

This matters beyond tidiness: that degenerate chart holds the full-chart population maximum, and including it would set the Sacred-7 scale 3.6× wrong.

## Measurements that contradicted the spec (§18r)

| Spec | Measured |
|---|---|
| 540 reproducible / 203 absent / **423 unverifiable** | **967 reproducible / 198 placeholders**. The "inputs never persisted" population does not exist — they reproduce exactly. That work item is unnecessary. |
| Mars Gemini / Moon Cancer have "chart present, <5 bodies" | `natal_positions` is `[]` — no chart at all |
| 284 agents with monica 0 | **285** |
| 5028 agents | 5032 → **5057** within four hours |

Independently confirmed: clone-excluded full-chart scale **0.0047205** (robust under all three exclusion criteria), and `longitude` = 0 across all 710 body positions.

## Ephemeris gate (§18s) — cleared, but the blocker moved

56 body-date pairs vs JPL Horizons: **0 sign mismatches**, worst deviation 0.4533°, controls ≤0.0011°. k20 is cleared at sign granularity.

Two things nearly produced a wrong answer:
- **Horizons returns rows sorted by JD, not TLIST order.** A positional zip reported 26 sign mismatches — pure artefact, caught only because a control mapped J2000 to 1875.
- **Calendar convention dwarfs ephemeris error by two orders of magnitude.** JS `Date` is proleptic Gregorian; historical dates are Julian. Same JD = May 21 vs May 26 — ≈66° of Moon.

So the blocker for the 8 ancients is **date attestation, not ephemeris accuracy**.

## Verification

- `bun run verify` → exit 0
- `bun scripts/checkNoStrayKalchmFormula.ts` → exit 0, allowlist = 1
- `checkNoNewClonedCharts.ts` → controls pass, baseline matches
- Both parity suites' assertions exercised via `bun` (jest ignores `/.claude/`, so **they still need a real jest + pytest run from the primary checkout before merge**)

## Not in this PR

Task C (the `yield_day` partial unique index) needs a prod migration; tasks D/F/H and the chart authoring are queued behind decisions already taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)