### PR TITLE
fix(economy): repair the 521.71 Spirit the ensure-then-mutate CTE dropped

### DIFF
--- a/.github/workflows/monica-integrity.yml
+++ b/.github/workflows/monica-integrity.yml
@@ -199,3 +199,25 @@ jobs:
         env:
           DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
         run: bun scripts/checkEconomySqlParses.ts
+
+      - name: Balances reconcile with their own ledger
+        # A FIFTH data witness, for a defect that lives in the RELATIONSHIP between
+        # two tables rather than inside either one. Every witness above passed while
+        # 521.7141 Spirit across 67 users sat in the ledger and never reached a
+        # balance: the ledger was correct, the balances were internally valid, no
+        # constraint was violated, no value drifted from an engine, no row was
+        # cloned, no field was fabricated. Nothing compared the two.
+        #
+        # The cause was `WITH ensure_balance AS (INSERT …) UPDATE token_balances …`:
+        # a data-modifying CTE gives every sub-statement ONE pre-statement snapshot,
+        # so the UPDATE could not see the row the CTE had just inserted. It failed
+        # silently because an empty RETURNING is indistinguishable from an
+        # idempotency replay at the call site.
+        #
+        # The comparison is PER USER and PER AXIS deliberately: offsetting per-user
+        # differences net to zero in a table-wide SUM, and only Spirit ever drifted
+        # (the four axes are separate statements in one transaction, so only the
+        # first met the missing-row state).
+        env:
+          DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
+        run: bun scripts/checkLedgerBalanceReconciliation.ts

--- a/scripts/checkLedgerBalanceReconciliation.ts
+++ b/scripts/checkLedgerBalanceReconciliation.ts
@@ -1,0 +1,172 @@
+/**
+ * Does every stored balance still equal the sum of its own ledger?
+ *
+ *   railway run --service Postgres -- bun scripts/checkLedgerBalanceReconciliation.ts
+ *
+ * Read-only against real data. The one transaction it opens is a CONTROL and is
+ * always rolled back. Exits non-zero on any drift, and non-zero as UNSOUND if a
+ * control fails — never green by finding nothing.
+ *
+ * ── The defect this locks out ────────────────────────────────────────────────
+ *
+ * `creditTokensSql` opened with `WITH ensure_balance AS (INSERT INTO
+ * token_balances … ON CONFLICT DO NOTHING)` and then `UPDATE token_balances …
+ * WHERE user_id = $1`. Every sub-statement of a data-modifying CTE runs against
+ * ONE snapshot taken before the statement, so the UPDATE could not see the row
+ * the CTE had just inserted: the ledger row committed and the balance never moved.
+ *
+ * `[MEASURED 2026-07-27]` it had silently cost **521.7141 Spirit across 67 users**,
+ * each shortfall exactly that user's FIRST Spirit credit. PR #653 replaced the CTE
+ * with an upsert; `scripts/repairSpiritLedgerDrift.ts` repaired the balances.
+ *
+ * ── Why none of the existing witnesses could see it ─────────────────────────
+ *
+ * The ledger was perfectly correct and the balances were internally valid — no
+ * constraint was violated, no value drifted from an engine, no row was cloned, no
+ * field was fabricated. The defect lived only in the RELATIONSHIP between two
+ * tables that nothing compared. It also failed silently at the call site, because
+ * `creditMultipleTokens` only records a result when `rows.length > 0`, which is
+ * indistinguishable from an idempotency replay.
+ *
+ * ── Why a per-axis check, and why per-user ──────────────────────────────────
+ *
+ * Only Spirit ever drifted, because the four axes are written as separate
+ * statements inside one transaction: the first statement's invisible insert IS
+ * visible to the second, so only the first axis met the missing-row state. A
+ * whole-table SUM would also have hidden it — offsetting per-user differences can
+ * net to zero — so the comparison is per user, per axis.
+ */
+import pg from "pg";
+
+const AXES = ["Spirit", "Essence", "Matter", "Substance"] as const;
+
+/** Per-user, per-axis comparison. `having` lets the control inject a fake drift. */
+const driftSql = (extraJoin = "", extraWhere = "TRUE") => `
+  WITH ledger AS (
+    SELECT user_id, token_type, sum(amount) AS total
+      FROM token_transactions GROUP BY 1, 2
+  ),
+  paired AS (
+    SELECT l.user_id, l.token_type, l.total AS ledger,
+           CASE lower(l.token_type)
+             WHEN 'spirit'    THEN b.spirit
+             WHEN 'essence'   THEN b.essence
+             WHEN 'matter'    THEN b.matter
+             WHEN 'substance' THEN b.substance
+           END AS balance
+      FROM token_balances b
+      JOIN ledger l ON l.user_id = b.user_id
+      ${extraJoin}
+     WHERE ${extraWhere}
+  )
+  SELECT user_id, token_type, ledger, balance, (ledger - balance) AS delta
+    FROM paired
+   WHERE balance IS NOT NULL
+     AND round(ledger::numeric, 6) <> round(balance::numeric, 6)`;
+
+const url = process.env.DATABASE_PUBLIC_URL || process.env.DATABASE_URL;
+if (!url) {
+  console.error("FAIL: no DATABASE_PUBLIC_URL / DATABASE_URL — this gate needs a real database.");
+  process.exit(1);
+}
+
+const client = new pg.Client({ connectionString: url, ssl: { rejectUnauthorized: false } });
+await client.connect();
+
+const problems: string[] = [];
+let unsound = false;
+
+try {
+  // ── CONTROL 1: can this gate reach populated tables at all? ──────────────
+  // A broken query and a clean database look identical from the outside.
+  const counts = await client.query(`
+    SELECT (SELECT count(*) FROM token_balances)     AS balances,
+           (SELECT count(*) FROM token_transactions) AS ledger_rows,
+           (SELECT count(DISTINCT user_id) FROM token_transactions) AS ledger_users`);
+  const { balances, ledger_rows, ledger_users } = counts.rows[0];
+  if (Number(balances) === 0 || Number(ledger_rows) === 0) {
+    console.error(`✗ CONTROL FAILED: token_balances=${balances}, token_transactions=${ledger_rows}. Nothing to reconcile — the gate cannot pass on an empty read.`);
+    unsound = true;
+  } else {
+    console.log(`✓ control: ${balances} balance rows, ${ledger_rows} ledger rows across ${ledger_users} users`);
+  }
+
+  // ── CONTROL 2: does the detector actually detect? ────────────────────────
+  // Inject a drift, confirm it is caught, roll it back. Without this, a query
+  // that silently matches nothing reports "reconciled" forever.
+  await client.query("BEGIN");
+  const victim = await client.query(
+    `SELECT user_id FROM token_balances b
+      WHERE EXISTS (SELECT 1 FROM token_transactions t WHERE t.user_id = b.user_id AND t.token_type = 'Spirit')
+      LIMIT 1`,
+  );
+  if (victim.rows.length === 0) {
+    console.error("✗ CONTROL FAILED: no user has any Spirit ledger row, so the detector cannot be exercised.");
+    unsound = true;
+  } else {
+    const victimId = victim.rows[0].user_id;
+    await client.query(`UPDATE token_balances SET spirit = spirit + 1.25 WHERE user_id = $1`, [victimId]);
+    const caught = await client.query(driftSql());
+    const sawIt = caught.rows.some(
+      (r: { user_id: string; token_type: string }) => r.user_id === victimId && r.token_type === "Spirit",
+    );
+    if (sawIt) {
+      console.log("✓ control: an injected 1.25 drift IS detected (rolled back)");
+    } else {
+      console.error("✗ CONTROL FAILED: injected a 1.25 Spirit drift and the detector did not report it. Every result below is meaningless.");
+      unsound = true;
+    }
+  }
+  await client.query("ROLLBACK");
+
+  // ── The check itself ────────────────────────────────────────────────────
+  const drift = await client.query(driftSql());
+  const rows = drift.rows as Array<{ user_id: string; token_type: string; ledger: string; balance: string; delta: string }>;
+
+  for (const axis of AXES) {
+    const forAxis = rows.filter((r) => r.token_type === axis);
+    if (forAxis.length === 0) {
+      console.log(`✓ ${axis}: every balance equals its ledger`);
+      continue;
+    }
+    const net = forAxis.reduce((s, r) => s + Number(r.delta), 0);
+    console.error(`✗ ${axis}: ${forAxis.length} user(s) drift, net ${net.toFixed(4)}`);
+    for (const r of forAxis.slice(0, 5)) {
+      console.error(`    ${r.user_id.slice(0, 8)}  ledger ${Number(r.ledger).toFixed(4)}  balance ${Number(r.balance).toFixed(4)}  delta ${Number(r.delta).toFixed(4)}`);
+    }
+    if (forAxis.length > 5) console.error(`    … ${forAxis.length - 5} more`);
+    problems.push(`${axis}: ${forAxis.length} users, net ${net.toFixed(4)}`);
+  }
+
+  // A ledger row whose user has NO balance row is the same defect one step
+  // earlier — the credit never created the row it was supposed to create.
+  const orphans = await client.query(`
+    SELECT count(DISTINCT t.user_id) AS users, round(sum(t.amount)::numeric, 4) AS total
+      FROM token_transactions t
+      LEFT JOIN token_balances b ON b.user_id = t.user_id
+     WHERE b.user_id IS NULL`);
+  const orphanUsers = Number(orphans.rows[0].users);
+  if (orphanUsers > 0) {
+    console.error(`✗ ${orphanUsers} user(s) have ledger rows but NO token_balances row (${orphans.rows[0].total} tokens)`);
+    problems.push(`${orphanUsers} users with a ledger but no balance row`);
+  } else {
+    console.log("✓ every user with a ledger row has a balance row");
+  }
+} catch (error) {
+  await client.query("ROLLBACK").catch(() => {});
+  console.error("✗ gate errored:", error instanceof Error ? error.message : error);
+  unsound = true;
+} finally {
+  await client.end();
+}
+
+if (unsound) {
+  console.error("\nUNSOUND — a control failed, so this run proves nothing. Fix the gate before trusting it.\n");
+  process.exit(1);
+}
+if (problems.length > 0) {
+  console.error(`\nFAILED (${problems.length}):\n${problems.map((p) => `  - ${p}`).join("\n")}\n`);
+  console.error("Repair with scripts/repairSpiritLedgerDrift.ts (dry run first) after confirming the CAUSE — a\nnew drift means a write path is bypassing the upsert, and repairing data without\nfixing that path just refills the same hole.\n");
+  process.exit(1);
+}
+console.log("\nPASS — every balance reconciles with its own ledger, on all four axes.\n");

--- a/scripts/repairSpiritLedgerDrift.ts
+++ b/scripts/repairSpiritLedgerDrift.ts
@@ -1,0 +1,172 @@
+/**
+ * One-time repair: credit the balances that the ensure-then-mutate CTE dropped.
+ *
+ *   railway run --service Postgres -- bun scripts/repairSpiritLedgerDrift.ts           # dry run
+ *   railway run --service Postgres -- bun scripts/repairSpiritLedgerDrift.ts --write   # apply
+ *
+ * ── What was lost ───────────────────────────────────────────────────────────
+ *
+ * `creditTokensSql` opened with `WITH ensure_balance AS (INSERT INTO
+ * token_balances … ON CONFLICT DO NOTHING)` and then `UPDATE token_balances …
+ * WHERE user_id = $1`. Every sub-statement of a data-modifying CTE runs against
+ * ONE snapshot taken before the statement, so that UPDATE could not see the row
+ * `ensure_balance` had just inserted: the ledger row committed and the balance
+ * never moved. PR #653 replaced it with an upsert (deployed 2026-07-26T22:03Z),
+ * so no new drift can accrue. This repairs the balances left behind.
+ *
+ * ── The measurement this repair is derived from ─────────────────────────────
+ *
+ * `[MEASURED 2026-07-27]` 67 users, **521.7141** Spirit. For **67 of 67** the
+ * shortfall equals exactly that user's FIRST Spirit credit — `initial_grant` 49
+ * users / 490.00, `agents_yield` 17 / 21.7141, `transit_attunement` 1 / 10.00.
+ * Controls: 15 Spirit-crediting users reconcile EXACTLY, and Essence, Matter and
+ * Substance drift by 0 across all 82, because `creditMultipleTokens` writes the
+ * four axes as separate statements in one transaction — only the first axis ever
+ * met the missing-row state, and Spirit is always first.
+ *
+ * ── Why balance-only, and why no new ledger rows ────────────────────────────
+ *
+ * The ledger already records these credits correctly; it is the balance that is
+ * wrong. Adding a `correction` row would make the ledger double-count the credit
+ * and break the `sum(amount) === balance` correspondence this repair exists to
+ * restore. Deleting the originals would rewrite an immutable ledger — rejected in
+ * #652 for a related case, on the grounds that userTimelineService ("earned") and
+ * dashboardPanelsService ("minted") read those rows.
+ *
+ * ── Safety ─────────────────────────────────────────────────────────────────
+ *
+ * Idempotent by construction: it credits exactly the residual `ledger - balance`,
+ * so a second run finds no drift and writes nothing. It also REFUSES to run if
+ * anything about the population has changed since the measurement above, rather
+ * than repairing a different defect than the one authorised — and it refuses
+ * outright on any NEGATIVE drift, which would mean taking tokens away and is a
+ * different finding needing its own decision.
+ */
+import pg from "pg";
+
+const WRITE = process.argv.includes("--write");
+
+/** From the 2026-07-27 measurement. A material change means STOP, not proceed. */
+const EXPECTED_USERS = 67;
+const EXPECTED_TOTAL = 521.7141;
+const TOTAL_TOLERANCE = 0.01;
+
+const DRIFT_SQL = `
+  WITH ledger AS (
+    SELECT user_id, sum(amount) AS total
+      FROM token_transactions WHERE token_type = 'Spirit' GROUP BY 1
+  )
+  SELECT b.user_id,
+         l.total   AS ledger,
+         b.spirit  AS balance,
+         (l.total - b.spirit) AS delta
+    FROM token_balances b
+    JOIN ledger l ON l.user_id = b.user_id
+   WHERE round(l.total::numeric, 6) <> round(b.spirit::numeric, 6)
+   ORDER BY (l.total - b.spirit) DESC`;
+
+const url = process.env.DATABASE_PUBLIC_URL || process.env.DATABASE_URL;
+if (!url) {
+  console.error("FAIL: no DATABASE_PUBLIC_URL / DATABASE_URL in env.");
+  process.exit(1);
+}
+
+const client = new pg.Client({ connectionString: url, ssl: { rejectUnauthorized: false } });
+await client.connect();
+
+let exitCode = 0;
+try {
+  await client.query("BEGIN");
+
+  const before = await client.query(DRIFT_SQL);
+  const rows = before.rows as Array<{ user_id: string; ledger: string; balance: string; delta: string }>;
+  const total = rows.reduce((sum, r) => sum + Number(r.delta), 0);
+  const negatives = rows.filter((r) => Number(r.delta) < 0);
+
+  console.log(`\nDrifted users: ${rows.length}   net Spirit owed: ${total.toFixed(4)}`);
+  console.table(
+    rows.slice(0, 10).map((r) => ({
+      user: r.user_id.slice(0, 8),
+      ledger: Number(r.ledger).toFixed(4),
+      balance: Number(r.balance).toFixed(4),
+      owed: Number(r.delta).toFixed(4),
+    })),
+  );
+  if (rows.length > 10) console.log(`  … ${rows.length - 10} more`);
+
+  // ── Refusals ────────────────────────────────────────────────────────────
+  if (negatives.length > 0) {
+    console.error(
+      `\nREFUSING: ${negatives.length} user(s) have a NEGATIVE drift (balance exceeds ledger). ` +
+        "Repairing those would REMOVE tokens; that is a different finding and needs its own decision.",
+    );
+    throw new Error("negative drift present");
+  }
+  if (rows.length === 0) {
+    console.log("\nNothing to repair — ledger and balances already agree. (Idempotent re-run.)");
+    await client.query("ROLLBACK");
+    await client.end();
+    process.exit(0);
+  }
+  if (rows.length !== EXPECTED_USERS || Math.abs(total - EXPECTED_TOTAL) > TOTAL_TOLERANCE) {
+    console.error(
+      `\nREFUSING: population changed since the authorised measurement ` +
+        `(expected ${EXPECTED_USERS} users / ${EXPECTED_TOTAL}, found ${rows.length} / ${total.toFixed(4)}). ` +
+        "Re-measure and re-authorise rather than repairing a different defect.",
+    );
+    throw new Error("population mismatch");
+  }
+
+  if (!WRITE) {
+    console.log("\nDRY RUN — no changes. Re-run with --write to apply.");
+    await client.query("ROLLBACK");
+    await client.end();
+    process.exit(0);
+  }
+
+  // ── Apply ───────────────────────────────────────────────────────────────
+  const applied = await client.query(`
+    WITH ledger AS (
+      SELECT user_id, sum(amount) AS total
+        FROM token_transactions WHERE token_type = 'Spirit' GROUP BY 1
+    ),
+    drift AS (
+      SELECT b.user_id, (l.total - b.spirit) AS delta
+        FROM token_balances b
+        JOIN ledger l ON l.user_id = b.user_id
+       WHERE round(l.total::numeric, 6) <> round(b.spirit::numeric, 6)
+         AND (l.total - b.spirit) > 0
+    )
+    UPDATE token_balances b
+       SET spirit = b.spirit + d.delta,
+           updated_at = now()
+      FROM drift d
+     WHERE b.user_id = d.user_id
+    RETURNING b.user_id`);
+
+  console.log(`\nUpdated ${applied.rowCount} balance rows.`);
+  if (applied.rowCount !== EXPECTED_USERS) {
+    console.error(`REFUSING to commit: updated ${applied.rowCount} rows, expected ${EXPECTED_USERS}.`);
+    throw new Error("unexpected row count");
+  }
+
+  // Verify INSIDE the transaction: commit only if the invariant now holds.
+  const after = await client.query(DRIFT_SQL);
+  if (after.rows.length !== 0) {
+    console.error(`REFUSING to commit: ${after.rows.length} user(s) still drift after the update.`);
+    throw new Error("drift survived the repair");
+  }
+  console.log("Verified in-transaction: 0 users drift on Spirit.");
+
+  await client.query("COMMIT");
+  console.log(`\nCOMMITTED — ${EXPECTED_USERS} balances credited, ${total.toFixed(4)} Spirit total.\n`);
+} catch (error) {
+  await client.query("ROLLBACK").catch(() => {});
+  console.error("\nROLLED BACK — nothing was written.");
+  console.error(error instanceof Error ? error.message : error);
+  exitCode = 1;
+} finally {
+  await client.end();
+}
+
+process.exit(exitCode);


### PR DESCRIPTION
PR #653 fixed the CAUSE. This repairs the DATA it left behind, and adds the
witness that would have caught it years earlier than any of the four we had.

## What was lost

`creditTokensSql` opened with `WITH ensure_balance AS (INSERT INTO token_balances
… ON CONFLICT DO NOTHING)` and then `UPDATE token_balances … WHERE user_id = $1`.
Every sub-statement of a data-modifying CTE runs against ONE snapshot taken
before the statement begins, so that UPDATE could not see the row `ensure_balance`
had just inserted: the ledger row committed and the balance never moved.

Proven directly against production, in a rolled-back transaction on a temp table:

    WITH ensure_row AS (INSERT INTO t (id) VALUES (1) ON CONFLICT DO NOTHING)
    UPDATE t SET v = v + 5 WHERE id = 1 RETURNING *
      -> 0 rows matched, and the row was left at v = 0

    INSERT INTO t (id, v) VALUES (2, 5)
      ON CONFLICT (id) DO UPDATE SET v = t.v + EXCLUDED.v
      -> 5, then 10 on a second run

## The measurement

[MEASURED 2026-07-27] 67 users, 521.7141 Spirit. For 67 of 67 the shortfall
equals EXACTLY that user's FIRST Spirit credit:

    initial_grant        49 users   490.0000
    agents_yield         17 users    21.7141
    transit_attunement    1 user     10.0000

Controls: 15 Spirit-crediting users reconciled exactly, and Essence, Matter and
Substance drifted by 0 across all 82. Only Spirit was ever affected because
`creditMultipleTokens` writes the four axes as separate statements inside one
transaction — the first statement's invisible insert IS visible to the second, so
only the first axis met the missing-row state, and Spirit is always first.

It failed silently because `creditMultipleTokens` records a result only when
`rows.length > 0`, which is indistinguishable from an idempotency replay.

## Why balance-only

The ledger already records these credits correctly; the balance is what is wrong.
A `correction` ledger row would make the ledger double-count the credit and break
the `sum(amount) === balance` correspondence this repair restores. Deleting the
originals rewrites an immutable ledger — rejected in #652 for a related case,
because userTimelineService ("earned") and dashboardPanelsService ("minted") read
those rows.

## Applied

    railway run --service Postgres -- bun scripts/repairSpiritLedgerDrift.ts --write
    -> Updated 67 balance rows
    -> Verified in-transaction: 0 users drift on Spirit
    -> COMMITTED

Re-verified afterwards on a fresh connection: all four axes now report 0
mismatched users and 0.0000 net drift, and no user has a ledger row without a
balance row. The script is idempotent by construction (it credits the residual
`ledger - balance`), refuses on any NEGATIVE drift, and refuses if the population
has changed from the authorised 67 / 521.7141 rather than repairing a different
defect.

## The fifth witness

`scripts/checkLedgerBalanceReconciliation.ts`, wired into the data job of
monica-integrity. All four existing witnesses passed throughout this incident:
the ledger was correct, the balances were internally valid, no constraint was
violated, no value drifted from an engine, no row was cloned, no field was
fabricated. The defect lived only in the RELATIONSHIP between two tables that
nothing compared.

Per user and per axis deliberately — offsetting differences net to zero in a
table-wide SUM. It carries two controls and exits non-zero as UNSOUND rather than
green if either fails: that it can reach populated tables, and that an injected
1.25 drift IS detected (rolled back). Verified: both controls pass, all four axes
reconcile.

Note `scripts/**` is excluded from tsconfig, so these files are not covered by
`tsc --noEmit`; both were run end-to-end against production instead.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)