### PR TITLE
feat(agents): allow historical births on the create path, and fix the year trap it exposes

### DIFF
--- a/src/app/api/agents/unified/__tests__/birthYearRange.test.ts
+++ b/src/app/api/agents/unified/__tests__/birthYearRange.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Historical births, and the two-digit-year trap that widening the range exposes.
+ *
+ * The create endpoint rejected any year outside 1900-2100 while
+ * `/api/internal/agent-sync` accepted anything — its own fixture is Hildegard of
+ * Bingen, 1098-09-17 — so the public path could not author what the sync path
+ * routinely does.
+ *
+ * The trap: `Date.UTC(year, …)` maps years 0-99 to 1900-1999. That is specified
+ * ECMAScript behaviour, so nothing errors; it silently shifts a birth by 1900
+ * years. Unreachable under the old floor, reachable the moment the range widens.
+ */
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body, init) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+import { calculateNatalChart } from "@/services/natalChartService";
+import { executeQuery } from "@/lib/database";
+import { MAX_BIRTH_YEAR, MIN_BIRTH_YEAR } from "@/lib/agents/birthYear";
+import { POST } from "../route";
+
+jest.mock("@/lib/database", () => ({ executeQuery: jest.fn() }));
+jest.mock("@/lib/auth/auth", () => ({
+  auth: jest.fn(async () => ({ user: { id: "creator-uuid-0001" } })),
+}));
+jest.mock("@/lib/rateLimit", () => ({ rateLimit: jest.fn(async () => ({ allowed: true })) }));
+jest.mock("@/services/natalChartService", () => ({ calculateNatalChart: jest.fn() }));
+jest.mock("@/lib/agents/persona/build-agent-context", () => ({ buildAgentContext: jest.fn() }));
+jest.mock("@/lib/serviceUrls", () => ({ getServiceUrlSafe: jest.fn(() => null) }));
+
+const SIGNS = ["leo", "taurus", "virgo", "cancer", "aries", "sagittarius", "capricorn", "aquarius", "pisces", "scorpio", "gemini"];
+const PLANETS = ["Sun", "Moon", "Mercury", "Venus", "Mars", "Jupiter", "Saturn", "Uranus", "Neptune", "Pluto", "Ascendant"];
+
+const serverChart = {
+  planets: PLANETS.map((name, i) => ({ name, sign: SIGNS[i], position: i * 30 + 15 })),
+  ascendant: "gemini",
+  elementalBalance: { Fire: 0.4, Water: 0.3, Earth: 0.2, Air: 0.1 },
+};
+
+const makeRequest = (body: unknown): any =>
+  ({ headers: { get: () => null }, json: async () => body }) as unknown as any;
+
+const create = (year: number, month = 9, day = 17, hour = 12, minute = 0) =>
+  POST(
+    makeRequest({
+      action: "create",
+      parameters: {
+        name: "Historical Agent",
+        purpose: "Pin the accepted birth-year range",
+        birthInfo: { year, month, day, hour, minute, latitude: 49.79, longitude: 8.12 },
+      },
+    }),
+  );
+
+/** birth_data is $4 of the user_profiles INSERT — index 3. */
+const BIRTH_DATA_PARAM = 3;
+
+function storedBirthData(): { dateTime: string } {
+  const call = (executeQuery as jest.Mock).mock.calls.find(([sql]: [string]) =>
+    sql.includes("INSERT INTO user_profiles"),
+  );
+  if (!call) throw new Error("INSERT INTO user_profiles was never called");
+  return JSON.parse(call[1][BIRTH_DATA_PARAM] as string);
+}
+
+describe("POST /api/agents/unified — accepted birth years", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (calculateNatalChart as jest.Mock).mockResolvedValue(serverChart);
+    (executeQuery as jest.Mock).mockResolvedValue({ rows: [], rowCount: 1 });
+  });
+
+  it("accepts a medieval birth the sync path already accepts", async () => {
+    const data = await (await create(1098)).json();
+
+    expect(data.success).toBe(true);
+    // Hildegard of Bingen — the agent-sync test fixture, previously rejected here.
+    expect(storedBirthData().dateTime).toBe("1098-09-17T12:00:00.000Z");
+  });
+
+  it("a two-digit year is NOT shifted into the 1900s", async () => {
+    const data = await (await create(50)).json();
+
+    expect(data.success).toBe(true);
+    // `Date.UTC(50, …)` would have made this 1950-09-17 — silently, no error.
+    expect(storedBirthData().dateTime).toBe("0050-09-17T12:00:00.000Z");
+    expect(storedBirthData().dateTime).not.toContain("1950");
+  });
+
+  it.each([MIN_BIRTH_YEAR, 1600, 1899, 1900, 2026, MAX_BIRTH_YEAR])(
+    "accepts year %s and stores it unchanged",
+    async (year) => {
+      const data = await (await create(year)).json();
+
+      expect(data.success).toBe(true);
+      expect(new Date(storedBirthData().dateTime).getUTCFullYear()).toBe(year);
+    },
+  );
+
+  it.each([0, -1, MAX_BIRTH_YEAR + 1, 3000])("still rejects year %s", async (year) => {
+    const res = await create(year);
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.success).toBe(false);
+    // A BCE birth needs a proleptic-calendar convention this codebase has never
+    // fixed; refusing beats silently inventing one.
+    expect(data.error).toContain(`year: ${MIN_BIRTH_YEAR}-${MAX_BIRTH_YEAR}`);
+  });
+
+  it("the other field validations are untouched", async () => {
+    for (const bad of [
+      { year: 1098, month: 13 },
+      { year: 1098, day: 32 },
+      { year: 1098, hour: 24 },
+    ]) {
+      const res = await create(bad.year, bad.month ?? 9, bad.day ?? 17, bad.hour ?? 12);
+      expect(res.status).toBe(400);
+    }
+  });
+});

--- a/src/app/api/agents/unified/route.ts
+++ b/src/app/api/agents/unified/route.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { NextResponse } from "next/server";
+import { MAX_BIRTH_YEAR, MIN_BIRTH_YEAR, birthMomentUtc } from "@/lib/agents/birthYear";
 import { buildAgentContext } from "@/lib/agents/persona/build-agent-context";
 import { auth } from "@/lib/auth/auth";
 import { executeQuery } from "@/lib/database";
@@ -153,8 +154,26 @@ export async function POST(request: NextRequest) {
         const latitude = Number(birthInfo.latitude);
         const longitude = Number(birthInfo.longitude);
 
+        // Historical births are legitimate here. `/api/internal/agent-sync`
+        // already accepts any birthDate — its own fixture is Hildegard of Bingen,
+        // 1098-09-17 — and the chart-bearing agent population is largely
+        // historical figures, so the 1900 floor only meant the public create path
+        // could not author what the sync path routinely does.
+        //
+        // ⚠️ [MEASURED 2026-07-27] this widening is what CREATES the pre-1600
+        // ephemeris exposure; it does not inherit it. Today NO stored chart has a
+        // pre-1600 birth — in fact only 4 rows in all of user_profiles carry a
+        // `dateTime` at all, every one of them 1900+. The production astrologize
+        // backend is pyswisseph/NASA JPL DE and handles these epochs, but when
+        // Railway is unreachable `/api/astrologize` falls back to
+        // astronomy-engine, which before ~1600 CE diverges from JPL Horizons by up
+        // to 0.53° (Pluto) and 0.45° (Moon) and raises NO error. Half a degree can
+        // move a body across a sign boundary, which changes its element, its
+        // dignity, and the whole ESMS profile. A backend-health precondition for
+        // pre-1600 births is the natural follow-up and is deliberately not bundled
+        // here.
         if (
-          isNaN(year) || year < 1900 || year > 2100 ||
+          isNaN(year) || year < MIN_BIRTH_YEAR || year > MAX_BIRTH_YEAR ||
           isNaN(month) || month < 1 || month > 12 ||
           isNaN(day) || day < 1 || day > 31 ||
           isNaN(hour) || hour < 0 || hour > 23 ||
@@ -163,19 +182,13 @@ export async function POST(request: NextRequest) {
           isNaN(longitude) || longitude < -180 || longitude > 180
         ) {
           return NextResponse.json(
-            { success: false, error: "Invalid birthInfo parameters or range (year: 1900-2100, lat: -90 to 90, lon: -180 to 180).", timestamp },
+            { success: false, error: `Invalid birthInfo parameters or range (year: ${MIN_BIRTH_YEAR}-${MAX_BIRTH_YEAR}, lat: -90 to 90, lon: -180 to 180).`, timestamp },
             { status: 400 }
           );
         }
 
         const birthData = {
-          dateTime: new Date(Date.UTC(
-            year,
-            month - 1,
-            day,
-            hour,
-            minute
-          )).toISOString(),
+          dateTime: birthMomentUtc(year, month, day, hour, minute).toISOString(),
           latitude,
           longitude,
           timezone: birthInfo.timezone || "UTC",

--- a/src/lib/agents/birthYear.ts
+++ b/src/lib/agents/birthYear.ts
@@ -1,0 +1,47 @@
+/**
+ * The accepted birth-year range for agent creation, and a birth instant that
+ * survives it.
+ *
+ * Lives here rather than in `api/agents/unified/route.ts` because a Next.js route
+ * module may only export route handlers and route config: exporting a constant
+ * from it fails typegen with
+ * `TS2344 … Property 'MIN_BIRTH_YEAR' is incompatible with index signature`.
+ */
+
+/**
+ * The floor is 1, not 1900. `/api/internal/agent-sync` has always accepted any
+ * birthDate — its own fixture is Hildegard of Bingen, 1098-09-17 — and the
+ * chart-bearing agent population is largely historical figures, so the public
+ * create path could not author what the sync path routinely does.
+ *
+ * It is not 0 or negative: a BCE birth needs a proleptic-calendar convention this
+ * codebase has never fixed, and inventing one silently is worse than refusing.
+ */
+export const MIN_BIRTH_YEAR = 1;
+export const MAX_BIRTH_YEAR = 2100;
+
+/**
+ * The birth instant in UTC, for any year in range.
+ *
+ * ⚠️ NOT `Date.UTC(year, …)`, which maps years 0-99 to 1900-1999. That is
+ * specified ECMAScript behaviour, so nothing throws — it silently shifts a birth
+ * by 1900 years. `[MEASURED 2026-07-27]`
+ *
+ *     new Date(Date.UTC(50, 0, 1))  ->  1950-01-01T00:00:00.000Z
+ *     setUTCFullYear(50)            ->  0050-01-01T00:00:00.000Z
+ *
+ * With the old 1900 floor the trap was unreachable; widening the range is exactly
+ * what exposes it.
+ */
+export function birthMomentUtc(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+): Date {
+  const moment = new Date(0);
+  moment.setUTCFullYear(year, month - 1, day);
+  moment.setUTCHours(hour, minute, 0, 0);
+  return moment;
+}


### PR DESCRIPTION
`/api/internal/agent-sync` has always accepted any birthDate — its own test
fixture is Hildegard of Bingen, 1098-09-17 — while the public create path rejected
anything before 1900. The chart-bearing agent population is largely historical
figures, so this endpoint could not author what the sync path routinely does.
Floor is now 1, not 1900.

## The trap widening exposes

`Date.UTC(year, …)` maps years 0-99 to 1900-1999. Specified ECMAScript behaviour,
so nothing throws — it silently shifts a birth by 1900 years.

  [MEASURED 2026-07-27]  new Date(Date.UTC(50, 0, 1))  ->  1950-01-01T00:00:00Z
                         setUTCFullYear(50)            ->  0050-01-01T00:00:00Z

Unreachable under the old floor, reachable the moment the range widens. Birth
moments are now built with `setUTCFullYear`, and a test pins `0050`, asserting the
stored value does not contain "1950".

The floor is 1 rather than 0 or negative on purpose: a BCE birth needs a
proleptic-calendar convention this codebase has never fixed, and inventing one
silently is worse than refusing.

The range and the date builder live in `src/lib/agents/birthYear.ts`, not in the
route. A Next.js route module may only export handlers and route config — the
first attempt exported the constants from the route and typegen rejected it with
`TS2344 … Property 'MIN_BIRTH_YEAR' is incompatible with index signature`. Caught
by the pre-commit hook, which is why it is worth having.

## ⚠️ This creates an ephemeris exposure rather than inheriting one

Stated plainly because it argues for a follow-up. [MEASURED 2026-07-27] NO stored
chart has a pre-1600 birth today — only 4 rows in all of `user_profiles` carry a
`dateTime` at all, every one 1900+, and 0 of the 71 chart-bearing agents has birth
data. So no pre-1600 chart has ever been computed here.

Production astrologize is pyswisseph/NASA JPL DE and handles these epochs. But
when Railway is unreachable, `/api/astrologize` falls back to astronomy-engine,
which before ~1600 CE diverges from JPL Horizons by up to 0.53° (Pluto) and 0.45°
(Moon) and raises NO error. Half a degree can move a body across a sign boundary,
which changes its element, its dignity, and the entire ESMS profile.

A backend-health precondition for pre-1600 births — refuse, or record provenance,
rather than silently accept a degraded chart — is the natural follow-up. It is
deliberately NOT bundled here so the widening can be reviewed on its own.

## Tests

13, including the boundaries (1, 1600, 1899, 1900, 2026, 2100 accepted; 0, -1,
2101, 3000 refused), the medieval fixture, the two-digit-year assertion, and a
check that month/day/hour validation is untouched.

Verified: 174 suites / 1539 tests, `tsc --noEmit` clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)