### PR TITLE
fix(physics): route all thermo consumers to canonical, and stop inventing physics

### DIFF
--- a/src/__tests__/thermoDenFloorPoleSubstitution.test.ts
+++ b/src/__tests__/thermoDenFloorPoleSubstitution.test.ts
@@ -232,17 +232,25 @@ describe("THERMO_DEN_FLOOR is a pole substitution (§18k k30)", () => {
     expect(Number.isFinite(served)).toBe(true);
   });
 
-  it("the isFinite guard IS reachable — a missing elemental key zeroes everything", () => {
-    // `[CORRECTED 2026-07-29]` The comment beside that guard said "not a
+  it("a missing elemental key now THROWS instead of silently zeroing everything", () => {
+    // `[CORRECTED 2026-07-29]` The comment beside the isFinite guard said "not a
     // reachable branch". A missing key destructures to undefined, every result
-    // becomes NaN, and all four fall through to 0.
+    // becomes NaN, and all four fell through to 0 — indistinguishable from a
+    // genuinely zero chart.
+    //
+    // `[FIXED 2026-07-30]` §18k k7. `assertThermodynamicInput` rejects it at the
+    // boundary and names the field, so malformed input can no longer masquerade
+    // as measured physics. This test previously PINNED the silent zeroing; it
+    // now pins its removal.
     const esms = { Spirit: 4, Essence: 4, Matter: 4, Substance: 2 };
     const missingAir = { Fire: 0.3, Water: 0.25, Earth: 0.2 } as never;
-    const r = calculateThermodynamics(esms as AlchemicalProperties, missingAir);
-    expect(Object.values(r)).toEqual([0, 0, 0, 0]);
+    expect(() =>
+      calculateThermodynamics(esms as AlchemicalProperties, missingAir),
+    ).toThrow(/elementalProps\.Air is undefined/);
 
-    // CONTROL: the complete object must NOT be all zeros, or the assertion above
-    // would pass for any input at all.
+    // CONTROL: the complete object still computes, and to the SAME value as
+    // before this change — the validator rejects malformed input without moving
+    // any healthy number.
     const complete = { Fire: 0.3, Water: 0.25, Air: 0.25, Earth: 0.2 };
     const c = calculateThermodynamics(esms as AlchemicalProperties, complete);
     expect(c.reactivity).toBe(2.0530045351473922);

--- a/src/__tests__/thermoFailsLoudly.test.ts
+++ b/src/__tests__/thermoFailsLoudly.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The canonical engine refuses to invent physics — §18k k7.
+ *
+ * `src/utils/monicaKalchmCalculations.ts` used to export a second six-field
+ * composite that fabricated twice over: a hardcoded
+ * `{heat: 0.08, entropy: 0.15, reactivity: 0.45, gregsEnergy: -0.02,
+ * kalchm: 2.5, monica: 1.0}` for a null argument, and per-field substitution
+ * (`Spirit/Essence/Matter -> 4`, `Substance -> 2`, every element -> `0.25`) for
+ * a missing or NaN value. A caller could not tell invented physics from
+ * measured physics.
+ *
+ * It is deleted; every consumer now calls `performAlchemicalAnalysis`, which
+ * throws. These tests pin BOTH halves of that contract — that it rejects
+ * garbage, AND that it still accepts every legitimate value, because a
+ * validator that rejects a real `0` would be a worse bug than the one it
+ * replaced.
+ */
+
+import {
+  calculateThermodynamics,
+  performAlchemicalAnalysis,
+  THERMO_DEN_FLOOR,
+  thermoQuotient,
+} from "@/data/unified/alchemicalCalculations";
+import type { AlchemicalProperties } from "@/types/celestial";
+import type { ElementalProperties } from "@/types/alchemy";
+
+const ESMS = { Spirit: 4, Essence: 3, Matter: 2, Substance: 1 } as AlchemicalProperties;
+const EL = { Fire: 0.3, Water: 0.25, Earth: 0.25, Air: 0.2 } as ElementalProperties;
+
+/** The exact object the deleted engine invented for a null argument. */
+const FABRICATED = {
+  heat: 0.08,
+  entropy: 0.15,
+  reactivity: 0.45,
+  gregsEnergy: -0.02,
+  kalchm: 2.5,
+  monica: 1.0,
+};
+
+describe("performAlchemicalAnalysis — the happy path still works (control)", () => {
+  it("returns six finite fields for well-formed input", () => {
+    const r = performAlchemicalAnalysis(ESMS, EL);
+    for (const k of ["heat", "entropy", "reactivity", "gregsEnergy", "kalchm", "monica"] as const) {
+      expect(typeof r[k]).toBe("number");
+      expect(Number.isFinite(r[k])).toBe(true);
+    }
+  });
+
+  it("never returns the fabricated object for real input", () => {
+    // If this ever matches, the fabrication came back.
+    expect(performAlchemicalAnalysis(ESMS, EL)).not.toEqual(FABRICATED);
+  });
+});
+
+describe("it THROWS instead of fabricating", () => {
+  it.each([
+    ["null alchemical", null, EL],
+    ["undefined alchemical", undefined, EL],
+    ["null elemental", ESMS, null],
+    ["undefined elemental", ESMS, undefined],
+  ])("%s", (_label, a, e) => {
+    expect(() =>
+      performAlchemicalAnalysis(a as never, e as never),
+    ).toThrow(TypeError);
+  });
+
+  it.each(["Spirit", "Essence", "Matter", "Substance"])(
+    "rejects a missing %s axis (used to become 4 or 2)",
+    (axis) => {
+      const broken = { ...ESMS } as Record<string, unknown>;
+      delete broken[axis];
+      expect(() => performAlchemicalAnalysis(broken as never, EL)).toThrow(
+        new RegExp(`alchemicalProps\\.${axis}`),
+      );
+    },
+  );
+
+  it.each(["Fire", "Water", "Earth", "Air"])(
+    "rejects a missing %s element (used to become 0.25)",
+    (element) => {
+      const broken = { ...EL } as Record<string, unknown>;
+      delete broken[element];
+      expect(() => performAlchemicalAnalysis(ESMS, broken as never)).toThrow(
+        new RegExp(`elementalProps\\.${element}`),
+      );
+    },
+  );
+
+  it("rejects NaN and Infinity, which the old typeof/isNaN guard let through", () => {
+    // The old guard was `typeof x === "number" && !isNaN(x)` — that caught NaN
+    // but ADMITTED Infinity, which then produced Infinity/Infinity = NaN
+    // downstream and surfaced as a silent 0.
+    expect(() => performAlchemicalAnalysis({ ...ESMS, Spirit: NaN } as never, EL)).toThrow();
+    expect(() => performAlchemicalAnalysis({ ...ESMS, Spirit: Infinity } as never, EL)).toThrow();
+    expect(() => performAlchemicalAnalysis(ESMS, { ...EL, Fire: -Infinity } as never)).toThrow();
+  });
+
+  it("names the caller and the offending field, not just 'invalid input'", () => {
+    expect(() => performAlchemicalAnalysis({ ...ESMS, Matter: undefined } as never, EL)).toThrow(
+      /performAlchemicalAnalysis: alchemicalProps\.Matter is undefined/,
+    );
+  });
+
+  it("applies to calculateThermodynamics too, so /api/alchemize inherits it", () => {
+    // The route wraps its body in try/catch and returns 500, which is the
+    // intended failure mode: a loud error rather than invented physics.
+    expect(() => calculateThermodynamics(null as never, EL)).toThrow(
+      /calculateThermodynamics: alchemicalProps is null/,
+    );
+  });
+});
+
+describe("⚠️ it does NOT reject legitimate values", () => {
+  it("accepts ZERO on every axis and every element", () => {
+    // 0 is a real, meaningful value for all eight fields. A validator that
+    // rejected it would be a worse regression than the fabrication it replaced
+    // — e.g. restaurantScoring legitimately passes Matter:0, Substance:0.
+    const zeroEsms = { Spirit: 0, Essence: 0, Matter: 0, Substance: 0 } as AlchemicalProperties;
+    const zeroEl = { Fire: 0, Water: 0, Earth: 0, Air: 0 } as ElementalProperties;
+    expect(() => performAlchemicalAnalysis(zeroEsms, zeroEl)).not.toThrow();
+    expect(() => performAlchemicalAnalysis({ ...ESMS, Matter: 0, Substance: 0 } as never, EL)).not.toThrow();
+
+    const r = performAlchemicalAnalysis(zeroEsms, zeroEl);
+    expect(Number.isFinite(r.kalchm)).toBe(true);
+    expect(Number.isFinite(r.monica)).toBe(true);
+  });
+
+  it("accepts negatives and raw (unnormalized, >1) elementals", () => {
+    // Dignity scores can be negative; aggregated recipe elementals exceed 1.
+    expect(() => performAlchemicalAnalysis({ ...ESMS, Spirit: -0.5 } as never, EL)).not.toThrow();
+    expect(() =>
+      performAlchemicalAnalysis(ESMS, { Fire: 1.4, Water: 0.6, Earth: 0.9, Air: 1.1 } as never),
+    ).not.toThrow();
+  });
+
+  it("ignores extra keys", () => {
+    expect(() =>
+      performAlchemicalAnalysis({ ...ESMS, Aether: 9 } as never, { ...EL, Void: 3 } as never),
+    ).not.toThrow();
+  });
+});
+
+describe("the second engine's `den > 0 ? n/d : 0` pole is gone", () => {
+  it("shares canonical's quotient, so a zero denominator is capped not zeroed", () => {
+    // The old form returned 0 where the true limit is +Infinity — the opposite
+    // direction from canonical, which caps at numerator / THERMO_DEN_FLOOR.
+    expect(thermoQuotient(25, 0)).toBe(25 / THERMO_DEN_FLOOR);
+    expect(thermoQuotient(25, 0)).not.toBe(0);
+  });
+
+  it("is exact for a positive denominator", () => {
+    expect(thermoQuotient(25, 1e-6)).toBe(25000000);
+    expect(thermoQuotient(25, 4)).toBe(6.25);
+  });
+});

--- a/src/components/PlanetaryCalculationsDemo.tsx
+++ b/src/components/PlanetaryCalculationsDemo.tsx
@@ -11,16 +11,16 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import {
+  performAlchemicalAnalysis,
+  type ThermodynamicMetrics,
+} from "@/data/unified/alchemicalCalculations";
 import { logger } from "@/lib/logger";
 import type { ElementalProperties } from "@/types/alchemy";
 import {
   calculateKineticProperties,
   type KineticMetrics,
 } from "@/utils/kineticCalculations";
-import {
-  calculateThermodynamicMetrics,
-  type ThermodynamicMetrics,
-} from "@/utils/monicaKalchmCalculations";
 import {
   calculateAlchemicalFromPlanets,
   aggregateZodiacElementals,
@@ -263,7 +263,7 @@ export const PlanetaryCalculationsDemo: React.FC = () => {
       setElementalProps(elemental);
 
       // Calculate thermodynamic metrics
-      const thermo = calculateThermodynamicMetrics(alchemical, elemental);
+      const thermo = performAlchemicalAnalysis(alchemical, elemental);
       setThermodynamicMetrics(thermo);
 
       // Calculate kinetic metrics (P=IV circuit model)
@@ -569,7 +569,7 @@ export const PlanetaryCalculationsDemo: React.FC = () => {
           <p className="text-sm text-gray-600 mb-4">
             Calculated using{" "}
             <code className="bg-gray-100 px-2 py-1 rounded">
-              calculateThermodynamicMetrics()
+              performAlchemicalAnalysis()
             </code>
           </p>
 

--- a/src/components/recommendations/EnhancedIngredientRecommender.tsx
+++ b/src/components/recommendations/EnhancedIngredientRecommender.tsx
@@ -18,6 +18,7 @@ import { useAlchemical } from "@/contexts/AlchemicalContext/hooks";
 import {
   calculateKalchm,
   deriveAlchemicalFromElemental,
+  performAlchemicalAnalysis,
 } from "@/data/unified/alchemicalCalculations";
 import type { UnifiedIngredient } from "@/data/unified/unifiedTypes";
 import { usePantry } from "@/hooks/usePantry";
@@ -32,7 +33,6 @@ import type { AlchemicalProperties } from "@/types/celestial";
 import { normalizeForDisplay } from "@/utils/elemental/normalization";
 import { calculateKineticProperties } from "@/utils/kineticCalculations";
 import { deriveLiveSkyQuantities } from "@/utils/liveSkyQuantities";
-import { calculateThermodynamicMetrics } from "@/utils/monicaKalchmCalculations";
 import { looseIncludes } from "@/utils/searchNormalize";
 import { getAssetUrl } from "@/utils/urlUtils";
 
@@ -459,11 +459,11 @@ function calculateCompatibilityScore(
   const currentAlchemical =
     astroCtx?.alchemical ?? deriveAlchemicalFromElemental(currentElementals);
 
-  const ingredientThermo = calculateThermodynamicMetrics(
+  const ingredientThermo = performAlchemicalAnalysis(
     ingredientAlchemical,
     ingredientElementals,
   );
-  const currentThermo = calculateThermodynamicMetrics(
+  const currentThermo = performAlchemicalAnalysis(
     currentAlchemical,
     currentElementals,
   );

--- a/src/data/unified/alchemicalCalculations.ts
+++ b/src/data/unified/alchemicalCalculations.ts
@@ -316,7 +316,7 @@ export const THERMO_DEN_FLOOR = 0.01;
  * derive it, do not delete it"). Nothing here re-derives or removes it; the
  * clamped band 848 .. 1608 that `/api/alchemize` serves is bit-identical.
  */
-function thermoQuotient(numerator: number, denominator: number): number {
+export function thermoQuotient(numerator: number, denominator: number): number {
   // Exact wherever the ratio is defined.
   if (denominator > 0) return numerator / denominator;
   // A true pole. Substitute the published cap; see the note above.
@@ -386,13 +386,79 @@ export function calculateKalchm(alchemicalProps: AlchemicalProperties): number {
   return Number.isFinite(kalchm) && kalchm > 0 ? kalchm : 1.0;
 }
 
+const ESMS_AXES = ["Spirit", "Essence", "Matter", "Substance"] as const;
+const ELEMENTS = ["Fire", "Water", "Earth", "Air"] as const;
+
+/**
+ * FAIL LOUDLY on malformed thermodynamic input. §18k k7.
+ *
+ * Replaces the fabrication layer that `src/utils/monicaKalchmCalculations.ts`
+ * carried, which returned a hardcoded
+ * `{heat: 0.08, entropy: 0.15, reactivity: 0.45, gregsEnergy: -0.02,
+ * kalchm: 2.5, monica: 1.0}` for a null argument and silently substituted
+ * `Spirit/Essence/Matter -> 4`, `Substance -> 2`, and every element -> `0.25`
+ * for a missing or NaN field. A caller could not tell invented physics from
+ * measured physics, which is the k12 class this codebase is eradicating.
+ *
+ * A hard seam here is the point: an upstream caller that cannot produce four
+ * finite ESMS axes and four finite elements has a bug, and the correct
+ * behaviour is to surface it — as a 500 from an API route, or a failed render
+ * — rather than to serve a plausible number nobody can audit.
+ *
+ * ⚠️ Note what is NOT rejected. `0` is a LEGITIMATE value for every one of
+ * these eight fields and passes: the old per-field guards used
+ * `typeof x === "number" && !isNaN(x)`, which also admitted `0` but admitted
+ * `Infinity` too. This requires FINITE, so `Infinity` — which produces
+ * `Infinity/Infinity = NaN` downstream — is now caught at the boundary instead
+ * of surfacing as a silent zero via the `Number.isFinite` guard below.
+ */
+function assertThermodynamicInput(
+  alchemicalProps: AlchemicalProperties,
+  elementalProps: ElementalProperties,
+  caller: string,
+): void {
+  if (!alchemicalProps || typeof alchemicalProps !== "object") {
+    throw new TypeError(
+      `${caller}: alchemicalProps is ${alchemicalProps === null ? "null" : typeof alchemicalProps}. ` +
+        `ESMS cannot be invented — pass four finite axes or resolve them upstream.`,
+    );
+  }
+  if (!elementalProps || typeof elementalProps !== "object") {
+    throw new TypeError(
+      `${caller}: elementalProps is ${elementalProps === null ? "null" : typeof elementalProps}. ` +
+        `Elementals cannot be invented — pass four finite elements or resolve them upstream.`,
+    );
+  }
+  for (const axis of ESMS_AXES) {
+    const v = (alchemicalProps as Record<string, unknown>)[axis];
+    if (typeof v !== "number" || !Number.isFinite(v)) {
+      throw new TypeError(
+        `${caller}: alchemicalProps.${axis} is ${String(v)} (expected a finite number). ` +
+          `A missing or non-finite axis used to be silently replaced with a literal.`,
+      );
+    }
+  }
+  for (const element of ELEMENTS) {
+    const v = (elementalProps as Record<string, unknown>)[element];
+    if (typeof v !== "number" || !Number.isFinite(v)) {
+      throw new TypeError(
+        `${caller}: elementalProps.${element} is ${String(v)} (expected a finite number). ` +
+          `A missing or non-finite element used to be silently replaced with 0.25.`,
+      );
+    }
+  }
+}
+
 /**
  * Calculate thermodynamic metrics including heat, entropy, reactivity, and Greg's Energy
+ *
+ * THROWS on malformed input — see `assertThermodynamicInput`.
  */
 export function calculateThermodynamics(
   alchemicalProps: AlchemicalProperties,
   elementalProps: ElementalProperties,
 ): Omit<ThermodynamicMetrics, "kalchm" | "monica"> {
+  assertThermodynamicInput(alchemicalProps, elementalProps, "calculateThermodynamics");
   const { Spirit, Essence, Matter, Substance } = alchemicalProps;
   const { Fire, Water, Air, Earth } = elementalProps;
 
@@ -428,17 +494,23 @@ export function calculateThermodynamics(
   const gregsEnergy = heat - entropy * reactivity;
 
   // ⚠️ `[CORRECTED 2026-07-29]` This comment claimed the guard was "not a
-  // reachable branch". It IS reached. An elemental object MISSING a key
-  // destructures to `undefined`, every arithmetic result becomes NaN, and all four
-  // values fall through to 0 (MEASURED: `{Fire:0.3, Water:0.25, Earth:0.2}` with no
-  // `Air` returns all zeros; control: the complete object returns
-  // reactivity 2.0530045351473922). So this guard is load-bearing for
-  // partially-populated caller input, not belt-and-braces.
+  // reachable branch". It WAS reached: an elemental object MISSING a key
+  // destructured to `undefined`, every arithmetic result became NaN, and all four
+  // values fell through to 0 (MEASURED: `{Fire:0.3, Water:0.25, Earth:0.2}` with no
+  // `Air` returned all zeros; control: the complete object returns
+  // reactivity 2.0530045351473922).
   //
-  // It is also a k12-shaped fallback — 0 is a legitimate value for all four of
-  // these quantities, so a caller cannot distinguish "genuinely zero" from "your
-  // input was malformed". Left as-is rather than widened into here; recorded so
-  // the next reader does not trust the old claim.
+  // `[RESOLVED 2026-07-30 — §18k k7]` That was a k12-shaped fallback: 0 is a
+  // legitimate value for all four quantities, so a caller could not distinguish
+  // "genuinely zero" from "your input was malformed". It is now rejected at the
+  // boundary by `assertThermodynamicInput`, which names the offending field, so
+  // NO malformed input can reach here any more.
+  //
+  // The guard is KEPT as a genuine last resort — it is now unreachable for
+  // missing/NaN/Infinity input, but a pathological combination of finite inputs
+  // could in principle still overflow to a non-finite quotient, and 0 is a safer
+  // last word than NaN escaping into a score. It is no longer load-bearing, and
+  // `thermoFailsLoudly.test.ts` pins that the boundary catches these cases first.
   return {
     heat: Number.isFinite(heat) ? heat : 0,
     entropy: Number.isFinite(entropy) ? entropy : 0,
@@ -475,12 +547,25 @@ export function calculateMonica(
 }
 
 /**
- * Complete alchemical analysis for an ingredient or cuisine
+ * Complete alchemical analysis for an ingredient or cuisine — heat, entropy,
+ * reactivity, Greg's Energy, kalchm and monica in one call.
+ *
+ * THE canonical six-field entry point. `src/utils/monicaKalchmCalculations.ts`
+ * exported a second composite of the same shape (`calculateThermodynamicMetrics`)
+ * which fabricated on bad input; it has been deleted and its consumers routed
+ * here. §18k k7.
+ *
+ * THROWS on malformed input — see `assertThermodynamicInput`.
  */
 export function performAlchemicalAnalysis(
   alchemicalProps: AlchemicalProperties,
   elementalProps: ElementalProperties,
 ): ThermodynamicMetrics {
+  // Assert HERE as well as in calculateThermodynamics, because calculateKalchm
+  // runs first and would otherwise fail on a null argument with an opaque
+  // "Cannot destructure property 'Spirit' of 'null'" rather than a message
+  // naming the caller and the offending field.
+  assertThermodynamicInput(alchemicalProps, elementalProps, "performAlchemicalAnalysis");
   // Calculate Kalchm
   const kalchm = calculateKalchm(alchemicalProps);
   // Calculate thermodynamic metrics;

--- a/src/lib/recipe-nft/fingerprint.ts
+++ b/src/lib/recipe-nft/fingerprint.ts
@@ -18,7 +18,7 @@
  *     description); rough count units ("2 medium") are flagged `gramsEstimated`.
  */
 
-import { calculateThermodynamicMetrics } from "@/utils/monicaKalchmCalculations";
+import { performAlchemicalAnalysis } from "@/data/unified/alchemicalCalculations";
 import { lookupIngredientFull } from "@/utils/recipeAlchemicalQuantities";
 import { parseAmount } from "./quantity";
 import type { MintableRecipe } from "./mintableRecipe";
@@ -369,7 +369,7 @@ export function computeRecipeFingerprint(recipe: MintableRecipe): RecipeFingerpr
     elementalSource = "authored";
   }
 
-  const metrics = calculateThermodynamicMetrics(
+  const metrics = performAlchemicalAnalysis(
     { Spirit: totals.spirit, Essence: totals.essence, Matter: totals.matter, Substance: totals.substance },
     elemental,
   );

--- a/src/services/UnifiedIngredientService.ts
+++ b/src/services/UnifiedIngredientService.ts
@@ -1,4 +1,5 @@
 import { getCurrentSeason } from "@/data/integrations/seasonal";
+import { performAlchemicalAnalysis as calcThermo } from "@/data/unified/alchemicalCalculations";
 import {
   unifiedBeverages,
   unifiedCookingStaples,
@@ -26,7 +27,6 @@ import type {
 } from "@/types/alchemy";
 import { alchemicalEngine } from "@/utils/alchemyInitializer";
 import { resolveIngredientByName } from "@/utils/ingredientResolution";
-import { calculateThermodynamicMetrics as calcThermo } from "@/utils/monicaKalchmCalculations";
 import type { Recipe } from "../types/recipe";
 
 /**
@@ -708,7 +708,7 @@ export class UnifiedIngredientService implements IngredientServiceInterface {
   /**
    * Calculate thermodynamic metrics from ingredient's elemental and alchemical properties
    */
-  calculateThermodynamicMetrics(
+  performAlchemicalAnalysis(
     ingredient: UnifiedIngredient,
   ): ThermodynamicProperties {
     const elemental = ingredient.elementalProperties || {
@@ -1297,9 +1297,9 @@ export class UnifiedIngredientService implements IngredientServiceInterface {
     // `energyProfile` are), so narrow the fallback-or-computed result to
     // the shape actually read below.
     const metrics1 = (ing1.thermodynamicProperties ||
-      this.calculateThermodynamicMetrics(ing1)) as ThermodynamicProperties;
+      this.performAlchemicalAnalysis(ing1)) as ThermodynamicProperties;
     const metrics2 = (ing2.thermodynamicProperties ||
-      this.calculateThermodynamicMetrics(ing2)) as ThermodynamicProperties;
+      this.performAlchemicalAnalysis(ing2)) as ThermodynamicProperties;
 
     // Calculate differences in key properties
     const heatDiff = Math.abs(metrics1?.heat - metrics2?.heat);

--- a/src/services/restaurantScoring.ts
+++ b/src/services/restaurantScoring.ts
@@ -15,6 +15,7 @@
  * elemental match or Monica calculation.
  */
 
+import { performAlchemicalAnalysis } from "@/data/unified/alchemicalCalculations";
 import type { ElementalProperties } from "@/types/alchemy";
 import type {
   AstrologicalState,
@@ -23,7 +24,6 @@ import type {
 } from "@/types/celestial";
 import type { YelpBusiness, AlchmScoredRestaurant } from "@/types/yelp";
 import { calculateElementalMatch } from "@/utils/cuisineRecommender";
-import { calculateThermodynamicMetrics } from "@/utils/monicaKalchmCalculations";
 import { PLANETARY_SECTARIAN_ALCHEMICAL } from "@/utils/planetaryAlchemyMapping";
 
 // ─── Constants ─────────────────────────────────────────────────────────────
@@ -83,8 +83,8 @@ export const SCORING_WEIGHTS = {
  * astrological moment, returning a full `AlchmScoredRestaurant`.
  *
  * Reuses existing scoring primitives:
- *   - `calculateElementalMatch`       (cuisineRecommender)
- *   - `calculateThermodynamicMetrics` (monicaKalchmCalculations) — real Monica
+ *   - `calculateElementalMatch`   (cuisineRecommender)
+ *   - `performAlchemicalAnalysis` (data/unified/alchemicalCalculations) — real Monica
  *
  * Cuisine ESMS is derived from the cuisine's planetary ruler via
  * `PLANETARY_SECTARIAN_ALCHEMICAL`, so it represents an authentic
@@ -104,7 +104,14 @@ export function scoreCuisineAgainstMoment(
   diurnal: boolean,
 ): AlchmScoredRestaurant {
   const cuisineKey = resolveCuisineKey(cuisineType, business.categories);
-  const cuisineProfile = CUISINE_ELEMENTAL_MAP[cuisineKey];
+  // Own-property check here too, so this cannot desync from resolveCuisineKey.
+  // Belt and braces on a user-controlled lookup: an inherited key would give
+  // four `undefined` elements, which now throws in performAlchemicalAnalysis
+  // instead of being fabricated into 0.25s — a user-triggerable 503 rather than
+  // silently wrong scores. Neither is acceptable; resolve to Default instead.
+  const cuisineProfile = Object.hasOwn(CUISINE_ELEMENTAL_MAP, cuisineKey)
+    ? CUISINE_ELEMENTAL_MAP[cuisineKey]
+    : CUISINE_ELEMENTAL_MAP.Default;
 
   const cuisineElement: ElementalProperties = {
     Fire: cuisineProfile.Fire,
@@ -126,18 +133,18 @@ export function scoreCuisineAgainstMoment(
   );
 
   // ── Factor 3: Monica compatibility ──
-  // Both Monica values come from `calculateThermodynamicMetrics` so they
+  // Both Monica values come from `performAlchemicalAnalysis` so they
   // are computed from the authoritative formula:
   //   Monica = -GregsEnergy / (Reactivity * ln(Kalchm))
   const cuisineAlchemical = deriveCuisineAlchemical(
     cuisineProfile.planetaryRuler,
     diurnal,
   );
-  const cuisineMonica = calculateThermodynamicMetrics(
+  const cuisineMonica = performAlchemicalAnalysis(
     cuisineAlchemical,
     cuisineElement,
   ).monica;
-  const momentMonica = calculateThermodynamicMetrics(
+  const momentMonica = performAlchemicalAnalysis(
     momentAlchemical,
     momentElement,
   ).monica;
@@ -197,7 +204,14 @@ function resolveCuisineKey(
   categories: YelpBusiness["categories"],
 ): string {
   const normalized = capitalize(cuisineType.trim());
-  if (CUISINE_ELEMENTAL_MAP[normalized]) return normalized;
+  // `Object.hasOwn`, NOT truthiness. `cuisineType` is a user-supplied query
+  // param, and a plain-object map inherits from Object.prototype — so
+  // `CUISINE_ELEMENTAL_MAP["__proto__"]` is Object.prototype (truthy), and
+  // "constructor"/"toString" are functions (also truthy). Each returned a key
+  // whose four element reads are all `undefined`, which the old engine then
+  // silently replaced with 0.25 apiece. MEASURED: `?cuisine=__proto__` produced
+  // `{Fire: undefined, Water: undefined, Earth: undefined, Air: undefined}`.
+  if (Object.hasOwn(CUISINE_ELEMENTAL_MAP, normalized)) return normalized;
 
   // Loose match — case-insensitive
   for (const key of Object.keys(CUISINE_ELEMENTAL_MAP)) {

--- a/src/utils/cuisine/cuisineSauceProfiler.ts
+++ b/src/utils/cuisine/cuisineSauceProfiler.ts
@@ -10,13 +10,15 @@
 import { cuisineFlavorProfiles } from "@/data/cuisineFlavorProfiles";
 import { cuisinesMap } from "@/data/cuisines";
 import { allSauces, type Sauce as DataSauce } from "@/data/sauces";
-import { deriveAlchemicalFromElemental } from "@/data/unified/alchemicalCalculations";
+import {
+  deriveAlchemicalFromElemental,
+  performAlchemicalAnalysis,
+} from "@/data/unified/alchemicalCalculations";
 import type { ElementalProperties } from "@/types/alchemy";
 import type { Cuisine } from "@/types/cuisine";
 import type { RecipeIngredient } from "@/types/recipe";
 import { normalizeForDisplay } from "@/utils/elemental/normalization";
 import { aggregateIngredientElementals } from "@/utils/hierarchicalRecipeCalculations";
-import { calculateThermodynamicMetrics } from "@/utils/monicaKalchmCalculations";
 
 // ============================================================================
 // Types
@@ -395,7 +397,7 @@ function enhanceSauceWithDynamicProperties(sauce: UnifiedSauce): UnifiedSauce {
 
   const elementalProperties = normalizeForDisplay(rawElementals);
   const alchemicalProperties = sauce.alchemicalProperties || deriveAlchemicalFromElemental(elementalProperties);
-  const thermodynamicProperties = calculateThermodynamicMetrics(alchemicalProperties, elementalProperties);
+  const thermodynamicProperties = performAlchemicalAnalysis(alchemicalProperties, elementalProperties);
 
   return {
     ...sauce,

--- a/src/utils/cuisine/thermodynamicResonance.ts
+++ b/src/utils/cuisine/thermodynamicResonance.ts
@@ -10,12 +10,12 @@
  * Provides sophisticated resonance analysis for enhanced cuisine recommendations.
  */
 
+import { performAlchemicalAnalysis } from "@/data/unified/alchemicalCalculations";
 import type {
   AlchemicalProperties,
   ElementalProperties,
   ThermodynamicProperties,
 } from "@/types/alchemy";
-import { calculateThermodynamicMetrics } from "@/utils/monicaKalchmCalculations";
 
 // ========== TYPE DEFINITIONS ==========
 
@@ -530,7 +530,7 @@ export function createUserThermodynamicProfile(
     reactivityPreference?: number;
   },
 ): UserThermodynamicProfile {
-  const thermodynamicMetrics = calculateThermodynamicMetrics(
+  const thermodynamicMetrics = performAlchemicalAnalysis(
     alchemicalProperties,
     elementalProperties,
   );

--- a/src/utils/cuisineAggregations.ts
+++ b/src/utils/cuisineAggregations.ts
@@ -11,6 +11,10 @@
  * Part of the three-tier hierarchical system: Ingredients → Recipes → Cuisines
  */
 
+import type {
+  AlchemicalProperties,
+  ThermodynamicMetrics,
+} from "@/data/unified/alchemicalCalculations";
 import type { ElementalProperties } from "@/types/alchemy";
 import type {
   CuisineSignature,
@@ -19,10 +23,6 @@ import type {
   PlanetaryPattern,
   RecipeComputedProperties,
 } from "@/types/hierarchy";
-import type {
-  AlchemicalProperties,
-  ThermodynamicMetrics,
-} from "./monicaKalchmCalculations";
 
 // ========== GLOBAL AVERAGES (for z-score calculation) ==========
 

--- a/src/utils/hierarchicalRecipeCalculations.ts
+++ b/src/utils/hierarchicalRecipeCalculations.ts
@@ -14,6 +14,8 @@
 import { calculateKinetics } from "@/calculations/kinetics";
 import type { KineticsCalculationInput } from "@/calculations/kinetics";
 import { ZERO_ELEMENTAL_PROPERTIES } from "@/constants/elementalCore";
+import { performAlchemicalAnalysis } from "@/data/unified/alchemicalCalculations";
+import type { ThermodynamicMetrics } from "@/data/unified/alchemicalCalculations";
 import { unifiedIngredientService } from "@/services/UnifiedIngredientService";
 import type {
   CookingMethod,
@@ -29,14 +31,12 @@ import type {
   KineticMetrics /*, KineticsCalculationInput */,
 } from "@/types/kinetics";
 import type { RecipeIngredient } from "@/types/recipe";
-import { calculateThermodynamicMetrics } from "./monicaKalchmCalculations";
 import {
   aggregateZodiacElementals,
   calculateAlchemicalFromPlanets,
   getDominantAlchemicalProperty,
   getDominantElement,
 } from "./planetaryAlchemyMapping";
-import type { ThermodynamicMetrics } from "./monicaKalchmCalculations";
 
 // ========== COOKING METHOD TRANSFORMATIONS ==========
 
@@ -358,7 +358,7 @@ export function computeRecipeProperties(
     : combinedElementals;
 
   // Step 6: Calculate thermodynamic metrics from ESMS + elementals
-  const thermodynamicMetrics = calculateThermodynamicMetrics(
+  const thermodynamicMetrics = performAlchemicalAnalysis(
     alchemicalProperties,
     finalElementals,
   );

--- a/src/utils/monicaKalchmCalculations.ts
+++ b/src/utils/monicaKalchmCalculations.ts
@@ -2,6 +2,7 @@ import { ALCHEMICAL_PILLARS, COOKING_METHOD_PILLAR_MAPPING } from "@/constants/a
 import {
   calculateKalchm as canonicalCalculateKalchm,
   calculateMonica,
+  thermoQuotient,
 } from "@/data/unified/alchemicalCalculations";
 import type { ElementalProperties } from "@/types/alchemy";
 import type { AlchemicalProperties } from "@/types/celestial";
@@ -47,7 +48,7 @@ export function calculateHeat(
     substance + essence + matter + water + air + earth,
     2,
   );
-  return denominator > 0 ? numerator / denominator : 0;
+  return thermoQuotient(numerator, denominator);
 }
 /**
  * Calculate Entropy: Measures disorder (active properties vs passive properties)
@@ -62,7 +63,7 @@ export function calculateEntropy(
     Math.pow(fire, 2) +
     Math.pow(air, 2);
   const denominator = Math.pow(essence + matter + earth + water, 2);
-  return denominator > 0 ? numerator / denominator : 0;
+  return thermoQuotient(numerator, denominator);
 }
 /**
  * Calculate Reactivity: Measures potential for change (volatile properties vs stable properties)
@@ -79,7 +80,7 @@ export function calculateReactivity(
     Math.pow(air, 2) +
     Math.pow(water, 2);
   const denominator = Math.pow(matter + earth, 2);
-  return denominator > 0 ? numerator / denominator : 0;
+  return thermoQuotient(numerator, denominator);
 }
 /**
  * Calculate Greg's Energy: Overall energy balance
@@ -157,82 +158,27 @@ export function calculateMonicaConstant(
 // element sat near 1. Its three call sites now use the canonical
 // `deriveAlchemicalFromElemental` (@/data/unified/alchemicalCalculations).
 // Do not reintroduce it — see docs/design/home-living-hero-stitch-prompt.md.
-/**
- * Calculate complete thermodynamic metrics from properties
- */
-export function calculateThermodynamicMetrics(
-  alchemical: AlchemicalProperties,
-  elemental: ElementalProperties,
-): ThermodynamicMetrics {
-  // Defensive checks for undefined/null inputs
-  if (!alchemical || !elemental) {
-    return {
-      heat: 0.08,
-      entropy: 0.15,
-      reactivity: 0.45,
-      gregsEnergy: -0.02,
-      kalchm: 2.5,
-      monica: 1.0,
-    };
-  }
-  // Defensive extraction with fallback values
-  const Spirit =
-    typeof alchemical.Spirit === "number" && !isNaN(alchemical.Spirit)
-      ? alchemical.Spirit
-      : 4;
-  const Essence =
-    typeof alchemical.Essence === "number" && !isNaN(alchemical.Essence)
-      ? alchemical.Essence
-      : 4;
-  const Matter =
-    typeof alchemical.Matter === "number" && !isNaN(alchemical.Matter)
-      ? alchemical.Matter
-      : 4;
-  const Substance =
-    typeof alchemical.Substance === "number" && !isNaN(alchemical.Substance)
-      ? alchemical.Substance
-      : 2;
-  const Fire =
-    typeof elemental.Fire === "number" && !isNaN(elemental.Fire)
-      ? elemental.Fire
-      : 0.25;
-  const Water =
-    typeof elemental.Water === "number" && !isNaN(elemental.Water)
-      ? elemental.Water
-      : 0.25;
-  const Air =
-    typeof elemental.Air === "number" && !isNaN(elemental.Air)
-      ? elemental.Air
-      : 0.25;
-  const Earth =
-    typeof elemental.Earth === "number" && !isNaN(elemental.Earth)
-      ? elemental.Earth
-      : 0.25;
-  const thermodynamicInputs = {
-    spirit: Spirit,
-    substance: Substance,
-    essence: Essence,
-    matter: Matter,
-    fire: Fire,
-    water: Water,
-    air: Air,
-    earth: Earth,
-  };
-  const heat = calculateHeat(thermodynamicInputs);
-  const entropy = calculateEntropy(thermodynamicInputs);
-  const reactivity = calculateReactivity(thermodynamicInputs);
-  const gregsEnergy = calculateGregsEnergy(heat, entropy, reactivity);
-  const kalchm = calculateKAlchm(Spirit, Essence, Matter, Substance);
-  const monica = calculateMonicaConstant(gregsEnergy, reactivity, kalchm);
-  return {
-    heat,
-    entropy,
-    reactivity,
-    gregsEnergy,
-    kalchm,
-    monica,
-  };
-}
+// `calculateThermodynamicMetrics` was DELETED here — §18k k7.
+//
+// It was the repo's SECOND six-field thermodynamic composite, and it fabricated
+// twice over:
+//
+//   1. `if (!alchemical || !elemental) return {heat: 0.08, entropy: 0.15,
+//      reactivity: 0.45, gregsEnergy: -0.02, kalchm: 2.5, monica: 1.0}` — six
+//      invented numbers, none derived from anything, returned as if measured.
+//   2. Per-field substitution when a value was missing or NaN:
+//      `Spirit/Essence/Matter -> 4`, `Substance -> 2`, every element -> `0.25`.
+//      A caller could not distinguish invented physics from real physics.
+//
+// All nine consumers now call `performAlchemicalAnalysis` in
+// `@/data/unified/alchemicalCalculations`, which returns the same six fields and
+// THROWS on malformed input instead (`assertThermodynamicInput`).
+//
+// The four primitives above (`calculateHeat`/`Entropy`/`Reactivity`/
+// `GregsEnergy`) are RETAINED because the Monica scoring block below still uses
+// them; they now share canonical's `thermoQuotient`, so their former
+// `den > 0 ? n/d : 0` pole — which returned 0 where the true limit is +Infinity
+// — is gone and they agree with canonical bit for bit.
 // ========== MONICA SCORING SYSTEM (0-100 Scale) ==========
 /**
  * Result of the Monica scoring algorithm for a recipe

--- a/src/utils/tiltSkilletCircuit.ts
+++ b/src/utils/tiltSkilletCircuit.ts
@@ -6,7 +6,7 @@
 // It does NOT re-derive any thermodynamics — every formula is reused:
 //   • quantity weighting       → quantityScaling.calculateQuantityFactor (gram-normalized, log)
 //   • ESMS from a blend        → quantityScaling.deriveESMSFromElemental
-//   • Heat/Entropy/Reactivity/GregsEnergy/Kalchm/Monica → monicaKalchmCalculations.calculateThermodynamicMetrics
+//   • Heat/Entropy/Reactivity/GregsEnergy/Kalchm/Monica → alchemicalCalculations.performAlchemicalAnalysis
 //   • Charge Q / Voltage V / Current I / Power P (P=IV) → cookingMethodKinetics.calculateMethodSpecificKinetics
 //   • R = Entropy, Losses = I²R, η = (P − Losses)/P     → same mapping as recipeCircuit/mealCircuit
 //
@@ -14,10 +14,10 @@
 // flows stage → stage), so the batch is a series circuit with total V, shared current, and I²R losses.
 
 import { ingredientsMap } from "@/data/ingredients";
+import { performAlchemicalAnalysis } from "@/data/unified/alchemicalCalculations";
 import type { ElementalProperties, AlchemicalProperties } from "@/types/alchemy";
 import type { KineticMetrics } from "@/types/kinetics";
 import { calculateMethodSpecificKinetics, getKineticProfile } from "./cookingMethodKinetics";
-import { calculateThermodynamicMetrics } from "./monicaKalchmCalculations";
 import { calculateQuantityFactor, deriveESMSFromElemental } from "./quantityScaling";
 
 const EPS = 1e-9;
@@ -44,7 +44,7 @@ export interface StageCircuit {
   name: string;
   blendedElemental: ElementalProperties;
   esms: AlchemicalProperties;
-  // thermodynamic substrate (from calculateThermodynamicMetrics)
+  // thermodynamic substrate (from performAlchemicalAnalysis)
   heat: number;
   entropy: number;
   reactivity: number;
@@ -135,7 +135,7 @@ export function computeStageCircuit(
 ): StageCircuit {
   const blendedElemental = blendStageElemental(stage.ingredients);
   const esms = deriveESMSFromElemental(blendedElemental);
-  const thermo = calculateThermodynamicMetrics(esms, blendedElemental);
+  const thermo = performAlchemicalAnalysis(esms, blendedElemental);
 
   const kinetics = calculateMethodSpecificKinetics({
     methodId: "tilt_skillet",


### PR DESCRIPTION
Ruling #2, §18k k7. One formula per runtime, and no invented numbers.

## What the fabrication was

`src/utils/monicaKalchmCalculations.ts:calculateThermodynamicMetrics` fabricated **twice over**:

1. `if (!alchemical || !elemental)` returned a hardcoded `{heat: 0.08, entropy: 0.15, reactivity: 0.45, gregsEnergy: -0.02, kalchm: 2.5, monica: 1.0}` — six invented numbers served as if measured.
2. Per-field substitution — `Spirit/Essence/Matter → 4`, `Substance → 2`, every element → `0.25` — whenever a value was missing or NaN.

A caller could not distinguish invented physics from real physics. Both are deleted.

## Routing

All **9** consumers now call canonical `performAlchemicalAnalysis`, which already returned the identical six fields — so no duplicate public name was created; consumers moved to canonical's existing export rather than canonical growing an alias of the deleted name.

`PlanetaryCalculationsDemo` · `EnhancedIngredientRecommender` · `cuisineSauceProfiler` · `thermodynamicResonance` · `fingerprint` · `UnifiedIngredientService` · `restaurantScoring` · `hierarchicalRecipeCalculations` · `tiltSkilletCircuit` — plus the two `type ThermodynamicMetrics` importers.

## Fail loudly

`assertThermodynamicInput` rejects null/undefined/missing/NaN/Infinity and names **the caller and the offending field**. It sits in *both* `calculateThermodynamics` and `performAlchemicalAnalysis` — the latter because `calculateKalchm` runs first and would otherwise fail with an opaque `Cannot destructure property 'Spirit' of null`.

`GET /api/alchemize` wraps its body in try/catch, so it inherits this as a clean **500** instead of invented physics.

### ⚠️ It does NOT reject legitimate values

`0` on any axis or element passes, and there is a test for it. A validator that rejected a real zero would be worse than the fabrication it replaces — `restaurantScoring` legitimately passes `Matter: 0, Substance: 0`. Negatives and raw (>1) elementals also pass.

The old guard was `typeof x === "number" && !isNaN(x)`, which **admitted `Infinity`**; that now fails at the boundary rather than surfacing as a silent `0`.

## The second engine's pole is gone

`calculateHeat/Entropy/Reactivity` returned `den > 0 ? n/d : 0` — fabricating `0` where the true limit is `+Infinity`, the **opposite direction** from canonical. They now share canonical's exported `thermoQuotient`, so the two engines agree bit for bit.

Those four primitives are **retained, not deleted** — the Monica scoring block still uses them, and that block is deliberately out of scope for this session.

## ⚠️ A real bug found while checking blast radius

`restaurantScoring.ts` looked up `CUISINE_ELEMENTAL_MAP[cuisineKey]` **by truthiness on a user-supplied query param**. A plain-object map inherits from `Object.prototype`, so:

```
?cuisine=__proto__     -> Object.prototype   (truthy)
?cuisine=constructor   -> function           (truthy)
?cuisine=toString      -> function           (truthy)
```

each yielding `{Fire: undefined, Water: undefined, Earth: undefined, Air: undefined}` — which the old engine silently turned into four `0.25`s. **Runtime-proven.** Under the new throw it would have become a *user-triggerable 503* from `/api/restaurants/discover|search` (`yelpService.ts:165` is unguarded).

Fixed at the root with `Object.hasOwn` in both `resolveCuisineKey` and the caller, falling back to the existing `Default` profile.

## Blast-radius survey (done before allowing the throw)

| site | reachability | worst case |
|---|---|---|
| `EnhancedIngredientRecommender` | 952/952 catalog ingredients have 4 finite ESMS + truthy Spirit — derive branch never taken | **severe if wrong** — app-wide ErrorBoundary at `providers.tsx:23` is the only boundary, so a throw replaces the whole shell. Hence the data check. |
| `PlanetaryCalculationsDemo` | dead file, zero importers | none |
| `thermodynamicResonance:533`, `hierarchicalRecipeCalculations:361`, `UnifiedIngredientService:727` | no production callers | none |
| `cuisineSauceProfiler` | inside try/catch | silent degrade |
| `restaurantScoring` | server-only, no render path | see fix above |
| `tiltSkilletCircuit` | — | route error page or 500 |
| `fingerprint` | already guarded by #676 | — |

## Tests

- **New** `src/__tests__/thermoFailsLoudly.test.ts` (22 cases) pins *both* halves: that it rejects each of the 8 fields individually, and that it still accepts zero, negatives, raw elementals and extra keys.
- `thermoDenFloorPoleSubstitution.test.ts` had a test **pinning the old silent zeroing**; it now pins the throw, with a control proving healthy input still returns the identical `reactivity = 2.0530045351473922`.

- `tsc --noEmit` clean · `eslint` clean · **184/184 suites, 1678 tests pass**

**Noted, not changed:** `cuisineAggregations.ts:190` `DEFAULT_GLOBAL_AVERAGES` carries the same six invented numbers as a `@deprecated` fallback constant. It is a documented default, not an engine path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)