### PR TITLE
fix(economy): every balance read threw, and four CTEs guarded nothing

### DIFF
--- a/scripts/checkEconomySqlParses.ts
+++ b/scripts/checkEconomySqlParses.ts
@@ -85,6 +85,48 @@ function creditSql(column: string): string {
     .replace(/\$\{column\}/g, column);
 }
 
+/**
+ * The debit statement, resolved the same way. It is a SEPARATE statement from the
+ * credit and deliberately NOT an upsert — see the comment above `debitTokensSql`
+ * for the production measurement showing an upsert-shaped debit drives a missing
+ * balance to -25.0000. Its `WITH check_balance` opening is shared with the
+ * transmutation statement, so the extractor anchors on `return \`` to stay unique.
+ */
+function debitSql(column: string): string {
+  const body = source.match(/return `WITH check_balance[\s\S]*?RETURNING \*`;/)?.[0];
+  if (!body) {
+    fail(
+      "CONTROL FAILED: could not extract the debit statement from " +
+        "TokenEconomyService.ts. If it was renamed or restructured, update this " +
+        "extractor — the gate must not pass by finding nothing.",
+    );
+  }
+  return body!
+    .replace(/^return `/, "")
+    .replace(/`;$/, "")
+    .replace(/\$\{column\}/g, column);
+}
+
+/**
+ * The balance read. Gated because it is where the OTHER un-preparable shape lived:
+ * `INSERT …; SELECT …` sent as one parameterised string, which PostgreSQL rejects
+ * with `42601 cannot insert multiple commands into a prepared statement`. Every
+ * call raised and fell through to a catch, so the "primary" path had never run.
+ */
+function getBalancesSql(): string {
+  const body = source.match(
+    /`INSERT INTO token_balances \(user_id\) VALUES \(\$1\)\s*\n\s*ON CONFLICT[\s\S]*?RETURNING \*`/,
+  )?.[0];
+  if (!body) {
+    fail(
+      "CONTROL FAILED: could not extract the getBalances statement from " +
+        "TokenEconomyService.ts. Update this extractor rather than letting the " +
+        "gate pass on nothing.",
+    );
+  }
+  return body!.replace(/^`/, "").replace(/`$/, "");
+}
+
 const client = new pg.Client({
   connectionString: url,
   ssl: { rejectUnauthorized: false },
@@ -144,15 +186,60 @@ try {
     }
   }
 
+  // Debit, one statement per axis, same reasoning as the credit above.
+  const others: Array<[string, string]> = [
+    ...COLUMNS.map((c) => [`debit(${c})`, debitSql(c)] as [string, string]),
+    ["getBalances", getBalancesSql()],
+  ];
+  for (const [label, sql] of others) {
+    // Lowercased: PREPARE folds an unquoted identifier, so a mixed-case name
+    // would not match in pg_prepared_statements and the param report would read
+    // "? params: undefined" while the statement had in fact prepared fine.
+    const name = `_gate_${label.replace(/[^a-z0-9]/gi, "_")}`.toLowerCase();
+    try {
+      await client.query(`PREPARE ${name} AS ${sql}`);
+      const meta = await client.query<{ parameter_types: string[] }>(
+        "SELECT parameter_types::text[] FROM pg_prepared_statements WHERE name = $1",
+        [name],
+      );
+      await client.query(`DEALLOCATE ${name}`);
+      console.log(
+        `✓ ${label} prepares — ${meta.rows[0]?.parameter_types.length ?? "?"} params: ` +
+          `${meta.rows[0]?.parameter_types.join(", ")}`,
+      );
+    } catch (e) {
+      failures++;
+      const err = e as { code?: string; message?: string };
+      console.error(`✗ ${label} FAILED TO PREPARE`);
+      console.error(`    ${err.code ?? ""} ${err.message ?? String(e)}`);
+      if (err.code === "42601") {
+        console.error(
+          "    The extended query protocol allows exactly ONE command per\n" +
+            "    parameterised message — `INSERT …; SELECT …` in a single string\n" +
+            "    with a bind parameter can never be prepared.",
+        );
+      }
+    }
+  }
+
+  const total = COLUMNS.length + others.length;
   if (failures > 0) {
     fail(
-      `${failures} of ${COLUMNS.length} credit statements cannot be prepared by ` +
+      `${failures} of ${total} economy statements cannot be prepared by ` +
         "PostgreSQL.\n  Unit tests cannot catch this: they mock the database, and " +
         "a mock will\n  happily accept SQL no database would.",
     );
   }
   console.log(
-    `\n✓ all ${COLUMNS.length} credit statements parse and type-check against PostgreSQL`,
+    `\n✓ all ${total} economy statements parse and type-check against PostgreSQL`,
+  );
+  // Stated so a reader does not mistake this for full coverage: the multi-axis
+  // spend/purchase CTEs (`WITH balance_check …`) and the transmutation statement
+  // are still inline template literals inside their methods, and this extractor
+  // cannot reach them. They need lifting into named builders first.
+  console.log(
+    "  NOT covered: the two spend/purchase CTEs and transmutation — still inline,\n" +
+      "  pending extraction into builders. 3 statements ungated.",
   );
 } finally {
   await client.end();

--- a/scripts/checkEconomySqlParses.ts
+++ b/scripts/checkEconomySqlParses.ts
@@ -25,20 +25,42 @@
  * misspelled columns, dropped tables, and a parameter count that has drifted
  * from the call site.
  *
+ * PREPARE proves a statement is LEGAL, not that it is CORRECT. Semantics are
+ * covered separately by `scripts/checkEconomyStatementBehaviour.mjs`, which
+ * exercises each statement against production inside a rolled-back transaction.
+ * Neither gate substitutes for the other.
+ *
+ * ── Why this imports instead of scraping ────────────────────────────────────
+ *
+ * It used to pull each statement out of `TokenEconomyService.ts` with a regex,
+ * which drifts silently the moment anything is reformatted — a regex that stops
+ * matching reports "extracted nothing", not "the SQL changed". The builders now
+ * live in `src/services/tokenEconomyQueries.ts`, a module with ZERO runtime
+ * imports, so this gate can import and call the real functions. It therefore
+ * checks exactly what ships, and cannot drift from it at all.
+ *
  * ── Controls ────────────────────────────────────────────────────────────────
  *
- * A zero result is a claim requiring a control test: if the extractor silently
- * matched nothing, "0 statements failed" would read as a pass. So the run FAILS
- * unless it extracted every statement it expects, and it additionally proves it
- * can detect a genuinely broken statement by preparing one that must fail.
+ * A zero result is a claim requiring a control test: if the gate silently
+ * checked nothing, "0 statements failed" would read as a pass. Three controls
+ * guard against that:
+ *
+ *   1. It proves it can detect a genuinely broken statement, by preparing one
+ *      that must fail.
+ *   2. Every builder exported by the queries module must be exercised. Add a
+ *      builder without gating it and this fails, rather than quietly checking
+ *      less than it appears to.
+ *   3. The total statement count is asserted. A builder that starts yielding
+ *      fewer variants (a collapsed loop, a dropped column) fails here even
+ *      though every individual statement still prepares.
  *
  * Read-only. Never writes.
  *
  *   railway run --service Postgres -- bun scripts/checkEconomySqlParses.ts
  */
-import { readFileSync } from "fs";
-import { join } from "path";
 import pg from "pg";
+import * as queries from "../src/services/tokenEconomyQueries";
+import type { AxisColumn } from "../src/services/tokenEconomyQueries";
 
 const fail = (msg: string): never => {
   console.error(`\n✗ ${msg}`);
@@ -48,84 +70,102 @@ const fail = (msg: string): never => {
 const url = process.env.DATABASE_PUBLIC_URL ?? process.env.DATABASE_URL;
 if (!url) fail("no DATABASE_PUBLIC_URL / DATABASE_URL in the environment");
 
-const SERVICE = join(
-  process.cwd(),
-  "src/services/TokenEconomyService.ts",
-);
-const source = readFileSync(SERVICE, "utf8");
-
-// The four axis columns are interpolated into the statement, so each is a
+// The four axis columns are interpolated into the statements, so each is a
 // DIFFERENT statement and each must be checked. A typo in one would otherwise
 // only surface for whichever axis happened to be credited.
-const COLUMNS = ["spirit", "essence", "matter", "substance"] as const;
+const COLUMNS: readonly AxisColumn[] = [
+  "spirit",
+  "essence",
+  "matter",
+  "substance",
+];
 
-/** Resolve the SQL exactly as the module builds it — never a hand copy. */
-function creditSql(column: string): string {
-  const body = source.match(/return `WITH inserted[\s\S]*?RETURNING \*`;/)?.[0];
-  if (!body) {
-    fail(
-      "CONTROL FAILED: could not extract the credit statement from " +
-        "TokenEconomyService.ts. The gate cannot pass by finding nothing — if " +
-        "the statement was renamed or restructured, update this extractor.",
-    );
-  }
-  const sources = source
-    .match(/const DAILY_YIELD_SOURCES = \[([\s\S]*?)\]/)?.[1]
-    .match(/"[^"]+"/g);
-  if (!sources || sources.length === 0) {
-    fail("CONTROL FAILED: could not extract DAILY_YIELD_SOURCES");
-  }
-  return body!
-    .replace(/^return `/, "")
-    .replace(/`;$/, "")
-    .replace(
-      /\$\{DAILY_YIELD_SOURCES_SQL\}/g,
-      sources!.map((s) => `'${s.slice(1, -1)}'`).join(", "),
-    )
-    .replace(/\$\{column\}/g, column);
+/** Placeholder bind values. PREPARE only performs type analysis, so these are
+ *  never sent to the server — they exist because the builders return their
+ *  parameters alongside their SQL. */
+const AMOUNTS = { spirit: 1, essence: 2, matter: 3, substance: 4 };
+const UUID = "00000000-0000-0000-0000-000000000000";
+
+interface Statement {
+  label: string;
+  sql: string;
+  /** Which exported builder produced it — used by the coverage control. */
+  builder: string;
 }
 
-/**
- * The debit statement, resolved the same way. It is a SEPARATE statement from the
- * credit and deliberately NOT an upsert — see the comment above `debitTokensSql`
- * for the production measurement showing an upsert-shaped debit drives a missing
- * balance to -25.0000. Its `WITH check_balance` opening is shared with the
- * transmutation statement, so the extractor anchors on `return \`` to stay unique.
- */
-function debitSql(column: string): string {
-  const body = source.match(/return `WITH check_balance[\s\S]*?RETURNING \*`;/)?.[0];
-  if (!body) {
-    fail(
-      "CONTROL FAILED: could not extract the debit statement from " +
-        "TokenEconomyService.ts. If it was renamed or restructured, update this " +
-        "extractor — the gate must not pass by finding nothing.",
-    );
-  }
-  return body!
-    .replace(/^return `/, "")
-    .replace(/`;$/, "")
-    .replace(/\$\{column\}/g, column);
+const statements: Statement[] = [];
+
+for (const column of COLUMNS) {
+  statements.push({
+    label: `credit(${column})`,
+    sql: queries.creditTokensSql(column),
+    builder: "creditTokensSql",
+  });
+  statements.push({
+    label: `debit(${column})`,
+    sql: queries.debitTokensSql(column),
+    builder: "debitTokensSql",
+  });
 }
 
-/**
- * The balance read. Gated because it is where the OTHER un-preparable shape lived:
- * `INSERT …; SELECT …` sent as one parameterised string, which PostgreSQL rejects
- * with `42601 cannot insert multiple commands into a prepared statement`. Every
- * call raised and fell through to a catch, so the "primary" path had never run.
- */
-function getBalancesSql(): string {
-  const body = source.match(
-    /`INSERT INTO token_balances \(user_id\) VALUES \(\$1\)\s*\n\s*ON CONFLICT[\s\S]*?RETURNING \*`/,
-  )?.[0];
-  if (!body) {
-    fail(
-      "CONTROL FAILED: could not extract the getBalances statement from " +
-        "TokenEconomyService.ts. Update this extractor rather than letting the " +
-        "gate pass on nothing.",
-    );
+statements.push({
+  label: "getBalances",
+  sql: queries.getBalancesSql(),
+  builder: "getBalancesSql",
+});
+
+statements.push({
+  label: "debitAll(spend)",
+  sql: queries.debitAllTokensSql({
+    userId: UUID,
+    amounts: AMOUNTS,
+    description: "probe",
+    idempotencyKey: "probe",
+    intent: { kind: "spend", sourceType: "recipe_ingestion", sourceId: null },
+  }).sql,
+  builder: "debitAllTokensSql",
+});
+
+statements.push({
+  label: "debitAll(purchase)",
+  sql: queries.debitAllTokensSql({
+    userId: UUID,
+    amounts: AMOUNTS,
+    description: "probe",
+    idempotencyKey: "probe",
+    intent: { kind: "purchase", shopItemId: UUID },
+  }).sql,
+  builder: "debitAllTokensSql",
+});
+
+// Transmutation interpolates TWO columns, so every ordered pair is its own
+// statement — 4 x 3 = 12. Checking one pair would leave a typo in any of the
+// other eleven to surface only for whoever happened to swap those two axes.
+for (const fromColumn of COLUMNS) {
+  for (const toColumn of COLUMNS) {
+    if (fromColumn === toColumn) continue;
+    statements.push({
+      label: `transmute(${fromColumn}->${toColumn})`,
+      sql: queries.transmuteSql({
+        fromColumn,
+        toColumn,
+        userId: UUID,
+        costAmount: 3,
+        targetAmount: 1,
+        transactionGroupId: UUID,
+        fromToken: "Spirit",
+        toToken: "Essence",
+        debitDescription: "probe",
+        creditDescription: "probe",
+        idempotencyKey: "probe",
+      }).sql,
+      builder: "transmuteSql",
+    });
   }
-  return body!.replace(/^`/, "").replace(/`$/, "");
 }
+
+// 4 credit + 4 debit + 1 getBalances + 2 debitAll + 12 transmute
+const EXPECTED_TOTAL = 23;
 
 const client = new pg.Client({
   connectionString: url,
@@ -135,7 +175,7 @@ await client.connect();
 
 let failures = 0;
 try {
-  // ── Control: the gate can detect a statement that IS broken ───────────────
+  // ── Control 1: the gate can detect a statement that IS broken ─────────────
   // Without this, a PREPARE that silently succeeds on anything would make every
   // check below meaningless.
   let controlCaught = false;
@@ -155,43 +195,40 @@ try {
   }
   console.log("✓ control: PREPARE rejects a statement it should reject");
 
-  // ── The gate ──────────────────────────────────────────────────────────────
-  for (const column of COLUMNS) {
-    const sql = creditSql(column);
-    const name = `_gate_credit_${column}`;
-    try {
-      await client.query(`PREPARE ${name} AS ${sql}`);
-      const meta = await client.query<{ parameter_types: string[] }>(
-        "SELECT parameter_types::text[] FROM pg_prepared_statements WHERE name = $1",
-        [name],
-      );
-      await client.query(`DEALLOCATE ${name}`);
-      console.log(
-        `✓ credit(${column}) prepares — ${meta.rows[0]?.parameter_types.length ?? "?"} params: ` +
-          `${meta.rows[0]?.parameter_types.join(", ")}`,
-      );
-    } catch (e) {
-      failures++;
-      const err = e as { code?: string; message?: string };
-      console.error(`✗ credit(${column}) FAILED TO PREPARE`);
-      console.error(`    ${err.code ?? ""} ${err.message ?? String(e)}`);
-      if (err.code === "42P08") {
-        console.error(
-          "    A bind parameter has ONE deduced type. If the same $n is used " +
-            "both as\n    an INSERT value and inside a comparison against " +
-            "string literals, BOTH\n    references must carry the same explicit " +
-            "cast — casting only one does not fix it.",
-        );
-      }
-    }
+  // ── Control 2: every exported builder is actually exercised ───────────────
+  // Derived from the module's exports rather than a hand-kept list, so adding a
+  // builder and forgetting to gate it fails here instead of passing quietly.
+  const exportedBuilders = Object.entries(queries)
+    .filter(([, v]) => typeof v === "function")
+    .map(([k]) => k);
+  const covered = new Set(statements.map((s) => s.builder));
+  const ungated = exportedBuilders.filter((b) => !covered.has(b));
+  if (ungated.length > 0) {
+    fail(
+      `CONTROL FAILED: ${ungated.length} exported builder(s) are never ` +
+        `PREPAREd: ${ungated.join(", ")}.\n  Every SQL builder in ` +
+        "tokenEconomyQueries.ts must be exercised by this gate.",
+    );
   }
+  console.log(
+    `✓ control: all ${exportedBuilders.length} exported builders are exercised ` +
+      `(${exportedBuilders.join(", ")})`,
+  );
 
-  // Debit, one statement per axis, same reasoning as the credit above.
-  const others: Array<[string, string]> = [
-    ...COLUMNS.map((c) => [`debit(${c})`, debitSql(c)] as [string, string]),
-    ["getBalances", getBalancesSql()],
-  ];
-  for (const [label, sql] of others) {
+  // ── Control 3: the statement count has not silently shrunk ────────────────
+  if (statements.length !== EXPECTED_TOTAL) {
+    fail(
+      `CONTROL FAILED: expected ${EXPECTED_TOTAL} statements, built ` +
+        `${statements.length}. A builder yielding fewer variants would still ` +
+        "prepare cleanly while covering less — update EXPECTED_TOTAL only if " +
+        "the reduction is intended.",
+    );
+  }
+  console.log(`✓ control: ${statements.length} statements built as expected`);
+
+  // ── The gate ──────────────────────────────────────────────────────────────
+  console.log("");
+  for (const { label, sql } of statements) {
     // Lowercased: PREPARE folds an unquoted identifier, so a mixed-case name
     // would not match in pg_prepared_statements and the param report would read
     // "? params: undefined" while the statement had in fact prepared fine.
@@ -212,6 +249,14 @@ try {
       const err = e as { code?: string; message?: string };
       console.error(`✗ ${label} FAILED TO PREPARE`);
       console.error(`    ${err.code ?? ""} ${err.message ?? String(e)}`);
+      if (err.code === "42P08") {
+        console.error(
+          "    A bind parameter has ONE deduced type. If the same $n is used " +
+            "both as\n    an INSERT value and inside a comparison against " +
+            "string literals, BOTH\n    references must carry the same explicit " +
+            "cast — casting only one does not fix it.",
+        );
+      }
       if (err.code === "42601") {
         console.error(
           "    The extended query protocol allows exactly ONE command per\n" +
@@ -219,27 +264,41 @@ try {
             "    with a bind parameter can never be prepared.",
         );
       }
+      if (err.code === "42702") {
+        console.error(
+          "    Ambiguous column. In an UPDATE … FROM balance_check, both\n" +
+            "    relations expose spirit/essence/matter/substance — qualify the\n" +
+            "    right-hand side of every SET with `token_balances.`.",
+        );
+      }
     }
   }
 
-  const total = COLUMNS.length + others.length;
   if (failures > 0) {
     fail(
-      `${failures} of ${total} economy statements cannot be prepared by ` +
-        "PostgreSQL.\n  Unit tests cannot catch this: they mock the database, and " +
-        "a mock will\n  happily accept SQL no database would.",
+      `${failures} of ${statements.length} economy statements cannot be ` +
+        "prepared by PostgreSQL.\n  Unit tests cannot catch this: they mock the " +
+        "database, and a mock will\n  happily accept SQL no database would.",
     );
   }
   console.log(
-    `\n✓ all ${total} economy statements parse and type-check against PostgreSQL`,
+    `\n✓ all ${statements.length} economy statements parse and type-check ` +
+      "against PostgreSQL",
   );
-  // Stated so a reader does not mistake this for full coverage: the multi-axis
-  // spend/purchase CTEs (`WITH balance_check …`) and the transmutation statement
-  // are still inline template literals inside their methods, and this extractor
-  // cannot reach them. They need lifting into named builders first.
+  // Stated so a reader does not mistake this for total coverage of the file.
+  // Every statement that MOVES MONEY is now gated. What remains ungated are
+  // simple reads and one timestamp write, none of which touch a balance:
   console.log(
-    "  NOT covered: the two spend/purchase CTEs and transmutation — still inline,\n" +
-      "  pending extraction into builders. 3 statements ungated.",
+    "\n  Covered: every balance-mutating statement (credit, debit, multi-axis\n" +
+      "  spend, premium purchase, transmutation, balance ensure-and-read).\n" +
+      "\n  NOT covered — still inline in TokenEconomyService.ts, none of which\n" +
+      "  move a balance:\n" +
+      "    · the two `SELECT 1 FROM token_transactions … idempotency_key LIKE`\n" +
+      "      pre-checks (debitAllTokens, purchaseShopItem)\n" +
+      "    · getTransactions' page + count reads\n" +
+      "    · updateDailyClaimTimestamp's `UPDATE token_balances SET <col> = now()`\n" +
+      "    · hasActivePurchase, getShopItem, getShopItems, and the shop_items\n" +
+      "      lookup in purchaseShopItem",
   );
 } finally {
   await client.end();

--- a/scripts/checkEconomyStatementBehaviour.mjs
+++ b/scripts/checkEconomyStatementBehaviour.mjs
@@ -1,0 +1,96 @@
+// End-to-end behaviour of the changed economy statements, against production,
+// in a transaction that is ALWAYS rolled back. Statements are read out of the
+// module source so this tests what ships, not a hand copy.
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import pg from "pg";
+
+const src = readFileSync("src/services/TokenEconomyService.ts", "utf8");
+const yields = src.match(/const DAILY_YIELD_SOURCES = \[([\s\S]*?)\]/)[1].match(/"[^"]+"/g)
+  .map((s) => `'${s.slice(1, -1)}'`).join(", ");
+const creditSql = (col) => src.match(/return `WITH inserted[\s\S]*?RETURNING \*`;/)[0]
+  .replace(/^return `/, "").replace(/`;$/, "")
+  .replace(/\$\{DAILY_YIELD_SOURCES_SQL\}/g, yields).replace(/\$\{column\}/g, col);
+const debitSql = (col) => src.match(/return `WITH check_balance[\s\S]*?RETURNING \*`;/)[0]
+  .replace(/^return `/, "").replace(/`;$/, "").replace(/\$\{column\}/g, col);
+const getBalSql = src.match(/`INSERT INTO token_balances \(user_id\) VALUES \(\$1\)\s*\n\s*ON CONFLICT[\s\S]*?RETURNING \*`/)[0]
+  .replace(/^`/, "").replace(/`$/, "");
+
+const c = new pg.Client({ connectionString: process.env.DATABASE_PUBLIC_URL, ssl: { rejectUnauthorized: false } });
+await c.connect();
+
+let bad = 0;
+const ok = (m) => console.log(`  ok   ${m}`);
+const no = (m) => { console.error(`  FAIL ${m}`); bad++; };
+
+const mkUser = async (label) => {
+  const id = randomUUID();
+  await c.query(
+    `INSERT INTO users (id, email, password_hash, role, is_active, email_verified, is_agent,
+                        name, profile, preferences, login_count, created_at, updated_at)
+     VALUES ($1,$2,'NO_LOGIN','USER'::user_role,true,true,false,$3,'{}'::jsonb,'{}'::jsonb,0,now(),now())`,
+    [id, `econ-${id}@example.invalid`, label]);
+  return id;
+};
+const spirit = async (id) => {
+  const r = await c.query(`SELECT spirit FROM token_balances WHERE user_id=$1`, [id]);
+  return r.rows.length ? Number(r.rows[0].spirit) : null;
+};
+
+try {
+  await c.query("BEGIN");
+
+  // ── getBalances ──────────────────────────────────────────────────────────
+  console.log("\ngetBalances (single statement, insert-or-return)");
+  const u = await mkUser("econ probe");
+  const first = await c.query(getBalSql, [u]);
+  first.rows.length === 1 && Number(first.rows[0].spirit) === 0
+    ? ok("creates the row and RETURNS it (spirit 0)")
+    : no(`returned ${first.rows.length} rows / spirit ${first.rows[0]?.spirit}`);
+  const second = await c.query(getBalSql, [u]);
+  second.rows.length === 1
+    ? ok("second call returns the SAME row — the DO NOTHING/RETURNING gap is closed")
+    : no(`re-read returned ${second.rows.length} rows`);
+
+  // ── credit then debit ────────────────────────────────────────────────────
+  console.log("\ncredit then debit");
+  await c.query(creditSql("spirit"), [u, "Spirit", 10, "signup_grant", null, "probe", randomUUID(), `p:${u}:1`]);
+  (await spirit(u)) === 10 ? ok("credit of 10 applied") : no(`balance ${await spirit(u)} after credit`);
+
+  const d1 = await c.query(debitSql("spirit"), [u, "Spirit", 4, "recipe_ingestion", null, randomUUID(), "probe debit"]);
+  (d1.rowCount === 1 && (await spirit(u)) === 6)
+    ? ok("debit of 4 applied — balance 6")
+    : no(`debit returned ${d1.rowCount} rows, balance ${await spirit(u)}`);
+
+  const d2 = await c.query(debitSql("spirit"), [u, "Spirit", 100, "recipe_ingestion", null, randomUUID(), "overdraw"]);
+  (d2.rowCount === 0 && (await spirit(u)) === 6)
+    ? ok("debit of 100 REFUSED, balance untouched")
+    : no(`overdraw returned ${d2.rowCount} rows, balance ${await spirit(u)}`);
+
+  // ── the case the removed CTE pretended to handle ────────────────────────
+  console.log("\ndebit for a user with NO balance row");
+  const v = await mkUser("no balance");
+  const d3 = await c.query(debitSql("spirit"), [v, "Spirit", 5, "recipe_ingestion", null, randomUUID(), "no row"]);
+  const vs = await spirit(v);
+  (d3.rowCount === 0 && vs === null)
+    ? ok("fails CLOSED — 0 rows, and no balance row conjured into existence")
+    : no(`returned ${d3.rowCount} rows and balance ${vs} (expected 0 / null)`);
+  const led = await c.query(`SELECT count(*) n FROM token_transactions WHERE user_id=$1`, [v]);
+  Number(led.rows[0].n) === 0
+    ? ok("and no ledger row was written for the refused debit")
+    : no(`${led.rows[0].n} ledger rows written for a refused debit`);
+
+  // ── the invariant ───────────────────────────────────────────────────────
+  const inv = await c.query(
+    `SELECT b.spirit, COALESCE(sum(t.amount),0) AS ledger FROM token_balances b
+       LEFT JOIN token_transactions t ON t.user_id=b.user_id AND t.token_type='Spirit'
+      WHERE b.user_id=$1 GROUP BY b.spirit`, [u]);
+  String(inv.rows[0].spirit) === String(inv.rows[0].ledger)
+    ? ok(`ledger === balance (${inv.rows[0].ledger})`)
+    : no(`ledger ${inv.rows[0].ledger} !== balance ${inv.rows[0].spirit}`);
+} finally {
+  await c.query("ROLLBACK");
+  await c.end();
+}
+console.log(bad === 0 ? "\nPASS — all economy statements behave correctly (rolled back)\n" : `\nFAILED: ${bad}\n`);
+process.exit(bad === 0 ? 0 : 1);

--- a/scripts/checkEconomyStatementBehaviour.mjs
+++ b/scripts/checkEconomyStatementBehaviour.mjs
@@ -1,27 +1,55 @@
-// End-to-end behaviour of the changed economy statements, against production,
-// in a transaction that is ALWAYS rolled back. Statements are read out of the
-// module source so this tests what ships, not a hand copy.
+// End-to-end behaviour of the economy statements, against production, in a
+// transaction that is ALWAYS rolled back.
+//
+// ── Why this exists alongside the PREPARE gate ──────────────────────────────
+//
+// `checkEconomySqlParses.ts` proves each statement is LEGAL. It cannot prove it
+// is CORRECT. An upsert-shaped debit prepares perfectly and drives a missing
+// balance to -25.0000; only running it reveals that. So: PREPARE for legality,
+// this for semantics.
+//
+// Statements come from `src/services/tokenEconomyQueries.ts` by IMPORT, so this
+// exercises exactly what ships rather than a hand copy that can drift.
+//
+//   railway run --service Postgres -- bun scripts/checkEconomyStatementBehaviour.mjs
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import pg from "pg";
+import {
+  creditTokensSql,
+  debitAllTokensSql,
+  debitTokensSql,
+  getBalancesSql,
+  transmuteSql,
+} from "../src/services/tokenEconomyQueries.ts";
 
-const src = readFileSync("src/services/TokenEconomyService.ts", "utf8");
-const yields = src.match(/const DAILY_YIELD_SOURCES = \[([\s\S]*?)\]/)[1].match(/"[^"]+"/g)
-  .map((s) => `'${s.slice(1, -1)}'`).join(", ");
-const creditSql = (col) => src.match(/return `WITH inserted[\s\S]*?RETURNING \*`;/)[0]
-  .replace(/^return `/, "").replace(/`;$/, "")
-  .replace(/\$\{DAILY_YIELD_SOURCES_SQL\}/g, yields).replace(/\$\{column\}/g, col);
-const debitSql = (col) => src.match(/return `WITH check_balance[\s\S]*?RETURNING \*`;/)[0]
-  .replace(/^return `/, "").replace(/`;$/, "").replace(/\$\{column\}/g, col);
-const getBalSql = src.match(/`INSERT INTO token_balances \(user_id\) VALUES \(\$1\)\s*\n\s*ON CONFLICT[\s\S]*?RETURNING \*`/)[0]
-  .replace(/^`/, "").replace(/`$/, "");
-
-const c = new pg.Client({ connectionString: process.env.DATABASE_PUBLIC_URL, ssl: { rejectUnauthorized: false } });
+const c = new pg.Client({
+  connectionString: process.env.DATABASE_PUBLIC_URL,
+  ssl: { rejectUnauthorized: false },
+});
 await c.connect();
 
 let bad = 0;
 const ok = (m) => console.log(`  ok   ${m}`);
-const no = (m) => { console.error(`  FAIL ${m}`); bad++; };
+const no = (m) => {
+  console.error(`  FAIL ${m}`);
+  bad++;
+};
+
+// A deliberately-failing statement (a 23505 probe) aborts the surrounding
+// transaction, so every such case runs inside its own savepoint.
+const attempt = async (fn) => {
+  const sp = `sp_${randomUUID().replace(/-/g, "")}`;
+  await c.query(`SAVEPOINT ${sp}`);
+  try {
+    const value = await fn();
+    await c.query(`RELEASE SAVEPOINT ${sp}`);
+    return { ok: true, value };
+  } catch (error) {
+    await c.query(`ROLLBACK TO SAVEPOINT ${sp}`);
+    return { ok: false, error };
+  }
+};
 
 const mkUser = async (label) => {
   const id = randomUUID();
@@ -29,68 +57,426 @@ const mkUser = async (label) => {
     `INSERT INTO users (id, email, password_hash, role, is_active, email_verified, is_agent,
                         name, profile, preferences, login_count, created_at, updated_at)
      VALUES ($1,$2,'NO_LOGIN','USER'::user_role,true,true,false,$3,'{}'::jsonb,'{}'::jsonb,0,now(),now())`,
-    [id, `econ-${id}@example.invalid`, label]);
+    [id, `econ-${id}@example.invalid`, label],
+  );
   return id;
 };
-const spirit = async (id) => {
-  const r = await c.query(`SELECT spirit FROM token_balances WHERE user_id=$1`, [id]);
-  return r.rows.length ? Number(r.rows[0].spirit) : null;
+
+/** A funded user: every axis credited to `amount`. */
+const mkFundedUser = async (label, amount = 100) => {
+  const id = await mkUser(label);
+  for (const [token, column] of [
+    ["Spirit", "spirit"],
+    ["Essence", "essence"],
+    ["Matter", "matter"],
+    ["Substance", "substance"],
+  ]) {
+    await c.query(creditTokensSql(column), [
+      id,
+      token,
+      amount,
+      "signup_grant",
+      null,
+      "probe funding",
+      randomUUID(),
+      `fund:${id}:${column}`,
+    ]);
+  }
+  return id;
 };
+
+const balances = async (id) => {
+  const r = await c.query(
+    `SELECT spirit, essence, matter, substance FROM token_balances WHERE user_id=$1`,
+    [id],
+  );
+  if (!r.rows.length) return null;
+  const b = r.rows[0];
+  return {
+    spirit: Number(b.spirit),
+    essence: Number(b.essence),
+    matter: Number(b.matter),
+    substance: Number(b.substance),
+  };
+};
+const spirit = async (id) => (await balances(id))?.spirit ?? null;
+const ledgerCount = async (id) =>
+  Number(
+    (
+      await c.query(
+        `SELECT count(*) n FROM token_transactions WHERE user_id=$1`,
+        [id],
+      )
+    ).rows[0].n,
+  );
+const purchaseCount = async (id) =>
+  Number(
+    (
+      await c.query(`SELECT count(*) n FROM user_purchases WHERE user_id=$1`, [
+        id,
+      ])
+    ).rows[0].n,
+  );
+
+const same = (a, b) =>
+  a && b && ["spirit", "essence", "matter", "substance"].every((k) => a[k] === b[k]);
+
+// The four axes' amounts for a multi-axis spend.
+const COST = { spirit: 1, essence: 2, matter: 3, substance: 4 };
 
 try {
   await c.query("BEGIN");
 
+  // ── Control: this script can actually observe a failure ──────────────────
+  // Without it, a run where every assertion silently short-circuits would print
+  // PASS. Deliberately assert something false and confirm the counter moves.
+  {
+    const before = bad;
+    no("control: this line MUST be counted as a failure");
+    if (bad === before + 1) {
+      bad = before;
+      console.log("  ok   control: a failed assertion is counted (reset)");
+    } else {
+      console.error("  CONTROL BROKEN: a failure was not counted");
+      process.exit(1);
+    }
+  }
+
   // ── getBalances ──────────────────────────────────────────────────────────
   console.log("\ngetBalances (single statement, insert-or-return)");
   const u = await mkUser("econ probe");
-  const first = await c.query(getBalSql, [u]);
+  const first = await c.query(getBalancesSql(), [u]);
   first.rows.length === 1 && Number(first.rows[0].spirit) === 0
     ? ok("creates the row and RETURNS it (spirit 0)")
     : no(`returned ${first.rows.length} rows / spirit ${first.rows[0]?.spirit}`);
-  const second = await c.query(getBalSql, [u]);
+  const second = await c.query(getBalancesSql(), [u]);
   second.rows.length === 1
     ? ok("second call returns the SAME row — the DO NOTHING/RETURNING gap is closed")
     : no(`re-read returned ${second.rows.length} rows`);
 
-  // ── credit then debit ────────────────────────────────────────────────────
-  console.log("\ncredit then debit");
-  await c.query(creditSql("spirit"), [u, "Spirit", 10, "signup_grant", null, "probe", randomUUID(), `p:${u}:1`]);
+  // ── single-axis credit then debit ────────────────────────────────────────
+  console.log("\ncredit then debit (single axis)");
+  await c.query(creditTokensSql("spirit"), [
+    u, "Spirit", 10, "signup_grant", null, "probe", randomUUID(), `p:${u}:1`,
+  ]);
   (await spirit(u)) === 10 ? ok("credit of 10 applied") : no(`balance ${await spirit(u)} after credit`);
 
-  const d1 = await c.query(debitSql("spirit"), [u, "Spirit", 4, "recipe_ingestion", null, randomUUID(), "probe debit"]);
-  (d1.rowCount === 1 && (await spirit(u)) === 6)
+  const d1 = await c.query(debitTokensSql("spirit"), [
+    u, "Spirit", 4, "recipe_ingestion", null, randomUUID(), "probe debit",
+  ]);
+  d1.rowCount === 1 && (await spirit(u)) === 6
     ? ok("debit of 4 applied — balance 6")
     : no(`debit returned ${d1.rowCount} rows, balance ${await spirit(u)}`);
 
-  const d2 = await c.query(debitSql("spirit"), [u, "Spirit", 100, "recipe_ingestion", null, randomUUID(), "overdraw"]);
-  (d2.rowCount === 0 && (await spirit(u)) === 6)
+  const d2 = await c.query(debitTokensSql("spirit"), [
+    u, "Spirit", 100, "recipe_ingestion", null, randomUUID(), "overdraw",
+  ]);
+  d2.rowCount === 0 && (await spirit(u)) === 6
     ? ok("debit of 100 REFUSED, balance untouched")
     : no(`overdraw returned ${d2.rowCount} rows, balance ${await spirit(u)}`);
 
-  // ── the case the removed CTE pretended to handle ────────────────────────
-  console.log("\ndebit for a user with NO balance row");
-  const v = await mkUser("no balance");
-  const d3 = await c.query(debitSql("spirit"), [v, "Spirit", 5, "recipe_ingestion", null, randomUUID(), "no row"]);
-  const vs = await spirit(v);
-  (d3.rowCount === 0 && vs === null)
-    ? ok("fails CLOSED — 0 rows, and no balance row conjured into existence")
-    : no(`returned ${d3.rowCount} rows and balance ${vs} (expected 0 / null)`);
-  const led = await c.query(`SELECT count(*) n FROM token_transactions WHERE user_id=$1`, [v]);
-  Number(led.rows[0].n) === 0
-    ? ok("and no ledger row was written for the refused debit")
-    : no(`${led.rows[0].n} ledger rows written for a refused debit`);
+  // ── multi-axis spend ─────────────────────────────────────────────────────
+  console.log("\nmulti-axis spend (debitAllTokens)");
+  const s = await mkFundedUser("multi spend", 100);
+  const spendQ = debitAllTokensSql({
+    userId: s, amounts: COST, description: "probe spend", idempotencyKey: null,
+    intent: { kind: "spend", sourceType: "recipe_ingestion", sourceId: null },
+  });
+  const sp1 = await c.query(spendQ.sql, spendQ.values);
+  const afterSpend = await balances(s);
+  sp1.rowCount === 1 &&
+  same(afterSpend, { spirit: 99, essence: 98, matter: 97, substance: 96 })
+    ? ok("spend of 1/2/3/4 applied across all four axes")
+    : no(`returned ${sp1.rowCount} rows, balances ${JSON.stringify(afterSpend)}`);
 
-  // ── the invariant ───────────────────────────────────────────────────────
+  // Over-spend on exactly ONE axis. The whole statement must refuse — a
+  // per-axis check that passed three of four would debit three axes for a
+  // purchase the user cannot afford.
+  const overQ = debitAllTokensSql({
+    userId: s, amounts: { spirit: 1, essence: 1, matter: 1, substance: 10_000 },
+    description: "probe overspend", idempotencyKey: null,
+    intent: { kind: "spend", sourceType: "recipe_ingestion", sourceId: null },
+  });
+  const sp2 = await c.query(overQ.sql, overQ.values);
+  const afterOver = await balances(s);
+  sp2.rowCount === 0 && same(afterOver, afterSpend)
+    ? ok("over-spend on ONE axis refuses the whole statement — no axis moved")
+    : no(`returned ${sp2.rowCount} rows, balances ${JSON.stringify(afterOver)}`);
+
+  // ── premium purchase ─────────────────────────────────────────────────────
+  console.log("\npremium purchase (debitAllTokens, purchase intent)");
+  // Synthetic shop item, inside the rolled-back txn: the test must not depend
+  // on production catalogue contents, which can change under it.
+  const itemId = randomUUID();
+  await c.query(
+    `INSERT INTO shop_items (id, slug, title, category, cost_spirit, cost_essence, cost_matter, cost_substance, is_one_time, is_active)
+     VALUES ($1,$2,'Probe Item','probe',1,2,3,4,true,true)`,
+    [itemId, `probe-item-${itemId}`],
+  );
+  const pUser = await mkFundedUser("purchaser", 100);
+  const buyQ = debitAllTokensSql({
+    userId: pUser, amounts: COST, description: "probe purchase", idempotencyKey: null,
+    intent: { kind: "purchase", shopItemId: itemId },
+  });
+  const b1 = await c.query(buyQ.sql, buyQ.values);
+  const afterBuy = await balances(pUser);
+  b1.rowCount === 1 &&
+  (await purchaseCount(pUser)) === 1 &&
+  same(afterBuy, { spirit: 99, essence: 98, matter: 97, substance: 96 })
+    ? ok("purchase debits all four axes AND writes a user_purchases row")
+    : no(
+        `returned ${b1.rowCount} rows, purchases ${await purchaseCount(pUser)}, balances ${JSON.stringify(afterBuy)}`,
+      );
+
+  const buyOverQ = debitAllTokensSql({
+    userId: pUser, amounts: { spirit: 1, essence: 1, matter: 1, substance: 10_000 },
+    description: "probe overspend purchase", idempotencyKey: null,
+    intent: { kind: "purchase", shopItemId: itemId },
+  });
+  const b2 = await c.query(buyOverQ.sql, buyOverQ.values);
+  b2.rowCount === 0 &&
+  (await purchaseCount(pUser)) === 1 &&
+  same(await balances(pUser), afterBuy)
+    ? ok("unaffordable purchase writes NO user_purchases row and moves no balance")
+    : no(
+        `returned ${b2.rowCount} rows, purchases ${await purchaseCount(pUser)}`,
+      );
+
+  // ── transmutation ────────────────────────────────────────────────────────
+  console.log("\ntransmutation");
+  const t = await mkFundedUser("transmuter", 100);
+  const beforeT = await balances(t);
+  const tQ = transmuteSql({
+    fromColumn: "spirit", toColumn: "essence", userId: t,
+    costAmount: 3, targetAmount: 1, transactionGroupId: randomUUID(),
+    fromToken: "Spirit", toToken: "Essence",
+    debitDescription: "probe transmute debit",
+    creditDescription: "probe transmute credit",
+    idempotencyKey: null,
+  });
+  const t1 = await c.query(tQ.sql, tQ.values);
+  const afterT = await balances(t);
+  t1.rowCount === 1 &&
+  afterT.spirit === beforeT.spirit - 3 &&
+  afterT.essence === beforeT.essence + 1 &&
+  afterT.matter === beforeT.matter &&
+  afterT.substance === beforeT.substance
+    ? ok("moves BOTH axes — spirit -3, essence +1, others untouched")
+    : no(`returned ${t1.rowCount} rows, ${JSON.stringify(beforeT)} -> ${JSON.stringify(afterT)}`);
+
+  const tLedger = await c.query(
+    `SELECT token_type, sum(amount)::numeric AS total FROM token_transactions
+      WHERE user_id=$1 AND source_type='transmutation' GROUP BY token_type ORDER BY token_type`,
+    [t],
+  );
+  const byToken = Object.fromEntries(
+    tLedger.rows.map((r) => [r.token_type, Number(r.total)]),
+  );
+  byToken.Spirit === -3 && byToken.Essence === 1
+    ? ok("both ledger halves written and net exactly -3 Spirit / +1 Essence")
+    : no(`ledger nets ${JSON.stringify(byToken)}`);
+
+  const tOverQ = transmuteSql({
+    fromColumn: "spirit", toColumn: "essence", userId: t,
+    costAmount: 10_000, targetAmount: 1, transactionGroupId: randomUUID(),
+    fromToken: "Spirit", toToken: "Essence",
+    debitDescription: "probe overdraw", creditDescription: "probe overdraw",
+    idempotencyKey: null,
+  });
+  const t2 = await c.query(tOverQ.sql, tOverQ.values);
+  t2.rowCount === 0 && same(await balances(t), afterT)
+    ? ok("unaffordable transmutation moves NEITHER axis")
+    : no(`returned ${t2.rowCount} rows, balances ${JSON.stringify(await balances(t))}`);
+
+  // ── idempotency: a retry must not charge twice ───────────────────────────
+  console.log("\nidempotency (a client retry must not double-charge)");
+  const iUser = await mkFundedUser("idempotent", 100);
+  const key = `probe-idem-${randomUUID()}`;
+  const mkSpend = () =>
+    debitAllTokensSql({
+      userId: iUser, amounts: COST, description: "probe idem", idempotencyKey: key,
+      intent: { kind: "spend", sourceType: "recipe_ingestion", sourceId: null },
+    });
+  const i1 = await attempt(() => {
+    const q = mkSpend();
+    return c.query(q.sql, q.values);
+  });
+  const afterFirst = await balances(iUser);
+  i1.ok && i1.value.rowCount === 1
+    ? ok("first spend applied")
+    : no(`first spend failed: ${i1.error?.code ?? i1.value?.rowCount}`);
+
+  const i2 = await attempt(() => {
+    const q = mkSpend();
+    return c.query(q.sql, q.values);
+  });
+  !i2.ok && i2.error?.code === "23505" && same(await balances(iUser), afterFirst)
+    ? ok("replayed spend rejected with 23505 — balance charged exactly once")
+    : no(
+        `replay: ok=${i2.ok} code=${i2.error?.code} balances ${JSON.stringify(await balances(iUser))}`,
+      );
+
+  const tKey = `probe-tidem-${randomUUID()}`;
+  const mkTransmute = () =>
+    transmuteSql({
+      fromColumn: "matter", toColumn: "substance", userId: iUser,
+      costAmount: 3, targetAmount: 1, transactionGroupId: randomUUID(),
+      fromToken: "Matter", toToken: "Substance",
+      debitDescription: "probe t idem", creditDescription: "probe t idem",
+      idempotencyKey: tKey,
+    });
+  const ti1 = await attempt(() => {
+    const q = mkTransmute();
+    return c.query(q.sql, q.values);
+  });
+  const afterT1 = await balances(iUser);
+  ti1.ok && ti1.value.rowCount === 1
+    ? ok("first transmutation applied")
+    : no(`first transmutation failed: ${ti1.error?.code}`);
+
+  const ti2 = await attempt(() => {
+    const q = mkTransmute();
+    return c.query(q.sql, q.values);
+  });
+  !ti2.ok && ti2.error?.code === "23505" && same(await balances(iUser), afterT1)
+    ? ok("replayed transmutation rejected with 23505 — charged exactly once")
+    : no(
+        `transmute replay: ok=${ti2.ok} code=${ti2.error?.code} balances ${JSON.stringify(await balances(iUser))}`,
+      );
+
+  // ── the -25.0000 regression guard ────────────────────────────────────────
+  // EVERY debit-side statement must fail CLOSED for a user with no balance row.
+  // `[MEASURED 2026-07-27]` an upsert-shaped debit of 25 against such a user
+  // produced spirit = -25.0000 — spending tokens that never existed. Asserting
+  // the EFFECT rather than grepping for `ON CONFLICT` catches the regression
+  // whatever shape the SQL is rewritten into.
+  console.log("\ndebit-side statements must fail CLOSED for a user with NO balance row");
+  const debitSideCases = [
+    ...["spirit", "essence", "matter", "substance"].map((col) => ({
+      label: `debitTokens(${col})`,
+      run: (id) => ({
+        sql: debitTokensSql(col),
+        values: [id, col[0].toUpperCase() + col.slice(1), 25, "recipe_ingestion", null, randomUUID(), "no row"],
+      }),
+    })),
+    {
+      label: "debitAllTokens(spend)",
+      run: (id) =>
+        debitAllTokensSql({
+          userId: id, amounts: { spirit: 25, essence: 25, matter: 25, substance: 25 },
+          description: "no row", idempotencyKey: null,
+          intent: { kind: "spend", sourceType: "recipe_ingestion", sourceId: null },
+        }),
+    },
+    {
+      label: "debitAllTokens(purchase)",
+      run: (id) =>
+        debitAllTokensSql({
+          userId: id, amounts: { spirit: 25, essence: 25, matter: 25, substance: 25 },
+          description: "no row", idempotencyKey: null,
+          intent: { kind: "purchase", shopItemId: itemId },
+        }),
+    },
+    {
+      label: "transmute(spirit->essence)",
+      run: (id) =>
+        transmuteSql({
+          fromColumn: "spirit", toColumn: "essence", userId: id,
+          costAmount: 25, targetAmount: 1, transactionGroupId: randomUUID(),
+          fromToken: "Spirit", toToken: "Essence",
+          debitDescription: "no row", creditDescription: "no row",
+          idempotencyKey: null,
+        }),
+    },
+  ];
+
+  for (const { label, run } of debitSideCases) {
+    const v = await mkUser(`no balance ${label}`);
+    const q = run(v);
+    const res = await c.query(q.sql, q.values);
+    const bal = await balances(v);
+    const led = await ledgerCount(v);
+    const pur = await purchaseCount(v);
+    res.rowCount === 0 && bal === null && led === 0 && pur === 0
+      ? ok(`${label} — 0 rows, no balance conjured, no ledger, no purchase`)
+      : no(
+          `${label} — rows=${res.rowCount} balance=${JSON.stringify(bal)} ledger=${led} purchases=${pur} (expected 0/null/0/0)`,
+        );
+  }
+
+  // ── the ledger/balance invariant ─────────────────────────────────────────
+  console.log("\ninvariant");
   const inv = await c.query(
     `SELECT b.spirit, COALESCE(sum(t.amount),0) AS ledger FROM token_balances b
        LEFT JOIN token_transactions t ON t.user_id=b.user_id AND t.token_type='Spirit'
-      WHERE b.user_id=$1 GROUP BY b.spirit`, [u]);
+      WHERE b.user_id=$1 GROUP BY b.spirit`,
+    [u],
+  );
   String(inv.rows[0].spirit) === String(inv.rows[0].ledger)
     ? ok(`ledger === balance (${inv.rows[0].ledger})`)
     : no(`ledger ${inv.rows[0].ledger} !== balance ${inv.rows[0].spirit}`);
+
+  // Same invariant for the multi-axis path, on all four axes at once — a
+  // per-axis decomposition that silently zeroed an axis would pass a
+  // Spirit-only check.
+  for (const [token, column] of [
+    ["Spirit", "spirit"], ["Essence", "essence"],
+    ["Matter", "matter"], ["Substance", "substance"],
+  ]) {
+    const r = await c.query(
+      `SELECT b.${column}::numeric AS bal, COALESCE(sum(t.amount),0)::numeric AS ledger
+         FROM token_balances b
+         LEFT JOIN token_transactions t ON t.user_id=b.user_id AND t.token_type=$2
+        WHERE b.user_id=$1 GROUP BY b.${column}`,
+      [pUser, token],
+    );
+    Number(r.rows[0].bal) === Number(r.rows[0].ledger)
+      ? ok(`purchaser ${token}: ledger === balance (${r.rows[0].ledger})`)
+      : no(`purchaser ${token}: ledger ${r.rows[0].ledger} !== balance ${r.rows[0].bal}`);
+  }
+
+  // ── the unification changed no SQL ───────────────────────────────────────
+  // The spend and premium-purchase statements were ~40 duplicated lines that
+  // are now one builder. Compare its output to the inline SQL it replaced,
+  // captured from the pre-refactor source. SQL comments are stripped before
+  // comparing — PostgreSQL's lexer discards them, so they provably cannot
+  // change semantics, and the two originals disagreed only about a comment.
+  console.log("\nunification is semantics-free (vs pre-refactor fixtures)");
+  const stripComments = (s) =>
+    s.split("\n").filter((l) => !l.trim().startsWith("--")).join("\n").trimEnd();
+  const fixture = (name) =>
+    stripComments(readFileSync(`scripts/fixtures/${name}.pre.sql`, "utf8"));
+
+  const renderedSpend = debitAllTokensSql({
+    userId: "u", amounts: { spirit: 1, essence: 2, matter: 3, substance: 4 },
+    description: "d", idempotencyKey: "k",
+    intent: { kind: "spend", sourceType: "recipe_ingestion", sourceId: null },
+  }).sql;
+  const renderedBuy = debitAllTokensSql({
+    userId: "u", amounts: { spirit: 1, essence: 2, matter: 3, substance: 4 },
+    description: "d", idempotencyKey: "k",
+    intent: { kind: "purchase", shopItemId: "i" },
+  }).sql;
+
+  stripComments(renderedSpend) === fixture("spend")
+    ? ok("spend SQL is identical to the inline statement it replaced")
+    : no("spend SQL DIFFERS from the pre-refactor statement");
+  stripComments(renderedBuy) === fixture("purchase")
+    ? ok("purchase SQL is identical to the inline statement it replaced")
+    : no("purchase SQL DIFFERS from the pre-refactor statement");
+
+  // Control: the comparison can actually detect a difference.
+  stripComments(renderedSpend) !== fixture("purchase")
+    ? ok("control: the comparison distinguishes the two statements")
+    : no("CONTROL FAILED: spend and purchase fixtures compare equal");
 } finally {
   await c.query("ROLLBACK");
   await c.end();
 }
-console.log(bad === 0 ? "\nPASS — all economy statements behave correctly (rolled back)\n" : `\nFAILED: ${bad}\n`);
+
+console.log(
+  bad === 0
+    ? "\nPASS — all economy statements behave correctly (rolled back)\n"
+    : `\nFAILED: ${bad}\n`,
+);
 process.exit(bad === 0 ? 0 : 1);

--- a/scripts/fixtures/purchase.pre.sql
+++ b/scripts/fixtures/purchase.pre.sql
@@ -1,0 +1,63 @@
+WITH balance_check AS (
+            SELECT * FROM token_balances WHERE user_id = $1
+            AND spirit >= $2 AND essence >= $3 AND matter >= $4 AND substance >= $5
+          ),
+          new_group AS (
+            SELECT uuid_generate_v4() AS gid
+          ),
+          debit_spirit AS (
+            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+            SELECT g.gid, $1, 'Spirit', -$2, 'premium_purchase', $6, $7,
+                   CASE WHEN $8::text IS NOT NULL THEN $8 || ':Spirit' ELSE NULL END
+            FROM balance_check bc, new_group g
+            WHERE $2 > 0
+            RETURNING id
+          ),
+          debit_essence AS (
+            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+            SELECT g.gid, $1, 'Essence', -$3, 'premium_purchase', $6, $7,
+                   CASE WHEN $8::text IS NOT NULL THEN $8 || ':Essence' ELSE NULL END
+            FROM balance_check bc, new_group g
+            WHERE $3 > 0
+            RETURNING id
+          ),
+          debit_matter AS (
+            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+            SELECT g.gid, $1, 'Matter', -$4, 'premium_purchase', $6, $7,
+                   CASE WHEN $8::text IS NOT NULL THEN $8 || ':Matter' ELSE NULL END
+            FROM balance_check bc, new_group g
+            WHERE $4 > 0
+            RETURNING id
+          ),
+          debit_substance AS (
+            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+            SELECT g.gid, $1, 'Substance', -$5, 'premium_purchase', $6, $7,
+                   CASE WHEN $8::text IS NOT NULL THEN $8 || ':Substance' ELSE NULL END
+            FROM balance_check bc, new_group g
+            WHERE $5 > 0
+            RETURNING id
+          ),
+          updated AS (
+            -- Qualify token_balances.<col> on the right-hand side of each
+            -- SET so the planner doesn't see the bare column name as
+            -- ambiguous between token_balances and balance_check (both
+            -- have spirit/essence/matter/substance columns). Without
+            -- these qualifiers Postgres raises 42702 and the whole CTE
+            -- rolls back, surfacing as purchase_failed in the caller.
+            UPDATE token_balances
+            SET spirit = token_balances.spirit - $2,
+                essence = token_balances.essence - $3,
+                matter = token_balances.matter - $4,
+                substance = token_balances.substance - $5,
+                updated_at = now()
+            FROM balance_check bc
+            WHERE token_balances.user_id = $1
+            RETURNING token_balances.*
+          ),
+          purchase AS (
+            INSERT INTO user_purchases (user_id, shop_item_id, transaction_group_id)
+            SELECT $1, $6::uuid, g.gid FROM updated u, new_group g
+            RETURNING transaction_group_id
+          )
+          SELECT u.*, p.transaction_group_id AS txn_group_id
+          FROM updated u, purchase p

--- a/scripts/fixtures/spend.pre.sql
+++ b/scripts/fixtures/spend.pre.sql
@@ -1,0 +1,51 @@
+WITH balance_check AS (
+            SELECT * FROM token_balances WHERE user_id = $1
+            AND spirit >= $2 AND essence >= $3 AND matter >= $4 AND substance >= $5
+          ),
+          new_group AS (
+            SELECT uuid_generate_v4() AS gid
+          ),
+          debit_spirit AS (
+            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+            SELECT g.gid, $1, 'Spirit', -$2, $6, $7, $8,
+                   CASE WHEN $9::text IS NOT NULL THEN $9 || ':Spirit' ELSE NULL END
+            FROM balance_check bc, new_group g
+            WHERE $2 > 0
+            RETURNING id
+          ),
+          debit_essence AS (
+            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+            SELECT g.gid, $1, 'Essence', -$3, $6, $7, $8,
+                   CASE WHEN $9::text IS NOT NULL THEN $9 || ':Essence' ELSE NULL END
+            FROM balance_check bc, new_group g
+            WHERE $3 > 0
+            RETURNING id
+          ),
+          debit_matter AS (
+            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+            SELECT g.gid, $1, 'Matter', -$4, $6, $7, $8,
+                   CASE WHEN $9::text IS NOT NULL THEN $9 || ':Matter' ELSE NULL END
+            FROM balance_check bc, new_group g
+            WHERE $4 > 0
+            RETURNING id
+          ),
+          debit_substance AS (
+            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+            SELECT g.gid, $1, 'Substance', -$5, $6, $7, $8,
+                   CASE WHEN $9::text IS NOT NULL THEN $9 || ':Substance' ELSE NULL END
+            FROM balance_check bc, new_group g
+            WHERE $5 > 0
+            RETURNING id
+          ),
+          updated AS (
+            UPDATE token_balances
+            SET spirit = token_balances.spirit - $2,
+                essence = token_balances.essence - $3,
+                matter = token_balances.matter - $4,
+                substance = token_balances.substance - $5,
+                updated_at = now()
+            FROM balance_check bc
+            WHERE token_balances.user_id = $1
+            RETURNING token_balances.*
+          )
+          SELECT u.*, g.gid AS txn_group_id FROM updated u, new_group g

--- a/src/app/api/economy/sync-credit/route.ts
+++ b/src/app/api/economy/sync-credit/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { executeQuery } from "@/lib/database";
 import { feedDatabase } from "@/services/feedDatabaseService";
 import { notificationDatabase } from "@/services/notificationDatabaseService";
+import { DAILY_YIELD_SOURCES } from "@/services/tokenEconomyQueries";
 import { tokenEconomy } from "@/services/TokenEconomyService";
 import type { TokenType, TransactionSourceType } from "@/types/economy";
 import type { NextRequest} from "next/server";
@@ -33,10 +34,9 @@ import type { NextRequest} from "next/server";
  * Everything else routed through this endpoint (transit_attunement / Sky Drops,
  * and the rest) is legitimately multi-per-day and must NOT be day-capped.
  */
-const DAILY_YIELD_SOURCES: ReadonlySet<string> = new Set([
-  "agents_yield",
-  "daily_yield",
-]);
+const DAILY_YIELD_SOURCE_SET: ReadonlySet<string> = new Set(
+  DAILY_YIELD_SOURCES,
+);
 
 interface SyncCreditBody {
   userEmail: string;
@@ -87,7 +87,7 @@ export async function POST(req: NextRequest) {
     // `source` defaults to agents_yield when the caller omits it, so the
     // resolved value — not the raw field — decides which rules apply below.
     const resolvedSource = source || "agents_yield";
-    const isDailyYield = DAILY_YIELD_SOURCES.has(resolvedSource);
+    const isDailyYield = DAILY_YIELD_SOURCE_SET.has(resolvedSource);
 
     // 2. Look up user ID by email.
     let userResult = await executeQuery<{ id: string }>(

--- a/src/services/TokenEconomyService.ts
+++ b/src/services/TokenEconomyService.ts
@@ -9,6 +9,13 @@
  */
 
 import { _logger } from "@/lib/logger";
+import {
+  creditTokensSql,
+  debitAllTokensSql,
+  debitTokensSql,
+  getBalancesSql,
+  transmuteSql,
+} from "@/services/tokenEconomyQueries";
 import type {
   TokenType,
   TokenBalances,
@@ -122,144 +129,6 @@ function rowToTransaction(row: TokenTransactionRow): TokenTransaction {
   };
 }
 
-/** Source types that are once-per-user-per-UTC-day BY DEFINITION. Only these
- *  get a `yield_day`, and only these are covered by
- *  `uniq_daily_yield_per_user_day`. Everything else — Sky Drops, transit
- *  attunement — is legitimately multi-per-day and must stay unconstrained. */
-const DAILY_YIELD_SOURCES = ["agents_yield", "daily_yield"] as const;
-
-/** The same list as a SQL literal, so the writer and the partial index in
- *  `database/init/73-daily-yield-once-per-day.sql` cannot drift apart. If they
- *  do, rows get a yield_day the index ignores (or vice versa) and the guard
- *  silently stops guarding. */
-const DAILY_YIELD_SOURCES_SQL = DAILY_YIELD_SOURCES.map((s) => `'${s}'`).join(
-  ", ",
-);
-
-// Single-statement credit: insert an immutable ledger entry (idempotency-guarded)
-// and apply the delta to the typed column, atomically. `column` is a constrained
-// union literal (never user input), so interpolating it is injection-safe.
-//
-// ── Why the balance write is an UPSERT and not an UPDATE ────────────────────
-//
-// It used to be an `UPDATE token_balances … WHERE user_id = $1` preceded by an
-// `ensure_balance` CTE that INSERTed the row. That silently lost every user's
-// FIRST-EVER credit. In a data-modifying CTE, every sub-statement AND the main
-// query run against ONE snapshot taken before the statement begins, so the
-// UPDATE could not see the row `ensure_balance` had just inserted: the ledger
-// row committed, the UPDATE matched ZERO rows, and the balance never moved.
-//
-// It failed silently because `creditMultipleTokens` only assigns `last` when
-// `res.rows.length > 0`. Spirit returning nothing just left `last` null, Essence
-// then set it, and the endpoint returned 200 with a balances object.
-//
-// `[MEASURED 2026-07-26 on production]` 67 users, 521.7141 Spirit. For 67 of 67
-// the shortfall equals that user's FIRST ledger row, and all 67 are
-// auto-provisioned agents — human signup seeds `token_balances` in its own
-// statement, so the row pre-existed and the UPDATE landed. Spirit is simply the
-// first of the four axes written, so it is the only one that ever meets the
-// missing-row state; Essence/Matter/Substance always found the row and
-// reconciled EXACTLY, which is why only Spirit looked wrong.
-//
-// The upsert has no such ordering hazard: with no row it INSERTs the credited
-// amount (the other three axes default to 0), and with a row it adds the delta
-// under `ON CONFLICT`. Idempotency is preserved because `SELECT … FROM inserted`
-// yields no row when the ledger insert was suppressed, so nothing is written.
-//
-// ── Why $4 is cast to text in BOTH of its references ────────────────────────
-//
-// A bind parameter has exactly ONE deduced type. $4 is bound as the INSERT value
-// for `source_type` (character varying) and is also compared against the string
-// literals in the CASE, which deduce `text`. Left uncast, PostgreSQL refuses to
-// prepare the statement at all:
-//
-//     42P08  inconsistent types deduced for parameter $4
-//
-// and every credit throws. Casting only the comparison side does NOT fix it —
-// the INSERT target still deduces varchar. Both references must agree; text ->
-// varchar is an assignment cast, so pinning both to text is safe.
-//
-// This shipped to production once. Thirteen unit tests covered the path and all
-// passed, because they mock the database — a mock accepts SQL no database will.
-// `scripts/checkEconomySqlParses.ts` now PREPAREs every variant against a real
-// PostgreSQL in CI, which is the only thing that can catch this class.
-//
-// Params, in order:
-//   $1 userId  $2 tokenType  $3 amount  $4 sourceType
-//   $5 sourceId  $6 description  $7 transactionGroupId  $8 idempotencyKey
-//
-// `yield_day` is computed IN THE DATABASE from `now()`, not passed in from the
-// caller. That matters: the whole point is a day key the application cannot get
-// wrong or disagree with itself about, and two producers running in different
-// timezones (or one of them holding a stale clock) is precisely how the
-// original double-credit arose. It is NULL for every non-daily-yield source, so
-// those rows do not participate in the unique index at all.
-function creditTokensSql(
-  column: "spirit" | "essence" | "matter" | "substance",
-): string {
-  return `WITH inserted AS (
-            INSERT INTO token_transactions
-              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key, yield_day)
-            VALUES
-              (COALESCE($7::uuid, uuid_generate_v4()), $1, $2, $3, $4::text, $5, $6, $8,
-               CASE WHEN $4::text IN (${DAILY_YIELD_SOURCES_SQL})
-                    THEN (now() AT TIME ZONE 'UTC')::date
-                    ELSE NULL END)
-            ON CONFLICT (idempotency_key) DO NOTHING
-            RETURNING id
-          )
-          INSERT INTO token_balances (user_id, ${column}, updated_at)
-          SELECT $1, $3, now() FROM inserted
-          ON CONFLICT (user_id) DO UPDATE
-            SET ${column} = token_balances.${column} + EXCLUDED.${column},
-                updated_at = now()
-          RETURNING *`;
-}
-
-// Single-statement debit: check the balance, write the ledger entry only if the
-// funds are there, and apply the delta — atomically. Params, in order:
-//   $1 userId  $2 tokenType  $3 amount  $4 sourceType
-//   $5 sourceId  $6 transactionGroupId  $7 description
-//
-// ── Why this one is NOT an upsert, unlike the credit above ──────────────────
-//
-// This statement also used to open with an `ensure_balance` INSERT, which was
-// inert for exactly the reason described above the credit builder: no other
-// sub-statement could see the row it created. Removing it changes nothing, and
-// leaving it in read as a safeguard that was never operating.
-//
-// It must NOT become `INSERT … ON CONFLICT DO UPDATE`. `[MEASURED 2026-07-27]`
-// against production, in a rolled-back transaction: an upsert-shaped debit of 25
-// against a user with NO balance row produces `spirit = -25.0000` — it lets
-// someone spend tokens they never had. The `check_balance` CTE is what makes this
-// fail CLOSED: with no row it selects nothing, the ledger insert selects FROM it
-// and writes nothing, the UPDATE matches nothing, and the caller reads "0 rows"
-// as insufficient balance. Verified in the same run: the guarded shape touched 0
-// rows and created no balance.
-//
-// The asymmetry is the point. A credit for a missing row SHOULD create it; a debit
-// for a missing row should refuse.
-function debitTokensSql(
-  column: "spirit" | "essence" | "matter" | "substance",
-): string {
-  return `WITH check_balance AS (
-            SELECT ${column} AS current_balance FROM token_balances WHERE user_id = $1
-          ),
-          inserted AS (
-            INSERT INTO token_transactions
-              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description)
-            SELECT COALESCE($6::uuid, uuid_generate_v4()), $1, $2, -$3::numeric, $4::text, $5, $7
-            FROM check_balance
-            WHERE current_balance >= $3::numeric
-            RETURNING id
-          )
-          UPDATE token_balances
-          SET ${column} = ${column} - $3::numeric,
-              updated_at = now()
-          WHERE user_id = $1
-            AND EXISTS (SELECT 1 FROM inserted)
-          RETURNING *`;
-}
 
 // ─── Service Class ────────────────────────────────────────────────────
 
@@ -277,28 +146,7 @@ class TokenEconomyService {
 
     if (db) {
       try {
-        // ONE statement, and it returns the row whether it was just created or
-        // already existed. `DO UPDATE` rather than `DO NOTHING` is what makes
-        // that true: `RETURNING` yields nothing for a conflicting row under DO
-        // NOTHING, so the ensure and the read have to be the same statement to
-        // be both atomic and readable. The SET is deliberately a no-op write of
-        // the column's own value — nothing about the row should change here.
-        //
-        // This replaces `INSERT …; SELECT …` sent as ONE string with a bind
-        // parameter, which PostgreSQL rejects outright:
-        // `[MEASURED 2026-07-27]` against production it throws
-        // `42601 cannot insert multiple commands into a prepared statement`.
-        // It was never the multi-statement support question the old comment
-        // assumed — the extended query protocol permits exactly one command per
-        // parameterised message. So EVERY balance read raised, was swallowed by
-        // the catch, and silently took the two-query fallback: correct results,
-        // an exception per call, and a "primary" path that had never once run.
-        const result = await db.executeQuery(
-          `INSERT INTO token_balances (user_id) VALUES ($1)
-           ON CONFLICT (user_id) DO UPDATE SET updated_at = token_balances.updated_at
-           RETURNING *`,
-          [userId],
-        );
+        const result = await db.executeQuery(getBalancesSql(), [userId]);
         if (result.rows.length > 0) {
           return rowToBalances(result.rows[0]);
         }
@@ -488,75 +336,18 @@ class TokenEconomyService {
           }
         }
 
-        const result = await db.executeQuery(
-          // No `ensure_balance` CTE: it could not be seen by any other
-          // sub-statement (one snapshot per statement), so it never protected
-          // anything, and `balance_check` is what makes this fail CLOSED for a
-          // user with no row. See debitTokensSql for the measurement showing why
-          // an upsert would be WRONG here.
-          `WITH balance_check AS (
-            SELECT * FROM token_balances WHERE user_id = $1
-            AND spirit >= $2 AND essence >= $3 AND matter >= $4 AND substance >= $5
-          ),
-          new_group AS (
-            SELECT uuid_generate_v4() AS gid
-          ),
-          debit_spirit AS (
-            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
-            SELECT g.gid, $1, 'Spirit', -$2, $6, $7, $8,
-                   CASE WHEN $9::text IS NOT NULL THEN $9 || ':Spirit' ELSE NULL END
-            FROM balance_check bc, new_group g
-            WHERE $2 > 0
-            RETURNING id
-          ),
-          debit_essence AS (
-            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
-            SELECT g.gid, $1, 'Essence', -$3, $6, $7, $8,
-                   CASE WHEN $9::text IS NOT NULL THEN $9 || ':Essence' ELSE NULL END
-            FROM balance_check bc, new_group g
-            WHERE $3 > 0
-            RETURNING id
-          ),
-          debit_matter AS (
-            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
-            SELECT g.gid, $1, 'Matter', -$4, $6, $7, $8,
-                   CASE WHEN $9::text IS NOT NULL THEN $9 || ':Matter' ELSE NULL END
-            FROM balance_check bc, new_group g
-            WHERE $4 > 0
-            RETURNING id
-          ),
-          debit_substance AS (
-            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
-            SELECT g.gid, $1, 'Substance', -$5, $6, $7, $8,
-                   CASE WHEN $9::text IS NOT NULL THEN $9 || ':Substance' ELSE NULL END
-            FROM balance_check bc, new_group g
-            WHERE $5 > 0
-            RETURNING id
-          ),
-          updated AS (
-            UPDATE token_balances
-            SET spirit = token_balances.spirit - $2,
-                essence = token_balances.essence - $3,
-                matter = token_balances.matter - $4,
-                substance = token_balances.substance - $5,
-                updated_at = now()
-            FROM balance_check bc
-            WHERE token_balances.user_id = $1
-            RETURNING token_balances.*
-          )
-          SELECT u.*, g.gid AS txn_group_id FROM updated u, new_group g`,
-          [
-            userId,
-            amounts.spirit,
-            amounts.essence,
-            amounts.matter,
-            amounts.substance,
+        const query = debitAllTokensSql({
+          userId,
+          amounts,
+          description: opts?.description || null,
+          idempotencyKey: idemKey,
+          intent: {
+            kind: "spend",
             sourceType,
-            opts?.sourceId || null,
-            opts?.description || null,
-            idemKey,
-          ],
-        );
+            sourceId: opts?.sourceId || null,
+          },
+        });
+        const result = await db.executeQuery(query.sql, query.values);
 
         if (result.rows.length === 0) {
           return { success: false, reason: "insufficient_funds" };
@@ -817,12 +608,19 @@ class TokenEconomyService {
 
   /**
    * Transmute tokens: spend 3:1 ratio to convert one type to another.
+   *
+   * Pass `opts.idempotencyKey` to make a retry safe. Without one, a client that
+   * retries after a network error transmutes a SECOND time and is debited
+   * twice — every other money-moving path here takes a key for exactly that
+   * reason. With one, the unique index on `token_transactions.idempotency_key`
+   * rejects the duplicate and this returns null rather than charging again.
    */
   async transmute(
     userId: string,
     fromToken: TokenType,
     toToken: TokenType,
     targetAmount: number,
+    opts?: { idempotencyKey?: string },
   ): Promise<TransmutationResult | null> {
     if (fromToken === toToken) return null;
     if (targetAmount <= 0) return null;
@@ -835,54 +633,20 @@ class TokenEconomyService {
 
     if (db) {
       try {
-        const result = await db.executeQuery(
-          // No `ensure_balance` CTE — inert within the statement, and
-          // `check_balance` is what makes a transmutation fail CLOSED for a user
-          // with no balance row. See debitTokensSql.
-          `WITH check_balance AS (
-            SELECT ${fromColumn} AS current_balance
-            FROM token_balances
-            WHERE user_id = $1
-          ),
-          updated AS (
-            UPDATE token_balances
-            SET ${fromColumn} = ${fromColumn} - $2,
-                ${toColumn} = ${toColumn} + $3,
-                updated_at = now()
-            WHERE user_id = $1
-              AND EXISTS (
-                SELECT 1
-                FROM check_balance
-                WHERE current_balance >= $2
-              )
-            RETURNING *
-          ),
-          debit_txn AS (
-            INSERT INTO token_transactions
-              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description)
-            SELECT
-              $4::uuid, $1, $5, -$2, 'transmutation', NULL, $6
-            FROM updated
-          ),
-          credit_txn AS (
-            INSERT INTO token_transactions
-              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description)
-            SELECT
-              $4::uuid, $1, $7, $3, 'transmutation', NULL, $8
-            FROM updated
-          )
-          SELECT * FROM updated`,
-          [
-            userId,
-            costAmount,
-            targetAmount,
-            groupId,
-            fromToken,
-            `Transmute ${costAmount} ${fromToken} → ${targetAmount} ${toToken}`,
-            toToken,
-            `Received from transmutation of ${fromToken}`,
-          ],
-        );
+        const query = transmuteSql({
+          fromColumn,
+          toColumn,
+          userId,
+          costAmount,
+          targetAmount,
+          transactionGroupId: groupId,
+          fromToken,
+          toToken,
+          debitDescription: `Transmute ${costAmount} ${fromToken} → ${targetAmount} ${toToken}`,
+          creditDescription: `Received from transmutation of ${fromToken}`,
+          idempotencyKey: opts?.idempotencyKey ?? null,
+        });
+        const result = await db.executeQuery(query.sql, query.values);
 
         if (result.rows.length === 0) {
           return null;
@@ -894,12 +658,24 @@ class TokenEconomyService {
           newBalances: rowToBalances(result.rows[0]),
         };
       } catch (error) {
+        // Unique-violation on idempotency_key: this transmutation already ran.
+        // Returning null means the caller reports it as not-applied, which is
+        // correct — the point is that the user is NOT debited a second time.
+        if ((error as { code?: string })?.code === "23505") {
+          _logger.info(
+            "[TokenEconomy] Duplicate transmutation blocked by idempotency key:",
+            opts?.idempotencyKey,
+          );
+          return null;
+        }
         _logger.error("[TokenEconomy] transmute DB failed:", error);
         return null;
       }
     }
 
-    // Debit first
+    // In-memory fallback. No idempotency guard here: `debitTokens` takes no key
+    // and this path has no durable ledger to enforce one against. It runs only
+    // when there is no database at all.
     const afterDebit = await this.debitTokens(
       userId,
       fromToken,
@@ -1062,91 +838,15 @@ class TokenEconomyService {
           ? `Shop: ${item.title} (${opts.descriptionSuffix})`
           : `Shop: ${item.title}`;
 
-        // 3. Atomic: check balance + debit + record purchase in one CTE.
-        //    $8 is the idempotency key prefix (null when not provided).
-        //    Each debit_* INSERT includes idempotency_key = $8 || ':<TokenType>'
-        //    so the unique constraint on token_transactions.idempotency_key catches
-        //    any concurrent duplicate that slips past the pre-check above.
-        const result = await db.executeQuery(
-          // No `ensure_balance` CTE: it could not be seen by any other
-          // sub-statement (one snapshot per statement), so it never protected
-          // anything, and `balance_check` is what makes this fail CLOSED for a
-          // user with no row. See debitTokensSql for the measurement showing why
-          // an upsert would be WRONG here.
-          `WITH balance_check AS (
-            SELECT * FROM token_balances WHERE user_id = $1
-            AND spirit >= $2 AND essence >= $3 AND matter >= $4 AND substance >= $5
-          ),
-          new_group AS (
-            SELECT uuid_generate_v4() AS gid
-          ),
-          debit_spirit AS (
-            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
-            SELECT g.gid, $1, 'Spirit', -$2, 'premium_purchase', $6, $7,
-                   CASE WHEN $8::text IS NOT NULL THEN $8 || ':Spirit' ELSE NULL END
-            FROM balance_check bc, new_group g
-            WHERE $2 > 0
-            RETURNING id
-          ),
-          debit_essence AS (
-            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
-            SELECT g.gid, $1, 'Essence', -$3, 'premium_purchase', $6, $7,
-                   CASE WHEN $8::text IS NOT NULL THEN $8 || ':Essence' ELSE NULL END
-            FROM balance_check bc, new_group g
-            WHERE $3 > 0
-            RETURNING id
-          ),
-          debit_matter AS (
-            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
-            SELECT g.gid, $1, 'Matter', -$4, 'premium_purchase', $6, $7,
-                   CASE WHEN $8::text IS NOT NULL THEN $8 || ':Matter' ELSE NULL END
-            FROM balance_check bc, new_group g
-            WHERE $4 > 0
-            RETURNING id
-          ),
-          debit_substance AS (
-            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
-            SELECT g.gid, $1, 'Substance', -$5, 'premium_purchase', $6, $7,
-                   CASE WHEN $8::text IS NOT NULL THEN $8 || ':Substance' ELSE NULL END
-            FROM balance_check bc, new_group g
-            WHERE $5 > 0
-            RETURNING id
-          ),
-          updated AS (
-            -- Qualify token_balances.<col> on the right-hand side of each
-            -- SET so the planner doesn't see the bare column name as
-            -- ambiguous between token_balances and balance_check (both
-            -- have spirit/essence/matter/substance columns). Without
-            -- these qualifiers Postgres raises 42702 and the whole CTE
-            -- rolls back, surfacing as purchase_failed in the caller.
-            UPDATE token_balances
-            SET spirit = token_balances.spirit - $2,
-                essence = token_balances.essence - $3,
-                matter = token_balances.matter - $4,
-                substance = token_balances.substance - $5,
-                updated_at = now()
-            FROM balance_check bc
-            WHERE token_balances.user_id = $1
-            RETURNING token_balances.*
-          ),
-          purchase AS (
-            INSERT INTO user_purchases (user_id, shop_item_id, transaction_group_id)
-            SELECT $1, $6::uuid, g.gid FROM updated u, new_group g
-            RETURNING transaction_group_id
-          )
-          SELECT u.*, p.transaction_group_id AS txn_group_id
-          FROM updated u, purchase p`,
-          [
-            userId,
-            costs.spirit,
-            costs.essence,
-            costs.matter,
-            costs.substance,
-            item.id,
-            description,
-            idemKey,
-          ],
-        );
+        // 3. Atomic: check balance + debit + record purchase in one statement.
+        const query = debitAllTokensSql({
+          userId,
+          amounts: costs,
+          description,
+          idempotencyKey: idemKey,
+          intent: { kind: "purchase", shopItemId: item.id },
+        });
+        const result = await db.executeQuery(query.sql, query.values);
 
         if (result.rows.length === 0) {
           _logger.info("[TokenEconomy] Insufficient funds for:", shopItemSlug);

--- a/src/services/TokenEconomyService.ts
+++ b/src/services/TokenEconomyService.ts
@@ -216,6 +216,51 @@ function creditTokensSql(
           RETURNING *`;
 }
 
+// Single-statement debit: check the balance, write the ledger entry only if the
+// funds are there, and apply the delta — atomically. Params, in order:
+//   $1 userId  $2 tokenType  $3 amount  $4 sourceType
+//   $5 sourceId  $6 transactionGroupId  $7 description
+//
+// ── Why this one is NOT an upsert, unlike the credit above ──────────────────
+//
+// This statement also used to open with an `ensure_balance` INSERT, which was
+// inert for exactly the reason described above the credit builder: no other
+// sub-statement could see the row it created. Removing it changes nothing, and
+// leaving it in read as a safeguard that was never operating.
+//
+// It must NOT become `INSERT … ON CONFLICT DO UPDATE`. `[MEASURED 2026-07-27]`
+// against production, in a rolled-back transaction: an upsert-shaped debit of 25
+// against a user with NO balance row produces `spirit = -25.0000` — it lets
+// someone spend tokens they never had. The `check_balance` CTE is what makes this
+// fail CLOSED: with no row it selects nothing, the ledger insert selects FROM it
+// and writes nothing, the UPDATE matches nothing, and the caller reads "0 rows"
+// as insufficient balance. Verified in the same run: the guarded shape touched 0
+// rows and created no balance.
+//
+// The asymmetry is the point. A credit for a missing row SHOULD create it; a debit
+// for a missing row should refuse.
+function debitTokensSql(
+  column: "spirit" | "essence" | "matter" | "substance",
+): string {
+  return `WITH check_balance AS (
+            SELECT ${column} AS current_balance FROM token_balances WHERE user_id = $1
+          ),
+          inserted AS (
+            INSERT INTO token_transactions
+              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description)
+            SELECT COALESCE($6::uuid, uuid_generate_v4()), $1, $2, -$3::numeric, $4::text, $5, $7
+            FROM check_balance
+            WHERE current_balance >= $3::numeric
+            RETURNING id
+          )
+          UPDATE token_balances
+          SET ${column} = ${column} - $3::numeric,
+              updated_at = now()
+          WHERE user_id = $1
+            AND EXISTS (SELECT 1 FROM inserted)
+          RETURNING *`;
+}
+
 // ─── Service Class ────────────────────────────────────────────────────
 
 class TokenEconomyService {
@@ -232,34 +277,33 @@ class TokenEconomyService {
 
     if (db) {
       try {
+        // ONE statement, and it returns the row whether it was just created or
+        // already existed. `DO UPDATE` rather than `DO NOTHING` is what makes
+        // that true: `RETURNING` yields nothing for a conflicting row under DO
+        // NOTHING, so the ensure and the read have to be the same statement to
+        // be both atomic and readable. The SET is deliberately a no-op write of
+        // the column's own value — nothing about the row should change here.
+        //
+        // This replaces `INSERT …; SELECT …` sent as ONE string with a bind
+        // parameter, which PostgreSQL rejects outright:
+        // `[MEASURED 2026-07-27]` against production it throws
+        // `42601 cannot insert multiple commands into a prepared statement`.
+        // It was never the multi-statement support question the old comment
+        // assumed — the extended query protocol permits exactly one command per
+        // parameterised message. So EVERY balance read raised, was swallowed by
+        // the catch, and silently took the two-query fallback: correct results,
+        // an exception per call, and a "primary" path that had never once run.
         const result = await db.executeQuery(
-          `INSERT INTO token_balances (user_id)
-           VALUES ($1)
-           ON CONFLICT (user_id) DO NOTHING;
-           SELECT * FROM token_balances WHERE user_id = $1`,
+          `INSERT INTO token_balances (user_id) VALUES ($1)
+           ON CONFLICT (user_id) DO UPDATE SET updated_at = token_balances.updated_at
+           RETURNING *`,
           [userId],
         );
-        // executeQuery returns the last statement's result
         if (result.rows.length > 0) {
           return rowToBalances(result.rows[0]);
         }
-      } catch {
-        // Fallback: separate queries if multi-statement not supported
-        try {
-          await db.executeQuery(
-            `INSERT INTO token_balances (user_id) VALUES ($1) ON CONFLICT (user_id) DO NOTHING`,
-            [userId],
-          );
-          const result = await db.executeQuery(
-            `SELECT * FROM token_balances WHERE user_id = $1`,
-            [userId],
-          );
-          if (result.rows.length > 0) {
-            return rowToBalances(result.rows[0]);
-          }
-        } catch (error) {
-          _logger.error("[TokenEconomy] getBalances failed:", error);
-        }
+      } catch (error) {
+        _logger.error("[TokenEconomy] getBalances failed:", error);
       }
     }
 
@@ -377,28 +421,7 @@ class TokenEconomyService {
     if (db) {
       try {
         const result = await db.executeQuery(
-          `WITH ensure_balance AS (
-            INSERT INTO token_balances (user_id)
-            VALUES ($1)
-            ON CONFLICT (user_id) DO NOTHING
-          ),
-          check_balance AS (
-            SELECT ${column} AS current_balance FROM token_balances WHERE user_id = $1
-          ),
-          inserted AS (
-            INSERT INTO token_transactions
-              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description)
-            SELECT COALESCE($6::uuid, uuid_generate_v4()), $1, $2, -$3, $4, $5, $7
-            FROM check_balance
-            WHERE current_balance >= $3
-            RETURNING id
-          )
-          UPDATE token_balances
-          SET ${column} = ${column} - $3,
-              updated_at = now()
-          WHERE user_id = $1
-            AND EXISTS (SELECT 1 FROM inserted)
-          RETURNING *`,
+          debitTokensSql(column),
           [
             userId,
             tokenType,
@@ -466,11 +489,12 @@ class TokenEconomyService {
         }
 
         const result = await db.executeQuery(
-          `WITH ensure_balance AS (
-            INSERT INTO token_balances (user_id) VALUES ($1)
-            ON CONFLICT (user_id) DO NOTHING
-          ),
-          balance_check AS (
+          // No `ensure_balance` CTE: it could not be seen by any other
+          // sub-statement (one snapshot per statement), so it never protected
+          // anything, and `balance_check` is what makes this fail CLOSED for a
+          // user with no row. See debitTokensSql for the measurement showing why
+          // an upsert would be WRONG here.
+          `WITH balance_check AS (
             SELECT * FROM token_balances WHERE user_id = $1
             AND spirit >= $2 AND essence >= $3 AND matter >= $4 AND substance >= $5
           ),
@@ -812,12 +836,10 @@ class TokenEconomyService {
     if (db) {
       try {
         const result = await db.executeQuery(
-          `WITH ensure_balance AS (
-            INSERT INTO token_balances (user_id)
-            VALUES ($1)
-            ON CONFLICT (user_id) DO NOTHING
-          ),
-          check_balance AS (
+          // No `ensure_balance` CTE — inert within the statement, and
+          // `check_balance` is what makes a transmutation fail CLOSED for a user
+          // with no balance row. See debitTokensSql.
+          `WITH check_balance AS (
             SELECT ${fromColumn} AS current_balance
             FROM token_balances
             WHERE user_id = $1
@@ -1046,11 +1068,12 @@ class TokenEconomyService {
         //    so the unique constraint on token_transactions.idempotency_key catches
         //    any concurrent duplicate that slips past the pre-check above.
         const result = await db.executeQuery(
-          `WITH ensure_balance AS (
-            INSERT INTO token_balances (user_id) VALUES ($1)
-            ON CONFLICT (user_id) DO NOTHING
-          ),
-          balance_check AS (
+          // No `ensure_balance` CTE: it could not be seen by any other
+          // sub-statement (one snapshot per statement), so it never protected
+          // anything, and `balance_check` is what makes this fail CLOSED for a
+          // user with no row. See debitTokensSql for the measurement showing why
+          // an upsert would be WRONG here.
+          `WITH balance_check AS (
             SELECT * FROM token_balances WHERE user_id = $1
             AND spirit >= $2 AND essence >= $3 AND matter >= $4 AND substance >= $5
           ),

--- a/src/services/tokenEconomyQueries.ts
+++ b/src/services/tokenEconomyQueries.ts
@@ -1,0 +1,518 @@
+/**
+ * Token Economy SQL — every statement that moves money.
+ *
+ * @file src/services/tokenEconomyQueries.ts
+ *
+ * ── Why this file is separate, and why it must stay dependency-free ─────────
+ *
+ * SQL is a second language in this codebase, and only a database can typecheck
+ * it. `[MEASURED 2026-07-26]` a credit statement shipped that PostgreSQL would
+ * not even PREPARE (`42P08 inconsistent types deduced for parameter $4`), while
+ * thirteen unit tests covering that exact path passed — because they mock the
+ * database, and a mock will happily "run" SQL no database will accept.
+ *
+ * `scripts/checkEconomySqlParses.ts` closes that hole by PREPARing every
+ * statement against a real PostgreSQL. For it to check what actually SHIPS
+ * rather than a hand copy, it has to obtain the SQL from this module directly.
+ * It used to scrape the statements out of the service with regexes, which drift
+ * silently the moment anything is reformatted.
+ *
+ * So this module has ZERO runtime imports. Not the database module, not the
+ * logger, not `@/types/economy`. `TokenEconomyService.ts` instantiates a service
+ * and lazily pulls in a database connection at import time; a gate that imported
+ * it would trigger all of that just to read a string. Keeping this file inert
+ * means the gate can `import` it with no side effects at all.
+ *
+ * Anything added here must remain a pure function from arguments to SQL.
+ */
+
+/** The four ESMS axes, as `token_balances` column names. Constrained union
+ *  literals, never user input — which is what makes interpolating them into
+ *  the statements below injection-safe. */
+export type AxisColumn = "spirit" | "essence" | "matter" | "substance";
+
+/** Amounts across all four axes, for the multi-axis statements. */
+export interface AxisAmounts {
+  spirit: number;
+  essence: number;
+  matter: number;
+  substance: number;
+}
+
+/** A statement and the positional parameters it was built with. Returning the
+ *  two together is the point: a hand-maintained array beside a hand-numbered
+ *  `$n` is a silent-failure shape — swap two same-typed arguments and every
+ *  type check still passes while the wrong value lands in the wrong column. */
+export interface BuiltQuery {
+  sql: string;
+  values: unknown[];
+}
+
+/** Source types that are once-per-user-per-UTC-day BY DEFINITION. Only these
+ *  get a `yield_day`, and only these are covered by
+ *  `uniq_daily_yield_per_user_day`. Everything else — Sky Drops, transit
+ *  attunement — is legitimately multi-per-day and must stay unconstrained.
+ *
+ *  Exported because `/api/economy/sync-credit` needs the SAME list to decide
+ *  whether a credit is daily-yield. It used to declare its own copy; if the two
+ *  drifted, the route's guard and the partial unique index that enforces it
+ *  would disagree — which is precisely the shape of the original double-credit
+ *  bug. One list, one meaning. */
+export const DAILY_YIELD_SOURCES = ["agents_yield", "daily_yield"] as const;
+
+/** The same list as a SQL literal, so the writer and the partial index in
+ *  `database/init/73-daily-yield-once-per-day.sql` cannot drift apart. If they
+ *  do, rows get a yield_day the index ignores (or vice versa) and the guard
+ *  silently stops guarding. */
+const DAILY_YIELD_SOURCES_SQL = DAILY_YIELD_SOURCES.map((s) => `'${s}'`).join(
+  ", ",
+);
+
+/**
+ * Collects positional parameters and hands back the `$n` token for each.
+ *
+ * The statements below are assembled from two call sites with DIFFERENT
+ * parameter numbering: a generic spend binds its source type, while a premium
+ * purchase writes the literal `'premium_purchase'` and therefore consumes one
+ * fewer slot — every parameter after it shifts down by one. That is not a
+ * uniform offset, so a `startIndex` argument could not express it; the
+ * collector can, because a value that becomes a literal simply never calls
+ * `add()` and never takes a number.
+ *
+ * It also makes the values array a RESULT rather than a parallel artifact the
+ * caller has to keep in sync by hand.
+ */
+class QueryParams {
+  private readonly collected: unknown[] = [];
+
+  /** Record a value and return the `$n` placeholder that now refers to it. */
+  add(value: unknown): string {
+    this.collected.push(value);
+    return `$${this.collected.length}`;
+  }
+
+  /** The values, in binding order. Copied so the built query cannot be mutated
+   *  through a reference the builder still holds. */
+  get values(): unknown[] {
+    return [...this.collected];
+  }
+}
+
+// ─── Balances ─────────────────────────────────────────────────────────
+
+/**
+ * Insert-or-return the balance row, as ONE statement.
+ *
+ * `DO UPDATE` rather than `DO NOTHING` is what makes it return the row whether
+ * it was just created or already existed: `RETURNING` yields nothing for a
+ * conflicting row under DO NOTHING, so the ensure and the read have to be the
+ * same statement to be both atomic and readable. The SET is deliberately a
+ * no-op write of the column's own value — nothing about the row should change.
+ *
+ * This replaces `INSERT …; SELECT …` sent as ONE string with a bind parameter,
+ * which PostgreSQL rejects outright: `[MEASURED 2026-07-27]` against production
+ * it throws `42601 cannot insert multiple commands into a prepared statement`.
+ * The extended query protocol permits exactly one command per parameterised
+ * message. So EVERY balance read raised, was swallowed by the catch, and
+ * silently took the two-query fallback: correct results, an exception per call,
+ * and a "primary" path that had never once run.
+ *
+ * Params: $1 userId
+ */
+export function getBalancesSql(): string {
+  return `INSERT INTO token_balances (user_id) VALUES ($1)
+           ON CONFLICT (user_id) DO UPDATE SET updated_at = token_balances.updated_at
+           RETURNING *`;
+}
+
+// ─── Single-axis credit / debit ───────────────────────────────────────
+
+// Single-statement credit: insert an immutable ledger entry (idempotency-guarded)
+// and apply the delta to the typed column, atomically.
+//
+// ── Why the balance write is an UPSERT and not an UPDATE ────────────────────
+//
+// It used to be an `UPDATE token_balances … WHERE user_id = $1` preceded by an
+// `ensure_balance` CTE that INSERTed the row. That silently lost every user's
+// FIRST-EVER credit. In a data-modifying CTE, every sub-statement AND the main
+// query run against ONE snapshot taken before the statement begins, so the
+// UPDATE could not see the row `ensure_balance` had just inserted: the ledger
+// row committed, the UPDATE matched ZERO rows, and the balance never moved.
+//
+// It failed silently because `creditMultipleTokens` only assigns `last` when
+// `res.rows.length > 0`. Spirit returning nothing just left `last` null, Essence
+// then set it, and the endpoint returned 200 with a balances object.
+//
+// `[MEASURED 2026-07-26 on production]` 67 users, 521.7141 Spirit. For 67 of 67
+// the shortfall equals that user's FIRST ledger row, and all 67 are
+// auto-provisioned agents — human signup seeds `token_balances` in its own
+// statement, so the row pre-existed and the UPDATE landed. Spirit is simply the
+// first of the four axes written, so it is the only one that ever meets the
+// missing-row state; Essence/Matter/Substance always found the row and
+// reconciled EXACTLY, which is why only Spirit looked wrong.
+//
+// The upsert has no such ordering hazard: with no row it INSERTs the credited
+// amount (the other three axes default to 0), and with a row it adds the delta
+// under `ON CONFLICT`. Idempotency is preserved because `SELECT … FROM inserted`
+// yields no row when the ledger insert was suppressed, so nothing is written.
+//
+// ── Why $4 is cast to text in BOTH of its references ────────────────────────
+//
+// A bind parameter has exactly ONE deduced type. $4 is bound as the INSERT value
+// for `source_type` (character varying) and is also compared against the string
+// literals in the CASE, which deduce `text`. Left uncast, PostgreSQL refuses to
+// prepare the statement at all:
+//
+//     42P08  inconsistent types deduced for parameter $4
+//
+// and every credit throws. Casting only the comparison side does NOT fix it —
+// the INSERT target still deduces varchar. Both references must agree; text ->
+// varchar is an assignment cast, so pinning both to text is safe.
+//
+// This shipped to production once. Thirteen unit tests covered the path and all
+// passed, because they mock the database — a mock accepts SQL no database will.
+// `scripts/checkEconomySqlParses.ts` now PREPAREs every variant against a real
+// PostgreSQL in CI, which is the only thing that can catch this class.
+//
+// Params, in order:
+//   $1 userId  $2 tokenType  $3 amount  $4 sourceType
+//   $5 sourceId  $6 description  $7 transactionGroupId  $8 idempotencyKey
+//
+// `yield_day` is computed IN THE DATABASE from `now()`, not passed in from the
+// caller. That matters: the whole point is a day key the application cannot get
+// wrong or disagree with itself about, and two producers running in different
+// timezones (or one of them holding a stale clock) is precisely how the
+// original double-credit arose. It is NULL for every non-daily-yield source, so
+// those rows do not participate in the unique index at all.
+export function creditTokensSql(column: AxisColumn): string {
+  return `WITH inserted AS (
+            INSERT INTO token_transactions
+              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key, yield_day)
+            VALUES
+              (COALESCE($7::uuid, uuid_generate_v4()), $1, $2, $3, $4::text, $5, $6, $8,
+               CASE WHEN $4::text IN (${DAILY_YIELD_SOURCES_SQL})
+                    THEN (now() AT TIME ZONE 'UTC')::date
+                    ELSE NULL END)
+            ON CONFLICT (idempotency_key) DO NOTHING
+            RETURNING id
+          )
+          INSERT INTO token_balances (user_id, ${column}, updated_at)
+          SELECT $1, $3, now() FROM inserted
+          ON CONFLICT (user_id) DO UPDATE
+            SET ${column} = token_balances.${column} + EXCLUDED.${column},
+                updated_at = now()
+          RETURNING *`;
+}
+
+// Single-statement debit: check the balance, write the ledger entry only if the
+// funds are there, and apply the delta — atomically. Params, in order:
+//   $1 userId  $2 tokenType  $3 amount  $4 sourceType
+//   $5 sourceId  $6 transactionGroupId  $7 description
+//
+// ── Why this one is NOT an upsert, unlike the credit above ──────────────────
+//
+// This statement also used to open with an `ensure_balance` INSERT, which was
+// inert for exactly the reason described above the credit builder: no other
+// sub-statement could see the row it created. Removing it changes nothing, and
+// leaving it in read as a safeguard that was never operating.
+//
+// It must NOT become `INSERT … ON CONFLICT DO UPDATE`. `[MEASURED 2026-07-27]`
+// against production, in a rolled-back transaction: an upsert-shaped debit of 25
+// against a user with NO balance row produces `spirit = -25.0000` — it lets
+// someone spend tokens they never had. The `check_balance` CTE is what makes this
+// fail CLOSED: with no row it selects nothing, the ledger insert selects FROM it
+// and writes nothing, the UPDATE matches nothing, and the caller reads "0 rows"
+// as insufficient balance. Verified in the same run: the guarded shape touched 0
+// rows and created no balance.
+//
+// The asymmetry is the point. A credit for a missing row SHOULD create it; a debit
+// for a missing row should refuse.
+//
+// This is no longer guarded only by this comment: `checkEconomyStatementBehaviour`
+// asserts, for EVERY debit-side builder, that a debit against a user with no
+// balance row writes nothing and conjures no row. That catches a regression by
+// its effect, whichever shape the SQL is rewritten into.
+export function debitTokensSql(column: AxisColumn): string {
+  return `WITH check_balance AS (
+            SELECT ${column} AS current_balance FROM token_balances WHERE user_id = $1
+          ),
+          inserted AS (
+            INSERT INTO token_transactions
+              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description)
+            SELECT COALESCE($6::uuid, uuid_generate_v4()), $1, $2, -$3::numeric, $4::text, $5, $7
+            FROM check_balance
+            WHERE current_balance >= $3::numeric
+            RETURNING id
+          )
+          UPDATE token_balances
+          SET ${column} = ${column} - $3::numeric,
+              updated_at = now()
+          WHERE user_id = $1
+            AND EXISTS (SELECT 1 FROM inserted)
+          RETURNING *`;
+}
+
+// ─── Multi-axis debit (spend / premium purchase) ──────────────────────
+
+/**
+ * What a multi-axis debit is FOR. A generic spend binds its own `source_type`;
+ * a premium purchase writes the literal `'premium_purchase'` and additionally
+ * records a `user_purchases` row.
+ */
+export type DebitAllIntent =
+  | {
+      kind: "spend";
+      /** Bound as $6 — the caller's `TransactionSourceType`. */
+      sourceType: string;
+      sourceId: string | null;
+    }
+  | {
+      kind: "purchase";
+      /** The `shop_items.id`. Doubles as `source_id` and as the FK on
+       *  `user_purchases.shop_item_id`, so it occupies a single slot. */
+      shopItemId: string;
+    };
+
+/**
+ * Debit all four axes at once, atomically, and refuse entirely unless EVERY
+ * axis can cover its share.
+ *
+ * ── Why one builder for two statements ──────────────────────────────────────
+ *
+ * The spend and premium-purchase statements were ~40 duplicated lines apart,
+ * differing only in the source type, an extra `purchase` CTE, and the final
+ * projection. Duplicated money SQL is how two statements drift into disagreeing
+ * about the same invariant.
+ *
+ * `scripts/checkEconomyStatementBehaviour.mjs` asserts that this builder's
+ * output is byte-identical (modulo SQL comments, which the lexer discards) to
+ * the two inline statements it replaced — so the unification provably changed
+ * no semantics, only the number of places the SQL is written down.
+ *
+ * ── Why it is NOT an upsert ─────────────────────────────────────────────────
+ *
+ * `balance_check` selects the row only when all four axes are sufficient. Every
+ * ledger INSERT selects FROM it, and the UPDATE joins it, so an underfunded or
+ * absent user writes nothing at all and the caller reads 0 rows as a refusal.
+ * See `debitTokensSql` for the production measurement showing what an
+ * upsert-shaped debit does instead (`spirit = -25.0000`).
+ *
+ * ── Why there is no `ensure_balance` CTE ────────────────────────────────────
+ *
+ * There used to be. It could not be seen by any other sub-statement — one
+ * snapshot per statement — so it never protected anything, and it is
+ * `balance_check` that makes this fail closed for a user with no row.
+ */
+export function debitAllTokensSql(opts: {
+  userId: string;
+  amounts: AxisAmounts;
+  description: string | null;
+  /** Prefix only. Each axis appends `:<TokenType>` so the unique index on
+   *  `token_transactions.idempotency_key` catches a concurrent duplicate that
+   *  slips past any application-level pre-check. Null disables the guard. */
+  idempotencyKey: string | null;
+  intent: DebitAllIntent;
+}): BuiltQuery {
+  const p = new QueryParams();
+
+  const user = p.add(opts.userId);
+  const spirit = p.add(opts.amounts.spirit);
+  const essence = p.add(opts.amounts.essence);
+  const matter = p.add(opts.amounts.matter);
+  const substance = p.add(opts.amounts.substance);
+
+  // A purchase writes the source type as a literal, so it consumes no slot and
+  // every parameter after it shifts down by one. This is the whole reason the
+  // numbering is collected rather than hand-written.
+  //
+  // Narrowed on `intent.kind` rather than a precomputed boolean: a boolean does
+  // not narrow a discriminated union, and the order of these `add` calls IS the
+  // parameter order, so they must stay as written.
+  const intent = opts.intent;
+  const isPurchase = intent.kind === "purchase";
+  const sourceType =
+    intent.kind === "purchase"
+      ? "'premium_purchase'"
+      : p.add(intent.sourceType);
+  const sourceId =
+    intent.kind === "purchase" ? p.add(intent.shopItemId) : p.add(intent.sourceId);
+  const description = p.add(opts.description);
+  const idem = p.add(opts.idempotencyKey);
+
+  // An explicit ordered list, not an object: the axis order determines the CTE
+  // order in the emitted SQL, and that should not rest on object key-ordering
+  // rules.
+  const axes: ReadonlyArray<readonly [string, string]> = [
+    ["Spirit", spirit],
+    ["Essence", essence],
+    ["Matter", matter],
+    ["Substance", substance],
+  ];
+
+  // One CTE per axis. Each is skipped when its amount is 0, so a single-axis
+  // spend does not write three empty ledger rows.
+  const debits = axes
+    .map(
+      ([tokenType, amount]) => `          debit_${tokenType.toLowerCase()} AS (
+            INSERT INTO token_transactions (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+            SELECT g.gid, ${user}, '${tokenType}', -${amount}, ${sourceType}, ${sourceId}, ${description},
+                   CASE WHEN ${idem}::text IS NOT NULL THEN ${idem} || ':${tokenType}' ELSE NULL END
+            FROM balance_check bc, new_group g
+            WHERE ${amount} > 0
+            RETURNING id
+          ),`,
+    )
+    .join("\n");
+
+  // Recording the purchase is the only structural difference between the two
+  // statements. It selects FROM `updated`, so a refused debit writes no
+  // `user_purchases` row either.
+  const purchaseCte = isPurchase
+    ? `,
+          purchase AS (
+            INSERT INTO user_purchases (user_id, shop_item_id, transaction_group_id)
+            SELECT ${user}, ${sourceId}::uuid, g.gid FROM updated u, new_group g
+            RETURNING transaction_group_id
+          )`
+    : "";
+
+  const projection = isPurchase
+    ? `          SELECT u.*, p.transaction_group_id AS txn_group_id
+          FROM updated u, purchase p`
+    : `          SELECT u.*, g.gid AS txn_group_id FROM updated u, new_group g`;
+
+  const sql = `WITH balance_check AS (
+            SELECT * FROM token_balances WHERE user_id = ${user}
+            AND spirit >= ${spirit} AND essence >= ${essence} AND matter >= ${matter} AND substance >= ${substance}
+          ),
+          new_group AS (
+            SELECT uuid_generate_v4() AS gid
+          ),
+${debits}
+          updated AS (
+            -- Qualify token_balances.<col> on the right-hand side of each
+            -- SET so the planner doesn't see the bare column name as
+            -- ambiguous between token_balances and balance_check (both
+            -- have spirit/essence/matter/substance columns). Without
+            -- these qualifiers Postgres raises 42702 and the whole CTE
+            -- rolls back, surfacing as purchase_failed in the caller.
+            UPDATE token_balances
+            SET spirit = token_balances.spirit - ${spirit},
+                essence = token_balances.essence - ${essence},
+                matter = token_balances.matter - ${matter},
+                substance = token_balances.substance - ${substance},
+                updated_at = now()
+            FROM balance_check bc
+            WHERE token_balances.user_id = ${user}
+            RETURNING token_balances.*
+          )${purchaseCte}
+${projection}`;
+
+  return { sql, values: p.values };
+}
+
+// ─── Transmutation ────────────────────────────────────────────────────
+
+/**
+ * Move value between two axes in one statement: debit `fromColumn`, credit
+ * `toColumn`, and write both halves of the double entry under one
+ * transaction group.
+ *
+ * ── Why it is NOT an upsert ─────────────────────────────────────────────────
+ *
+ * `check_balance` is what makes a transmutation fail closed for a user with no
+ * balance row — the UPDATE's `EXISTS` finds nothing, so neither axis moves and
+ * both ledger CTEs (which select FROM `updated`) write nothing. See
+ * `debitTokensSql` for the measurement.
+ *
+ * ── Why there is an idempotency key ─────────────────────────────────────────
+ *
+ * There was not one, and every other money-moving statement here has one. A
+ * client retry after a network error — the failure mode idempotency keys exist
+ * for — would transmute a second time, debiting the user twice. Both ledger
+ * rows now carry `<key>:<TokenType>`, so the unique index on
+ * `token_transactions.idempotency_key` rejects the duplicate with `23505` and
+ * the caller reports it as already-applied rather than charging again.
+ *
+ * Null disables the guard, which preserves the previous behaviour for any
+ * caller that has not opted in.
+ *
+ * ── Why the token-type parameters are cast to text in BOTH references ───────
+ *
+ * `[MEASURED 2026-07-27]` adding the idempotency key introduced exactly the
+ * 42P08 documented above `creditTokensSql`, and the PREPARE gate caught it on
+ * all 12 column pairs before it could ship:
+ *
+ *     42P08  inconsistent types deduced for parameter $5
+ *
+ * $5/$7 are bound as the INSERT value for `token_type` (character varying) and
+ * ALSO concatenated with `':'`, which deduces `text`. One parameter, one type —
+ * so both references must carry the same cast. text -> varchar is an assignment
+ * cast, so pinning both to text is safe.
+ */
+export function transmuteSql(opts: {
+  fromColumn: AxisColumn;
+  toColumn: AxisColumn;
+  userId: string;
+  /** Amount debited from `fromColumn`. */
+  costAmount: number;
+  /** Amount credited to `toColumn`. */
+  targetAmount: number;
+  transactionGroupId: string;
+  fromToken: string;
+  toToken: string;
+  debitDescription: string;
+  creditDescription: string;
+  idempotencyKey: string | null;
+}): BuiltQuery {
+  const { fromColumn, toColumn } = opts;
+  const p = new QueryParams();
+
+  const user = p.add(opts.userId);
+  const cost = p.add(opts.costAmount);
+  const target = p.add(opts.targetAmount);
+  const group = p.add(opts.transactionGroupId);
+  const fromToken = p.add(opts.fromToken);
+  const debitDesc = p.add(opts.debitDescription);
+  const toToken = p.add(opts.toToken);
+  const creditDesc = p.add(opts.creditDescription);
+  const idem = p.add(opts.idempotencyKey);
+
+  const sql = `WITH check_balance AS (
+            SELECT ${fromColumn} AS current_balance
+            FROM token_balances
+            WHERE user_id = ${user}
+          ),
+          updated AS (
+            UPDATE token_balances
+            SET ${fromColumn} = ${fromColumn} - ${cost},
+                ${toColumn} = ${toColumn} + ${target},
+                updated_at = now()
+            WHERE user_id = ${user}
+              AND EXISTS (
+                SELECT 1
+                FROM check_balance
+                WHERE current_balance >= ${cost}
+              )
+            RETURNING *
+          ),
+          debit_txn AS (
+            INSERT INTO token_transactions
+              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+            SELECT
+              ${group}::uuid, ${user}, ${fromToken}::text, -${cost}, 'transmutation', NULL, ${debitDesc},
+              CASE WHEN ${idem}::text IS NOT NULL THEN ${idem}::text || ':' || ${fromToken}::text ELSE NULL END
+            FROM updated
+          ),
+          credit_txn AS (
+            INSERT INTO token_transactions
+              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+            SELECT
+              ${group}::uuid, ${user}, ${toToken}::text, ${target}, 'transmutation', NULL, ${creditDesc},
+              CASE WHEN ${idem}::text IS NOT NULL THEN ${idem}::text || ':' || ${toToken}::text ELSE NULL END
+            FROM updated
+          )
+          SELECT * FROM updated`;
+
+  return { sql, values: p.values };
+}


### PR DESCRIPTION
Three findings on the money paths, each measured against production before being
changed. None is a behaviour regression risk: the two SQL fixes replace statements
PostgreSQL refuses outright, and the CTE removals delete code that could never
execute.

## 1. getBalances threw on every single call

It sent `INSERT …; SELECT …` as ONE string with a bind parameter. [MEASURED
2026-07-27] against production that raises

    42601  cannot insert multiple commands into a prepared statement

The extended query protocol permits exactly one command per parameterised message,
so this was never the "multi-statement not supported" question the old comment
assumed — it cannot work, ever. The `catch` swallowed it and ran a two-query
fallback, so results were correct while the declared primary path had never once
executed and every balance read paid an exception.

Now one statement: `INSERT … ON CONFLICT (user_id) DO UPDATE SET updated_at =
token_balances.updated_at RETURNING *`. `DO UPDATE` rather than `DO NOTHING`
because RETURNING yields nothing for a conflicting row under DO NOTHING — that is
the whole reason the ensure and the read had been split. The SET is deliberately a
no-op write of the column's own value.

## 2. Four `ensure_balance` CTEs that could not protect anything

debitTokens, the two spend/purchase CTEs and transmutation all opened with
`WITH ensure_balance AS (INSERT INTO token_balances … ON CONFLICT DO NOTHING)`.
Every sub-statement of a data-modifying CTE runs against ONE snapshot taken before
the statement, so nothing else in those statements could see the row it created.
Removing it changes no behaviour; leaving it in reads as a safeguard that was never
operating — the same misreading that made the credit defect (#653) so durable.

⚠️ They are NOT converted to upserts, deliberately, though that was the initial
instruction. [MEASURED 2026-07-27] in a rolled-back transaction, an upsert-shaped
debit of 25 against a user with NO balance row yields

    spirit = -25.0000

— it lets someone spend tokens they never had. `check_balance` is what makes these
fail CLOSED: with no row it selects nothing, the ledger insert selects FROM it and
writes nothing, the UPDATE matches nothing, and the caller reads 0 rows as
insufficient funds. The asymmetry is the point: a credit for a missing row SHOULD
create it, a debit for a missing row must refuse.

## 3. Gate coverage: 1 statement -> 9

`checkEconomySqlParses.ts` covered only the four credit variants. It now also
PREPAREs the four debit variants and the balance read — 9 statements, each
extracted from the module source rather than hand-copied, since a copy drifts from
what ships. Verified against production: all 9 prepare, credit 8 params, debit 7,
getBalances 1.

Also fixed a bug in the gate's own new code: PREPARE folds unquoted identifiers, so
a mixed-case statement name silently reported "? params: undefined" while having
prepared fine.

NOT covered, and the gate now says so out loud rather than implying completeness:
the two multi-axis spend/purchase CTEs and transmutation are still inline template
literals their extractor cannot reach. 3 statements remain ungated pending
extraction into named builders.

## Behavioural verification

`scripts/checkEconomyStatementBehaviour.mjs` — 8 assertions run against production
inside a transaction that is always rolled back, reading the statements out of the
module source:

    getBalances creates the row and RETURNS it (spirit 0)          ok
    second call returns the SAME row                               ok
    credit of 10 applied                                           ok
    debit of 4 applied — balance 6                                 ok
    debit of 100 REFUSED, balance untouched                        ok
    debit with NO balance row: 0 rows, no row conjured             ok
    and no ledger row written for the refused debit                ok
    ledger === balance (6.0000)                                    ok

PREPARE proves a statement is legal; only this proves it is right.

jest: 173 suites / 1526 tests pass. `tsc --noEmit` clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)