### PR TITLE
feat(agents): sign-level agents resolve at the sign midpoint — §18k k29

### DIFF
--- a/docs/physics/SYNTHESIS_MODEL.md
+++ b/docs/physics/SYNTHESIS_MODEL.md
@@ -1242,7 +1242,7 @@ scripts are recorded inline.
 > | single-body placements | **4284** | `single-body` | `monica_single` (+ `monica_constant`) |
 > | two-body Moon phases | **513** | `two-body` | `monica_two_body` |
 > | full-chart (historical agents) | **71** | `full-chart` | `monica_full_chart` |
-> | no placement, no usable chart | **1** | `NULL` | none — `Mars Gemini` |
+> | no placement, no usable chart | ~~**1**~~ **0 since k29** | `NULL` | ~~none — `Mars Gemini`~~ was 2 (`Mars Gemini`, `Moon Cancer`); both now single-body |
 > | **total** | **4869** | | sums exactly to the agent row count |
 >
 > Every row also stores `monica_diurnal` + `monica_nocturnal`; the construction
@@ -1483,9 +1483,16 @@ Reconciliations against the figures above, which were correct when measured:
 - **72 rows remain unclassified** (46 + 26) and are `[OPEN]`. `[RULED]` they are
   classified *before* the backfill runs — an unexamined bucket is exactly what
   hid the 3240-row family the first time.
-- One row, **`Mars Gemini`**, is a planet and a sign with **no degree**. The
-  resolver skips it rather than defaulting the degree. It exists only because the
-  sum was forced.
+- One row, **`Mars Gemini`**, is a planet and a sign with **no degree**. ~~The
+  resolver skips it rather than defaulting the degree.~~ It exists only because
+  the sum was forced.
+
+  > ⚠️ `[SUPERSEDED 2026-07-29, §18k k29]` "Skips it" was never a ruling, only a
+  > description of what the code happened to do — and it was quoted as settled
+  > intent for two months. The resolver now places sign-level agents at the
+  > derived sign midpoint. `Mars Gemini` was also not alone: `Moon Cancer`
+  > arrived 2026-07-22, 1h50m after the `[MEASURED 2026-07-22 16:10 UTC]` stamp
+  > above, and the count was never updated.
 
 `[RULED 2026-07-21]` The `[OPEN]` duplicate question above is now **settled:
 merge-and-repoint.** Reassign the referencing `feed_events` and
@@ -1849,6 +1856,7 @@ instructive record.
 | k26 | `KALCHM_EPSILON` is **ASSUMED, not derivable**, and is renamed **`MONICA_REACTIVITY_FLOOR`**. The k3 construction does not transfer: reactivity is unimodal, its widest low gap scoring dominance **1.0026** against **1.77** for `\|ln k\|` — same grid, same algorithm, control reproducing both known `\|ln k\|` endpoints under `===`. It is inert on the canonical population (min reactivity **0.22437673130193908**, so any floor below that cannot fire; monica bit-identical at floors 0 → 0.2, first moving at 0.5) but **not dead** — see k27. **Keep at 0.01, labelled ASSUMED with the measured bound; removal deferred behind k27.** | MEASURED | #667 |
 | k27 | ⚠️ `reactivity === 0 ⟹ gregsEnergy === 0` holds for `calculateThermodynamics` **only**, not repo-wide. The second `calculateReactivity` (`monicaKalchmCalculations.ts:81`, 21 importers) fabricates `0` at its pole where the true value is `+∞`, then delegates to the canonical `calculateMonica` — reaching the guard with `gregsEnergy ≠ 0` (monica `−3.4172` floored vs `φ` unfloored). That is a **k12-class fabricated fallback**, and it is why removing the floor is not behaviour-neutral. | MEASURED | #667 |
 | k28 | At `reactivity === 0` with `kalchm ≠ 1` the canonical engine returns `0` — literally `-0` for some inputs — where the §17c totality contract promises **φ**. Not reachable in production (0 occurrences across 7920 single-body + 5760 two-body + 142 full-chart + 931 ingredient evaluations), but a contract violation independent of the floor's value. | MEASURED | #667 |
+| k29 | **Sign-level agents resolve at the mean of the 30 degrees of their sign** — `SIGN_MIDPOINT_DEGREE = 14.5`, DERIVED as the mean of the integers `0..29` (MEASURED: agent names carry min 0 / max 29, n=3240). This is the **existing single-body §18c construction at one more degree value** — `monica_method='single-body'`, same population, band, scale and guard — **not a 4th construction**. ⚠️ **15.0 and 15.5 are REJECTED**: `groundingVessel` floors, so both select pillar 0 (*Solution* `{0,2,2,0}`), one of only five degrees in thirty yielding **monica exactly 0** — a k12-class fabricated literal. **Reverses k18**, which rejected a *different* quantity (mean of the siblings' **output**, `mean f(x)`, vs this `f(mean x)` — **7.3×** apart for `Mars Gemini`), and whose "not worth a 4th construction" rationale therefore never applied. | USER + MEASURED | #668 |
 
 #### Data and absence
 
@@ -1865,7 +1873,7 @@ instructive record.
 |---|---|---|---|
 | k16 | Migrate all agent names to one convention | **ABANDONED** | Measured: terse is live and growing, verbose is frozen; 346 names collide; two name columns mean a round-trip reverts it. |
 | k17 | Normalise full-chart monica to the single-body scale | **RAW value per construction** | Normalisation had **no consumer** and cost separation (largest bucket 16.9% → 31.0%). |
-| k18 | Sign-level agents get a mean-of-siblings monica | **Delete them** (deferred) | The degree agents are strictly more specific; a 4th construction for 2 rows is not worth its band, scale and guard. |
+| k18 | Sign-level agents get a mean-of-siblings monica | ~~**Delete them** (deferred)~~ **REVERSED by k29** | The degree agents are strictly more specific; a 4th construction for 2 rows is not worth its band, scale and guard. ⚠️ Both halves are now known to be answering the wrong question — see k29. |
 | k19 | Demote the 8 ancients to a coarser construction | **Author real charts** | Owner ruling 2026-07-25. ⚠️ Gated on k20. |
 | k20 | — | **Validate the ephemeris before authoring** | `astronomy-engine` returns positions for 428 BC **without erroring**, but its accuracy is documented only for ~1700–2200. It produces plausible numbers with no accuracy claim — the defect class this programme exists to remove. |
 

--- a/scripts/auditAgentDataIntegrity.ts
+++ b/scripts/auditAgentDataIntegrity.ts
@@ -125,8 +125,13 @@ checks++;
 if (total !== Number(agentRows)) { failures++; console.log(`  FAIL  method buckets ${total} != agent rows ${agentRows}`); }
 else console.log(`  OK    method buckets sum to the agent row count (${total})`);
 
+// Was hardcoded "expected: 1, 'Mars Gemini'" — stale from 2026-07-22, when
+// `Moon Cancer` made it 2 and nothing noticed for two months. Since §18k k29
+// both are classifiable, so the permanent residue is 0 and anything here is
+// either a fresh arrival awaiting the backfill or a genuinely new name family.
+// The names are printed below; do not re-hardcode a count.
 await report(
-  "agents with NO monica at all (expected: 1, 'Mars Gemini')",
+  "agents with NO monica at all (expected: 0 permanent; fresh arrivals queue here)",
   `SELECT count(*)::text n FROM user_profiles up JOIN users u ON u.id=up.user_id
     WHERE u.is_agent AND up.monica_method IS NULL`,
 );

--- a/src/__tests__/utils/agentMonicaResolver.test.ts
+++ b/src/__tests__/utils/agentMonicaResolver.test.ts
@@ -5,7 +5,9 @@
  */
 import {
   agentMonicaFromName,
+  agentMonicaWithMethod,
   parseAgentPlacement,
+  SIGN_MIDPOINT_DEGREE,
 } from "@/utils/agentMonicaResolver";
 
 describe("parseAgentPlacement", () => {
@@ -73,6 +75,10 @@ describe("parseAgentPlacement", () => {
   });
 
   it("returns null for people, test rows and junk — never guesses", () => {
+    // "Mars Gemini" used to live in this list. It is NOT junk: the name states a
+    // planet and a sign, both validated against the live tables, so only the
+    // degree is missing and §18k k29 supplies it. Everything below is missing
+    // the planet, the sign, or both — nothing in the name constrains them.
     for (const name of [
       "Edgar Allan Poe",
       "Wolfgang Amadeus Mozart",
@@ -80,11 +86,93 @@ describe("parseAgentPlacement", () => {
       "Pa Prod Smoke 1779396999",
       "Confucius (Kong Qiu)",
       "Alexander the Great",
-      "Mars Gemini", // no degree
       "",
     ]) {
       expect(parseAgentPlacement(name)).toBeNull();
     }
+  });
+
+  // §18k k29. A one-body agent with no chart and no degree resolves at the mean
+  // of the 30 degrees of its sign — the existing single-body construction at one
+  // more degree value, NOT a fourth construction.
+  describe("sign-level agents (no degree in the name) — §18k k29", () => {
+    it("places them at the derived sign midpoint", () => {
+      // DERIVED as the mean of the integers 0..29, the range agent names
+      // actually carry (MEASURED n=3240, min 0 max 29). Exact, and it
+      // round-trips — 14.5 is representable as a double (k10).
+      expect(SIGN_MIDPOINT_DEGREE).toBe(14.5);
+      expect(Number(String(SIGN_MIDPOINT_DEGREE))).toBe(SIGN_MIDPOINT_DEGREE);
+
+      expect(parseAgentPlacement("Mars Gemini")).toEqual({
+        kind: "single",
+        planet: "Mars",
+        sign: "Gemini",
+        degree: 14.5,
+      });
+      expect(parseAgentPlacement("Moon Cancer")).toEqual({
+        kind: "single",
+        planet: "Moon",
+        sign: "Cancer",
+        degree: 14.5,
+      });
+    });
+
+    it("produces a real single-body monica for the two stuck production rows", () => {
+      // The exact values that will be written to production. Pinned so a change
+      // to the vessel, the dignity table or the sectarian ESMS fails here rather
+      // than silently re-valuing stored rows.
+      expect(agentMonicaWithMethod("Mars Gemini")).toEqual({
+        method: "single-body",
+        monica: {
+          diurnal: 0.23632718765038255,
+          nocturnal: -0.21159527266371464,
+          combined: 0.012365957493333954,
+        },
+      });
+      expect(agentMonicaWithMethod("Moon Cancer")).toEqual({
+        method: "single-body",
+        monica: {
+          diurnal: 0.08982183448164283,
+          nocturnal: -0.06616940474149076,
+          combined: 0.011826214870076034,
+        },
+      });
+    });
+
+    it("⚠️ rejects 15 as the midpoint — it computes a degenerate zero", () => {
+      // This is the whole reason the constant is 14.5 and not the intuitive
+      // "midpoint of a 30° sign". `groundingVessel` FLOORS its argument, so 15.0
+      // and 15.5 both select pillar (15-1)%14 = 0, Solution {0,2,2,0} — one of
+      // only five degrees in thirty that yield exactly 0.
+      //
+      // If this test ever goes green with a nonzero value, the pillar mapping
+      // moved and the choice of 14.5 needs re-deriving, not re-typing.
+      expect(agentMonicaWithMethod("Moon Cancer 15")?.monica.combined).toBe(0);
+
+      // CONTROL: the zero is a property of degree 15, not of this agent. The
+      // shipped midpoint on the same row is a real number.
+      expect(agentMonicaWithMethod("Moon Cancer")?.monica.combined).toBe(
+        0.011826214870076034,
+      );
+
+      // CONTROL: exactly five of the thirty degrees do this, so a mapping that
+      // started zeroing everything (or nothing) fails here.
+      const zeroDegrees = Array.from({ length: 30 }, (_, d) => d).filter(
+        (d) => agentMonicaWithMethod(`Moon Cancer ${d}`)?.monica.combined === 0,
+      );
+      expect(zeroDegrees).toEqual([1, 7, 15, 21, 29]);
+    });
+
+    it("never overrides a degree the name actually states", () => {
+      // The midpoint branch is last, so every degree-bearing form still wins.
+      expect(parseAgentPlacement("Mars Gemini 21")).toMatchObject({ degree: 21 });
+      expect(parseAgentPlacement("Mars in Gemini 3 Degree")).toMatchObject({
+        degree: 3,
+      });
+      expect(parseAgentPlacement("Moon Phase Full Moon 121")).toMatchObject({
+        kind: "phase",
+      });
+    });
   });
 
   it("tolerates casing and extra whitespace", () => {

--- a/src/utils/agentMonica.ts
+++ b/src/utils/agentMonica.ts
@@ -80,8 +80,19 @@ function toSignKey(sign: string): SignKey | null {
  * is how six engines came to disagree.
  */
 export function groundingVessel(degree: number, dignityEsmsScale: number): ESMS {
-  // Degree 1..30 → one of the 14 alchemical processes (§7a). The array is
-  // 0-indexed, so pillar id = index + 1.
+  // Degree → one of the 14 alchemical processes (§7a). The array is 0-indexed,
+  // so pillar id = index + 1.
+  //
+  // ⚠️ The `- 1` treats the degree as 1..30, but every caller passes 0-based
+  // degrees: agent names carry 0..29 (MEASURED, n=3240) and `fromAbsoluteDegree`
+  // returns `a % 30`. So degree 0 maps to pillar 13, the same cell as degree 14.
+  // This is UNIFORM across all 4330 single-body agents, so it produces no drift
+  // and is NOT corrected here — changing it would silently re-value every stored
+  // row. Recorded because the mismatch is what makes the §18k k29 sign-midpoint
+  // convention-dependent: `Math.floor` sends 15.0 and 15.5 to the same pillar.
+  //
+  // Note this floors, so a fractional degree is legitimate input (k29 passes
+  // 14.5) and lands in the pillar of its integer part.
   const idx = ((Math.floor(degree) - 1) % 14 + 14) % 14;
   const eff = ALCHEMICAL_PILLARS[idx].effects;
 

--- a/src/utils/agentMonicaResolver.ts
+++ b/src/utils/agentMonicaResolver.ts
@@ -50,6 +50,44 @@ const asPlanet = (s: string): string | null => {
   return PLANETS.includes(k) ? k : null;
 };
 
+/**
+ * The degree a SIGN-LEVEL agent is placed at — an agent whose name gives a
+ * planet and a sign but no degree ("Mars Gemini", "Moon Cancer"). §18k k29.
+ *
+ * ── The ruling ──────────────────────────────────────────────────────────────
+ *
+ * `[USER 2026-07-28]` A one-body agent with no chart and no degree resolves to
+ * the **mathematical average of the 30 degrees of its sign**. This is NOT a
+ * fourth construction: it is the existing single-body §18c calc invoked at one
+ * more degree value, landing inside the existing population, band, scale and
+ * guard. (⚠️ §18k k18 rejected "mean-of-siblings" — the mean of the 30 siblings'
+ * OUTPUT monica. That is a different quantity: monica is nonlinear, and the two
+ * differ by 7.3× for Mars Gemini. k18's "not worth a 4th construction" rationale
+ * does not apply here. See k29.)
+ *
+ * ── Why 14.5 and not 15 ─────────────────────────────────────────────────────
+ *
+ * DERIVED as the mean of the integers the degree actually ranges over. Agent
+ * names carry `0..29` — MEASURED across the 3240 degree-bearing production rows,
+ * min 0 / max 29 — and `fromAbsoluteDegree` below returns `a % 30`, also 0-based.
+ * The mean of 0..29 is 14.5.
+ *
+ * ⚠️ The intuitive "midpoint of a 30° sign" = 15.0 is WRONG here, and silently
+ * so. `groundingVessel` floors its argument, so 15.0 and 15.5 both select pillar
+ * index `(15 - 1) % 14 = 0` — Solution `{0,2,2,0}` — which is one of only five
+ * degrees in thirty that yield a monica of exactly 0. `Moon Cancer` at degree 15
+ * computes to **0 in both sects**: indistinguishable from the fabricated-literal
+ * class k12 exists to forbid. At 14.5 it floors to 14 → pillar 13, Protection
+ * `{1,1,1,1}`, and computes a real 0.011826214870076034.
+ *
+ * Expressed as an expression rather than a typed literal so it re-derives from
+ * its own stated basis (k10), and 14.5 is exactly representable as a double so
+ * it round-trips.
+ */
+const AGENT_DEGREE_MIN = 0;
+const AGENT_DEGREE_MAX = 29;
+export const SIGN_MIDPOINT_DEGREE = (AGENT_DEGREE_MIN + AGENT_DEGREE_MAX) / 2;
+
 /** Absolute ecliptic degree (0–359) → sign + degree within that sign. */
 function fromAbsoluteDegree(n: number): { sign: string; degree: number } {
   const a = ((n % 360) + 360) % 360;
@@ -145,6 +183,26 @@ export function parseAgentPlacement(rawName: string): AgentPlacement | null {
       planet: asPlanet(m[1])!,
       sign: asSign(m[2])!,
       degree: Number(m[3]),
+    };
+  }
+
+  // `<Planet> <Sign>` — a SIGN-LEVEL agent, no degree in the name. §18k k29.
+  //
+  // This is the LAST branch deliberately: every degree-bearing form above must
+  // win, so a name that states its degree never falls back to the midpoint.
+  //
+  // It is not a guess. The planet and the sign are both stated by the name and
+  // both validated against the live tables, so the only missing coordinate is
+  // the degree — and the ruling supplies it as the mean of the degrees the sign
+  // spans. Contrast the null cases below it: those are missing the planet, the
+  // sign, or both, and nothing in the name constrains them.
+  m = name.match(/^([A-Za-z]+) ([A-Za-z]+)$/);
+  if (m && asPlanet(m[1]) && asSign(m[2])) {
+    return {
+      kind: "single",
+      planet: asPlanet(m[1])!,
+      sign: asSign(m[2])!,
+      degree: SIGN_MIDPOINT_DEGREE,
     };
   }
 


### PR DESCRIPTION
Closes a question that has been re-opened at least three times. **Why** it kept re-opening is more interesting than the fix.

## Why this kept coming back

The owner ruled months ago that a one-body agent with no chart and no degree takes *"the mathematical average of the 30 degrees of its sign"*. **That ruling was never written down anywhere** — not `docs/`, not `docs/adr/`, not `CONTEXT.md`, not any commit body or merged PR. *(Control: the same git-log grep finds 551 hits for "monica", so the search reaches commit bodies.)*

Meanwhile the decision log — the artifact built to be *"the numbered home for the rulings"* — records the **opposite** at **k18**: *"Sign-level agents get a mean-of-siblings monica → Delete them (deferred)"*. So every agent consulting §18k correctly re-derives deletion and re-opens the question.

⚠️ **And k18 ruled on a different quantity.**

| | construction | Mars Gemini |
|---|---|---|
| k18 rejected | mean of the 30 siblings' **output** — `mean f(x)` | `0.09042814217875952` |
| the owner ruled | mean of the **position**, computed once — `f(mean x)` | `0.012365957493333954` |

monica is nonlinear: **7.3× apart**. *(Control: the sibling sweep reports 7 distinct values across the 30 degrees, so a constant-output artifact is excluded.)*

k18's rationale — *"a 4th construction for 2 rows is not worth its band, scale and guard"* — is **correct for mean-of-siblings** and **false for what was actually ruled**, which is the *existing* single-body §18c calc at one more degree value: same population, band, scale, guard. **A recorded rejection was defeating a proposal nobody was making.**

Third mechanism: the test suite pinned the behaviour under the title *"never guesses"*, listing `"Mars Gemini"` beside `"Edgar Allan Poe"` — so anyone attempting the change without the ruling in hand reads that as encoded intent and backs out.

## Why 14.5 and not 15 — this would have shipped a fabricated zero

`groundingVessel` **floors** its argument (`Math.floor(degree) - 1`). So 15.0 and 15.5 are not two candidate answers — they're the **same** answer:

| candidate | floor | pillar | Mars Gemini | Moon Cancer |
|---|---:|---|---|---|
| **14.5** | 14 | 13 · *Protection* `{1,1,1,1}` | `0.012365957493333954` | `0.011826214870076034` |
| 15.0 / 15.5 | 15 | 0 · *Solution* `{0,2,2,0}` | ~0 | **exactly 0** |

Degree 15 is one of exactly **five** degrees in thirty that yield a monica of zero *(control: the other 25 produce none)*. Choosing the intuitive "midpoint of a 30° sign" would give `Moon Cancer` **0 in both sects** — indistinguishable from the fabricated-literal class **k12** exists to forbid.

14.5 is also the *faithful* reading, not a dodge: it is the mean of the integers **0..29**, and 0..29 is MEASURED to be the exact degree range agent names carry (min 0, max 29, n=3240). Written as an expression over its stated endpoints so it re-derives (**k10**), and exactly representable so it round-trips.

The five zero-producing degrees are **pinned by test**, so a moved pillar mapping fails loudly rather than silently re-valuing the midpoint.

## The change

One branch in `parseAgentPlacement`, deliberately **last** so every degree-bearing form still wins. Planet and sign both validated through the existing `asPlanet`/`asSign` tables, which already reject person-shaped names.

It is **not a guess**: the name states the planet and the sign; only the degree is missing, and the ruling supplies it. The remaining null cases are missing the planet, the sign, or both.

## Verified against production (dry run — nothing written)

```
no placement, no chart                : 0      (was 2)
single-body -> monica_single          : 4333
NEW arrivals (were NULL, now computed): 19
accounted for                         : 5196 / 5196  OK
NON-FINITE (must be 0)                : 0
```

19 is far under the `--max-new=500` bound. **The backfill is deferred until this deploys** — writing from a branch would classify production rows while production still returns null for them.

## Also corrected

⚠️ The §18 status header claimed **one** such row. It has been **two** since 2026-07-22 — `Moon Cancer` arrived **1h50m after** that header's own `[MEASURED 2026-07-22 16:10 UTC]` stamp, and the count was never updated. That count is load-bearing in k18's argument. `auditAgentDataIntegrity.ts` carried the same stale `expected: 1` hardcode.

§18's *"the resolver skips it rather than defaulting the degree"* was never a ruling — only a description of what the code happened to do — yet was quoted as settled intent for two months. Marked superseded.

`groundingVessel`'s *"Degree 1..30"* comment does not describe its input: every caller passes 0-based degrees, so degree 0 shares pillar 13 with degree 14. Uniform across all 4330 single-body agents, causes no drift, and is **not** corrected here — changing it would silently re-value every stored row. Recorded because it is exactly why the midpoint is convention-dependent.

## Rulings

§18k **k29** (the ruling, with 15.0/15.5 rejected on measurement); **k18** marked REVERSED, both entries kept per §18k precedent.

## Verification

`tsc --noEmit` clean · **179 suites / 1607 tests** green · `bun run build` clean · new tests **red-checked** — 3 of 4 fail without the resolver branch; the 4th is a regression guard that correctly passes both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)