### PR TITLE
economy: finish the collector migration — no call site hand-orders parameters now

### DIFF
--- a/scripts/checkEconomySqlParses.ts
+++ b/scripts/checkEconomySqlParses.ts
@@ -60,7 +60,10 @@
  */
 import pg from "pg";
 import * as queries from "../src/services/tokenEconomyQueries";
-import type { AxisColumn } from "../src/services/tokenEconomyQueries";
+import type {
+  AxisColumn,
+  TokenTypeName,
+} from "../src/services/tokenEconomyQueries";
 
 const fail = (msg: string): never => {
   console.error(`\n✗ ${msg}`);
@@ -80,6 +83,15 @@ const COLUMNS: readonly AxisColumn[] = [
   "substance",
 ];
 
+// The credit/debit builders derive their column from the token type, so they
+// are driven by the token names rather than the column names.
+const TOKEN_TYPES: readonly TokenTypeName[] = [
+  "Spirit",
+  "Essence",
+  "Matter",
+  "Substance",
+];
+
 /** Placeholder bind values. PREPARE only performs type analysis, so these are
  *  never sent to the server — they exist because the builders return their
  *  parameters alongside their SQL. */
@@ -95,22 +107,39 @@ interface Statement {
 
 const statements: Statement[] = [];
 
-for (const column of COLUMNS) {
+for (const tokenType of TOKEN_TYPES) {
   statements.push({
-    label: `credit(${column})`,
-    sql: queries.creditTokensSql(column),
+    label: `credit(${queries.columnFor(tokenType)})`,
+    sql: queries.creditTokensSql({
+      userId: UUID,
+      tokenType,
+      amount: 1,
+      sourceType: "signup_grant",
+      sourceId: null,
+      description: "probe",
+      transactionGroupId: UUID,
+      idempotencyKey: "probe",
+    }).sql,
     builder: "creditTokensSql",
   });
   statements.push({
-    label: `debit(${column})`,
-    sql: queries.debitTokensSql(column),
+    label: `debit(${queries.columnFor(tokenType)})`,
+    sql: queries.debitTokensSql({
+      userId: UUID,
+      tokenType,
+      amount: 1,
+      sourceType: "recipe_ingestion",
+      sourceId: null,
+      transactionGroupId: UUID,
+      description: "probe",
+    }).sql,
     builder: "debitTokensSql",
   });
 }
 
 statements.push({
   label: "getBalances",
-  sql: queries.getBalancesSql(),
+  sql: queries.getBalancesSql(UUID).sql,
   builder: "getBalancesSql",
 });
 
@@ -198,8 +227,14 @@ try {
   // ── Control 2: every exported builder is actually exercised ───────────────
   // Derived from the module's exports rather than a hand-kept list, so adding a
   // builder and forgetting to gate it fails here instead of passing quietly.
+  // Exported functions that are NOT SQL builders and so have nothing to
+  // PREPARE. Listed explicitly rather than filtered by a name pattern: adding
+  // an export then has to be a conscious decision here, instead of silently
+  // slipping past a `endsWith("Sql")` test.
+  const NON_BUILDER_EXPORTS = new Set(["columnFor"]);
+
   const exportedBuilders = Object.entries(queries)
-    .filter(([, v]) => typeof v === "function")
+    .filter(([k, v]) => typeof v === "function" && !NON_BUILDER_EXPORTS.has(k))
     .map(([k]) => k);
   const covered = new Set(statements.map((s) => s.builder));
   const ungated = exportedBuilders.filter((b) => !covered.has(b));

--- a/scripts/checkEconomyStatementBehaviour.mjs
+++ b/scripts/checkEconomyStatementBehaviour.mjs
@@ -65,22 +65,18 @@ const mkUser = async (label) => {
 /** A funded user: every axis credited to `amount`. */
 const mkFundedUser = async (label, amount = 100) => {
   const id = await mkUser(label);
-  for (const [token, column] of [
-    ["Spirit", "spirit"],
-    ["Essence", "essence"],
-    ["Matter", "matter"],
-    ["Substance", "substance"],
-  ]) {
-    await c.query(creditTokensSql(column), [
-      id,
-      token,
+  for (const tokenType of ["Spirit", "Essence", "Matter", "Substance"]) {
+    const q = creditTokensSql({
+      userId: id,
+      tokenType,
       amount,
-      "signup_grant",
-      null,
-      "probe funding",
-      randomUUID(),
-      `fund:${id}:${column}`,
-    ]);
+      sourceType: "signup_grant",
+      sourceId: null,
+      description: "probe funding",
+      transactionGroupId: randomUUID(),
+      idempotencyKey: `fund:${id}:${tokenType}`,
+    });
+    await c.query(q.sql, q.values);
   }
   return id;
 };
@@ -145,32 +141,40 @@ try {
   // ── getBalances ──────────────────────────────────────────────────────────
   console.log("\ngetBalances (single statement, insert-or-return)");
   const u = await mkUser("econ probe");
-  const first = await c.query(getBalancesSql(), [u]);
+  const getBal = getBalancesSql(u);
+  const first = await c.query(getBal.sql, getBal.values);
   first.rows.length === 1 && Number(first.rows[0].spirit) === 0
     ? ok("creates the row and RETURNS it (spirit 0)")
     : no(`returned ${first.rows.length} rows / spirit ${first.rows[0]?.spirit}`);
-  const second = await c.query(getBalancesSql(), [u]);
+  const second = await c.query(getBal.sql, getBal.values);
   second.rows.length === 1
     ? ok("second call returns the SAME row — the DO NOTHING/RETURNING gap is closed")
     : no(`re-read returned ${second.rows.length} rows`);
 
   // ── single-axis credit then debit ────────────────────────────────────────
   console.log("\ncredit then debit (single axis)");
-  await c.query(creditTokensSql("spirit"), [
-    u, "Spirit", 10, "signup_grant", null, "probe", randomUUID(), `p:${u}:1`,
-  ]);
+  const creditQ = creditTokensSql({
+    userId: u, tokenType: "Spirit", amount: 10, sourceType: "signup_grant",
+    sourceId: null, description: "probe", transactionGroupId: randomUUID(),
+    idempotencyKey: `p:${u}:1`,
+  });
+  await c.query(creditQ.sql, creditQ.values);
   (await spirit(u)) === 10 ? ok("credit of 10 applied") : no(`balance ${await spirit(u)} after credit`);
 
-  const d1 = await c.query(debitTokensSql("spirit"), [
-    u, "Spirit", 4, "recipe_ingestion", null, randomUUID(), "probe debit",
-  ]);
+  const debitQ = debitTokensSql({
+    userId: u, tokenType: "Spirit", amount: 4, sourceType: "recipe_ingestion",
+    sourceId: null, transactionGroupId: randomUUID(), description: "probe debit",
+  });
+  const d1 = await c.query(debitQ.sql, debitQ.values);
   d1.rowCount === 1 && (await spirit(u)) === 6
     ? ok("debit of 4 applied — balance 6")
     : no(`debit returned ${d1.rowCount} rows, balance ${await spirit(u)}`);
 
-  const d2 = await c.query(debitTokensSql("spirit"), [
-    u, "Spirit", 100, "recipe_ingestion", null, randomUUID(), "overdraw",
-  ]);
+  const overQ1 = debitTokensSql({
+    userId: u, tokenType: "Spirit", amount: 100, sourceType: "recipe_ingestion",
+    sourceId: null, transactionGroupId: randomUUID(), description: "overdraw",
+  });
+  const d2 = await c.query(overQ1.sql, overQ1.values);
   d2.rowCount === 0 && (await spirit(u)) === 6
     ? ok("debit of 100 REFUSED, balance untouched")
     : no(`overdraw returned ${d2.rowCount} rows, balance ${await spirit(u)}`);
@@ -352,12 +356,13 @@ try {
   // whatever shape the SQL is rewritten into.
   console.log("\ndebit-side statements must fail CLOSED for a user with NO balance row");
   const debitSideCases = [
-    ...["spirit", "essence", "matter", "substance"].map((col) => ({
-      label: `debitTokens(${col})`,
-      run: (id) => ({
-        sql: debitTokensSql(col),
-        values: [id, col[0].toUpperCase() + col.slice(1), 25, "recipe_ingestion", null, randomUUID(), "no row"],
-      }),
+    ...["Spirit", "Essence", "Matter", "Substance"].map((tokenType) => ({
+      label: `debitTokens(${tokenType})`,
+      run: (id) =>
+        debitTokensSql({
+          userId: id, tokenType, amount: 25, sourceType: "recipe_ingestion",
+          sourceId: null, transactionGroupId: randomUUID(), description: "no row",
+        }),
     })),
     {
       label: "debitAllTokens(spend)",
@@ -469,6 +474,56 @@ try {
   stripComments(renderedSpend) !== fixture("purchase")
     ? ok("control: the comparison distinguishes the two statements")
     : no("CONTROL FAILED: spend and purchase fixtures compare equal");
+
+  // ── the collector reshape changed no SQL either ──────────────────────────
+  // credit/debit/getBalances moved from hand-numbered `$1..$8` beside a
+  // hand-ordered array to the QueryParams collector. The parameters are
+  // collected in the SAME order the arrays supplied them, so the rendered SQL
+  // must be unchanged. Fixtures captured from the pre-reshape builders.
+  console.log("\ncollector reshape is semantics-free (vs pre-reshape fixtures)");
+  for (const tokenType of ["Spirit", "Essence", "Matter", "Substance"]) {
+    const col = tokenType.toLowerCase();
+    const credit = creditTokensSql({
+      userId: "u", tokenType, amount: 1, sourceType: "signup_grant",
+      sourceId: null, description: "d", transactionGroupId: "g",
+      idempotencyKey: "k",
+    }).sql;
+    const debit = debitTokensSql({
+      userId: "u", tokenType, amount: 1, sourceType: "recipe_ingestion",
+      sourceId: null, transactionGroupId: "g", description: "d",
+    }).sql;
+    stripComments(credit) === fixture(`credit.${col}`)
+      ? ok(`creditTokensSql(${tokenType}) SQL unchanged by the reshape`)
+      : no(`creditTokensSql(${tokenType}) SQL CHANGED`);
+    stripComments(debit) === fixture(`debit.${col}`)
+      ? ok(`debitTokensSql(${tokenType}) SQL unchanged by the reshape`)
+      : no(`debitTokensSql(${tokenType}) SQL CHANGED`);
+  }
+  stripComments(getBalancesSql("u").sql) === fixture("getBalances")
+    ? ok("getBalancesSql SQL unchanged by the reshape")
+    : no("getBalancesSql SQL CHANGED");
+
+  // The reshape's real payload: the values array is now produced by the
+  // builder, in binding order, rather than hand-written beside the `$n`s.
+  const credited = creditTokensSql({
+    userId: "U", tokenType: "Essence", amount: 7, sourceType: "signup_grant",
+    sourceId: "SRC", description: "DESC", transactionGroupId: "GRP",
+    idempotencyKey: "IDEM",
+  });
+  JSON.stringify(credited.values) ===
+  JSON.stringify(["U", "Essence", 7, "signup_grant", "SRC", "DESC", "GRP", "IDEM"])
+    ? ok("creditTokensSql binds values in $1..$8 order")
+    : no(`creditTokensSql values are ${JSON.stringify(credited.values)}`);
+
+  // And the column can no longer disagree with the token type, because there
+  // is only one argument to get wrong.
+  creditTokensSql({
+    userId: "U", tokenType: "Matter", amount: 1, sourceType: "signup_grant",
+    sourceId: null, description: null, transactionGroupId: null,
+    idempotencyKey: null,
+  }).sql.includes("INSERT INTO token_balances (user_id, matter, updated_at)")
+    ? ok("column is derived from the token type — they cannot desync")
+    : no("token type 'Matter' did not select the matter column");
 } finally {
   await c.query("ROLLBACK");
   await c.end();

--- a/scripts/fixtures/credit.essence.pre.sql
+++ b/scripts/fixtures/credit.essence.pre.sql
@@ -1,0 +1,17 @@
+WITH inserted AS (
+            INSERT INTO token_transactions
+              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key, yield_day)
+            VALUES
+              (COALESCE($7::uuid, uuid_generate_v4()), $1, $2, $3, $4::text, $5, $6, $8,
+               CASE WHEN $4::text IN ('agents_yield', 'daily_yield')
+                    THEN (now() AT TIME ZONE 'UTC')::date
+                    ELSE NULL END)
+            ON CONFLICT (idempotency_key) DO NOTHING
+            RETURNING id
+          )
+          INSERT INTO token_balances (user_id, essence, updated_at)
+          SELECT $1, $3, now() FROM inserted
+          ON CONFLICT (user_id) DO UPDATE
+            SET essence = token_balances.essence + EXCLUDED.essence,
+                updated_at = now()
+          RETURNING *

--- a/scripts/fixtures/credit.matter.pre.sql
+++ b/scripts/fixtures/credit.matter.pre.sql
@@ -1,0 +1,17 @@
+WITH inserted AS (
+            INSERT INTO token_transactions
+              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key, yield_day)
+            VALUES
+              (COALESCE($7::uuid, uuid_generate_v4()), $1, $2, $3, $4::text, $5, $6, $8,
+               CASE WHEN $4::text IN ('agents_yield', 'daily_yield')
+                    THEN (now() AT TIME ZONE 'UTC')::date
+                    ELSE NULL END)
+            ON CONFLICT (idempotency_key) DO NOTHING
+            RETURNING id
+          )
+          INSERT INTO token_balances (user_id, matter, updated_at)
+          SELECT $1, $3, now() FROM inserted
+          ON CONFLICT (user_id) DO UPDATE
+            SET matter = token_balances.matter + EXCLUDED.matter,
+                updated_at = now()
+          RETURNING *

--- a/scripts/fixtures/credit.spirit.pre.sql
+++ b/scripts/fixtures/credit.spirit.pre.sql
@@ -1,0 +1,17 @@
+WITH inserted AS (
+            INSERT INTO token_transactions
+              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key, yield_day)
+            VALUES
+              (COALESCE($7::uuid, uuid_generate_v4()), $1, $2, $3, $4::text, $5, $6, $8,
+               CASE WHEN $4::text IN ('agents_yield', 'daily_yield')
+                    THEN (now() AT TIME ZONE 'UTC')::date
+                    ELSE NULL END)
+            ON CONFLICT (idempotency_key) DO NOTHING
+            RETURNING id
+          )
+          INSERT INTO token_balances (user_id, spirit, updated_at)
+          SELECT $1, $3, now() FROM inserted
+          ON CONFLICT (user_id) DO UPDATE
+            SET spirit = token_balances.spirit + EXCLUDED.spirit,
+                updated_at = now()
+          RETURNING *

--- a/scripts/fixtures/credit.substance.pre.sql
+++ b/scripts/fixtures/credit.substance.pre.sql
@@ -1,0 +1,17 @@
+WITH inserted AS (
+            INSERT INTO token_transactions
+              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key, yield_day)
+            VALUES
+              (COALESCE($7::uuid, uuid_generate_v4()), $1, $2, $3, $4::text, $5, $6, $8,
+               CASE WHEN $4::text IN ('agents_yield', 'daily_yield')
+                    THEN (now() AT TIME ZONE 'UTC')::date
+                    ELSE NULL END)
+            ON CONFLICT (idempotency_key) DO NOTHING
+            RETURNING id
+          )
+          INSERT INTO token_balances (user_id, substance, updated_at)
+          SELECT $1, $3, now() FROM inserted
+          ON CONFLICT (user_id) DO UPDATE
+            SET substance = token_balances.substance + EXCLUDED.substance,
+                updated_at = now()
+          RETURNING *

--- a/scripts/fixtures/debit.essence.pre.sql
+++ b/scripts/fixtures/debit.essence.pre.sql
@@ -1,0 +1,17 @@
+WITH check_balance AS (
+            SELECT essence AS current_balance FROM token_balances WHERE user_id = $1
+          ),
+          inserted AS (
+            INSERT INTO token_transactions
+              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description)
+            SELECT COALESCE($6::uuid, uuid_generate_v4()), $1, $2, -$3::numeric, $4::text, $5, $7
+            FROM check_balance
+            WHERE current_balance >= $3::numeric
+            RETURNING id
+          )
+          UPDATE token_balances
+          SET essence = essence - $3::numeric,
+              updated_at = now()
+          WHERE user_id = $1
+            AND EXISTS (SELECT 1 FROM inserted)
+          RETURNING *

--- a/scripts/fixtures/debit.matter.pre.sql
+++ b/scripts/fixtures/debit.matter.pre.sql
@@ -1,0 +1,17 @@
+WITH check_balance AS (
+            SELECT matter AS current_balance FROM token_balances WHERE user_id = $1
+          ),
+          inserted AS (
+            INSERT INTO token_transactions
+              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description)
+            SELECT COALESCE($6::uuid, uuid_generate_v4()), $1, $2, -$3::numeric, $4::text, $5, $7
+            FROM check_balance
+            WHERE current_balance >= $3::numeric
+            RETURNING id
+          )
+          UPDATE token_balances
+          SET matter = matter - $3::numeric,
+              updated_at = now()
+          WHERE user_id = $1
+            AND EXISTS (SELECT 1 FROM inserted)
+          RETURNING *

--- a/scripts/fixtures/debit.spirit.pre.sql
+++ b/scripts/fixtures/debit.spirit.pre.sql
@@ -1,0 +1,17 @@
+WITH check_balance AS (
+            SELECT spirit AS current_balance FROM token_balances WHERE user_id = $1
+          ),
+          inserted AS (
+            INSERT INTO token_transactions
+              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description)
+            SELECT COALESCE($6::uuid, uuid_generate_v4()), $1, $2, -$3::numeric, $4::text, $5, $7
+            FROM check_balance
+            WHERE current_balance >= $3::numeric
+            RETURNING id
+          )
+          UPDATE token_balances
+          SET spirit = spirit - $3::numeric,
+              updated_at = now()
+          WHERE user_id = $1
+            AND EXISTS (SELECT 1 FROM inserted)
+          RETURNING *

--- a/scripts/fixtures/debit.substance.pre.sql
+++ b/scripts/fixtures/debit.substance.pre.sql
@@ -1,0 +1,17 @@
+WITH check_balance AS (
+            SELECT substance AS current_balance FROM token_balances WHERE user_id = $1
+          ),
+          inserted AS (
+            INSERT INTO token_transactions
+              (transaction_group_id, user_id, token_type, amount, source_type, source_id, description)
+            SELECT COALESCE($6::uuid, uuid_generate_v4()), $1, $2, -$3::numeric, $4::text, $5, $7
+            FROM check_balance
+            WHERE current_balance >= $3::numeric
+            RETURNING id
+          )
+          UPDATE token_balances
+          SET substance = substance - $3::numeric,
+              updated_at = now()
+          WHERE user_id = $1
+            AND EXISTS (SELECT 1 FROM inserted)
+          RETURNING *

--- a/scripts/fixtures/getBalances.pre.sql
+++ b/scripts/fixtures/getBalances.pre.sql
@@ -1,0 +1,3 @@
+INSERT INTO token_balances (user_id) VALUES ($1)
+           ON CONFLICT (user_id) DO UPDATE SET updated_at = token_balances.updated_at
+           RETURNING *

--- a/src/services/TokenEconomyService.ts
+++ b/src/services/TokenEconomyService.ts
@@ -10,6 +10,7 @@
 
 import { _logger } from "@/lib/logger";
 import {
+  columnFor,
   creditTokensSql,
   debitAllTokensSql,
   debitTokensSql,
@@ -146,7 +147,8 @@ class TokenEconomyService {
 
     if (db) {
       try {
-        const result = await db.executeQuery(getBalancesSql(), [userId]);
+        const query = getBalancesSql(userId);
+        const result = await db.executeQuery(query.sql, query.values);
         if (result.rows.length > 0) {
           return rowToBalances(result.rows[0]);
         }
@@ -188,21 +190,21 @@ class TokenEconomyService {
     }
 
     const db = await getDbModule();
-    const column = tokenType.toLowerCase() as "spirit" | "essence" | "matter" | "substance";
 
     if (db) {
       try {
         // Single atomic statement (insert ledger row + apply delta).
-        const result = await db.executeQuery(creditTokensSql(column), [
+        const query = creditTokensSql({
           userId,
           tokenType,
           amount,
           sourceType,
-          opts?.sourceId || null,
-          opts?.description || null,
-          opts?.transactionGroupId || null,
-          opts?.idempotencyKey || null,
-        ]);
+          sourceId: opts?.sourceId || null,
+          description: opts?.description || null,
+          transactionGroupId: opts?.transactionGroupId || null,
+          idempotencyKey: opts?.idempotencyKey || null,
+        });
+        const result = await db.executeQuery(query.sql, query.values);
 
         if (result.rows.length > 0) {
           return rowToBalances(result.rows[0]);
@@ -226,7 +228,7 @@ class TokenEconomyService {
     }
 
     const balances = await this.getBalances(userId);
-    balances[column] += amount;
+    balances[columnFor(tokenType)] += amount;
     balances.updatedAt = new Date().toISOString();
 
     memoryTransactions.push({
@@ -263,23 +265,20 @@ class TokenEconomyService {
   ): Promise<TokenBalances | null> {
     if (amount <= 0) return null;
 
-    const column = tokenType.toLowerCase() as "spirit" | "essence" | "matter" | "substance";
     const db = await getDbModule();
 
     if (db) {
       try {
-        const result = await db.executeQuery(
-          debitTokensSql(column),
-          [
-            userId,
-            tokenType,
-            amount,
-            sourceType,
-            opts?.sourceId || null,
-            opts?.transactionGroupId || null,
-            opts?.description || null,
-          ],
-        );
+        const query = debitTokensSql({
+          userId,
+          tokenType,
+          amount,
+          sourceType,
+          sourceId: opts?.sourceId || null,
+          transactionGroupId: opts?.transactionGroupId || null,
+          description: opts?.description || null,
+        });
+        const result = await db.executeQuery(query.sql, query.values);
 
         if (result.rows.length > 0) {
           return rowToBalances(result.rows[0]);
@@ -292,6 +291,7 @@ class TokenEconomyService {
     }
 
     // In-memory fallback
+    const column = columnFor(tokenType);
     const balances = await this.getBalances(userId);
     if (balances[column] < amount) return null;
 
@@ -410,24 +410,20 @@ class TokenEconomyService {
           let last: Record<string, unknown> | null = null;
           for (const { tokenType, amount } of credits) {
             if (amount <= 0) continue;
-            const column = tokenType.toLowerCase() as
-              | "spirit"
-              | "essence"
-              | "matter"
-              | "substance";
             const idemKey = opts?.idempotencyKey
               ? `${opts.idempotencyKey}:${tokenType}`
               : null;
-            const res = await client.query(creditTokensSql(column), [
+            const query = creditTokensSql({
               userId,
               tokenType,
               amount,
               sourceType,
-              opts?.sourceId || null,
-              opts?.description || null,
-              groupId,
-              idemKey,
-            ]);
+              sourceId: opts?.sourceId || null,
+              description: opts?.description || null,
+              transactionGroupId: groupId,
+              idempotencyKey: idemKey,
+            });
+            const res = await client.query(query.sql, query.values);
             if (res.rows.length > 0) last = res.rows[0];
           }
           return last;

--- a/src/services/tokenEconomyQueries.ts
+++ b/src/services/tokenEconomyQueries.ts
@@ -31,6 +31,21 @@
  *  the statements below injection-safe. */
 export type AxisColumn = "spirit" | "essence" | "matter" | "substance";
 
+/** The same four axes as written in `token_transactions.token_type`. Declared
+ *  here rather than imported from `@/types/economy` to keep this module free of
+ *  runtime imports; it is structurally identical to `TokenType`. */
+export type TokenTypeName = "Spirit" | "Essence" | "Matter" | "Substance";
+
+/** The balance column a token type is stored in.
+ *
+ *  The builders derive this rather than accepting a column AND a token type as
+ *  separate arguments. Two arguments that must agree can disagree: passing
+ *  `"spirit"` with `"Essence"` would write an Essence ledger row while moving
+ *  the spirit balance, and every type check would pass. One argument makes that
+ *  unrepresentable. */
+export const columnFor = (tokenType: TokenTypeName): AxisColumn =>
+  tokenType.toLowerCase() as AxisColumn;
+
 /** Amounts across all four axes, for the multi-axis statements. */
 export interface AxisAmounts {
   spirit: number;
@@ -117,12 +132,16 @@ class QueryParams {
  * silently took the two-query fallback: correct results, an exception per call,
  * and a "primary" path that had never once run.
  *
- * Params: $1 userId
  */
-export function getBalancesSql(): string {
-  return `INSERT INTO token_balances (user_id) VALUES ($1)
+export function getBalancesSql(userId: string): BuiltQuery {
+  const p = new QueryParams();
+  const user = p.add(userId);
+  return {
+    sql: `INSERT INTO token_balances (user_id) VALUES (${user})
            ON CONFLICT (user_id) DO UPDATE SET updated_at = token_balances.updated_at
-           RETURNING *`;
+           RETURNING *`,
+    values: p.values,
+  };
 }
 
 // ─── Single-axis credit / debit ───────────────────────────────────────
@@ -174,40 +193,57 @@ export function getBalancesSql(): string {
 // `scripts/checkEconomySqlParses.ts` now PREPAREs every variant against a real
 // PostgreSQL in CI, which is the only thing that can catch this class.
 //
-// Params, in order:
-//   $1 userId  $2 tokenType  $3 amount  $4 sourceType
-//   $5 sourceId  $6 description  $7 transactionGroupId  $8 idempotencyKey
-//
 // `yield_day` is computed IN THE DATABASE from `now()`, not passed in from the
 // caller. That matters: the whole point is a day key the application cannot get
 // wrong or disagree with itself about, and two producers running in different
 // timezones (or one of them holding a stale clock) is precisely how the
 // original double-credit arose. It is NULL for every non-daily-yield source, so
 // those rows do not participate in the unique index at all.
-export function creditTokensSql(column: AxisColumn): string {
-  return `WITH inserted AS (
+export function creditTokensSql(opts: {
+  userId: string;
+  tokenType: TokenTypeName;
+  amount: number;
+  sourceType: string;
+  sourceId: string | null;
+  description: string | null;
+  transactionGroupId: string | null;
+  idempotencyKey: string | null;
+}): BuiltQuery {
+  const column = columnFor(opts.tokenType);
+  const p = new QueryParams();
+
+  const user = p.add(opts.userId);
+  const tokenType = p.add(opts.tokenType);
+  const amount = p.add(opts.amount);
+  const sourceType = p.add(opts.sourceType);
+  const sourceId = p.add(opts.sourceId);
+  const description = p.add(opts.description);
+  const group = p.add(opts.transactionGroupId);
+  const idem = p.add(opts.idempotencyKey);
+
+  const sql = `WITH inserted AS (
             INSERT INTO token_transactions
               (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key, yield_day)
             VALUES
-              (COALESCE($7::uuid, uuid_generate_v4()), $1, $2, $3, $4::text, $5, $6, $8,
-               CASE WHEN $4::text IN (${DAILY_YIELD_SOURCES_SQL})
+              (COALESCE(${group}::uuid, uuid_generate_v4()), ${user}, ${tokenType}, ${amount}, ${sourceType}::text, ${sourceId}, ${description}, ${idem},
+               CASE WHEN ${sourceType}::text IN (${DAILY_YIELD_SOURCES_SQL})
                     THEN (now() AT TIME ZONE 'UTC')::date
                     ELSE NULL END)
             ON CONFLICT (idempotency_key) DO NOTHING
             RETURNING id
           )
           INSERT INTO token_balances (user_id, ${column}, updated_at)
-          SELECT $1, $3, now() FROM inserted
+          SELECT ${user}, ${amount}, now() FROM inserted
           ON CONFLICT (user_id) DO UPDATE
             SET ${column} = token_balances.${column} + EXCLUDED.${column},
                 updated_at = now()
           RETURNING *`;
+
+  return { sql, values: p.values };
 }
 
 // Single-statement debit: check the balance, write the ledger entry only if the
-// funds are there, and apply the delta — atomically. Params, in order:
-//   $1 userId  $2 tokenType  $3 amount  $4 sourceType
-//   $5 sourceId  $6 transactionGroupId  $7 description
+// funds are there, and apply the delta — atomically.
 //
 // ── Why this one is NOT an upsert, unlike the credit above ──────────────────
 //
@@ -232,24 +268,45 @@ export function creditTokensSql(column: AxisColumn): string {
 // asserts, for EVERY debit-side builder, that a debit against a user with no
 // balance row writes nothing and conjures no row. That catches a regression by
 // its effect, whichever shape the SQL is rewritten into.
-export function debitTokensSql(column: AxisColumn): string {
-  return `WITH check_balance AS (
-            SELECT ${column} AS current_balance FROM token_balances WHERE user_id = $1
+export function debitTokensSql(opts: {
+  userId: string;
+  tokenType: TokenTypeName;
+  amount: number;
+  sourceType: string;
+  sourceId: string | null;
+  transactionGroupId: string | null;
+  description: string | null;
+}): BuiltQuery {
+  const column = columnFor(opts.tokenType);
+  const p = new QueryParams();
+
+  const user = p.add(opts.userId);
+  const tokenType = p.add(opts.tokenType);
+  const amount = p.add(opts.amount);
+  const sourceType = p.add(opts.sourceType);
+  const sourceId = p.add(opts.sourceId);
+  const group = p.add(opts.transactionGroupId);
+  const description = p.add(opts.description);
+
+  const sql = `WITH check_balance AS (
+            SELECT ${column} AS current_balance FROM token_balances WHERE user_id = ${user}
           ),
           inserted AS (
             INSERT INTO token_transactions
               (transaction_group_id, user_id, token_type, amount, source_type, source_id, description)
-            SELECT COALESCE($6::uuid, uuid_generate_v4()), $1, $2, -$3::numeric, $4::text, $5, $7
+            SELECT COALESCE(${group}::uuid, uuid_generate_v4()), ${user}, ${tokenType}, -${amount}::numeric, ${sourceType}::text, ${sourceId}, ${description}
             FROM check_balance
-            WHERE current_balance >= $3::numeric
+            WHERE current_balance >= ${amount}::numeric
             RETURNING id
           )
           UPDATE token_balances
-          SET ${column} = ${column} - $3::numeric,
+          SET ${column} = ${column} - ${amount}::numeric,
               updated_at = now()
-          WHERE user_id = $1
+          WHERE user_id = ${user}
             AND EXISTS (SELECT 1 FROM inserted)
           RETURNING *`;
+
+  return { sql, values: p.values };
 }
 
 // ─── Multi-axis debit (spend / premium purchase) ──────────────────────


### PR DESCRIPTION
Phase 2 of the plan agreed in #658. `creditTokensSql`, `debitTokensSql` and `getBalancesSql` moved verbatim in that PR and still returned a bare SQL string next to a hand-ordered array at each call site. They now use the `QueryParams` collector and return `{ sql, values }`, like the other three builders.

Four call sites lose their arrays: `creditTokens`, `debitTokens`, `getBalances`, and the per-token loop in `creditMultipleTokens`. Every balance-mutating query in the service now reads `executeQuery(query.sql, query.values)`.

## Why

An array beside a hand-numbered `$n` is a silent-failure shape:

```
[userId, tokenType, amount, sourceType, sourceId, description, groupId, idemKey]
```

Five strings in a row — swap two and every type check still passes while the wrong value lands in the wrong column. The collector makes the values array a **result** of building the statement rather than a parallel artifact kept in sync by hand.

The credit/debit builders also now **derive** the balance column from the token type instead of taking both. Two arguments that must agree can disagree: passing `"spirit"` with `"Essence"` would write an Essence ledger row while moving the spirit balance. One argument makes that unrepresentable, and it removes four `as "spirit" | …` casts from the service.

## The SQL is untouched — asserted, not claimed

Nine fixtures captured from `origin/master`'s builders are committed, and the behavioural gate checks every reshaped statement renders identically to them. A provenance control confirmed the fixtures really do come from master's builders, so the comparison is not circular.

## Verification

Production, in a rolled-back transaction; a leak check confirmed nothing persisted.

- **23/23 PREPARE**, 3/3 controls green
- **Behaviour**: all prior cases, plus 9 reshape-identity assertions, the values array binds in `$1..$8` order, and `'Matter'` provably selects the `matter` column
- **174 suites / 1546 tests** pass — identical to base, measured by stashing
- `tsc --noEmit` clean; lint 17 warnings, all pre-existing, none in these files

The gate's exported-builder control needed an explicit non-builder allowlist for `columnFor`, listed by name rather than filtered by an `endsWith("Sql")` pattern, so a future export has to be a conscious decision instead of silently slipping past.

## Deliberately not in scope

The ~10 simple reads (`getTransactions`, `getShopItems`, `hasActivePurchase`, the idempotency `LIKE` probes, the daily-claim timestamp `UPDATE`) are unchanged — still ungated and still hand-ordered. None move a balance. `getTransactions`' `[userId, limit, offset]` is the only one with real swap risk, and it returns the wrong page rather than the wrong money.

🤖 Generated with [Claude Code](https://claude.com/claude-code)