### PR TITLE
refactor(physics): repoint production kalchm/monica call sites to the canonical engine

### DIFF
--- a/src/components/home/CookingMethodPreview.tsx
+++ b/src/components/home/CookingMethodPreview.tsx
@@ -17,11 +17,11 @@ import {
   traditionalCookingMethods,
   transformationMethods,
 } from "@/data/cooking/methods";
-import { getCookingMethodPillar } from "@/utils/alchemicalPillarUtils";
 import {
-  calculateKAlchm,
-  calculateMonicaConstant,
-} from "@/utils/monicaKalchmCalculations";
+  calculateKalchm,
+  calculateMonica,
+} from "@/data/unified/alchemicalCalculations";
+import { getCookingMethodPillar } from "@/utils/alchemicalPillarUtils";
 import { calculateAlchemicalFromPlanets } from "@/utils/planetaryAlchemyMapping";
 
 interface MethodData {
@@ -316,18 +316,18 @@ export default function CookingMethodPreview() {
         const gregsEnergy = result.gregsEnergy;
 
         // Calculate Kalchm using TRANSFORMED ESMS (method-specific equilibrium constant)
-        const kalchm = calculateKAlchm(
-          transformedESMS.Spirit,
-          transformedESMS.Essence,
-          transformedESMS.Matter,
-          transformedESMS.Substance,
-        );
+        const kalchm = calculateKalchm({
+          Spirit: transformedESMS.Spirit,
+          Essence: transformedESMS.Essence,
+          Matter: transformedESMS.Matter,
+          Substance: transformedESMS.Substance,
+        });
 
         // Use method-specific reactivity for Monica calculation
         const reactivity = methodThermo.reactivity;
         const monica =
           gregsEnergy !== null && kalchm
-            ? calculateMonicaConstant(gregsEnergy, reactivity, kalchm)
+            ? calculateMonica(gregsEnergy, reactivity, kalchm)
             : null;
 
         const monicaClass = classifyMonica(monica);

--- a/src/components/recommendations/EnhancedCookingMethodRecommender.tsx
+++ b/src/components/recommendations/EnhancedCookingMethodRecommender.tsx
@@ -34,6 +34,10 @@ import {
 } from "@/data/cooking/methods";
 import type { MethodPhysicalReference } from "@/data/cooking/physicalReference";
 import { METHOD_PHYSICAL_REFERENCE } from "@/data/cooking/physicalReference";
+import {
+  calculateKalchm,
+  calculateMonica,
+} from "@/data/unified/alchemicalCalculations";
 import { useUserElementalBias } from "@/hooks/useUserElementalBias";
 import type {
   AlchemicalProperties,
@@ -42,11 +46,7 @@ import type {
 import { getCookingMethodPillar } from "@/utils/alchemicalPillarUtils";
 import { calculateMethodSpecificKinetics, getKineticProfile } from "@/utils/cookingMethodKinetics";
 import { projectZScoreTarget } from "@/utils/enhancedCompatibilityScoring";
-import {
-  calculateKAlchm,
-  calculateMonicaConstant,
-  calculateMonicaOptimizationScore,
-} from "@/utils/monicaKalchmCalculations";
+import { calculateMonicaOptimizationScore } from "@/utils/monicaKalchmCalculations";
 import { calculateAlchemicalFromPlanets } from "@/utils/planetaryAlchemyMapping";
 import {
   calculateHarmonyIndex,
@@ -524,9 +524,9 @@ export default function EnhancedCookingMethodRecommender({ onDoubleClickMethod }
         Air: method.elementalEffect.Air, Earth: method.elementalEffect.Earth,
       }).gregsEnergy;
 
-      const kalchm = calculateKAlchm(transformedESMS.Spirit, transformedESMS.Essence, transformedESMS.Matter, transformedESMS.Substance);
+      const kalchm = calculateKalchm(transformedESMS);
       const reactivity = methodThermo.reactivity;
-      const monica = gregsEnergy !== null && kalchm ? calculateMonicaConstant(gregsEnergy, reactivity, kalchm) : null;
+      const monica = gregsEnergy !== null && kalchm ? calculateMonica(gregsEnergy, reactivity, kalchm) : null;
       const monicaModifiers = monica !== null ? calculatePillarMonicaModifiers(monica) : { temperatureAdjustment: 0, timingAdjustment: 0, intensityModifier: "neutral" as const };
       const optimalConditions = method.thermodynamicProperties && monica !== null ? calculateOptimalCookingConditions(monica, method.thermodynamicProperties) : null;
 

--- a/src/components/recommendations/EnhancedIngredientRecommender.tsx
+++ b/src/components/recommendations/EnhancedIngredientRecommender.tsx
@@ -15,6 +15,7 @@ import Image from "next/image";
 import Link from "next/link";
 import React, { useEffect, useMemo, useState } from "react";
 import { useAlchemical } from "@/contexts/AlchemicalContext/hooks";
+import { calculateKalchm } from "@/data/unified/alchemicalCalculations";
 import type { UnifiedIngredient } from "@/data/unified/unifiedTypes";
 import { usePantry } from "@/hooks/usePantry";
 import { useUserElementalBias } from "@/hooks/useUserElementalBias";
@@ -31,7 +32,6 @@ import { deriveLiveSkyQuantities } from "@/utils/liveSkyQuantities";
 import {
   calculateThermodynamicMetrics,
   elementalToAlchemicalApproximation,
-  calculateKAlchm,
 } from "@/utils/monicaKalchmCalculations";
 import { looseIncludes } from "@/utils/searchNormalize";
 import { getAssetUrl } from "@/utils/urlUtils";
@@ -2189,12 +2189,12 @@ export const EnhancedIngredientRecommender: React.FC<
                       const kalchmValue =
                         ingredient.kalchm ??
                         (alch?.Spirit
-                          ? calculateKAlchm(
-                              alch.Spirit,
-                              alch.Essence,
-                              alch.Matter,
-                              alch.Substance,
-                            )
+                          ? calculateKalchm({
+                              Spirit: alch.Spirit,
+                              Essence: alch.Essence,
+                              Matter: alch.Matter,
+                              Substance: alch.Substance,
+                            })
                           : null);
                       if (kalchmValue == null) return null;
                       return (

--- a/src/utils/methodAlchemicalSnapshot.ts
+++ b/src/utils/methodAlchemicalSnapshot.ts
@@ -11,16 +11,16 @@ import { calculateGregsEnergy } from "@/calculations/gregsEnergy";
 import type { KineticMetrics } from "@/calculations/kinetics";
 import type { AlchemicalPillar } from "@/constants/alchemicalPillars";
 import { getCookingMethodThermodynamics } from "@/constants/alchemicalPillars";
+import {
+  calculateKalchm,
+  calculateMonica,
+} from "@/data/unified/alchemicalCalculations";
 import type { CookingMethodData, CookingMethodKineticProfile } from "@/types/cookingMethod";
 import { getCookingMethodPillar } from "@/utils/alchemicalPillarUtils";
 import {
   calculateMethodSpecificKinetics,
   getKineticProfile,
 } from "@/utils/cookingMethodKinetics";
-import {
-  calculateKAlchm,
-  calculateMonicaConstant,
-} from "@/utils/monicaKalchmCalculations";
 import { calculateAlchemicalFromPlanets } from "@/utils/planetaryAlchemyMapping";
 import {
   calculateHarmonyIndex,
@@ -151,14 +151,14 @@ export function computeMethodSnapshot(
     Earth: method.elementalEffect.Earth,
   }).gregsEnergy;
 
-  const kalchm = calculateKAlchm(
-    transformedESMS.Spirit,
-    transformedESMS.Essence,
-    transformedESMS.Matter,
-    transformedESMS.Substance,
-  );
+  const kalchm = calculateKalchm({
+    Spirit: transformedESMS.Spirit,
+    Essence: transformedESMS.Essence,
+    Matter: transformedESMS.Matter,
+    Substance: transformedESMS.Substance,
+  });
   const monica = kalchm
-    ? calculateMonicaConstant(gregsEnergy, thermo.reactivity, kalchm)
+    ? calculateMonica(gregsEnergy, thermo.reactivity, kalchm)
     : null;
 
   let kinetics: KineticMetrics | null = null;


### PR DESCRIPTION
## Why this is zero-movement

`src/utils/monicaKalchmCalculations.ts` already delegates:

```
calculateKAlchm(s,e,m,sub)     -> canonicalCalculateKalchm({Spirit,Essence,Matter,Substance})
calculateMonicaConstant(g,r,k) -> calculateMonica(g,r,k)
```

Both wrapper bodies are pure adapters with **no arithmetic of their own**, so calling canonical directly cannot move a value. Confirmed by the existing unification gate — `src/__tests__/thermodynamicDegenerateCharacterisation.test.ts` passes 21/21, including *"all three return the same value"* across every degenerate case (kalchm 1, 1.0001, 1.05, 0, negative; reactivity 0, 1e-9; all-zero).

## Repointed — 7 call sites, 4 files

- `src/components/home/CookingMethodPreview.tsx:319,330`
- `src/components/recommendations/EnhancedCookingMethodRecommender.tsx:527,529`
- `src/components/recommendations/EnhancedIngredientRecommender.tsx:2192`
- `src/utils/methodAlchemicalSnapshot.ts:154,161`

## NOT repointed — a name-collision trap

`calculateKAlchm` / `calculateMonicaConstant` are **also** exported by the third engine, `src/calculations/core/kalchmEngine.ts`, which `src/calculations/index.ts` publishes via `export * from "./core/kalchmEngine"`. These resolve there, not here, and are out of scope:

- `src/utils/menuPlanner/nutritionalCalculator.ts:367,369` — imports `kalchmEngine`
- `src/calculations/core/alchemicalCalculations.ts:189,195` — imports `./kalchmEngine`
- `src/calculations/core/kalchmEngine.ts:411,418` — its own

`src/lib/core-energy-rules.ts:264` is an unrelated static class method.

## The wrappers stay — deliberately

They are now referenced only by the module's own internals and by the two characterisation tests that exist to catch a re-divergence: `thermodynamicDegenerateCharacterisation.test.ts` imports all **three** monica implementations by their public entry points, and `kalchmFloorDivergence.test.ts` does the same for kalchm.

Deleting the wrappers would silently remove one of three subjects from each gate. That is a coverage decision, not a repoint, and belongs in its own change.

## Verification

- `tsc --noEmit` clean
- `eslint` clean
- 181/181 jest suites, 1620 tests pass
- diff is exactly 36 insertions / 36 deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)