### PR TITLE
economy: make the daily-yield guard atomic; extract the Python engine so its gate can run

### DIFF
--- a/.github/workflows/monica-integrity.yml
+++ b/.github/workflows/monica-integrity.yml
@@ -70,6 +70,29 @@ jobs:
         # neither of the others can see it.
         run: bun scripts/checkNoStrayKalchmFormula.ts
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cross-runtime engine parity (Python half)
+        # The kalchm formula exists once PER RUNTIME, and the AST gate above is a
+        # TypeScript gate — it structurally cannot see the Python engine, which
+        # serves production traffic via backend/Dockerfile's uvicorn CMD.
+        #
+        # Both halves read the SAME golden vectors
+        # (backend/tests/kalchm_golden_vectors.json), so a change to either
+        # runtime that is not mirrored in the other fails here.
+        #
+        # Only pytest is installed, deliberately: the engine module has NO
+        # framework imports, and keeping it that way is the property being
+        # protected. If this step ever needs fastapi to collect, the engine has
+        # been re-entangled with the web app and the gate is one refactor away
+        # from being skipped.
+        run: |
+          python -m pip install --quiet pytest
+          python -m pytest backend/tests/test_kalchm_parity.py -q
+
   # ---------------------------------------------------------------------------
   # Data. master + cron only: it needs production credentials, so it must never
   # run on a pull_request from a fork.

--- a/backend/alchm_kitchen/main.py
+++ b/backend/alchm_kitchen/main.py
@@ -32,6 +32,16 @@ from backend.database import get_db, Recipe, Ingredient, Recommendation, SystemM
 # New Auth Middleware import
 from backend.alchm_kitchen.auth_middleware import get_current_user
 
+# The kalchm/monica engine. It lives in its own module, with no framework
+# imports, so the cross-runtime parity gate can import it on a bare Python —
+# a gate that cannot be collected reads as a pass.
+from backend.alchm_kitchen.thermodynamics import (
+    MONICA_EQUILIBRIUM,
+    THERMO_DEN_FLOOR,
+    compute_kalchm_monica,
+)
+
+
 from backend.alchm_kitchen.recipe_generator import get_astrological_recipes
 try:
     import swisseph as swe
@@ -479,105 +489,6 @@ PLANET_ALCHM_PERIODS = {
 PERIOD_LOG_MIN = math.log10(0.003)
 PERIOD_LOG_MAX = math.log10(247.94)
 
-# ── The kalchm/monica engine constants, ported from TypeScript ───────────────
-#
-# This is the SECOND runtime that computes kalchm, so these must stay pinned to
-# src/data/unified/alchemicalCalculations.ts. The shared golden vectors in
-# backend/tests/test_kalchm_parity.py assert both runtimes agree bit-for-bit;
-# change a value here and that test fails.
-#
-# DERIVED, not tuned: the midpoint of a MEASURED bimodal gap in |ln kalchm| over
-# the single-body grid (11 planets x 12 signs x 30 degrees x 2 sects = 7920
-# points, a census not a sample). The degenerate cluster ends at exactly 0 and
-# the healthy values begin at 0.21878586815274545. The TS side re-derives both
-# endpoints in src/__tests__/monicaLnEpsilonDerivation.test.ts and FAILS if the
-# grid moves — update this literal in lockstep, never independently.
-MONICA_LN_EPSILON = 0.10939293407637272
-
-# The harmonic-ideal monica (golden ratio), returned for a perfectly balanced
-# (degenerate) alchemical state. monica is TOTAL: it is always finite, and this
-# engine never returns None or NaN.
-MONICA_EQUILIBRIUM = 1.618
-
-# Divide-by-zero guard for reactivity. Not derived — reactivity has no bimodal
-# structure to place it in; its only requirement is being small relative to real
-# reactivities, which it is.
-KALCHM_EPSILON = 0.01
-
-# Floor for the heat/entropy/reactivity denominators, matching
-# THERMO_DEN_FLOOR in src/data/unified/alchemicalCalculations.ts. Unlike the
-# kalchm denominator (which cannot reach 0 because x^x >= 0.6922), these three
-# ARE genuinely reachable at 0, so a guard is required. It must be a FLOOR and
-# not the truthiness fallback `(den or 1)` this file used: `or 1` substitutes
-# 1 for a zero denominator, which is 100x smaller than the floored value and
-# therefore understates the quantity by 100x at exactly the point where it
-# matters most.
-THERMO_DEN_FLOOR = 0.01
-
-
-def compute_kalchm_monica(
-    spirit: float,
-    essence: float,
-    matter: float,
-    substance: float,
-    reactivity: float,
-    gregs_energy: float,
-) -> tuple:
-    """The ONE kalchm/monica implementation in the Python runtime.
-
-    kalchm = (S^S * E^E) / (M^M * Su^Su),  monica = -gregsEnergy / (reactivity * ln kalchm)
-
-    Mirrors ``calculateKalchm`` / ``calculateMonica`` in
-    ``src/data/unified/alchemicalCalculations.ts``. Every behaviour below was
-    measured against that module over shared golden vectors; see
-    ``backend/tests/test_kalchm_parity.py``.
-
-    Three defects this replaces, each verified before removal:
-
-    1. ``(kalchm_denominator or 1)`` — a truthiness fallback. It was unreachable
-       for real input (x^x has a global minimum of 0.6922006275556402 at x=1/e,
-       so the denominator is never 0 for non-negative axes) and actively WRONG
-       for a negative one, because a complex denominator of 0+0j is falsy.
-    2. Unclamped negatives. Python's ``**`` returns a COMPLEX number for a
-       negative base with a fractional exponent — ``(-0.5) ** (-0.5)`` is
-       ``8.66e-17-1.414j`` — where JS ``Math.pow`` returns NaN. That complex
-       value then raised ``TypeError: '>' not supported between instances of
-       'complex' and 'int'``, surfacing as an HTTP 500. Clamping negatives to 0
-       makes the two runtimes agree in TYPE as well as value.
-    3. ``monica = 1.0`` — a fabricated literal, neither the equilibrium constant
-       nor an honest absence. Worse, the guard was the bare ``ln_k != 0``, which
-       excludes only the single point ln_k == 0 and does nothing about ln_k
-       merely SMALL: at kalchm = 1.00002 it returned -49999.5 where canonical
-       returns phi, a ~31000x error that is finite and plausible-looking, so it
-       survives every downstream ``isfinite`` check and reaches the database.
-    """
-    # Clamp NEGATIVES only. Zero passes through untouched because 0**0 is
-    # exactly 1 — the true limit of x^x — so a zeroed axis needs no handling.
-    def non_neg(x: float) -> float:
-        return x if x > 0 else 0.0
-
-    s = non_neg(spirit)
-    e = non_neg(essence)
-    m = non_neg(matter)
-    sub = non_neg(substance)
-
-    kalchm = ((s ** s) * (e ** e)) / ((m ** m) * (sub ** sub))
-    if not math.isfinite(kalchm) or kalchm <= 0:
-        return 1.0, MONICA_EQUILIBRIUM
-
-    # A degenerate BAND, not a bare `!= 0`. Inside it the chart is at
-    # equilibrium and monica is the golden ratio rather than a divergence.
-    ln_k = math.log(kalchm)
-    if abs(ln_k) < MONICA_LN_EPSILON:
-        return kalchm, MONICA_EQUILIBRIUM
-
-    safe_reactivity = reactivity
-    if abs(reactivity) < KALCHM_EPSILON:
-        safe_reactivity = math.copysign(KALCHM_EPSILON, reactivity if reactivity else 1.0)
-
-    monica = -gregs_energy / (safe_reactivity * ln_k)
-    # Totality: never NaN, never None, never infinite.
-    return kalchm, (monica if math.isfinite(monica) else MONICA_EQUILIBRIUM)
 
 PLANETARY_ALCHEMY = {
     "Sun": {"Spirit": 1, "Essence": 0, "Matter": 0, "Substance": 0},

--- a/backend/alchm_kitchen/thermodynamics.py
+++ b/backend/alchm_kitchen/thermodynamics.py
@@ -1,0 +1,115 @@
+"""The kalchm / monica engine — the ONE implementation in the Python runtime.
+
+Deliberately a standalone module with **no framework imports**. It is pure
+arithmetic, and the cross-runtime parity gate that guards it
+(``backend/tests/test_kalchm_parity.py``) must be runnable on a bare Python
+without FastAPI, SQLAlchemy or pyswisseph installed. When this lived inside
+``main.py`` the test could not be collected at all — importing it pulled in the
+whole web application — which is precisely the shape of gate that ends up
+skipped in CI and then reported as green.
+
+Pinned to the TypeScript canonical engine
+(``src/data/unified/alchemicalCalculations.ts``) by shared golden vectors in
+``backend/tests/kalchm_golden_vectors.json``.
+"""
+import math
+
+# ── The kalchm/monica engine constants, ported from TypeScript ───────────────
+#
+# This is the SECOND runtime that computes kalchm, so these must stay pinned to
+# src/data/unified/alchemicalCalculations.ts. The shared golden vectors in
+# backend/tests/test_kalchm_parity.py assert both runtimes agree bit-for-bit;
+# change a value here and that test fails.
+#
+# DERIVED, not tuned: the midpoint of a MEASURED bimodal gap in |ln kalchm| over
+# the single-body grid (11 planets x 12 signs x 30 degrees x 2 sects = 7920
+# points, a census not a sample). The degenerate cluster ends at exactly 0 and
+# the healthy values begin at 0.21878586815274545. The TS side re-derives both
+# endpoints in src/__tests__/monicaLnEpsilonDerivation.test.ts and FAILS if the
+# grid moves — update this literal in lockstep, never independently.
+MONICA_LN_EPSILON = 0.10939293407637272
+
+# The harmonic-ideal monica (golden ratio), returned for a perfectly balanced
+# (degenerate) alchemical state. monica is TOTAL: it is always finite, and this
+# engine never returns None or NaN.
+MONICA_EQUILIBRIUM = 1.618
+
+# Divide-by-zero guard for reactivity. Not derived — reactivity has no bimodal
+# structure to place it in; its only requirement is being small relative to real
+# reactivities, which it is.
+KALCHM_EPSILON = 0.01
+
+# Floor for the heat/entropy/reactivity denominators, matching
+# THERMO_DEN_FLOOR in src/data/unified/alchemicalCalculations.ts. Unlike the
+# kalchm denominator (which cannot reach 0 because x^x >= 0.6922), these three
+# ARE genuinely reachable at 0, so a guard is required. It must be a FLOOR and
+# not the truthiness fallback `(den or 1)` this file used: `or 1` substitutes
+# 1 for a zero denominator, which is 100x smaller than the floored value and
+# therefore understates the quantity by 100x at exactly the point where it
+# matters most.
+THERMO_DEN_FLOOR = 0.01
+
+
+def compute_kalchm_monica(
+    spirit: float,
+    essence: float,
+    matter: float,
+    substance: float,
+    reactivity: float,
+    gregs_energy: float,
+) -> tuple:
+    """The ONE kalchm/monica implementation in the Python runtime.
+
+    kalchm = (S^S * E^E) / (M^M * Su^Su),  monica = -gregsEnergy / (reactivity * ln kalchm)
+
+    Mirrors ``calculateKalchm`` / ``calculateMonica`` in
+    ``src/data/unified/alchemicalCalculations.ts``. Every behaviour below was
+    measured against that module over shared golden vectors; see
+    ``backend/tests/test_kalchm_parity.py``.
+
+    Three defects this replaces, each verified before removal:
+
+    1. ``(kalchm_denominator or 1)`` — a truthiness fallback. It was unreachable
+       for real input (x^x has a global minimum of 0.6922006275556402 at x=1/e,
+       so the denominator is never 0 for non-negative axes) and actively WRONG
+       for a negative one, because a complex denominator of 0+0j is falsy.
+    2. Unclamped negatives. Python's ``**`` returns a COMPLEX number for a
+       negative base with a fractional exponent — ``(-0.5) ** (-0.5)`` is
+       ``8.66e-17-1.414j`` — where JS ``Math.pow`` returns NaN. That complex
+       value then raised ``TypeError: '>' not supported between instances of
+       'complex' and 'int'``, surfacing as an HTTP 500. Clamping negatives to 0
+       makes the two runtimes agree in TYPE as well as value.
+    3. ``monica = 1.0`` — a fabricated literal, neither the equilibrium constant
+       nor an honest absence. Worse, the guard was the bare ``ln_k != 0``, which
+       excludes only the single point ln_k == 0 and does nothing about ln_k
+       merely SMALL: at kalchm = 1.00002 it returned -49999.5 where canonical
+       returns phi, a ~31000x error that is finite and plausible-looking, so it
+       survives every downstream ``isfinite`` check and reaches the database.
+    """
+    # Clamp NEGATIVES only. Zero passes through untouched because 0**0 is
+    # exactly 1 — the true limit of x^x — so a zeroed axis needs no handling.
+    def non_neg(x: float) -> float:
+        return x if x > 0 else 0.0
+
+    s = non_neg(spirit)
+    e = non_neg(essence)
+    m = non_neg(matter)
+    sub = non_neg(substance)
+
+    kalchm = ((s ** s) * (e ** e)) / ((m ** m) * (sub ** sub))
+    if not math.isfinite(kalchm) or kalchm <= 0:
+        return 1.0, MONICA_EQUILIBRIUM
+
+    # A degenerate BAND, not a bare `!= 0`. Inside it the chart is at
+    # equilibrium and monica is the golden ratio rather than a divergence.
+    ln_k = math.log(kalchm)
+    if abs(ln_k) < MONICA_LN_EPSILON:
+        return kalchm, MONICA_EQUILIBRIUM
+
+    safe_reactivity = reactivity
+    if abs(reactivity) < KALCHM_EPSILON:
+        safe_reactivity = math.copysign(KALCHM_EPSILON, reactivity if reactivity else 1.0)
+
+    monica = -gregs_energy / (safe_reactivity * ln_k)
+    # Totality: never NaN, never None, never infinite.
+    return kalchm, (monica if math.isfinite(monica) else MONICA_EQUILIBRIUM)

--- a/backend/tests/test_kalchm_parity.py
+++ b/backend/tests/test_kalchm_parity.py
@@ -17,7 +17,11 @@ import os
 
 import pytest
 
-from backend.alchm_kitchen.main import (
+# Imports the ENGINE module, not the FastAPI app. Importing
+# backend.alchm_kitchen.main pulls in fastapi/sqlalchemy/pyswisseph and this
+# suite could not be COLLECTED at all without them — a parity gate that cannot
+# run is worse than no gate, because its absence reads as a pass.
+from backend.alchm_kitchen.thermodynamics import (
     KALCHM_EPSILON,
     MONICA_EQUILIBRIUM,
     MONICA_LN_EPSILON,

--- a/database/init/73-daily-yield-once-per-day.sql
+++ b/database/init/73-daily-yield-once-per-day.sql
@@ -1,0 +1,83 @@
+-- Make the daily-yield guard ATOMIC.
+--
+-- ── The defect ──────────────────────────────────────────────────────────────
+--
+-- `POST /api/economy/sync-credit` §3b stops the same user being paid daily yield
+-- twice in a UTC day. It does it with a SELECT followed later by an INSERT —
+-- a check-then-act with nothing between them. Two concurrent requests can both
+-- pass the SELECT and both credit.
+--
+-- Key-based idempotency cannot cover this class. Two producers pay the same
+-- economic event under structurally non-colliding namespaces:
+--     in-repo cron   DailyYieldService.ts   `daily:agents:<uuid>:<date>`
+--     this endpoint  caller-supplied        `agentic:yield:<email>:<date>`
+-- Different strings for the same event, so the existing
+-- `token_transactions_idempotency_key_key` UNIQUE constraint never fires.
+--
+-- MEASURED 2026-07-19..21: 120 violating groups/day, ~227 excess tokens/day.
+-- It stopped on 2026-07-22 when the semantic guard shipped, and there have been
+-- zero since — but that guard holds only because the cron (00:30 UTC) and the
+-- external producer happen not to overlap. The route's own comment admits this.
+-- Scheduling luck is not a constraint.
+--
+-- ── Why a generated column and not an index expression ──────────────────────
+--
+-- The obvious `UNIQUE (..., (created_at AT TIME ZONE 'UTC')::date)` is REJECTED
+-- by Postgres: `timezone(text, timestamptz)` is STABLE, not IMMUTABLE, because
+-- timezone definitions can change. Index expressions must be IMMUTABLE. A
+-- stored generated column computed once at write time sidesteps that.
+--
+-- ── Why history is left alone ───────────────────────────────────────────────
+--
+-- 364 historical rows across 42 users would violate this index. They are NOT
+-- deleted, and the column is deliberately NULL for them.
+--
+-- MEASURED before choosing this: for Essence, Matter and Substance the ledger
+-- sum currently equals the stored balance EXACTLY (2908.87 / 5018.70 / 2693.64).
+-- Deleting 364 rows would remove 688.16 tokens from the ledger while
+-- `token_balances` stayed put, destroying that exact correspondence and leaving
+-- `userTimelineService` ("earned") and `dashboardPanelsService` ("minted")
+-- permanently under-reporting against balances that never moved.
+--
+-- Postgres allows unlimited NULLs in a unique index, so historical rows with a
+-- NULL yield_day simply do not participate. New rows get a real date and ARE
+-- constrained. The correctness goal is met in full without an irreversible
+-- delete and without rewriting an immutable ledger.
+
+-- ── 1. The day key ──────────────────────────────────────────────────────────
+--
+-- NULL for every existing row. The application sets it on new daily-yield
+-- writes; it stays NULL for every other source_type, which is what keeps
+-- multi-per-day sources (Sky Drops, transit attunement) unconstrained.
+ALTER TABLE token_transactions
+  ADD COLUMN IF NOT EXISTS yield_day date;
+
+COMMENT ON COLUMN token_transactions.yield_day IS
+  'UTC day of a daily-yield credit, set by the writer. NULL for every other '
+  'source_type and for all rows predating 2026-07-26, which is what lets the '
+  'partial unique index below constrain new writes without rewriting history. '
+  'Daily yield is once-per-user-per-UTC-day BY DEFINITION — this column makes '
+  'the database enforce that definition instead of the application re-checking '
+  'it non-atomically.';
+
+-- ── 2. The constraint ───────────────────────────────────────────────────────
+--
+-- One row per (user, source, token axis, UTC day). `creditMultipleTokens`
+-- writes one row PER AXIS, so token_type MUST be in the key — without it a
+-- single legitimate credit event (4 rows) would self-conflict.
+--
+-- NOT `CREATE INDEX CONCURRENTLY`: the migration runner wraps each file in a
+-- transaction, and CONCURRENTLY cannot run inside one. The table is small
+-- (~5.3k daily-yield rows), so the brief lock is acceptable.
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_daily_yield_per_user_day
+  ON token_transactions (user_id, source_type, token_type, yield_day)
+  WHERE source_type IN ('agents_yield', 'daily_yield')
+    AND yield_day IS NOT NULL;
+
+COMMENT ON INDEX uniq_daily_yield_per_user_day IS
+  'Atomic backstop for the daily-yield double-credit. The application guard in '
+  'sync-credit §3b is a check-then-act and cannot survive concurrency; this '
+  'turns the second writer into a unique violation the route already handles '
+  'as a 409. Partial on yield_day IS NOT NULL so the 364 historical violating '
+  'rows (2026-07-19..22) are untouched — see the header for why they are not '
+  'deleted.';

--- a/src/__tests__/api/syncCreditDailyGuard.test.ts
+++ b/src/__tests__/api/syncCreditDailyGuard.test.ts
@@ -24,6 +24,10 @@ let queryQueue: Array<{ rows: unknown[] }>;
 let executedSql: string[];
 let creditCalls: Array<{ userId: string; source: string }>;
 let claimStamps: Array<{ userId: string; site: string }>;
+/** When true, creditMultipleTokens returns null — what it does when the DB
+ *  rejects a racing credit via uniq_daily_yield_per_user_day. Must be named
+ *  `mock*` to be referenceable from inside a jest.mock factory. */
+let mockCreditReturnsNull = false;
 
 jest.mock("@/lib/database", () => ({
   executeQuery: jest.fn(async (sql: string) => {
@@ -37,6 +41,7 @@ jest.mock("@/services/TokenEconomyService", () => ({
     creditMultipleTokens: jest.fn(
       async (userId: string, _credits: unknown, source: string) => {
         creditCalls.push({ userId, source });
+        if (mockCreditReturnsNull) return null;
         return { spirit: 1, essence: 1, matter: 1, substance: 1 };
       },
     ),
@@ -85,6 +90,7 @@ beforeEach(() => {
   executedSql = [];
   creditCalls = [];
   claimStamps = [];
+  mockCreditReturnsNull = false;
 });
 
 describe("sync-credit — semantic daily guard", () => {
@@ -241,5 +247,49 @@ describe("sync-credit — the secret still gates everything", () => {
 
     expect(res.status).toBe(401);
     expect(executedSql).toEqual([]);
+  });
+});
+
+/**
+ * The ATOMIC half of the guard.
+ *
+ * Everything above tests the application-level §3b check. That check is a
+ * check-then-act — a SELECT, then an INSERT, with nothing between them — so two
+ * concurrent requests can both pass it and both credit. It held in production
+ * only because the in-repo cron (00:30 UTC) and the external producer happened
+ * not to overlap, which the route's own comment concedes is scheduling luck.
+ *
+ * `database/init/73-daily-yield-once-per-day.sql` closes that with
+ * `uniq_daily_yield_per_user_day`, a partial unique index on
+ * (user_id, source_type, token_type, yield_day). When the application guard
+ * loses a race, the second writer gets a 23505 and the route must answer 409 —
+ * the same answer it gives for an idempotency replay, and the correct one: the
+ * day's yield IS already applied.
+ *
+ * VERIFIED against production 2026-07-26 with savepoint-isolated probes — the
+ * duplicate is rejected, and a different day, a different token axis, and the
+ * multi-per-day sources are all still allowed.
+ */
+describe("sync-credit — the DB backstop when the app guard loses a race", () => {
+  it("409s instead of 500ing when the unique index rejects a racing credit", async () => {
+    queryQueue = [FOUND_USER, HAS_CHART, NO_ROWS, NO_ROWS];
+    // creditMultipleTokens returns null on the unique violation (it classifies
+    // 23505/uniq_daily_yield_per_user_day as "already applied", not a fault).
+    mockCreditReturnsNull = true;
+
+    const res = await POST(post(YIELD_BODY));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ ok: false, reason: "already_applied" });
+  });
+
+  it("does not stamp a daily-claim timestamp for a credit that was rejected", async () => {
+    // Stamping after a losing race would tell the CRON the yield was paid by
+    // this endpoint when it was not, turning a prevented double-credit into a
+    // silently SKIPPED one — the opposite failure, and harder to notice.
+    queryQueue = [FOUND_USER, HAS_CHART, NO_ROWS, NO_ROWS];
+    mockCreditReturnsNull = true;
+
+    await POST(post(YIELD_BODY));
+    expect(claimStamps).toHaveLength(0);
   });
 });

--- a/src/services/TokenEconomyService.ts
+++ b/src/services/TokenEconomyService.ts
@@ -122,12 +122,33 @@ function rowToTransaction(row: TokenTransactionRow): TokenTransaction {
   };
 }
 
+/** Source types that are once-per-user-per-UTC-day BY DEFINITION. Only these
+ *  get a `yield_day`, and only these are covered by
+ *  `uniq_daily_yield_per_user_day`. Everything else — Sky Drops, transit
+ *  attunement — is legitimately multi-per-day and must stay unconstrained. */
+const DAILY_YIELD_SOURCES = ["agents_yield", "daily_yield"] as const;
+
+/** The same list as a SQL literal, so the writer and the partial index in
+ *  `database/init/73-daily-yield-once-per-day.sql` cannot drift apart. If they
+ *  do, rows get a yield_day the index ignores (or vice versa) and the guard
+ *  silently stops guarding. */
+const DAILY_YIELD_SOURCES_SQL = DAILY_YIELD_SOURCES.map((s) => `'${s}'`).join(
+  ", ",
+);
+
 // Single-statement credit: ensure the balance row exists, insert an immutable
 // ledger entry (idempotency-guarded), and apply the delta to the typed column —
 // all atomically. `column` is a constrained union literal (never user input),
 // so interpolating it is injection-safe. Params, in order:
 //   $1 userId  $2 tokenType  $3 amount  $4 sourceType
 //   $5 sourceId  $6 description  $7 transactionGroupId  $8 idempotencyKey
+//
+// `yield_day` is computed IN THE DATABASE from `now()`, not passed in from the
+// caller. That matters: the whole point is a day key the application cannot get
+// wrong or disagree with itself about, and two producers running in different
+// timezones (or one of them holding a stale clock) is precisely how the
+// original double-credit arose. It is NULL for every non-daily-yield source, so
+// those rows do not participate in the unique index at all.
 function creditTokensSql(
   column: "spirit" | "essence" | "matter" | "substance",
 ): string {
@@ -138,9 +159,12 @@ function creditTokensSql(
           ),
           inserted AS (
             INSERT INTO token_transactions
-              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key, yield_day)
             VALUES
-              (COALESCE($7::uuid, uuid_generate_v4()), $1, $2, $3, $4, $5, $6, $8)
+              (COALESCE($7::uuid, uuid_generate_v4()), $1, $2, $3, $4, $5, $6, $8,
+               CASE WHEN $4 IN (${DAILY_YIELD_SOURCES_SQL})
+                    THEN (now() AT TIME ZONE 'UTC')::date
+                    ELSE NULL END)
             ON CONFLICT (idempotency_key) DO NOTHING
             RETURNING id
           )
@@ -560,6 +584,27 @@ class TokenEconomyService {
         // reflects any prior claim, so return the current balance.
         return this.getBalances(userId);
       } catch (error) {
+        // A unique violation on `uniq_daily_yield_per_user_day` is not a
+        // failure — it is the atomic backstop doing its job. The application
+        // guard in sync-credit §3b is a check-then-act SELECT, so two concurrent
+        // requests can both pass it; this index is what makes the second one
+        // lose. Returning null routes it to the same 409 "already_applied" the
+        // caller already produces for an idempotency replay, which is exactly
+        // the right answer: the day's yield IS already applied.
+        //
+        // Distinguished from a genuine fault so it is not logged as an error and
+        // does not read as an incident. 23505 = unique_violation.
+        const pgError = error as { code?: string; constraint?: string };
+        if (
+          pgError?.code === "23505" &&
+          pgError?.constraint === "uniq_daily_yield_per_user_day"
+        ) {
+          _logger.info(
+            `[TokenEconomy] daily-yield double-credit prevented by the DB for user ${userId} (${sourceType}); ` +
+              "the application guard lost a race and the index caught it.",
+          );
+          return null;
+        }
         _logger.error(
           "[TokenEconomy] creditMultipleTokens failed, rolled back:",
           error,


### PR DESCRIPTION
Two things that could not be finished before #651 merged, plus one reversal on new evidence.

## 1. The parity gate added in #651 could not actually run

`pytest` could not even **collect** `backend/tests/test_kalchm_parity.py`:

```
ModuleNotFoundError: No module named 'fastapi'
```

Reaching `compute_kalchm_monica` meant importing `backend.alchm_kitchen.main`, which drags in fastapi, sqlalchemy and pyswisseph. **A gate that cannot be collected reads as a pass** — the exact failure this programme keeps finding.

Extracted to `backend/alchm_kitchen/thermodynamics.py`: pure arithmetic, `import math` and nothing else. Still exactly one implementation in the Python runtime; `main.py` imports from it. CI now runs the pytest half installing **only pytest** — deliberately, so that if the step ever needs fastapi to collect, the engine has been re-entangled with the web app and the gate is one refactor from being skipped.

### The real test run you asked for

From a clean checkout of master in a sibling worktree (jest ignores `/.claude/`, which is why this could not be confirmed pre-merge):

| suite | result |
|---|---|
| `kalchmCrossRuntimeParity` + `kalchmFloorDivergence` | **47 passed** |
| all 9 kalchm/monica suites | **162 passed** |
| `pytest test_kalchm_parity.py` | **41 passed** |
| economy / token / sync | **36 passed** |

Both new files confirmed present in `--listTests`, not merely "no failures".

## 2. The daily-yield guard is now atomic

`sync-credit` §3b is a check-then-act SELECT. Two concurrent requests both pass it. Key idempotency structurally cannot help — the two producers use non-colliding namespaces for the same event. It has held since Jul 22 only because the cron and the external producer don't overlap; the route's own comment concedes that is luck.

`uniq_daily_yield_per_user_day` — partial unique index on `(user_id, source_type, token_type, yield_day)`. `token_type` is in the key because `creditMultipleTokens` writes one row **per axis**; without it a legitimate 4-row credit self-conflicts. `yield_day` is a real column, not an index expression: Postgres rejects `(created_at AT TIME ZONE 'UTC')::date` because `timezone()` is STABLE, not IMMUTABLE. It is computed **in the database** from `now()`, never passed in — producers with disagreeing clocks is how the original defect arose.

### ⚠️ This reverses the "dedupe the rows" decision, on evidence found while doing it

364 rows across 42 users would violate the index, and the plan was to delete them. Measuring first changed the answer:

> For **Essence, Matter and Substance the ledger sum currently equals the stored balance EXACTLY** — 2908.87 / 5018.70 / 2693.64.

Deleting 364 rows removes 688.16 tokens from an immutable ledger while `token_balances` stays put — destroying that exact correspondence and leaving `userTimelineService` ("earned") and `dashboardPanelsService` ("minted") permanently under-reporting against balances that never moved. The dedupe was chosen on the belief that it "does not change balances", which is true, but it breaks something else that is currently exact.

Postgres allows unlimited NULLs in a unique index, so historical rows with a NULL `yield_day` don't participate. **Full correctness, no irreversible delete, no rewriting an immutable ledger.**

### Verified against production

Applied, then probed with **SAVEPOINT-isolated** inserts — a bare sequence is useless here, because the expected violation aborts the transaction and every later probe fails with "current transaction is aborted", which reads as a failing control while exercising nothing:

| probe | result |
|---|---|
| duplicate: same user/source/axis/day, **different key** | rejected 23505 ✓ |
| same axis, next day | allowed ✓ |
| different axis, same day | allowed ✓ |
| `transit_attunement` ×2 (multi-per-day) | allowed ✓ |
| `daily_yield` duplicate | rejected 23505 ✓ |

Rolled back; 0 probe rows persisted.

## 3. Production backfill (also completed this session)

Followed the write protocol end to end: deploy confirmed **by measurement** (live reactivity 2.226 is below the old form's hard lower bound of ~10.6, so the deployed code cannot be the old code) → fresh snapshot → **restore proven inside a rolled-back transaction** across all four populations and all seven monica columns → dry run → abort rule evaluated → write → three witnesses.

- 41 new arrivals classified; **5061/5061 accounted for, non-finite 0**
- φ share moved ≤ 0.08 pt in every population (abort threshold was "a point or two")
- drift check: **drifted 0, missing 0, wrong-method 0**
- integrity audit: **23 checks, 0 failures**
- clone detector: baseline matches, no new clones

The restore proof caught a real defect in *itself* first: a hand-written 5-column restore left `monica_diurnal`/`monica_nocturnal` NULL and the `monica_both_sects_present` CHECK rejected it — the same defect class that made 694 rows unrecoverable, reproduced live in about thirty seconds. Columns are now discovered from `information_schema`, never hardcoded.

## ⚠️ Separate pre-existing finding, not investigated

**Spirit does not reconcile** for those same 42 users: ledger 3819.13 vs balance 3495.13, a **324.00 gap**. Unrelated to the double-credit, which over-credited and would push the other way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)