### PR TITLE
fix(astrologize): at the parse boundary, a fallback 0 invents a SIGN, not just an angle

### DIFF
--- a/src/__tests__/parseBoundaryLongitude.test.ts
+++ b/src/__tests__/parseBoundaryLongitude.test.ts
@@ -1,0 +1,124 @@
+/**
+ * The parse boundary must not invent a placement — and here inventing a longitude
+ * means inventing a SIGN.
+ *
+ * `formatRailwayResponse` derives the sign from the longitude
+ * (`getSignFromLongitude`), so the old
+ * `pd.exactLongitude ?? pd.longitude ?? pd.eclipticLongitude ?? 0` did not merely
+ * fabricate an angle: it produced a confident **0° Aries**, indistinguishable
+ * downstream from a measured placement. Two defects in one expression —
+ *
+ *   1. the terminal `?? 0` fabricates;
+ *   2. `0` is not nullish, so a zero in the FIRST key stopped the chain and the
+ *      other two were never consulted.
+ *
+ * `[MEASURED 2026-07-27]` against the production backend
+ * (`/api/planetary/positions`, 14 bodies): every body carries `exactLongitude`,
+ * none carries it as 0, and none carries `longitude` or `eclipticLongitude` at all.
+ * The branch is therefore unreachable on the live path — which is why it sat here
+ * for so long. These tests exercise it directly instead of waiting for an outage.
+ */
+import { formatRailwayResponse, getSignFromLongitude } from "@/server/lib/astrology-utils";
+import type { PlanetaryRequest } from "@/lib/validation/railway";
+
+const PARAMS = {
+  year: 1984, month: 9, date: 17, hour: 12, minute: 0,
+  latitude: 49.79, longitude: 8.12, zodiacSystem: "tropical",
+} as unknown as PlanetaryRequest;
+
+/** The real backend shape, as measured: exactLongitude only, on every body. */
+const MEASURED = {
+  sun: { exactLongitude: 174.76408840358263, sign: "virgo", degree: 24.76, minute: 45, isRetrograde: false },
+  moon: { exactLongitude: 33.2, sign: "taurus", degree: 3.2, minute: 12, isRetrograde: false },
+  mercury: { exactLongitude: 182.5, sign: "libra", degree: 2.5, minute: 30, isRetrograde: false },
+  venus: { exactLongitude: 110, sign: "cancer", degree: 20, minute: 0, isRetrograde: false },
+  mars: { exactLongitude: 8, sign: "aries", degree: 8, minute: 0, isRetrograde: false },
+  jupiter: { exactLongitude: 265, sign: "sagittarius", degree: 25, minute: 0, isRetrograde: false },
+  saturn: { exactLongitude: 281, sign: "capricorn", degree: 11, minute: 0, isRetrograde: false },
+  uranus: { exactLongitude: 310, sign: "aquarius", degree: 10, minute: 0, isRetrograde: false },
+  neptune: { exactLongitude: 340, sign: "pisces", degree: 10, minute: 0, isRetrograde: false },
+  pluto: { exactLongitude: 220, sign: "scorpio", degree: 10, minute: 0, isRetrograde: false },
+};
+
+const respond = (planetary_positions: Record<string, unknown>) =>
+  formatRailwayResponse({ planetary_positions } as never, PARAMS);
+
+const longitudeOf = (res: ReturnType<typeof formatRailwayResponse>, key: string) =>
+  (res._celestialBodies as Record<string, { ChartPosition: { Ecliptic: { DecimalDegrees: number } } }>)[key]
+    ?.ChartPosition?.Ecliptic?.DecimalDegrees;
+
+const signOf = (res: ReturnType<typeof formatRailwayResponse>, key: string) =>
+  (res._celestialBodies as Record<string, { Sign: { key: string } }>)[key]?.Sign?.key;
+
+describe("formatRailwayResponse — the longitude parse boundary", () => {
+  it("CONTROL: the measured backend shape round-trips with every body intact", () => {
+    const res = respond(MEASURED);
+
+    expect(res._celestialBodies.all).toHaveLength(10);
+    expect(longitudeOf(res, "sun")).toBe(174.76408840358263);
+    expect(signOf(res, "sun")).toBe("virgo");
+    expect(signOf(res, "pluto")).toBe("scorpio");
+    // If this control breaks, every assertion below is vacuous.
+  });
+
+  it("drops a body with NO longitude rather than placing it at 0° Aries", () => {
+    const res = respond({ ...MEASURED, pluto: { sign: "scorpio", isRetrograde: false } });
+
+    expect(signOf(res, "pluto")).toBeUndefined();
+    expect(res._celestialBodies.all).toHaveLength(9);
+    // The old code produced a Pluto in aries at 0°, which nothing downstream could
+    // tell apart from a real placement.
+    expect(res._celestialBodies.all.map((b) => b.key)).not.toContain("pluto");
+  });
+
+  it("passes OVER a zero first key instead of stopping at it", () => {
+    // The chain-stop half of the defect: `0 ?? next` never reaches `next`, because
+    // 0 is not nullish. Here the real value is in the second key.
+    const res = respond({
+      ...MEASURED,
+      pluto: { exactLongitude: 0, longitude: 220, sign: "scorpio", isRetrograde: false },
+    });
+
+    expect(longitudeOf(res, "pluto")).toBe(220);
+    expect(signOf(res, "pluto")).toBe("scorpio");
+  });
+
+  it.each([
+    ["eclipticLongitude", { eclipticLongitude: 220 }],
+    ["longitude", { longitude: 220 }],
+  ])("still honours the alternate key %s when it is the only one present", (_label, patch) => {
+    const res = respond({ ...MEASURED, pluto: { ...patch, sign: "scorpio", isRetrograde: false } });
+
+    expect(longitudeOf(res, "pluto")).toBe(220);
+    expect(signOf(res, "pluto")).toBe("scorpio");
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, null, undefined, "220"])(
+    "treats a non-finite or non-numeric longitude (%p) as absent",
+    (exactLongitude) => {
+      const res = respond({
+        ...MEASURED,
+        pluto: { exactLongitude, sign: "scorpio", isRetrograde: false },
+      });
+
+      // Dropped, not silently 0 — and definitely not NaN°, which getSignFromLongitude
+      // would turn into aries as well.
+      expect(signOf(res, "pluto")).toBeUndefined();
+    },
+  );
+
+  it("a body genuinely at 0° Aries is indistinguishable from absence — and is dropped", () => {
+    // Stated as a known, accepted cost rather than left implicit: this pipeline
+    // cannot tell a true 0.000000° from the placeholder, and the placeholder is the
+    // systematic case while a true 0 is measure-zero.
+    const res = respond({ ...MEASURED, mars: { exactLongitude: 0, sign: "aries", isRetrograde: false } });
+
+    expect(signOf(res, "mars")).toBeUndefined();
+  });
+
+  it("getSignFromLongitude is why 0 is dangerous here", () => {
+    // The mechanism, pinned: 0 is not a neutral value at this boundary.
+    expect(getSignFromLongitude(0)).toEqual({ sign: "aries", degree: 0 });
+    expect(getSignFromLongitude(220).sign).toBe("scorpio");
+  });
+});

--- a/src/app/api/agents/unified/__tests__/route.test.ts
+++ b/src/app/api/agents/unified/__tests__/route.test.ts
@@ -1,0 +1,409 @@
+/**
+ * What `agents/unified` writes into `user_profiles.natal_positions` must be what
+ * `parseNatalPositions` can read back.
+ *
+ * The bug these pin: the route stored `formattedChart.planets` verbatim — an
+ * OBJECT keyed by planet name — while every other writer (the PA sync path via
+ * `/api/internal/agent-sync`, and `/api/economy/sync-debit`) stores an ARRAY of
+ * `{ planet, sign, degree }`. `parseNatalPositions` begins with
+ * `if (!Array.isArray(raw)) return null`, so a chart written here yielded NO
+ * full-chart monica at all and every consumer skipped the row.
+ *
+ * `[MEASURED 2026-07-26]` on production `jsonb_typeof(natal_positions)` was
+ * `array` for all 5084 rows, so no object-shaped row ever landed — the divergence
+ * was latent, and there was no data to repair. What was missing was this
+ * assertion: nothing tied the writer's shape to the reader's, so they drifted.
+ */
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn((body, init) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    })),
+  },
+}));
+
+import { calculateNatalChart } from "@/services/natalChartService";
+import { executeQuery } from "@/lib/database";
+import {
+  MIN_CHART_BODIES,
+  fullChartMonica,
+  natalPositionsFromChart,
+  parseNatalPositions,
+  statesALongitude,
+} from "@/utils/fullChartMonica";
+import { POST } from "../route";
+
+jest.mock("@/lib/database", () => ({
+  executeQuery: jest.fn(),
+}));
+jest.mock("@/lib/auth/auth", () => ({
+  auth: jest.fn(async () => ({ user: { id: "creator-uuid-0001" } })),
+}));
+jest.mock("@/lib/rateLimit", () => ({
+  rateLimit: jest.fn(async () => ({ allowed: true })),
+}));
+jest.mock("@/services/natalChartService", () => ({
+  calculateNatalChart: jest.fn(),
+}));
+// Module-scope imports of the route that the "create" path never touches.
+jest.mock("@/lib/agents/persona/build-agent-context", () => ({
+  buildAgentContext: jest.fn(),
+}));
+jest.mock("@/lib/serviceUrls", () => ({
+  getServiceUrlSafe: jest.fn(() => null),
+}));
+
+/**
+ * A fixed chart in the shape `calculateNatalChart` really returns: lowercase
+ * signs (`normalizeSignName`), `position` as ABSOLUTE ecliptic longitude, and
+ * an `Ascendant` entry alongside the ten planets.
+ */
+const CHART_LONGITUDES: Record<string, { sign: string; position: number }> = {
+  Sun: { sign: "leo", position: 135 },
+  Moon: { sign: "taurus", position: 33 },
+  Mercury: { sign: "virgo", position: 152.5 },
+  Venus: { sign: "cancer", position: 110 },
+  Mars: { sign: "aries", position: 8 },
+  Jupiter: { sign: "sagittarius", position: 265 },
+  Saturn: { sign: "capricorn", position: 281 },
+  Uranus: { sign: "aquarius", position: 310 },
+  Neptune: { sign: "pisces", position: 340 },
+  Pluto: { sign: "scorpio", position: 220 },
+  Ascendant: { sign: "gemini", position: 75 },
+};
+
+const serverChart = {
+  planets: Object.entries(CHART_LONGITUDES).map(([name, p]) => ({
+    name,
+    sign: p.sign,
+    position: p.position,
+  })),
+  ascendant: "gemini",
+  elementalBalance: { Fire: 0.4, Water: 0.3, Earth: 0.2, Air: 0.1 },
+};
+
+const CREATE_BODY = {
+  action: "create",
+  parameters: {
+    name: "Test Agent",
+    purpose: "Pin the natal_positions shape",
+    // In range: the route rejects a year outside 1900-2100 outright.
+    birthInfo: {
+      year: 1984,
+      month: 9,
+      day: 17,
+      hour: 12,
+      minute: 0,
+      latitude: 49.79,
+      longitude: 8.12,
+      timezone: "Europe/Berlin",
+      locationName: "Bermersheim vor der Höhe",
+    },
+  },
+};
+
+function makeRequest(body: unknown): any {
+  return {
+    headers: { get: () => null },
+    json: async () => body,
+  } as unknown as any;
+}
+
+/** The parameter array of the `INSERT INTO user_profiles` the route just ran. */
+function captureUserProfilesParams(): unknown[] {
+  const call = (executeQuery as jest.Mock).mock.calls.find(([sql]: [string]) =>
+    sql.includes("INSERT INTO user_profiles"),
+  );
+  if (!call) throw new Error("INSERT INTO user_profiles was never called");
+  return call[1];
+}
+
+/** natal_positions is $6 of that INSERT — index 5. */
+const NATAL_POSITIONS_PARAM = 5;
+/** natal_chart is $5 — index 4. */
+const NATAL_CHART_PARAM = 4;
+
+async function createAgent(): Promise<unknown[]> {
+  const res = await POST(makeRequest(CREATE_BODY));
+  const data = await res.json();
+  // Guard: a failed create would make every assertion below vacuous, and the
+  // route reports the reason in the body — surface it rather than a bare false.
+  if (data.success !== true) throw new Error(`create failed: ${JSON.stringify(data)}`);
+  return captureUserProfilesParams();
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (calculateNatalChart as jest.Mock).mockResolvedValue(serverChart);
+  (executeQuery as jest.Mock).mockResolvedValue({ rows: [], rowCount: 1 });
+});
+
+describe("POST /api/agents/unified — the natal_positions it writes", () => {
+  it("writes an ARRAY, not an object keyed by planet name", async () => {
+    const params = await createAgent();
+    const written = JSON.parse(params[NATAL_POSITIONS_PARAM] as string);
+
+    expect(Array.isArray(written)).toBe(true);
+    // Same test Postgres answers with jsonb_typeof, and the same one the
+    // canonical parser applies on its first line.
+    expect(written).toHaveLength(Object.keys(CHART_LONGITUDES).length);
+  });
+
+  it("round-trips through parseNatalPositions to a non-null chart", async () => {
+    const params = await createAgent();
+    const written = JSON.parse(params[NATAL_POSITIONS_PARAM] as string);
+
+    const positions = parseNatalPositions(written);
+    expect(positions).not.toBeNull();
+    expect(Object.keys(positions!).sort()).toEqual(
+      Object.keys(CHART_LONGITUDES).sort(),
+    );
+    // Non-vacuity: a chart this size clears the usability floor by a margin, so
+    // the assertion above is not passing on a boundary.
+    expect(Object.keys(positions!).length).toBeGreaterThan(MIN_CHART_BODIES);
+  });
+
+  it("yields a real full-chart monica for the row it just wrote", async () => {
+    const params = await createAgent();
+    const written = JSON.parse(params[NATAL_POSITIONS_PARAM] as string);
+
+    // The consumer that the object shape silently starved: both backfill
+    // (`scripts/backfillMonicaPerConstruction.ts`) and the drift check skip any
+    // row whose chart parses to null.
+    const monica = fullChartMonica(written);
+    expect(monica).not.toBeNull();
+    expect(Number.isFinite(monica!.diurnal)).toBe(true);
+    expect(Number.isFinite(monica!.nocturnal)).toBe(true);
+    expect(monica!.combined).toBe((monica!.diurnal + monica!.nocturnal) / 2);
+  });
+
+  it("carries the REAL absolute longitude in `position`, the key the parser reads", async () => {
+    const params = await createAgent();
+    const written = JSON.parse(params[NATAL_POSITIONS_PARAM] as string) as Array<
+      Record<string, unknown>
+    >;
+
+    for (const row of written) {
+      const expected = CHART_LONGITUDES[row.planet as string];
+      expect(expected).toBeDefined();
+      expect(row.sign).toBe(expected.sign);
+      expect(row.position).toBe(expected.position);
+      expect(row.degree).toBe(expected.position % 30);
+      // `longitude` is not on this contract. The route's own chart blob uses
+      // that name, and copying it here would read to the parser as no
+      // longitude at all — see the parser test below for why that matters.
+      expect(row.longitude).toBeUndefined();
+    }
+  });
+
+  it("leaves the natal_chart blob's own shape alone", async () => {
+    const params = await createAgent();
+    const chart = JSON.parse(params[NATAL_CHART_PARAM] as string);
+
+    // natal_chart is a different contract: an object keyed by planet name, read
+    // by the client. Only natal_positions changed shape.
+    expect(Array.isArray(chart.planets)).toBe(false);
+    expect(chart.planets.Sun).toMatchObject({ sign: "leo", longitude: 135 });
+  });
+});
+
+/**
+ * The ascendant of the same stored blob.
+ *
+ * The bug these pin: `formattedChart.ascendant` came from
+ * `SIGN_ORDER.indexOf(serverChart.ascendant) * 30` against a Capitalised list,
+ * while every sign `calculateNatalChart` returns is lowercase
+ * (`normalizeSignName`). `indexOf` was always -1, so the stored ascendant was
+ * always 0 — and `flattenNatalChart` (`src/lib/mcp/synastryTools.ts:213-237`)
+ * reads a numeric `ascendant` as an absolute longitude, so such a row would put an
+ * Ascendant fabricated at 0° Aries into every synastry score and transit overlay
+ * that read it. `midheaven` was never computed at all, yet shipped the same
+ * literal 0 through the same reader.
+ *
+ * `[MEASURED 2026-07-26]` all 71 chart-bearing agents in production hold a
+ * NON-ZERO numeric ascendant and none holds a zero midheaven, so no surviving row
+ * bears this create path's signature and there is nothing to repair — the same
+ * latency, and the same cause, as the shape defect above.
+ */
+describe("POST /api/agents/unified — the ascendant it writes", () => {
+  const SIGNS = [
+    "aries", "taurus", "gemini", "cancer", "leo", "virgo",
+    "libra", "scorpio", "sagittarius", "capricorn", "aquarius", "pisces",
+  ];
+
+  async function storedChart(): Promise<Record<string, unknown>> {
+    const params = await createAgent();
+    return JSON.parse(params[NATAL_CHART_PARAM] as string);
+  }
+
+  it("stores the chart's REAL ascendant longitude", async () => {
+    const chart = await storedChart();
+
+    // 75°, the Ascendant body's own longitude. Distinguishes all three
+    // candidates: 0 was the bug, 60 would be the sign-start reconstruction the
+    // broken lookup was reaching for, 75 is the angle the chart actually states.
+    expect(chart.ascendant).toBe(CHART_LONGITUDES.Ascendant.position);
+    expect(chart.ascendant).not.toBe(0);
+    expect(chart.ascendant).not.toBe(SIGNS.indexOf("gemini") * 30);
+  });
+
+  it("the stored longitude falls in the ascendant's own sign", async () => {
+    const chart = await storedChart();
+
+    // The consistency the old code could not have had: a longitude of 0 lands in
+    // aries, which disagrees with every ascendant sign but one.
+    const sign = SIGNS[Math.floor((chart.ascendant as number) / 30)];
+    expect(sign).toBe(CHART_LONGITUDES.Ascendant.sign);
+    expect(sign).toBe(serverChart.ascendant);
+  });
+
+  it("writes null, not 0, when the chart carries no Ascendant body", async () => {
+    (calculateNatalChart as jest.Mock).mockResolvedValue({
+      ...serverChart,
+      planets: serverChart.planets.filter((p) => p.name !== "Ascendant"),
+    });
+
+    // null is skipped by flattenNatalChart; 0 would be placed at 0° Aries.
+    expect((await storedChart()).ascendant).toBeNull();
+  });
+
+  it("a placeholder ascendant is absent from BOTH fields, not null in one and 0° Aries in the other", async () => {
+    (calculateNatalChart as jest.Mock).mockResolvedValue({
+      ...serverChart,
+      planets: serverChart.planets.map((p) =>
+        p.name === "Ascendant" ? { ...p, position: 0 } : p,
+      ),
+    });
+
+    const params = await createAgent();
+    const chart = JSON.parse(params[NATAL_CHART_PARAM] as string);
+    const positions = JSON.parse(params[NATAL_POSITIONS_PARAM] as string) as Array<
+      Record<string, unknown>
+    >;
+
+    // The disagreement this pins: natal_chart said "no angle" while
+    // natal_positions still carried the body at position 0, where the parser
+    // would hand it to alchemize as a real placement at 0° aries — with the
+    // sign gemini beside it.
+    expect(chart.ascendant).toBeNull();
+    expect(positions.some((r) => r.planet === "Ascendant")).toBe(false);
+    // The ten real planets survive, so the chart is still usable.
+    expect(positions).toHaveLength(Object.keys(CHART_LONGITUDES).length - 1);
+    expect(parseNatalPositions(positions)).not.toBeNull();
+  });
+
+  it("writes null for a placeholder ascendant at longitude 0", async () => {
+    // What `fetchPlanetaryPositions` produces when the astrologize response has
+    // no ascendant: a locally derived SIGN paired with the 0 initialiser. The
+    // pair is self-contradictory — 0 is 0° aries, not 15° gemini — so the angle
+    // is absent, not zero.
+    (calculateNatalChart as jest.Mock).mockResolvedValue({
+      ...serverChart,
+      planets: serverChart.planets.map((p) =>
+        p.name === "Ascendant" ? { ...p, position: 0 } : p,
+      ),
+    });
+
+    expect((await storedChart()).ascendant).toBeNull();
+  });
+
+  it("omits midheaven rather than storing an MC it never computed", async () => {
+    const chart = await storedChart();
+
+    expect(chart.midheaven).toBeUndefined();
+    expect("midheaven" in chart).toBe(false);
+  });
+
+  it("still records the ascendant among the planets it writes", async () => {
+    // The angle survives in natal_positions too, where the parser reads it as a
+    // body — so this fix does not depend on the natal_chart blob alone.
+    const params = await createAgent();
+    const positions = JSON.parse(params[NATAL_POSITIONS_PARAM] as string) as Array<
+      Record<string, unknown>
+    >;
+
+    const ascendant = positions.find((r) => r.planet === "Ascendant");
+    expect(ascendant?.position).toBe(CHART_LONGITUDES.Ascendant.position);
+  });
+});
+
+describe("natalPositionsFromChart / parseNatalPositions — the contract itself", () => {
+  /** The route's chart-blob shape, as `formattedChart.planets` builds it. */
+  const chartPlanets = Object.fromEntries(
+    Object.entries(CHART_LONGITUDES).map(([name, p]) => [
+      name,
+      {
+        sign: p.sign,
+        degree: p.position % 30,
+        retrograde: false,
+        longitude: p.position,
+      },
+    ]),
+  );
+
+  it("the OLD payload — the chart object itself — parses to null", () => {
+    // The defect, stated directly. If this ever starts returning a chart, the
+    // shape assertions above stop being load-bearing.
+    expect(parseNatalPositions(chartPlanets)).toBeNull();
+  });
+
+  it("the encoded array parses back to every body", () => {
+    const rows = natalPositionsFromChart(chartPlanets);
+    const positions = parseNatalPositions(JSON.parse(JSON.stringify(rows)));
+
+    expect(positions).not.toBeNull();
+    for (const [planet, p] of Object.entries(CHART_LONGITUDES)) {
+      expect(positions![planet].exactLongitude).toBe(p.position);
+      expect(positions![planet].sign).toBe(p.sign);
+    }
+  });
+
+  it("`position` is what the parser believes — sign and degree do not override it", () => {
+    // Why the key matters. Here `position` disagrees with sign+degree; the
+    // parser follows `position`. A row that named the field `longitude` instead
+    // would land on the sign+degree reconstruction with no error anywhere.
+    const [followed] = Object.values(
+      parseNatalPositions([
+        { planet: "Sun", sign: "aries", degree: 1, position: 200.25 },
+        ...natalPositionsFromChart(chartPlanets).slice(1),
+      ])!,
+    );
+    expect(followed.exactLongitude).toBe(200.25);
+    expect(followed.degree).toBeCloseTo(20.25, 10);
+  });
+
+  it.each([
+    ["NaN", Number.NaN],
+    ["a placeholder 0", 0],
+    ["Infinity", Number.POSITIVE_INFINITY],
+  ])("drops a body whose longitude is %s rather than placing it at 0° of its sign", (_label, longitude) => {
+    const rows = natalPositionsFromChart({
+      ...chartPlanets,
+      Chiron: { sign: "libra", longitude: longitude as number },
+    });
+
+    expect(rows.some((r) => r.planet === "Chiron")).toBe(false);
+    expect(rows).toHaveLength(Object.keys(CHART_LONGITUDES).length);
+  });
+
+  it("statesALongitude is the one rule both writers apply", () => {
+    // Single-sourced deliberately: the encoder and the route's ascendant used to
+    // carry their own copy of this test, which is how the two fields of one row
+    // came to disagree about the same body.
+    expect(statesALongitude(135.0341)).toBe(true);
+    expect(statesALongitude(-12.5)).toBe(true); // negative is still a stated angle
+    expect(statesALongitude(0)).toBe(false);
+    expect(statesALongitude(Number.NaN)).toBe(false);
+    expect(statesALongitude(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+
+  it("an empty chart encodes to [] — the literal readers already treat as absent", () => {
+    // Not `{}`: every consumer's emptiness guard is
+    // `natal_positions::text NOT IN ('[]', 'null', '{}')`, and jsonbOrNull
+    // treats both as absent, but only `[]` is type-correct for this column.
+    expect(natalPositionsFromChart({})).toEqual([]);
+    expect(parseNatalPositions([])).toBeNull();
+  });
+});

--- a/src/app/api/agents/unified/route.ts
+++ b/src/app/api/agents/unified/route.ts
@@ -8,6 +8,7 @@ import { getServiceUrlSafe } from "@/lib/serviceUrls";
 import { calculateNatalChart } from "@/services/natalChartService";
 import { alchemize, type PlanetaryPosition } from "@/services/RealAlchemizeService";
 import { isDiurnalAt } from "@/utils/astrology/positions";
+import { natalPositionsFromChart, statesALongitude } from "@/utils/fullChartMonica";
 import type { NextRequest} from "next/server";
 
 export const dynamic = "force-dynamic";
@@ -19,6 +20,48 @@ const RATE_LIMIT = { window: 60_000, max: 20, bucket: "agents-unified" };
 interface UnifiedAgentRequest {
   action: string;
   parameters?: any;
+}
+
+/**
+ * The chart's Ascendant longitude, or null when the chart states no angle.
+ *
+ * `calculateNatalChart` carries the Ascendant in `planets` alongside the ten
+ * bodies, and in production it is a real computed angle — the pyswisseph backend
+ * returns `ascendant.exactLongitude` (`[MEASURED 2026-07-26]` 135.0341° for a
+ * 1984-09-17T12:00Z birth at 49.79N 8.12E, source `backend-pyswisseph`).
+ *
+ * This replaces `SIGN_ORDER.indexOf(serverChart.ascendant) * 30`, which looked a
+ * sign up in a Capitalised list while every sign from `normalizeSignName` is
+ * lowercase: `indexOf` was therefore ALWAYS -1 and the stored ascendant was
+ * ALWAYS 0. (Same defect class as the one already documented in
+ * `src/utils/astrology/natalAlchemy.ts` — a lowercase sign against capitalised
+ * keys, failing silently.) Even had the lookup worked it would have rounded the
+ * angle down to its sign's first degree; the exact longitude is right here.
+ *
+ * That 0 would not have been inert: `flattenNatalChart`
+ * (`src/lib/mcp/synastryTools.ts`) reads a numeric `ascendant` as an absolute
+ * longitude, so it would place a fabricated Ascendant at 0° Aries into every
+ * synastry score and transit overlay that read such a row.
+ *
+ * `[MEASURED 2026-07-26]` no production row carries one: all **71** chart-bearing
+ * agents hold a non-zero numeric ascendant, **0** hold a zero, and no row holds a
+ * zero midheaven. As with the `natal_positions` shape below, no surviving row
+ * bears this create path's signature (a later PA sync COALESCEs `natal_chart`, so
+ * this says nothing survives, not that nothing was ever written) — which is why
+ * both defects were latent, and why there is no data to repair.
+ *
+ * `statesALongitude` decides what counts as an angle at all, and is the SAME rule
+ * `natalPositionsFromChart` applies to the bodies — so a placeholder is absent
+ * from both fields of this row, never null in one and 0° Aries in the other. null
+ * makes every reader skip the point, where 0 makes all of them place it at 0°
+ * Aries.
+ */
+function ascendantLongitude(
+  planets: Array<{ name: string; position: number }>,
+): number | null {
+  const ascendant = planets.find((p) => p.name === "Ascendant");
+  if (!ascendant || !statesALongitude(ascendant.position)) return null;
+  return ascendant.position;
 }
 
 export async function POST(request: NextRequest) {
@@ -161,8 +204,15 @@ export async function POST(request: NextRequest) {
           planets: {} as Record<string, { sign: string; degree: number; retrograde: boolean; longitude: number }>,
           houses: {} as Record<string, number>,
           aspects: [] as any[],
-          ascendant: 0,
-          midheaven: 0
+          // A real angle or null, never a placeholder — see ascendantLongitude().
+          ascendant: null as number | null,
+          // No `midheaven` key. Nothing in this chart computes an MC, and the
+          // field was previously initialised to 0 and never written — which
+          // `flattenNatalChart` would read as a real MC at 0° Aries, exactly as it
+          // would the ascendant. An absent key is skipped there instead. (The 71
+          // prod rows that DO carry a midheaven were written elsewhere; none is
+          // 0.) `/api/planetary-rectification` computes a real MC if one is
+          // ever wanted here.
         };
 
         serverChart.planets.forEach((p) => {
@@ -174,9 +224,7 @@ export async function POST(request: NextRequest) {
           };
         });
 
-        const SIGN_ORDER = ['Aries', 'Taurus', 'Gemini', 'Cancer', 'Leo', 'Virgo', 'Libra', 'Scorpio', 'Sagittarius', 'Capricorn', 'Aquarius', 'Pisces'];
-        const ascIdx = SIGN_ORDER.indexOf(serverChart.ascendant);
-        formattedChart.ascendant = ascIdx >= 0 ? ascIdx * 30 : 0;
+        formattedChart.ascendant = ascendantLongitude(serverChart.planets);
 
         // §18e — a real thermodynamic monica from the whole chart, via the
         // canonical engine. This replaces a longitude average
@@ -241,7 +289,13 @@ export async function POST(request: NextRequest) {
             purpose,
             JSON.stringify(birthData),
             JSON.stringify(formattedChart),
-            JSON.stringify(formattedChart.planets || {}),
+            // natal_positions is an ARRAY of {planet, sign, degree, position} —
+            // the shape `parseNatalPositions` reads and the shape the other two
+            // writers (PA sync, sync-debit) store. This used to pass
+            // `formattedChart.planets` straight through, which is an OBJECT keyed
+            // by planet name; the parser rejects a non-array outright, so a chart
+            // written here produced NO full-chart monica for any consumer.
+            JSON.stringify(natalPositionsFromChart(formattedChart.planets)),
             monicaConstant,
             // §18j — this agent has a real birth chart, so monica_constant is
             // built by the full-chart engine (alchemize()), not the single-body

--- a/src/app/api/astrologize/route.ts
+++ b/src/app/api/astrologize/route.ts
@@ -18,6 +18,7 @@ import {
   type RailwayPlanetData,
 } from "@/lib/validation/railway";
 import { getAccuratePlanetaryPositions, getSignFromLongitude } from "@/utils/astrology/positions";
+import { statesALongitude } from "@/utils/fullChartMonica";
 import type { NextRequest } from "next/server";
 
 export const dynamic = "force-dynamic";
@@ -145,6 +146,8 @@ function formatRailwayResponse(
 
   const bodies: Record<string, CelestialBody> = {};
   const allBodies: CelestialBody[] = [];
+  /** Bodies dropped for want of a usable longitude — reported, never fabricated. */
+  const unusableBodies: string[] = [];
 
   const positionsData =
     railwayData.planetary_positions ??
@@ -159,11 +162,25 @@ function formatRailwayResponse(
     if (!planetData || typeof planetData !== "object") continue;
 
     const pd = planetData;
-    const longitude =
-      pd.exactLongitude ??
-      pd.longitude ??
-      pd.eclipticLongitude ??
-      0;
+
+    // ⚠️ The SIGN comes from this longitude on the next line, so a fallback `0`
+    // invents 0° ARIES rather than merely an angle. And because `0` is not nullish,
+    // the old `?? ?? ?? 0` chain also STOPPED at a zero first key instead of trying
+    // the other two. Per-candidate `statesALongitude` fixes both halves.
+    //
+    // `[MEASURED 2026-07-27]` against the production backend, 14 bodies: all carry
+    // `exactLongitude`, none as 0, and none carries `longitude` or
+    // `eclipticLongitude` — so the first candidate always wins and this is
+    // unreachable on the live path. (This whole function is a duplicate of
+    // `formatRailwayResponse` in `src/server/lib/astrology-utils.ts`, which is why
+    // the same fix appears twice; unifying them is a separate change.)
+    const longitude = [pd.exactLongitude, pd.longitude, pd.eclipticLongitude].find(
+      (candidate) => statesALongitude(candidate as number),
+    );
+    if (longitude === undefined) {
+      unusableBodies.push(capitalizedKey);
+      continue;
+    }
 
     const { sign, degree: degreeInSign } = getSignFromLongitude(longitude);
     const degrees = Math.floor(degreeInSign);
@@ -191,6 +208,13 @@ function formatRailwayResponse(
     allBodies.push(body);
   }
 
+  if (unusableBodies.length > 0) {
+    console.warn(
+      `[astrologize] dropped ${unusableBodies.length} body/bodies with no usable ` +
+        `longitude: ${unusableBodies.join(", ")}`,
+    );
+  }
+
   // Extract Ascendant if the backend computed it (added via PySwisseph modifications)
   let ascendant: AscendantData | undefined;
   const positionsRecord = positionsData;
@@ -199,18 +223,29 @@ function formatRailwayResponse(
     (positionsRecord.ascendant);
 
   if (ascData) {
-    const ascLong =
-      ascData.exactLongitude ??
-      ascData.longitude ??
-      ascData.eclipticLongitude ??
-      0;
-    const { sign: ascSign, degree: ascDeg } = getSignFromLongitude(ascLong);
-    ascendant = {
-      sign: ascSign,
-      degree: Math.floor(ascDeg),
-      minute: Math.floor((ascDeg - Math.floor(ascDeg)) * 60),
-      exactLongitude: ascLong,
-    };
+    const ascLong = [ascData.exactLongitude, ascData.longitude, ascData.eclipticLongitude].find(
+      (candidate) => statesALongitude(candidate as number),
+    );
+    if (ascLong === undefined) {
+      // `ascendant` stays undefined — the field is optional precisely so that
+      // "we do not have one" can be said. This matters more than the planet case:
+      // `natalChartService` tests `data.ascendant?.sign`, so a fabricated
+      // `{sign: "aries", exactLongitude: 0}` SATISFIES that test and suppresses the
+      // local sidereal-time derivation that would otherwise produce a real sign.
+      // Leaving it absent hands the question to that derivation instead.
+      console.warn(
+        "[astrologize] backend returned an Ascendant with no usable longitude; " +
+          "omitting it so the local derivation runs instead of storing 0° Aries",
+      );
+    } else {
+      const { sign: ascSign, degree: ascDeg } = getSignFromLongitude(ascLong);
+      ascendant = {
+        sign: ascSign,
+        degree: Math.floor(ascDeg),
+        minute: Math.floor((ascDeg - Math.floor(ascDeg)) * 60),
+        exactLongitude: ascLong,
+      };
+    }
   }
 
   return {

--- a/src/server/lib/astrology-utils.ts
+++ b/src/server/lib/astrology-utils.ts
@@ -1,4 +1,5 @@
 import * as Astronomy from "astronomy-engine";
+import { statesALongitude } from "@/utils/fullChartMonica";
 import { 
   type PlanetaryRequest, 
   type RailwayPositionsResponse, 
@@ -94,6 +95,8 @@ export function formatRailwayResponse(
 
   const bodies: Record<string, CelestialBody> = {};
   const allBodies: CelestialBody[] = [];
+  /** Bodies dropped for want of a usable longitude — reported, never fabricated. */
+  const unusableBodies: string[] = [];
 
   const positionsData =
     railwayData.planetary_positions ??
@@ -106,7 +109,33 @@ export function formatRailwayResponse(
     if (!planetData || typeof planetData !== "object") continue;
 
     const pd = planetData;
-    const longitude = pd.exactLongitude ?? pd.longitude ?? pd.eclipticLongitude ?? 0;
+
+    // ⚠️ The SIGN is derived from this longitude two lines down, so a fallback `0`
+    // does not merely invent an angle — it invents 0° ARIES, and every consumer
+    // downstream reads that as a measured placement.
+    //
+    // This was `pd.exactLongitude ?? pd.longitude ?? pd.eclipticLongitude ?? 0`.
+    // Two defects in one expression: the terminal `?? 0` fabricates, and because
+    // `0` is not nullish the chain also STOPS at a zero in the first key and never
+    // consults the other two. `statesALongitude` is applied per candidate instead,
+    // so a zero is passed over rather than accepted or treated as a terminator.
+    //
+    // `[MEASURED 2026-07-27]` against the production backend
+    // (`/api/planetary/positions`, 14 bodies): every body carries `exactLongitude`,
+    // none carries it as 0, and NO body carries `longitude` or `eclipticLongitude`
+    // at all. So on the live path the first candidate always wins and this branch
+    // is unreachable — which is exactly why it could sit here fabricating Aries for
+    // a malformed response without anyone noticing.
+    const longitude = [pd.exactLongitude, pd.longitude, pd.eclipticLongitude].find(
+      (candidate) => statesALongitude(candidate as number),
+    );
+    if (longitude === undefined) {
+      // Skip the body rather than place it at 0° Aries. The loop already skips a
+      // body with no data at all; a body with no usable longitude is the same
+      // condition, and an absent body is honest where a fabricated one is not.
+      unusableBodies.push(capitalizedKey);
+      continue;
+    }
 
     const { sign, degree: degreeInSign } = getSignFromLongitude(longitude);
     const degrees = Math.floor(degreeInSign);
@@ -132,6 +161,15 @@ export function formatRailwayResponse(
 
     bodies[key] = body;
     allBodies.push(body);
+  }
+
+  if (unusableBodies.length > 0) {
+    // Visible, not swallowed: a short chart is a real event worth seeing in logs,
+    // where a chart quietly padded with Aries placements is not.
+    console.warn(
+      `[formatRailwayResponse] dropped ${unusableBodies.length} body/bodies with no ` +
+        `usable longitude: ${unusableBodies.join(", ")}`,
+    );
   }
 
   return {

--- a/src/utils/fullChartMonica.ts
+++ b/src/utils/fullChartMonica.ts
@@ -132,6 +132,71 @@ export function parseNatalPositions(
 }
 
 /**
+ * The write side of the same contract: a chart keyed by planet name becomes the
+ * canonical stored row array.
+ *
+ * `natal_positions` is an ARRAY in every writer. `agents/unified` used to store
+ * its `formattedChart.planets` verbatim — an OBJECT keyed by planet name — which
+ * `parseNatalPositions` rejects on its first line, so such a chart yielded no
+ * full-chart monica at all and every caller skipped the row. No object-shaped row
+ * ever reached production (`jsonb_typeof` was `array` for all 5084 rows on
+ * 2026-07-26), so this closed a latent divergence, not a live one. The encoder
+ * lives beside the parser, and the round-trip between them is asserted in
+ * `src/app/api/agents/unified/__tests__/route.test.ts` — the missing assertion is
+ * what let the two shapes drift in the first place.
+ *
+ * The absolute longitude goes in `position`, the key the parser reads — never in
+ * `longitude`, for the reasons `normaliseNatalPositions` sets out above. This
+ * writer therefore emits nothing for that normaliser to strip, and satisfies
+ * `scripts/checkNoFabricatedNatalFields.ts`, which exists to catch exactly this:
+ * a NEW write path routing around the strip.
+ *
+ * Worth knowing if you ever change the key: the parser falls back to
+ * `signIndex * 30 + degree`, which on a chart whose `degree` agrees with its sign
+ * reconstructs the SAME number. A round-trip assertion alone therefore cannot see
+ * the wrong key — hence the explicit `position` assertion in the route test.
+ */
+export function natalPositionsFromChart(
+  planets: Record<string, { sign: string; longitude: number }>,
+): NatalPositionRow[] {
+  return Object.entries(planets)
+    .filter(([, p]) => statesALongitude(p.longitude))
+    .map(([planet, p]) => ({
+      planet,
+      sign: p.sign,
+      degree: p.longitude % 30,
+      position: p.longitude,
+    }));
+}
+
+/**
+ * Does this value state an ecliptic longitude, or merely occupy the field?
+ *
+ * ONE rule, shared by everything that writes a chart out of `calculateNatalChart`
+ * — the `natal_positions` encoder above and the `natal_chart` ascendant in
+ * `agents/unified`. Having it in two places is how the two fields come to
+ * disagree about the same body.
+ *
+ * Non-finite is rejected because JSON renders NaN as null, and the parser's
+ * `degree ?? 0` fallback would then place the body at 0° of its sign — a
+ * fabricated position with no warning.
+ *
+ * Exactly `0` is rejected for the same reason one step earlier: every longitude in
+ * this pipeline passes through a `?? 0`, so a zero cannot be told apart from an
+ * absent measurement. Two known non-observations produce it —
+ * `fetchPlanetaryPositions` leaves the ascendant at its 0 initialiser when the
+ * astrologize response carries none (deriving only the SIGN, locally, from
+ * sidereal time), and the offline planetary fallback carries
+ * `Ascendant: [0, 0, 0, "aries"]`, documented in place as a placeholder. Both are
+ * systematic; a genuine 0.000000° is measure-zero and indistinguishable anyway.
+ * Compare `normaliseNatalPositions` above, which rejects a zero `longitude` on
+ * exactly the same grounds.
+ */
+export function statesALongitude(value: number): boolean {
+  return Number.isFinite(value) && value !== 0;
+}
+
+/**
  * The reference instant used when a chart has NO birth data.
  *
  * ⚠️ It does NOT decide the answer. Sect is passed explicitly for each sect, so


### PR DESCRIPTION
Group B of the fabricated-longitude sweep, kept separate from the writers (#660)
because these feed `buildAspectsWithStrength` and could in principle move ESMS.

## Two defects in one expression

    pd.exactLongitude ?? pd.longitude ?? pd.eclipticLongitude ?? 0

1. The terminal `?? 0` fabricates — and the very next line is
   `getSignFromLongitude(longitude)`, so it does not merely invent an angle, it
   invents a confident **0° Aries** that nothing downstream can tell apart from a
   measured placement.
2. `0` is not nullish, so a zero in the FIRST key STOPPED the chain and the other
   two were never consulted. The fallbacks could not do the job they were added for.

Now each candidate is tested with `statesALongitude` — the same predicate the
writers use, imported rather than re-implemented — so a zero is passed over instead
of being accepted or acting as a terminator. When no candidate states an angle the
body is DROPPED (the loop already skips a body with no data at all) and the drop is
logged. An absent body is honest; a fabricated one is not.

For the Ascendant the fix matters more than for a planet, and differently:
`natalChartService` tests `data.ascendant?.sign`, so a fabricated
`{sign: "aries", exactLongitude: 0}` SATISFIED that test and suppressed the local
sidereal-time derivation that would otherwise have produced a real sign. Leaving
`ascendant` undefined — the field is optional precisely so absence can be stated —
hands the question back to that derivation.

## Measured before changing anything

`[MEASURED 2026-07-27]` against the production backend
`POST /api/planetary/positions`, 14 bodies returned:

    bodies WITHOUT exactLongitude              : none
    bodies with exactLongitude == 0            : none
    bodies carrying longitude/eclipticLongitude: none

So the first candidate always wins and this branch is UNREACHABLE on the live path
— which is exactly why it could sit here fabricating Aries for a malformed response
without anyone noticing, and why the tests exercise it directly rather than waiting
for an outage.

Drift, before and after, via `scripts/checkAgentMonicaDrift.ts` against production:
IDENTICAL — 4322 + 732 + 71 + 2 = 5127/5127, φ shares 3.7% / 3.9% / 0.0%, and the
same 56 rows needing attention (pre-existing, unrelated to this change; remedy is
`backfillMonicaPerConstruction.ts`, not run here). Worth being precise about what
that proves: the drift check recomputes agent monica from NAMES, and agents carry no
birth data, so it does not exercise this parse path at all. It is a regression check
that nothing else moved. The evidence for THIS path is the measurement above plus
the tests.

## Also found: the parser exists twice

`formatRailwayResponse` in `src/app/api/astrologize/route.ts` is a duplicate of the
one in `src/server/lib/astrology-utils.ts`, which is why the same fix appears in
both files. The route's copy additionally handles the Ascendant; the server copy
does not. Unifying them is a separate change and is noted in both.

## Tests — 12

Measured backend shape as the CONTROL (10 bodies, sub-arcminute longitudes intact);
a body with no longitude dropped rather than placed at 0° Aries; a zero first key
passed OVER in favour of a real second key; both alternate keys still honoured when
they are the only one present; NaN / Infinity / null / undefined / "220" all treated
as absent; and `getSignFromLongitude(0) === {sign: "aries", degree: 0}` pinned as
the mechanism that makes 0 dangerous here rather than neutral.

One accepted cost, stated rather than left implicit: a body genuinely at 0.000000°
Aries is indistinguishable from the placeholder and is dropped. The placeholder is
systematic; a true 0 is measure-zero.

Verified: 177 suites / 1583 tests, `tsc --noEmit` clean, eslint clean on both
touched files (`src/server/**` is outside the eslint config's scope).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

**Stacked on #657** (needs `statesALongitude`). Sibling of #660 — independent of it. Retarget to `master` once #657 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)