### PR TITLE
fix(agents): classify at the writer agents actually come from — #666 patched the wrong files

### DIFF
--- a/.github/workflows/monica-integrity.yml
+++ b/.github/workflows/monica-integrity.yml
@@ -252,3 +252,26 @@ jobs:
         env:
           DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
         run: bun scripts/checkLedgerBalanceReconciliation.ts
+
+      - name: Agents leave the writer already classified
+        if: ${{ !cancelled() && steps.db-secret.outcome == 'success' }}
+        # A SIXTH data witness, and the only one that tests a WRITER rather than
+        # stored state. It executes the real provisioning statements — extracted
+        # from the route/service source, never hand-copied — against real
+        # PostgreSQL inside a transaction that is always rolled back.
+        #
+        # It is added to CI here because it was not wired in when it was written.
+        # #666 shipped it, and it has never run: not in this workflow, not in
+        # package.json, not anywhere. So the regression it exists to catch went
+        # on happening in production for a further day, unobserved.
+        #
+        # That is the second half of the same lesson. #666 also pointed the gate
+        # at `sync-debit` and `internal/agent-sync`, neither of which creates
+        # agents — `[MEASURED 2026-07-29]` 370 of 370 arrivals over seven days
+        # carry `userDatabaseService.ensureAgent`'s fingerprint and 0 carry
+        # sync-debit's. A gate can execute real SQL against a real database,
+        # report honestly, pass, and still prove nothing, if it is aimed at a
+        # statement nobody runs. Section 3b now covers the real producer.
+        env:
+          DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
+        run: bun scripts/checkAgentClassifiedAtCreation.mjs

--- a/scripts/checkAgentClassifiedAtCreation.mjs
+++ b/scripts/checkAgentClassifiedAtCreation.mjs
@@ -47,6 +47,43 @@ function syncDebitProfileSql() {
   return sql.slice(1, -1);
 }
 
+/**
+ * The profile UPSERT from `userDatabaseService.ensureAgent`, extracted from the
+ * module source. This is the statement 370 of 370 real arrivals go through.
+ */
+function ensureAgentProfileSql() {
+  const src = readFileSync("src/services/userDatabaseService.ts", "utf8");
+
+  // Scope to the ensureAgent body FIRST. There are four `INSERT INTO
+  // user_profiles` statements in this module and a file-wide regex would
+  // happily verify one of the other three — which is the same class of mistake
+  // that let #666 pass while the real producer went unpatched.
+  const start = src.indexOf("async ensureAgent");
+  if (start === -1) {
+    console.error("CONTROL FAILED: no `async ensureAgent` in userDatabaseService.ts. Update this extractor.");
+    process.exit(1);
+  }
+  const nextMethod = src.slice(start + 1).search(/\n {2}(?:async )?[a-zA-Z_]\w*\s*\(/);
+  const body = nextMethod === -1 ? src.slice(start) : src.slice(start, start + 1 + nextMethod);
+
+  const sql = body.match(/`(INSERT INTO user_profiles[\s\S]*?updated_at = CURRENT_TIMESTAMP)`/)?.[1];
+  if (!sql) {
+    console.error("CONTROL FAILED: no profile UPSERT inside ensureAgent. Update this extractor.");
+    process.exit(1);
+  }
+  // The point of this whole section: if ensureAgent's UPSERT does not classify,
+  // say so precisely rather than reporting an extraction problem.
+  if (!/monica_method/.test(sql)) {
+    console.error(
+      "FAIL: ensureAgent's profile UPSERT does not write monica_method.\n" +
+        "      This is the path 370/370 real arrivals take, so every new agent\n" +
+        "      lands unclassified and the nightly backfill papers over it.",
+    );
+    process.exit(1);
+  }
+  return sql;
+}
+
 const client = new pg.Client({ connectionString: url, ssl: { rejectUnauthorized: false } });
 await client.connect();
 
@@ -131,12 +168,78 @@ try {
 
   // ── 3. an unresolvable name must stay NULL, not fabricate ───────────────
   console.log("\n3. unresolvable name");
-  const oddUser = await mkAgent("Mars Gemini");
+  // NB: this used to be "Mars Gemini", which §18k k29 made RESOLVABLE (planet +
+  // sign, degree supplied at the sign midpoint). A person's name is missing the
+  // planet and the sign, so nothing constrains it and it must stay NULL.
+  const oddUser = await mkAgent("Edgar Allan Poe");
   await client.query(SQL, params(oddUser, null, null));
   const odd = await classification(oddUser);
   if (odd.monica_method === null && odd.monica_single === null && odd.monica_two_body === null) {
     ok("left entirely NULL — no invented classification");
   } else no(`fabricated ${JSON.stringify(odd)}`);
+
+  // ── 3b. THE ACTUAL PRODUCER ─────────────────────────────────────────────
+  //
+  // `[MEASURED 2026-07-29]` Sections 1-3 verify the two endpoints #666 believed
+  // were the writers. They are not. Over seven days, 370 of 370 arrivals carry
+  // `ensureAgent`'s fingerprint and 0 carry sync-debit's — so every assertion
+  // above passed while every real arrival landed unclassified.
+  //
+  // The lesson is not that the gate was wrong. It executed real SQL against a
+  // real database and reported honestly. It was POINTED AT THE WRONG STATEMENT,
+  // and nothing in it could notice. Hence this section, and hence the assertion
+  // at the end that the extractor still finds something.
+  console.log("\n3b. ensureAgent — the path 370/370 real arrivals actually take");
+  const ENSURE_SQL = ensureAgentProfileSql();
+  const ensureParams = (userId, name, resolved) => [
+    userId,
+    name,
+    resolved?.method ?? null,
+    resolved?.monica.combined ?? null,
+    resolved?.monica.diurnal ?? null,
+    resolved?.monica.nocturnal ?? null,
+  ];
+
+  for (const [label, name, wantMethod] of [
+    ["phase", "Moon Phase Full Moon 121", "two-body"],
+    ["single-body", "Venus Taurus 12", "single-body"],
+    ["person", "Edgar Allan Poe", null],
+  ]) {
+    // ensureAgent INSERTs the profile row itself, so unlike above there must be
+    // no pre-existing row — that is the branch real arrivals take.
+    const uid = randomUUID();
+    const email = `ensure-${uid.slice(0, 8)}@agentic.alchm.kitchen`;
+    await client.query(
+      `INSERT INTO users (id, email, password_hash, role, is_active, email_verified, is_agent,
+                          name, profile, preferences, login_count, created_at, updated_at)
+       VALUES ($1,$2,'AGENT_NO_LOGIN','USER'::user_role,true,true,true,$3,$4,'{}'::jsonb,0,now(),now())`,
+      [uid, email, name, JSON.stringify({ email, isAgent: true, name })],
+    );
+    await client.query(ENSURE_SQL, ensureParams(uid, name, agentMonicaWithMethod(name)));
+    const got = await classification(uid);
+    if (got.monica_method === wantMethod) {
+      ok(`${label}: fresh INSERT classified as ${String(wantMethod)}`);
+    } else {
+      no(`${label}: expected method ${String(wantMethod)}, got ${JSON.stringify(got)}`);
+    }
+
+    // ON CONFLICT branch. The invariant is NOT "never writes again" — a row
+    // still NULL must accept a later classification, which is how a resolver
+    // improvement reaches rows already in the table. The invariant is that an
+    // ALREADY-CLASSIFIED row is never re-classified. Re-run with a deliberately
+    // DIFFERENT classification and require the right one of those two.
+    const other = agentMonicaWithMethod("Sun Aries 5");
+    await client.query(ENSURE_SQL, ensureParams(uid, name, other));
+    const after = await classification(uid);
+    if (wantMethod === null) {
+      if (after.monica_method === "single-body") ok(`${label}: still-NULL row accepts a later classification`);
+      else no(`${label}: still-NULL row refused a later classification — ${JSON.stringify(after)}`);
+    } else if (after.monica_method === got.monica_method && after.monica_single === got.monica_single) {
+      ok(`${label}: already-classified row is NOT re-classified`);
+    } else {
+      no(`${label}: re-classified ${JSON.stringify(got)} -> ${JSON.stringify(after)}`);
+    }
+  }
 
   // ── 4. CONTROL: the pre-fix shape must be REJECTED by the constraint ────
   // Without this, the assertions above could be passing for reasons unrelated to

--- a/src/services/userDatabaseService.ts
+++ b/src/services/userDatabaseService.ts
@@ -8,6 +8,7 @@ import { randomUUID } from "crypto";
 import type { UserProfile } from "@/contexts/UserContext";
 import type { User, UserRole } from "@/lib/auth/jwt-auth";
 import { _logger } from "@/lib/logger";
+import { agentMonicaWithMethod } from "@/utils/agentMonicaResolver";
 import { safeJsonParse } from "@/utils/typeGuards";
 
 // Extended User type with profile data
@@ -428,13 +429,90 @@ class UserDatabaseService {
           throw new Error("ensureAgent: upsert returned no row");
         }
         const finalId = insertUser.rows[0].id as string;
+
+        // ── Classify at creation (§18) ──────────────────────────────────────
+        //
+        // THIS is the agent producer. #666 added classification-at-creation to
+        // `sync-debit` and `internal/agent-sync`, but `[MEASURED 2026-07-29]`
+        // 370 of 370 arrivals over seven days carry THIS path's fingerprint and
+        // 0 carry sync-debit's — so every new agent still landed unclassified
+        // and the nightly backfill went on papering over it.
+        //
+        // The fingerprint that settles it: `users.created_at`,
+        // `user_profiles.created_at` and `updated_at` agree to the MICROSECOND,
+        // which only happens inside one transaction (`now()` is transaction-
+        // start). Two autocommit statements differ by ~86ms on this database.
+        // sync-debit also unconditionally inserts a `token_balances` row and
+        // these arrivals have none.
+        //
+        // Resolution is from `resolvedName` — the same string written to
+        // `user_profiles.name` — because `checkAgentMonicaDrift.ts` re-derives
+        // from that column. Classifying any other string would report as drift
+        // on a row written correctly.
+        const resolved = agentMonicaWithMethod(resolvedName, (error) =>
+          console.warn(
+            `[ensureAgent] unclassifiable phase in "${resolvedName}" —` +
+              ` left for the nightly backfill to surface. ${String(error)}`,
+          ),
+        );
+        const method = resolved?.method ?? null;
+        const combined = resolved?.monica.combined ?? null;
+
+        // §18o: each construction writes its OWN column, or four CHECK
+        // constraints reject the row —
+        //   monica_method_matches_column      method='X' requires monica_X NOT NULL
+        //   monica_one_construction           at most ONE construction column set
+        //   monica_constant_single_body_only  constant IS NULL OR method='single-body'
+        //   monica_both_sects_present         both sects, or neither
+        // An unresolvable name leaves every column NULL, which all four allow.
+        //
+        // The DO UPDATE branch is gated on `monica_method IS NULL` so this is
+        // FIRST-TIME classification only: re-classification belongs to the
+        // backfill, and an unconditional write could set a second construction
+        // column on a row that already has one, or clobber a hand-authored
+        // full-chart value.
+        //
+        // NB: no backticks in the SQL comments below — one would terminate this
+        // template literal and break the build.
         await client.query(
-          `INSERT INTO user_profiles (user_id, name)
-           VALUES ($1, $2)
+          `INSERT INTO user_profiles
+             (user_id, name, monica_method, monica_constant, monica_single,
+              monica_two_body, monica_diurnal, monica_nocturnal)
+           VALUES
+             ($1, $2, $3,
+              CASE WHEN $3 = 'single-body' THEN $4::numeric END,
+              CASE WHEN $3 = 'single-body' THEN $4::numeric END,
+              CASE WHEN $3 = 'two-body'    THEN $4::numeric END,
+              CASE WHEN $3 IS NOT NULL     THEN $5::numeric END,
+              CASE WHEN $3 IS NOT NULL     THEN $6::numeric END)
            ON CONFLICT (user_id) DO UPDATE
              SET name = COALESCE(EXCLUDED.name, user_profiles.name),
+                 -- first-time classification only; see the note above
+                 monica_constant = CASE
+                   WHEN user_profiles.monica_method IS NULL AND $3 = 'single-body'
+                   THEN $4::numeric ELSE user_profiles.monica_constant END,
+                 monica_single = CASE
+                   WHEN user_profiles.monica_method IS NULL AND $3 = 'single-body'
+                   THEN $4::numeric ELSE user_profiles.monica_single END,
+                 monica_two_body = CASE
+                   WHEN user_profiles.monica_method IS NULL AND $3 = 'two-body'
+                   THEN $4::numeric ELSE user_profiles.monica_two_body END,
+                 monica_diurnal = CASE
+                   WHEN user_profiles.monica_method IS NULL AND $3 IS NOT NULL
+                   THEN $5::numeric ELSE user_profiles.monica_diurnal END,
+                 monica_nocturnal = CASE
+                   WHEN user_profiles.monica_method IS NULL AND $3 IS NOT NULL
+                   THEN $6::numeric ELSE user_profiles.monica_nocturnal END,
+                 monica_method = COALESCE(user_profiles.monica_method, $3),
                  updated_at = CURRENT_TIMESTAMP`,
-          [finalId, resolvedName],
+          [
+            finalId,
+            resolvedName,
+            method,
+            combined,
+            resolved?.monica.diurnal ?? null,
+            resolved?.monica.nocturnal ?? null,
+          ],
         );
       });
 


### PR DESCRIPTION
#666 was titled *"classify agents at creation"*. It did not — and **why** is worth more than the fix.

## The producer is `ensureAgent`, not sync-debit

#666 added classification to `sync-debit` and `internal/agent-sync`. Neither creates agents. `[MEASURED 2026-07-29]` over seven days, **370 of 370** arrivals carry `userDatabaseService.ensureAgent`'s fingerprint and **0** carry sync-debit's:

- `users.created_at`, `user_profiles.created_at` and `updated_at` agree **to the microsecond**. That only happens inside one transaction, since `now()` is transaction-start. `ensureAgent` uses `db.withTransaction`; sync-debit issues two separate autocommit statements. *Measured on this database: two autocommit statements differ by ~86ms; two inside one `BEGIN` are identical.*
- sync-debit unconditionally inserts a `token_balances` row. These arrivals have none. *(Control: 3662 agents do have one.)*

So the leak stayed fully open. The first batch after #666 went READY — four `Moon Phase Full Moon` rows, **39m40s later** — is entirely unclassified. And none are unparseable: `agentMonicaWithMethod('Moon Phase Full Moon 121')` resolves cleanly. There is simply **no classification code on that path**.

> ⚠️ The evidence originally offered for this was *also* wrong, and is recorded so it isn't reused: *"the UPDATE sets `updated_at = now()`, so an equal timestamp proves it never ran."* Under the real transactional producer, an in-transaction UPDATE sets `updated_at` = `created_at` exactly — so equality proves nothing. The conclusion survives only on the independent `monica_method IS NULL` evidence.

## The gate #666 shipped has never run

`scripts/checkAgentClassifiedAtCreation.mjs` is referenced **nowhere** — not in the workflow, not in `package.json`. Wired in here as the sixth DB witness.

That's the second half of one lesson. The gate is *well built*: it executes real SQL, extracted from source rather than hand-copied, against real PostgreSQL in a rolled-back transaction. It passed. It proved nothing, because it was **aimed at two statements nobody runs** — and nothing inside it could notice.

## Verified by executing, not by reading

Against production PostgreSQL inside a transaction rolled back at the end *(rollback verified: 0 probe rows remained)*:

- **PREPARE** succeeds. *Control: `SELECT no_such_column` rejected with `42703`, so the check can say no.*
- All four CHECK constraints satisfied for single-body, two-body and unresolvable input. *Control: a row with two construction columns is rejected by `monica_one_construction`.*
- An **already-classified** row is **not** re-classified when re-run with a deliberately different classification.
- A **still-NULL** row **does** accept a later classification — not a bug; it's what lets a resolver improvement (k29) reach rows already in the table.

> ⚠️ My first probe asserted *"a re-run never writes again"* and reported two failures. **The probe was wrong, not the code** — the invariant is the pair above. Corrected before shipping rather than after.

New gate section **3b** covers the real producer and is **red-checked**: reverted to master's `ensureAgent` it fails with *"ensureAgent's profile UPSERT does not write monica_method"* — naming the actual defect rather than an extraction problem.

## Extractor scoped, not widened

There are **four** `INSERT INTO user_profiles` statements in that module, so the extractor locates the `ensureAgent` body first and searches within it. A file-wide regex would cheerfully verify one of the other three — the same class of mistake as verifying the wrong route.

## Also

Section 3's "unresolvable name" example was `Mars Gemini`, which §18k **k29** ([#668](https://github.com/gregcastro23/WhatToEatNext/pull/668)) makes resolvable. Changed to a person's name — missing the planet and the sign, so it stays NULL under any resolver.

## Verification

`tsc --noEmit` clean · **179 suites / 1603 tests** green · `bun run build` clean · the extended gate **passes** against production and **fails** when the fix is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)