### PR TITLE
economy: gate the last 14 statements — and stop splicing a day count into SQL

### DIFF
--- a/scripts/checkEconomySqlParses.ts
+++ b/scripts/checkEconomySqlParses.ts
@@ -193,8 +193,91 @@ for (const fromColumn of COLUMNS) {
   }
 }
 
-// 4 credit + 4 debit + 1 getBalances + 2 debitAll + 12 transmute
-const EXPECTED_TOTAL = 23;
+// ── Reads and bookkeeping ───────────────────────────────────────────────────
+// None of these moves a balance, but PREPARE still catches a renamed column, a
+// dropped table, or a parameter count that has drifted from its call site.
+// Statements whose text varies with an argument get one entry per variant: a
+// gate that checked only the default shape would not be checking the others.
+
+statements.push({
+  label: "idempotencyProbe",
+  sql: queries.idempotencyProbeSql("probe").sql,
+  builder: "idempotencyProbeSql",
+});
+
+for (const site of ["main", "agents"] as const) {
+  statements.push({
+    label: `dailyClaim(${site})`,
+    sql: queries.dailyClaimTimestampSql({ userId: UUID, site }).sql,
+    builder: "dailyClaimTimestampSql",
+  });
+}
+
+statements.push({
+  label: "transactionsPage",
+  sql: queries.transactionsPageSql({ userId: UUID, limit: 20, offset: 0 }).sql,
+  builder: "transactionsPageSql",
+});
+
+statements.push({
+  label: "transactionCount",
+  sql: queries.transactionCountSql(UUID).sql,
+  builder: "transactionCountSql",
+});
+
+statements.push({
+  label: "shopItemForPurchase",
+  sql: queries.shopItemForPurchaseSql("probe-slug").sql,
+  builder: "shopItemForPurchaseSql",
+});
+
+statements.push({
+  label: "userOwnsItem",
+  sql: queries.userOwnsItemSql({ userId: UUID, slug: "probe-slug" }).sql,
+  builder: "userOwnsItemSql",
+});
+
+// Both branches: the date-bounded variant is the one whose day count used to be
+// spliced into the statement text rather than bound.
+statements.push({
+  label: "hasActivePurchase(any age)",
+  sql: queries.hasActivePurchaseSql({ userId: UUID, slug: "probe-slug" }).sql,
+  builder: "hasActivePurchaseSql",
+});
+statements.push({
+  label: "hasActivePurchase(maxAgeDays)",
+  sql: queries.hasActivePurchaseSql({
+    userId: UUID,
+    slug: "probe-slug",
+    maxAgeDays: 30,
+  }).sql,
+  builder: "hasActivePurchaseSql",
+});
+
+statements.push({
+  label: "shopItemDetail",
+  sql: queries.shopItemDetailSql("probe-slug").sql,
+  builder: "shopItemDetailSql",
+});
+
+// All four filter combinations. `onlyActive` defaults to true, so the no-options
+// call is NOT the unfiltered statement — both are checked.
+for (const [label, opts] of [
+  ["default", undefined],
+  ["category", { category: "probe" }],
+  ["all", { onlyActive: false }],
+  ["category+all", { category: "probe", onlyActive: false }],
+] as const) {
+  statements.push({
+    label: `shopItems(${label})`,
+    sql: queries.shopItemsSql(opts).sql,
+    builder: "shopItemsSql",
+  });
+}
+
+// 4 credit + 4 debit + 1 getBalances + 2 debitAll + 12 transmute = 23 money
+// statements, plus 14 reads/bookkeeping.
+const EXPECTED_TOTAL = 37;
 
 const client = new pg.Client({
   connectionString: url,
@@ -320,20 +403,15 @@ try {
     `\n✓ all ${statements.length} economy statements parse and type-check ` +
       "against PostgreSQL",
   );
-  // Stated so a reader does not mistake this for total coverage of the file.
-  // Every statement that MOVES MONEY is now gated. What remains ungated are
-  // simple reads and one timestamp write, none of which touch a balance:
+  // Coverage is now total for this service, and that claim is enforced rather
+  // than asserted: `TokenEconomyService.ts` contains no SQL of its own, so the
+  // exported-builder control above is the same thing as "every statement".
   console.log(
-    "\n  Covered: every balance-mutating statement (credit, debit, multi-axis\n" +
-      "  spend, premium purchase, transmutation, balance ensure-and-read).\n" +
-      "\n  NOT covered — still inline in TokenEconomyService.ts, none of which\n" +
-      "  move a balance:\n" +
-      "    · the two `SELECT 1 FROM token_transactions … idempotency_key LIKE`\n" +
-      "      pre-checks (debitAllTokens, purchaseShopItem)\n" +
-      "    · getTransactions' page + count reads\n" +
-      "    · updateDailyClaimTimestamp's `UPDATE token_balances SET <col> = now()`\n" +
-      "    · hasActivePurchase, getShopItem, getShopItems, and the shop_items\n" +
-      "      lookup in purchaseShopItem",
+    "\n  Coverage is COMPLETE for TokenEconomyService: it holds no SQL of its\n" +
+      "  own — every statement it sends comes from tokenEconomyQueries.ts, and\n" +
+      "  control 2 fails if any exported builder goes unexercised.\n" +
+      "\n  This gate covers that ONE service. Economy SQL living elsewhere (API\n" +
+      "  routes, crons, migrations) is out of its scope and still ungated.",
   );
 } finally {
   await client.end();

--- a/scripts/checkEconomyStatementBehaviour.mjs
+++ b/scripts/checkEconomyStatementBehaviour.mjs
@@ -17,10 +17,19 @@ import { readFileSync } from "node:fs";
 import pg from "pg";
 import {
   creditTokensSql,
+  dailyClaimTimestampSql,
   debitAllTokensSql,
   debitTokensSql,
   getBalancesSql,
+  hasActivePurchaseSql,
+  idempotencyProbeSql,
+  shopItemDetailSql,
+  shopItemForPurchaseSql,
+  shopItemsSql,
+  transactionCountSql,
+  transactionsPageSql,
   transmuteSql,
+  userOwnsItemSql,
 } from "../src/services/tokenEconomyQueries.ts";
 
 const c = new pg.Client({
@@ -409,6 +418,171 @@ try {
         );
   }
 
+  // ── reads and bookkeeping ────────────────────────────────────────────────
+  // These move no balance, but two of them decide whether money moves at all
+  // (the idempotency probe) or which rows a user is shown, so a silent
+  // misbehaviour is not harmless.
+  console.log("\nreads and bookkeeping");
+
+  // The probe must match the keys the WRITERS actually produce. This is a
+  // cross-builder agreement: debitAllTokensSql writes `<prefix>:<TokenType>`,
+  // one row per axis, and the probe searches on `<prefix>:%`. If those two
+  // conventions ever drift, duplicate detection silently stops working and the
+  // only thing standing between a client retry and a double-charge is the
+  // unique index.
+  {
+    const pu = await mkFundedUser("probe convention", 100);
+    const key = `probe-convention-${randomUUID()}`;
+    const q = debitAllTokensSql({
+      userId: pu, amounts: COST, description: "probe", idempotencyKey: key,
+      intent: { kind: "spend", sourceType: "recipe_ingestion", sourceId: null },
+    });
+    await c.query(q.sql, q.values);
+    const probe = idempotencyProbeSql(key);
+    const hit = await c.query(probe.sql, probe.values);
+    hit.rows.length === 1
+      ? ok("idempotencyProbe FINDS the keys debitAllTokensSql writes")
+      : no(`probe found ${hit.rows.length} rows for a key that was just written`);
+
+    // Control: it must not match a different key. A probe that matched
+    // everything would also "pass" the assertion above.
+    const miss = idempotencyProbeSql(`${key}-other`);
+    const missRes = await c.query(miss.sql, miss.values);
+    missRes.rows.length === 0
+      ? ok("control: the probe does NOT match an unrelated key")
+      : no(`probe matched ${missRes.rows.length} rows for an unrelated key`);
+  }
+
+  // limit/offset are two adjacent integers — the swap this refactor exists to
+  // prevent. Assert they are not transposed, by checking the pages differ and
+  // the ordering is newest-first.
+  {
+    const tu = await mkUser("pager");
+    for (let i = 0; i < 3; i++) {
+      const q = creditTokensSql({
+        userId: tu, tokenType: "Spirit", amount: i + 1, sourceType: "signup_grant",
+        sourceId: null, description: `page probe ${i}`, transactionGroupId: randomUUID(),
+        idempotencyKey: `page:${tu}:${i}`,
+      });
+      await c.query(q.sql, q.values);
+    }
+    const p1 = transactionsPageSql({ userId: tu, limit: 2, offset: 0 });
+    const p2 = transactionsPageSql({ userId: tu, limit: 2, offset: 2 });
+    const r1 = await c.query(p1.sql, p1.values);
+    const r2 = await c.query(p2.sql, p2.values);
+    r1.rows.length === 2 && r2.rows.length === 1
+      ? ok("transactionsPage honours limit and offset in the right order")
+      : no(`limit 2 offset 0 -> ${r1.rows.length} rows, offset 2 -> ${r2.rows.length} (expected 2 / 1)`);
+    // A transposed limit/offset would be LIMIT 0 OFFSET 2, returning nothing —
+    // so a non-empty first page is itself the discriminator.
+    r1.rows[0] && new Date(r1.rows[0].created_at) >= new Date(r1.rows[1].created_at)
+      ? ok("transactionsPage orders newest-first")
+      : no("transactionsPage ordering is not newest-first");
+
+    const cnt = transactionCountSql(tu);
+    Number((await c.query(cnt.sql, cnt.values)).rows[0].total) === 3
+      ? ok("transactionCount counts every row, unaffected by paging")
+      : no("transactionCount disagrees with the rows written");
+  }
+
+  // The shop reads, and the date bound that used to be spliced into the text.
+  {
+    const su = await mkUser("shopper");
+    const activeId = randomUUID();
+    const inactiveId = randomUUID();
+    const activeSlug = `probe-active-${activeId}`;
+    const inactiveSlug = `probe-inactive-${inactiveId}`;
+    const cat = `probe-cat-${randomUUID()}`;
+    for (const [id, slug, isActive] of [
+      [activeId, activeSlug, true],
+      [inactiveId, inactiveSlug, false],
+    ]) {
+      await c.query(
+        `INSERT INTO shop_items (id, slug, title, category, cost_spirit, cost_essence,
+                                 cost_matter, cost_substance, is_one_time, is_active)
+         VALUES ($1,$2,'Probe',$3,1,1,1,1,true,$4)`,
+        [id, slug, cat, isActive],
+      );
+    }
+
+    const forPurchase = shopItemForPurchaseSql(activeSlug);
+    (await c.query(forPurchase.sql, forPurchase.values)).rows.length === 1
+      ? ok("shopItemForPurchase finds an ACTIVE item")
+      : no("shopItemForPurchase missed an active item");
+    const inactiveLookup = shopItemForPurchaseSql(inactiveSlug);
+    (await c.query(inactiveLookup.sql, inactiveLookup.values)).rows.length === 0
+      ? ok("shopItemForPurchase refuses an INACTIVE item")
+      : no("shopItemForPurchase returned an inactive item — it would be buyable");
+
+    const detail = shopItemDetailSql(inactiveSlug);
+    (await c.query(detail.sql, detail.values)).rows.length === 1
+      ? ok("shopItemDetail reads an inactive item (display, not purchase)")
+      : no("shopItemDetail could not read an inactive item");
+
+    const listDefault = shopItemsSql({ category: cat });
+    const listAll = shopItemsSql({ category: cat, onlyActive: false });
+    const nDefault = (await c.query(listDefault.sql, listDefault.values)).rows.length;
+    const nAll = (await c.query(listAll.sql, listAll.values)).rows.length;
+    nDefault === 1 && nAll === 2
+      ? ok("shopItems hides inactive by DEFAULT; onlyActive:false includes them")
+      : no(`shopItems default -> ${nDefault}, onlyActive:false -> ${nAll} (expected 1 / 2)`);
+
+    // hasActivePurchase, and the maxAgeDays bound that is now a parameter.
+    const owns0 = userOwnsItemSql({ userId: su, slug: activeSlug });
+    (await c.query(owns0.sql, owns0.values)).rows.length === 0
+      ? ok("userOwnsItem is false before any purchase")
+      : no("userOwnsItem reported ownership with no purchase");
+
+    await c.query(
+      `INSERT INTO user_purchases (user_id, shop_item_id, transaction_group_id, purchased_at)
+       VALUES ($1,$2,$3, now() - interval '40 days')`,
+      [su, activeId, randomUUID()],
+    );
+    const owns1 = userOwnsItemSql({ userId: su, slug: activeSlug });
+    (await c.query(owns1.sql, owns1.values)).rows.length === 1
+      ? ok("userOwnsItem is true after a purchase")
+      : no("userOwnsItem missed a purchase");
+
+    const anyAge = hasActivePurchaseSql({ userId: su, slug: activeSlug });
+    (await c.query(anyAge.sql, anyAge.values)).rows.length === 1
+      ? ok("hasActivePurchase with no age bound finds a 40-day-old purchase")
+      : no("hasActivePurchase missed an unbounded purchase");
+
+    const within30 = hasActivePurchaseSql({ userId: su, slug: activeSlug, maxAgeDays: 30 });
+    (await c.query(within30.sql, within30.values)).rows.length === 0
+      ? ok("hasActivePurchase(30) EXCLUDES the 40-day-old purchase — the bound binds")
+      : no("maxAgeDays=30 still matched a 40-day-old purchase");
+
+    const within90 = hasActivePurchaseSql({ userId: su, slug: activeSlug, maxAgeDays: 90 });
+    (await c.query(within90.sql, within90.values)).rows.length === 1
+      ? ok("hasActivePurchase(90) INCLUDES it — so the exclusion above is the bound, not a broken query")
+      : no("maxAgeDays=90 failed to match a 40-day-old purchase");
+  }
+
+  // The daily-claim stamp writes the column its site names, and only that one.
+  {
+    const cu = await mkUser("claimer");
+    const bal = getBalancesSql(cu);
+    await c.query(bal.sql, bal.values);
+    for (const [site, written, untouched] of [
+      ["main", "last_daily_claim_at", "last_daily_claim_agents_at"],
+      ["agents", "last_daily_claim_agents_at", "last_daily_claim_at"],
+    ]) {
+      const v = await mkUser(`claimer ${site}`);
+      const b = getBalancesSql(v);
+      await c.query(b.sql, b.values);
+      const q = dailyClaimTimestampSql({ userId: v, site });
+      await c.query(q.sql, q.values);
+      const r = await c.query(
+        `SELECT last_daily_claim_at, last_daily_claim_agents_at FROM token_balances WHERE user_id=$1`,
+        [v],
+      );
+      r.rows[0][written] !== null && r.rows[0][untouched] === null
+        ? ok(`dailyClaim(${site}) stamps ${written} and leaves ${untouched} alone`)
+        : no(`dailyClaim(${site}) wrote ${JSON.stringify(r.rows[0])}`);
+    }
+  }
+
   // ── the ledger/balance invariant ─────────────────────────────────────────
   console.log("\ninvariant");
   const inv = await c.query(
@@ -514,6 +688,53 @@ try {
   JSON.stringify(["U", "Essence", 7, "signup_grant", "SRC", "DESC", "GRP", "IDEM"])
     ? ok("creditTokensSql binds values in $1..$8 order")
     : no(`creditTokensSql values are ${JSON.stringify(credited.values)}`);
+
+  // ── the lifted reads changed no SQL either ──────────────────────────────
+  // Every read moved out of TokenEconomyService verbatim. Fixtures captured
+  // from origin/master's inline literals; each variant rendered the way the
+  // original code rendered it.
+  console.log("\nlifted reads are semantics-free (vs pre-lift fixtures)");
+  const readCases = [
+    ["idempotencyProbe", idempotencyProbeSql("K").sql],
+    ["dailyClaim.main", dailyClaimTimestampSql({ userId: "u", site: "main" }).sql],
+    ["dailyClaim.agents", dailyClaimTimestampSql({ userId: "u", site: "agents" }).sql],
+    ["transactionsPage", transactionsPageSql({ userId: "u", limit: 1, offset: 0 }).sql],
+    ["transactionCount", transactionCountSql("u").sql],
+    ["shopItemForPurchase", shopItemForPurchaseSql("s").sql],
+    ["userOwnsItem", userOwnsItemSql({ userId: "u", slug: "s" }).sql],
+    ["shopItemDetail", shopItemDetailSql("s").sql],
+    ["shopItems.default", shopItemsSql().sql],
+    ["shopItems.category", shopItemsSql({ category: "x" }).sql],
+    ["shopItems.all", shopItemsSql({ onlyActive: false }).sql],
+    ["shopItems.categoryAll", shopItemsSql({ category: "x", onlyActive: false }).sql],
+  ];
+  for (const [name, rendered] of readCases) {
+    stripComments(rendered) === fixture(name)
+      ? ok(`${name} SQL unchanged by the lift`)
+      : no(`${name} SQL CHANGED`);
+  }
+
+  // hasActivePurchase is the ONE read that deliberately changed: its day count
+  // moved from spliced-into-the-text to a bound parameter. The no-bound variant
+  // must still be identical; the bounded one must NOT interpolate its value.
+  stripComments(hasActivePurchaseSql({ userId: "u", slug: "s" }).sql) ===
+  fixture("hasActivePurchase.nodate")
+    ? ok("hasActivePurchase (no age bound) SQL unchanged by the lift")
+    : no("hasActivePurchase (no age bound) SQL CHANGED");
+
+  const bounded = hasActivePurchaseSql({ userId: "u", slug: "s", maxAgeDays: 30 });
+  !bounded.sql.includes("30") && bounded.values.includes(30)
+    ? ok("hasActivePurchase(30) BINDS the day count — it appears in values, not in the SQL")
+    : no(`maxAgeDays leaked into the statement text: ${bounded.sql}`);
+
+  // The case that made this worth fixing: a hostile value must land in the
+  // parameter list, not in the statement.
+  const hostile = hasActivePurchaseSql({
+    userId: "u", slug: "s", maxAgeDays: "1 days' OR true --",
+  });
+  !hostile.sql.includes("OR true") && hostile.values.includes("1 days' OR true --")
+    ? ok("a hostile maxAgeDays cannot reach the statement text")
+    : no("hostile maxAgeDays was interpolated into the SQL");
 
   // And the column can no longer disagree with the token type, because there
   // is only one argument to get wrong.

--- a/scripts/fixtures/dailyClaim.agents.pre.sql
+++ b/scripts/fixtures/dailyClaim.agents.pre.sql
@@ -1,0 +1,1 @@
+UPDATE token_balances SET last_daily_claim_agents_at = now(), updated_at = now() WHERE user_id = $1

--- a/scripts/fixtures/dailyClaim.main.pre.sql
+++ b/scripts/fixtures/dailyClaim.main.pre.sql
@@ -1,0 +1,1 @@
+UPDATE token_balances SET last_daily_claim_at = now(), updated_at = now() WHERE user_id = $1

--- a/scripts/fixtures/hasActivePurchase.nodate.pre.sql
+++ b/scripts/fixtures/hasActivePurchase.nodate.pre.sql
@@ -1,0 +1,5 @@
+SELECT 1 FROM user_purchases up
+           JOIN shop_items si ON si.id = up.shop_item_id
+           WHERE up.user_id = $1 AND si.slug = $2
+           
+           LIMIT 1

--- a/scripts/fixtures/idempotencyProbe.pre.sql
+++ b/scripts/fixtures/idempotencyProbe.pre.sql
@@ -1,0 +1,1 @@
+SELECT 1 FROM token_transactions WHERE idempotency_key LIKE $1 LIMIT 1

--- a/scripts/fixtures/shopItemDetail.pre.sql
+++ b/scripts/fixtures/shopItemDetail.pre.sql
@@ -1,0 +1,4 @@
+SELECT id, slug, title, description, category,
+                  cost_spirit, cost_essence, cost_matter, cost_substance,
+                  is_one_time, is_active
+           FROM shop_items WHERE slug = $1

--- a/scripts/fixtures/shopItemForPurchase.pre.sql
+++ b/scripts/fixtures/shopItemForPurchase.pre.sql
@@ -1,0 +1,1 @@
+SELECT * FROM shop_items WHERE slug = $1 AND is_active = true

--- a/scripts/fixtures/shopItems.all.pre.sql
+++ b/scripts/fixtures/shopItems.all.pre.sql
@@ -1,0 +1,6 @@
+SELECT id, slug, title, description, category,
+                cost_spirit, cost_essence, cost_matter, cost_substance,
+                is_one_time, is_active, sort_order
+         FROM shop_items
+         
+         ORDER BY sort_order ASC, title ASC

--- a/scripts/fixtures/shopItems.category.pre.sql
+++ b/scripts/fixtures/shopItems.category.pre.sql
@@ -1,0 +1,6 @@
+SELECT id, slug, title, description, category,
+                cost_spirit, cost_essence, cost_matter, cost_substance,
+                is_one_time, is_active, sort_order
+         FROM shop_items
+         WHERE category = $1 AND is_active = true
+         ORDER BY sort_order ASC, title ASC

--- a/scripts/fixtures/shopItems.categoryAll.pre.sql
+++ b/scripts/fixtures/shopItems.categoryAll.pre.sql
@@ -1,0 +1,6 @@
+SELECT id, slug, title, description, category,
+                cost_spirit, cost_essence, cost_matter, cost_substance,
+                is_one_time, is_active, sort_order
+         FROM shop_items
+         WHERE category = $1
+         ORDER BY sort_order ASC, title ASC

--- a/scripts/fixtures/shopItems.default.pre.sql
+++ b/scripts/fixtures/shopItems.default.pre.sql
@@ -1,0 +1,6 @@
+SELECT id, slug, title, description, category,
+                cost_spirit, cost_essence, cost_matter, cost_substance,
+                is_one_time, is_active, sort_order
+         FROM shop_items
+         WHERE is_active = true
+         ORDER BY sort_order ASC, title ASC

--- a/scripts/fixtures/transactionCount.pre.sql
+++ b/scripts/fixtures/transactionCount.pre.sql
@@ -1,0 +1,1 @@
+SELECT COUNT(*)::int AS total FROM token_transactions WHERE user_id = $1

--- a/scripts/fixtures/transactionsPage.pre.sql
+++ b/scripts/fixtures/transactionsPage.pre.sql
@@ -1,0 +1,4 @@
+SELECT * FROM token_transactions
+             WHERE user_id = $1
+             ORDER BY created_at DESC
+             LIMIT $2 OFFSET $3

--- a/scripts/fixtures/userOwnsItem.pre.sql
+++ b/scripts/fixtures/userOwnsItem.pre.sql
@@ -1,0 +1,3 @@
+SELECT 1 FROM user_purchases up
+             JOIN shop_items si ON si.id = up.shop_item_id
+             WHERE up.user_id = $1 AND si.slug = $2

--- a/src/services/TokenEconomyService.ts
+++ b/src/services/TokenEconomyService.ts
@@ -12,10 +12,19 @@ import { _logger } from "@/lib/logger";
 import {
   columnFor,
   creditTokensSql,
+  dailyClaimTimestampSql,
   debitAllTokensSql,
   debitTokensSql,
   getBalancesSql,
+  hasActivePurchaseSql,
+  idempotencyProbeSql,
+  shopItemDetailSql,
+  shopItemForPurchaseSql,
+  shopItemsSql,
+  transactionCountSql,
+  transactionsPageSql,
   transmuteSql,
+  userOwnsItemSql,
 } from "@/services/tokenEconomyQueries";
 import type {
   TokenType,
@@ -327,10 +336,8 @@ class TokenEconomyService {
     if (db) {
       try {
         if (idemKey) {
-          const dup = await db.executeQuery(
-            `SELECT 1 FROM token_transactions WHERE idempotency_key LIKE $1 LIMIT 1`,
-            [`${idemKey}:%`],
-          );
+          const probe = idempotencyProbeSql(idemKey);
+          const dup = await db.executeQuery(probe.sql, probe.values);
           if (dup.rows.length > 0) {
             return { success: false, reason: "already_applied" };
           }
@@ -552,15 +559,12 @@ class TokenEconomyService {
    * 'main' updates last_daily_claim_at; 'agents' updates last_daily_claim_agents_at.
    */
   async updateDailyClaimTimestamp(userId: string, site: "main" | "agents" = "main"): Promise<void> {
-    const column = site === "agents" ? "last_daily_claim_agents_at" : "last_daily_claim_at";
     const db = await getDbModule();
 
     if (db) {
       try {
-        await db.executeQuery(
-          `UPDATE token_balances SET ${column} = now(), updated_at = now() WHERE user_id = $1`,
-          [userId],
-        );
+        const query = dailyClaimTimestampSql({ userId, site });
+        await db.executeQuery(query.sql, query.values);
       } catch (error) {
         _logger.error("[TokenEconomy] updateDailyClaimTimestamp failed:", error);
       }
@@ -721,18 +725,11 @@ class TokenEconomyService {
 
     if (db) {
       try {
+        const page = transactionsPageSql({ userId, limit, offset });
+        const count = transactionCountSql(userId);
         const [txnResult, countResult] = await Promise.all([
-          db.executeQuery(
-            `SELECT * FROM token_transactions
-             WHERE user_id = $1
-             ORDER BY created_at DESC
-             LIMIT $2 OFFSET $3`,
-            [userId, limit, offset],
-          ),
-          db.executeQuery(
-            `SELECT COUNT(*)::int AS total FROM token_transactions WHERE user_id = $1`,
-            [userId],
-          ),
+          db.executeQuery(page.sql, page.values),
+          db.executeQuery(count.sql, count.values),
         ]);
 
         return {
@@ -787,10 +784,8 @@ class TokenEconomyService {
     if (db) {
       try {
         // 1. Look up the shop item
-        const itemResult = await db.executeQuery(
-          `SELECT * FROM shop_items WHERE slug = $1 AND is_active = true`,
-          [shopItemSlug],
-        );
+        const lookup = shopItemForPurchaseSql(shopItemSlug);
+        const itemResult = await db.executeQuery(lookup.sql, lookup.values);
         const item = itemResult.rows[0];
         if (!item) {
           _logger.warn("[TokenEconomy] Shop item not found:", shopItemSlug);
@@ -799,12 +794,8 @@ class TokenEconomyService {
 
         // 2. Check if one-time item already purchased
         if (item.is_one_time) {
-          const existing = await db.executeQuery(
-            `SELECT 1 FROM user_purchases up
-             JOIN shop_items si ON si.id = up.shop_item_id
-             WHERE up.user_id = $1 AND si.slug = $2`,
-            [userId, shopItemSlug],
-          );
+          const owned = userOwnsItemSql({ userId, slug: shopItemSlug });
+          const existing = await db.executeQuery(owned.sql, owned.values);
           if (existing.rows.length > 0) {
             _logger.info("[TokenEconomy] One-time item already purchased:", shopItemSlug);
             return { success: false, reason: "already_owned" };
@@ -814,10 +805,8 @@ class TokenEconomyService {
         // 2b. Idempotency pre-check: reject duplicate submissions (client retry after network error)
         const idemKey = opts?.idempotencyKey ?? null;
         if (idemKey) {
-          const dup = await db.executeQuery(
-            `SELECT 1 FROM token_transactions WHERE idempotency_key LIKE $1 LIMIT 1`,
-            [`${idemKey}:%`],
-          );
+          const probe = idempotencyProbeSql(idemKey);
+          const dup = await db.executeQuery(probe.sql, probe.values);
           if (dup.rows.length > 0) {
             _logger.info("[TokenEconomy] Duplicate purchase blocked by idempotency key:", idemKey);
             return { success: false, reason: "already_applied" };
@@ -884,18 +873,12 @@ class TokenEconomyService {
 
     if (db) {
       try {
-        const dateCondition = maxAgeDays
-          ? `AND up.purchased_at >= now() - interval '${maxAgeDays} days'`
-          : "";
-
-        const result = await db.executeQuery(
-          `SELECT 1 FROM user_purchases up
-           JOIN shop_items si ON si.id = up.shop_item_id
-           WHERE up.user_id = $1 AND si.slug = $2
-           ${dateCondition}
-           LIMIT 1`,
-          [userId, shopItemSlug],
-        );
+        const query = hasActivePurchaseSql({
+          userId,
+          slug: shopItemSlug,
+          maxAgeDays,
+        });
+        const result = await db.executeQuery(query.sql, query.values);
         return result.rows.length > 0;
       } catch (error) {
         _logger.error("[TokenEconomy] hasActivePurchase failed:", error);
@@ -925,13 +908,8 @@ class TokenEconomyService {
 
     if (db) {
       try {
-        const result = await db.executeQuery(
-          `SELECT id, slug, title, description, category,
-                  cost_spirit, cost_essence, cost_matter, cost_substance,
-                  is_one_time, is_active
-           FROM shop_items WHERE slug = $1`,
-          [slug],
-        );
+        const query = shopItemDetailSql(slug);
+        const result = await db.executeQuery(query.sql, query.values);
         const row = result.rows[0];
         if (!row) return null;
         return {
@@ -976,29 +954,8 @@ class TokenEconomyService {
     if (!db) return [];
 
     try {
-      const where: string[] = [];
-      const params: unknown[] = [];
-      let idx = 1;
-
-      if (opts?.category) {
-        where.push(`category = $${idx++}`);
-        params.push(opts.category);
-      }
-      if (opts?.onlyActive !== false) {
-        where.push(`is_active = true`);
-      }
-
-      const whereClause = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
-
-      const result = await db.executeQuery(
-        `SELECT id, slug, title, description, category,
-                cost_spirit, cost_essence, cost_matter, cost_substance,
-                is_one_time, is_active, sort_order
-         FROM shop_items
-         ${whereClause}
-         ORDER BY sort_order ASC, title ASC`,
-        params,
-      );
+      const query = shopItemsSql(opts);
+      const result = await db.executeQuery(query.sql, query.values);
 
       return result.rows.map(row => ({
         id: row.id,

--- a/src/services/tokenEconomyQueries.ts
+++ b/src/services/tokenEconomyQueries.ts
@@ -1,5 +1,5 @@
 /**
- * Token Economy SQL — every statement that moves money.
+ * Token Economy SQL — every statement `TokenEconomyService` sends to PostgreSQL.
  *
  * @file src/services/tokenEconomyQueries.ts
  *
@@ -572,4 +572,198 @@ export function transmuteSql(opts: {
           SELECT * FROM updated`;
 
   return { sql, values: p.values };
+}
+
+// ─── Reads and bookkeeping ────────────────────────────────────────────
+//
+// None of the statements below moves a balance. They are here for the same two
+// reasons the money statements are: the PREPARE gate can only check SQL it can
+// reach, and a hand-numbered `$n` beside a hand-ordered array is a shape where
+// swapping two same-typed arguments type-checks and silently does the wrong
+// thing.
+
+/**
+ * Has any transaction already been written under this idempotency key?
+ *
+ * The writers store `<prefix>:<TokenType>`, one row per axis, so the probe has
+ * to match on the prefix. That `:%` suffix lives HERE rather than at the call
+ * sites: it is the same convention `debitAllTokensSql` encodes when it writes
+ * the keys, and the two must agree. Passing the raw prefix and appending `:%`
+ * by hand at each caller is how they drift.
+ *
+ * `LIKE` with a caller-supplied prefix is safe because the prefix is BOUND, not
+ * interpolated — a `%` inside it would widen the match but cannot alter the
+ * statement.
+ */
+export function idempotencyProbeSql(keyPrefix: string): BuiltQuery {
+  const p = new QueryParams();
+  const prefix = p.add(`${keyPrefix}:%`);
+  return {
+    sql: `SELECT 1 FROM token_transactions WHERE idempotency_key LIKE ${prefix} LIMIT 1`,
+    values: p.values,
+  };
+}
+
+/** Which column records a site's daily claim. Two sites, two columns; derived
+ *  from the site so the caller cannot name a column that does not exist. */
+export type ClaimSite = "main" | "agents";
+const CLAIM_COLUMN: Record<ClaimSite, string> = {
+  main: "last_daily_claim_at",
+  agents: "last_daily_claim_agents_at",
+};
+
+/** Stamp the site-specific daily-claim timestamp. */
+export function dailyClaimTimestampSql(opts: {
+  userId: string;
+  site: ClaimSite;
+}): BuiltQuery {
+  const column = CLAIM_COLUMN[opts.site];
+  const p = new QueryParams();
+  const user = p.add(opts.userId);
+  return {
+    sql: `UPDATE token_balances SET ${column} = now(), updated_at = now() WHERE user_id = ${user}`,
+    values: p.values,
+  };
+}
+
+/**
+ * One page of a user's ledger, newest first.
+ *
+ * `limit` and `offset` are two adjacent integers — the one parameter pair here
+ * where a hand-ordered array could silently swap and return the wrong page.
+ */
+export function transactionsPageSql(opts: {
+  userId: string;
+  limit: number;
+  offset: number;
+}): BuiltQuery {
+  const p = new QueryParams();
+  const user = p.add(opts.userId);
+  const limit = p.add(opts.limit);
+  const offset = p.add(opts.offset);
+  return {
+    sql: `SELECT * FROM token_transactions
+             WHERE user_id = ${user}
+             ORDER BY created_at DESC
+             LIMIT ${limit} OFFSET ${offset}`,
+    values: p.values,
+  };
+}
+
+/** Total ledger rows for a user, for paging. */
+export function transactionCountSql(userId: string): BuiltQuery {
+  const p = new QueryParams();
+  const user = p.add(userId);
+  return {
+    sql: `SELECT COUNT(*)::int AS total FROM token_transactions WHERE user_id = ${user}`,
+    values: p.values,
+  };
+}
+
+/** The purchasable item behind a slug. Filters `is_active` because an inactive
+ *  item must not be buyable — distinct from `shopItemDetailSql`, which reads an
+ *  item for display regardless of its active state. */
+export function shopItemForPurchaseSql(slug: string): BuiltQuery {
+  const p = new QueryParams();
+  const s = p.add(slug);
+  return {
+    sql: `SELECT * FROM shop_items WHERE slug = ${s} AND is_active = true`,
+    values: p.values,
+  };
+}
+
+/** Does this user already own this item? Used to enforce one-time items. */
+export function userOwnsItemSql(opts: {
+  userId: string;
+  slug: string;
+}): BuiltQuery {
+  const p = new QueryParams();
+  const user = p.add(opts.userId);
+  const slug = p.add(opts.slug);
+  return {
+    sql: `SELECT 1 FROM user_purchases up
+             JOIN shop_items si ON si.id = up.shop_item_id
+             WHERE up.user_id = ${user} AND si.slug = ${slug}`,
+    values: p.values,
+  };
+}
+
+/**
+ * Does this user hold a CURRENT purchase of this item?
+ *
+ * ── Why `maxAgeDays` is bound rather than interpolated ──────────────────────
+ *
+ * It used to be spliced straight into the statement text:
+ *
+ *     AND up.purchased_at >= now() - interval '${maxAgeDays} days'
+ *
+ * `maxAgeDays` is typed `number`, but a value arriving from `request.json()` is
+ * `any` at runtime, so a string would have been concatenated into the SQL. No
+ * caller passed the argument, so the branch was unreachable and nothing was
+ * exploitable — but it was one call site away from being an injection point,
+ * and a PREPARE gate cannot check a statement whose text depends on a value.
+ *
+ * `make_interval` takes the day count as an ordinary bound parameter, so the
+ * statement text is now fixed no matter what the caller passes.
+ */
+export function hasActivePurchaseSql(opts: {
+  userId: string;
+  slug: string;
+  maxAgeDays?: number;
+}): BuiltQuery {
+  const p = new QueryParams();
+  const user = p.add(opts.userId);
+  const slug = p.add(opts.slug);
+  const dateCondition =
+    opts.maxAgeDays === undefined
+      ? ""
+      : `AND up.purchased_at >= now() - make_interval(days => ${p.add(opts.maxAgeDays)}::int)`;
+  return {
+    sql: `SELECT 1 FROM user_purchases up
+           JOIN shop_items si ON si.id = up.shop_item_id
+           WHERE up.user_id = ${user} AND si.slug = ${slug}
+           ${dateCondition}
+           LIMIT 1`,
+    values: p.values,
+  };
+}
+
+/** The shop catalogue entry for a slug, whatever its active state. */
+export function shopItemDetailSql(slug: string): BuiltQuery {
+  const p = new QueryParams();
+  const s = p.add(slug);
+  return {
+    sql: `SELECT id, slug, title, description, category,
+                  cost_spirit, cost_essence, cost_matter, cost_substance,
+                  is_one_time, is_active
+           FROM shop_items WHERE slug = ${s}`,
+    values: p.values,
+  };
+}
+
+/**
+ * The shop catalogue, optionally filtered.
+ *
+ * `onlyActive` defaults to true, and specifically on `!== false`: passing no
+ * options at all must still hide inactive items. Only an explicit `false`
+ * widens the query.
+ */
+export function shopItemsSql(opts?: {
+  category?: string;
+  onlyActive?: boolean;
+}): BuiltQuery {
+  const p = new QueryParams();
+  const where: string[] = [];
+  if (opts?.category) where.push(`category = ${p.add(opts.category)}`);
+  if (opts?.onlyActive !== false) where.push(`is_active = true`);
+  const whereClause = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
+  return {
+    sql: `SELECT id, slug, title, description, category,
+                cost_spirit, cost_essence, cost_matter, cost_substance,
+                is_one_time, is_active, sort_order
+         FROM shop_items
+         ${whereClause}
+         ORDER BY sort_order ASC, title ASC`,
+    values: p.values,
+  };
 }


### PR DESCRIPTION
Phase 3, completing the migration begun in #658 and #662. `TokenEconomyService.ts` now contains **no SQL of its own** — the ten remaining inline statements move into `tokenEconomyQueries.ts`, and the PREPARE gate goes **23 → 37** statements.

These are reads and bookkeeping rather than money movement, but two of them decide whether money moves at all.

## The one that was not a pure move

`hasActivePurchase` spliced its day count straight into the statement text:

```sql
AND up.purchased_at >= now() - interval '${maxAgeDays} days'
```

`maxAgeDays` is typed `number`, but a value arriving via `request.json()` is `any` at runtime, so a string would have been concatenated into the SQL. **Both call sites omit the argument**, so the branch was unreachable and nothing was exploitable — this was one call site away, not a live hole.

It is now `make_interval(days => $3::int)`, an ordinary bound parameter. The gate proves it two ways: the statement PREPAREs with `integer` as `$3`, and the behavioural test feeds it `1 days' OR true --` and asserts that value lands in the values array rather than the statement text.

A statement whose *text* depends on a caller's value also cannot be gated at all, which is the other reason this had to change.

## Cross-builder agreement, now asserted

`idempotencyProbeSql` owns the `:%` suffix instead of each caller appending it. The writers store `<prefix>:<TokenType>`, one row per axis; the probe searches `<prefix>:%`. Two halves of one convention that were written down in three places. The behavioural gate now writes a spend under a key, asserts the probe finds it, and includes a negative control that it does *not* match a neighbouring key. If those conventions drift, duplicate detection silently stops working and only the unique index stands between a client retry and a double charge.

## My own fixture extractor was wrong, and identity caught it

The `shopItems` extraction regex used `[\s\S]*?` and matched from `getShopItem`'s projection through 70 lines of TypeScript to `getShopItems`' `ORDER BY`. It matched **exactly once**, so my "matched exactly once" control passed — uniqueness is not correctness. The byte-identity assertion is what failed.

Every pattern now uses `[^`+"`"+`]*` so a match cannot cross a backtick, plus a line-count ceiling. Both controls are documented in the script.

## Verification

Production, in a rolled-back transaction. The leak check now covers the shop/purchase probe rows too, with a control proving its predicates can see rows at all.

- **37/37 PREPARE.** Controls green: 14/14 exported builders exercised, count asserted, and PREPARE still provably rejects a bad statement
- **Behaviour**: idempotency-probe convention + negative control; `limit`/`offset` not transposed and newest-first ordering; active/inactive shop visibility; `maxAgeDays` at 30 excludes and at 90 includes the same 40-day-old row; each claim site stamping only its own column
- **13 identity fixtures** for the lifted reads, all matching
- 174 suites / 1546 tests, `tsc` clean, lint 17 warnings (all pre-existing)

## Scope

The gate's closing note now says coverage is **complete for this service** — enforced rather than asserted, since the service holds no SQL and control 2 fails on any unexercised builder. It also states what it does *not* cover: economy SQL living in API routes, crons, and migrations is outside this gate's scope and remains ungated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)