### PR TITLE
fix(charts): three routes persisted an invented ascendant and a 0 longitude

### DIFF
--- a/src/app/api/agents/unified/__tests__/route.test.ts
+++ b/src/app/api/agents/unified/__tests__/route.test.ts
@@ -1,0 +1,409 @@
+/**
+ * What `agents/unified` writes into `user_profiles.natal_positions` must be what
+ * `parseNatalPositions` can read back.
+ *
+ * The bug these pin: the route stored `formattedChart.planets` verbatim — an
+ * OBJECT keyed by planet name — while every other writer (the PA sync path via
+ * `/api/internal/agent-sync`, and `/api/economy/sync-debit`) stores an ARRAY of
+ * `{ planet, sign, degree }`. `parseNatalPositions` begins with
+ * `if (!Array.isArray(raw)) return null`, so a chart written here yielded NO
+ * full-chart monica at all and every consumer skipped the row.
+ *
+ * `[MEASURED 2026-07-26]` on production `jsonb_typeof(natal_positions)` was
+ * `array` for all 5084 rows, so no object-shaped row ever landed — the divergence
+ * was latent, and there was no data to repair. What was missing was this
+ * assertion: nothing tied the writer's shape to the reader's, so they drifted.
+ */
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body, init) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+import { calculateNatalChart } from "@/services/natalChartService";
+import { executeQuery } from "@/lib/database";
+import {
+  MIN_CHART_BODIES,
+  fullChartMonica,
+  natalPositionsFromChart,
+  parseNatalPositions,
+  statesALongitude,
+} from "@/utils/fullChartMonica";
+import { POST } from "../route";
+
+jest.mock("@/lib/database", () => ({
+  executeQuery: jest.fn(),
+}));
+jest.mock("@/lib/auth/auth", () => ({
+  auth: jest.fn(async () => ({ user: { id: "creator-uuid-0001" } })),
+}));
+jest.mock("@/lib/rateLimit", () => ({
+  rateLimit: jest.fn(async () => ({ allowed: true })),
+}));
+jest.mock("@/services/natalChartService", () => ({
+  calculateNatalChart: jest.fn(),
+}));
+// Module-scope imports of the route that the "create" path never touches.
+jest.mock("@/lib/agents/persona/build-agent-context", () => ({
+  buildAgentContext: jest.fn(),
+}));
+jest.mock("@/lib/serviceUrls", () => ({
+  getServiceUrlSafe: jest.fn(() => null),
+}));
+
+/**
+ * A fixed chart in the shape `calculateNatalChart` really returns: lowercase
+ * signs (`normalizeSignName`), `position` as ABSOLUTE ecliptic longitude, and
+ * an `Ascendant` entry alongside the ten planets.
+ */
+const CHART_LONGITUDES: Record<string, { sign: string; position: number }> = {
+  Sun: { sign: "leo", position: 135 },
+  Moon: { sign: "taurus", position: 33 },
+  Mercury: { sign: "virgo", position: 152.5 },
+  Venus: { sign: "cancer", position: 110 },
+  Mars: { sign: "aries", position: 8 },
+  Jupiter: { sign: "sagittarius", position: 265 },
+  Saturn: { sign: "capricorn", position: 281 },
+  Uranus: { sign: "aquarius", position: 310 },
+  Neptune: { sign: "pisces", position: 340 },
+  Pluto: { sign: "scorpio", position: 220 },
+  Ascendant: { sign: "gemini", position: 75 },
+};
+
+const serverChart = {
+  planets: Object.entries(CHART_LONGITUDES).map(([name, p]) => ({
+    name,
+    sign: p.sign,
+    position: p.position,
+  })),
+  ascendant: "gemini",
+  elementalBalance: { Fire: 0.4, Water: 0.3, Earth: 0.2, Air: 0.1 },
+};
+
+const CREATE_BODY = {
+  action: "create",
+  parameters: {
+    name: "Test Agent",
+    purpose: "Pin the natal_positions shape",
+    // In range: the route rejects a year outside 1900-2100 outright.
+    birthInfo: {
+      year: 1984,
+      month: 9,
+      day: 17,
+      hour: 12,
+      minute: 0,
+      latitude: 49.79,
+      longitude: 8.12,
+      timezone: "Europe/Berlin",
+      locationName: "Bermersheim vor der Höhe",
+    },
+  },
+};
+
+function makeRequest(body: unknown): any {
+  return {
+    headers: { get: () => null },
+    json: async () => body,
+  } as unknown as any;
+}
+
+/** The parameter array of the `INSERT INTO user_profiles` the route just ran. */
+function captureUserProfilesParams(): unknown[] {
+  const call = (executeQuery as jest.Mock).mock.calls.find(([sql]: [string]) =>
+    sql.includes("INSERT INTO user_profiles"),
+  );
+  if (!call) throw new Error("INSERT INTO user_profiles was never called");
+  return call[1];
+}
+
+/** natal_positions is $6 of that INSERT — index 5. */
+const NATAL_POSITIONS_PARAM = 5;
+/** natal_chart is $5 — index 4. */
+const NATAL_CHART_PARAM = 4;
+
+async function createAgent(): Promise<unknown[]> {
+  const res = await POST(makeRequest(CREATE_BODY));
+  const data = await res.json();
+  // Guard: a failed create would make every assertion below vacuous, and the
+  // route reports the reason in the body — surface it rather than a bare false.
+  if (data.success !== true) throw new Error(`create failed: ${JSON.stringify(data)}`);
+  return captureUserProfilesParams();
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (calculateNatalChart as jest.Mock).mockResolvedValue(serverChart);
+  (executeQuery as jest.Mock).mockResolvedValue({ rows: [], rowCount: 1 });
+});
+
+describe("POST /api/agents/unified — the natal_positions it writes", () => {
+  it("writes an ARRAY, not an object keyed by planet name", async () => {
+    const params = await createAgent();
+    const written = JSON.parse(params[NATAL_POSITIONS_PARAM] as string);
+
+    expect(Array.isArray(written)).toBe(true);
+    // Same test Postgres answers with jsonb_typeof, and the same one the
+    // canonical parser applies on its first line.
+    expect(written).toHaveLength(Object.keys(CHART_LONGITUDES).length);
+  });
+
+  it("round-trips through parseNatalPositions to a non-null chart", async () => {
+    const params = await createAgent();
+    const written = JSON.parse(params[NATAL_POSITIONS_PARAM] as string);
+
+    const positions = parseNatalPositions(written);
+    expect(positions).not.toBeNull();
+    expect(Object.keys(positions!).sort()).toEqual(
+      Object.keys(CHART_LONGITUDES).sort(),
+    );
+    // Non-vacuity: a chart this size clears the usability floor by a margin, so
+    // the assertion above is not passing on a boundary.
+    expect(Object.keys(positions!).length).toBeGreaterThan(MIN_CHART_BODIES);
+  });
+
+  it("yields a real full-chart monica for the row it just wrote", async () => {
+    const params = await createAgent();
+    const written = JSON.parse(params[NATAL_POSITIONS_PARAM] as string);
+
+    // The consumer that the object shape silently starved: both backfill
+    // (`scripts/backfillMonicaPerConstruction.ts`) and the drift check skip any
+    // row whose chart parses to null.
+    const monica = fullChartMonica(written);
+    expect(monica).not.toBeNull();
+    expect(Number.isFinite(monica!.diurnal)).toBe(true);
+    expect(Number.isFinite(monica!.nocturnal)).toBe(true);
+    expect(monica!.combined).toBe((monica!.diurnal + monica!.nocturnal) / 2);
+  });
+
+  it("carries the REAL absolute longitude in `position`, the key the parser reads", async () => {
+    const params = await createAgent();
+    const written = JSON.parse(params[NATAL_POSITIONS_PARAM] as string) as Array<
+      Record<string, unknown>
+    >;
+
+    for (const row of written) {
+      const expected = CHART_LONGITUDES[row.planet as string];
+      expect(expected).toBeDefined();
+      expect(row.sign).toBe(expected.sign);
+      expect(row.position).toBe(expected.position);
+      expect(row.degree).toBe(expected.position % 30);
+      // `longitude` is not on this contract. The route's own chart blob uses
+      // that name, and copying it here would read to the parser as no
+      // longitude at all — see the parser test below for why that matters.
+      expect(row.longitude).toBeUndefined();
+    }
+  });
+
+  it("leaves the natal_chart blob's own shape alone", async () => {
+    const params = await createAgent();
+    const chart = JSON.parse(params[NATAL_CHART_PARAM] as string);
+
+    // natal_chart is a different contract: an object keyed by planet name, read
+    // by the client. Only natal_positions changed shape.
+    expect(Array.isArray(chart.planets)).toBe(false);
+    expect(chart.planets.Sun).toMatchObject({ sign: "leo", longitude: 135 });
+  });
+});
+
+/**
+ * The ascendant of the same stored blob.
+ *
+ * The bug these pin: `formattedChart.ascendant` came from
+ * `SIGN_ORDER.indexOf(serverChart.ascendant) * 30` against a Capitalised list,
+ * while every sign `calculateNatalChart` returns is lowercase
+ * (`normalizeSignName`). `indexOf` was always -1, so the stored ascendant was
+ * always 0 — and `flattenNatalChart` (`src/lib/mcp/synastryTools.ts:213-237`)
+ * reads a numeric `ascendant` as an absolute longitude, so such a row would put an
+ * Ascendant fabricated at 0° Aries into every synastry score and transit overlay
+ * that read it. `midheaven` was never computed at all, yet shipped the same
+ * literal 0 through the same reader.
+ *
+ * `[MEASURED 2026-07-26]` all 71 chart-bearing agents in production hold a
+ * NON-ZERO numeric ascendant and none holds a zero midheaven, so no surviving row
+ * bears this create path's signature and there is nothing to repair — the same
+ * latency, and the same cause, as the shape defect above.
+ */
+describe("POST /api/agents/unified — the ascendant it writes", () => {
+  const SIGNS = [
+    "aries", "taurus", "gemini", "cancer", "leo", "virgo",
+    "libra", "scorpio", "sagittarius", "capricorn", "aquarius", "pisces",
+  ];
+
+  async function storedChart(): Promise<Record<string, unknown>> {
+    const params = await createAgent();
+    return JSON.parse(params[NATAL_CHART_PARAM] as string);
+  }
+
+  it("stores the chart's REAL ascendant longitude", async () => {
+    const chart = await storedChart();
+
+    // 75°, the Ascendant body's own longitude. Distinguishes all three
+    // candidates: 0 was the bug, 60 would be the sign-start reconstruction the
+    // broken lookup was reaching for, 75 is the angle the chart actually states.
+    expect(chart.ascendant).toBe(CHART_LONGITUDES.Ascendant.position);
+    expect(chart.ascendant).not.toBe(0);
+    expect(chart.ascendant).not.toBe(SIGNS.indexOf("gemini") * 30);
+  });
+
+  it("the stored longitude falls in the ascendant's own sign", async () => {
+    const chart = await storedChart();
+
+    // The consistency the old code could not have had: a longitude of 0 lands in
+    // aries, which disagrees with every ascendant sign but one.
+    const sign = SIGNS[Math.floor((chart.ascendant as number) / 30)];
+    expect(sign).toBe(CHART_LONGITUDES.Ascendant.sign);
+    expect(sign).toBe(serverChart.ascendant);
+  });
+
+  it("writes null, not 0, when the chart carries no Ascendant body", async () => {
+    (calculateNatalChart as jest.Mock).mockResolvedValue({
+      ...serverChart,
+      planets: serverChart.planets.filter((p) => p.name !== "Ascendant"),
+    });
+
+    // null is skipped by flattenNatalChart; 0 would be placed at 0° Aries.
+    expect((await storedChart()).ascendant).toBeNull();
+  });
+
+  it("a placeholder ascendant is absent from BOTH fields, not null in one and 0° Aries in the other", async () => {
+    (calculateNatalChart as jest.Mock).mockResolvedValue({
+      ...serverChart,
+      planets: serverChart.planets.map((p) =>
+        p.name === "Ascendant" ? { ...p, position: 0 } : p,
+      ),
+    });
+
+    const params = await createAgent();
+    const chart = JSON.parse(params[NATAL_CHART_PARAM] as string);
+    const positions = JSON.parse(params[NATAL_POSITIONS_PARAM] as string) as Array<
+      Record<string, unknown>
+    >;
+
+    // The disagreement this pins: natal_chart said "no angle" while
+    // natal_positions still carried the body at position 0, where the parser
+    // would hand it to alchemize as a real placement at 0° aries — with the
+    // sign gemini beside it.
+    expect(chart.ascendant).toBeNull();
+    expect(positions.some((r) => r.planet === "Ascendant")).toBe(false);
+    // The ten real planets survive, so the chart is still usable.
+    expect(positions).toHaveLength(Object.keys(CHART_LONGITUDES).length - 1);
+    expect(parseNatalPositions(positions)).not.toBeNull();
+  });
+
+  it("writes null for a placeholder ascendant at longitude 0", async () => {
+    // What `fetchPlanetaryPositions` produces when the astrologize response has
+    // no ascendant: a locally derived SIGN paired with the 0 initialiser. The
+    // pair is self-contradictory — 0 is 0° aries, not 15° gemini — so the angle
+    // is absent, not zero.
+    (calculateNatalChart as jest.Mock).mockResolvedValue({
+      ...serverChart,
+      planets: serverChart.planets.map((p) =>
+        p.name === "Ascendant" ? { ...p, position: 0 } : p,
+      ),
+    });
+
+    expect((await storedChart()).ascendant).toBeNull();
+  });
+
+  it("omits midheaven rather than storing an MC it never computed", async () => {
+    const chart = await storedChart();
+
+    expect(chart.midheaven).toBeUndefined();
+    expect("midheaven" in chart).toBe(false);
+  });
+
+  it("still records the ascendant among the planets it writes", async () => {
+    // The angle survives in natal_positions too, where the parser reads it as a
+    // body — so this fix does not depend on the natal_chart blob alone.
+    const params = await createAgent();
+    const positions = JSON.parse(params[NATAL_POSITIONS_PARAM] as string) as Array<
+      Record<string, unknown>
+    >;
+
+    const ascendant = positions.find((r) => r.planet === "Ascendant");
+    expect(ascendant?.position).toBe(CHART_LONGITUDES.Ascendant.position);
+  });
+});
+
+describe("natalPositionsFromChart / parseNatalPositions — the contract itself", () => {
+  /** The route's chart-blob shape, as `formattedChart.planets` builds it. */
+  const chartPlanets = Object.fromEntries(
+    Object.entries(CHART_LONGITUDES).map(([name, p]) => [
+      name,
+      {
+        sign: p.sign,
+        degree: p.position % 30,
+        retrograde: false,
+        longitude: p.position,
+      },
+    ]),
+  );
+
+  it("the OLD payload — the chart object itself — parses to null", () => {
+    // The defect, stated directly. If this ever starts returning a chart, the
+    // shape assertions above stop being load-bearing.
+    expect(parseNatalPositions(chartPlanets)).toBeNull();
+  });
+
+  it("the encoded array parses back to every body", () => {
+    const rows = natalPositionsFromChart(chartPlanets);
+    const positions = parseNatalPositions(JSON.parse(JSON.stringify(rows)));
+
+    expect(positions).not.toBeNull();
+    for (const [planet, p] of Object.entries(CHART_LONGITUDES)) {
+      expect(positions![planet].exactLongitude).toBe(p.position);
+      expect(positions![planet].sign).toBe(p.sign);
+    }
+  });
+
+  it("`position` is what the parser believes — sign and degree do not override it", () => {
+    // Why the key matters. Here `position` disagrees with sign+degree; the
+    // parser follows `position`. A row that named the field `longitude` instead
+    // would land on the sign+degree reconstruction with no error anywhere.
+    const [followed] = Object.values(
+      parseNatalPositions([
+        { planet: "Sun", sign: "aries", degree: 1, position: 200.25 },
+        ...natalPositionsFromChart(chartPlanets).slice(1),
+      ])!,
+    );
+    expect(followed.exactLongitude).toBe(200.25);
+    expect(followed.degree).toBeCloseTo(20.25, 10);
+  });
+
+  it.each([
+    ["NaN", Number.NaN],
+    ["a placeholder 0", 0],
+    ["Infinity", Number.POSITIVE_INFINITY],
+  ])("drops a body whose longitude is %s rather than placing it at 0° of its sign", (_label, longitude) => {
+    const rows = natalPositionsFromChart({
+      ...chartPlanets,
+      Chiron: { sign: "libra", longitude: longitude as number },
+    });
+
+    expect(rows.some((r) => r.planet === "Chiron")).toBe(false);
+    expect(rows).toHaveLength(Object.keys(CHART_LONGITUDES).length);
+  });
+
+  it("statesALongitude is the one rule both writers apply", () => {
+    // Single-sourced deliberately: the encoder and the route's ascendant used to
+    // carry their own copy of this test, which is how the two fields of one row
+    // came to disagree about the same body.
+    expect(statesALongitude(135.0341)).toBe(true);
+    expect(statesALongitude(-12.5)).toBe(true); // negative is still a stated angle
+    expect(statesALongitude(0)).toBe(false);
+    expect(statesALongitude(Number.NaN)).toBe(false);
+    expect(statesALongitude(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+
+  it("an empty chart encodes to [] — the literal readers already treat as absent", () => {
+    // Not `{}`: every consumer's emptiness guard is
+    // `natal_positions::text NOT IN ('[]', 'null', '{}')`, and jsonbOrNull
+    // treats both as absent, but only `[]` is type-correct for this column.
+    expect(natalPositionsFromChart({})).toEqual([]);
+    expect(parseNatalPositions([])).toBeNull();
+  });
+});

--- a/src/app/api/agents/unified/route.ts
+++ b/src/app/api/agents/unified/route.ts
@@ -8,6 +8,7 @@ import { getServiceUrlSafe } from "@/lib/serviceUrls";
 import { calculateNatalChart } from "@/services/natalChartService";
 import { alchemize, type PlanetaryPosition } from "@/services/RealAlchemizeService";
 import { isDiurnalAt } from "@/utils/astrology/positions";
+import { natalPositionsFromChart, statesALongitude } from "@/utils/fullChartMonica";
 import type { NextRequest} from "next/server";
 
 export const dynamic = "force-dynamic";
@@ -19,6 +20,48 @@ const RATE_LIMIT = { window: 60_000, max: 20, bucket: "agents-unified" };
 interface UnifiedAgentRequest {
   action: string;
   parameters?: any;
+}
+
+/**
+ * The chart's Ascendant longitude, or null when the chart states no angle.
+ *
+ * `calculateNatalChart` carries the Ascendant in `planets` alongside the ten
+ * bodies, and in production it is a real computed angle — the pyswisseph backend
+ * returns `ascendant.exactLongitude` (`[MEASURED 2026-07-26]` 135.0341° for a
+ * 1984-09-17T12:00Z birth at 49.79N 8.12E, source `backend-pyswisseph`).
+ *
+ * This replaces `SIGN_ORDER.indexOf(serverChart.ascendant) * 30`, which looked a
+ * sign up in a Capitalised list while every sign from `normalizeSignName` is
+ * lowercase: `indexOf` was therefore ALWAYS -1 and the stored ascendant was
+ * ALWAYS 0. (Same defect class as the one already documented in
+ * `src/utils/astrology/natalAlchemy.ts` — a lowercase sign against capitalised
+ * keys, failing silently.) Even had the lookup worked it would have rounded the
+ * angle down to its sign's first degree; the exact longitude is right here.
+ *
+ * That 0 would not have been inert: `flattenNatalChart`
+ * (`src/lib/mcp/synastryTools.ts`) reads a numeric `ascendant` as an absolute
+ * longitude, so it would place a fabricated Ascendant at 0° Aries into every
+ * synastry score and transit overlay that read such a row.
+ *
+ * `[MEASURED 2026-07-26]` no production row carries one: all **71** chart-bearing
+ * agents hold a non-zero numeric ascendant, **0** hold a zero, and no row holds a
+ * zero midheaven. As with the `natal_positions` shape below, no surviving row
+ * bears this create path's signature (a later PA sync COALESCEs `natal_chart`, so
+ * this says nothing survives, not that nothing was ever written) — which is why
+ * both defects were latent, and why there is no data to repair.
+ *
+ * `statesALongitude` decides what counts as an angle at all, and is the SAME rule
+ * `natalPositionsFromChart` applies to the bodies — so a placeholder is absent
+ * from both fields of this row, never null in one and 0° Aries in the other. null
+ * makes every reader skip the point, where 0 makes all of them place it at 0°
+ * Aries.
+ */
+function ascendantLongitude(
+  planets: Array<{ name: string; position: number }>,
+): number | null {
+  const ascendant = planets.find((p) => p.name === "Ascendant");
+  if (!ascendant || !statesALongitude(ascendant.position)) return null;
+  return ascendant.position;
 }
 
 export async function POST(request: NextRequest) {
@@ -161,8 +204,15 @@ export async function POST(request: NextRequest) {
           planets: {} as Record<string, { sign: string; degree: number; retrograde: boolean; longitude: number }>,
           houses: {} as Record<string, number>,
           aspects: [] as any[],
-          ascendant: 0,
-          midheaven: 0
+          // A real angle or null, never a placeholder — see ascendantLongitude().
+          ascendant: null as number | null,
+          // No `midheaven` key. Nothing in this chart computes an MC, and the
+          // field was previously initialised to 0 and never written — which
+          // `flattenNatalChart` would read as a real MC at 0° Aries, exactly as it
+          // would the ascendant. An absent key is skipped there instead. (The 71
+          // prod rows that DO carry a midheaven were written elsewhere; none is
+          // 0.) `/api/planetary-rectification` computes a real MC if one is
+          // ever wanted here.
         };
 
         serverChart.planets.forEach((p) => {
@@ -174,9 +224,7 @@ export async function POST(request: NextRequest) {
           };
         });
 
-        const SIGN_ORDER = ['Aries', 'Taurus', 'Gemini', 'Cancer', 'Leo', 'Virgo', 'Libra', 'Scorpio', 'Sagittarius', 'Capricorn', 'Aquarius', 'Pisces'];
-        const ascIdx = SIGN_ORDER.indexOf(serverChart.ascendant);
-        formattedChart.ascendant = ascIdx >= 0 ? ascIdx * 30 : 0;
+        formattedChart.ascendant = ascendantLongitude(serverChart.planets);
 
         // §18e — a real thermodynamic monica from the whole chart, via the
         // canonical engine. This replaces a longitude average
@@ -241,7 +289,13 @@ export async function POST(request: NextRequest) {
             purpose,
             JSON.stringify(birthData),
             JSON.stringify(formattedChart),
-            JSON.stringify(formattedChart.planets || {}),
+            // natal_positions is an ARRAY of {planet, sign, degree, position} —
+            // the shape `parseNatalPositions` reads and the shape the other two
+            // writers (PA sync, sync-debit) store. This used to pass
+            // `formattedChart.planets` straight through, which is an OBJECT keyed
+            // by planet name; the parser rejects a non-array outright, so a chart
+            // written here produced NO full-chart monica for any consumer.
+            JSON.stringify(natalPositionsFromChart(formattedChart.planets)),
             monicaConstant,
             // §18j — this agent has a real birth chart, so monica_constant is
             // built by the full-chart engine (alchemize()), not the single-body

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -9,6 +9,7 @@
  */
 
 import { NextResponse } from "next/server";
+import { natalBodiesFromRawPositions, unusableChartMessage } from "@/lib/astrology/natalBodies";
 import { auth } from "@/lib/auth/auth";
 import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
 import { _logger } from "@/lib/logger";
@@ -17,7 +18,7 @@ import { getPlanetaryPositionsForDateTime } from "@/services/astrologizeApi";
 import { reportQuestEventBestEffort } from "@/services/questEventReporter";
 import { userDatabase } from "@/services/userDatabaseService";
 import type { Planet, ZodiacSignType, Element, Modality } from "@/types/celestial";
-import type { NatalChart, PlanetInfo } from "@/types/natalChart";
+import type { NatalChart } from "@/types/natalChart";
 import { buildAspectsWithStrength } from "@/utils/aspectCalculator";
 import { validatePlanetaryPositions, formatValidationResult } from "@/utils/astrology/planetaryValidation";
 import { calculateEnhancedAlchemicalFromPlanets, isSectDiurnalForBirth } from "@/utils/planetaryAlchemyMapping";
@@ -189,25 +190,31 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const positions: Record<Planet, ZodiacSignType> = {
-      Sun: rawPositions.Sun?.sign,
-      Moon: rawPositions.Moon?.sign,
-      Mercury: rawPositions.Mercury?.sign,
-      Venus: rawPositions.Venus?.sign,
-      Mars: rawPositions.Mars?.sign,
-      Jupiter: rawPositions.Jupiter?.sign,
-      Saturn: rawPositions.Saturn?.sign,
-      Uranus: rawPositions.Uranus?.sign,
-      Neptune: rawPositions.Neptune?.sign,
-      Pluto: rawPositions.Pluto?.sign,
-      Ascendant: rawPositions.Ascendant?.sign || "aries",
-    };
-
-    const planets: PlanetInfo[] = Object.entries(positions).map(([pname, sign]) => ({
-      name: pname as Planet,
-      sign,
-      position: rawPositions[pname]?.exactLongitude ?? 0,
-    }));
+    // One shared builder, and it REFUSES rather than filling gaps in. This block
+    // used to invent an "aries" ascendant, a 0 longitude for any body the API did
+    // not price, and `undefined` signs inside a Record that forbids them — then
+    // PERSISTED the result. See src/lib/astrology/natalBodies.ts.
+    const bodies = natalBodiesFromRawPositions(rawPositions);
+    if (!bodies.ok) {
+      _logger.error(
+        "[POST /api/onboarding] unusable chart",
+        { unusable: bodies.unusable },
+      );
+      return NextResponse.json(
+        { success: false, message: unusableChartMessage(bodies.unusable) },
+        { status: 503 },
+      );
+    }
+    if (bodies.derivedLongitudes.length > 0) {
+      // Not an error: the placement is still consistent with its sign. Logged
+      // because a chart built at sign resolution is a DERIVED value, not a
+      // measured one, and that distinction should be visible.
+      _logger.warn(
+        "[POST /api/onboarding] longitude derived from sign+degree",
+        { bodies: bodies.derivedLongitudes },
+      );
+    }
+    const { positions, planets } = bodies;
 
     const natalChart: NatalChart = {
       birthData: {

--- a/src/app/api/user/charts/__tests__/noFabricatedChart.test.ts
+++ b/src/app/api/user/charts/__tests__/noFabricatedChart.test.ts
@@ -1,0 +1,146 @@
+/**
+ * The property that matters end to end: a chart that cannot be stated is never
+ * PERSISTED.
+ *
+ * This route saved whatever it could assemble, and what it assembled included an
+ * invented "aries" ascendant and a `?? 0` longitude — then handed it to
+ * `createSavedChart`. The unit tests for `natalBodiesFromRawPositions` cover the
+ * builder; this covers the thing a user would actually be shown later, by asserting
+ * the database is never reached.
+ */
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body, init) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+import { getPlanetaryPositionsForDateTime } from "@/services/astrologizeApi";
+import { commensalDatabase } from "@/services/commensalDatabaseService";
+import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { POST } from "../route";
+
+jest.mock("@/lib/auth/validateRequest", () => ({
+  getUserIdFromRequest: jest.fn(async () => "11111111-1111-4111-8111-111111111111"),
+}));
+jest.mock("@/services/astrologizeApi", () => ({ getPlanetaryPositionsForDateTime: jest.fn() }));
+jest.mock("@/services/commensalDatabaseService", () => ({
+  commensalDatabase: { createSavedChart: jest.fn(), listSavedCharts: jest.fn() },
+}));
+jest.mock("@/services/userDatabaseService", () => ({
+  userDatabase: { getUserById: jest.fn() },
+}));
+jest.mock("@/lib/logger", () => ({
+  _logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+}));
+
+const MEASURED = {
+  Sun: { sign: "virgo", degree: 24.76, exactLongitude: 174.7641 },
+  Moon: { sign: "taurus", degree: 3.2, exactLongitude: 33.2 },
+  Mercury: { sign: "libra", degree: 2.5, exactLongitude: 182.5 },
+  Venus: { sign: "cancer", degree: 20, exactLongitude: 110 },
+  Mars: { sign: "aries", degree: 8, exactLongitude: 8 },
+  Jupiter: { sign: "sagittarius", degree: 25, exactLongitude: 265 },
+  Saturn: { sign: "capricorn", degree: 11, exactLongitude: 281 },
+  Uranus: { sign: "aquarius", degree: 10, exactLongitude: 310 },
+  Neptune: { sign: "pisces", degree: 10, exactLongitude: 340 },
+  Pluto: { sign: "scorpio", degree: 10, exactLongitude: 220 },
+  Ascendant: { sign: "leo", degree: 15.03, exactLongitude: 135.0341 },
+};
+
+const request = (): any =>
+  ({
+    json: async () => ({
+      label: "Cosmic identity",
+      birthData: { dateTime: "1984-09-17T12:00:00.000Z", latitude: 49.79, longitude: 8.12 },
+    }),
+  }) as unknown as any;
+
+describe("POST /api/user/charts — a fabricated chart is never saved", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getUserIdFromRequest as jest.Mock).mockResolvedValue("11111111-1111-4111-8111-111111111111");
+    (commensalDatabase.createSavedChart as jest.Mock).mockResolvedValue({ id: "chart_1" });
+  });
+
+  it("CONTROL: a complete chart IS saved, with its measured longitudes", async () => {
+    (getPlanetaryPositionsForDateTime as jest.Mock).mockResolvedValue(MEASURED);
+
+    const res = await POST(request());
+    expect((await res.json()).success).toBe(true);
+    expect(commensalDatabase.createSavedChart).toHaveBeenCalledTimes(1);
+
+    const saved = (commensalDatabase.createSavedChart as jest.Mock).mock.calls[0][0];
+    const sun = saved.natalChart.planets.find((p: { name: string }) => p.name === "Sun");
+    expect(sun.position).toBe(174.7641);
+    expect(saved.natalChart.ascendant).toBe("leo");
+    // If this control ever fails, every refusal assertion below is vacuous.
+  });
+
+  it("returns 503 and saves NOTHING when the ascendant is missing", async () => {
+    (getPlanetaryPositionsForDateTime as jest.Mock).mockResolvedValue({
+      ...MEASURED,
+      Ascendant: undefined,
+    });
+
+    const res = await POST(request());
+    const data = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(data.success).toBe(false);
+    expect(data.message).toContain("Ascendant");
+    // The whole point: no row, rather than a row claiming an Aries rising.
+    expect(commensalDatabase.createSavedChart).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 and saves NOTHING when a planet is missing", async () => {
+    (getPlanetaryPositionsForDateTime as jest.Mock).mockResolvedValue({
+      ...MEASURED,
+      Pluto: undefined,
+    });
+
+    const res = await POST(request());
+
+    expect(res.status).toBe(503);
+    expect(commensalDatabase.createSavedChart).not.toHaveBeenCalled();
+  });
+
+  it("still saves when a longitude is absent, deriving it from the sign", async () => {
+    (getPlanetaryPositionsForDateTime as jest.Mock).mockResolvedValue({
+      ...MEASURED,
+      Pluto: { sign: "scorpio", degree: 10 },
+    });
+
+    const res = await POST(request());
+    expect((await res.json()).success).toBe(true);
+
+    const saved = (commensalDatabase.createSavedChart as jest.Mock).mock.calls[0][0];
+    const pluto = saved.natalChart.planets.find((p: { name: string }) => p.name === "Pluto");
+    // 210 (scorpio) + 10 — inside the sign the row itself states. Never 0.
+    expect(pluto.position).toBe(220);
+    expect(pluto.position).not.toBe(0);
+  });
+
+  it("no saved body ever carries a 0 longitude paired with a non-Aries sign", async () => {
+    // The signature of the old defect, stated as an invariant over the whole chart.
+    (getPlanetaryPositionsForDateTime as jest.Mock).mockResolvedValue(
+      Object.fromEntries(
+        Object.entries(MEASURED).map(([body, p]) => [body, { sign: p.sign, degree: p.degree }]),
+      ),
+    );
+
+    await POST(request());
+    const saved = (commensalDatabase.createSavedChart as jest.Mock).mock.calls[0][0];
+
+    for (const planet of saved.natalChart.planets) {
+      if (planet.sign !== "aries") expect(planet.position).not.toBe(0);
+      expect(Math.floor(planet.position / 30)).toBe(
+        ["aries", "taurus", "gemini", "cancer", "leo", "virgo",
+         "libra", "scorpio", "sagittarius", "capricorn", "aquarius", "pisces"].indexOf(planet.sign),
+      );
+    }
+  });
+});

--- a/src/app/api/user/charts/route.ts
+++ b/src/app/api/user/charts/route.ts
@@ -5,7 +5,9 @@
  */
 
 import { NextResponse } from "next/server";
+import { natalBodiesFromRawPositions, unusableChartMessage } from "@/lib/astrology/natalBodies";
 import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
+import { _logger } from "@/lib/logger";
 import { getPlanetaryPositionsForDateTime } from "@/services/astrologizeApi";
 import { commensalDatabase } from "@/services/commensalDatabaseService";
 import { userDatabase } from "@/services/userDatabaseService";
@@ -236,25 +238,31 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const positions: Record<Planet, ZodiacSignType> = {
-    Sun: rawPositions.Sun?.sign,
-    Moon: rawPositions.Moon?.sign,
-    Mercury: rawPositions.Mercury?.sign,
-    Venus: rawPositions.Venus?.sign,
-    Mars: rawPositions.Mars?.sign,
-    Jupiter: rawPositions.Jupiter?.sign,
-    Saturn: rawPositions.Saturn?.sign,
-    Uranus: rawPositions.Uranus?.sign,
-    Neptune: rawPositions.Neptune?.sign,
-    Pluto: rawPositions.Pluto?.sign,
-    Ascendant: rawPositions.Ascendant?.sign || "aries",
-  };
-
-  const planets: PlanetInfo[] = Object.entries(positions).map(([pname, sign]) => ({
-    name: pname as Planet,
-    sign,
-    position: rawPositions[pname]?.exactLongitude ?? 0,
-  }));
+  // One shared builder, and it REFUSES rather than filling gaps in. This block
+  // used to invent an "aries" ascendant, a 0 longitude for any body the API did
+  // not price, and `undefined` signs inside a Record that forbids them — then
+  // PERSISTED the result. See src/lib/astrology/natalBodies.ts.
+  const bodies = natalBodiesFromRawPositions(rawPositions);
+  if (!bodies.ok) {
+    _logger.error(
+      "[POST /api/user/charts] unusable chart",
+      { unusable: bodies.unusable },
+    );
+    return NextResponse.json(
+      { success: false, message: unusableChartMessage(bodies.unusable) },
+      { status: 503 },
+    );
+  }
+  if (bodies.derivedLongitudes.length > 0) {
+    // Not an error: the placement is still consistent with its sign. Logged
+    // because a chart built at sign resolution is a DERIVED value, not a
+    // measured one, and that distinction should be visible.
+    _logger.warn(
+      "[POST /api/user/charts] longitude derived from sign+degree",
+      { bodies: bodies.derivedLongitudes },
+    );
+  }
+  const { positions, planets } = bodies;
 
   const diurnal = isSectDiurnalForBirth(birthDate);
 

--- a/src/app/api/user/commensals/route.ts
+++ b/src/app/api/user/commensals/route.ts
@@ -5,13 +5,14 @@
  */
 
 import { NextResponse } from "next/server";
+import { natalBodiesFromRawPositions, unusableChartMessage } from "@/lib/astrology/natalBodies";
 import { getDatabaseUserFromRequest } from "@/lib/auth/validateRequest";
 import { _logger } from "@/lib/logger";
 import { getPlanetaryPositionsForDateTime } from "@/services/astrologizeApi";
 import { commensalDatabase } from "@/services/commensalDatabaseService";
 import { reportQuestEventBestEffort } from "@/services/questEventReporter";
 import type { Planet, ZodiacSignType, Element, Modality } from "@/types/celestial";
-import type { BirthData, NatalChart, PlanetInfo, GroupMember } from "@/types/natalChart";
+import type { BirthData, NatalChart, GroupMember } from "@/types/natalChart";
 import { calculateAlchemicalFromPlanets } from "@/utils/planetaryAlchemyMapping";
 import type { NextRequest } from "next/server";
 
@@ -148,25 +149,31 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const positions: Record<Planet, ZodiacSignType> = {
-    Sun: rawPositions.Sun?.sign,
-    Moon: rawPositions.Moon?.sign,
-    Mercury: rawPositions.Mercury?.sign,
-    Venus: rawPositions.Venus?.sign,
-    Mars: rawPositions.Mars?.sign,
-    Jupiter: rawPositions.Jupiter?.sign,
-    Saturn: rawPositions.Saturn?.sign,
-    Uranus: rawPositions.Uranus?.sign,
-    Neptune: rawPositions.Neptune?.sign,
-    Pluto: rawPositions.Pluto?.sign,
-    Ascendant: rawPositions.Ascendant?.sign || "aries",
-  };
-
-  const planets: PlanetInfo[] = Object.entries(positions).map(([pname, sign]) => ({
-    name: pname as Planet,
-    sign,
-    position: rawPositions[pname]?.exactLongitude ?? 0,
-  }));
+  // One shared builder, and it REFUSES rather than filling gaps in. This block
+  // used to invent an "aries" ascendant, a 0 longitude for any body the API did
+  // not price, and `undefined` signs inside a Record that forbids them — then
+  // PERSISTED the result. See src/lib/astrology/natalBodies.ts.
+  const bodies = natalBodiesFromRawPositions(rawPositions);
+  if (!bodies.ok) {
+    _logger.error(
+      "[POST /api/user/commensals] unusable chart",
+      { unusable: bodies.unusable },
+    );
+    return NextResponse.json(
+      { success: false, message: unusableChartMessage(bodies.unusable) },
+      { status: 503 },
+    );
+  }
+  if (bodies.derivedLongitudes.length > 0) {
+    // Not an error: the placement is still consistent with its sign. Logged
+    // because a chart built at sign resolution is a DERIVED value, not a
+    // measured one, and that distinction should be visible.
+    _logger.warn(
+      "[POST /api/user/commensals] longitude derived from sign+degree",
+      { bodies: bodies.derivedLongitudes },
+    );
+  }
+  const { positions, planets } = bodies;
 
   const natalChart: NatalChart = {
     birthData: { dateTime: birthData.dateTime, latitude: birthData.latitude, longitude: birthData.longitude, timezone: birthData.timezone },

--- a/src/lib/astrology/__tests__/natalBodies.test.ts
+++ b/src/lib/astrology/__tests__/natalBodies.test.ts
@@ -1,0 +1,153 @@
+/**
+ * A natal chart is either whole or refused — never filled in.
+ *
+ * The bug these pin: `/api/user/charts`, `/api/user/commensals` and
+ * `/api/onboarding` each carried a byte-identical block that PERSISTED a chart
+ * built from three fabrications —
+ *
+ *   position:   rawPositions[p]?.exactLongitude ?? 0      -> 0° Aries
+ *   Ascendant:  rawPositions.Ascendant?.sign || "aries"   -> a rising sign
+ *   the rest:   rawPositions.Sun?.sign                    -> undefined, inside a
+ *                                                            Record that forbids it
+ *
+ * A fabricated zero is worse than an absent value: it survives `Number.isFinite`,
+ * satisfies NOT NULL, and STOPS a later `a ?? b ?? c` chain because 0 is not
+ * nullish. Upstream that shape put `longitude: 0` on 710 of 710 stored bodies.
+ */
+import {
+  NATAL_BODIES,
+  natalBodiesFromRawPositions,
+  unusableChartMessage,
+} from "@/lib/astrology/natalBodies";
+
+/** A complete, measured chart as the astrologize layer reports one. */
+const MEASURED: Record<string, { sign: string; degree: number; exactLongitude: number }> = {
+  Sun: { sign: "virgo", degree: 24.76, exactLongitude: 174.7641 },
+  Moon: { sign: "taurus", degree: 3.2, exactLongitude: 33.2 },
+  Mercury: { sign: "libra", degree: 2.5, exactLongitude: 182.5 },
+  Venus: { sign: "cancer", degree: 20, exactLongitude: 110 },
+  Mars: { sign: "aries", degree: 8, exactLongitude: 8 },
+  Jupiter: { sign: "sagittarius", degree: 25, exactLongitude: 265 },
+  Saturn: { sign: "capricorn", degree: 11, exactLongitude: 281 },
+  Uranus: { sign: "aquarius", degree: 10, exactLongitude: 310 },
+  Neptune: { sign: "pisces", degree: 10, exactLongitude: 340 },
+  Pluto: { sign: "scorpio", degree: 10, exactLongitude: 220 },
+  Ascendant: { sign: "leo", degree: 15.03, exactLongitude: 135.0341 },
+};
+
+const withBody = (body: string, patch: unknown) => ({ ...MEASURED, [body]: patch });
+
+describe("natalBodiesFromRawPositions", () => {
+  it("CONTROL: a complete measured chart passes through untouched", () => {
+    const result = natalBodiesFromRawPositions(MEASURED);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.planets).toHaveLength(NATAL_BODIES.length);
+    expect(result.derivedLongitudes).toEqual([]);
+    // Non-vacuity: the REAL longitudes survive, to sub-arcminute precision.
+    for (const body of NATAL_BODIES) {
+      const planet = result.planets.find((p) => p.name === body);
+      expect(planet?.position).toBe(MEASURED[body].exactLongitude);
+      expect(planet?.sign).toBe(MEASURED[body].sign);
+    }
+    expect(result.positions.Ascendant).toBe("leo");
+  });
+
+  describe("a missing longitude is DERIVED from the sign, never zeroed", () => {
+    it.each([undefined, 0, Number.NaN, Number.POSITIVE_INFINITY])(
+      "exactLongitude %s becomes signIndex*30 + degree",
+      (exactLongitude) => {
+        const result = natalBodiesFromRawPositions(
+          withBody("Pluto", { sign: "scorpio", degree: 10, exactLongitude }),
+        );
+
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        const pluto = result.planets.find((p) => p.name === "Pluto");
+        // scorpio is index 7 -> 210 + 10. NOT 0, which would read as 0° Aries and
+        // contradict the sign the same row states.
+        expect(pluto?.position).toBe(220);
+        expect(pluto?.sign).toBe("scorpio");
+        expect(result.derivedLongitudes).toContain("Pluto");
+      },
+    );
+
+    it("falls back to the sign's first degree when the degree is missing too", () => {
+      const result = natalBodiesFromRawPositions(withBody("Pluto", { sign: "scorpio" }));
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // Sign resolution is the floor, and it is still IN scorpio.
+      expect(result.planets.find((p) => p.name === "Pluto")?.position).toBe(210);
+      expect(result.derivedLongitudes).toContain("Pluto");
+    });
+
+    it("reports every derived body, so a degraded chart is visible", () => {
+      const raw = Object.fromEntries(
+        Object.entries(MEASURED).map(([body, p]) => [body, { sign: p.sign, degree: p.degree }]),
+      );
+      const result = natalBodiesFromRawPositions(raw);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.derivedLongitudes).toHaveLength(NATAL_BODIES.length);
+    });
+  });
+
+  describe("a chart that cannot be stated is refused", () => {
+    it("refuses a missing Ascendant instead of calling it aries", () => {
+      const result = natalBodiesFromRawPositions(withBody("Ascendant", undefined));
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.unusable).toEqual(["Ascendant"]);
+      // The precise defect: it must not silently become the first sign.
+      expect(unusableChartMessage(result.unusable)).toContain("Ascendant");
+    });
+
+    it.each(["Sun", "Moon", "Pluto"])("refuses a missing %s rather than storing undefined", (body) => {
+      const result = natalBodiesFromRawPositions(withBody(body, undefined));
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.unusable).toEqual([body]);
+    });
+
+    it.each([{ sign: "" }, { sign: "not-a-sign" }, { sign: null }, { sign: 7 }])(
+      "refuses an unrecognised sign %p",
+      (patch) => {
+        expect(natalBodiesFromRawPositions(withBody("Venus", patch)).ok).toBe(false);
+      },
+    );
+
+    it("lists EVERY unusable body, not just the first", () => {
+      let raw: Record<string, unknown> = MEASURED;
+      for (const body of ["Sun", "Mars", "Ascendant"]) raw = { ...raw, [body]: undefined };
+      const result = natalBodiesFromRawPositions(raw);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.unusable).toEqual(["Sun", "Mars", "Ascendant"]);
+    });
+
+    it.each([null, undefined, {}])("refuses %p outright", (raw) => {
+      const result = natalBodiesFromRawPositions(raw as never);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      // Every body, so the message names the real problem rather than one symptom.
+      expect(result.unusable).toHaveLength(NATAL_BODIES.length);
+    });
+  });
+
+  it("accepts a sign in any casing, since the ingest layer is inconsistent", () => {
+    const result = natalBodiesFromRawPositions(
+      withBody("Venus", { sign: "Cancer", degree: 20, exactLongitude: 110 }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.positions.Venus).toBe("cancer");
+  });
+});

--- a/src/lib/astrology/natalBodies.ts
+++ b/src/lib/astrology/natalBodies.ts
@@ -1,0 +1,135 @@
+/**
+ * Turn raw astrologize positions into the bodies of a natal chart — or say why it
+ * cannot be done.
+ *
+ * ── The three fabrications this replaces ────────────────────────────────────
+ *
+ * `/api/user/charts`, `/api/user/commensals` and `/api/onboarding` each carried a
+ * byte-identical copy of this block, and each PERSISTS its result
+ * (`createSavedChart`, `createManualCompanion`, the user's profile):
+ *
+ * ```ts
+ * const positions: Record<Planet, ZodiacSignType> = {
+ *   Sun: rawPositions.Sun?.sign,                      // silently undefined
+ *   …
+ *   Ascendant: rawPositions.Ascendant?.sign || "aries",   // fabricated sign
+ * };
+ * const planets: PlanetInfo[] = Object.entries(positions).map(([pname, sign]) => ({
+ *   name: pname as Planet,
+ *   sign,
+ *   position: rawPositions[pname]?.exactLongitude ?? 0,   // fabricated longitude
+ * }));
+ * ```
+ *
+ * 1. `?? 0` invents an ecliptic longitude. A fabricated zero is worse than an
+ *    absent value: it survives `Number.isFinite`, satisfies a NOT NULL column, and
+ *    STOPS any later `a ?? b ?? c` chain, because 0 is not nullish. Upstream that
+ *    exact shape put `longitude: 0` on 710 of 710 stored bodies and made an audit
+ *    "find" 71 all-zero charts that were fine — see `normaliseNatalPositions` in
+ *    `src/utils/fullChartMonica.ts`.
+ * 2. `|| "aries"` invents a rising sign, the one placement a reader is most likely
+ *    to quote back to the user as fact.
+ * 3. The other ten resolve to `undefined` inside a `Record<Planet, ZodiacSignType>`
+ *    that says they cannot be — so `calcDominantElement` and friends silently score
+ *    an incomplete chart as if it were whole.
+ *
+ * ── What replaces them ─────────────────────────────────────────────────────
+ *
+ * A chart that cannot be stated is REFUSED, not filled in. All three callers
+ * already return 503 when the calculation throws; unusable output is the same
+ * condition and now takes the same exit. A stored chart is therefore either whole
+ * or absent.
+ *
+ * The longitude is never invented, but it may be DERIVED:
+ *   - MEASURED — `exactLongitude` when it states an angle (`statesALongitude`).
+ *   - DERIVED  — otherwise `signIndex * 30 + degree`, which is CONSISTENT with the
+ *     sign rather than contradicting it, and is exactly the fallback the canonical
+ *     reader `parseNatalPositions` applies. Sign-resolution at worst; never 0°
+ *     Aries for a body the chart places in Scorpio.
+ *
+ * `statesALongitude` is imported, not re-implemented: it is the same rule the
+ * agent-side writer uses, and a fourth copy is how the rule comes to differ.
+ */
+import type { Planet, ZodiacSignType } from "@/types/celestial";
+import type { PlanetInfo } from "@/types/natalChart";
+import { statesALongitude } from "@/utils/fullChartMonica";
+import { ZODIAC_ELEMENTS } from "@/utils/planetaryAlchemyMapping";
+
+const SIGN_KEYS = Object.keys(ZODIAC_ELEMENTS).map((s) => s.toLowerCase());
+
+/**
+ * The bodies every stored natal chart here is expected to carry. The Ascendant is
+ * included: it is a real computed angle in this pipeline (`fetchPlanetaryPositions`
+ * derives one from sidereal time when the backend omits it), and every consumer
+ * treats it as present.
+ */
+export const NATAL_BODIES = [
+  "Sun", "Moon", "Mercury", "Venus", "Mars",
+  "Jupiter", "Saturn", "Uranus", "Neptune", "Pluto",
+  "Ascendant",
+] as const;
+
+/** One body as the astrologize layer reports it. Every field is optional there. */
+export interface RawBodyPosition {
+  sign?: unknown;
+  degree?: number;
+  exactLongitude?: number;
+}
+
+export type NatalBodies =
+  | {
+      ok: true;
+      positions: Record<Planet, ZodiacSignType>;
+      planets: PlanetInfo[];
+      /** Bodies whose longitude was derived from sign+degree, not measured. */
+      derivedLongitudes: string[];
+    }
+  | { ok: false; unusable: string[] };
+
+/**
+ * Build the bodies, or report which ones cannot be stated.
+ *
+ * A body is unusable when its sign is missing or is not a zodiac sign — there is
+ * nothing to derive a placement from, and inventing one is the defect above.
+ */
+export function natalBodiesFromRawPositions(
+  raw: Record<string, RawBodyPosition | undefined> | null | undefined,
+): NatalBodies {
+  const positions = {} as Record<Planet, ZodiacSignType>;
+  const planets: PlanetInfo[] = [];
+  const unusable: string[] = [];
+  const derivedLongitudes: string[] = [];
+
+  for (const body of NATAL_BODIES) {
+    const entry = raw?.[body];
+    const sign = String(entry?.sign ?? "").toLowerCase();
+    const signIndex = SIGN_KEYS.indexOf(sign);
+    if (signIndex < 0) {
+      unusable.push(body);
+      continue;
+    }
+
+    let position: number;
+    if (statesALongitude(entry?.exactLongitude as number)) {
+      position = entry!.exactLongitude!;
+    } else {
+      position = signIndex * 30 + (Number.isFinite(entry?.degree) ? entry!.degree! : 0);
+      derivedLongitudes.push(body);
+    }
+
+    positions[body] = sign as ZodiacSignType;
+    planets.push({ name: body, sign: sign as ZodiacSignType, position });
+  }
+
+  if (unusable.length > 0) return { ok: false, unusable };
+  return { ok: true, positions, planets, derivedLongitudes };
+}
+
+/** The 503 body all three routes return when a chart cannot be stated. */
+export function unusableChartMessage(unusable: string[]): string {
+  return (
+    "Planetary calculation returned an unusable chart " +
+    `(no valid sign for: ${unusable.join(", ")}). ` +
+    "Please try again later."
+  );
+}

--- a/src/types/natalChart.ts
+++ b/src/types/natalChart.ts
@@ -39,7 +39,20 @@ export interface BirthData {
 export interface PlanetInfo {
   name: Planet;
   sign: ZodiacSignType;
-  /** Ecliptic longitude in decimal degrees (0-360). Sub-arcminute precision. 0 means unknown/legacy. */
+  /**
+   * Ecliptic longitude in decimal degrees (0-360), sub-arcminute where measured.
+   *
+   * ⚠️ `0` is NOT a sentinel for "unknown" in anything written after 2026-07-27.
+   * It used to be — `position: rawPositions[p]?.exactLongitude ?? 0` — and that is
+   * precisely the defect `src/lib/astrology/natalBodies.ts` exists to remove: a
+   * fabricated zero survives `Number.isFinite`, satisfies NOT NULL, stops a `??`
+   * chain, and reads as 0° Aries to every consumer. New writers either state a
+   * measured longitude, DERIVE one from sign+degree (consistent with the sign), or
+   * refuse to produce the chart at all.
+   *
+   * Rows written before then may still carry a `0` that means nothing. Treat a 0 on
+   * legacy data as suspect rather than as a placement.
+   */
   position: number;
 }
 

--- a/src/utils/fullChartMonica.ts
+++ b/src/utils/fullChartMonica.ts
@@ -132,6 +132,71 @@ export function parseNatalPositions(
 }
 
 /**
+ * The write side of the same contract: a chart keyed by planet name becomes the
+ * canonical stored row array.
+ *
+ * `natal_positions` is an ARRAY in every writer. `agents/unified` used to store
+ * its `formattedChart.planets` verbatim — an OBJECT keyed by planet name — which
+ * `parseNatalPositions` rejects on its first line, so such a chart yielded no
+ * full-chart monica at all and every caller skipped the row. No object-shaped row
+ * ever reached production (`jsonb_typeof` was `array` for all 5084 rows on
+ * 2026-07-26), so this closed a latent divergence, not a live one. The encoder
+ * lives beside the parser, and the round-trip between them is asserted in
+ * `src/app/api/agents/unified/__tests__/route.test.ts` — the missing assertion is
+ * what let the two shapes drift in the first place.
+ *
+ * The absolute longitude goes in `position`, the key the parser reads — never in
+ * `longitude`, for the reasons `normaliseNatalPositions` sets out above. This
+ * writer therefore emits nothing for that normaliser to strip, and satisfies
+ * `scripts/checkNoFabricatedNatalFields.ts`, which exists to catch exactly this:
+ * a NEW write path routing around the strip.
+ *
+ * Worth knowing if you ever change the key: the parser falls back to
+ * `signIndex * 30 + degree`, which on a chart whose `degree` agrees with its sign
+ * reconstructs the SAME number. A round-trip assertion alone therefore cannot see
+ * the wrong key — hence the explicit `position` assertion in the route test.
+ */
+export function natalPositionsFromChart(
+  planets: Record<string, { sign: string; longitude: number }>,
+): NatalPositionRow[] {
+  return Object.entries(planets)
+    .filter(([, p]) => statesALongitude(p.longitude))
+    .map(([planet, p]) => ({
+      planet,
+      sign: p.sign,
+      degree: p.longitude % 30,
+      position: p.longitude,
+    }));
+}
+
+/**
+ * Does this value state an ecliptic longitude, or merely occupy the field?
+ *
+ * ONE rule, shared by everything that writes a chart out of `calculateNatalChart`
+ * — the `natal_positions` encoder above and the `natal_chart` ascendant in
+ * `agents/unified`. Having it in two places is how the two fields come to
+ * disagree about the same body.
+ *
+ * Non-finite is rejected because JSON renders NaN as null, and the parser's
+ * `degree ?? 0` fallback would then place the body at 0° of its sign — a
+ * fabricated position with no warning.
+ *
+ * Exactly `0` is rejected for the same reason one step earlier: every longitude in
+ * this pipeline passes through a `?? 0`, so a zero cannot be told apart from an
+ * absent measurement. Two known non-observations produce it —
+ * `fetchPlanetaryPositions` leaves the ascendant at its 0 initialiser when the
+ * astrologize response carries none (deriving only the SIGN, locally, from
+ * sidereal time), and the offline planetary fallback carries
+ * `Ascendant: [0, 0, 0, "aries"]`, documented in place as a placeholder. Both are
+ * systematic; a genuine 0.000000° is measure-zero and indistinguishable anyway.
+ * Compare `normaliseNatalPositions` above, which rejects a zero `longitude` on
+ * exactly the same grounds.
+ */
+export function statesALongitude(value: number): boolean {
+  return Number.isFinite(value) && value !== 0;
+}
+
+/**
  * The reference instant used when a chart has NO birth data.
  *
  * ⚠️ It does NOT decide the answer. Sect is passed explicitly for each sect, so


### PR DESCRIPTION
The human-path twin of the agent-path defect in #657, and worse in one respect:
these charts are SAVED. `/api/user/charts` → `createSavedChart`,
`/api/user/commensals` → `createManualCompanion`, `/api/onboarding` → the user's
profile.

All three carried a byte-identical copy of this block, with three fabrications in
seven lines:

    const positions: Record<Planet, ZodiacSignType> = {
      Sun: rawPositions.Sun?.sign,                       // undefined, silently
      …
      Ascendant: rawPositions.Ascendant?.sign || "aries", // an invented rising sign
    };
    const planets: PlanetInfo[] = Object.entries(positions).map(([pname, sign]) => ({
      name: pname as Planet,
      sign,
      position: rawPositions[pname]?.exactLongitude ?? 0, // an invented longitude
    }));

1. `?? 0` invents an ecliptic longitude. A fabricated zero is worse than an absent
   value: it survives `Number.isFinite`, satisfies NOT NULL, and STOPS any later
   `a ?? b ?? c` chain, because 0 is not nullish. That exact shape put
   `longitude: 0` on 710 of 710 stored bodies upstream and made an audit "find" 71
   all-zero charts that were fine (see `normaliseNatalPositions`).
2. `|| "aries"` invents the one placement a user is most likely to be told as fact.
   And it fires on the ascendant specifically — the body whose sign a reader quotes.
3. The other ten resolve to `undefined` inside a `Record<Planet, ZodiacSignType>`
   that says they cannot be, so `calcDominantElement` and
   `calculateEnhancedAlchemicalFromPlanets` scored an incomplete chart as whole.

## The replacement

One builder, `src/lib/astrology/natalBodies.ts`, and it REFUSES rather than
filling in: a chart that cannot be stated returns 503 — the same exit all three
routes already take when the calculation throws — so a stored chart is either whole
or absent. `natalBodiesFromRawPositions` reports EVERY unusable body, not the first,
and the message names them.

A longitude is never invented, but it may be DERIVED, and the two are distinguished:
  - MEASURED — `exactLongitude` when it states an angle (`statesALongitude`).
  - DERIVED  — otherwise `signIndex * 30 + degree`, which is CONSISTENT with the
    sign instead of contradicting it, and is exactly the fallback the canonical
    reader `parseNatalPositions` already applies. Sign resolution at worst; never
    0° Aries for a body the same row places in Scorpio.

Derived bodies are logged, because a chart built at sign resolution is a different
kind of value from a measured one and that should be visible rather than inferred.

`statesALongitude` is imported from `fullChartMonica`, not re-implemented — it is
the same rule the agent-side writer uses, and a fourth copy is how the rule comes
to differ from itself.

## The type contract carried the sentinel too

`PlanetInfo.position` was documented as "0 means unknown/legacy". That is what made
the fabrication look sanctioned. Now: new writers never emit 0 as a sentinel, and a
0 on legacy rows is to be treated as suspect rather than as a placement.

## Tests — 25, red-checked

20 on the builder (measured pass-through as the CONTROL; derivation for undefined /
0 / NaN / Infinity; refusal for a missing or unrecognised sign; every unusable body
listed; null/undefined/{} refused) and 5 on the route, which assert the database is
never reached:

  reverting `charts/route.ts` to the old block fails 4 of the 5, and the CONTROL —
  a complete chart IS saved with its measured longitudes — stays green, so the
  failures are the defect and not a broken harness.

One route-level invariant is stated directly over the whole saved chart: no body
carries a 0 longitude paired with a non-Aries sign, and every body's
`floor(position / 30)` equals its own sign's index.

Verified: 176 suites / 1571 tests, `tsc --noEmit` clean, eslint clean on every
touched file, and `checkNoFabricatedNatalFields.ts` still passes against production
with its controls (710 bodies, keys `degree`/`planet`/`sign` only).

Group B of this sweep — the two parse boundaries in `astrology-utils.ts` and
`astrologize/route.ts` — is deliberately NOT here: those feed
`buildAspectsWithStrength`, so turning a fabricated 0 into an absence changes
computed ESMS and needs its own drift measurement.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

**Stacked on #657** (needs `statesALongitude` from it). Retarget to `master` once #657 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)