### PR TITLE
fix(physics): drop the Earth double-count in elemental → ESMS derivation

### DIFF
--- a/docs/HIERARCHICAL_SYSTEM_IMPLEMENTATION.md
+++ b/docs/HIERARCHICAL_SYSTEM_IMPLEMENTATION.md
@@ -257,7 +257,21 @@ steaming: { Fire: 0.6, Water: 1.4, Earth: 0.9, Air: 1.1 }
 1. `elementalToAlchemical(elemental)` in `monicaKalchmCalculations.ts`
    - **Status:** **DELETED 2026-07-29** (was: deprecated with console warnings). It had zero
      importers; its only caller was `performEnhancedAnalysis`, itself unimported.
-   - **Replacement:** `elementalToAlchemicalApproximation(elemental)` (clearly marked as approximation)
+   - **Replacement:** `deriveAlchemicalFromElemental(elemental)` from
+     `@/data/unified/alchemicalCalculations`
+   - **Preferred:** `calculateAlchemicalFromPlanets(positions)`
+
+2. `elementalToAlchemicalApproximation(elemental)` in `monicaKalchmCalculations.ts`
+   - **Status:** **DELETED 2026-07-30.** It DOUBLE-COUNTED EARTH — `elemental.Earth` appeared
+     at full weight in both `Matter` and `Substance`, giving Earth a transfer coefficient of
+     2.0 against Air's 0.4 (a 5.0x spread). Its three live call sites were repointed.
+   - **Replacement:** `deriveAlchemicalFromElemental(elemental)` (coefficients Fire 1.0 /
+     Water 1.2 / Earth 1.2 / Air 0.6 — a 2.0x spread, pinned by
+     `src/__tests__/elementalToEsmsTransfer.test.ts`).
+   - ⚠️ **Do not describe the replacement as "mass-preserving".** It is not: ΣESMS still
+     varies with the input mix (measured 0.76 .. 1.13 over normalized inputs). It happens to
+     sum to exactly 1.0 only when `Water + Earth == 2 x Air`, which balanced test vectors
+     satisfy by coincidence. The defensible claim is the removal of the double count.
    - **Preferred:** `calculateAlchemicalFromPlanets(positions)`
 
 ### Files That Need Updates
@@ -285,7 +299,9 @@ steaming: { Fire: 0.6, Water: 1.4, Earth: 0.9, Air: 1.1 }
 1. Search for `calculateAlchemicalProperties(` calls
 2. Replace with `calculateAlchemicalFromPlanets(planetaryPositions)`
 3. Ensure planetary positions are available in context
-4. If planetary positions unavailable, use `elementalToAlchemicalApproximation()` with warning comment
+4. If planetary positions unavailable, use `deriveAlchemicalFromElemental()` from
+   `@/data/unified/alchemicalCalculations`, with a warning comment
+   (`elementalToAlchemicalApproximation()` was deleted 2026-07-30 — it double-counted Earth)
 
 ## Next Steps
 

--- a/src/__tests__/elementalToEsmsTransfer.test.ts
+++ b/src/__tests__/elementalToEsmsTransfer.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Elemental -> ESMS derivation: the transfer coefficients, pinned.
+ *
+ * `elementalToAlchemicalApproximation` was deleted because it DOUBLE-COUNTED
+ * EARTH: `elemental.Earth` appeared at full weight in BOTH `Matter` and
+ * `Substance`, so a unit of Earth produced 2.0 units of ESMS while a unit of
+ * Air produced 0.4. That is not a tuning choice, it is a structural defect —
+ * the same input element contributing twice to the total.
+ *
+ * The "transfer coefficient" of an element is measured, not asserted: feed a
+ * one-hot elemental vector and sum the four ESMS outputs. Nothing here restates
+ * the formula, so this file cannot drift from the implementation the way a
+ * copied formula would.
+ *
+ * ⚠️ NOTE WHAT IS *NOT* CLAIMED HERE. Canonical is **not** mass-preserving
+ * either — its coefficients are Fire 1.0 / Water 1.2 / Earth 1.2 / Air 0.6, so
+ * ΣESMS still varies with the input MIX (measured 0.76 .. 1.13 across
+ * normalized inputs). The defensible claim for the swap is narrower and
+ * survives measurement: Earth no longer counts twice, and the spread across
+ * elements collapses from 5.0x to 2.0x.
+ */
+
+import { deriveAlchemicalFromElemental } from "@/data/unified/alchemicalCalculations";
+import type { ElementalProperties } from "@/types/alchemy";
+
+const ELEMENTS = ["Fire", "Water", "Earth", "Air"] as const;
+
+const zero = (): ElementalProperties => ({ Fire: 0, Water: 0, Earth: 0, Air: 0 });
+
+/** One-hot input for a single element. */
+const oneHot = (el: (typeof ELEMENTS)[number]): ElementalProperties => ({
+  ...zero(),
+  [el]: 1,
+});
+
+const esmsSum = (e: ReturnType<typeof deriveAlchemicalFromElemental>) =>
+  e.Spirit + e.Essence + e.Matter + e.Substance;
+
+/** How much total ESMS one unit of `el` contributes. */
+const transferCoefficient = (el: (typeof ELEMENTS)[number]) =>
+  esmsSum(deriveAlchemicalFromElemental(oneHot(el)));
+
+describe("elemental -> ESMS transfer coefficients", () => {
+  it("gives Earth the same order of weight as every other element", () => {
+    // THE REGRESSION GUARD. The deleted approximation scored Earth at 2.0.
+    // Anything at or above 2.0 means Earth is being counted twice again.
+    expect(transferCoefficient("Earth")).toBeLessThan(2.0);
+  });
+
+  it("matches the canonical coefficients exactly", () => {
+    expect(transferCoefficient("Fire")).toBeCloseTo(1.0, 10);
+    expect(transferCoefficient("Water")).toBeCloseTo(1.2, 10);
+    expect(transferCoefficient("Earth")).toBeCloseTo(1.2, 10);
+    expect(transferCoefficient("Air")).toBeCloseTo(0.6, 10);
+  });
+
+  it("keeps the spread across elements within 2x", () => {
+    // The deleted approximation spanned 0.4 (Air) .. 2.0 (Earth) = 5.0x.
+    const coefficients = ELEMENTS.map(transferCoefficient);
+    const spread = Math.max(...coefficients) / Math.min(...coefficients);
+    expect(spread).toBeCloseTo(2.0, 10);
+    expect(spread).toBeLessThan(5.0);
+  });
+
+  it("no single element dominates the Matter/Substance pair", () => {
+    // The precise shape of the old defect: Earth landed at full weight in two
+    // different output axes at once. Assert no element does that any more.
+    for (const el of ELEMENTS) {
+      const out = deriveAlchemicalFromElemental(oneHot(el));
+      const atFullWeight = [out.Spirit, out.Essence, out.Matter, out.Substance].filter(
+        (v) => v >= 1,
+      );
+      expect(atFullWeight.length).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("is linear, so the coefficients fully describe it (control)", () => {
+    // If this fails the coefficient model above is not a valid summary and the
+    // rest of this file proves less than it claims.
+    const mixed: ElementalProperties = { Fire: 0.4, Water: 0.3, Earth: 0.2, Air: 0.1 };
+    const predicted =
+      0.4 * transferCoefficient("Fire") +
+      0.3 * transferCoefficient("Water") +
+      0.2 * transferCoefficient("Earth") +
+      0.1 * transferCoefficient("Air");
+    expect(esmsSum(deriveAlchemicalFromElemental(mixed))).toBeCloseTo(predicted, 10);
+  });
+
+  it("is NOT mass-preserving, and that is recorded rather than assumed", () => {
+    // Guards against someone later "documenting" mass preservation because two
+    // convenient inputs happen to sum to 1. They do so only when W+E == 2A.
+    const airHeavy: ElementalProperties = { Fire: 0.1, Water: 0.1, Earth: 0.1, Air: 0.7 };
+    const earthHeavy: ElementalProperties = { Fire: 0.1, Water: 0.1, Earth: 0.7, Air: 0.1 };
+    expect(esmsSum(deriveAlchemicalFromElemental(airHeavy))).toBeCloseTo(0.76, 10);
+    expect(esmsSum(deriveAlchemicalFromElemental(earthHeavy))).toBeCloseTo(1.12, 10);
+
+    // The coincidence that makes it *look* mass-preserving:
+    const balanced: ElementalProperties = { Fire: 0.25, Water: 0.25, Earth: 0.25, Air: 0.25 };
+    expect(esmsSum(deriveAlchemicalFromElemental(balanced))).toBeCloseTo(1.0, 10);
+  });
+});

--- a/src/__tests__/liveSkyQuantities.test.ts
+++ b/src/__tests__/liveSkyQuantities.test.ts
@@ -1,5 +1,5 @@
+import { deriveAlchemicalFromElemental } from '../data/unified/alchemicalCalculations';
 import { deriveLiveSkyQuantities } from '../utils/liveSkyQuantities';
-import { elementalToAlchemicalApproximation } from '../utils/monicaKalchmCalculations';
 
 /**
  * The exact shape AlchemicalContext's provider builds (see provider.tsx
@@ -37,17 +37,23 @@ describe('deriveLiveSkyQuantities', () => {
     expect(total).toBeGreaterThan(0);
   });
 
-  test('does NOT reproduce the elemental approximation it replaced', () => {
-    // The approximation reads Fire/Water/Earth/Air; the engine reads the planets.
-    // If these ever coincide, the fix is not doing anything.
+  test('does NOT reproduce the elemental derivation it replaced', () => {
+    // The elemental derivation reads Fire/Water/Earth/Air; the engine reads the
+    // planets. If these ever coincide, the fix is not doing anything.
+    //
+    // This used to compare against `elementalToAlchemicalApproximation`, which
+    // has been deleted for double-counting Earth. The guard is unchanged in
+    // intent: the live-sky engine must not collapse onto whatever the cheap
+    // elemental fallback returns, and that fallback is now the canonical
+    // `deriveAlchemicalFromElemental`.
     const esms = deriveLiveSkyQuantities(CONTEXT_POSITIONS, true)!;
-    const approximated = elementalToAlchemicalApproximation({
+    const derived = deriveAlchemicalFromElemental({
       Fire: 0.25,
       Water: 0.25,
       Earth: 0.25,
       Air: 0.25,
     });
-    expect(esms.Spirit).not.toBeCloseTo(approximated.Spirit, 3);
+    expect(esms.Spirit).not.toBeCloseTo(derived.Spirit, 3);
   });
 
   test('sect changes the result, so isDaytime is actually honoured', () => {

--- a/src/components/recommendations/EnhancedIngredientRecommender.tsx
+++ b/src/components/recommendations/EnhancedIngredientRecommender.tsx
@@ -15,7 +15,10 @@ import Image from "next/image";
 import Link from "next/link";
 import React, { useEffect, useMemo, useState } from "react";
 import { useAlchemical } from "@/contexts/AlchemicalContext/hooks";
-import { calculateKalchm } from "@/data/unified/alchemicalCalculations";
+import {
+  calculateKalchm,
+  deriveAlchemicalFromElemental,
+} from "@/data/unified/alchemicalCalculations";
 import type { UnifiedIngredient } from "@/data/unified/unifiedTypes";
 import { usePantry } from "@/hooks/usePantry";
 import { useUserElementalBias } from "@/hooks/useUserElementalBias";
@@ -29,10 +32,7 @@ import type { AlchemicalProperties } from "@/types/celestial";
 import { normalizeForDisplay } from "@/utils/elemental/normalization";
 import { calculateKineticProperties } from "@/utils/kineticCalculations";
 import { deriveLiveSkyQuantities } from "@/utils/liveSkyQuantities";
-import {
-  calculateThermodynamicMetrics,
-  elementalToAlchemicalApproximation,
-} from "@/utils/monicaKalchmCalculations";
+import { calculateThermodynamicMetrics } from "@/utils/monicaKalchmCalculations";
 import { looseIncludes } from "@/utils/searchNormalize";
 import { getAssetUrl } from "@/utils/urlUtils";
 
@@ -449,16 +449,15 @@ function calculateCompatibilityScore(
     (fireCompat + waterCompat + earthCompat + airCompat) / 4;
 
   // An ingredient is not a chart — it has no planets — so its quantities come
-  // from its own data, and the elemental approximation is a legitimate fallback.
+  // from its own data, and an elemental derivation is a legitimate fallback.
   const ingredientAlchemical = ingredientAlchemicalProps?.Spirit
     ? ingredientAlchemicalProps
-    : elementalToAlchemicalApproximation(ingredientElementals);
+    : deriveAlchemicalFromElemental(ingredientElementals);
   // The current moment DOES have planets, so its quantities are derived from
-  // them (once per render, in astroCtx). The approximation — whose own docstring
-  // says it is "NOT the correct method" — is now only reached when positions are
-  // unavailable, the single case it was written for.
+  // them (once per render, in astroCtx). The elemental derivation is only
+  // reached when positions are unavailable, the single case it exists for.
   const currentAlchemical =
-    astroCtx?.alchemical ?? elementalToAlchemicalApproximation(currentElementals);
+    astroCtx?.alchemical ?? deriveAlchemicalFromElemental(currentElementals);
 
   const ingredientThermo = calculateThermodynamicMetrics(
     ingredientAlchemical,

--- a/src/utils/cuisine/cuisineSauceProfiler.ts
+++ b/src/utils/cuisine/cuisineSauceProfiler.ts
@@ -10,15 +10,13 @@
 import { cuisineFlavorProfiles } from "@/data/cuisineFlavorProfiles";
 import { cuisinesMap } from "@/data/cuisines";
 import { allSauces, type Sauce as DataSauce } from "@/data/sauces";
+import { deriveAlchemicalFromElemental } from "@/data/unified/alchemicalCalculations";
 import type { ElementalProperties } from "@/types/alchemy";
 import type { Cuisine } from "@/types/cuisine";
 import type { RecipeIngredient } from "@/types/recipe";
 import { normalizeForDisplay } from "@/utils/elemental/normalization";
 import { aggregateIngredientElementals } from "@/utils/hierarchicalRecipeCalculations";
-import {
-  calculateThermodynamicMetrics,
-  elementalToAlchemicalApproximation
-} from "@/utils/monicaKalchmCalculations";
+import { calculateThermodynamicMetrics } from "@/utils/monicaKalchmCalculations";
 
 // ============================================================================
 // Types
@@ -396,7 +394,7 @@ function enhanceSauceWithDynamicProperties(sauce: UnifiedSauce): UnifiedSauce {
   }
 
   const elementalProperties = normalizeForDisplay(rawElementals);
-  const alchemicalProperties = sauce.alchemicalProperties || elementalToAlchemicalApproximation(elementalProperties);
+  const alchemicalProperties = sauce.alchemicalProperties || deriveAlchemicalFromElemental(elementalProperties);
   const thermodynamicProperties = calculateThermodynamicMetrics(alchemicalProperties, elementalProperties);
 
   return {

--- a/src/utils/monicaKalchmCalculations.ts
+++ b/src/utils/monicaKalchmCalculations.ts
@@ -150,32 +150,13 @@ export function calculateMonicaConstant(
   return calculateMonica(gregsEnergy, reactivity, K_alchm);
 }
 // ========== HELPER FUNCTIONS ==========
-/**
- * Convert elemental properties to approximated alchemical properties
- *
- * ⚠️ WARNING: This is an APPROXIMATION and NOT the correct method!
- *
- * The ONLY correct way to calculate ESMS (Spirit, Essence, Matter, Substance)
- * is through planetary positions using calculateAlchemicalFromPlanets().
- *
- * This function should ONLY be used as a fallback when planetary data is
- * completely unavailable. It provides a rough approximation based on elemental
- * correlations, but lacks the precision and accuracy of the true alchemical method.
- *
- * @deprecated Prefer calculateAlchemicalFromPlanets() whenever possible
- * @param elemental - Elemental properties (Fire, Water, Earth, Air)
- * @returns Approximated alchemical properties (NOT accurate)
- */
-export function elementalToAlchemicalApproximation(
-  elemental: ElementalProperties,
-): AlchemicalProperties {
-  return {
-    Spirit: elemental.Fire + ((elemental as any)?.Air || 0) * 0.2, // Rough approximation
-    Essence: elemental.Water + ((elemental as any)?.Air || 0) * 0.2, // Rough approximation
-    Matter: elemental.Earth + ((elemental as any)?.Water || 0) * 0.2, // Rough approximation
-    Substance: elemental.Earth + ((elemental as any)?.Fire || 0) * 0.2, // Rough approximation
-  };
-}
+//
+// `elementalToAlchemicalApproximation` was DELETED here. It double-counted
+// Earth: `elemental.Earth` appeared at FULL weight in both Matter and
+// Substance, giving Earth a transfer coefficient of 2.0 where every other
+// element sat near 1. Its three call sites now use the canonical
+// `deriveAlchemicalFromElemental` (@/data/unified/alchemicalCalculations).
+// Do not reintroduce it — see docs/design/home-living-hero-stitch-prompt.md.
 /**
  * Calculate complete thermodynamic metrics from properties
  */


### PR DESCRIPTION
## The defect

`elementalToAlchemicalApproximation` put `elemental.Earth` at **full weight in both** `Matter` and `Substance`:

```
Spirit:    Fire  + Air * 0.2
Essence:   Water + Air * 0.2
Matter:    Earth + Water * 0.2
Substance: Earth + Fire  * 0.2      <- Earth counted a second time
```

One unit of Earth produced **2.0** units of ESMS; one unit of Air produced **0.4**. A 5.0× spread, with the same input contributing twice to the total. That is a structural defect, not a tuning choice.

## The change

All three live call sites repointed to canonical `deriveAlchemicalFromElemental`:

- `src/components/recommendations/EnhancedIngredientRecommender.tsx:455,461`
- `src/utils/cuisine/cuisineSauceProfiler.ts:399`

| element | old (deleted) | canonical |
|---|---|---|
| Fire | 1.2 | **1.0** |
| Water | 1.2 | **1.2** |
| Earth | **2.0** | **1.2** |
| Air | 0.4 | **0.6** |
| spread | **5.0×** | **2.0×** |

The function is then deleted — after #674 removed the module's internal island it had no other caller, and `docs/design/home-living-hero-stitch-prompt.md:409` already recorded that it "must not be resurrected."

## ⚠️ This is a deliberate behavioural change, not a refactor

Measured over the **reachable** input set — base `0.25` blended 70/30 with `useUserElementalBias`, which hands a date-only guest a pure one-hot, so each axis is confined to `[0.175, 0.475]`; N = 200,004:

| quantity | max delta |
|---|---|
| monica | **1.0067** (62% of monica) |
| kalchm | 0.0987 |
| heat | **31.2%** |

The worst point (Earth one-hot) **crosses the `MONICA_LN_EPSILON` degeneracy boundary** — monica stops being the φ fallback and becomes a real number. The old numbers were produced by double-counted mass, so this is a correction, not a regression.

## ⚠️ The justification is NOT "canonical is mass-preserving"

It isn't, and the claim would not survive its own round-trip check. Canonical's ΣESMS varies with the input **mix** — measured **0.76 … 1.13** across normalized inputs. It equals exactly 1.0 only when `Water + Earth == 2 × Air`, which balanced vectors like `{.25,.25,.25,.25}` and `{.7,.1,.1,.1}` satisfy *by coincidence*. That coincidence is how the claim looked true.

The defensible claim is narrower and holds under measurement: **Earth is no longer counted twice.**

## Tests

**New** `src/__tests__/elementalToEsmsTransfer.test.ts` pins the coefficients by **measuring** them (one-hot in, sum ESMS out) rather than restating the formula, so it cannot drift from the implementation. Includes:
- a regression guard (`Earth < 2.0`)
- a **linearity control** proving the coefficient model is a valid summary of the function
- an explicit *non*-mass-preserving assertion, so nobody later "documents" mass preservation from a convenient vector

`liveSkyQuantities.test.ts` used the deleted function as a **negative control** ("the live-sky engine must not collapse onto the cheap elemental fallback"). Repointed to `deriveAlchemicalFromElemental` — unchanged in intent, since that is now the fallback in question.

- `tsc --noEmit` clean
- `eslint` clean
- **183/183 suites, 1655 tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)