### PR TITLE
fix(recipe-nft): close the zero-cost mint pole, gate the quote route, enforce the flag

### DIFF
--- a/src/__tests__/recipeNftMintCostPole.test.ts
+++ b/src/__tests__/recipeNftMintCostPole.test.ts
@@ -1,0 +1,194 @@
+/**
+ * The mint cost basis IS the ingredient mass — so anything that zeroes or
+ * overflows the mass zeroes or corrupts the price.
+ *
+ * Every case below was MEASURED reachable through a schema-valid payload on
+ * `origin/master` @ cfed12a8 before this fix: `cosmicRecipeSchema` puts no
+ * `.min(1)` on `ingredients` and no format on `quantity`, and
+ * `computeRecipeFingerprint` turned a zero/overflowed mass into all-zero or
+ * NaN coins instead of failing. `baseMintCost` passes those coins straight to
+ * `purchaseShopItem({ overrideCosts })`, i.e. a free (or NaN) mint.
+ *
+ * Two layers are pinned here, deliberately:
+ *   1. the VALIDATOR (`parseRecipeForMint`) rejects the payload, and
+ *   2. the ENGINE (`computeRecipeFingerprint`) throws even if the validator is
+ *      bypassed — so the two drifting apart is loud, not free.
+ *
+ * ⚠️ If a test here fails, do not relax the bound to match. The bound is the
+ * price floor.
+ */
+
+import { featuredRecipe, type CosmicRecipe } from "@/data/featuredRecipe";
+import { computeRecipeFingerprint, TARGET_ESMS } from "@/lib/recipe-nft/fingerprint";
+import { parseRecipeForMint } from "@/lib/recipe-nft/mintableRecipe";
+import { QUANTITY_MAX, QUANTITY_MIN, parseAmount, rejectMintQuantity } from "@/lib/recipe-nft/quantity";
+
+/** The shipped fixture with its ingredient list swapped. */
+function withIngredients(ingredients: CosmicRecipe["ingredients"]): CosmicRecipe {
+  return { ...featuredRecipe, ingredients };
+}
+
+/** One well-formed ingredient, quantity overridden. */
+function oneIngredient(quantity: string, unit = "g"): CosmicRecipe["ingredients"] {
+  return [
+    {
+      name: "whole milk",
+      quantity,
+      unit,
+      optional: false,
+      substitutions: [],
+    },
+  ];
+}
+
+describe("the shipped fixture is healthy (control)", () => {
+  it("validates and prices at TARGET_ESMS — proving these probes can pass", () => {
+    const parsed = parseRecipeForMint(featuredRecipe);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.complete).toBe(true);
+
+    const fp = computeRecipeFingerprint(featuredRecipe);
+    // aSharp is the four-coin sum, normalized to the economy target.
+    expect(fp.aSharp).toBeCloseTo(TARGET_ESMS, 1);
+    for (const coin of [fp.totals.spirit, fp.totals.essence, fp.totals.matter, fp.totals.substance]) {
+      expect(Number.isFinite(coin)).toBe(true);
+      expect(coin).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("parseAmount — the behaviour the bounds exist for", () => {
+  it('parses "" to a legitimate-looking finite 0, NOT NaN', () => {
+    // This is the whole reason `QUANTITY_MIN` cannot be expressed as an
+    // isFinite check. If this ever becomes NaN, the empty-string case is
+    // handled upstream and this suite's `""` test is testing nothing.
+    expect(parseAmount("")).toBe(0);
+    expect(Number.isFinite(parseAmount(""))).toBe(true);
+  });
+
+  it("returns NaN for genuinely non-numeric amounts", () => {
+    expect(Number.isNaN(parseAmount("to taste"))).toBe(true);
+    expect(Number.isNaN(parseAmount("a splash"))).toBe(true);
+  });
+
+  it("still handles mixed numbers and fractions", () => {
+    expect(parseAmount("1 1/2")).toBe(1.5);
+    expect(parseAmount("3/4")).toBe(0.75);
+    expect(parseAmount("250")).toBe(250);
+  });
+});
+
+describe("rejectMintQuantity", () => {
+  it.each([
+    ["", "not_positive"],
+    ["0", "not_positive"],
+    ["0.0", "not_positive"],
+    ["-100", "not_positive"],
+    ["1e-320", "too_small"],
+    ["1e308", "too_large"],
+  ])("rejects %p as %s", (quantity, reason) => {
+    expect(rejectMintQuantity(quantity as string)).toBe(reason);
+  });
+
+  it.each(["250", "1 1/2", "3/4", "0.5", "to taste", "a pinch"])(
+    "accepts %p",
+    (quantity) => {
+      expect(rejectMintQuantity(quantity)).toBeNull();
+    },
+  );
+
+  it("accepts values exactly at both bounds", () => {
+    expect(rejectMintQuantity(String(QUANTITY_MIN))).toBeNull();
+    expect(rejectMintQuantity(String(QUANTITY_MAX))).toBeNull();
+  });
+});
+
+describe("parseRecipeForMint rejects every measured zero-cost payload", () => {
+  it("rejects a recipe with no ingredients", () => {
+    const parsed = parseRecipeForMint(withIngredients([]));
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toMatch(/at least one ingredient/);
+  });
+
+  it.each([
+    ["empty quantity string", ""],
+    ["explicit zero", "0"],
+    ["negative quantity", "-100"],
+    ["denormal quantity", "1e-320"],
+    ["overflowing quantity", "1e308"],
+  ])("rejects %s", (_label, quantity) => {
+    const parsed = parseRecipeForMint(withIngredients(oneIngredient(quantity)));
+    expect(parsed.ok).toBe(false);
+    expect(parsed.recipe).toBeUndefined();
+    expect(parsed.error).toMatch(/ingredients\.0\.quantity/);
+  });
+
+  it("rejects a bad quantity anywhere in the list, not just the first", () => {
+    const parsed = parseRecipeForMint(
+      withIngredients([...oneIngredient("250"), ...oneIngredient("0")]),
+    );
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toMatch(/ingredients\.1\.quantity/);
+  });
+
+  it("STILL ACCEPTS a non-numeric quantity — that is a supported input", () => {
+    // "to taste" resolves to a nominal mass by design. Rejecting it would be a
+    // regression, not extra safety.
+    const parsed = parseRecipeForMint(withIngredients(oneIngredient("to taste", "")));
+    expect(parsed.ok).toBe(true);
+  });
+
+  it("applies to the RELAXED schema too, not just the strict one", () => {
+    // Drop a cosmology field so the strict parse fails and the relaxed one runs.
+    const relaxed = { ...withIngredients(oneIngredient("0")) } as Record<string, unknown>;
+    delete relaxed.astro_explanation;
+    delete relaxed.alignment_score;
+
+    const parsed = parseRecipeForMint(relaxed);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toMatch(/ingredients\.0\.quantity/);
+
+    // Control: the same relaxed shape with a good quantity DOES validate,
+    // proving the rejection above came from the quantity and not the deletions.
+    const control = { ...relaxed, ingredients: oneIngredient("250") };
+    const ok = parseRecipeForMint(control);
+    expect(ok.ok).toBe(true);
+    expect(ok.complete).toBe(false);
+  });
+});
+
+describe("computeRecipeFingerprint fails loudly when the validator is bypassed", () => {
+  // These call the engine DIRECTLY with payloads `parseRecipeForMint` would
+  // reject, which is what a future caller that forgets to validate looks like.
+  it("throws rather than emitting an all-zero cost basis", () => {
+    expect(() => computeRecipeFingerprint(withIngredients([]))).toThrow(
+      /no usable ingredient mass/,
+    );
+    expect(() => computeRecipeFingerprint(withIngredients(oneIngredient("0")))).toThrow(
+      /no usable ingredient mass/,
+    );
+    expect(() => computeRecipeFingerprint(withIngredients(oneIngredient("-100")))).toThrow(
+      /no usable ingredient mass/,
+    );
+  });
+
+  it("throws rather than emitting a non-finite cost basis", () => {
+    // 1e308 kg overflows on the unit multiply; 1e-320 g makes normScale overflow.
+    expect(() =>
+      computeRecipeFingerprint(withIngredients(oneIngredient("1e308", "kg"))),
+    ).toThrow(/no usable ingredient mass|non-finite/);
+    expect(() =>
+      computeRecipeFingerprint(withIngredients(oneIngredient("1e-320", "g"))),
+    ).toThrow(/no usable ingredient mass|non-finite/);
+  });
+
+  it("never returns a zero or NaN coin for any input it does accept", () => {
+    // Sweep the accepted quantity range; every survivor must be priceable.
+    for (const q of ["1e-6", "0.5", "1", "250", "1000", "1e6"]) {
+      const fp = computeRecipeFingerprint(withIngredients(oneIngredient(q)));
+      const coins = [fp.totals.spirit, fp.totals.essence, fp.totals.matter, fp.totals.substance];
+      for (const c of coins) expect(Number.isFinite(c)).toBe(true);
+      expect(fp.aSharp).toBeCloseTo(TARGET_ESMS, 1);
+    }
+  });
+});

--- a/src/app/api/recipes/mint-quote/route.ts
+++ b/src/app/api/recipes/mint-quote/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { gateDemoOrAuth } from "@/lib/auth/demoAccess";
 import { parseRecipeForMint } from "@/lib/recipe-nft/mintableRecipe";
 import { buildMintQuote } from "@/lib/recipe-nft/quote";
 import type { NextRequest } from "next/server";
@@ -12,8 +13,20 @@ export const runtime = "nodejs";
  * the recipe and returns its fingerprint + four-coin cost so the recipe builder
  * can show what minting a just-generated recipe would cost. The recipe is
  * re-validated server-side; the quote reflects server-computed ESMS only.
+ *
+ * AUTH REQUIRED. This runs the full ingredient-catalog fingerprint over a
+ * client-supplied recipe body, so it is the same compute surface as `/mint`
+ * minus the debit. It was unauthenticated, which made every degenerate-input
+ * path in `computeRecipeFingerprint` anonymously reachable. `dailyDemoQuota: 0`
+ * matches `/mint` — there is no demo tier for this.
  */
 export async function POST(request: NextRequest) {
+  const access = await gateDemoOrAuth(request, { dailyDemoQuota: 0, feature: "mint recipe quote" });
+  if (access.mode !== "auth") {
+    if (access.mode === "denied") return access.blocked;
+    return NextResponse.json({ error: "Sign in to quote a recipe mint." }, { status: 401 });
+  }
+
   let body: unknown;
   try {
     body = await request.json();

--- a/src/app/api/recipes/mint/route.ts
+++ b/src/app/api/recipes/mint/route.ts
@@ -43,6 +43,20 @@ export async function POST(request: NextRequest) {
   }
   const userId = access.userId;
 
+  // The flag gates the WHOLE route, not just the on-chain leg.
+  //
+  // This route previously had no `recipeNftEnabled()` check at all. With the
+  // flag off, `mintRecipeOnChain` returns `pending_chain` (minter.ts) and the
+  // ledger row was still written — so the permanent `content_hash` UNIQUE claim
+  // was taken on a deployment that cannot actually mint. Reject before the ESMS
+  // debit, so there is nothing to refund.
+  if (!recipeNftEnabled()) {
+    return NextResponse.json(
+      { error: "mint_unavailable", detail: "Recipe NFT minting is not enabled on this deployment." },
+      { status: 503 },
+    );
+  }
+
   let body: unknown;
   try {
     body = await request.json();

--- a/src/lib/recipe-nft/fingerprint.ts
+++ b/src/lib/recipe-nft/fingerprint.ts
@@ -20,6 +20,7 @@
 
 import { calculateThermodynamicMetrics } from "@/utils/monicaKalchmCalculations";
 import { lookupIngredientFull } from "@/utils/recipeAlchemicalQuantities";
+import { parseAmount } from "./quantity";
 import type { MintableRecipe } from "./mintableRecipe";
 import type {
   CoinAmounts,
@@ -110,16 +111,6 @@ const round = (n: number, d = 4): number => {
   return Math.round(n * f) / f;
 };
 const clamp = (n: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, n));
-
-function parseAmount(raw: string): number {
-  const s = raw.trim();
-  const mixed = s.match(/^(\d+)\s+(\d+)\/(\d+)$/);
-  if (mixed) return Number(mixed[1]) + Number(mixed[2]) / Number(mixed[3]);
-  const frac = s.match(/^(\d+)\/(\d+)$/);
-  if (frac) return Number(frac[1]) / Number(frac[2]);
-  const n = Number(s);
-  return Number.isFinite(n) ? n : NaN;
-}
 
 const normalizeUnit = (u: string) => u.toLowerCase().trim().replace(/s$/, "");
 
@@ -314,17 +305,39 @@ export function computeRecipeFingerprint(recipe: MintableRecipe): RecipeFingerpr
   );
   // Normalize to the fixed economy target: every recipe's four coins sum to
   // TARGET_ESMS, so all recipes cost the same to mint. Only the SPLIT varies,
-  // preserving the raw potency-weighted ratio between coins. A degenerate recipe
-  // with no resolved ESMS (rawTotal 0) yields all-zero totals rather than NaN.
+  // preserving the raw potency-weighted ratio between coins.
+  //
+  // FAIL LOUDLY. This used to read `rawTotal > 0 ? TARGET_ESMS / rawTotal : 0`,
+  // which turned a degenerate recipe into all-zero totals — and since these
+  // totals ARE the mint cost basis (`cost.ts baseMintCost`), that was a free
+  // mint. `mintableRecipe.ts` now rejects the inputs that get here, so reaching
+  // this throw means the validator and the engine have drifted apart; that is a
+  // bug to surface, never a price to charge.
   const rawTotal =
     weighted.spirit + weighted.essence + weighted.matter + weighted.substance;
-  const normScale = rawTotal > 0 ? TARGET_ESMS / rawTotal : 0;
+  if (!Number.isFinite(rawTotal) || rawTotal <= 0) {
+    throw new Error(
+      `computeRecipeFingerprint: recipe "${recipe.id}" has no usable ingredient mass ` +
+        `(rawTotal=${rawTotal}). Refusing to emit a zero/non-finite cost basis.`,
+    );
+  }
+  const normScale = TARGET_ESMS / rawTotal;
   const totals: CoinAmounts = {
     spirit: weighted.spirit * normScale,
     essence: weighted.essence * normScale,
     matter: weighted.matter * normScale,
     substance: weighted.substance * normScale,
   };
+  // `normScale` can still overflow if `rawTotal` is denormal, which makes every
+  // coin Infinity or NaN. Assert on the OUTPUT rather than trusting the input.
+  for (const [coin, value] of Object.entries(totals)) {
+    if (!Number.isFinite(value) || value < 0) {
+      throw new Error(
+        `computeRecipeFingerprint: recipe "${recipe.id}" produced a non-finite ${coin} ` +
+          `coin (${value}, normScale=${normScale}). Refusing to emit it as a cost basis.`,
+      );
+    }
+  }
   const aSharp = totals.spirit + totals.essence + totals.matter + totals.substance;
 
   // Ingredient-derived elemental shares (potency-weighted); fall back to authored.

--- a/src/lib/recipe-nft/mintableRecipe.ts
+++ b/src/lib/recipe-nft/mintableRecipe.ts
@@ -12,6 +12,7 @@
  */
 
 import { cosmicRecipeSchema } from "@/types/cosmicRecipeSchema";
+import { QUANTITY_MAX, QUANTITY_MIN, rejectMintQuantity } from "./quantity";
 import type { z } from "zod";
 
 export type RecipeSource = "generated" | "scan" | "seeded" | "curated";
@@ -47,17 +48,80 @@ export interface ParseResult {
 }
 
 /**
+ * Mint-only structural checks that the AUTHORING schema deliberately does not make.
+ *
+ * `cosmicRecipeSchema` is the LLM structured-output contract; constraining it
+ * would change what the generator is asked to produce. These rules therefore
+ * live on the mint path only, and apply to BOTH the strict and relaxed parses.
+ *
+ * Each rule exists because it is a measured route to a degenerate mint cost —
+ * the cost basis IS the ingredient mass, so anything that zeroes or overflows
+ * the mass zeroes or corrupts the price:
+ *
+ *   • no ingredients      -> the fingerprint's reduce seed {0,0,0,0} is the
+ *                            answer, so all four coins are 0. A free mint.
+ *   • quantity ""         -> `Number("") === 0`, finite, so mass is 0. Same.
+ *   • quantity "0" / "-5" -> mass <= 0, so the normalisation scale is 0. Same.
+ *   • quantity 1e308      -> overflows to Infinity on the unit multiply, so
+ *                            every coin becomes NaN and the debit is NaN.
+ *   • quantity 1e-320     -> denormal; positive and finite, but the scale
+ *                            `TARGET_ESMS / rawTotal` overflows to Infinity.
+ *
+ * A NON-NUMERIC quantity ("to taste") is intentionally still accepted — the
+ * engine assigns it a nominal mass by design.
+ */
+function mintStructureError(recipe: MintableRecipe): string | null {
+  if (recipe.ingredients.length === 0) {
+    return "ingredients: a mintable recipe must list at least one ingredient";
+  }
+
+  for (let i = 0; i < recipe.ingredients.length; i++) {
+    const ing = recipe.ingredients[i];
+    const rejection = rejectMintQuantity(ing.quantity);
+    if (!rejection) continue;
+
+    const where = `ingredients.${i}.quantity`;
+    const got = JSON.stringify(ing.quantity);
+    switch (rejection) {
+      case "not_positive":
+        return `${where}: must be a positive amount (got ${got})`;
+      case "too_small":
+        return `${where}: is below the minimum mintable amount ${QUANTITY_MIN} (got ${got})`;
+      case "too_large":
+        return `${where}: exceeds the maximum mintable amount ${QUANTITY_MAX} (got ${got})`;
+      default:
+        return `${where}: is not a usable amount (got ${got})`;
+    }
+  }
+
+  return null;
+}
+
+/**
  * Validate a posted recipe for minting. Prefers the strict schema (fully
  * cosmology-enriched, as generated recipes are); falls back to the relaxed
  * mintable schema so ingested recipes still validate. Returns a structured
  * result rather than throwing.
+ *
+ * Both parses are additionally subjected to `mintStructureError`, so a payload
+ * cannot slip a degenerate cost basis through by satisfying the strict schema.
  */
 export function parseRecipeForMint(input: unknown): ParseResult {
   const strict = cosmicRecipeSchema.safeParse(input);
-  if (strict.success) return { ok: true, recipe: strict.data, complete: true };
+  if (strict.success) {
+    const structural = mintStructureError(strict.data);
+    return structural
+      ? { ok: false, complete: false, error: structural }
+      : { ok: true, recipe: strict.data, complete: true };
+  }
 
   const relaxed = mintableRecipeSchema.safeParse(input);
-  if (relaxed.success) return { ok: true, recipe: relaxed.data, complete: false };
+  if (relaxed.success) {
+    const structural = mintStructureError(relaxed.data);
+    return structural
+      ? { ok: false, complete: false, error: structural }
+      : { ok: true, recipe: relaxed.data, complete: false };
+  }
 
   return {
     ok: false,

--- a/src/lib/recipe-nft/quantity.ts
+++ b/src/lib/recipe-nft/quantity.ts
@@ -1,0 +1,74 @@
+/**
+ * Recipe quantity parsing + the bounds a mintable quantity must satisfy.
+ *
+ * Extracted so the validator (`mintableRecipe.ts`) and the engine
+ * (`fingerprint.ts`) share ONE definition of "what this string means". A second
+ * copy in the validator would be the standard drift trap: the gate would accept
+ * exactly the inputs the engine mis-reads.
+ */
+
+/**
+ * Parse a recipe quantity string to a number.
+ *
+ * Handles mixed numbers ("1 1/2"), bare fractions ("3/4") and plain decimals.
+ * Returns NaN for anything non-numeric ("to taste", "a splash") — that is a
+ * SUPPORTED input, not an error: `estimateMass` deliberately falls back to a
+ * nominal gram weight for it.
+ *
+ * ⚠️ `Number("") === 0`, and `Number.isFinite(0)` is true, so an empty string
+ * parses to a legitimate-looking 0 rather than NaN. That is the single most
+ * important behaviour here — see `QUANTITY_MIN`.
+ */
+export function parseAmount(raw: string): number {
+  const s = raw.trim();
+  const mixed = s.match(/^(\d+)\s+(\d+)\/(\d+)$/);
+  if (mixed) return Number(mixed[1]) + Number(mixed[2]) / Number(mixed[3]);
+  const frac = s.match(/^(\d+)\/(\d+)$/);
+  if (frac) return Number(frac[1]) / Number(frac[2]);
+  const n = Number(s);
+  return Number.isFinite(n) ? n : NaN;
+}
+
+/**
+ * Smallest numeric quantity a mintable recipe may state.
+ *
+ * BASIS: chosen to sit far above the denormal range and far below any real
+ * measure. The smallest unit in `PRECISE_UNITS` is a pinch at 0.5 g, so a
+ * plausible smallest quantity is ~0.1 pinch = 5e-2; 1e-6 leaves six orders of
+ * margin for exotic units while still rejecting the failure mode it exists for:
+ * a denormal like `1e-320` is > 0 and finite, so it passes every naive guard,
+ * but it drives `TARGET_ESMS / rawTotal` past `Number.MAX_VALUE` and the
+ * normalisation scale becomes Infinity.
+ */
+export const QUANTITY_MIN = 1e-6;
+
+/**
+ * Largest numeric quantity a mintable recipe may state.
+ *
+ * BASIS: the largest multiplier any unit applies is 1000 (kg, l), so the
+ * gram figure is at most 1e9 — nine orders below `Number.MAX_VALUE`, which
+ * leaves the summation across ingredients no way to reach Infinity. It is also
+ * absurdly generous as a recipe amount (1e6 kg). Rejects the measured overflow:
+ * `1e308` is finite and passes `Number.isFinite`, but `1e308 * 1000` is
+ * Infinity, which makes every ESMS total NaN.
+ */
+export const QUANTITY_MAX = 1e6;
+
+export type QuantityRejection = "not_a_number" | "not_positive" | "too_small" | "too_large";
+
+/**
+ * Validate a quantity string for MINTING specifically.
+ *
+ * Returns null when acceptable. A non-numeric string is accepted (see
+ * `parseAmount`); a numeric one must be strictly positive and within bounds.
+ */
+export function rejectMintQuantity(raw: string): QuantityRejection | null {
+  const n = parseAmount(raw);
+  // Non-numeric ("to taste") is fine — the engine assigns it a nominal mass.
+  if (Number.isNaN(n)) return null;
+  if (!Number.isFinite(n)) return "not_a_number";
+  if (n <= 0) return "not_positive";
+  if (n < QUANTITY_MIN) return "too_small";
+  if (n > QUANTITY_MAX) return "too_large";
+  return null;
+}


### PR DESCRIPTION
The mint cost basis **is** the recipe's ingredient mass, so anything that zeroes or overflows the mass zeroes or corrupts the price. Three independent gaps let a **schema-valid** payload reach `purchaseShopItem({ overrideCosts })` with a degenerate cost.

All three are MEASURED on `cfed12a8`, not inferred. `recipe_nft_mints` is still **0 rows**, so nothing is locked in yet.

---

## 1 — Zero-cost / NaN mint

`fingerprint.ts` read `rawTotal > 0 ? TARGET_ESMS / rawTotal : 0`, so a degenerate recipe produced all-zero coins — which `cost.ts baseMintCost` passes straight through as `overrideCosts`. **A free mint.**

Reachable because `cosmicRecipeSchema` has no `.min(1)` on `ingredients` and no format on `quantity`:

| payload | mechanism |
|---|---|
| `ingredients: []` | the reduce seed `{0,0,0,0}` *is* the answer |
| `quantity: ""` | `Number("") === 0`, finite — mass 0 |
| `quantity: "0"` / `"-100"` | mass ≤ 0 → `normScale = 0` |
| `quantity: "1e308"` | overflows on the unit multiply; **every coin NaN** |
| `quantity: "1e-320"` | denormal; `TARGET_ESMS / rawTotal` overflows to Infinity |

Fixed in **two layers**, deliberately:

- **Validator** — `parseRecipeForMint` applies `mintStructureError` to *both* the strict and relaxed parses. A payload could otherwise satisfy the strict schema and skip the check entirely.
- **Engine** — `computeRecipeFingerprint` now **throws** instead of emitting a zero or non-finite basis, asserting on the **output coins** rather than trusting the input. Reaching it means validator and engine have drifted; that is a bug to surface, never a price to charge.

A **non-numeric** quantity (`"to taste"`) is still accepted — the engine assigns it a nominal mass by design. Pinned by a test so nobody "hardens" it away.

### Why `cosmicRecipeSchema` is untouched

It is the **LLM structured-output contract** (`generate-cosmic-recipe`, `agentRecipePrewarm`). Constraining it would change what the generator is asked to produce. The rules belong on the mint path — which is exactly what `mintableRecipe.ts` is for.

New `src/lib/recipe-nft/quantity.ts` holds `parseAmount` + the bounds, shared by validator and engine so they cannot disagree about what a string means. A second copy in the validator would be the standard drift trap: the gate would accept exactly the inputs the engine mis-reads. Both bounds carry their BASIS in the doc comment.

## 2 — Unauthenticated quote route

`POST /api/recipes/mint-quote` had **no auth of any kind**. It runs the full ingredient-catalog fingerprint over a client-supplied body — the same compute surface as `/mint` minus the debit — so every path above was anonymously reachable.

Now `gateDemoOrAuth` with `dailyDemoQuota: 0`, matching `/mint`. `quoteRecipeMint` already returns `null` on `!res.ok` and the UI renders nothing when `!mintQuote?.enabled`, so anon degrades cleanly with no UI change.

## 3 — Feature flag not enforced on the route

`mint/route.ts` had **no** `recipeNftEnabled()` check. With the flag off, `mintRecipeOnChain` returns `pending_chain` (`minter.ts:62`) and **the ledger row was written anyway** — so the permanent `content_hash` UNIQUE claim could be taken on a deployment that cannot actually mint.

The guard sits **before the ESMS debit**, so there is nothing to refund. Production already has the flag true, so this is a no-op there and a real gate everywhere else.

---

## Verification

recipe-nft had **zero** test coverage. Adds `src/__tests__/recipeNftMintCostPole.test.ts` — 29 cases.

**The suite was confirmed able to fail.** Reverting only `mintableRecipe.ts` + `fingerprint.ts` to `cfed12a8`:

```
Tests: 10 failed, 19 passed, 29 total
```

The 10 red are the vulnerability cases; the 19 that stay green are the controls (shipped-fixture health, `parseAmount` semantics) — which is the correct signature, not an accident.

- `tsc --noEmit` clean
- `eslint` clean
- **182/182 suites, 1649 tests pass**

## Not in scope

`fingerprint.ts:386` `round(metrics.monica ?? 1, 4)` is left alone — measured **inert** (`calculateMonica` is total; 0 non-finite over 38,416 ESMS combinations). With the guards above, the five previously-unguarded sibling fields can no longer go non-finite either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)