### PR TITLE
ci(integrity): stop failing on a queue depth, and clear that queue on a schedule

### DIFF
--- a/.github/workflows/monica-backfill.yml
+++ b/.github/workflows/monica-backfill.yml
@@ -1,0 +1,103 @@
+# Classify newly-arrived agents, nightly.
+#
+# This is the ONLY workflow in the repository that WRITES to production. Every
+# guard below exists because of that.
+#
+# ── Why it exists ───────────────────────────────────────────────────────────
+#
+# Agents arrive without a monica and a backfill assigns one from the agent's own
+# name. `[MEASURED 2026-07-28]` ~50 arrive per day (7-day range 43-57), and six
+# appeared within fifteen minutes of a backfill finishing. Left to a human, the
+# queue is never empty for long — which is how the integrity gate came to be red
+# on master continuously from 2026-07-26, and, because a failed step used to
+# cancel the rest of the job, silently skipped the four gates behind it including
+# the economy SQL and ledger/balance gates.
+#
+# So the queue is cleared on a schedule, and the integrity check now treats queue
+# depth as a threshold rather than a defect (scripts/checkAgentMonicaDrift.ts).
+#
+# ── Why 06:45 UTC ───────────────────────────────────────────────────────────
+#
+# Thirty minutes ahead of the 07:15 integrity cron in monica-integrity.yml, so
+# the board is clear when the check runs. Not so close that a slow run overlaps
+# it: a normal run takes well under a minute.
+#
+# ── Why this is safe to run unattended ──────────────────────────────────────
+#
+#   * values are DERIVED from each agent's own name — deterministic, and the
+#     drift check independently re-computes every one of them afterwards
+#   * the script snapshots to monica_preconstruction_<timestamp> before writing
+#   * it migrates in ONE transaction
+#   * --max-new bounds first-time classification, so a classifier or schema change
+#     re-deciding the whole population stops and waits for a human instead of
+#     rewriting thousands of rows overnight
+#   * schedule + manual dispatch ONLY. Never on push or pull_request: a workflow
+#     that writes to production must not be triggerable by opening a PR.
+
+name: Monica Backfill
+
+on:
+  schedule:
+    - cron: "45 6 * * *"
+  workflow_dispatch:
+    inputs:
+      max_new:
+        description: "Bound on first-time classifications (raise only after reading a dry run)"
+        required: false
+        default: "500"
+
+concurrency:
+  # Never two writers at once. `cancel-in-progress: false` deliberately — a write
+  # in flight is not something to cancel; the transaction should finish.
+  group: monica-backfill
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    name: Classify new agents
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Require the database secret
+        # FAIL, do not skip. A skipped write job renders green, and "the backfill
+        # is running" would then be an assumption rather than a fact — with the
+        # queue quietly growing until the integrity threshold trips days later.
+        env:
+          DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
+        run: |
+          if [ -z "$DATABASE_PUBLIC_URL" ]; then
+            echo "::error::DATABASE_PUBLIC_URL secret is not set — the nightly backfill is NOT operational."
+            exit 1
+          fi
+          echo "database secret present"
+
+      - name: Dry run (what would change)
+        # Runs first and is kept in the log even when the write succeeds. If a
+        # write is ever wrong, the plan that produced it is the first thing anyone
+        # needs, and reconstructing it after the fact is not possible.
+        env:
+          DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
+        run: bun scripts/backfillMonicaPerConstruction.ts
+
+      - name: Backfill
+        env:
+          DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
+          MAX_NEW: ${{ github.event.inputs.max_new || '500' }}
+        run: bun scripts/backfillMonicaPerConstruction.ts --write --max-new="$MAX_NEW"
+
+      - name: Verify the write against a fresh computation
+        # The write is only as trustworthy as its verification. This re-derives
+        # every stored value from the engine and fails on any disagreement, so a
+        # backfill that wrote something wrong cannot report success.
+        if: ${{ !cancelled() }}
+        env:
+          DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
+        run: bun scripts/checkAgentMonicaDrift.ts

--- a/scripts/backfillMonicaPerConstruction.ts
+++ b/scripts/backfillMonicaPerConstruction.ts
@@ -242,6 +242,41 @@ if (!WRITE) {
   process.exit(0);
 }
 
+// ── Blast-radius bound, for the UNATTENDED path ─────────────────────────────
+//
+// This runs on a schedule now (.github/workflows/monica-backfill.yml, 06:45 UTC),
+// so nobody reads the dry run first. `[MEASURED 2026-07-28]` a normal night is
+// ~50 newly-arrived agents (7-day range 43-57). A run that suddenly wants to
+// classify thousands is not a busy night — it is a classifier or schema change
+// re-deciding the whole population, and it should stop and wait for a human
+// rather than rewrite 5000 rows at 06:45 while everyone is asleep.
+//
+// Bounded on NEW arrivals only. Re-computation of already-classified rows is
+// idempotent and provably value-preserving (the drift check verifies it), so it
+// is not the dangerous quantity; first-time assignment is.
+//
+// --max-new=<n> overrides, for the deliberate manual run that follows an alert.
+const maxNewArg = process.argv.find((a) => a.startsWith("--max-new="));
+const MAX_NEW = maxNewArg ? Number(maxNewArg.split("=")[1]) : Number.POSITIVE_INFINITY;
+if (!Number.isFinite(MAX_NEW) && maxNewArg) {
+  console.error(`FATAL: --max-new expects a number, got "${maxNewArg}"`);
+  await client.end();
+  process.exit(1);
+}
+if (newlyComputed > MAX_NEW) {
+  console.error(
+    `\n*** REFUSING TO WRITE: ${newlyComputed} agents would be classified for the first\n` +
+      `    time, above the --max-new=${MAX_NEW} bound. Ordinary growth is ~50/night.\n` +
+      `    This is what a classifier or schema change re-deciding the population\n` +
+      `    looks like. Inspect the dry run, then re-run with a raised bound if the\n` +
+      `    count is genuinely expected:\n` +
+      `      railway run --service Postgres -- bun scripts/backfillMonicaPerConstruction.ts --write --max-new=${newlyComputed}\n` +
+      `    Nothing was written. ***`,
+  );
+  await client.end();
+  process.exit(1);
+}
+
 const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\..+/, "").replace("T", "_");
 const snapshot = `monica_preconstruction_${stamp}`;
 if (!/^monica_preconstruction_\d{8}_\d{6}$/.test(snapshot)) {

--- a/scripts/checkAgentMonicaDrift.ts
+++ b/scripts/checkAgentMonicaDrift.ts
@@ -217,9 +217,65 @@ for (const [k, xs] of Object.entries(values)) {
   }
 }
 
-const sum = (t: Tally) => t.drifted + t.missing + t.wrongMethod;
-const bad = sum(tally.single) + sum(tally.phase) + sum(tally.fullChart) + problems.length;
+// ── Two different things were being reported as one ─────────────────────────
+//
+// `drifted` and `wrongMethod` are DEFECTS: a stored value disagrees with a fresh
+// computation, or sits in the wrong column. Neither can happen through ordinary
+// operation, and either means something overwrote a value it should not have.
+// Any occurrence fails, always.
+//
+// `missing` is a QUEUE DEPTH. Agents arrive without a monica and a backfill
+// assigns one; a non-zero count is the system working, not breaking.
+// `[MEASURED 2026-07-28]` roughly 50 new agents per day (7-day range 43-57), and
+// six had already appeared within fifteen minutes of a backfill finishing. A gate
+// that fails on any missing row is therefore red almost all the time.
+//
+// That conflation had a real cost: this check failed on master continuously from
+// 2026-07-26, and because a failed step used to cancel the rest of the job, it
+// silently skipped four gates behind it — including the economy SQL and
+// ledger/balance gates, which had never run at all. A routine condition was
+// switching off the checks that guard money.
+//
+// So `missing` fails only above a threshold that ordinary growth cannot reach.
+const MISSING_QUEUE_THRESHOLD = 150;
+//
+// Derivation, not a round number picked for comfort: ~50 arrivals/day, and the
+// scheduled backfill (06:45 UTC, ahead of the 07:15 integrity cron) clears the
+// queue daily. Steady-state depth at the worst moment of a day is therefore ~50,
+// and 150 is three days of accumulation — high enough that organic growth never
+// trips it, low enough to catch the failure that matters: the backfill silently
+// not running, or a writer producing unclassified rows en masse. A count between
+// the two is reported loudly and passes.
+
+const defects = (t: Tally) => t.drifted + t.wrongMethod;
+const totalDefects =
+  defects(tally.single) + defects(tally.phase) + defects(tally.fullChart) + problems.length;
+const totalMissing = tally.single.missing + tally.phase.missing + tally.fullChart.missing;
+const queueOverflowed = totalMissing > MISSING_QUEUE_THRESHOLD;
+const bad = totalDefects + (queueOverflowed ? totalMissing : 0);
+
 if (problems.length) console.error("\ninvariant failures:\n  " + problems.join("\n  "));
+
+if (totalMissing > 0 && !queueOverflowed) {
+  // Visible but not fatal. Printed even on an otherwise-clean run so the queue
+  // never grows unnoticed — silence here is how a stalled backfill would hide.
+  console.log(
+    `\nqueue: ${totalMissing} agent(s) awaiting classification ` +
+      `(threshold ${MISSING_QUEUE_THRESHOLD}; ~50 arrive per day and the 06:45 UTC ` +
+      `backfill clears them). Not a defect.`,
+  );
+}
+if (queueOverflowed) {
+  console.error(
+    `\n*** ${totalMissing} agents await classification, above the ${MISSING_QUEUE_THRESHOLD} threshold.\n` +
+      `    That is more than ordinary growth produces, so the scheduled backfill\n` +
+      `    (.github/workflows/monica-backfill.yml, 06:45 UTC) is likely not running,\n` +
+      `    or a writer has begun inserting agents without a monica. Check the\n` +
+      `    workflow's recent runs BEFORE re-running the backfill by hand — a\n` +
+      `    backfill that succeeds hides the reason the queue grew. ***`,
+  );
+}
+
 if (bad === 0) {
   console.log(
     `\nOK — all ${tally.single.checked + tally.phase.checked + tally.fullChart.checked} backfilled agents ` +
@@ -232,13 +288,18 @@ if (bad === 0) {
   // `monica_method = 'two-body'|'full-chart'`, which the
   // `monica_constant_single_body_only` CHECK rejects. A gate that reports a
   // problem and then names the wrong fix is worse than one that stays quiet.
-  console.error(
-    `\n*** ${bad} row(s) need attention. Remedy:\n` +
-      `      railway run --service Postgres -- bun scripts/backfillMonicaPerConstruction.ts --write\n` +
-      `    It is idempotent, classifies by NAME, and handles all three constructions.\n` +
-      `    Do NOT use backfillAgentMonica.ts / backfillPhaseMonica.ts — they are\n` +
-      `    pre-§18o and write monica_constant for two-body/full-chart rows, which\n` +
-      `    the monica_constant_single_body_only constraint now rejects. ***`,
-  );
+  if (totalDefects > 0) {
+    console.error(
+      `\n*** ${totalDefects} DEFECT(s): a stored value disagrees with a fresh\n` +
+        `    computation, or sits in the wrong column. Neither happens through\n` +
+        `    ordinary operation — something overwrote a value it should not have.\n` +
+        `    Remedy:\n` +
+        `      railway run --service Postgres -- bun scripts/backfillMonicaPerConstruction.ts --write\n` +
+        `    It is idempotent, classifies by NAME, and handles all three constructions.\n` +
+        `    Do NOT use backfillAgentMonica.ts / backfillPhaseMonica.ts — they are\n` +
+        `    pre-§18o and write monica_constant for two-body/full-chart rows, which\n` +
+        `    the monica_constant_single_body_only constraint now rejects. ***`,
+    );
+  }
   process.exit(1);
 }


### PR DESCRIPTION
Follow-up to #664. Unmasking the gates showed the remaining problem clearly: the
drift check was reporting two unrelated things through one exit code.

## The split

`drifted` and `wrong-method` are DEFECTS — a stored value disagrees with a fresh
computation, or sits in the wrong column. Neither can arise from ordinary
operation; either means something overwrote a value it should not have. Any
occurrence still fails, immediately.

`missing` is a QUEUE DEPTH. Agents arrive without a monica and a backfill assigns
one. `[MEASURED 2026-07-28]` ~50 arrive per day (7-day range 43-57), and FOUR had
appeared within twenty minutes of the backfill finishing. A gate that fails on any
missing row is therefore red essentially always — which is exactly how this check
came to be red on master from 2026-07-26 onward, skipping four gates behind it,
including the economy SQL and ledger/balance gates that had never run at all.

A routine, self-resolving condition was switching off the checks that guard money.

`missing` now fails only above `MISSING_QUEUE_THRESHOLD = 150`, and the number is
derived rather than chosen for comfort: ~50 arrivals/day, cleared nightly, so the
worst-case steady-state depth is ~50 and 150 is three days of accumulation. High
enough that growth never trips it; low enough to catch what matters — the backfill
silently not running, or a writer emitting unclassified rows en masse. Anything
between is printed on every run, including clean ones, so a growing queue cannot
hide in silence.

## The schedule

`.github/workflows/monica-backfill.yml`, 06:45 UTC — thirty minutes ahead of the
07:15 integrity cron, so the board is clear when the check runs.

This is the ONLY workflow in the repository that writes to production, so:
  * schedule + workflow_dispatch ONLY. Never push or pull_request: a workflow that
    writes to production must not be triggerable by opening a PR.
  * `concurrency: cancel-in-progress: false` — a write in flight is not something
    to cancel; let the transaction finish.
  * the dry run executes first and stays in the log even on success. If a write is
    ever wrong, the plan that produced it is the first thing anyone needs, and it
    cannot be reconstructed afterwards.
  * the drift check runs AFTER the write and re-derives every stored value, so a
    backfill that wrote something wrong cannot report success.
  * the secret check FAILS rather than skips — "the backfill is running" must be a
    fact, not an assumption, or the queue grows unnoticed until the threshold trips
    days later.

## A blast-radius bound on the unattended write

`--max-new=<n>` caps FIRST-TIME classifications; the workflow passes 500. Nobody
reads the dry run at 06:45, and a run that suddenly wants to classify thousands is
not a busy night — it is a classifier or schema change re-deciding the whole
population, and it should stop and wait for a human rather than rewrite 5000 rows
overnight. Re-computation of already-classified rows is deliberately NOT bounded:
it is idempotent and provably value-preserving (the drift check verifies exactly
that), so first-time assignment is the dangerous quantity, not the row count.

## Verified, including both failure paths

  queue below threshold   4 awaiting, "Not a defect", exit 0, fresh-computation
                          check still passing over all 5181 rows
  queue above threshold   threshold forced to 0 -> exit 1 with the diagnostic
                          naming the workflow to check FIRST, since a backfill
                          that succeeds hides the reason the queue grew
  bound refuses           --write --max-new=0 -> "REFUSING TO WRITE: 4 agents
                          would be classified", nothing written, remedy printed
                          with the exact command and count

Workflow parsed and its resolved triggers/steps listed: schedule + dispatch only,
no push/pull_request. jest 178 suites / 1596 tests.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)