### PR TITLE
fix(economy): every credit threw — plus the fabricated longitude, and real token rates

### DIFF
--- a/.github/workflows/monica-integrity.yml
+++ b/.github/workflows/monica-integrity.yml
@@ -184,3 +184,18 @@ jobs:
         env:
           DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
         run: bun scripts/checkNoFabricatedNatalFields.ts
+
+      - name: Economy SQL parses against PostgreSQL
+        # SQL is a second language here and ONLY the database can typecheck it.
+        # The credit statement once shipped in a state PostgreSQL refused to
+        # prepare at all (42P08, a bind parameter deduced as two different
+        # types) — so every credit threw. Thirteen unit tests covered that path
+        # and all thirteen passed, because they mock the database, and a mock
+        # accepts SQL no database would.
+        #
+        # PREPARE does parse + parameter-type analysis and writes NOTHING: no
+        # transaction, no rows. It also catches a misspelled column and a
+        # parameter count that has drifted from the call site.
+        env:
+          DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
+        run: bun scripts/checkEconomySqlParses.ts

--- a/.github/workflows/monica-integrity.yml
+++ b/.github/workflows/monica-integrity.yml
@@ -166,3 +166,21 @@ jobs:
         env:
           DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
         run: bun scripts/checkNoNewClonedCharts.ts
+
+      - name: No fabricated fields on stored natal bodies
+        # A FOURTH data witness. The other three all passed while every one of the
+        # 710 stored bodies carried `longitude: 0` — a fabricated literal, since
+        # the upstream producer evaluates `data?.longitude ?? data?.degrees ?? 0`
+        # over objects that have neither key. Drift-clean (the canonical parser
+        # ignores it), structurally valid, and not a clone, so nothing else saw it.
+        #
+        # `0` is not nullish, so a `?? longitude ??` chain STOPS there and never
+        # reaches `degree` — which is how an earlier audit "found" 71 all-zero
+        # charts that were nothing of the kind.
+        #
+        # The ingest endpoints now strip the key, but the upstream provisioning
+        # scripts are run BY HAND against this database. This step is what notices
+        # if that stripping is ever removed or routed around by a new write path.
+        env:
+          DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
+        run: bun scripts/checkNoFabricatedNatalFields.ts

--- a/backend/alchm_kitchen/main.py
+++ b/backend/alchm_kitchen/main.py
@@ -36,9 +36,9 @@ from backend.alchm_kitchen.auth_middleware import get_current_user
 # imports, so the cross-runtime parity gate can import it on a bare Python —
 # a gate that cannot be collected reads as a pass.
 from backend.alchm_kitchen.thermodynamics import (
-    MONICA_EQUILIBRIUM,
     THERMO_DEN_FLOOR,
     compute_kalchm_monica,
+    planetary_hour_esms,
 )
 
 
@@ -843,7 +843,17 @@ class TokenRatesResult(BaseModel):
     Matter: float
     Substance: float
     kalchm: float
-    monica: float
+    # NULLABLE, deliberately. monica = -gregsEnergy / (reactivity * ln kalchm),
+    # and both gregsEnergy and reactivity are functions of the four ELEMENTS.
+    # Elements come from SIGNS; this endpoint is given only a planetary HOUR,
+    # which names a ruling planet and no sign. So monica is genuinely not
+    # derivable here, and null says that. Substituting a literal would invent
+    # data — which is exactly what the previous `monica=1.0` did.
+    #
+    # kalchm is a different case: it is (S^S * E^E) / (M^M * Su^Su), a function
+    # of the ESMS axes ALONE, and those the planetary hour does determine. So
+    # kalchm is real and monica is absent, which is not an inconsistency.
+    monica: Optional[float] = None
     planetaryHour: Optional[str] = None
     isDaytime: Optional[bool] = None
 
@@ -888,13 +898,27 @@ async def calculate_token_rates_endpoint(request: TokenRatesRequest):
     except Exception:
         pass
         
-    # kalchm 1.0 is the true degenerate value for a unit ESMS vector, and monica
-    # at that kalchm is the equilibrium constant — NOT 1.0, which was a
-    # fabricated literal. The four unit axes remain a declared convention for
-    # this rate endpoint rather than a measurement.
+    # The four axes are MEASURED from the resolved planetary hour, not declared.
+    # Previously they were the literals (1,1,1,1), which made kalchm 1.0 for
+    # every hour of every day — a constant wearing the shape of a computation.
+    #
+    # The construction is single-body (§18c): the ruling planet's own sectarian
+    # row plus the Ascendant grounding vessel. Without the vessel a ruler
+    # contributes to one axis, the other three are 0, and the result carries no
+    # information. With it, e.g. a diurnal Sun hour gives (2,1,1,1) -> kalchm 4.0
+    # and a nocturnal Moon hour gives (1,1,2,1) -> kalchm 0.25.
+    esms = planetary_hour_esms(planetary_hour, is_day)
+    kalchm, _ = compute_kalchm_monica(
+        esms["Spirit"], esms["Essence"], esms["Matter"], esms["Substance"],
+        # Reactivity and gregsEnergy are element-derived and unavailable here, so
+        # the monica this returns would be meaningless. It is discarded and the
+        # field is reported as null — see TokenRatesResult.monica.
+        reactivity=1.0, gregs_energy=1.0,
+    )
     return TokenRatesResult(
-        Spirit=1.0, Essence=1.0, Matter=1.0, Substance=1.0,
-        kalchm=1.0, monica=MONICA_EQUILIBRIUM,
+        Spirit=esms["Spirit"], Essence=esms["Essence"],
+        Matter=esms["Matter"], Substance=esms["Substance"],
+        kalchm=kalchm, monica=None,
         planetaryHour=planetary_hour,
         isDaytime=is_day
     )

--- a/backend/alchm_kitchen/thermodynamics.py
+++ b/backend/alchm_kitchen/thermodynamics.py
@@ -113,3 +113,70 @@ def compute_kalchm_monica(
     monica = -gregs_energy / (safe_reactivity * ln_k)
     # Totality: never NaN, never None, never infinite.
     return kalchm, (monica if math.isfinite(monica) else MONICA_EQUILIBRIUM)
+
+
+# ── Planet -> ESMS, by sect ─────────────────────────────────────────────────
+#
+# The SECOND copy of this table in the project. The first is
+# `PLANETARY_SECTARIAN_ESMS` in src/utils/planetaryAlchemyMapping.ts, which is
+# canonical: it is what the chart engine, RealAlchemizeService and all three
+# agent-monica constructions read.
+#
+# A second copy is a divergence hazard of exactly the kind this module exists to
+# contain — a Python reactivity formula silently drifted from its TypeScript
+# original for months and was 3.17x wrong. So this copy is NOT trusted on sight:
+# backend/tests/kalchm_golden_vectors.json carries the table as generated FROM
+# the TypeScript source, and test_kalchm_parity.py asserts this dict equals it
+# entry for entry, both sects. If someone edits one side only, that test fails.
+#
+# Ascendant is not a planet. It is the GROUNDING VESSEL: without it a single
+# body contributes to at most one axis, three axes are 0, and kalchm collapses to
+# a degenerate value carrying no information. It is what makes a one-body
+# reading meaningful, and it is why it is 1 on every axis in both sects.
+PLANETARY_SECTARIAN_ESMS: dict[str, dict[str, dict[str, float]]] = {
+    "Sun":       {"diurnal": {"Spirit": 1, "Essence": 0, "Matter": 0, "Substance": 0},
+                  "nocturnal": {"Spirit": 1, "Essence": 0, "Matter": 0, "Substance": 0}},
+    "Moon":      {"diurnal": {"Spirit": 0, "Essence": 1, "Matter": 0, "Substance": 0},
+                  "nocturnal": {"Spirit": 0, "Essence": 0, "Matter": 1, "Substance": 0}},
+    "Mercury":   {"diurnal": {"Spirit": 1, "Essence": 0, "Matter": 0, "Substance": 0},
+                  "nocturnal": {"Spirit": 0, "Essence": 0, "Matter": 0, "Substance": 1}},
+    "Venus":     {"diurnal": {"Spirit": 0, "Essence": 1, "Matter": 0, "Substance": 0},
+                  "nocturnal": {"Spirit": 0, "Essence": 0, "Matter": 1, "Substance": 0}},
+    "Mars":      {"diurnal": {"Spirit": 0, "Essence": 1, "Matter": 0, "Substance": 0},
+                  "nocturnal": {"Spirit": 0, "Essence": 0, "Matter": 1, "Substance": 0}},
+    "Jupiter":   {"diurnal": {"Spirit": 1, "Essence": 0, "Matter": 0, "Substance": 0},
+                  "nocturnal": {"Spirit": 0, "Essence": 1, "Matter": 0, "Substance": 0}},
+    "Saturn":    {"diurnal": {"Spirit": 1, "Essence": 0, "Matter": 0, "Substance": 0},
+                  "nocturnal": {"Spirit": 0, "Essence": 0, "Matter": 1, "Substance": 0}},
+    "Uranus":    {"diurnal": {"Spirit": 0, "Essence": 1, "Matter": 0, "Substance": 0},
+                  "nocturnal": {"Spirit": 0, "Essence": 0, "Matter": 1, "Substance": 0}},
+    "Neptune":   {"diurnal": {"Spirit": 0, "Essence": 1, "Matter": 0, "Substance": 0},
+                  "nocturnal": {"Spirit": 0, "Essence": 0, "Matter": 0, "Substance": 1}},
+    "Pluto":     {"diurnal": {"Spirit": 0, "Essence": 1, "Matter": 0, "Substance": 0},
+                  "nocturnal": {"Spirit": 0, "Essence": 0, "Matter": 1, "Substance": 0}},
+    "Ascendant": {"diurnal": {"Spirit": 1, "Essence": 1, "Matter": 1, "Substance": 1},
+                  "nocturnal": {"Spirit": 1, "Essence": 1, "Matter": 1, "Substance": 1}},
+}
+
+AXES = ("Spirit", "Essence", "Matter", "Substance")
+
+
+def planetary_hour_esms(ruler: str, is_daytime: bool) -> dict[str, float]:
+    """ESMS for a single ruling planet, grounded by the Ascendant vessel.
+
+    This is the SINGLE-BODY construction (§18c), the same shape the TypeScript
+    side uses for a one-placement agent: the planet's own sectarian row plus the
+    Ascendant vessel. The vessel is not decoration — drop it and Matter and
+    Substance are both 0 for most rulers, which sends the denominator to 1 and
+    makes kalchm depend on the numerator alone.
+
+    An unknown ruler returns the vessel by itself rather than raising: this feeds
+    a rate endpoint, and a KeyError there would be a 500. The vessel alone is
+    ESMS (1,1,1,1) -> kalchm 1.0, which is honestly degenerate rather than wrong.
+    """
+    sect = "diurnal" if is_daytime else "nocturnal"
+    vessel = PLANETARY_SECTARIAN_ESMS["Ascendant"][sect]
+    row = PLANETARY_SECTARIAN_ESMS.get(ruler, {}).get(sect)
+    if row is None:
+        return {a: float(vessel[a]) for a in AXES}
+    return {a: float(row[a] + vessel[a]) for a in AXES}

--- a/backend/tests/kalchm_golden_vectors.json
+++ b/backend/tests/kalchm_golden_vectors.json
@@ -236,5 +236,161 @@
       "expectedReactivity": 1.8245874441960752,
       "expectedGregsEnergy": -0.2321123146538833
     }
-  ]
+  ],
+  "planetarySectarianEsms": {
+    "Sun": {
+      "diurnal": {
+        "Spirit": 1,
+        "Essence": 0,
+        "Matter": 0,
+        "Substance": 0
+      },
+      "nocturnal": {
+        "Spirit": 1,
+        "Essence": 0,
+        "Matter": 0,
+        "Substance": 0
+      }
+    },
+    "Moon": {
+      "diurnal": {
+        "Spirit": 0,
+        "Essence": 1,
+        "Matter": 0,
+        "Substance": 0
+      },
+      "nocturnal": {
+        "Spirit": 0,
+        "Essence": 0,
+        "Matter": 1,
+        "Substance": 0
+      }
+    },
+    "Mercury": {
+      "diurnal": {
+        "Spirit": 1,
+        "Essence": 0,
+        "Matter": 0,
+        "Substance": 0
+      },
+      "nocturnal": {
+        "Spirit": 0,
+        "Essence": 0,
+        "Matter": 0,
+        "Substance": 1
+      }
+    },
+    "Venus": {
+      "diurnal": {
+        "Spirit": 0,
+        "Essence": 1,
+        "Matter": 0,
+        "Substance": 0
+      },
+      "nocturnal": {
+        "Spirit": 0,
+        "Essence": 0,
+        "Matter": 1,
+        "Substance": 0
+      }
+    },
+    "Mars": {
+      "diurnal": {
+        "Spirit": 0,
+        "Essence": 1,
+        "Matter": 0,
+        "Substance": 0
+      },
+      "nocturnal": {
+        "Spirit": 0,
+        "Essence": 0,
+        "Matter": 1,
+        "Substance": 0
+      }
+    },
+    "Jupiter": {
+      "diurnal": {
+        "Spirit": 1,
+        "Essence": 0,
+        "Matter": 0,
+        "Substance": 0
+      },
+      "nocturnal": {
+        "Spirit": 0,
+        "Essence": 1,
+        "Matter": 0,
+        "Substance": 0
+      }
+    },
+    "Saturn": {
+      "diurnal": {
+        "Spirit": 1,
+        "Essence": 0,
+        "Matter": 0,
+        "Substance": 0
+      },
+      "nocturnal": {
+        "Spirit": 0,
+        "Essence": 0,
+        "Matter": 1,
+        "Substance": 0
+      }
+    },
+    "Uranus": {
+      "diurnal": {
+        "Spirit": 0,
+        "Essence": 1,
+        "Matter": 0,
+        "Substance": 0
+      },
+      "nocturnal": {
+        "Spirit": 0,
+        "Essence": 0,
+        "Matter": 1,
+        "Substance": 0
+      }
+    },
+    "Neptune": {
+      "diurnal": {
+        "Spirit": 0,
+        "Essence": 1,
+        "Matter": 0,
+        "Substance": 0
+      },
+      "nocturnal": {
+        "Spirit": 0,
+        "Essence": 0,
+        "Matter": 0,
+        "Substance": 1
+      }
+    },
+    "Pluto": {
+      "diurnal": {
+        "Spirit": 0,
+        "Essence": 1,
+        "Matter": 0,
+        "Substance": 0
+      },
+      "nocturnal": {
+        "Spirit": 0,
+        "Essence": 0,
+        "Matter": 1,
+        "Substance": 0
+      }
+    },
+    "Ascendant": {
+      "diurnal": {
+        "Spirit": 1,
+        "Essence": 1,
+        "Matter": 1,
+        "Substance": 1
+      },
+      "nocturnal": {
+        "Spirit": 1,
+        "Essence": 1,
+        "Matter": 1,
+        "Substance": 1
+      }
+    }
+  }
 }

--- a/backend/tests/test_kalchm_parity.py
+++ b/backend/tests/test_kalchm_parity.py
@@ -22,10 +22,13 @@ import pytest
 # suite could not be COLLECTED at all without them — a parity gate that cannot
 # run is worse than no gate, because its absence reads as a pass.
 from backend.alchm_kitchen.thermodynamics import (
+    AXES,
     KALCHM_EPSILON,
     MONICA_EQUILIBRIUM,
     MONICA_LN_EPSILON,
+    PLANETARY_SECTARIAN_ESMS,
     THERMO_DEN_FLOOR,
+    planetary_hour_esms,
     compute_kalchm_monica,
 )
 
@@ -230,3 +233,81 @@ def test_denominator_guard_is_a_floor_not_a_truthiness_fallback():
     num = 25.0
     assert num / max(0.0, THERMO_DEN_FLOOR) == 2500.0
     assert num / (0.0 or 1) == 25.0
+
+
+# ── Planet -> ESMS table parity ─────────────────────────────────────────────
+#
+# The token-rates endpoint needs a planet -> ESMS mapping, so a SECOND copy of
+# that table now exists in Python. A second copy of anything in this project is a
+# divergence hazard: the reactivity formula below drifted from its TypeScript
+# original for months and was 3.17x wrong, and nothing in either type system
+# noticed. These pin the table the same way the formula is pinned — against a
+# contract file GENERATED from the canonical TypeScript symbol.
+
+GOLDEN_ESMS = GOLDEN["planetarySectarianEsms"]
+
+
+def test_esms_table_contract_is_populated():
+    """CONTROL. Every assertion below iterates the contract, so an empty or
+    truncated contract would make all of them pass vacuously."""
+    assert len(GOLDEN_ESMS) == 11, f"expected 10 planets + Ascendant, got {len(GOLDEN_ESMS)}"
+    assert "Ascendant" in GOLDEN_ESMS, "the grounding vessel is missing from the contract"
+    for body, sects in GOLDEN_ESMS.items():
+        assert set(sects) == {"diurnal", "nocturnal"}, f"{body} is missing a sect"
+
+
+def test_python_esms_table_matches_canonical_typescript_exactly():
+    """Entry for entry, both sects. `==` on the numbers, not approx."""
+    assert set(PLANETARY_SECTARIAN_ESMS) == set(GOLDEN_ESMS), (
+        "the Python table and the canonical TypeScript table disagree on WHICH "
+        f"bodies exist: python-only={set(PLANETARY_SECTARIAN_ESMS) - set(GOLDEN_ESMS)}, "
+        f"ts-only={set(GOLDEN_ESMS) - set(PLANETARY_SECTARIAN_ESMS)}"
+    )
+    for body, sects in GOLDEN_ESMS.items():
+        for sect, axes in sects.items():
+            for axis, value in axes.items():
+                assert PLANETARY_SECTARIAN_ESMS[body][sect][axis] == value, (
+                    f"{body}.{sect}.{axis}: python "
+                    f"{PLANETARY_SECTARIAN_ESMS[body][sect][axis]!r} vs canonical {value!r}"
+                )
+
+
+def test_the_ascendant_is_a_vessel_on_every_axis_in_both_sects():
+    """Asserting the prose. The Ascendant is not a planet — it is the grounding
+    vessel, and it is 1 on all four axes precisely so that a single body can
+    produce a non-degenerate kalchm. A green test beside that claim proves
+    nothing unless the claim is asserted."""
+    for sect in ("diurnal", "nocturnal"):
+        for axis in AXES:
+            assert PLANETARY_SECTARIAN_ESMS["Ascendant"][sect][axis] == 1
+
+
+def test_a_planetary_hour_is_never_degenerate_without_the_vessel_being_the_reason():
+    """Every real ruler must give a kalchm that carries information. If a future
+    edit drops the vessel, most rulers collapse to kalchm 1.0 and this fails."""
+    informative = 0
+    for ruler in GOLDEN_ESMS:
+        if ruler == "Ascendant":
+            continue
+        for is_day in (True, False):
+            e = planetary_hour_esms(ruler, is_day)
+            assert sum(e.values()) == 5.0, f"{ruler} lost the vessel: {e}"
+            kalchm, _ = compute_kalchm_monica(
+                e["Spirit"], e["Essence"], e["Matter"], e["Substance"], 1.0, 1.0)
+            assert math.isfinite(kalchm) and kalchm > 0
+            if kalchm != 1.0:
+                informative += 1
+    assert informative == 20, (
+        f"only {informative} of 20 planetary hours produce a non-degenerate "
+        "kalchm — the previous implementation produced 0 of 20 by returning the "
+        "literal 1.0 for every hour"
+    )
+
+
+def test_an_unknown_ruler_degrades_to_the_vessel_rather_than_raising():
+    """This feeds a rate endpoint; a KeyError there is a 500. The vessel alone is
+    (1,1,1,1) -> kalchm 1.0, which is honestly degenerate rather than invented."""
+    e = planetary_hour_esms("Nibiru", True)
+    assert e == {"Spirit": 1.0, "Essence": 1.0, "Matter": 1.0, "Substance": 1.0}
+    kalchm, _ = compute_kalchm_monica(1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+    assert kalchm == 1.0

--- a/docs/physics/ALCHM_AGENTS_ETH_BRIEF_ROUND2.md
+++ b/docs/physics/ALCHM_AGENTS_ETH_BRIEF_ROUND2.md
@@ -4,9 +4,12 @@
 
 > ## ⚠️ Read this line before anything else
 >
-> **Pinned reference: `f919172fc2bbf660caa07d18002b33bd869997e2`**
-> (branch `claude/wten-thermodynamics-completion-852fa3`, PR
-> [#651](https://github.com/gregcastro23/WhatToEatNext/pull/651))
+> **Pinned reference: `3097a0bd` on `master`** — PR
+> [#651](https://github.com/gregcastro23/WhatToEatNext/pull/651) as merged.
+>
+> *(Superseded pin: `f919172fc2bbf660caa07d18002b33bd869997e2`, the pre-merge
+> branch commit. The squash merge made it a non-ancestor of `master` — still
+> fetchable, but `git show 3097a0bd:<path>` is the one to use.)*
 >
 > Every file path and line number below is relative to **that commit**. A bare
 > filesystem path is *not* a reference to a version, and the reader cannot tell
@@ -142,7 +145,49 @@ all 286 compositions proves the heuristic can only produce `[2.50, 5.21]`, so
 
 ---
 
-## 5. Round 3
+## 5. Addendum — corrections earned by the round-2 reply (2026-07-26)
+
+**5a. "Test the band, never the point" was stated without its precondition, and
+that was our error.** The reply measured AAE's own population and found the
+degenerate gap COLLAPSES as bodies are added — 1 body 0.0956, 2 bodies 0.00419,
+3 bodies 3.22e-05, complete charts > 2.0. That is a continuum, and no band is
+derivable from it. Our constant would have discarded 26,882 of 570,240
+legitimate three-body results.
+
+We re-measured ours on the same day. WTEN's single-body population **does** have
+the gap:
+
+| candidate band | grid points inside |
+|---|---|
+| 0.05 | 660 / 7920 |
+| 0.1244355 (two-body derived) | 660 / 7920 |
+| 0.1093929 (widest gap, the shipped constant) | 660 / 7920 |
+
+660 points sit at exactly 0 and the next value is 0.218786 — **nothing in
+between**, which is why all three candidate boundaries select the identical set.
+The constant is the midpoint of that gap and it reproduces.
+
+So both measurements are right, about different objects. This is §18o again:
+a single-body construction and a partial multi-body chart are not the same thing
+and must not share a constant. **The transferable rule is not the number, it is:
+derive the band from YOUR measured population, and if the gap is not there, do
+not invent one.** Rejecting partial charts at the request boundary is the better
+fix and we would not have found it.
+
+**5b. §3b was misattributed.** `[2.50, 5.21]` and "286 compositions" describe
+AAE's own `server.ts` heuristic, not anything in WTEN — there is no such
+heuristic here at the pinned SHA. The ruling (delete the two unreachable tiers)
+stands on AAE's evidence; the provenance in §3b was wrong and is withdrawn.
+
+**5c. Confirmed from our side.** The lost-parens reactivity defect reproduced in
+two further runtimes, and the gate blind spot generalised to a third and fourth.
+Also worth recording for whoever takes the nullable-migration session:
+`lib/monica/monica-constant.ts` ships `(Spirit·φ + Essence)/(Matter + Substance
++ 1)` under the Monica name, so the stored `monicaConstant` is not the
+thermodynamic Monica at all — a naming collision of exactly the kind our own
+constructor census is cataloguing.
+
+## 6. Round 3
 
 Not scheduled. WTEN's remaining open items (a partial unique index for the
 daily-yield guard, a provenance column, chart authoring for 10 cloned rows) are

--- a/scripts/checkEconomySqlParses.ts
+++ b/scripts/checkEconomySqlParses.ts
@@ -1,0 +1,159 @@
+/**
+ * CI gate: does the economy SQL actually PARSE against PostgreSQL?
+ *
+ * ── Why this exists ─────────────────────────────────────────────────────────
+ *
+ * `[MEASURED 2026-07-26]` the credit statement shipped to production in a state
+ * where PostgreSQL rejected it outright:
+ *
+ *     42P08  inconsistent types deduced for parameter $4
+ *
+ * `$4` (sourceType) was bound BOTH as the INSERT value for a `character varying`
+ * column AND, uncast, inside `CASE WHEN $4 IN ('agents_yield','daily_yield')`,
+ * where the literals made it `text`. A bind parameter has exactly ONE deduced
+ * type, so the statement could not be prepared at all — every credit threw.
+ *
+ * Thirteen unit tests covered that code path and all thirteen passed, because
+ * they mock the database. A mocked `executeQuery` will happily "run" SQL that no
+ * PostgreSQL will accept. That is the defect class this gate closes: SQL is a
+ * second language in this codebase and only the database can typecheck it.
+ *
+ * ── Why PREPARE ─────────────────────────────────────────────────────────────
+ *
+ * PREPARE performs parse + parameter-type analysis — exactly where 42P08 fires —
+ * and writes NOTHING. No transaction, no rows, no side effects. It also catches
+ * misspelled columns, dropped tables, and a parameter count that has drifted
+ * from the call site.
+ *
+ * ── Controls ────────────────────────────────────────────────────────────────
+ *
+ * A zero result is a claim requiring a control test: if the extractor silently
+ * matched nothing, "0 statements failed" would read as a pass. So the run FAILS
+ * unless it extracted every statement it expects, and it additionally proves it
+ * can detect a genuinely broken statement by preparing one that must fail.
+ *
+ * Read-only. Never writes.
+ *
+ *   railway run --service Postgres -- bun scripts/checkEconomySqlParses.ts
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+import pg from "pg";
+
+const fail = (msg: string): never => {
+  console.error(`\n✗ ${msg}`);
+  process.exit(1);
+};
+
+const url = process.env.DATABASE_PUBLIC_URL ?? process.env.DATABASE_URL;
+if (!url) fail("no DATABASE_PUBLIC_URL / DATABASE_URL in the environment");
+
+const SERVICE = join(
+  process.cwd(),
+  "src/services/TokenEconomyService.ts",
+);
+const source = readFileSync(SERVICE, "utf8");
+
+// The four axis columns are interpolated into the statement, so each is a
+// DIFFERENT statement and each must be checked. A typo in one would otherwise
+// only surface for whichever axis happened to be credited.
+const COLUMNS = ["spirit", "essence", "matter", "substance"] as const;
+
+/** Resolve the SQL exactly as the module builds it — never a hand copy. */
+function creditSql(column: string): string {
+  const body = source.match(/return `WITH inserted[\s\S]*?RETURNING \*`;/)?.[0];
+  if (!body) {
+    fail(
+      "CONTROL FAILED: could not extract the credit statement from " +
+        "TokenEconomyService.ts. The gate cannot pass by finding nothing — if " +
+        "the statement was renamed or restructured, update this extractor.",
+    );
+  }
+  const sources = source
+    .match(/const DAILY_YIELD_SOURCES = \[([\s\S]*?)\]/)?.[1]
+    .match(/"[^"]+"/g);
+  if (!sources || sources.length === 0) {
+    fail("CONTROL FAILED: could not extract DAILY_YIELD_SOURCES");
+  }
+  return body!
+    .replace(/^return `/, "")
+    .replace(/`;$/, "")
+    .replace(
+      /\$\{DAILY_YIELD_SOURCES_SQL\}/g,
+      sources!.map((s) => `'${s.slice(1, -1)}'`).join(", "),
+    )
+    .replace(/\$\{column\}/g, column);
+}
+
+const client = new pg.Client({
+  connectionString: url,
+  ssl: { rejectUnauthorized: false },
+});
+await client.connect();
+
+let failures = 0;
+try {
+  // ── Control: the gate can detect a statement that IS broken ───────────────
+  // Without this, a PREPARE that silently succeeds on anything would make every
+  // check below meaningless.
+  let controlCaught = false;
+  try {
+    await client.query(
+      "PREPARE _gate_control AS SELECT * FROM a_table_that_does_not_exist_xyz",
+    );
+    await client.query("DEALLOCATE _gate_control");
+  } catch {
+    controlCaught = true;
+  }
+  if (!controlCaught) {
+    fail(
+      "CONTROL FAILED: PREPARE accepted a statement against a nonexistent " +
+        "table, so it is not validating anything.",
+    );
+  }
+  console.log("✓ control: PREPARE rejects a statement it should reject");
+
+  // ── The gate ──────────────────────────────────────────────────────────────
+  for (const column of COLUMNS) {
+    const sql = creditSql(column);
+    const name = `_gate_credit_${column}`;
+    try {
+      await client.query(`PREPARE ${name} AS ${sql}`);
+      const meta = await client.query<{ parameter_types: string[] }>(
+        "SELECT parameter_types::text[] FROM pg_prepared_statements WHERE name = $1",
+        [name],
+      );
+      await client.query(`DEALLOCATE ${name}`);
+      console.log(
+        `✓ credit(${column}) prepares — ${meta.rows[0]?.parameter_types.length ?? "?"} params: ` +
+          `${meta.rows[0]?.parameter_types.join(", ")}`,
+      );
+    } catch (e) {
+      failures++;
+      const err = e as { code?: string; message?: string };
+      console.error(`✗ credit(${column}) FAILED TO PREPARE`);
+      console.error(`    ${err.code ?? ""} ${err.message ?? String(e)}`);
+      if (err.code === "42P08") {
+        console.error(
+          "    A bind parameter has ONE deduced type. If the same $n is used " +
+            "both as\n    an INSERT value and inside a comparison against " +
+            "string literals, BOTH\n    references must carry the same explicit " +
+            "cast — casting only one does not fix it.",
+        );
+      }
+    }
+  }
+
+  if (failures > 0) {
+    fail(
+      `${failures} of ${COLUMNS.length} credit statements cannot be prepared by ` +
+        "PostgreSQL.\n  Unit tests cannot catch this: they mock the database, and " +
+        "a mock will\n  happily accept SQL no database would.",
+    );
+  }
+  console.log(
+    `\n✓ all ${COLUMNS.length} credit statements parse and type-check against PostgreSQL`,
+  );
+} finally {
+  await client.end();
+}

--- a/scripts/checkNoFabricatedMonicaFallback.ts
+++ b/scripts/checkNoFabricatedMonicaFallback.ts
@@ -52,6 +52,36 @@ interface Finding {
  * needs a domain ruling per site, and failing CI on all of them today would just
  * get this check disabled. They are REPORTED, loudly, and left to the recipes
  * pass.
+ *
+ * ── Why this stops at monica and does NOT cover kalchm or the ESMS axes ──────
+ *
+ * Asked and MEASURED 2026-07-26, after the same defect class turned up on the
+ * token-rate path (`Spirit … : 0.5` and `kalchm … : 1.0` in TokensClient).
+ * Applying these exact patterns more widely across src/ yields:
+ *
+ *     monica        18 sites   (the current report)
+ *     kalchm        36 sites
+ *     ESMS axes     73 sites
+ *
+ * and the great majority of the latter two are CORRECT. They are
+ * empty-collection guards (`kalchmValues.length > 0 ? Math.min(...) : 0`), the
+ * canonical engine's own totality clamp (`Number.isFinite(kalchm) && kalchm > 0
+ * ? kalchm : 1.0` at alchemicalCalculations.ts:189 — the documented contract,
+ * not a fabrication), and weighting defaults that are genuinely configuration.
+ * `Spirit`/`Essence`/`Matter`/`Substance` are also ordinary identifiers used far
+ * beyond the ESMS axes.
+ *
+ * Adding 109 mostly-false findings to an 18-line report is exactly how the
+ * `?.` / `?:` false positives nearly killed this check before it shipped. So the
+ * scope stays monica, deliberately, and the token-rate defect is held instead by
+ * a targeted test:
+ * `src/services/__tests__/TokensClient.noFabricatedQuantities.test.ts`.
+ *
+ * If this is revisited, the tractable version is narrower than "any literal
+ * fallback": flag literals only where a quantity crosses a TRUST BOUNDARY — an
+ * unvalidated `response.json() as T`, a JSONB column read, a cross-repo payload.
+ * That is where fabrication actually enters. The interior sites above are
+ * arithmetic over values that already exist.
  */
 const AGENT_READ_PATH = /monica(_constant|_single|_two_body|_full_chart|Constant)\b/;
 

--- a/scripts/checkNoFabricatedNatalFields.ts
+++ b/scripts/checkNoFabricatedNatalFields.ts
@@ -1,0 +1,179 @@
+/**
+ * CI detector: does any stored natal body carry the fabricated `longitude` key?
+ *
+ * ── The defect this locks out ────────────────────────────────────────────────
+ *
+ * `[MEASURED 2026-07-26]` before the fix, `longitude` was present on **710 of 710**
+ * stored bodies across all 71 chart-bearing agents, and `0` was its **only
+ * distinct value**. It never held a measurement. Its origin is upstream, in the
+ * agent-authoring repo:
+ *
+ *     longitude: data?.longitude ?? data?.degrees ?? 0
+ *
+ * evaluated over objects carrying `{ sign, degree, retrograde, house }` — neither
+ * `longitude` nor `degrees` exists on them, so the chain reaches the literal `0`
+ * every single time.
+ *
+ * ── Why a fabricated zero is worse than an absent key ───────────────────────
+ *
+ * `0` is not nullish, so a `p.position ?? p.longitude ?? …` chain STOPS at it and
+ * never reaches `degree`. An audit written that way "found" 71 identical all-zero
+ * charts — false. The real data was in `sign` + `degree` throughout. An absent
+ * key would have routed correctly on the first attempt.
+ *
+ * ── Why a detector and not just a migration ─────────────────────────────────
+ *
+ * The producer is in another repo, reached through `/api/internal/agent-sync` and
+ * `/api/economy/sync-debit`. Those endpoints now strip the key on ingest
+ * (`normaliseNatalPositions`), but the upstream provisioning scripts are run by
+ * hand and the stripping is the only thing standing between them and a
+ * re-fabrication. This gate is what notices if that stripping is ever removed,
+ * bypassed, or routed around by a new write path.
+ *
+ * ── Controls ────────────────────────────────────────────────────────────────
+ *
+ * A zero result is a claim requiring a control test: a broken query and a clean
+ * database look identical from the outside. This script asserts it can reach a
+ * populated agent table, that chart-bearing agents exist, and that its key-level
+ * scan actually descends into bodies (by counting the `sign` keys it MUST find).
+ * If any control fails it exits non-zero as UNSOUND — never as "clean".
+ *
+ * Read-only. Never writes.
+ *
+ *   railway run --service Postgres -- bun scripts/checkNoFabricatedNatalFields.ts
+ */
+import pg from "pg";
+
+/**
+ * Keys that must never appear on a stored natal body.
+ *
+ * `longitude` is redundant as well as fabricated: sign + degree already
+ * determine it, and the canonical parser (`parseNatalPositions`) has always
+ * derived it as `signIndex * 30 + degree`.
+ */
+const FORBIDDEN_BODY_KEYS = ["longitude"] as const;
+
+/** Keys that every stored body is expected to carry — used as the scan control. */
+const REQUIRED_BODY_KEYS = ["planet", "sign", "degree"] as const;
+
+const fail = (msg: string): never => {
+  console.error(`\n✗ ${msg}`);
+  process.exit(1);
+};
+
+const url = process.env.DATABASE_PUBLIC_URL ?? process.env.DATABASE_URL;
+if (!url) fail("no DATABASE_PUBLIC_URL / DATABASE_URL in the environment");
+
+const client = new pg.Client({
+  connectionString: url,
+  ssl: { rejectUnauthorized: false },
+});
+await client.connect();
+
+try {
+  // ── Control 1: the population is reachable and carries charts ─────────────
+  const pop = await client.query<{ agents: string; with_chart: string }>(`
+    SELECT COUNT(*) AS agents,
+           COUNT(*) FILTER (
+             WHERE jsonb_typeof(up.natal_positions) = 'array'
+               AND jsonb_array_length(up.natal_positions) > 0
+           ) AS with_chart
+      FROM user_profiles up
+      JOIN users u ON u.id = up.user_id
+     WHERE u.is_agent = true
+  `);
+  const agents = Number(pop.rows[0]?.agents ?? 0);
+  const withChart = Number(pop.rows[0]?.with_chart ?? 0);
+
+  if (agents === 0) {
+    fail(
+      "CONTROL FAILED: zero agent rows. A key scan over an empty set trivially " +
+        "finds nothing, so this is not an all-clear.",
+    );
+  }
+  if (withChart === 0) {
+    fail(
+      `CONTROL FAILED: ${agents} agents but ZERO carrying a chart. Either the ` +
+        "natal_positions shape changed or the predicate is wrong.",
+    );
+  }
+
+  // ── The scan: every key on every stored body, counted ─────────────────────
+  const keys = await client.query<{ k: string; n: string; rows: string }>(`
+    SELECT k,
+           COUNT(*)                  AS n,
+           COUNT(DISTINCT up.user_id) AS rows
+      FROM user_profiles up
+      JOIN users u ON u.id = up.user_id
+      CROSS JOIN LATERAL jsonb_array_elements(up.natal_positions) body
+      CROSS JOIN LATERAL jsonb_object_keys(body) k
+     WHERE u.is_agent = true
+       AND jsonb_typeof(up.natal_positions) = 'array'
+       AND jsonb_array_length(up.natal_positions) > 0
+     GROUP BY k
+     ORDER BY COUNT(*) DESC
+  `);
+
+  const seen = new Map(keys.rows.map((r) => [r.k, r]));
+
+  // ── Control 2: the scan actually descended into bodies ────────────────────
+  // Without this, a query that returns no rows for ANY reason reads as "no
+  // forbidden keys" — the precise failure mode this programme keeps hitting.
+  const missingRequired = REQUIRED_BODY_KEYS.filter((k) => !seen.has(k));
+  if (missingRequired.length > 0) {
+    fail(
+      `CONTROL FAILED: the key scan did not find ${missingRequired.join(", ")} on ` +
+        "any body. Every stored body carries those, so the scan is unsound — " +
+        "it cannot be trusted to have found a forbidden key either.",
+    );
+  }
+  const bodies = Number(seen.get("planet")!.n);
+  console.log(
+    `✓ control: ${agents} agents, ${withChart} carrying a chart, ` +
+      `${bodies} bodies scanned, ${keys.rows.length} distinct keys`,
+  );
+
+  // ── The assertion ─────────────────────────────────────────────────────────
+  const violations = FORBIDDEN_BODY_KEYS.map((k) => seen.get(k)).filter(
+    (r): r is { k: string; n: string; rows: string } => r !== undefined,
+  );
+
+  if (violations.length > 0) {
+    for (const v of violations) {
+      console.error(
+        `\n✗ forbidden key \`${v.k}\` on ${v.n} bodies across ${v.rows} chart(s)`,
+      );
+      const vals = await client.query<{ val: string; n: string }>(
+        `
+        SELECT COALESCE(body->>$1, 'JSON null') AS val, COUNT(*) AS n
+          FROM user_profiles up
+          JOIN users u ON u.id = up.user_id
+          CROSS JOIN LATERAL jsonb_array_elements(up.natal_positions) body
+         WHERE u.is_agent = true
+           AND jsonb_typeof(up.natal_positions) = 'array'
+           AND body ? $1
+         GROUP BY 1 ORDER BY 2 DESC LIMIT 5
+      `,
+        [v.k],
+      );
+      console.error(
+        `    values: ${vals.rows.map((x) => `${x.val} (${x.n})`).join(", ")}`,
+      );
+    }
+    console.error(
+      "\n  A fabricated literal is standing in for an absent measurement on the " +
+        "agent-monica path.\n  Strip it at ingest (normaliseNatalPositions) and " +
+        "clean the stored rows.\n  Note `0` is NOT nullish: a `?? longitude ??` " +
+        "chain stops at it and never reaches `degree`.",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ no forbidden keys (${FORBIDDEN_BODY_KEYS.join(", ")}) on any of the ` +
+      `${bodies} stored bodies`,
+  );
+  console.log(`  keys present: ${keys.rows.map((r) => r.k).join(", ")}`);
+} finally {
+  await client.end();
+}

--- a/src/__tests__/natalPositionsLongitudeStrip.test.ts
+++ b/src/__tests__/natalPositionsLongitudeStrip.test.ts
@@ -1,0 +1,136 @@
+/**
+ * The dead `longitude` key on `natal_positions`, and the ingest boundary that
+ * removes it.
+ *
+ * ── The defect ──────────────────────────────────────────────────────────────
+ *
+ * `[MEASURED 2026-07-26 on production]` `longitude` was present on **710 of 710**
+ * stored bodies across all 71 chart-bearing agents, and `0` was its **only
+ * distinct value**. Its origin is upstream, in the agent-authoring repo:
+ *
+ *     longitude: data?.longitude ?? data?.degrees ?? 0
+ *
+ * over objects carrying `{ sign, degree, retrograde, house }` — neither
+ * `longitude` nor `degrees` exists on them, so the chain reaches the literal `0`
+ * every time. A fabricated literal standing in for an absent measurement, which
+ * is the exact class this programme exists to remove.
+ *
+ * ── Why it is actively harmful, not merely redundant ────────────────────────
+ *
+ * `0` is not nullish, so a `p.position ?? p.longitude ?? …` chain STOPS at the
+ * zero and never reaches `degree`. An earlier audit was written that way and
+ * "found" 71 identical all-zero charts. That was false — the real data was in
+ * `sign` + `degree` the whole time.
+ *
+ * These tests pin BOTH halves: that the canonical parser never consults the key
+ * (so removing it is a no-op for monica), and that the normaliser removes it.
+ */
+import {
+  MIN_CHART_BODIES,
+  fullChartMonica,
+  normaliseNatalPositions,
+  parseNatalPositions,
+} from "@/utils/fullChartMonica";
+
+/** A real stored chart, shape-exact: Adam Smith, as held in production. */
+const STORED_CHART = [
+  { planet: "Sun", sign: "Gemini", degree: 25.0, longitude: 0 },
+  { planet: "Moon", sign: "Pisces", degree: 11.4, longitude: 0 },
+  { planet: "Mercury", sign: "Aquarius", degree: 20.3, longitude: 0 },
+  { planet: "Venus", sign: "Gemini", degree: 5.3, longitude: 0 },
+  { planet: "Mars", sign: "Taurus", degree: 22.0, longitude: 0 },
+  { planet: "Jupiter", sign: "Virgo", degree: 6.5, longitude: 0 },
+  { planet: "Saturn", sign: "Libra", degree: 8.1, longitude: 0 },
+  { planet: "Uranus", sign: "Scorpio", degree: 6.7, longitude: 0 },
+  { planet: "Neptune", sign: "Scorpio", degree: 12.9, longitude: 0 },
+  { planet: "Pluto", sign: "Capricorn", degree: 18.2, longitude: 0 },
+];
+
+describe("natal_positions — the dead longitude key", () => {
+  it("CONTROL: the fixture is the real shape and is actually parseable", () => {
+    // Without this control, every assertion below could pass against a fixture
+    // the parser rejects outright — a green suite proving nothing.
+    expect(STORED_CHART).toHaveLength(10);
+    expect(STORED_CHART.every((b) => "longitude" in b)).toBe(true);
+    expect(new Set(STORED_CHART.map((b) => b.longitude))).toEqual(new Set([0]));
+    expect(Object.keys(parseNatalPositions(STORED_CHART) ?? {})).toHaveLength(10);
+  });
+
+  it("the canonical parser derives longitude from sign+degree, never from the key", () => {
+    const parsed = parseNatalPositions(STORED_CHART)!;
+    // Gemini is the 3rd sign (index 2) -> 2*30 + 25.0 = 85.0. If the parser had
+    // read the stored `longitude`, this would be 0.
+    expect(parsed.Sun.exactLongitude).toBe(85);
+    expect(parsed.Mars.exactLongitude).toBe(52); // Taurus (1) -> 30 + 22.0
+    expect(Object.values(parsed).every((p) => p.exactLongitude !== 0)).toBe(true);
+  });
+
+  it("removing the key changes NOTHING about the resulting monica", () => {
+    // This is the reader-tolerance proof for the production write: the stored
+    // rows may lose the key without any monica moving.
+    const stripped = normaliseNatalPositions(STORED_CHART);
+    expect(JSON.stringify(parseNatalPositions(stripped))).toBe(
+      JSON.stringify(parseNatalPositions(STORED_CHART)),
+    );
+
+    const before = fullChartMonica(STORED_CHART)!;
+    const after = fullChartMonica(stripped)!;
+    expect(after.diurnal).toBe(before.diurnal); // === , not toBeCloseTo
+    expect(after.nocturnal).toBe(before.nocturnal);
+    expect(after.combined).toBe(before.combined);
+  });
+
+  it("strips the fabricated zero, leaving the rest of the body untouched", () => {
+    const out = normaliseNatalPositions(STORED_CHART) as Array<
+      Record<string, unknown>
+    >;
+    expect(out.some((b) => "longitude" in b)).toBe(false);
+    expect(out[0]).toEqual({ planet: "Sun", sign: "Gemini", degree: 25.0 });
+  });
+
+  it("promotes a REAL longitude to `position` rather than discarding it", () => {
+    // No stored row takes this branch today (all 710 are 0). It exists so that
+    // fixing the upstream producer improves the data instead of being silently
+    // thrown away by a blanket delete.
+    const [row] = normaliseNatalPositions([
+      { planet: "Sun", sign: "Gemini", degree: 25.0, longitude: 85.0 },
+    ]) as Array<Record<string, unknown>>;
+    expect(row).toEqual({ planet: "Sun", sign: "Gemini", degree: 25.0, position: 85.0 });
+    expect(parseNatalPositions([row, ...STORED_CHART.slice(1)])!.Sun.exactLongitude).toBe(85);
+  });
+
+  it("never lets a stray longitude overwrite an existing `position`", () => {
+    const [row] = normaliseNatalPositions([
+      { planet: "Sun", sign: "Gemini", degree: 25.0, position: 85.0, longitude: 999 },
+    ]) as Array<Record<string, unknown>>;
+    expect(row.position).toBe(85.0);
+    expect("longitude" in row).toBe(false);
+  });
+
+  it("is a total function — passes through anything that is not a body array", () => {
+    // The column holds `[]` for 5013 of 5084 production rows, and the ingest
+    // payload is unvalidated JSON from another repo. A throw here would be a
+    // 500 on the sync path.
+    expect(normaliseNatalPositions([])).toEqual([]);
+    expect(normaliseNatalPositions(null)).toBeNull();
+    expect(normaliseNatalPositions(undefined)).toBeUndefined();
+    expect(normaliseNatalPositions({ Sun: { sign: "Gemini" } })).toEqual({
+      Sun: { sign: "Gemini" },
+    });
+    expect(normaliseNatalPositions([null, 7, "x"])).toEqual([null, 7, "x"]);
+  });
+
+  it("a non-finite longitude is treated as fabrication, not as data", () => {
+    const out = normaliseNatalPositions([
+      { planet: "Sun", sign: "Gemini", degree: 25.0, longitude: Number.NaN },
+      { planet: "Moon", sign: "Pisces", degree: 11.4, longitude: null },
+    ]) as Array<Record<string, unknown>>;
+    expect(out.every((b) => !("longitude" in b) && !("position" in b))).toBe(true);
+  });
+
+  it("MIN_CHART_BODIES still gates a chart stripped of the key", () => {
+    // Stripping must not accidentally make a too-small chart look usable.
+    const short = normaliseNatalPositions(STORED_CHART.slice(0, MIN_CHART_BODIES - 1));
+    expect(parseNatalPositions(short)).toBeNull();
+  });
+});

--- a/src/app/api/economy/sync-debit/route.ts
+++ b/src/app/api/economy/sync-debit/route.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import { NextResponse, type NextRequest } from "next/server";
 import { executeQuery } from "@/lib/database";
 import { agentMonicaFromName } from "@/utils/agentMonicaResolver";
+import { normaliseNatalPositions } from "@/utils/fullChartMonica";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -178,7 +179,11 @@ export async function POST(req: NextRequest) {
       const monicaCandidate = resolvedMonica?.combined ?? null;
       const hasNatalChart =
         ap.natalChart && typeof ap.natalChart === "object" && Object.keys(ap.natalChart).length > 0;
-      const hasNatalPositions = Array.isArray(ap.natalPositions) && (ap.natalPositions as unknown[]).length > 0;
+      // Strip the fabricated `longitude: 0` on the way in — see
+      // normaliseNatalPositions. This endpoint is a live ingest path, so
+      // cleaning stored rows without cleaning here would let the key return.
+      const natalPositions = normaliseNatalPositions(ap.natalPositions);
+      const hasNatalPositions = Array.isArray(natalPositions) && (natalPositions as unknown[]).length > 0;
       const hasBirthData = ap.birthDate || ap.birthTime || ap.birthLocation;
 
       // COALESCE so a null/empty field in this fire never wipes a previously
@@ -202,7 +207,7 @@ export async function POST(req: NextRequest) {
           hasNatalChart,
           JSON.stringify(ap.natalChart || {}),
           hasNatalPositions,
-          JSON.stringify(ap.natalPositions || []),
+          JSON.stringify(natalPositions || []),
           dominantElementCandidate,
           monicaCandidate,
           hasBirthData,

--- a/src/app/api/internal/agent-sync/route.ts
+++ b/src/app/api/internal/agent-sync/route.ts
@@ -13,6 +13,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { withTransaction } from "@/lib/database";
 import { agentMonicaFromName } from "@/utils/agentMonicaResolver";
 import { jsonbOrNull } from "@/services/userDatabaseService";
+import { normaliseNatalPositions } from "@/utils/fullChartMonica";
 
 /** `{}` and `[]` mean "absent" here, exactly as jsonbOrNull treats them. */
 const nonEmpty = <T,>(v: T): T | undefined => (jsonbOrNull(v) === null ? undefined : v);
@@ -126,6 +127,12 @@ export async function POST(req: NextRequest) {
     // COALESCE below reads as "leave the stored value alone."
     void monicaConstant; // intentionally ignored — see comment above
     const resolvedMonica = agentMonicaFromName(resolvedName);
+
+    // The upstream producer emits `longitude: data?.longitude ?? data?.degrees ?? 0`
+    // over objects carrying neither key, so every body arrives with a fabricated
+    // `longitude: 0`. This is the boundary that upstream crosses, so it is the
+    // boundary that strips it — see normaliseNatalPositions.
+    const cleanNatalPositions = normaliseNatalPositions(natalPositions);
     const parsedMonicaConstant = resolvedMonica?.combined ?? null;
 
     const userProfilePayload = {
@@ -193,7 +200,7 @@ export async function POST(req: NextRequest) {
             // empty one. NULL correctly leaves the stored value alone.
             jsonbOrNull(birthData),
             jsonbOrNull(natalChart),
-            jsonbOrNull(natalPositions),
+            jsonbOrNull(cleanNatalPositions),
             parsedMonicaConstant,
             resolvedMonica?.diurnal ?? null,
             resolvedMonica?.nocturnal ?? null,
@@ -237,7 +244,7 @@ export async function POST(req: NextRequest) {
             // empty one. NULL correctly leaves the stored value alone.
             jsonbOrNull(birthData),
             jsonbOrNull(natalChart),
-            jsonbOrNull(natalPositions),
+            jsonbOrNull(cleanNatalPositions),
             parsedMonicaConstant,
             resolvedMonica?.diurnal ?? null,
             resolvedMonica?.nocturnal ?? null,

--- a/src/app/api/internal/agent-sync/route.ts
+++ b/src/app/api/internal/agent-sync/route.ts
@@ -11,8 +11,8 @@
 import { randomUUID } from "crypto";
 import { NextResponse, type NextRequest } from "next/server";
 import { withTransaction } from "@/lib/database";
-import { agentMonicaFromName } from "@/utils/agentMonicaResolver";
 import { jsonbOrNull } from "@/services/userDatabaseService";
+import { agentMonicaFromName } from "@/utils/agentMonicaResolver";
 import { normaliseNatalPositions } from "@/utils/fullChartMonica";
 
 /** `{}` and `[]` mean "absent" here, exactly as jsonbOrNull treats them. */

--- a/src/lib/api/alchm-client.ts
+++ b/src/lib/api/alchm-client.ts
@@ -44,7 +44,21 @@ export interface TokenRatesResult {
   Matter: number;
   Substance: number;
   kalchm: number;
-  monica: number;
+  /**
+   * NULL when the rate endpoint has no elemental input.
+   *
+   * monica = −gregsEnergy / (reactivity · ln kalchm), and both gregsEnergy and
+   * reactivity are functions of the four ELEMENTS. Elements come from SIGNS,
+   * and this endpoint is given only a planetary HOUR — a ruling planet, no
+   * sign. So monica is not derivable and the server says so rather than
+   * substituting a literal (it used to return 1.0 unconditionally).
+   *
+   * `kalchm` is not in the same position: it is a function of the ESMS axes
+   * alone, which the planetary hour does determine, so it is a real value.
+   *
+   * Handle the absence at the display layer. Do NOT `?? 1` it.
+   */
+  monica: number | null;
 }
 
 export interface RuneAgentRequest {

--- a/src/services/TokenEconomyService.ts
+++ b/src/services/TokenEconomyService.ts
@@ -136,10 +136,55 @@ const DAILY_YIELD_SOURCES_SQL = DAILY_YIELD_SOURCES.map((s) => `'${s}'`).join(
   ", ",
 );
 
-// Single-statement credit: ensure the balance row exists, insert an immutable
-// ledger entry (idempotency-guarded), and apply the delta to the typed column —
-// all atomically. `column` is a constrained union literal (never user input),
-// so interpolating it is injection-safe. Params, in order:
+// Single-statement credit: insert an immutable ledger entry (idempotency-guarded)
+// and apply the delta to the typed column, atomically. `column` is a constrained
+// union literal (never user input), so interpolating it is injection-safe.
+//
+// ── Why the balance write is an UPSERT and not an UPDATE ────────────────────
+//
+// It used to be an `UPDATE token_balances … WHERE user_id = $1` preceded by an
+// `ensure_balance` CTE that INSERTed the row. That silently lost every user's
+// FIRST-EVER credit. In a data-modifying CTE, every sub-statement AND the main
+// query run against ONE snapshot taken before the statement begins, so the
+// UPDATE could not see the row `ensure_balance` had just inserted: the ledger
+// row committed, the UPDATE matched ZERO rows, and the balance never moved.
+//
+// It failed silently because `creditMultipleTokens` only assigns `last` when
+// `res.rows.length > 0`. Spirit returning nothing just left `last` null, Essence
+// then set it, and the endpoint returned 200 with a balances object.
+//
+// `[MEASURED 2026-07-26 on production]` 67 users, 521.7141 Spirit. For 67 of 67
+// the shortfall equals that user's FIRST ledger row, and all 67 are
+// auto-provisioned agents — human signup seeds `token_balances` in its own
+// statement, so the row pre-existed and the UPDATE landed. Spirit is simply the
+// first of the four axes written, so it is the only one that ever meets the
+// missing-row state; Essence/Matter/Substance always found the row and
+// reconciled EXACTLY, which is why only Spirit looked wrong.
+//
+// The upsert has no such ordering hazard: with no row it INSERTs the credited
+// amount (the other three axes default to 0), and with a row it adds the delta
+// under `ON CONFLICT`. Idempotency is preserved because `SELECT … FROM inserted`
+// yields no row when the ledger insert was suppressed, so nothing is written.
+//
+// ── Why $4 is cast to text in BOTH of its references ────────────────────────
+//
+// A bind parameter has exactly ONE deduced type. $4 is bound as the INSERT value
+// for `source_type` (character varying) and is also compared against the string
+// literals in the CASE, which deduce `text`. Left uncast, PostgreSQL refuses to
+// prepare the statement at all:
+//
+//     42P08  inconsistent types deduced for parameter $4
+//
+// and every credit throws. Casting only the comparison side does NOT fix it —
+// the INSERT target still deduces varchar. Both references must agree; text ->
+// varchar is an assignment cast, so pinning both to text is safe.
+//
+// This shipped to production once. Thirteen unit tests covered the path and all
+// passed, because they mock the database — a mock accepts SQL no database will.
+// `scripts/checkEconomySqlParses.ts` now PREPAREs every variant against a real
+// PostgreSQL in CI, which is the only thing that can catch this class.
+//
+// Params, in order:
 //   $1 userId  $2 tokenType  $3 amount  $4 sourceType
 //   $5 sourceId  $6 description  $7 transactionGroupId  $8 idempotencyKey
 //
@@ -152,27 +197,22 @@ const DAILY_YIELD_SOURCES_SQL = DAILY_YIELD_SOURCES.map((s) => `'${s}'`).join(
 function creditTokensSql(
   column: "spirit" | "essence" | "matter" | "substance",
 ): string {
-  return `WITH ensure_balance AS (
-            INSERT INTO token_balances (user_id)
-            VALUES ($1)
-            ON CONFLICT (user_id) DO NOTHING
-          ),
-          inserted AS (
+  return `WITH inserted AS (
             INSERT INTO token_transactions
               (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key, yield_day)
             VALUES
-              (COALESCE($7::uuid, uuid_generate_v4()), $1, $2, $3, $4, $5, $6, $8,
-               CASE WHEN $4 IN (${DAILY_YIELD_SOURCES_SQL})
+              (COALESCE($7::uuid, uuid_generate_v4()), $1, $2, $3, $4::text, $5, $6, $8,
+               CASE WHEN $4::text IN (${DAILY_YIELD_SOURCES_SQL})
                     THEN (now() AT TIME ZONE 'UTC')::date
                     ELSE NULL END)
             ON CONFLICT (idempotency_key) DO NOTHING
             RETURNING id
           )
-          UPDATE token_balances
-          SET ${column} = ${column} + $3,
-              updated_at = now()
-          WHERE user_id = $1
-            AND EXISTS (SELECT 1 FROM inserted)
+          INSERT INTO token_balances (user_id, ${column}, updated_at)
+          SELECT $1, $3, now() FROM inserted
+          ON CONFLICT (user_id) DO UPDATE
+            SET ${column} = token_balances.${column} + EXCLUDED.${column},
+                updated_at = now()
           RETURNING *`;
 }
 

--- a/src/services/TokensClient.ts
+++ b/src/services/TokensClient.ts
@@ -23,7 +23,8 @@ export interface TokenRatesResult {
   Matter: number;
   Substance: number;
   kalchm: number;
-  monica: number;
+  /** null when the source had no elemental input — see alchm-client.ts. */
+  monica: number | null;
   // Additional backend metrics
   projections?: {
     nextHour: {
@@ -74,7 +75,12 @@ function computeTokensFromAlchemical(
     Matter,
     Substance,
     kalchm: typeof ar?.kalchm === "number" ? ar.kalchm : 1.0,
-    monica: typeof ar?.monica === "number" ? ar.monica : 1.0,
+    // NOT `: 1.0`. The backend now returns monica === null when it has no
+    // elemental input — a planetary hour names a ruling planet, not a sign, and
+    // monica = −gregsEnergy/(reactivity · ln kalchm) needs elements. A literal
+    // here would re-invent exactly the value the server declined to invent, and
+    // 1.0 is not even the degenerate value (that is φ = 1.618).
+    monica: typeof ar?.monica === "number" ? ar.monica : null,
   };
 }
 

--- a/src/services/TokensClient.ts
+++ b/src/services/TokensClient.ts
@@ -1,6 +1,10 @@
+import { calculateKalchm } from "@/data/unified/alchemicalCalculations";
 import { alchmAPI, type TokenRatesRequest } from "@/lib/api/alchm-client";
 import { _logger as logger } from "@/lib/logger";
-import { getCurrentAlchemicalState } from "@/services/RealAlchemizeService";
+import {
+  getCurrentAlchemicalState,
+  type StandardizedAlchemicalResult,
+} from "@/services/RealAlchemizeService";
 import type { ElementalProperties } from "@/types/celestial";
 
 export interface TokenRatesInput {
@@ -55,32 +59,101 @@ export interface TokenRatesResult {
   }>;
 }
 
+/**
+ * Map the canonical engine's result onto the token-rate shape.
+ *
+ * ── Why this takes a TYPE and not `unknown` ─────────────────────────────────
+ *
+ * It used to take `unknown`, narrow each field with `typeof x === "number"`, and
+ * substitute a literal when the narrowing failed — `0.5` for each ESMS axis and
+ * `1.0` for kalchm. Those are fabricated quantities: downstream, an invented
+ * 0.5 is indistinguishable from a measured one. (`0.5` is also the same magic
+ * number agent registration once wrote into `monicaConstant`.)
+ *
+ * The substitutions were also unreachable. The sole caller passes
+ * `getCurrentAlchemicalState()`, whose `StandardizedAlchemicalResult` declares
+ * `esms` (all four axes), `kalchm` and `monica` as required numbers.
+ * `[MEASURED 2026-07-26]` calling it returns
+ * `esms {3.8914, 5.2642, 1.8918, 1.1930}`, `kalchm 300875.5648`,
+ * `monica 0.02208` — no branch fires.
+ *
+ * So the guards defended nothing and the literals could only ever mislead. The
+ * parameter is typed instead: absence is now impossible by construction rather
+ * than papered over at runtime.
+ *
+ * The path where absence CAN arise is the backend one, which casts an unvalidated
+ * JSON body to `TokenRatesResult`. That is handled in `calculateRates` below.
+ */
 function computeTokensFromAlchemical(
-  alchemicalResult: unknown,
+  alchemicalResult: StandardizedAlchemicalResult,
 ): TokenRatesResult {
-  const ar =
-    alchemicalResult && typeof alchemicalResult === "object"
-      ? (alchemicalResult as Record<string, unknown>)
-      : undefined;
-  const esms = ar?.esms as Record<string, unknown> | undefined;
-
-  const Spirit = typeof esms?.Spirit === "number" ? esms.Spirit : 0.5;
-  const Essence = typeof esms?.Essence === "number" ? esms.Essence : 0.5;
-  const Matter = typeof esms?.Matter === "number" ? esms.Matter : 0.5;
-  const Substance = typeof esms?.Substance === "number" ? esms.Substance : 0.5;
-
+  const { Spirit, Essence, Matter, Substance } = alchemicalResult.esms;
   return {
     Spirit,
     Essence,
     Matter,
     Substance,
-    kalchm: typeof ar?.kalchm === "number" ? ar.kalchm : 1.0,
-    // NOT `: 1.0`. The backend now returns monica === null when it has no
-    // elemental input — a planetary hour names a ruling planet, not a sign, and
-    // monica = −gregsEnergy/(reactivity · ln kalchm) needs elements. A literal
-    // here would re-invent exactly the value the server declined to invent, and
-    // 1.0 is not even the degenerate value (that is φ = 1.618).
-    monica: typeof ar?.monica === "number" ? ar.monica : null,
+    kalchm: alchemicalResult.kalchm,
+    monica: alchemicalResult.monica,
+  };
+}
+
+/** The fields a token-rate response must carry to be usable at all. */
+const REQUIRED_RATE_FIELDS = [
+  "Spirit",
+  "Essence",
+  "Matter",
+  "Substance",
+] as const;
+
+/**
+ * Validate a backend token-rate response instead of trusting the cast.
+ *
+ * `AlchmAPIClient.request` ends in `response.json() as Promise<TResponse>` — a
+ * bare assertion over an unvalidated body. If the server omits an axis, the
+ * caller holds `undefined` while the type says `number`, and it renders as one.
+ *
+ * Returns null when the body is unusable, which the caller treats exactly like a
+ * thrown request: fall through to the local engine. That is strictly better than
+ * either a fabricated literal (invents data) or a half-populated object (lies in
+ * the type) — the local path produces a real, complete answer.
+ *
+ * `monica` is deliberately NOT required. The backend returns `monica: null` by
+ * design when it has no elemental input, because monica needs elements, elements
+ * come from signs, and a planetary hour names no sign.
+ *
+ * `kalchm` is also not required, because it is RECOVERABLE: it is a function of
+ * the four ESMS axes alone, so when the axes are present it is recomputed with
+ * the canonical engine rather than defaulted. Deriving it is not inventing it.
+ */
+function validateRateResponse(value: unknown): TokenRatesResult | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+
+  for (const field of REQUIRED_RATE_FIELDS) {
+    if (typeof raw[field] !== "number" || !Number.isFinite(raw[field])) {
+      return null;
+    }
+  }
+  const Spirit = raw.Spirit as number;
+  const Essence = raw.Essence as number;
+  const Matter = raw.Matter as number;
+  const Substance = raw.Substance as number;
+
+  return {
+    ...raw,
+    Spirit,
+    Essence,
+    Matter,
+    Substance,
+    kalchm:
+      typeof raw.kalchm === "number" && Number.isFinite(raw.kalchm)
+        ? raw.kalchm
+        : calculateKalchm({ Spirit, Essence, Matter, Substance }),
+    monica:
+      typeof raw.monica === "number" && Number.isFinite(raw.monica)
+        ? raw.monica
+        : null,
   };
 }
 
@@ -110,16 +183,29 @@ export class TokensClient {
           esms: input.esms,
         };
 
-        const result = await alchmAPI.calculateTokenRates(request);
-        // FIXME(types-only): _logger.debug takes (message, data); the extra
-        // "TokensClient" category arg shifts data and drops `result` at runtime.
-        // Preserved as-is — fix arg order in a behavior change, not this pass.
-        void (logger.debug as (...args: unknown[]) => Promise<void>)(
-          "TokensClient",
-          "Backend calculation successful",
-          result,
-        );
-        return result;
+        const raw = await alchmAPI.calculateTokenRates(request);
+        const result = validateRateResponse(raw);
+        if (!result) {
+          // A body that does not carry the four axes is unusable. Falling
+          // through to the local engine yields a real, complete answer;
+          // returning the object anyway would hand callers `undefined` typed
+          // as `number`, which renders as one.
+          void (logger.warn as (...args: unknown[]) => Promise<void>)(
+            "TokensClient",
+            "Backend token rates missing required ESMS axes, falling back to local",
+            raw,
+          );
+        } else {
+          // FIXME(types-only): _logger.debug takes (message, data); the extra
+          // "TokensClient" category arg shifts data and drops `result` at runtime.
+          // Preserved as-is — fix arg order in a behavior change, not this pass.
+          void (logger.debug as (...args: unknown[]) => Promise<void>)(
+            "TokensClient",
+            "Backend calculation successful",
+            result,
+          );
+          return result;
+        }
       } catch (error) {
         // FIXME(types-only): _logger.warn takes (message, data); the extra
         // "TokensClient" category arg shifts data and drops `error` at runtime.

--- a/src/services/__tests__/TokensClient.noFabricatedQuantities.test.ts
+++ b/src/services/__tests__/TokensClient.noFabricatedQuantities.test.ts
@@ -1,0 +1,157 @@
+/**
+ * TokensClient must never invent a quantity.
+ *
+ * ── What was there ──────────────────────────────────────────────────────────
+ *
+ * `computeTokensFromAlchemical` took `unknown`, narrowed each field with
+ * `typeof x === "number"`, and substituted a literal when that failed:
+ *
+ *     const Spirit = typeof esms?.Spirit === "number" ? esms.Spirit : 0.5;
+ *     ... Essence, Matter, Substance likewise
+ *     kalchm: typeof ar?.kalchm === "number" ? ar.kalchm : 1.0,
+ *
+ * Five fabricated quantities. Downstream an invented 0.5 is indistinguishable
+ * from a measured one — the defect class the thermodynamics programme exists to
+ * remove. `0.5` is also the magic number agent registration once wrote into
+ * `monicaConstant`.
+ *
+ * They were also unreachable: the sole caller passes `getCurrentAlchemicalState()`,
+ * whose type declares all six fields as required numbers, and a live call
+ * returns real values for every one. So the guards defended nothing and the
+ * literals could only mislead.
+ *
+ * ── Where absence really comes from ─────────────────────────────────────────
+ *
+ * The backend path. `AlchmAPIClient.request` ends in
+ * `response.json() as Promise<TResponse>` — a bare assertion over an
+ * unvalidated body. That is what `validateRateResponse` now covers.
+ */
+import { calculateKalchm } from "@/data/unified/alchemicalCalculations";
+
+const mockCalculateTokenRates = jest.fn();
+
+jest.mock("@/lib/api/alchm-client", () => ({
+  alchmAPI: {
+    calculateTokenRates: (...args: unknown[]) =>
+      mockCalculateTokenRates(...args),
+  },
+}));
+
+jest.mock("@/lib/logger", () => ({
+  _logger: { debug: jest.fn(), warn: jest.fn(), info: jest.fn(), error: jest.fn() },
+}));
+
+/** A complete, plausible backend body. */
+const COMPLETE = {
+  Spirit: 2,
+  Essence: 1,
+  Matter: 1,
+  Substance: 1,
+  kalchm: 4,
+  monica: 1.618,
+};
+
+async function clientWithBackend() {
+  process.env.NEXT_PUBLIC_BACKEND_URL = "https://backend.invalid";
+  process.env.NEXT_PUBLIC_TOKENS_BACKEND = "true";
+  jest.resetModules();
+  const { TokensClient } = await import("@/services/TokensClient");
+  return new TokensClient();
+}
+
+describe("TokensClient — no fabricated quantities", () => {
+  beforeEach(() => {
+    mockCalculateTokenRates.mockReset();
+  });
+
+  it("CONTROL: a complete backend body is returned as-is", async () => {
+    // Without this, every assertion below could pass because the backend path
+    // never runs at all and everything silently falls through to local.
+    mockCalculateTokenRates.mockResolvedValue({ ...COMPLETE });
+    const result = await (await clientWithBackend()).calculateRates();
+    expect(mockCalculateTokenRates).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject(COMPLETE);
+  });
+
+  it("recomputes an absent kalchm from the axes instead of defaulting to 1.0", async () => {
+    // kalchm is RECOVERABLE — it is a function of the four ESMS axes alone. So
+    // deriving it is not inventing it, and 1.0 would have been wrong: for
+    // (2,1,1,1) the true value is 4.
+    const { kalchm: _drop, ...noKalchm } = COMPLETE;
+    mockCalculateTokenRates.mockResolvedValue(noKalchm);
+    const result = await (await clientWithBackend()).calculateRates();
+
+    const expected = calculateKalchm({
+      Spirit: 2,
+      Essence: 1,
+      Matter: 1,
+      Substance: 1,
+    });
+    expect(expected).toBe(4); // pin the value, not just the agreement
+    expect(result.kalchm).toBe(expected);
+    expect(result.kalchm).not.toBe(1.0);
+  });
+
+  it("maps an absent monica to null, never to a literal", async () => {
+    // The backend returns monica: null BY DESIGN when it has no elemental
+    // input. Re-inventing it here would undo exactly the honesty the server
+    // just exercised — and 1.0 is not even the degenerate value (that is φ).
+    const { monica: _drop, ...noMonica } = COMPLETE;
+    mockCalculateTokenRates.mockResolvedValue(noMonica);
+    expect((await (await clientWithBackend()).calculateRates()).monica).toBeNull();
+
+    mockCalculateTokenRates.mockResolvedValue({ ...COMPLETE, monica: null });
+    expect((await (await clientWithBackend()).calculateRates()).monica).toBeNull();
+  });
+
+  it("preserves a legitimate ZERO axis rather than treating it as absent", async () => {
+    // 0 is falsy and is a REAL value here — 284 single-body agents have monica
+    // exactly 0, an algebraically proven cluster. A truthiness test would
+    // replace this with 0.5.
+    mockCalculateTokenRates.mockResolvedValue({ ...COMPLETE, Essence: 0 });
+    const result = await (await clientWithBackend()).calculateRates();
+    expect(result.Essence).toBe(0);
+  });
+
+  it.each([
+    ["a missing axis", { ...COMPLETE, Matter: undefined }],
+    ["a non-numeric axis", { ...COMPLETE, Spirit: "2" }],
+    ["a NaN axis", { ...COMPLETE, Substance: Number.NaN }],
+    ["an empty body", {}],
+    ["null", null],
+  ])(
+    "falls back to the local engine on %s, rather than fabricating",
+    async (_label, body) => {
+      mockCalculateTokenRates.mockResolvedValue(body);
+      const result = await (await clientWithBackend()).calculateRates();
+
+      // The local engine produced this, so it is complete and real.
+      for (const axis of ["Spirit", "Essence", "Matter", "Substance"] as const) {
+        expect(typeof result[axis]).toBe("number");
+        expect(Number.isFinite(result[axis])).toBe(true);
+        // The old code's fabricated value. Any axis landing exactly here would
+        // be indistinguishable from a measurement.
+        expect(result[axis]).not.toBe(0.5);
+      }
+      expect(result.kalchm).not.toBe(1.0);
+    },
+  );
+
+  it("the local path carries the engine's own values through untouched", async () => {
+    process.env.NEXT_PUBLIC_TOKENS_BACKEND = "false";
+    jest.resetModules();
+    const [{ TokensClient }, { getCurrentAlchemicalState }] = await Promise.all([
+      import("@/services/TokensClient"),
+      import("@/services/RealAlchemizeService"),
+    ]);
+    const engine = getCurrentAlchemicalState();
+    const result = await new TokensClient().calculateRates();
+
+    expect(result.Spirit).toBe(engine.esms.Spirit);
+    expect(result.Essence).toBe(engine.esms.Essence);
+    expect(result.Matter).toBe(engine.esms.Matter);
+    expect(result.Substance).toBe(engine.esms.Substance);
+    expect(result.kalchm).toBe(engine.kalchm);
+    expect(mockCalculateTokenRates).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/fullChartMonica.ts
+++ b/src/utils/fullChartMonica.ts
@@ -39,12 +39,66 @@ export const MIN_CHART_BODIES = 5;
 /**
  * A stored `natal_positions` entry. Both shapes appear in production: some rows
  * carry an absolute `position` (ecliptic longitude), others only `sign`+`degree`.
+ *
+ * `longitude` is NOT on this contract. It is accepted on ingest only so that
+ * `normaliseNatalPositions` can strip it — see that function.
  */
 export interface NatalPositionRow {
   planet?: string;
   sign?: string;
   degree?: number;
   position?: number;
+}
+
+/**
+ * Strip the dead `longitude` key from an incoming or stored `natal_positions`
+ * blob, promoting it to `position` on the one branch where it carries meaning.
+ *
+ * ── Why the key is dead ─────────────────────────────────────────────────────
+ *
+ * `[MEASURED 2026-07-26]` `longitude` was present on **710 of 710** stored
+ * bodies across all 71 charts, and `0` was its **only distinct value**. It is a
+ * fabricated literal, not a measurement. Its origin is upstream, in the
+ * agent-authoring repo:
+ *
+ * ```ts
+ * longitude: data?.longitude ?? data?.degrees ?? 0   // extractNatalPositions
+ * ```
+ *
+ * The objects it reads carry `{ sign, degree, retrograde, house }` — neither
+ * `longitude` nor `degrees` exists on them, so the chain falls through to the
+ * literal `0` every single time.
+ *
+ * ── Why it is worse than merely useless ─────────────────────────────────────
+ *
+ * A `p.position ?? p.longitude ?? …` chain does **not** route around it, because
+ * `0` is not nullish: the chain stops at the zero and never reaches `degree`.
+ * That is how an earlier audit "found" 71 identical all-zero charts — false; the
+ * real data was in `sign` + `degree` all along (Adam Smith: Sun Gemini 25°).
+ * Sign + degree already determine longitude, so the key is redundant as well as
+ * wrong, and the canonical parser below has always ignored it.
+ *
+ * ── Why a real longitude is promoted rather than dropped ────────────────────
+ *
+ * Dropping unconditionally would mean that if the upstream fallback is ever
+ * fixed, WTEN would silently discard the better value. A non-zero finite
+ * `longitude` IS an absolute ecliptic longitude, which is exactly what
+ * `position` means here — so it is moved there, where the parser reads it.
+ * No stored row takes this branch today (all 710 are 0); it exists so that
+ * fixing the producer improves the data instead of being thrown away.
+ */
+export function normaliseNatalPositions(raw: unknown): unknown {
+  if (!Array.isArray(raw)) return raw;
+  return raw.map((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return entry;
+    const row = entry as Record<string, unknown>;
+    if (!("longitude" in row)) return entry;
+    const { longitude, ...rest } = row;
+    const lon = Number(longitude);
+    const carriesMeaning =
+      Number.isFinite(lon) && lon !== 0 && rest.position === undefined;
+    return carriesMeaning ? { ...rest, position: lon } : rest;
+  });
 }
 
 /**


### PR DESCRIPTION
Four commits. **The first one is a production outage fix and is the reason to merge quickly.**

---

## 1. `796d4552` — every credit has been throwing since #652 merged ⚠️

```
42P08  inconsistent types deduced for parameter $4
```

`$4` (sourceType) is bound **both** as the INSERT value for a `character varying` column **and**, uncast, inside `CASE WHEN $4 IN ('agents_yield','daily_yield')`, where the literals deduce `text`. A bind parameter has one deduced type, so PostgreSQL refused the statement outright — it could not even be `PREPARE`d. Casting only the comparison side does not fix it.

**Thirteen unit tests covered this path and all thirteen passed**, because they mock the database. That is the real defect; the missing cast is only its first symptom.

### The older bug the same statement was hiding

Every user's **first-ever credit** was silently dropped. The balance write was `UPDATE … WHERE user_id = $1` preceded by an `ensure_balance` CTE — but in a data-modifying CTE every sub-statement and the main query run against **one snapshot taken before the statement begins**, so the `UPDATE` could not see the row `ensure_balance` had just inserted. Ledger row committed, `UPDATE` matched zero rows, balance never moved.

Silent because `creditMultipleTokens` only assigns `last` when `rows.length > 0`.

**Measured on production: 67 users, 521.7141 Spirit.** For 67 of 67 the shortfall equals exactly that user's *first* ledger row; all 67 are auto-provisioned agents (human signup seeds `token_balances` separately, so the row pre-existed). Spirit is simply the first axis written, so it alone ever meets the missing-row state — E/M/S reconcile exactly.

This **corrects an earlier report of mine**: the gap is not 324.00 and not confined to the 42 double-credit users.

Fixed with an upsert. Verified against production in a rolled-back transaction — **17 checks, 0 failures**: parse, first-credit-applied, accumulation, ledger == balance per axis, idempotent repeat suppressed, `yield_day` only for daily-yield sources, and 23505 still raised by `uniq_daily_yield_per_user_day`.

**Gate:** `scripts/checkEconomySqlParses.ts` `PREPARE`s every variant against real PostgreSQL in CI (parse + type analysis, writes nothing). Proven to catch this bug — against the pre-fix statement it reports `42P08` for all four axes.

**Not included:** the 521.71 already-lost tokens. Repairing an immutable ledger is a separate decision, not a hotfix.

---

## 2. `4eefd2a0` — the stored `longitude` was a fabricated 0 on all 710 natal bodies

Present on **710 of 710** bodies across all 71 charts, with `0` its only distinct value. Origin is upstream: `longitude: data?.longitude ?? data?.degrees ?? 0` over objects carrying neither key.

An absent key would be harmless. A fabricated `0` is not — it is not nullish, so a `?? longitude ??` chain stops there and never reaches `degree`. An audit written that way once "found" 71 all-zero charts; the real data was in `sign` + `degree` throughout.

Three existing witnesses passed on this the whole time. Adds a fourth that scans stored body **keys**, with a control that fails the run if it cannot find `planet`/`sign`/`degree`.

Production: 71 rows / 710 bodies under full protocol — snapshot, restore proven byte-identical in a rolled-back transaction, dry run, and an abort rule requiring every row to differ by *exactly* the key removal. Post-write: full-chart 71 checked / **0 drifted**, audit 23 checks 0 failures, new detector passes (it exits 1 against the pre-write database).

## 3. `c2256fe8` — token rates returned a constant wearing the shape of a computation

`/api/tokens/calculate` resolved a planetary hour, threw it away, and returned `(1,1,1,1)` with `kalchm=1.0` for every hour of every day. Axes are now measured from the ruling planet plus the Ascendant vessel: **20 of 20 hours now give a non-degenerate kalchm, against 0 of 20.**

`monica` is now **null** here — it needs elements, elements come from signs, and an hour names no sign. Widening the type surfaced a *second* `TokenRatesResult` mapping absent monica to `1.0`; the type checker found it, no grep would have. The new Python ESMS table is generated from the canonical TypeScript symbol and asserted entry-for-entry in the parity suite.

## 4. `6aecb5e3` — re-pin the cross-repo brief and record what its reply corrected

Also records a measurement worth keeping: the degenerate-band constant reproduces on WTEN's population (660 grid points at exactly 0, next value 0.218786, nothing between) while collapsing to a continuum on a partial-chart population. Both correct about different objects.

---

## Verification

`46` pytest · `197` jest across 15 suites · `tsc --noEmit` clean · 17/17 production checks · all four data witnesses green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)