### PR TITLE
ci(integrity): replace a tautological invariant, and run the two PR-breakable gates before merge

### DIFF
--- a/.github/workflows/monica-integrity.yml
+++ b/.github/workflows/monica-integrity.yml
@@ -94,6 +94,84 @@ jobs:
           python -m pytest backend/tests/test_kalchm_parity.py -q
 
   # ---------------------------------------------------------------------------
+  # PRE-MERGE. The two gates a PULL REQUEST DIFF can actually break, run BEFORE
+  # the code reaches master.
+  #
+  # The problem this solves: every DB gate ran only on master + cron, so the
+  # earliest anything could fail was after merge, with the deploy already in
+  # flight. `[MEASURED 2026-07-29]` five master SHAs whose integrity run concluded
+  # `failure` each received a Production deployment of that same SHA, three
+  # created strictly after the failure verdict. The gate was not a gate; it was a
+  # notification.
+  #
+  # ── Two deliberate limits, both load-bearing ──────────────────────────────
+  #
+  # 1. `pull_request`, NOT `pull_request_target`, and same-repo ONLY.
+  #    `pull_request_target` runs with the base repo's secrets against the PR's
+  #    code — here that means `bun install --frozen-lockfile` on a PR-AUTHORED
+  #    lockfile with DATABASE_PUBLIC_URL in the environment, i.e. arbitrary
+  #    postinstall code holding production database credentials. The head-repo
+  #    condition below is what keeps this safe; do not remove it, and do not
+  #    "fix" a skipped fork PR by switching the trigger.
+  #
+  # 2. ONLY the diff-sensitive gates. The other five assert production DATA
+  #    state that no PR diff controls. As required checks they would block every
+  #    unrelated PR on someone else's data condition — the drift check was red
+  #    across eight consecutive runs over ~20 hours for a self-resolving queue
+  #    caused by no PR at all. That is the exact failure #665 was written to stop,
+  #    and promoting the whole workflow would reintroduce it.
+  # ---------------------------------------------------------------------------
+  pre-merge-sql:
+    name: SQL a PR can break (pre-merge)
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Setup safe directory
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Require the database secret
+        id: db-secret
+        env:
+          DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
+        run: |
+          if [ -z "$DATABASE_PUBLIC_URL" ]; then
+            echo "DATABASE_PUBLIC_URL is not set — these gates cannot run." >&2
+            exit 1
+          fi
+          echo "secret present"
+
+      - name: Economy SQL parses against PostgreSQL
+        if: ${{ !cancelled() && steps.db-secret.outcome == 'success' }}
+        # Diff-sensitive: it imports the live query builders, so a PR that edits
+        # them can make this fail. PREPARE writes nothing.
+        env:
+          DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
+        run: bun scripts/checkEconomySqlParses.ts
+
+      - name: Agents leave the writer already classified
+        if: ${{ !cancelled() && steps.db-secret.outcome == 'success' }}
+        # Diff-sensitive: it extracts the provisioning statements from the route
+        # and service SOURCE and executes them, rolled back. A PR that edits
+        # either writer changes what this runs.
+        env:
+          DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
+        run: bun scripts/checkAgentClassifiedAtCreation.mjs
+
+  # ---------------------------------------------------------------------------
   # Data. master + cron only: it needs production credentials, so it must never
   # run on a pull_request from a fork.
   # ---------------------------------------------------------------------------

--- a/scripts/auditAgentDataIntegrity.ts
+++ b/scripts/auditAgentDataIntegrity.ts
@@ -118,12 +118,41 @@ const cov = await client.query<{ method: string; n: string }>(
 );
 console.table(cov.rows);
 const total = cov.rows.reduce((s, r) => s + Number(r.n), 0);
-const { rows: [{ n: agentRows }] } = await client.query<{ n: string }>(
-  `SELECT count(*)::text n FROM user_profiles up JOIN users u ON u.id=up.user_id WHERE u.is_agent`,
+
+// ⚠️ The denominator used to be `count(*) FROM user_profiles JOIN users` — the
+// SAME join the buckets above come from, so the comparison was self-referential
+// and could not fail. This workflow calls this script its "SECOND, INDEPENDENT
+// witness"; a witness that reproduces the first one's blind spot is not
+// independent. Read the population from `users` alone, and account for the rows
+// the join cannot see.
+const { rows: [pop] } = await client.query<{ agents: string; no_profile: string }>(
+  `SELECT
+     (SELECT count(*) FROM users WHERE is_agent)::text AS agents,
+     (SELECT count(*) FROM users u
+        LEFT JOIN user_profiles up ON up.user_id = u.id
+       WHERE u.is_agent AND up.user_id IS NULL)::text AS no_profile`,
 );
+const agentPop = Number(pop.agents);
+const noProfile = Number(pop.no_profile);
 checks++;
-if (total !== Number(agentRows)) { failures++; console.log(`  FAIL  method buckets ${total} != agent rows ${agentRows}`); }
-else console.log(`  OK    method buckets sum to the agent row count (${total})`);
+if (total + noProfile !== agentPop) {
+  failures++;
+  console.log(
+    `  FAIL  method buckets ${total} + ${noProfile} with no profile row != ${agentPop} agents`,
+  );
+} else {
+  console.log(
+    `  OK    method buckets (${total}) + no-profile rows (${noProfile}) = ${agentPop} agents`,
+  );
+}
+// Surfaced separately because it is invisible to every join-based check here.
+checks++;
+if (noProfile > 56) {
+  failures++;
+  console.log(`  FAIL  ${noProfile} agents have no user_profiles row (known frozen cohort: 56)`);
+} else {
+  console.log(`  OK    ${noProfile} agents with no profile row, within the known cohort of 56`);
+}
 
 // Was hardcoded "expected: 1, 'Mars Gemini'" — stale from 2026-07-22, when
 // `Moon Cancer` made it 2 and nothing noticed for two months. Since §18k k29

--- a/scripts/checkAgentMonicaDrift.ts
+++ b/scripts/checkAgentMonicaDrift.ts
@@ -34,6 +34,39 @@ import { fullChartMonica } from "@/utils/fullChartMonica";
  *  the engine DECLINED to compute; a rising share is a health signal (§18p). */
 const PHI_THRESHOLD = 0.10;
 
+/**
+ * Agents allowed to exist with NO `user_profiles` row at all.
+ *
+ * `[MEASURED 2026-07-29]` exactly 56, and the cohort is FROZEN: 52 are the legacy
+ * `@agents.alchm.kitchen` seed, each with a properly-provisioned twin at
+ * `@agentic.alchm.kitchen` (52/52 email-stem collisions; control: 0 collisions
+ * among profiled agents), 0 transactions, 0 feed events. Of the 550 agents
+ * created 2026-07-20..29, ZERO lack a profile; the newest profile-less agent is
+ * 2026-07-19.
+ *
+ * So this is a "must not grow" assertion, not a tolerance. It is deliberately
+ * set to the exact current count: `sync-credit`'s users insert
+ * (`src/app/api/economy/sync-credit/route.ts`) still has no matching
+ * `user_profiles` insert for non-daily-yield sources, so the population CAN
+ * grow — and if it does, every DB gate in this workflow is blind to the new rows
+ * because they all share the same self-referential join.
+ */
+const NO_PROFILE_BUDGET = 56;
+
+/**
+ * Agents allowed to have an unparseable name AND no usable chart.
+ *
+ * `[MEASURED 2026-07-29]` ZERO, since §18k k29 made sign-level names resolvable.
+ * A genuine person agent carries a chart and is counted as full-chart instead,
+ * so nothing legitimately lands here any more.
+ *
+ * This is the invariant that actually detects a resolver regression — see the
+ * note at check 1b. Budget 0 is deliberate: one row here needs a human, and
+ * looking at one is cheap. Two rows sat in this bucket unobserved for two months
+ * because it fed neither the exit code nor the "all N agents match" denominator.
+ */
+const NOT_A_PLACEMENT_BUDGET = 0;
+
 const TOLERANCE = 1e-5;
 
 const client = new pg.Client({
@@ -60,6 +93,33 @@ const { rows } = await client.query<{
           up.monica_method, up.natal_positions, up.updated_at::text
      FROM user_profiles up JOIN users u ON u.id = up.user_id
     WHERE u.is_agent AND up.name IS NOT NULL`,
+);
+
+// The DENOMINATOR, read independently of the rows above.
+//
+// ⚠️ This exists because the invariant below used to compare `rows` against
+// itself. Every path through the tally loop increments exactly one counter, so
+// `totalClassified === rows.length` held IDENTICALLY — it could not fail for any
+// input. It was advertised as the defence against "the failure that once
+// silently dropped 3240 rows", and a test that moved 3240 rows into an
+// unrecognised name family still printed its sum and exited 0.
+//
+// The join above cannot see an agent with no `user_profiles` row at all, and
+// there are 56 of those. A self-referential denominator is blind to exactly the
+// population it is supposed to be counting.
+const { rows: [census] } = await client.query<{
+  agents: string;
+  no_profile_row: string;
+  profile_no_name: string;
+}>(
+  `SELECT
+     (SELECT count(*) FROM users WHERE is_agent)::text AS agents,
+     (SELECT count(*) FROM users u
+        LEFT JOIN user_profiles up ON up.user_id = u.id
+       WHERE u.is_agent AND up.user_id IS NULL)::text AS no_profile_row,
+     (SELECT count(*) FROM users u
+        JOIN user_profiles up ON up.user_id = u.id
+       WHERE u.is_agent AND up.name IS NULL)::text AS profile_no_name`,
 );
 await client.end();
 
@@ -191,16 +251,102 @@ if (examples.length) console.log("\n" + examples.join("\n"));
 // ── the ruled invariants, beyond drift ────────────────────────────────────
 const problems: string[] = [];
 
-// 1. Populations sum EXACTLY to the agent row count. A count that stops summing
-//    means a new name family appeared or the resolver stopped recognising one —
-//    the failure that once silently dropped 3240 rows.
+// 1. Populations sum EXACTLY to the AGENT POPULATION — not to the rows this
+//    script happened to fetch.
+//
+//    ⚠️ TWO corrections to what this check used to claim, both measured:
+//
+//    (a) It compared the tally against `rows.length`, which is a TAUTOLOGY.
+//        Every path through the loop increments exactly one counter, so the
+//        equality held for any input whatsoever. The denominator now comes from
+//        `census`, read by its own query against `users`.
+//
+//    (b) Its stated purpose — catching "the failure that once silently dropped
+//        3240 rows" — is NOT something any sum can do, and the fixed version
+//        cannot do it either. A name family that stops resolving falls through
+//        `parseAgentPlacement` -> null and `fullChartMonica` -> null into
+//        `notAPlacementNoChart`, which is INSIDE the sum. The total does not
+//        move. What catches that failure is invariant 1b below: a budget on the
+//        bucket itself. Recorded so the comment stops promising coverage the
+//        arithmetic cannot provide.
+//
+//    ⚠️ And be honest about what the fixed sum is worth. The three census terms
+//    partition the agent population exactly, so `accountedFor === agents` is
+//    STILL close to an identity — it can only differ if the population changes
+//    between the two queries. That is worth reporting (it means these numbers
+//    are a smear across a moving table, not a snapshot) but it is NOT a defect
+//    detector. Do not let a future reader mistake it for one again.
+//
+//    The assertions that can actually fail on bad data are the two BUDGETS: the
+//    no-profile-row count below, and check 1b. Both were verified by injection —
+//    a simulated resolver regression moved 464 rows and the sum stayed balanced
+//    at 5284/5284 while 1b fired.
+//
+//    The sum's real contribution is that it PRINTS the no-profile population,
+//    which no gate in this workflow could previously see at all.
 const totalClassified =
   tally.single.checked + tally.phase.checked + tally.fullChart.checked +
   unparseable + notAPlacementNoChart;
-console.log(`\npopulations sum: ${tally.single.checked} + ${tally.phase.checked} + ` +
-  `${tally.fullChart.checked} + ${unparseable + notAPlacementNoChart} = ${totalClassified} / ${rows.length}`);
+const agents = Number(census.agents);
+const noProfileRow = Number(census.no_profile_row);
+const profileNoName = Number(census.profile_no_name);
+const accountedFor = totalClassified + noProfileRow + profileNoName;
+
+console.log(
+  `\npopulations sum: ${tally.single.checked} + ${tally.phase.checked} + ` +
+    `${tally.fullChart.checked} + ${unparseable + notAPlacementNoChart} = ${totalClassified} profiled` +
+    `\n                 + ${noProfileRow} with no profile row + ${profileNoName} with a NULL name` +
+    `\n                 = ${accountedFor} / ${agents} agents`,
+);
+
+// The trivial half, kept only because a mismatch here means the tally loop
+// itself is broken (a row falling through every branch).
 if (totalClassified !== rows.length) {
-  problems.push(`populations do not sum: ${totalClassified} classified vs ${rows.length} rows`);
+  problems.push(`tally does not cover its own rows: ${totalClassified} vs ${rows.length}`);
+}
+// The half that can actually fail.
+if (accountedFor !== agents) {
+  problems.push(
+    `populations do not sum to the agent census: ${accountedFor} accounted for vs ${agents} agents ` +
+      `(${agents - accountedFor} unaccounted)`,
+  );
+}
+// A no-profile agent is invisible to every other gate in this workflow, because
+// they all share this script's self-referential join. Report it as a standing
+// number so it cannot grow unobserved; 56 is the known legacy cohort.
+if (noProfileRow > NO_PROFILE_BUDGET) {
+  problems.push(
+    `${noProfileRow} agents have no user_profiles row, above the budget of ${NO_PROFILE_BUDGET}. ` +
+      `Something is creating agents without a profile — see sync-credit's users insert.`,
+  );
+}
+
+// 1b. THE ONE THAT CATCHES A RESOLVER REGRESSION.
+//
+// `notAPlacementNoChart` is the bucket a row falls into when its name does not
+// parse AND it has no usable chart. Post-§18k k29 the correct value is EXACTLY
+// ZERO: sign-level names resolve at the sign midpoint, and a genuine person
+// agent carries a chart and lands in `fullChart` instead.
+//
+// This is the assertion the sum was wrongly credited with. If a name family
+// stops resolving, every one of its rows lands here and this fires immediately —
+// whereas the sum stays balanced because this bucket is one of its terms.
+//
+// It is also the fix for a two-month blind spot: `Mars Gemini` and `Moon Cancer`
+// sat in this bucket since 2026-05-24 and 2026-07-22, were subtracted from the
+// "all N agents match" denominator, and never contributed to the exit code. The
+// audit script's hardcoded `expected: 1` had been stale since the second one
+// arrived and nothing noticed.
+//
+// Budget 0 deliberately, not a tolerance. A single new row here is either a
+// resolver regression or a name family nobody has ruled on — both need a human,
+// and both are cheap to look at while there is one of them rather than 3240.
+if (notAPlacementNoChart > NOT_A_PLACEMENT_BUDGET) {
+  problems.push(
+    `${notAPlacementNoChart} agents have a name that does not parse AND no usable chart ` +
+      `(budget ${NOT_A_PLACEMENT_BUDGET}). Either the resolver stopped recognising a name ` +
+      `family, or a new one arrived that needs a ruling. The names are printed above.`,
+  );
 }
 
 // 2. φ share per population. φ is the engine declining to compute; a rising


### PR DESCRIPTION
Two defects of the same shape: a check that reports confidently while being **structurally incapable of failing**.

## 1. The sum invariant could not fail, and never could have

`checkAgentMonicaDrift.ts` asserted `totalClassified === rows.length`. Every path through the tally loop increments exactly one counter, so that equality held **identically, for any input**. It was advertised as the defence against *"the failure that once silently dropped 3240 rows"* — and a test that moved 3240 rows into an unrecognised name family printed its sum and exited 0.

`auditAgentDataIntegrity.ts`, which this workflow calls the *"SECOND, INDEPENDENT witness"*, had the same shape: its denominator came from the same `user_profiles JOIN users` as its buckets. A witness that reproduces the first one's blind spot is not independent.

> ⚠️ **Fixing the denominator does not make the sum a defect detector.** I checked rather than assumed. A name family that stops resolving falls through `parseAgentPlacement` → null and `fullChartMonica` → null into `notAPlacementNoChart` — which is *inside* the sum. MEASURED by injecting a resolver regression: **464 rows moved and the sum stayed balanced at 5284/5284.**

So the sum is kept only for what it can honestly do: its denominator now comes from `users` alone, which lets it **print the 56 agents with no `user_profiles` row** — a population every join-based gate here is blind to. The comment states plainly that the remaining equality is close to an identity across two reads. Overclaiming is what caused the original problem.

## 1b. The invariant that actually catches it

A budget on `notAPlacementNoChart`, which is **0** since §18k k29. Under the same injected regression it fires immediately:

```
464 agents have a name that does not parse AND no usable chart (budget 0)
```

This also closes a two-month blind spot: `Mars Gemini` and `Moon Cancer` sat in that bucket from 2026-05-24 and 2026-07-22, were **subtracted from the "all N agents match" denominator**, and never reached the exit code.

Plus `NO_PROFILE_BUDGET = 56` — a must-not-grow assertion on the frozen legacy cohort. `sync-credit`'s users insert still has no matching `user_profiles` insert for non-daily-yield sources, so the population *can* grow.

## 2. No pre-merge path ran the DB gates at all

They ran on master + cron only, so the earliest failure was **after merge, with the deploy in flight**. `[MEASURED]` five master SHAs whose integrity run concluded `failure` each received a Production deployment of that same SHA — three created strictly *after* the failure verdict. Not a gate; a notification.

New `pre-merge-sql` job, with two deliberate limits:

| limit | why it is load-bearing |
|---|---|
| `pull_request` **same-repo only**, never `pull_request_target` | That trigger runs base-repo secrets against PR code — here, `bun install --frozen-lockfile` on a **PR-authored lockfile** with `DATABASE_PUBLIC_URL` in env. Arbitrary postinstall code holding production DB credentials. |
| Only the **two diff-sensitive** gates | The other five assert production *data* state no PR controls. As required checks they'd block unrelated PRs on someone else's data condition — the drift check was red for 8 consecutive runs over ~20h on a self-resolving queue caused by no PR. Exactly what #665 was written to stop. |

The whole workflow is deliberately **not** promoted to a required check.

## Verification — every assertion red-checked, then restored

- injected resolver regression → 1b fires, sum stays balanced *(the point)*
- `NO_PROFILE_BUDGET` lowered to 10 → the no-profile assertion fires
- restored: drift check `EXIT=0`; integrity audit **ALL CLEAR, 24 checks, 0 failures**
- workflow YAML parses; `pre-merge-sql` condition asserted; control confirms **zero** non-comment `pull_request_target` lines

`tsc --noEmit` clean · **179 suites / 1607 tests** green.

## Incidental, worth recording

Population is **5284** with `missing 0` across all three constructions — 32 agents have arrived since the backfill and **every one was classified at creation**. #669's writer fix is confirmed working in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)