### PR TITLE
fix(agents): classify agents at creation — three bugs, the third hidden behind the first two

### DIFF
--- a/scripts/checkAgentClassifiedAtCreation.mjs
+++ b/scripts/checkAgentClassifiedAtCreation.mjs
@@ -1,0 +1,172 @@
+/**
+ * Does a newly-provisioned agent leave the writer already classified?
+ *
+ *   railway run --service Postgres -- bun scripts/checkAgentClassifiedAtCreation.mjs
+ *
+ * Executes the REAL statements from the two provisioning endpoints against a real
+ * PostgreSQL, inside a transaction that is ALWAYS rolled back. The SQL is read out
+ * of the route source rather than hand-copied, because a copy drifts from what
+ * ships and would then verify something other than the code.
+ *
+ * ── What this exists to catch ───────────────────────────────────────────────
+ *
+ * `[MEASURED 2026-07-28]` 110 agents sat unclassified in production, and of the
+ * 1506 in that family that DID have a monica, every one got it from a backfill —
+ * not one had ever been classified within five minutes of creation. Two bugs in
+ * `sync-debit`:
+ *
+ *   1. the monica was resolved from `agentProfile.name` (an optional payload
+ *      field) instead of the name the endpoint itself derives and STORES
+ *   2. only the single-body construction was attempted, so all 92 Moon-phase
+ *      agents resolved to null
+ *
+ * And a third, latent behind them: the statement wrote `monica_constant` plus
+ * `monica_method='single-body'` without `monica_single`, which the CHECK
+ * constraint `monica_method_matches_column` REJECTS. Fixing 1 and 2 alone would
+ * have converted a silent NULL into a FAILED DEBIT on every provisioning call.
+ * That is why this asserts by executing, not by reading.
+ */
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import pg from "pg";
+
+const url = process.env.DATABASE_PUBLIC_URL || process.env.DATABASE_URL;
+if (!url) {
+  console.error("FAIL: no DATABASE_PUBLIC_URL / DATABASE_URL — this check needs a real database.");
+  process.exit(1);
+}
+
+/** The profile UPSERT from sync-debit, extracted from the module source. */
+function syncDebitProfileSql() {
+  const src = readFileSync("src/app/api/economy/sync-debit/route.ts", "utf8");
+  const sql = src.match(/`UPDATE user_profiles SET[\s\S]*?WHERE user_id = \$1`/)?.[0];
+  if (!sql) {
+    console.error("CONTROL FAILED: could not extract the sync-debit profile UPDATE. Update this extractor.");
+    process.exit(1);
+  }
+  return sql.slice(1, -1);
+}
+
+const client = new pg.Client({ connectionString: url, ssl: { rejectUnauthorized: false } });
+await client.connect();
+
+let failures = 0;
+const ok = (m) => console.log(`  ok   ${m}`);
+const no = (m) => { console.error(`  FAIL ${m}`); failures++; };
+
+const mkAgent = async (name) => {
+  const id = randomUUID();
+  const email = `${name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${id.slice(0, 8)}@agentic.alchm.kitchen`;
+  await client.query(
+    `INSERT INTO users (id, email, password_hash, role, is_active, email_verified, is_agent,
+                        name, profile, preferences, login_count, created_at, updated_at)
+     VALUES ($1,$2,'AGENT_NO_LOGIN','USER'::user_role,true,true,true,$3,$4,'{}'::jsonb,0,now(),now())`,
+    [id, email, name, JSON.stringify({ email, isAgent: true, name })],
+  );
+  await client.query(`INSERT INTO user_profiles (user_id, name) VALUES ($1,$2)`, [id, name]);
+  return id;
+};
+
+const classification = async (userId) => {
+  const r = await client.query(
+    `SELECT monica_method, monica_constant::text, monica_single::text,
+            monica_two_body::text, monica_diurnal::text
+       FROM user_profiles WHERE user_id = $1`,
+    [userId],
+  );
+  return r.rows[0];
+};
+
+const SQL = syncDebitProfileSql();
+
+// $8/$11/$12/$13 are the monica params; the rest mirror a metadata-less payload,
+// which is exactly the case that was failing (agentProfile with no `name`).
+const params = (userId, monica, method) => [
+  userId, null, false, "{}", false, "[]", null,
+  monica === null ? null : String(monica.combined),
+  false, "{}",
+  monica === null ? null : String(monica.diurnal),
+  monica === null ? null : String(monica.nocturnal),
+  method,
+];
+
+try {
+  await client.query("BEGIN");
+
+  const { agentMonicaWithMethod } = await import("../src/utils/agentMonicaResolver.ts");
+
+  // ── 1. a Moon-phase agent (92 of the 110) ───────────────────────────────
+  console.log("\n1. phase agent — the population that was dropped wholesale");
+  const phaseName = "Moon Phase Waning Gibbous 284";
+  const phaseResolved = agentMonicaWithMethod(phaseName);
+  if (phaseResolved?.method === "two-body") ok(`${phaseName} resolves as two-body`);
+  else no(`${phaseName} resolved as ${phaseResolved?.method ?? "NULL"}, expected two-body`);
+
+  const phaseUser = await mkAgent(phaseName);
+  await client.query(SQL, params(phaseUser, phaseResolved?.monica ?? null, phaseResolved?.method ?? null));
+  const phase = await classification(phaseUser);
+  if (phase.monica_method === "two-body") ok("stored monica_method = two-body");
+  else no(`stored monica_method = ${phase.monica_method}, expected two-body`);
+  if (phase.monica_two_body !== null) ok(`value in monica_two_body (${phase.monica_two_body})`);
+  else no("monica_two_body is NULL — the value went somewhere else");
+  if (phase.monica_constant === null) ok("monica_constant left NULL (single-body-only column)");
+  else no(`monica_constant = ${phase.monica_constant}, must be NULL for two-body`);
+
+  // ── 2. a single-body agent with NO name in the payload ──────────────────
+  console.log("\n2. single-body agent, metadata-less — bug 1's exact case");
+  const singleName = "Mercury Pisces 16";
+  const singleResolved = agentMonicaWithMethod(singleName);
+  if (singleResolved?.method === "single-body") ok(`${singleName} resolves as single-body`);
+  else no(`${singleName} resolved as ${singleResolved?.method ?? "NULL"}`);
+
+  const singleUser = await mkAgent(singleName);
+  await client.query(SQL, params(singleUser, singleResolved?.monica ?? null, singleResolved?.method ?? null));
+  const single = await classification(singleUser);
+  if (single.monica_method === "single-body") ok("stored monica_method = single-body");
+  else no(`stored monica_method = ${single.monica_method}`);
+  if (single.monica_single !== null) ok(`value in monica_single (${single.monica_single})`);
+  else no("monica_single is NULL — monica_method_matches_column would reject this");
+  if (single.monica_constant !== null) ok("monica_constant also set (single-body only)");
+  else no("monica_constant is NULL");
+
+  // ── 3. an unresolvable name must stay NULL, not fabricate ───────────────
+  console.log("\n3. unresolvable name");
+  const oddUser = await mkAgent("Mars Gemini");
+  await client.query(SQL, params(oddUser, null, null));
+  const odd = await classification(oddUser);
+  if (odd.monica_method === null && odd.monica_single === null && odd.monica_two_body === null) {
+    ok("left entirely NULL — no invented classification");
+  } else no(`fabricated ${JSON.stringify(odd)}`);
+
+  // ── 4. CONTROL: the pre-fix shape must be REJECTED by the constraint ────
+  // Without this, the assertions above could be passing for reasons unrelated to
+  // the fix. This is the statement the old code effectively issued.
+  console.log("\n4. control — the pre-fix write must violate the CHECK constraint");
+  await client.query("SAVEPOINT ctl");
+  try {
+    await client.query(
+      `UPDATE user_profiles SET monica_constant = $2::numeric, monica_method = 'single-body'
+        WHERE user_id = $1`,
+      [oddUser, "0.5"],
+    );
+    no("constraint did NOT reject monica_constant + single-body without monica_single");
+    await client.query("ROLLBACK TO SAVEPOINT ctl");
+  } catch (e) {
+    await client.query("ROLLBACK TO SAVEPOINT ctl");
+    if (e.code === "23514") ok(`rejected with ${e.code} (${e.constraint}) — the fix is load-bearing`);
+    else no(`rejected with ${e.code}, expected 23514`);
+  }
+} catch (error) {
+  console.error("\nunexpected error:", error?.message ?? error);
+  failures++;
+} finally {
+  await client.query("ROLLBACK");
+  await client.end();
+}
+
+console.log(
+  failures === 0
+    ? "\nPASS — agents leave the writer already classified, in the right column.\n"
+    : `\nFAILED (${failures})\n`,
+);
+process.exit(failures === 0 ? 0 : 1);

--- a/src/app/api/economy/sync-debit/route.ts
+++ b/src/app/api/economy/sync-debit/route.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "crypto";
 import { NextResponse, type NextRequest } from "next/server";
 import { executeQuery } from "@/lib/database";
-import { agentMonicaFromName } from "@/utils/agentMonicaResolver";
+import { agentMonicaWithMethod } from "@/utils/agentMonicaResolver";
 import { normaliseNatalPositions } from "@/utils/fullChartMonica";
 
 export const dynamic = "force-dynamic";
@@ -115,9 +115,19 @@ export async function POST(req: NextRequest) {
   ].filter(Boolean).join(" ");
 
   try {
-    // 1. Look up user — auto-provision agentic emails
-    let userResult = await executeQuery<{ id: string }>(
-      "SELECT id FROM users WHERE email = $1 LIMIT 1",
+    // 1. Look up user — auto-provision agentic emails.
+    //
+    // `profile_name` is selected because the monica below MUST be resolved from
+    // the name this row actually STORES. `checkAgentMonicaDrift.ts` re-derives
+    // every value from `user_profiles.name`, so a writer that classified some
+    // other string would be reported as drift on a row it wrote correctly.
+    /** The name the row carries — the string the monica must be resolved from. */
+    let storedName: string | null = null;
+    let userResult = await executeQuery<{ id: string; profile_name: string | null }>(
+      `SELECT u.id, up.name AS profile_name
+         FROM users u
+         LEFT JOIN user_profiles up ON up.user_id = u.id
+        WHERE u.email = $1 LIMIT 1`,
       [email],
     );
 
@@ -126,7 +136,8 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ ok: false, reason: "user_not_found" }, { status: 404 });
       }
       const displayName = deriveAgentDisplayName(email, metadata);
-      userResult = await executeQuery<{ id: string }>(
+      storedName = displayName;
+      userResult = await executeQuery<{ id: string; profile_name: string | null }>(
         `INSERT INTO users (email, password_hash, role, is_active, email_verified, is_agent, name, profile, preferences, login_count, created_at, updated_at)
          VALUES ($1, 'AGENT_NO_LOGIN', 'USER'::user_role, true, true, true, $2, $3, '{}'::jsonb, 0, now(), now())
          ON CONFLICT (email) DO UPDATE SET is_agent = true
@@ -143,6 +154,7 @@ export async function POST(req: NextRequest) {
       );
     }
     const userId = userResult.rows[0].id;
+    storedName ??= userResult.rows[0].profile_name;
 
     // 1.5 Update Agent Profile if metadata present.
     // Treat the payload as Record<string, unknown> — the planetary-agents
@@ -172,10 +184,44 @@ export async function POST(req: NextRequest) {
       // OWN name, never taken from the AlchmAgentsETH payload: the old
       // `COALESCE(payload.monicaConstant, ...)` is how 3600 rows came to hold
       // round (0,1) sentinels that were never a thermodynamic monica at all.
-      // A name that is not a single-body placement yields null, which the
-      // COALESCE below reads as "leave the stored value alone".
-      const agentName = (ap.name as string | undefined) ?? null;
-      const resolvedMonica = agentName ? agentMonicaFromName(agentName) : null;
+      // A name that resolves to no construction yields null, which the COALESCE
+      // below reads as "leave the stored value alone".
+      //
+      // ── Two bugs lived in the two lines this replaces ────────────────────
+      //
+      //     const agentName = (ap.name as string | undefined) ?? null;
+      //     const resolvedMonica = agentName ? agentMonicaFromName(agentName) : null;
+      //
+      // 1. WRONG INPUT. `ap.name` is an optional payload field, while the name
+      //    this endpoint DERIVES and STORES comes from `deriveAgentDisplayName`
+      //    (the email local-part, title-cased). When the producer omits
+      //    `agentProfile.name` — which it evidently does — `agentName` was null,
+      //    so no monica was computed, while `hasNatalChart` was evaluated from a
+      //    different field and the chart WAS written. Hence rows with a chart, a
+      //    perfectly resolvable stored name, and a NULL monica.
+      // 2. MISSING CONSTRUCTION. `agentMonicaFromName` covers single-body only
+      //    and returns null for a Moon-phase agent, so every phase agent was
+      //    inserted unclassified even when a name was supplied.
+      //
+      // `[MEASURED 2026-07-28]` 110 agents were sitting unclassified: 92 phase
+      // (bug 2), 16 single-body whose stored names resolve fine (bug 1), 2
+      // genuinely unparseable. NONE of the 1506 agents in this family had EVER
+      // been classified within five minutes of creation — every value they hold
+      // came from a backfill.
+      //
+      // Resolution order is the stored name FIRST. `checkAgentMonicaDrift.ts`
+      // re-derives from `user_profiles.name`, so classifying any other string
+      // would report as drift on a row written correctly. `ap.name` remains a
+      // fallback for the case where no profile name exists yet.
+      const onUnclassifiedPhase = (error: unknown) =>
+        console.warn(
+          `[sync-debit] phase agent with an unclassifiable phase: ${storedName ?? "(no name)"} —` +
+            ` left for the nightly backfill to surface. ${String(error)}`,
+        );
+      const resolved =
+        (storedName ? agentMonicaWithMethod(storedName, onUnclassifiedPhase) : null) ??
+        (typeof ap.name === "string" ? agentMonicaWithMethod(ap.name, onUnclassifiedPhase) : null);
+      const resolvedMonica = resolved?.monica ?? null;
       const monicaCandidate = resolvedMonica?.combined ?? null;
       const hasNatalChart =
         ap.natalChart && typeof ap.natalChart === "object" && Object.keys(ap.natalChart).length > 0;
@@ -188,16 +234,50 @@ export async function POST(req: NextRequest) {
 
       // COALESCE so a null/empty field in this fire never wipes a previously
       // written value — every tick keeps the row fresh without regression.
+      //
+      // ── §18o: each construction writes its OWN column ────────────────────
+      //
+      // Four CHECK constraints police this, and the previous statement satisfied
+      // them only by accident. It wrote `monica_constant` plus
+      // `monica_method='single-body'` and never `monica_single`, which
+      // `monica_method_matches_column` REJECTS:
+      //
+      //   monica_constant_single_body_only  constant IS NULL OR method='single-body'
+      //   monica_method_matches_column      method='X' requires monica_X NOT NULL
+      //   monica_one_construction           at most ONE construction column set
+      //
+      // It never fired only because the resolution bug above left the method NULL.
+      // Fixing the resolution ALONE would therefore have converted a silent NULL
+      // into a failed debit on every agent-provisioning call — which is why this
+      // is verified by executing it, not by reading it.
+      //
+      // Every write is gated on `monica_method IS NULL`, so this performs
+      // FIRST-TIME classification only. Re-classification belongs to the backfill;
+      // an unconditional write could set a second construction column on a row
+      // that already has one (violating monica_one_construction) or overwrite the
+      // hand-authored full-chart value of a chart-bearing agent.
+      //
+      // NB: SQL comments inside this template literal must not contain backticks —
+      // a backtick terminates the literal and breaks the build.
       await executeQuery(
         `UPDATE user_profiles SET
            bio              = COALESCE($2, bio),
            natal_chart      = CASE WHEN $3::boolean THEN $4::jsonb ELSE natal_chart END,
            natal_positions  = CASE WHEN $5::boolean THEN $6::jsonb ELSE natal_positions END,
            dominant_element = COALESCE($7, dominant_element),
-           monica_constant  = COALESCE($8::numeric, monica_constant),
-           monica_diurnal   = COALESCE($11::numeric, monica_diurnal),
-           monica_nocturnal = COALESCE($12::numeric, monica_nocturnal),
-           monica_method    = COALESCE($13, monica_method),
+           -- See the note above this statement: value into its own construction
+           -- column, first-time classification only.
+           monica_constant  = CASE WHEN monica_method IS NULL AND $13 = 'single-body'
+                                   THEN $8::numeric ELSE monica_constant END,
+           monica_single    = CASE WHEN monica_method IS NULL AND $13 = 'single-body'
+                                   THEN $8::numeric ELSE monica_single END,
+           monica_two_body  = CASE WHEN monica_method IS NULL AND $13 = 'two-body'
+                                   THEN $8::numeric ELSE monica_two_body END,
+           monica_diurnal   = CASE WHEN monica_method IS NULL AND $13 IS NOT NULL
+                                   THEN $11::numeric ELSE monica_diurnal END,
+           monica_nocturnal = CASE WHEN monica_method IS NULL AND $13 IS NOT NULL
+                                   THEN $12::numeric ELSE monica_nocturnal END,
+           monica_method    = COALESCE(monica_method, $13),
            birth_data       = CASE WHEN $9::boolean THEN $10::jsonb ELSE birth_data END,
            updated_at       = now()
          WHERE user_id = $1`,
@@ -218,10 +298,11 @@ export async function POST(req: NextRequest) {
           }),
           resolvedMonica?.diurnal ?? null,
           resolvedMonica?.nocturnal ?? null,
-          // agentMonicaFromName only resolves single-body placements (it
-          // returns null for phase agents), so a resolved value is always
-          // this method — see §18j.
-          resolvedMonica ? "single-body" : null,
+          // The construction that actually produced the value — 'two-body' for a
+          // Moon-phase agent. Hardcoding 'single-body' here would have stamped a
+          // phase agent with the wrong method, which `checkAgentMonicaDrift.ts`
+          // reports as `wrong-method` and the §18o column constraint rejects.
+          resolved?.method ?? null,
         ]
       );
     }

--- a/src/app/api/internal/agent-sync/route.ts
+++ b/src/app/api/internal/agent-sync/route.ts
@@ -12,7 +12,7 @@ import { randomUUID } from "crypto";
 import { NextResponse, type NextRequest } from "next/server";
 import { withTransaction } from "@/lib/database";
 import { jsonbOrNull } from "@/services/userDatabaseService";
-import { agentMonicaFromName } from "@/utils/agentMonicaResolver";
+import { agentMonicaWithMethod } from "@/utils/agentMonicaResolver";
 import { normaliseNatalPositions } from "@/utils/fullChartMonica";
 
 /** `{}` and `[]` mean "absent" here, exactly as jsonbOrNull treats them. */
@@ -122,11 +122,23 @@ export async function POST(req: NextRequest) {
     // `monicaConstant` straight from the sync payload (PA's own legacy,
     // unsigned, disconnected formula) via a bare parseFloat with no
     // validation — a fourth write path the original three-site §18e fix
-    // missed. `agentMonicaFromName` only resolves single-body placements and
-    // returns null for anything else (a phase agent, a person), which the
+    // missed. A name that matches no construction yields null, which the
     // COALESCE below reads as "leave the stored value alone."
+    //
+    // `agentMonicaWithMethod` covers BOTH constructions. It previously called
+    // `agentMonicaFromName`, which is single-body only, so every Moon-phase agent
+    // synced through here was written unclassified — the same gap measured on
+    // sync-debit, latent here but identical in kind. It is also writer-safe: the
+    // two-body resolver THROWS for an unclassifiable phase, which must not turn a
+    // sync into a 500.
     void monicaConstant; // intentionally ignored — see comment above
-    const resolvedMonica = agentMonicaFromName(resolvedName);
+    const resolved = agentMonicaWithMethod(resolvedName, (error) =>
+      console.warn(
+        `[agent-sync] phase agent with an unclassifiable phase: ${resolvedName} —` +
+          ` left for the nightly backfill to surface. ${String(error)}`,
+      ),
+    );
+    const resolvedMonica = resolved?.monica ?? null;
 
     // The upstream producer emits `longitude: data?.longitude ?? data?.degrees ?? 0`
     // over objects carrying neither key, so every body arrives with a fabricated
@@ -175,18 +187,26 @@ export async function POST(req: NextRequest) {
         // Upsert user profile
         await client.query(
           `INSERT INTO user_profiles (
-             user_id, name, bio, birth_data, natal_chart, natal_positions, monica_constant, monica_diurnal, monica_nocturnal, monica_method, dominant_element
-           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+             user_id, name, bio, birth_data, natal_chart, natal_positions,
+             monica_constant, monica_single, monica_two_body,
+             monica_diurnal, monica_nocturnal, monica_method, dominant_element
+           ) VALUES ($1, $2, $3, $4, $5, $6,
+             CASE WHEN $10 = 'single-body' THEN $7::numeric END,
+             CASE WHEN $10 = 'single-body' THEN $7::numeric END,
+             CASE WHEN $10 = 'two-body'    THEN $7::numeric END,
+             $8, $9, $10, $11)
            ON CONFLICT (user_id) DO UPDATE SET
              name = COALESCE(EXCLUDED.name, user_profiles.name),
              bio = COALESCE(EXCLUDED.bio, user_profiles.bio),
              birth_data = COALESCE(EXCLUDED.birth_data, user_profiles.birth_data),
              natal_chart = COALESCE(EXCLUDED.natal_chart, user_profiles.natal_chart),
              natal_positions = COALESCE(EXCLUDED.natal_positions, user_profiles.natal_positions),
-             monica_constant = COALESCE(EXCLUDED.monica_constant, user_profiles.monica_constant),
+             monica_constant = COALESCE(user_profiles.monica_constant, EXCLUDED.monica_constant),
+             monica_single = COALESCE(user_profiles.monica_single, EXCLUDED.monica_single),
+             monica_two_body = COALESCE(user_profiles.monica_two_body, EXCLUDED.monica_two_body),
              monica_diurnal = COALESCE(EXCLUDED.monica_diurnal, user_profiles.monica_diurnal),
              monica_nocturnal = COALESCE(EXCLUDED.monica_nocturnal, user_profiles.monica_nocturnal),
-             monica_method = COALESCE(EXCLUDED.monica_method, user_profiles.monica_method),
+             monica_method = COALESCE(user_profiles.monica_method, EXCLUDED.monica_method),
              dominant_element = COALESCE(EXCLUDED.dominant_element, user_profiles.dominant_element),
              updated_at = now()`,
           [
@@ -204,7 +224,7 @@ export async function POST(req: NextRequest) {
             parsedMonicaConstant,
             resolvedMonica?.diurnal ?? null,
             resolvedMonica?.nocturnal ?? null,
-            resolvedMonica ? "single-body" : null,
+            resolved?.method ?? null,
             dominantElement || null
           ]
         );
@@ -231,8 +251,14 @@ export async function POST(req: NextRequest) {
 
         await client.query(
           `INSERT INTO user_profiles (
-             user_id, name, bio, birth_data, natal_chart, natal_positions, monica_constant, monica_diurnal, monica_nocturnal, monica_method, dominant_element
-           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+             user_id, name, bio, birth_data, natal_chart, natal_positions,
+             monica_constant, monica_single, monica_two_body,
+             monica_diurnal, monica_nocturnal, monica_method, dominant_element
+           ) VALUES ($1, $2, $3, $4, $5, $6,
+             CASE WHEN $10 = 'single-body' THEN $7::numeric END,
+             CASE WHEN $10 = 'single-body' THEN $7::numeric END,
+             CASE WHEN $10 = 'two-body'    THEN $7::numeric END,
+             $8, $9, $10, $11)`,
           [
             wtenUserId,
             resolvedName,
@@ -248,7 +274,7 @@ export async function POST(req: NextRequest) {
             parsedMonicaConstant,
             resolvedMonica?.diurnal ?? null,
             resolvedMonica?.nocturnal ?? null,
-            resolvedMonica ? "single-body" : null,
+            resolved?.method ?? null,
             dominantElement || null
           ]
         );

--- a/src/utils/agentMonicaResolver.ts
+++ b/src/utils/agentMonicaResolver.ts
@@ -183,3 +183,50 @@ export function twoBodyMonicaFromName(name: string): AgentMonica | null {
   if (!placement || placement.kind !== "phase") return null;
   return twoBodyMonica(placement.phase ?? "", placement.sign, placement.degree);
 }
+
+/** A resolved monica together with the `monica_method` the row must be stamped with. */
+export interface ResolvedAgentMonica {
+  monica: AgentMonica;
+  method: "single-body" | "two-body";
+}
+
+/**
+ * Both constructions, for a WRITER — the one entry point a request handler should
+ * use when provisioning an agent.
+ *
+ * ── Why this exists ─────────────────────────────────────────────────────────
+ *
+ * `agentMonicaFromName` covers single-body placements and returns null for
+ * everything else. Writers called only that, so every Moon-phase agent was
+ * inserted with a NULL monica and left for a backfill to classify.
+ * `[MEASURED 2026-07-28]` of 110 unclassified agents, **92 were phase agents**
+ * that `twoBodyMonicaFromName` resolves perfectly — the construction existed and
+ * was simply never called on the write path.
+ *
+ * ── Why it cannot throw ─────────────────────────────────────────────────────
+ *
+ * `twoBodyMonicaFromName` THROWS `UnknownMoonPhaseError` for a name that is a
+ * phase agent whose phase cannot be classified. That is right for a backfill: the
+ * throw means "my population, unclassified", and swallowing it would silently drop
+ * rows. It is wrong inside a request handler on the money path, where it would
+ * turn an odd agent name into a failed debit.
+ *
+ * So the throw is caught here and reported through `onUnclassifiedPhase`, and the
+ * row is left NULL for the nightly backfill — which does surface it. The
+ * distinction the throw carries is preserved by the callback, not discarded.
+ */
+export function agentMonicaWithMethod(
+  name: string,
+  onUnclassifiedPhase?: (error: unknown) => void,
+): ResolvedAgentMonica | null {
+  const single = agentMonicaFromName(name);
+  if (single) return { monica: single, method: "single-body" };
+
+  try {
+    const twoBody = twoBodyMonicaFromName(name);
+    return twoBody ? { monica: twoBody, method: "two-body" } : null;
+  } catch (error) {
+    onUnclassifiedPhase?.(error);
+    return null;
+  }
+}


### PR DESCRIPTION
Closes the leak the nightly backfill was papering over. `[MEASURED 2026-07-28]`
of the 1506 agents in this family holding a monica, EVERY one got it from a
backfill: not a single agent had ever been classified within five minutes of
creation.

## Bug 1 — resolved from the wrong string (sync-debit)

    const agentName = (ap.name as string | undefined) ?? null;
    const resolvedMonica = agentName ? agentMonicaFromName(agentName) : null;

`ap.name` is an OPTIONAL payload field. The name the endpoint derives and STORES
comes from `deriveAgentDisplayName` (the email local-part, title-cased). When the
producer omits `agentProfile.name` — which it evidently does — `agentName` was
null so nothing was computed, while `hasNatalChart` was read from a different
field and the chart WAS written. Hence rows with a chart, a perfectly resolvable
stored name, and a NULL monica.

Now resolved from the stored name first, `ap.name` as fallback. Order matters:
`checkAgentMonicaDrift.ts` re-derives from `user_profiles.name`, so classifying
any other string would be reported as drift on a row written correctly.

## Bug 2 — only one of two constructions was attempted (both writers)

`agentMonicaFromName` is single-body only and returns null for a Moon-phase
agent. `twoBodyMonicaFromName` has existed all along and was never called on any
write path. Of the 110 unclassified agents, **92 were phase agents** it resolves
perfectly.

New `agentMonicaWithMethod` composes both and returns the `monica_method` to
stamp. It is deliberately WRITER-SAFE: `twoBodyMonicaFromName` THROWS
`UnknownMoonPhaseError` for an unclassifiable phase — correct for a backfill,
where the throw means "my population, unclassified" — but inside a request
handler that would turn an odd agent name into a failed debit. The throw is
caught, reported through a callback, and the row left for the nightly backfill,
which does surface it. The distinction is preserved, not discarded.

## Bug 3 — which the first two were hiding

Both writers wrote `monica_constant` + `monica_method='single-body'` and NEVER
`monica_single`. The §18o CHECK constraint `monica_method_matches_column` rejects
exactly that. It had never fired only because bugs 1 and 2 left the method NULL,
which satisfies the constraint's all-null branch.

**Fixing the resolution alone would have converted a silent NULL into a failed
debit on every agent-provisioning call.** Proven, not reasoned: the verification
below issues the pre-fix write and requires PostgreSQL to reject it —

    23514  monica_method_matches_column

Values now go in the column their construction owns (single-body ->
monica_constant + monica_single; two-body -> monica_two_body, constant left
NULL), gated on `monica_method IS NULL` so this performs FIRST-TIME
classification only. Re-classification stays with the backfill: an unconditional
write could set a second construction column (violating monica_one_construction)
or overwrite a chart-bearing agent's hand-authored full-chart value.

## Verification — executed, not read

`scripts/checkAgentClassifiedAtCreation.mjs` runs the REAL statements, extracted
from the route source rather than hand-copied, against production inside a
transaction that is always rolled back:

    phase agent      resolves two-body; stored method=two-body; value in
                     monica_two_body (0.365075); monica_constant left NULL
    single-body,     resolves single-body; stored method=single-body; value in
    metadata-less    monica_single (-0.151622); monica_constant also set
    unresolvable     left entirely NULL — nothing invented
    CONTROL          the pre-fix write is REJECTED, 23514
                     monica_method_matches_column

Both rewritten agent-sync statements PREPARE (11 params each). 37 economy
statements still parse. jest 178 suites / 1596 tests. Drift check clean: 5185
agents match a fresh computation, queue 8 (threshold 150).

The nightly backfill and the queue threshold stay: they now cover genuine
stragglers (two permanently unparseable names) rather than the whole daily
intake.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)