### PR TITLE
feat(environment): Dual-Baseline ingestion — elevation trunk + daily anomaly

### DIFF
--- a/.github/workflows/monica-integrity.yml
+++ b/.github/workflows/monica-integrity.yml
@@ -171,6 +171,17 @@ jobs:
           DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
         run: bun scripts/checkAgentClassifiedAtCreation.mjs
 
+      - name: Environmental SQL parses against PostgreSQL
+        if: ${{ !cancelled() && steps.db-secret.outcome == 'success' }}
+        # Diff-sensitive: it imports the live query builders AND applies
+        # migration 74, so a PR that edits either one changes what this runs.
+        # Self-provisioning — it creates the schema inside a transaction and
+        # rolls back, so it works before the migration is applied anywhere and
+        # verifies that the migration and the queries agree.
+        env:
+          DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
+        run: bun scripts/checkEnvironmentalSqlParses.ts
+
   # ---------------------------------------------------------------------------
   # Data. master + cron only: it needs production credentials, so it must never
   # run on a pull_request from a fork.

--- a/database/init/74-environmental-observations.sql
+++ b/database/init/74-environmental-observations.sql
@@ -1,0 +1,108 @@
+-- Environmental Thermodynamics — Dual-Baseline Engine, ingestion tables.
+--
+-- Two tables by design:
+--
+--   environmental_observations  raw readings, 90-day retention. The audit trail.
+--                               Never read on the request hot path.
+--   environmental_baselines     one row per geohash. The precomputed median/MAD
+--                               the daily anomaly is measured against.
+--
+-- Raw is retained for 90 days rather than the 30 the window needs, so the
+-- statistic can be recomputed, audited, or changed without data loss. Robust
+-- statistics cannot be updated incrementally the way a mean can — median and MAD
+-- need the actual sample set — so the raw rows are not optional.
+--
+-- NOTE: the migration runner wraps each file in a transaction, so no
+-- CREATE INDEX CONCURRENTLY here.
+
+CREATE TABLE IF NOT EXISTS environmental_observations (
+  -- Geohash precision 5 (~4.9 km). Finer is false precision against an ~11 km
+  -- model grid, and coarser spans too much elevation in mountainous terrain.
+  geohash5           VARCHAR(5)   NOT NULL,
+  observed_at        TIMESTAMPTZ  NOT NULL,
+
+  -- STATION pressure, never sea-level-adjusted (MSLP/QNH). MSLP has the altitude
+  -- signal removed by construction: stored here it would make Denver read ~101
+  -- kPa and silently erase the single largest term in the whole engine.
+  surface_pressure_kpa  NUMERIC(7,3) NOT NULL,
+
+  -- Dew point is the transported invariant. Relative humidity is NOT stored:
+  -- it is a ratio against a temperature-dependent saturation pressure, so it
+  -- does not survive the trip from outdoor air to indoor air. RH is recomputed
+  -- at the indoor temperature when it is actually needed.
+  dew_point_c        NUMERIC(6,3) NOT NULL,
+  air_temp_c         NUMERIC(6,3) NOT NULL,
+
+  -- 'forecast' = live sampling; 'archive' = one-time backfill seeding the window.
+  -- Kept distinct so a baseline can always be attributed to how it was obtained.
+  source             VARCHAR(16)  NOT NULL,
+
+  created_at         TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT environmental_observations_pkey PRIMARY KEY (geohash5, observed_at),
+  CONSTRAINT environmental_observations_source_check
+    CHECK (source IN ('forecast', 'archive')),
+  -- Bounds are deliberately wide enough for any real place on Earth and tight
+  -- enough to reject a unit mix-up: Pa instead of kPa, or °F instead of °C.
+  CONSTRAINT environmental_observations_pressure_range
+    CHECK (surface_pressure_kpa > 45 AND surface_pressure_kpa < 115),
+  CONSTRAINT environmental_observations_dew_point_range
+    CHECK (dew_point_c > -90 AND dew_point_c < 60)
+);
+
+-- Serves the window scan: "the last N days for this geohash, newest first".
+CREATE INDEX IF NOT EXISTS environmental_observations_window_idx
+  ON environmental_observations (geohash5, observed_at DESC);
+
+-- Serves the 90-day retention sweep across all geohashes.
+CREATE INDEX IF NOT EXISTS environmental_observations_retention_idx
+  ON environmental_observations (observed_at);
+
+
+CREATE TABLE IF NOT EXISTS environmental_baselines (
+  geohash5            VARCHAR(5)   PRIMARY KEY,
+
+  -- Full-DEM elevation for the location, NOT the geohash cell centroid. This is
+  -- the dominant term in the engine and the reason a p5 key is acceptable for
+  -- weather but not for altitude.
+  elevation_m         NUMERIC(7,2) NOT NULL,
+  elevation_basis     VARCHAR(16)  NOT NULL,
+
+  -- Robust trailing-window statistics. These are the z-score denominators.
+  -- Median/MAD rather than mean/sigma: the outliers are what the engine exists
+  -- to detect, and a classical sigma lets an outlier inflate the denominator
+  -- that would have caught it.
+  pressure_median_kpa     NUMERIC(7,3) NOT NULL,
+  pressure_mad_sigma_kpa  NUMERIC(7,4) NOT NULL,
+  dew_point_median_c      NUMERIC(6,3) NOT NULL,
+  dew_point_mad_sigma_c   NUMERIC(6,4) NOT NULL,
+
+  -- Days actually behind the statistics above. MAD over a handful of samples is
+  -- close to meaningless, so this gates the advisory's confidence basis.
+  sample_days         INTEGER      NOT NULL,
+
+  -- True while the window was seeded from the archive rather than sampled live.
+  -- Lets the engine be honest about provenance on a location's first day.
+  archive_seeded      BOOLEAN      NOT NULL DEFAULT FALSE,
+
+  last_computed_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  created_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT environmental_baselines_elevation_basis_check
+    CHECK (elevation_basis IN ('MEASURED', 'DERIVED', 'COMPUTED', 'ABSENT')),
+  CONSTRAINT environmental_baselines_sample_days_check
+    CHECK (sample_days >= 0),
+  -- A negative dispersion is impossible; zero is legal and means "no observed
+  -- spread", which callers must surface as an undefined z rather than Infinity.
+  CONSTRAINT environmental_baselines_dispersion_check
+    CHECK (pressure_mad_sigma_kpa >= 0 AND dew_point_mad_sigma_c >= 0)
+);
+
+-- Serves the staleness sweep: which baselines need recomputing.
+CREATE INDEX IF NOT EXISTS environmental_baselines_staleness_idx
+  ON environmental_baselines (last_computed_at);
+
+COMMENT ON TABLE environmental_observations IS
+  'Raw weather readings per geohash5, 90-day retention. Station pressure only, never MSLP.';
+COMMENT ON TABLE environmental_baselines IS
+  'Per-geohash climatic baseline: robust median/MAD over the trailing window, plus full-DEM elevation.';

--- a/scripts/checkEnvironmentalSqlParses.ts
+++ b/scripts/checkEnvironmentalSqlParses.ts
@@ -1,0 +1,240 @@
+/**
+ * CI gate: does the environmental ingestion SQL actually PARSE against PostgreSQL?
+ *
+ * ── Why this exists ─────────────────────────────────────────────────────────
+ *
+ * SQL is a second language in this codebase and only the database can typecheck
+ * it. `[MEASURED 2026-07-26]` the credit statement shipped in a state PostgreSQL
+ * rejected outright (42P08, inconsistent types deduced for a parameter) while
+ * thirteen unit tests covering that exact path passed — because they mock the
+ * database, and a mocked `executeQuery` will happily "run" SQL no PostgreSQL
+ * will accept.
+ *
+ * This gate closes the same defect class for the ingestion layer.
+ *
+ * ── Why PREPARE ─────────────────────────────────────────────────────────────
+ *
+ * PREPARE performs parse + parameter-type analysis — exactly where 42P08 fires —
+ * and writes NOTHING. No transaction, no rows, no side effects. It also catches
+ * misspelled columns, dropped tables, and a parameter count that has drifted
+ * from its call site.
+ *
+ * PREPARE proves a statement is LEGAL, not that it is CORRECT.
+ *
+ * ── Why this imports instead of scraping ────────────────────────────────────
+ *
+ * `src/services/environmentalQueries.ts` has ZERO runtime imports, so this gate
+ * imports and calls the real builders. It therefore checks exactly what ships
+ * and cannot drift from it. A regex that stops matching would report "extracted
+ * nothing", not "the SQL changed".
+ *
+ * ── Controls ────────────────────────────────────────────────────────────────
+ *
+ * A zero result is a claim requiring a control test: if this gate silently
+ * checked nothing, "0 statements failed" would read as a pass. Three controls:
+ *
+ *   1. It proves it can detect a genuinely broken statement.
+ *   2. Every builder exported by the queries module must be exercised. Add a
+ *      builder without gating it and this fails, rather than quietly checking
+ *      less than it appears to.
+ *   3. The statement count is asserted, so a builder that starts yielding
+ *      fewer variants fails here even though each one still prepares.
+ *
+ * ── Why it provisions its own schema ────────────────────────────────────────
+ *
+ * The gate applies `database/init/74-environmental-observations.sql` inside a
+ * transaction, prepares every statement against it, and ROLLS BACK. Nothing
+ * persists — not a table, not a row.
+ *
+ * That means it can run against any database, including production, before the
+ * migration has been applied anywhere. It also verifies something a
+ * schema-assuming gate cannot: that the migration and the queries agree. A
+ * column renamed in one and not the other fails here, at review time, instead
+ * of at deploy time.
+ *
+ * Never writes. Every statement runs inside a transaction that is rolled back.
+ *
+ *   railway run --service Postgres -- bun scripts/checkEnvironmentalSqlParses.ts
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import pg from "pg";
+import * as queries from "../src/services/environmentalQueries";
+
+const fail = (msg: string): never => {
+  console.error(`\n✗ ${msg}`);
+  process.exit(1);
+};
+
+const url = process.env.DATABASE_PUBLIC_URL ?? process.env.DATABASE_URL;
+if (!url) fail("no DATABASE_PUBLIC_URL / DATABASE_URL in the environment");
+
+interface GatedStatement {
+  /** Which exported builder produced it — used by the coverage control. */
+  builder: string;
+  sql: string;
+}
+
+const statements: GatedStatement[] = [
+  { builder: "buildInsertObservation", sql: queries.buildInsertObservation() },
+  { builder: "buildSelectWindowObservations", sql: queries.buildSelectWindowObservations() },
+  { builder: "buildUpsertBaseline", sql: queries.buildUpsertBaseline() },
+  { builder: "buildSelectBaseline", sql: queries.buildSelectBaseline() },
+  {
+    builder: "buildSelectGeohashesDueForSampling",
+    sql: queries.buildSelectGeohashesDueForSampling(),
+  },
+  { builder: "buildSelectStaleBaselines", sql: queries.buildSelectStaleBaselines() },
+  { builder: "buildPruneObservations", sql: queries.buildPruneObservations() },
+  { builder: "buildCountObservations", sql: queries.buildCountObservations() },
+  { builder: "buildSummarizeBaselines", sql: queries.buildSummarizeBaselines() },
+];
+
+/**
+ * Bumped deliberately when a builder is added or removed. A silent drop here is
+ * the failure this constant exists to catch.
+ */
+const EXPECTED_STATEMENT_COUNT = 9;
+
+const client = new pg.Client({
+  connectionString: url,
+  ssl: { rejectUnauthorized: false },
+});
+
+const MIGRATION_PATH = join(
+  import.meta.dirname ?? __dirname,
+  "..",
+  "database",
+  "init",
+  "74-environmental-observations.sql",
+);
+
+async function main(): Promise<void> {
+  await client.connect();
+
+  // ── Provision the schema inside a transaction that is always rolled back ──
+  // Nothing here persists. This also proves the migration and the queries agree.
+  const migrationSql = readFileSync(MIGRATION_PATH, "utf8");
+  await client.query("BEGIN");
+  try {
+    await client.query(migrationSql);
+  } catch (error) {
+    await client.query("ROLLBACK");
+    const err = error as { code?: string; message?: string };
+    fail(
+      `the migration itself failed to apply: ${err.code ?? ""} ${err.message ?? String(error)}\n` +
+        `  ${MIGRATION_PATH}`,
+    );
+  }
+  console.log("✓ migration 74 applies cleanly (inside a rolled-back transaction)");
+
+  // ── Control 1: the gate can detect a statement that IS broken ─────────────
+  // Inside a savepoint: the failure is deliberate, and any error aborts the
+  // enclosing transaction. Without this, the control poisons every statement
+  // after it and they all report 25P02 rather than their own verdict.
+  let controlCaught = false;
+  await client.query("SAVEPOINT _env_gate_control_sp");
+  try {
+    await client.query(
+      "PREPARE _env_gate_control AS SELECT * FROM a_table_that_does_not_exist_xyz",
+    );
+    await client.query("DEALLOCATE _env_gate_control");
+    await client.query("RELEASE SAVEPOINT _env_gate_control_sp");
+  } catch {
+    controlCaught = true;
+    await client.query("ROLLBACK TO SAVEPOINT _env_gate_control_sp");
+  }
+  if (!controlCaught) {
+    fail(
+      "control failed: PREPARE accepted a statement referencing a nonexistent table. " +
+        "This gate cannot detect anything and its pass is meaningless.",
+    );
+  }
+  console.log("✓ control: PREPARE rejects a statement it should reject");
+
+  // ── Control 2: every exported builder is actually exercised ───────────────
+  const exportedBuilders = Object.keys(queries).filter(
+    (key) => typeof (queries as Record<string, unknown>)[key] === "function",
+  );
+  const exercised = new Set(statements.map((s) => s.builder));
+  const unexercised = exportedBuilders.filter((name) => !exercised.has(name));
+  if (unexercised.length > 0) {
+    fail(
+      `control failed: ${unexercised.length} exported builder(s) go unchecked: ` +
+        `${unexercised.join(", ")}. Every builder exported by ` +
+        "environmentalQueries.ts must be exercised by this gate.",
+    );
+  }
+  console.log(
+    `✓ control: all ${exportedBuilders.length} exported builders are exercised`,
+  );
+
+  // ── Control 3: the statement count has not silently shrunk ────────────────
+  if (statements.length !== EXPECTED_STATEMENT_COUNT) {
+    fail(
+      `control failed: built ${statements.length} statements, expected ` +
+        `${EXPECTED_STATEMENT_COUNT}. If a builder was intentionally added or ` +
+        "removed, update EXPECTED_STATEMENT_COUNT deliberately.",
+    );
+  }
+  console.log(`✓ control: ${statements.length} statements built as expected`);
+
+  // ── The gate proper ───────────────────────────────────────────────────────
+  const failures: Array<{ builder: string; code?: string; message: string }> = [];
+
+  for (const [index, { builder, sql }] of statements.entries()) {
+    const name = `_env_gate_${index}`;
+    const savepoint = `_env_gate_sp_${index}`;
+    // Each statement gets its own savepoint so one failure cannot abort the
+    // transaction and cascade every later statement into a bogus 25P02. Each
+    // builder must report its OWN verdict, or the gate's output is misleading
+    // about where the defect actually is.
+    await client.query(`SAVEPOINT ${savepoint}`);
+    try {
+      await client.query(`PREPARE ${name} AS ${sql}`);
+      await client.query(`DEALLOCATE ${name}`);
+      await client.query(`RELEASE SAVEPOINT ${savepoint}`);
+      console.log(`  ✓ ${builder}`);
+    } catch (error) {
+      await client.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
+      const err = error as { code?: string; message?: string };
+      failures.push({
+        builder,
+        code: err.code,
+        message: err.message ?? String(error),
+      });
+      console.error(`  ✗ ${builder}  ${err.code ?? ""} ${err.message ?? ""}`);
+    }
+  }
+
+  // Discard the provisional schema. Nothing this gate did survives.
+  await client.query("ROLLBACK");
+  console.log("✓ transaction rolled back — no schema or rows persisted");
+
+  if (failures.length > 0) {
+    fail(
+      `${failures.length}/${statements.length} statement(s) could not be prepared. ` +
+        "PostgreSQL cannot run this SQL; no amount of mocked-DB tests will show it.",
+    );
+  }
+
+  console.log(
+    `\n✓ all ${statements.length} environmental statements PREPARE cleanly.\n` +
+      "  This proves they are LEGAL, not that they are CORRECT.\n",
+  );
+}
+
+main()
+  .catch(async (error) => {
+    // Best-effort rollback so a mid-run throw cannot leave the provisional
+    // schema behind on an open connection.
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      /* connection already gone; nothing to undo */
+    }
+    fail(error instanceof Error ? error.message : String(error));
+  })
+  .finally(() => {
+    void client.end();
+  });

--- a/src/__tests__/environmentalPhysics.test.ts
+++ b/src/__tests__/environmentalPhysics.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Golden vectors for the environmental physics layer.
+ *
+ * These pin the math to values that exist OUTSIDE this repo — the ISA standard
+ * atmosphere, published geohash vectors, and a live Open-Meteo reading captured
+ * on 2026-07-30. A test that only checks the code against itself would have
+ * happily blessed the sea-level-pressure bug this file exists to prevent.
+ *
+ * @file src/__tests__/environmentalPhysics.test.ts
+ */
+
+import {
+  ENVIRONMENT_GEOHASH_PRECISION,
+  decodeGeohashCenter,
+  encodeGeohash,
+  sampleHourForGeohash,
+} from "@/lib/environment/geohash";
+import {
+  SEA_LEVEL_PRESSURE_KPA,
+  elevationFromPressure,
+  isPlausibleStationPressure,
+  pressureFromElevation,
+} from "@/lib/environment/isa";
+import { assertStationPressure } from "@/lib/environment/openMeteoClient";
+import {
+  MAD_TO_SIGMA,
+  madSigma,
+  median,
+  robustStat,
+  robustZScore,
+} from "@/lib/environment/robustStats";
+
+// `[MEASURED 2026-07-30]` Open-Meteo, Denver (39.7392, -104.9903).
+// Captured live; both fields at the same timestamp.
+const DENVER_ELEVATION_M = 1599;
+const DENVER_SURFACE_PRESSURE_KPA = 84.04; // surface_pressure: 840.4 hPa
+const DENVER_MSL_PRESSURE_KPA = 100.6; // pressure_msl:   1006.0 hPa
+
+describe("ISA barometric formula", () => {
+  it("returns standard pressure at sea level", () => {
+    expect(pressureFromElevation(0)).toBeCloseTo(SEA_LEVEL_PRESSURE_KPA, 6);
+  });
+
+  it("matches published values at real elevations", () => {
+    // Denver ~1599 m → ~83.5 kPa; Mexico City ~2240 m → ~77.2 kPa.
+    expect(pressureFromElevation(DENVER_ELEVATION_M)).toBeCloseTo(83.53, 1);
+    expect(pressureFromElevation(2240)).toBeCloseTo(77.16, 1);
+  });
+
+  it("round-trips through the inverse", () => {
+    for (const elevation of [0, 500, 1599, 2240, 3640, 5100]) {
+      expect(elevationFromPressure(pressureFromElevation(elevation))).toBeCloseTo(elevation, 3);
+    }
+  });
+
+  it("refuses elevations above the troposphere ceiling", () => {
+    expect(() => pressureFromElevation(12_000)).toThrow(/troposphere/i);
+  });
+
+  it("refuses a non-finite elevation rather than producing NaN", () => {
+    expect(() => pressureFromElevation(Number.NaN)).toThrow(RangeError);
+  });
+});
+
+describe("station pressure vs sea-level pressure — the MSLP trap", () => {
+  it("accepts a real station reading at elevation", () => {
+    expect(isPlausibleStationPressure(DENVER_SURFACE_PRESSURE_KPA, DENVER_ELEVATION_M)).toBe(true);
+    expect(() =>
+      assertStationPressure(DENVER_SURFACE_PRESSURE_KPA, DENVER_ELEVATION_M),
+    ).not.toThrow();
+  });
+
+  it("rejects the sea-level-adjusted reading for the same place and time", () => {
+    // This is the whole point. pressure_msl looks like a perfectly ordinary
+    // pressure — it is simply the wrong one, and using it silently erases the
+    // largest term in the engine.
+    expect(isPlausibleStationPressure(DENVER_MSL_PRESSURE_KPA, DENVER_ELEVATION_M)).toBe(false);
+    expect(() => assertStationPressure(DENVER_MSL_PRESSURE_KPA, DENVER_ELEVATION_M)).toThrow(
+      /pressure_msl instead of surface_pressure/,
+    );
+  });
+
+  it("quantifies the error the trap would cause", () => {
+    // The two fields differ by ~16.6 kPa at Denver. At the Clausius-Clapeyron
+    // slope of 0.281 °C/kPa that is ~4.7 °C of boiling point — larger than any
+    // weather anomaly this engine will ever report.
+    const deltaKpa = DENVER_MSL_PRESSURE_KPA - DENVER_SURFACE_PRESSURE_KPA;
+    expect(deltaKpa).toBeGreaterThan(15);
+    expect(deltaKpa * 0.281).toBeGreaterThan(4);
+  });
+
+  it("still accepts genuine synoptic extremes at sea level", () => {
+    // A deep low (950 hPa) must not be mistaken for a wrong-field ingestion,
+    // and neither must the record low (870 hPa, Typhoon Tip) or a strong high.
+    expect(isPlausibleStationPressure(95.0, 0)).toBe(true);
+    expect(isPlausibleStationPressure(87.0, 0)).toBe(true);
+    expect(isPlausibleStationPressure(108.4, 0)).toBe(true);
+  });
+
+  it("declines to judge below the discrimination floor", () => {
+    // Under ~600 m, MSLP and station pressure are closer together than ordinary
+    // weather moves either one. The honest answer is "cannot tell", which this
+    // returns as plausible rather than inventing a verdict.
+    expect(isPlausibleStationPressure(101.3, 200)).toBe(true);
+    expect(isPlausibleStationPressure(99.0, 200)).toBe(true);
+  });
+
+  it("discriminates by which hypothesis the reading is closer to", () => {
+    // Mexico City, 2240 m → ISA baseline ~77.2 kPa.
+    expect(isPlausibleStationPressure(77.5, 2240)).toBe(true); // real station reading
+    expect(isPlausibleStationPressure(101.0, 2240)).toBe(false); // sea-level-adjusted
+
+    // A storm at altitude is still nearer its own baseline than sea level.
+    expect(isPlausibleStationPressure(74.0, 2240)).toBe(true);
+  });
+});
+
+describe("robust statistics", () => {
+  it("computes median for odd and even samples", () => {
+    expect(median([3, 1, 5, 2, 4])).toBe(3);
+    expect(median([4, 1, 3, 2])).toBe(2.5);
+  });
+
+  it("refuses an empty sample rather than returning zero", () => {
+    // A fabricated zero baseline would propagate into every anomaly the
+    // location ever reports.
+    expect(() => median([])).toThrow(RangeError);
+    expect(() => madSigma([])).toThrow(RangeError);
+  });
+
+  it("scales MAD to a sigma-equivalent", () => {
+    expect(madSigma([1, 2, 3, 4, 5])).toBeCloseTo(1 * MAD_TO_SIGMA, 6);
+  });
+
+  it("resists an outlier that would wreck a classical sigma", () => {
+    const withOutlier = [1, 2, 3, 4, 100];
+    const stat = robustStat(withOutlier);
+
+    // Median is unmoved by the outlier.
+    expect(stat.median).toBe(3);
+    expect(stat.madSigma).toBeCloseTo(1.4826, 4);
+
+    // A classical sigma would be ~43 — thirty times wider — and would rate the
+    // outlier as barely 2 sigma, suppressing exactly the alert it should raise.
+    const mean = withOutlier.reduce((a, b) => a + b, 0) / withOutlier.length;
+    const classicalSigma = Math.sqrt(
+      withOutlier.reduce((acc, v) => acc + (v - mean) ** 2, 0) / withOutlier.length,
+    );
+    expect(classicalSigma).toBeGreaterThan(20 * stat.madSigma);
+
+    // Against the robust baseline the outlier is unmistakable.
+    expect(robustZScore(100, stat)!).toBeGreaterThan(50);
+  });
+
+  it("returns null — not Infinity — for a degenerate baseline", () => {
+    // Every observation identical: the window genuinely cannot say how unusual
+    // today is, and the honest answer is "unknown".
+    const flat = robustStat([10, 10, 10, 10, 10]);
+    expect(flat.madSigma).toBe(0);
+    expect(robustZScore(99, flat)).toBeNull();
+  });
+
+  it("returns null for a non-finite observation", () => {
+    expect(robustZScore(Number.NaN, robustStat([1, 2, 3]))).toBeNull();
+  });
+});
+
+describe("geohash", () => {
+  it("matches the published reference vector", () => {
+    // The canonical (57.64911, 10.40744) → "u4pruydqqvj" example.
+    expect(encodeGeohash(57.64911, 10.40744, 11)).toBe("u4pruydqqvj");
+    expect(encodeGeohash(57.64911, 10.40744, 5)).toBe("u4pru");
+  });
+
+  it("encodes the null island", () => {
+    expect(encodeGeohash(0, 0, 5)).toBe("s0000");
+  });
+
+  it("defaults to the environmental precision", () => {
+    expect(encodeGeohash(39.7392, -104.9903)).toHaveLength(ENVIRONMENT_GEOHASH_PRECISION);
+  });
+
+  it("decodes to a centre inside the original cell", () => {
+    const geohash = encodeGeohash(39.7392, -104.9903, 5);
+    const center = decodeGeohashCenter(geohash);
+    // A p5 cell is ~4.9 km, so the centre is within ~0.05° of any point in it.
+    expect(Math.abs(center.latitude - 39.7392)).toBeLessThan(0.05);
+    expect(Math.abs(center.longitude - -104.9903)).toBeLessThan(0.05);
+    expect(encodeGeohash(center.latitude, center.longitude, 5)).toBe(geohash);
+  });
+
+  it("rejects out-of-range coordinates instead of wrapping", () => {
+    expect(() => encodeGeohash(91, 0)).toThrow(RangeError);
+    expect(() => encodeGeohash(0, 181)).toThrow(RangeError);
+  });
+
+  it("derives a stable sampling hour in range", () => {
+    const geohash = encodeGeohash(39.7392, -104.9903, 5);
+    const hour = sampleHourForGeohash(geohash);
+    expect(hour).toBeGreaterThanOrEqual(0);
+    expect(hour).toBeLessThan(24);
+    // Deterministic: the same cell must sample at the same hour every day, or
+    // the semidiurnal tide leaks back into the window's dispersion.
+    expect(sampleHourForGeohash(geohash)).toBe(hour);
+  });
+
+  it("spreads distinct cells across different hours", () => {
+    const hours = new Set(
+      ["u4pru", "s0000", "9xj64", "gcpvj", "dr5re", "xn774", "6gyf4", "kzf24"].map(
+        sampleHourForGeohash,
+      ),
+    );
+    // Not a uniformity proof — just that the derivation is not degenerate, which
+    // would stampede the whole fleet into one cron minute.
+    expect(hours.size).toBeGreaterThan(1);
+  });
+});

--- a/src/app/api/admin/environment/seed/route.ts
+++ b/src/app/api/admin/environment/seed/route.ts
@@ -1,0 +1,183 @@
+/**
+ * Admin Environmental Seed API
+ *
+ * POST /api/admin/environment/seed — seed one or more locations' 30-day
+ *   climatic baseline from the ERA5 archive, right now.
+ * GET  /api/admin/environment/seed — fleet-wide ingestion health.
+ *
+ * @requires Authentication - Admin role required
+ *
+ * ── Why this exists ─────────────────────────────────────────────────────────
+ *
+ * The hourly cron only samples geohashes that ALREADY have a baseline row, and
+ * nothing creates that first row until the public advisory API lands. Without a
+ * manual trigger the ingestion layer would sit idle for the rest of the
+ * sequence, and the baseline clock is a wall-clock dependency — every day not
+ * ingesting is a day added to the critical path.
+ *
+ * Seeding is idempotent: a geohash that already holds archive rows is returned
+ * as-is rather than re-fetched, so this is safe to re-run.
+ *
+ * Coordinates arrive in the POST body, never the query string, and are coarsened
+ * to a ~5 km geohash on the way in. No precise location reaches a URL or an
+ * access log.
+ *
+ * @file src/app/api/admin/environment/seed/route.ts
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import { validateAdminRequest } from "@/lib/auth/validateRequest";
+import { ENVIRONMENT_GEOHASH_PRECISION, encodeGeohash } from "@/lib/environment/geohash";
+import { _logger } from "@/lib/logger";
+import { seedFromArchive, summarizeIngestion } from "@/services/environmentalIngestService";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+/**
+ * Each location is an outbound archive fetch plus ~30 writes, against a 60 s
+ * budget. Callers seed in batches rather than one giant request.
+ */
+const MAX_LOCATIONS_PER_REQUEST = 5;
+
+interface SeedLocation {
+  latitude: number;
+  longitude: number;
+  label?: string;
+}
+
+function parseLocations(body: unknown): SeedLocation[] | string {
+  if (typeof body !== "object" || body === null) return "body must be a JSON object";
+
+  const raw = (body as { locations?: unknown }).locations;
+  if (!Array.isArray(raw)) {
+    return "body.locations must be an array of { latitude, longitude }";
+  }
+  if (raw.length === 0) return "body.locations is empty";
+  if (raw.length > MAX_LOCATIONS_PER_REQUEST) {
+    return `at most ${MAX_LOCATIONS_PER_REQUEST} locations per request`;
+  }
+
+  const parsed: SeedLocation[] = [];
+  for (const [index, entry] of raw.entries()) {
+    if (typeof entry !== "object" || entry === null) {
+      return `locations[${index}] must be an object`;
+    }
+    const { latitude, longitude, label } = entry as Record<string, unknown>;
+    if (typeof latitude !== "number" || !Number.isFinite(latitude)) {
+      return `locations[${index}].latitude must be a finite number`;
+    }
+    if (typeof longitude !== "number" || !Number.isFinite(longitude)) {
+      return `locations[${index}].longitude must be a finite number`;
+    }
+    parsed.push({
+      latitude,
+      longitude,
+      label: typeof label === "string" ? label : undefined,
+    });
+  }
+  return parsed;
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = await validateAdminRequest(request);
+  if ("error" in authResult) return authResult.error;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, message: "invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = parseLocations(body);
+  if (typeof parsed === "string") {
+    return NextResponse.json({ success: false, message: parsed }, { status: 400 });
+  }
+
+  const seeded: Array<Record<string, unknown>> = [];
+  const failed: Array<{ geohash5: string; label?: string; error: string }> = [];
+
+  for (const location of parsed) {
+    // Coarsen before anything is logged or persisted.
+    let geohash5: string;
+    try {
+      geohash5 = encodeGeohash(
+        location.latitude,
+        location.longitude,
+        ENVIRONMENT_GEOHASH_PRECISION,
+      );
+    } catch (error) {
+      failed.push({
+        geohash5: "(invalid)",
+        label: location.label,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+
+    try {
+      const baseline = await seedFromArchive(location.latitude, location.longitude);
+      if (!baseline) {
+        // The archive returned nothing usable. Reported as a failure rather
+        // than a zeroed baseline — a fabricated median would poison every
+        // anomaly this location ever reports.
+        failed.push({
+          geohash5,
+          label: location.label,
+          error: "archive returned no usable observations; no baseline written",
+        });
+        continue;
+      }
+      seeded.push({
+        geohash5,
+        label: location.label,
+        elevation_m: baseline.elevationM,
+        sample_days: baseline.sampleDays,
+        pressure_median_kpa: baseline.pressureMedianKpa,
+        pressure_mad_sigma_kpa: baseline.pressureMadSigmaKpa,
+        dew_point_median_c: baseline.dewPointMedianC,
+        dew_point_mad_sigma_c: baseline.dewPointMadSigmaC,
+        archive_seeded: baseline.archiveSeeded,
+      });
+    } catch (error) {
+      // Surfaced, not swallowed. A wrong-field ingestion throws at the client
+      // boundary and that message is exactly what an operator needs to read.
+      failed.push({
+        geohash5,
+        label: location.label,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  void _logger.info("Admin environmental seed", {
+    requested: parsed.length,
+    seeded: seeded.length,
+    failed: failed.length,
+  });
+
+  return NextResponse.json({
+    success: failed.length === 0,
+    requested: parsed.length,
+    seeded,
+    failed,
+  });
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await validateAdminRequest(request);
+  if ("error" in authResult) return authResult.error;
+
+  try {
+    const summary = await summarizeIngestion();
+    return NextResponse.json({ success: true, ...summary });
+  } catch (error) {
+    console.error("[admin/environment/seed] summary failed:", error);
+    return NextResponse.json(
+      { success: false, live: false, message: "Failed to read ingestion state" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/cron/environmental-ingest/route.ts
+++ b/src/app/api/cron/environmental-ingest/route.ts
@@ -1,0 +1,106 @@
+/**
+ * Environmental ingestion — cron endpoint.
+ *
+ * Runs hourly, but each geohash is sampled only once a day, at its own derived
+ * UTC hour. That serves two purposes: sampling the same hour every day keeps the
+ * semidiurnal atmospheric tide (~1–2 hPa) out of the window's dispersion instead
+ * of inflating MAD and desensitizing every z-score, and deriving the hour from
+ * the geohash spreads the fleet across the day rather than stampeding one minute.
+ *
+ * Each run: sample the geohashes due this hour, recompute their robust
+ * baselines, then sweep expired raw observations.
+ *
+ * Idempotent. A geohash already sampled today is skipped by the due-query, so a
+ * retried or double-fired cron does not double-write.
+ *
+ * Schedule: hourly at :10.
+ * Auth: `Authorization: Bearer <CRON_SECRET>` (shared cron auth).
+ *
+ * @file src/app/api/cron/environmental-ingest/route.ts
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import { isAuthorizedCron } from "@/app/api/cron/_lib/cronAuth";
+import { _logger } from "@/lib/logger";
+import {
+  getGeohashesDueForSampling,
+  pruneOldObservations,
+  sampleGeohash,
+} from "@/services/environmentalIngestService";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+/**
+ * Ceiling on geohashes touched per invocation. Each one is an outbound HTTP call
+ * plus a handful of writes, and the function has a 60 s budget. Anything not
+ * reached this hour is picked up by the next run — the due-query orders by
+ * staleness, so nothing starves.
+ */
+const MAX_GEOHASHES_PER_RUN = 40;
+
+export async function GET(request: NextRequest) {
+  if (!isAuthorizedCron(request)) {
+    return NextResponse.json({ success: false, message: "Unauthorized" }, { status: 401 });
+  }
+
+  const utcHour = new Date().getUTCHours();
+
+  try {
+    const due = await getGeohashesDueForSampling(utcHour, MAX_GEOHASHES_PER_RUN);
+
+    let sampled = 0;
+    let rowsWritten = 0;
+    const failures: Array<{ geohash5: string; error: string }> = [];
+
+    for (const { geohash5, elevationM } of due) {
+      try {
+        const { written } = await sampleGeohash(geohash5, elevationM);
+        sampled++;
+        rowsWritten += written;
+      } catch (error) {
+        // One bad cell must not abort the sweep. Failures are counted and
+        // reported rather than swallowed — a run that silently sampled nothing
+        // would otherwise look identical to a run with nothing to do.
+        failures.push({
+          geohash5,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    const pruned = await pruneOldObservations();
+
+    void _logger.info("Environmental ingestion sweep complete", {
+      utcHour,
+      due: due.length,
+      sampled,
+      rowsWritten,
+      failed: failures.length,
+      pruned,
+    });
+
+    return NextResponse.json({
+      success: true,
+      utcHour,
+      due: due.length,
+      sampled,
+      rowsWritten,
+      pruned,
+      failed: failures.length,
+      // Surfaced, not hidden: a wrong-field ingestion throws at the client
+      // boundary, and that message is exactly what an operator needs to see.
+      failures: failures.slice(0, 10),
+    });
+  } catch (error) {
+    void _logger.error("Environmental ingestion sweep failed", { error, utcHour });
+    return NextResponse.json(
+      {
+        success: false,
+        message: error instanceof Error ? error.message : "Ingestion failed",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/constants/environmentalResponseProfiles.ts
+++ b/src/constants/environmentalResponseProfiles.ts
@@ -1,0 +1,455 @@
+import type {
+  EnvironmentalResponseProfile,
+  PhysicalCoefficient,
+  RegimeKinetics,
+} from "@/types/environmentalResponseSchema";
+
+/**
+ * Worked exemplar profiles for the Dual-Baseline Engine.
+ *
+ * Five methods chosen because each one breaks a naive design:
+ *   - `roasting`         — surface and interior respond to humidity in OPPOSITE directions
+ *   - `pressure_cooking` — the vessel's gauge composes with ambient rather than cancelling it
+ *   - `baking`           — two humidity clocks at once (dough surface vs. pantry flour)
+ *   - `dehydrating`      — humidity is first-order and pressure is not negligible
+ *   - `frying`           — the method that should mostly report "nothing to say today"
+ *
+ * The remaining 26 canonical methods land in follow-up work. Shipping five sourced
+ * profiles beats thirty invented ones.
+ */
+
+// ============================================================================
+// Shared physics constants — DERIVED, not tunable
+// ============================================================================
+
+/**
+ * Clausius–Clapeyron slope at 1 atm: dT/dP = R·T²/(L·P).
+ * 8.314 × 373.15² / (40660 × 101325) = 2.810e-4 K/Pa = 0.281 °C/kPa.
+ */
+const CLAUSIUS_CLAPEYRON_SLOPE: PhysicalCoefficient = {
+  value: 0.281,
+  unit: "degC_per_kPa",
+  basis: "DERIVED",
+  source: "dT/dP = R·T²/(L·P); R=8.314 J/mol·K, T=373.15 K, L=40660 J/mol, P=101.325 kPa",
+  tunable: false,
+};
+
+/**
+ * Isothermal gas expansion, Boyle: V ∝ 1/P, so dV/V per kPa = 1/P = 1/101.325.
+ *
+ * This is the coefficient that most needs protecting from "tuning". A 1.5 kPa
+ * front — a genuinely large weather anomaly — buys 1.5% extra bubble volume, not
+ * a 15% change in proofing time. Any copy claiming otherwise is not describing
+ * this coefficient.
+ */
+const BOYLE_EXPANSION_PER_KPA: PhysicalCoefficient = {
+  value: 0.00987,
+  unit: "fraction_per_kPa",
+  basis: "DERIVED",
+  source: "Boyle's law V ∝ 1/P; dV/V per kPa = 1/101.325 kPa at sea-level standard",
+  tunable: false,
+};
+
+/**
+ * Closed-cavity ambient coupling.
+ *
+ * Bounded by a mass balance rather than guessed. A ~50 L oven cavity at a 20 °C
+ * ambient dew point holds ~0.87 g of water (17.3 g/m³ × 0.05 m³). A 2 kg roast
+ * releases 200–400 g of water over the cook. Even at ~10 cavity air changes, the
+ * ambient contribution is ~9 g against ~300 g — under 3%.
+ *
+ * The practical consequence: for a CLOSED oven, outdoor humidity is not a
+ * meaningful driver of cavity humidity, and advisories built on the assumption
+ * that it is will be confidently wrong.
+ */
+const CLOSED_CAVITY_COUPLING: PhysicalCoefficient = {
+  value: 0.03,
+  unit: "fraction",
+  basis: "DERIVED",
+  source:
+    "Mass balance: ambient-supplied vapour (~0.87 g per 50 L cavity at 20 °C dew point, " +
+    "~9 g over ~10 air changes) vs. food-released vapour (200–400 g per 2 kg roast)",
+  tunable: true,
+};
+
+/** Open-air cooking: the ambient air IS the cooking atmosphere. Coupling is unity by definition. */
+const OPEN_AIR_COUPLING: PhysicalCoefficient = {
+  value: 1.0,
+  unit: "fraction",
+  basis: "DERIVED",
+  source: "Open-air method; the cooking atmosphere is ambient air by definition",
+  tunable: false,
+};
+
+/**
+ * Wheat-flour sorption → dough hydration.
+ *
+ * Flour EMC runs ~9% at 30% RH to ~15% at 75% RH (20–25 °C), i.e. ~0.13 points of
+ * flour moisture per RH point. At 65% baker's hydration, 1 point of flour moisture
+ * displaces 1/0.65 = 1.54% of formula water. Near a 21 °C indoor temperature the
+ * dew-point→RH slope is ~3.3 RH points per °C.
+ *
+ *   0.13 × 0.0154 × 3.3 ≈ 0.0066 per °C of dew-point anomaly.
+ *
+ * So a +4 °C dew-point anomaly, AT FULL EQUILIBRATION, justifies holding back
+ * ~2.6% of formula water — not 10%. The dew-point→RH slope is nonlinear, hence
+ * tunable and clamped.
+ */
+const FLOUR_HYDRATION_PER_DEGC: PhysicalCoefficient = {
+  value: -0.0066,
+  unit: "hydration_fraction_per_degC_dewpoint",
+  basis: "DERIVED",
+  source:
+    "Wheat flour sorption isotherm (~0.13 %moisture per %RH, 20–25 °C) × 1/0.65 baker's " +
+    "hydration × 3.3 %RH per °C dew point at 21 °C (Magnus–Tetens, linearized at Td≈10 °C)",
+  tunable: true,
+};
+
+// ============================================================================
+// Regime kinetics  (Q3C)
+// ============================================================================
+
+export const REGIME_KINETICS: Partial<Record<string, RegimeKinetics>> = {
+  saturation_limited: {
+    regime: "saturation_limited",
+    activationEnergyKjMol: {
+      value: 110,
+      unit: "kJ_per_mol",
+      basis: "MEASURED",
+      source: "Legume/starch softening kinetics, literature range 80–120 kJ/mol; midpoint",
+      tunable: true,
+    },
+    referenceTemperatureK: 370,
+    // exp(110000/8.314 × (1/370 − 1/380)) = 2.56
+    q10AtReference: 2.56,
+    lethalityZValueC: 10,
+  },
+  setpoint_limited: {
+    regime: "setpoint_limited",
+    activationEnergyKjMol: {
+      value: 120,
+      unit: "kJ_per_mol",
+      basis: "MEASURED",
+      source: "Maillard browning kinetics, literature range 100–160 kJ/mol; low-mid",
+      tunable: true,
+    },
+    referenceTemperatureK: 430,
+    // exp(120000/8.314 × (1/430 − 1/440)) = 2.14
+    q10AtReference: 2.14,
+    lethalityZValueC: null,
+  },
+};
+
+// ============================================================================
+// Exemplar profiles
+// ============================================================================
+
+/**
+ * ROASTING — the opposed-channel case.
+ *
+ * Higher ambient moisture raises the wet-bulb plateau, so the INTERIOR pushes
+ * through the evaporative stall faster. Simultaneously it lowers the vapour-pressure
+ * deficit, so the SURFACE takes longer to dry out and browning is DELAYED.
+ * Same method, same driver, opposite signs. A per-method scalar would have to
+ * pick one and silently discard the other.
+ *
+ * Both effects are then scaled by CLOSED_CAVITY_COUPLING (~0.03), which is what
+ * stops this profile from emitting a confident "crank the oven 10 °C" advisory
+ * off a humid day. In a closed oven, it will almost always self-suppress.
+ */
+const roasting: EnvironmentalResponseProfile = {
+  method: "roasting",
+  primaryRegime: "setpoint_limited",
+  channels: [
+    {
+      channel: "surface",
+      regime: "evaporation_limited",
+      ambientCoupling: CLOSED_CAVITY_COUPLING,
+      pressure: null,
+      humidity: {
+        coefficient: {
+          value: 0.018,
+          unit: "time_fraction_per_degC_dewpoint",
+          basis: "DERIVED",
+          source:
+            "Surface drying rate ∝ vapour-pressure deficit; d(VPD)/d(Td) at 21 °C reference " +
+            "normalized to time-to-dry at oven cavity conditions",
+          tunable: true,
+        },
+        axis: "time_multiplier",
+        minimumEffect: 0.03,
+        minimumZ: 1.5,
+        maximumEffect: 0.2,
+      },
+      humidityClock: "instant",
+      mechanism:
+        "Higher ambient moisture lowers the vapour-pressure deficit at the surface, " +
+        "slowing the drying front and delaying the onset of Maillard browning.",
+    },
+    {
+      channel: "interior",
+      regime: "setpoint_limited",
+      ambientCoupling: CLOSED_CAVITY_COUPLING,
+      pressure: null,
+      humidity: {
+        coefficient: {
+          value: -0.012,
+          unit: "time_fraction_per_degC_dewpoint",
+          basis: "DERIVED",
+          source:
+            "Wet-bulb plateau rises with absolute humidity, reducing evaporative cooling " +
+            "of the interior stall; sign is opposite the surface channel",
+          tunable: true,
+        },
+        axis: "time_multiplier",
+        minimumEffect: 0.03,
+        minimumZ: 1.5,
+        maximumEffect: 0.15,
+      },
+      humidityClock: "instant",
+      mechanism:
+        "A higher wet-bulb temperature means less evaporative cooling, so the interior " +
+        "climbs through the stall plateau sooner.",
+    },
+  ],
+  vesselPressure: null,
+  notes:
+    "Opposed channels are intentional. Do not collapse them to a net scalar — the " +
+    "correct advisory is 'browning lags, core runs ahead', not an averaged nothing.",
+};
+
+/**
+ * PRESSURE_COOKING — the gauge-composition case.
+ *
+ * A weight or spring valve regulates to a fixed GAUGE pressure, so absolute
+ * pressure is ambient + gauge. Altitude propagates straight through the appliance:
+ * 15 psi (103 kPa) gauge over Denver's 83.4 kPa ambient is 186 kPa absolute
+ * (~117 °C), not the sea-level 204 kPa (~121 °C). The pressure cooker rescales
+ * the altitude penalty; it does not cancel it.
+ */
+const pressureCooking: EnvironmentalResponseProfile = {
+  method: "pressure_cooking",
+  primaryRegime: "saturation_limited",
+  channels: [
+    {
+      channel: "medium",
+      regime: "saturation_limited",
+      ambientCoupling: {
+        value: 1.0,
+        unit: "fraction",
+        basis: "DERIVED",
+        source: "Sealed vessel regulates gauge pressure; ambient adds directly to absolute",
+        tunable: false,
+      },
+      pressure: {
+        coefficient: CLAUSIUS_CLAPEYRON_SLOPE,
+        axis: "temperature_delta_c",
+        minimumEffect: 0.5,
+        // Elevation-driven, not anomaly-driven. Geography is always true, so it is
+        // never statistically gated — a Denver user should always be told.
+        minimumZ: 0,
+        maximumEffect: 15,
+      },
+      humidity: null,
+      humidityClock: "instant",
+      mechanism:
+        "The valve holds a fixed pressure ABOVE ambient, so a lower ambient pressure " +
+        "lowers the absolute pressure in the vessel and with it the saturation temperature.",
+    },
+  ],
+  vesselPressure: {
+    regulation: "fixed_gauge",
+    gaugeKpa: {
+      value: 103.4,
+      unit: "kPa",
+      basis: "MEASURED",
+      source: "15 psi gauge, standard stovetop weight valve; 15 × 6.89476 kPa/psi",
+      tunable: false,
+    },
+    canningAdvisory: true,
+  },
+  notes:
+    "Electric units (Instant Pot class) regulate lower, ~10–11.6 psi. Model them as a " +
+    "separate 'electronic' variant rather than reusing this gauge value.",
+};
+
+/**
+ * BAKING — the two-clock case.
+ *
+ * Three channels on three different timescales:
+ *   - `leavening`  reads TODAY's pressure (gas expands the instant it is formed)
+ *   - `surface`    reads TODAY's dew point (crust skin forms in minutes)
+ *   - `ingredient` reads the LAGGED dew point (flour in a sealed bin equilibrates
+ *                  over days, so today's spike has not reached it yet)
+ *
+ * Driving the Pantry Hydration Index off today's reading would claim an effect the
+ * sorption process has not had time to produce.
+ */
+const baking: EnvironmentalResponseProfile = {
+  method: "baking",
+  primaryRegime: "leavening_limited",
+  channels: [
+    {
+      channel: "leavening",
+      regime: "leavening_limited",
+      ambientCoupling: {
+        value: 1.0,
+        unit: "fraction",
+        basis: "DERIVED",
+        source: "Dough is at ambient pressure throughout proofing; coupling is unity",
+        tunable: false,
+      },
+      pressure: {
+        coefficient: BOYLE_EXPANSION_PER_KPA,
+        axis: "expansion_multiplier",
+        // 5% expansion needs a ~5 kPa anomaly — far beyond normal weather. This
+        // gate is why the leavening advisory correctly stays silent on most days.
+        minimumEffect: 0.05,
+        minimumZ: 1.5,
+        maximumEffect: 0.25,
+      },
+      humidity: null,
+      humidityClock: "instant",
+      mechanism:
+        "Lower ambient pressure lets the same mass of CO2 occupy more volume, so the " +
+        "dough reaches a given rise sooner.",
+    },
+    {
+      channel: "ingredient",
+      regime: "ambient_limited",
+      ambientCoupling: {
+        value: 0.6,
+        unit: "fraction",
+        basis: "DERIVED",
+        source:
+          "Fraction of indoor vapour pressure reaching flour in typical domestic storage " +
+          "(paper bag / non-airtight bin); sealed containers approach 0",
+        tunable: true,
+      },
+      pressure: null,
+      humidity: {
+        coefficient: FLOUR_HYDRATION_PER_DEGC,
+        axis: "hydration_multiplier",
+        minimumEffect: 0.015,
+        // Lower than the instant-clock channels: the EMA has already smoothed out
+        // single-day noise, so a sustained shift is meaningful at a lower z.
+        minimumZ: 1.0,
+        maximumEffect: 0.05,
+      },
+      humidityClock: "lagged",
+      mechanism:
+        "Flour is hygroscopic and equilibrates with stored air over days, so a sustained " +
+        "humid spell — not a single humid day — leaves it holding extra water.",
+    },
+  ],
+  vesselPressure: null,
+  notes:
+    "Exposed sugar work (macarons, pulled sugar) is the SAME driver on the 'instant' " +
+    "clock and belongs on its own method key, not folded in here.",
+};
+
+/**
+ * DEHYDRATING — humidity first-order, pressure genuinely non-negligible.
+ * The one regime where the daily anomaly regularly clears its own threshold.
+ */
+const dehydrating: EnvironmentalResponseProfile = {
+  method: "dehydrating",
+  primaryRegime: "evaporation_limited",
+  channels: [
+    {
+      channel: "surface",
+      regime: "evaporation_limited",
+      ambientCoupling: OPEN_AIR_COUPLING,
+      pressure: {
+        coefficient: {
+          value: -0.006,
+          unit: "time_fraction_per_kPa",
+          basis: "DERIVED",
+          source:
+            "Evaporation rate ∝ (e_s − e_a)/P; lower ambient pressure raises the diffusion " +
+            "coefficient and the driving ratio",
+          tunable: true,
+        },
+        axis: "time_multiplier",
+        minimumEffect: 0.03,
+        minimumZ: 1.5,
+        maximumEffect: 0.25,
+      },
+      humidity: {
+        coefficient: {
+          value: 0.055,
+          unit: "time_fraction_per_degC_dewpoint",
+          basis: "DERIVED",
+          source:
+            "Drying time ∝ 1/VPD; d(VPD)/d(Td) via Magnus–Tetens linearized at 21 °C, Td≈10 °C",
+          tunable: true,
+        },
+        axis: "time_multiplier",
+        minimumEffect: 0.05,
+        minimumZ: 1.5,
+        maximumEffect: 0.6,
+      },
+      humidityClock: "instant",
+      mechanism:
+        "Drying is driven by vapour-pressure deficit; humid air shrinks the deficit and " +
+        "the water has nowhere to go.",
+    },
+  ],
+  vesselPressure: null,
+};
+
+/**
+ * FRYING — the negative control.
+ *
+ * Included deliberately. Oil at 190 °C is a sealed thermal mass whose temperature
+ * is set by the burner, not the weather; ambient humidity coupling is ~0. Pressure
+ * does shift the food's internal moisture plateau, but only by ~0.28 °C per kPa
+ * against a ~90 °C driving differential — well under 1%, so the daily anomaly
+ * self-suppresses and only the elevation baseline ever surfaces.
+ *
+ * If this profile ever emits a daily advisory, the engine has a bug.
+ */
+const frying: EnvironmentalResponseProfile = {
+  method: "frying",
+  primaryRegime: "setpoint_limited",
+  channels: [
+    {
+      channel: "interior",
+      regime: "saturation_limited",
+      ambientCoupling: {
+        value: 0.05,
+        unit: "fraction",
+        basis: "DERIVED",
+        source: "Oil is a thermal mass at ~190 °C held by the burner; ambient air does not reach the food's moisture plateau",
+        tunable: true,
+      },
+      pressure: {
+        coefficient: CLAUSIUS_CLAPEYRON_SLOPE,
+        axis: "temperature_delta_c",
+        // Requires ~7 kPa to clear — i.e. elevation, never weather.
+        minimumEffect: 2.0,
+        // Elevation-driven. Not z-gated, but the effect floor alone keeps this
+        // silent on every weather day, which is the intended negative-control behavior.
+        minimumZ: 0,
+        maximumEffect: 15,
+      },
+      humidity: null,
+      humidityClock: "instant",
+      mechanism:
+        "The water inside the food boils at the ambient-pressure saturation temperature, " +
+        "so at altitude steam drives out earlier and the crust sets before the centre catches up.",
+    },
+  ],
+  vesselPressure: null,
+  notes: "Negative control. A daily-anomaly advisory here indicates a threshold-gating bug.",
+};
+
+export const ENVIRONMENTAL_RESPONSE_PROFILES: Partial<
+  Record<string, EnvironmentalResponseProfile>
+> = {
+  roasting,
+  pressure_cooking: pressureCooking,
+  baking,
+  dehydrating,
+  frying,
+};

--- a/src/lib/environment/geohash.ts
+++ b/src/lib/environment/geohash.ts
@@ -1,0 +1,144 @@
+/**
+ * Geohash encoding for the environmental cache key.
+ *
+ * Precision 5 (~4.9 × 4.9 km) is the cache key for weather. Finer than that is
+ * false precision: Open-Meteo's model grid is ~11 km, so a p6 key would produce
+ * ~30× the rows while resolving detail the upstream data does not contain.
+ *
+ * Elevation is deliberately NOT derived from this key. A ~5 km cell in rugged
+ * terrain can span enough elevation to move the boiling point by more than a
+ * degree, and elevation is the dominant term in the whole engine — it is stored
+ * per-location at full DEM fidelity instead.
+ *
+ * Coarsening to p5 also means no precise user location enters a URL, a query
+ * string, or an access log.
+ *
+ * @file src/lib/environment/geohash.ts
+ */
+
+const BASE32 = "0123456789bcdefghjkmnpqrstuvwxyz";
+
+/** The precision used for every environmental cache key. */
+export const ENVIRONMENT_GEOHASH_PRECISION = 5;
+
+/**
+ * Encode a coordinate as a geohash.
+ *
+ * @param latitude  Degrees, −90…90.
+ * @param longitude Degrees, −180…180.
+ * @param precision Characters of output. Defaults to the environmental standard.
+ */
+export function encodeGeohash(
+  latitude: number,
+  longitude: number,
+  precision: number = ENVIRONMENT_GEOHASH_PRECISION,
+): string {
+  if (!Number.isFinite(latitude) || latitude < -90 || latitude > 90) {
+    throw new RangeError(`latitude must be within -90..90, received ${latitude}`);
+  }
+  if (!Number.isFinite(longitude) || longitude < -180 || longitude > 180) {
+    throw new RangeError(`longitude must be within -180..180, received ${longitude}`);
+  }
+  if (!Number.isInteger(precision) || precision < 1 || precision > 12) {
+    throw new RangeError(`precision must be an integer within 1..12, received ${precision}`);
+  }
+
+  let latMin = -90;
+  let latMax = 90;
+  let lonMin = -180;
+  let lonMax = 180;
+
+  let hash = "";
+  let bit = 0;
+  let chunk = 0;
+  let evenBit = true; // even bits index longitude, odd bits latitude
+
+  while (hash.length < precision) {
+    if (evenBit) {
+      const lonMid = (lonMin + lonMax) / 2;
+      if (longitude >= lonMid) {
+        chunk = (chunk << 1) + 1;
+        lonMin = lonMid;
+      } else {
+        chunk = chunk << 1;
+        lonMax = lonMid;
+      }
+    } else {
+      const latMid = (latMin + latMax) / 2;
+      if (latitude >= latMid) {
+        chunk = (chunk << 1) + 1;
+        latMin = latMid;
+      } else {
+        chunk = chunk << 1;
+        latMax = latMid;
+      }
+    }
+    evenBit = !evenBit;
+
+    if (++bit === 5) {
+      hash += BASE32[chunk];
+      bit = 0;
+      chunk = 0;
+    }
+  }
+
+  return hash;
+}
+
+/**
+ * Centre of a geohash cell.
+ *
+ * Correct for querying a weather provider, since the cell is smaller than the
+ * model grid. NOT a source of elevation — see the file header.
+ */
+export function decodeGeohashCenter(geohash: string): { latitude: number; longitude: number } {
+  if (!/^[0-9bcdefghjkmnpqrstuvwxyz]+$/.test(geohash)) {
+    throw new RangeError(`invalid geohash: ${geohash}`);
+  }
+
+  let latMin = -90;
+  let latMax = 90;
+  let lonMin = -180;
+  let lonMax = 180;
+  let evenBit = true;
+
+  for (const char of geohash) {
+    const index = BASE32.indexOf(char);
+    for (let shift = 4; shift >= 0; shift--) {
+      const bitValue = (index >> shift) & 1;
+      if (evenBit) {
+        const lonMid = (lonMin + lonMax) / 2;
+        if (bitValue === 1) lonMin = lonMid;
+        else lonMax = lonMid;
+      } else {
+        const latMid = (latMin + latMax) / 2;
+        if (bitValue === 1) latMin = latMid;
+        else latMax = latMid;
+      }
+      evenBit = !evenBit;
+    }
+  }
+
+  return {
+    latitude: (latMin + latMax) / 2,
+    longitude: (lonMin + lonMax) / 2,
+  };
+}
+
+/**
+ * The UTC hour at which this geohash is sampled, 0–23.
+ *
+ * Sampling the SAME hour every day keeps the semidiurnal atmospheric tide
+ * (~1–2 hPa, a real periodic signal) out of the window's dispersion. Left in, it
+ * inflates MAD and desensitizes every z-score computed against it.
+ *
+ * Deriving the hour from the geohash also spreads the global fleet's ingestion
+ * evenly across the day instead of stampeding one cron minute.
+ */
+export function sampleHourForGeohash(geohash: string): number {
+  let accumulator = 0;
+  for (let i = 0; i < geohash.length; i++) {
+    accumulator = (accumulator * 31 + geohash.charCodeAt(i)) >>> 0;
+  }
+  return accumulator % 24;
+}

--- a/src/lib/environment/isa.ts
+++ b/src/lib/environment/isa.ts
@@ -1,0 +1,136 @@
+/**
+ * International Standard Atmosphere — elevation ↔ pressure.
+ *
+ * This is the DERIVED trunk of the Dual-Baseline Engine. Elevation sets a
+ * location's permanent pressure baseline; live weather only ever perturbs it.
+ * The relative scale matters and is easy to get backwards:
+ *
+ *   Denver (1609 m)          →  83.4 kPa  →  −17.9 kPa vs sea level
+ *   A hurricane at sea level →  95.0 kPa  →   −6.3 kPa vs sea level
+ *
+ * Geography outweighs even extreme weather by roughly 3×, and outweighs a
+ * routine daily swing by an order of magnitude.
+ *
+ * Valid through the troposphere (~11 km). Every populated place on Earth is
+ * well inside that; the highest permanent settlement is ~5.1 km.
+ *
+ * @file src/lib/environment/isa.ts
+ */
+
+/** Standard sea-level pressure, ISA. */
+export const SEA_LEVEL_PRESSURE_KPA = 101.325;
+
+/**
+ * ISA troposphere exponent, g·M/(R·L).
+ * 9.80665 × 0.0289644 / (8.31447 × 0.0065) = 5.25588
+ */
+const ISA_EXPONENT = 5.25588;
+
+/** L/T0 = 0.0065 K/m / 288.15 K = 2.25577e-5 per metre. */
+const ISA_LAPSE_RATIO = 2.25577e-5;
+
+/** Upper bound of the ISA troposphere model, in metres. */
+const ISA_TROPOSPHERE_CEILING_M = 11_000;
+
+/**
+ * Pressure at a given elevation under the standard atmosphere.
+ *
+ * This is the *climatic baseline* pressure, not a live reading. It answers
+ * "what does this location normally sit at", which is the denominator the daily
+ * anomaly is measured against.
+ *
+ * @param elevationM Metres above mean sea level.
+ * @returns Absolute pressure in kPa.
+ */
+export function pressureFromElevation(elevationM: number): number {
+  if (!Number.isFinite(elevationM)) {
+    throw new RangeError(`elevationM must be finite, received ${elevationM}`);
+  }
+  if (elevationM > ISA_TROPOSPHERE_CEILING_M) {
+    throw new RangeError(
+      `elevationM ${elevationM} exceeds the ISA troposphere ceiling (${ISA_TROPOSPHERE_CEILING_M} m); ` +
+        `the model does not apply above the tropopause`,
+    );
+  }
+  return SEA_LEVEL_PRESSURE_KPA * Math.pow(1 - ISA_LAPSE_RATIO * elevationM, ISA_EXPONENT);
+}
+
+/**
+ * Inverse: the elevation whose standard pressure equals `pressureKpa`.
+ *
+ * Useful as a sanity check on a station reading, NOT as a way to recover a
+ * user's true elevation — real weather moves surface pressure by a few kPa,
+ * which is hundreds of metres of apparent elevation. Elevation must come from
+ * a DEM lookup; this function exists to cross-check, not to substitute.
+ *
+ * @param pressureKpa Absolute pressure in kPa.
+ * @returns Metres above mean sea level under ISA.
+ */
+export function elevationFromPressure(pressureKpa: number): number {
+  if (!Number.isFinite(pressureKpa) || pressureKpa <= 0) {
+    throw new RangeError(`pressureKpa must be a positive finite number, received ${pressureKpa}`);
+  }
+  const ratio = Math.pow(pressureKpa / SEA_LEVEL_PRESSURE_KPA, 1 / ISA_EXPONENT);
+  return (1 - ratio) / ISA_LAPSE_RATIO;
+}
+
+/**
+ * Minimum gap between a location's ISA baseline and sea-level standard for the
+ * MSLP check below to mean anything. 7 kPa corresponds to roughly 600 m.
+ *
+ * Below that, ordinary synoptic weather (±3.5 kPa) can move a genuine station
+ * reading further from its baseline than the MSLP offset would — the two
+ * hypotheses become indistinguishable, and any verdict would be a coin flip
+ * dressed up as a check.
+ */
+const MSLP_DISCRIMINATION_FLOOR_KPA = 7;
+
+/**
+ * Guard against the single most likely silent failure in this subsystem:
+ * ingesting sea-level-adjusted pressure (MSLP / QNH) where station pressure is
+ * required.
+ *
+ * MSLP has the altitude signal removed by construction — it extrapolates the
+ * station reading down to sea level using an ISA lapse rate. Feed it to a
+ * boiling-point solver and Denver returns ~100 °C, which looks entirely
+ * plausible and is wrong everywhere except the coast.
+ *
+ * ── Why this is discriminative rather than a tolerance band ─────────────────
+ *
+ * A fixed band around the ISA baseline cannot work. It has to be wide enough to
+ * admit a real hurricane (950 hPa is 6.3 kPa below standard, and the record low
+ * is 14.3 kPa below) yet narrow enough to reject an MSLP reading — and at low
+ * elevations those two ranges overlap completely.
+ *
+ * So this asks the discriminating question instead: is the reading closer to
+ * sea-level standard than to where this elevation says it should be? That
+ * separates the two hypotheses directly, and at high elevation the gap is
+ * enormous. `[MEASURED 2026-07-30]` Denver at 1599 m:
+ *
+ *     surface_pressure  84.04 kPa → 0.5 kPa from baseline, 17.3 from sea level
+ *     pressure_msl     100.60 kPa → 17.1 kPa from baseline, 0.7 from sea level
+ *
+ * ── What it cannot do ───────────────────────────────────────────────────────
+ *
+ * Near sea level it returns "plausible" unconditionally, because there is
+ * genuinely nothing to detect: MSLP and station pressure converge as elevation
+ * approaches zero, which is also why the trap causes little error there. This
+ * is a guard for elevated locations — where the bug actually matters — and it
+ * declines to guess everywhere else rather than inventing a verdict.
+ *
+ * @param pressureKpa The value claiming to be station/surface pressure.
+ * @param elevationM Known elevation of the location.
+ * @returns false only when the reading is better explained as sea-level-adjusted.
+ */
+export function isPlausibleStationPressure(pressureKpa: number, elevationM: number): boolean {
+  const expected = pressureFromElevation(elevationM);
+
+  // Too low for the two hypotheses to be distinguishable — decline to judge.
+  if (Math.abs(expected - SEA_LEVEL_PRESSURE_KPA) < MSLP_DISCRIMINATION_FLOOR_KPA) {
+    return true;
+  }
+
+  const distanceToExpected = Math.abs(pressureKpa - expected);
+  const distanceToSeaLevel = Math.abs(pressureKpa - SEA_LEVEL_PRESSURE_KPA);
+  return distanceToExpected <= distanceToSeaLevel;
+}

--- a/src/lib/environment/openMeteoClient.ts
+++ b/src/lib/environment/openMeteoClient.ts
@@ -1,0 +1,238 @@
+/**
+ * Open-Meteo client for the environmental ingestion layer.
+ *
+ * Keyless, matching the OpenStreetMap/Overpass precedent already used for
+ * restaurant lookup. Three endpoints:
+ *
+ *   forecast   live hourly sampling
+ *   archive    ERA5 reanalysis, used once per location to seed the window
+ *   elevation  90 m DEM, the full-fidelity elevation this engine depends on
+ *
+ * ── The one field that matters ──────────────────────────────────────────────
+ *
+ * `surface_pressure`, never `pressure_msl`. `[MEASURED 2026-07-30]` for Denver
+ * (39.7392, −104.9903, elevation 1599 m) at the same timestamp:
+ *
+ *     surface_pressure   840.4 hPa  →  boiling point 94.9 °C
+ *     pressure_msl      1006.0 hPa  →  boiling point 99.8 °C
+ *
+ * Sea-level-adjusted pressure has the altitude signal removed by construction,
+ * so reading it produces a 4.9 °C error that looks entirely plausible and is
+ * wrong everywhere except the coast. `assertStationPressure` below exists solely
+ * to make that mistake impossible to ship silently.
+ *
+ * @file src/lib/environment/openMeteoClient.ts
+ */
+
+import { isPlausibleStationPressure } from "./isa";
+
+const FORECAST_URL = "https://api.open-meteo.com/v1/forecast";
+const ARCHIVE_URL = "https://archive-api.open-meteo.com/v1/archive";
+const ELEVATION_URL = "https://api.open-meteo.com/v1/elevation";
+
+/**
+ * ERA5 reanalysis lags real time by roughly five days. Seeding a window that
+ * runs right up to today would silently return short.
+ */
+export const ARCHIVE_LAG_DAYS = 6;
+
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/** `[MEASURED 2026-07-30]` Open-Meteo reports pressure in hPa; this engine stores kPa. */
+const HPA_TO_KPA = 0.1;
+
+export interface EnvironmentSample {
+  observedAt: Date;
+  surfacePressureKpa: number;
+  dewPointC: number;
+  airTempC: number;
+  source: "forecast" | "archive";
+}
+
+/**
+ * Field names mirror Open-Meteo's wire format exactly and must not be
+ * camelCased — they are the API's keys, not ours.
+ */
+interface OpenMeteoHourlyResponse {
+  elevation?: number;
+  hourly?: {
+    time?: string[];
+    surface_pressure?: Array<number | null>;
+    dew_point_2m?: Array<number | null>;
+    temperature_2m?: Array<number | null>;
+  };
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { accept: "application/json" },
+    });
+    if (!response.ok) {
+      throw new Error(`Open-Meteo responded ${response.status} ${response.statusText}`);
+    }
+    return (await response.json()) as T;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Reject a reading that cannot be station pressure at this elevation.
+ *
+ * Throws rather than clamping or defaulting. A wrong-field ingestion is not a
+ * degraded reading to be smoothed over — it is a value that would poison every
+ * baseline computed from it, and it must fail loudly at the boundary.
+ */
+export function assertStationPressure(pressureKpa: number, elevationM: number): void {
+  if (!isPlausibleStationPressure(pressureKpa, elevationM)) {
+    throw new Error(
+      `Refusing pressure ${pressureKpa.toFixed(2)} kPa at elevation ${elevationM} m: ` +
+        `implausible as station pressure. This is the signature of reading ` +
+        `pressure_msl instead of surface_pressure.`,
+    );
+  }
+}
+
+/**
+ * Zip Open-Meteo's parallel arrays into samples, dropping any hour with a null
+ * in any required field.
+ *
+ * Nulls are dropped rather than interpolated or zero-filled. A fabricated 0 kPa
+ * would sail through as a real observation and wreck the window's median.
+ */
+function toSamples(
+  payload: OpenMeteoHourlyResponse,
+  elevationM: number,
+  source: "forecast" | "archive",
+): EnvironmentSample[] {
+  const hourly = payload.hourly;
+  if (!hourly?.time?.length) return [];
+
+  // Renamed on destructure: the wire keys are snake_case, our locals are not.
+  const {
+    time,
+    surface_pressure: surfacePressureSeries,
+    dew_point_2m: dewPointSeries,
+    temperature_2m: airTempSeries,
+  } = hourly;
+  if (!surfacePressureSeries || !dewPointSeries || !airTempSeries) {
+    throw new Error(
+      "Open-Meteo response is missing a required hourly field " +
+        "(surface_pressure, dew_point_2m, temperature_2m)",
+    );
+  }
+
+  const samples: EnvironmentSample[] = [];
+  for (let i = 0; i < time.length; i++) {
+    const pressureHpa = surfacePressureSeries[i];
+    const dewPoint = dewPointSeries[i];
+    const airTemp = airTempSeries[i];
+    if (pressureHpa == null || dewPoint == null || airTemp == null) continue;
+
+    const surfacePressureKpa = pressureHpa * HPA_TO_KPA;
+    assertStationPressure(surfacePressureKpa, elevationM);
+
+    samples.push({
+      // Open-Meteo hourly timestamps are UTC when no timezone is requested.
+      observedAt: new Date(`${time[i]}Z`),
+      surfacePressureKpa,
+      dewPointC: dewPoint,
+      airTempC: airTemp,
+      source,
+    });
+  }
+  return samples;
+}
+
+/**
+ * Full-fidelity DEM elevation for a coordinate.
+ *
+ * Deliberately separate from the weather call: the weather cache is keyed at
+ * geohash p5 (~5 km), which is far too coarse for elevation in mountainous
+ * terrain, and elevation is the dominant term in the entire engine.
+ */
+export async function fetchElevation(latitude: number, longitude: number): Promise<number> {
+  const url = `${ELEVATION_URL}?latitude=${latitude}&longitude=${longitude}`;
+  const payload = await fetchJson<{ elevation?: number[] }>(url);
+  const elevation = payload.elevation?.[0];
+  if (elevation == null || !Number.isFinite(elevation)) {
+    throw new Error(`Open-Meteo elevation lookup returned no value for ${latitude},${longitude}`);
+  }
+  return elevation;
+}
+
+/** Live hourly readings for the current day. */
+export async function fetchForecastSamples(
+  latitude: number,
+  longitude: number,
+  elevationM: number,
+): Promise<EnvironmentSample[]> {
+  const url =
+    `${FORECAST_URL}?latitude=${latitude}&longitude=${longitude}` +
+    `&hourly=surface_pressure,dew_point_2m,temperature_2m&forecast_days=1`;
+  const payload = await fetchJson<OpenMeteoHourlyResponse>(url);
+  return toSamples(payload, elevationM, "forecast");
+}
+
+/**
+ * ERA5 reanalysis over a date range, used once per location to seed the window.
+ *
+ * This is what makes a location's anomalies valid on day one instead of after a
+ * month of waiting — the same trailing-30d robust statistic, with the window
+ * filled rather than accumulated.
+ *
+ * @param startDate ISO date, YYYY-MM-DD.
+ * @param endDate ISO date, YYYY-MM-DD. Must respect ARCHIVE_LAG_DAYS.
+ */
+export async function fetchArchiveSamples(
+  latitude: number,
+  longitude: number,
+  elevationM: number,
+  startDate: string,
+  endDate: string,
+): Promise<EnvironmentSample[]> {
+  const url =
+    `${ARCHIVE_URL}?latitude=${latitude}&longitude=${longitude}` +
+    `&start_date=${startDate}&end_date=${endDate}` +
+    `&hourly=surface_pressure,dew_point_2m,temperature_2m`;
+  const payload = await fetchJson<OpenMeteoHourlyResponse>(url);
+  return toSamples(payload, elevationM, "archive");
+}
+
+/**
+ * Reduce hourly samples to one reading per UTC day, taken at a fixed hour.
+ *
+ * Sampling the same hour each day keeps the semidiurnal atmospheric tide
+ * (~1–2 hPa, a real periodic signal) out of the window's dispersion. Averaging
+ * whole days would also remove it, but would flatten the genuine synoptic peaks
+ * this engine exists to detect.
+ *
+ * When the target hour is missing for a day, the nearest available hour is used
+ * rather than dropping the day — a gap costs more than a couple of hours of tide.
+ */
+export function reduceToDailyAtHour(
+  samples: readonly EnvironmentSample[],
+  targetUtcHour: number,
+): EnvironmentSample[] {
+  const byDay = new Map<string, EnvironmentSample>();
+
+  for (const sample of samples) {
+    const dayKey = sample.observedAt.toISOString().slice(0, 10);
+    const existing = byDay.get(dayKey);
+    if (!existing) {
+      byDay.set(dayKey, sample);
+      continue;
+    }
+    const distance = Math.abs(sample.observedAt.getUTCHours() - targetUtcHour);
+    const existingDistance = Math.abs(existing.observedAt.getUTCHours() - targetUtcHour);
+    if (distance < existingDistance) byDay.set(dayKey, sample);
+  }
+
+  return [...byDay.values()].sort(
+    (a, b) => a.observedAt.getTime() - b.observedAt.getTime(),
+  );
+}

--- a/src/lib/environment/robustStats.ts
+++ b/src/lib/environment/robustStats.ts
@@ -1,0 +1,86 @@
+/**
+ * Robust location and dispersion for the climatic baseline.
+ *
+ * Median and MAD rather than mean and σ, because the events this engine exists
+ * to flag ARE the outliers. A classical σ lets a storm inflate the very
+ * denominator that would have detected it — one hurricane widens the spread
+ * enough to suppress the following month of alerts. The median is unmoved by up
+ * to half the sample, so a genuine outlier stays an outlier.
+ *
+ * @file src/lib/environment/robustStats.ts
+ */
+
+/** MAD → σ-equivalent, for a normally distributed variable. 1/Φ⁻¹(0.75). */
+export const MAD_TO_SIGMA = 1.4826;
+
+/**
+ * Below this, the sample is treated as having no measurable spread and z-scores
+ * are refused rather than returned as Infinity. In kPa and °C alike, a MAD-sigma
+ * this small means every observation in the window was effectively identical.
+ */
+const DEGENERATE_SIGMA = 1e-9;
+
+export interface RobustStat {
+  median: number;
+  /** MAD × 1.4826. Zero when the sample has no spread — callers must check. */
+  madSigma: number;
+  sampleCount: number;
+}
+
+/**
+ * Median of a numeric sample. Does not mutate the input.
+ *
+ * @throws RangeError on an empty sample — an empty median is not zero, and
+ *   returning zero here would fabricate a baseline.
+ */
+export function median(values: readonly number[]): number {
+  if (values.length === 0) {
+    throw new RangeError("median() requires at least one value; an empty sample has no median");
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = sorted.length >> 1;
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * Median absolute deviation, scaled to a σ-equivalent.
+ *
+ * Returns 0 for a degenerate sample (all values identical, or a single
+ * observation). That is a real answer — "no observed spread" — and is
+ * deliberately not smoothed into a small positive number, which would
+ * manufacture z-scores out of nothing.
+ */
+export function madSigma(values: readonly number[]): number {
+  if (values.length === 0) {
+    throw new RangeError("madSigma() requires at least one value");
+  }
+  const m = median(values);
+  const deviations = values.map((v) => Math.abs(v - m));
+  return median(deviations) * MAD_TO_SIGMA;
+}
+
+export function robustStat(values: readonly number[]): RobustStat {
+  return {
+    median: median(values),
+    madSigma: madSigma(values),
+    sampleCount: values.length,
+  };
+}
+
+/**
+ * Standardize an observation against a robust baseline.
+ *
+ * Returns `null` — never Infinity or NaN — when the baseline has no measurable
+ * spread. A degenerate window cannot say how unusual today is, and the honest
+ * answer is "unknown", which callers must propagate as an ABSENT basis rather
+ * than treating as zero.
+ *
+ * @param value Today's observation.
+ * @param stat The trailing-window baseline.
+ * @returns Signed z in MAD-sigmas, or null when undefined.
+ */
+export function robustZScore(value: number, stat: RobustStat): number | null {
+  if (!Number.isFinite(value)) return null;
+  if (stat.madSigma <= DEGENERATE_SIGMA) return null;
+  return (value - stat.median) / stat.madSigma;
+}

--- a/src/services/environmentalIngestService.ts
+++ b/src/services/environmentalIngestService.ts
@@ -1,0 +1,297 @@
+/**
+ * Environmental ingestion — the Dual-Baseline Engine's data layer.
+ *
+ * Responsibilities, in the order a location experiences them:
+ *
+ *   1. First sight  → resolve full-DEM elevation, seed the 30-day window from
+ *                     the ERA5 archive, compute a baseline. Valid on day one.
+ *   2. Every day    → sample the live forecast at the geohash's fixed UTC hour.
+ *   3. After each   → recompute the robust median/MAD the anomaly is measured
+ *      sample         against.
+ *   4. Nightly      → prune raw observations past the 90-day retention.
+ *
+ * Raw SQL via `executeQuery`, with every statement built in
+ * `environmentalQueries.ts` so the PREPARE gate can verify exactly what ships.
+ *
+ * @file src/services/environmentalIngestService.ts
+ */
+
+import { executeQuery } from "@/lib/database/connection";
+import {
+  ENVIRONMENT_GEOHASH_PRECISION,
+  decodeGeohashCenter,
+  encodeGeohash,
+  sampleHourForGeohash,
+} from "@/lib/environment/geohash";
+import {
+  ARCHIVE_LAG_DAYS,
+  fetchArchiveSamples,
+  fetchElevation,
+  fetchForecastSamples,
+  reduceToDailyAtHour,
+  type EnvironmentSample,
+} from "@/lib/environment/openMeteoClient";
+import { robustStat } from "@/lib/environment/robustStats";
+import { _logger } from "@/lib/logger";
+import {
+  buildCountObservations,
+  buildInsertObservation,
+  buildPruneObservations,
+  buildSelectBaseline,
+  buildSelectGeohashesDueForSampling,
+  buildSelectWindowObservations,
+  buildSummarizeBaselines,
+  buildUpsertBaseline,
+} from "@/services/environmentalQueries";
+
+/** Trailing window the robust statistics are computed over. */
+export const BASELINE_WINDOW_DAYS = 30;
+
+/** Raw retention. Longer than the window so the statistic stays recomputable. */
+export const OBSERVATION_RETENTION_DAYS = 90;
+
+/**
+ * Below this, MAD is too unstable to standardize against and the engine must
+ * report an ABSENT confidence basis rather than a confident z-score.
+ */
+export const MINIMUM_CREDIBLE_SAMPLE_DAYS = 14;
+
+export interface BaselineRow {
+  geohash5: string;
+  elevationM: number;
+  elevationBasis: string;
+  pressureMedianKpa: number;
+  pressureMadSigmaKpa: number;
+  dewPointMedianC: number;
+  dewPointMadSigmaC: number;
+  sampleDays: number;
+  archiveSeeded: boolean;
+  lastComputedAt: Date;
+}
+
+function toIsoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+async function insertSamples(geohash5: string, samples: readonly EnvironmentSample[]): Promise<number> {
+  const sql = buildInsertObservation();
+  let written = 0;
+  for (const sample of samples) {
+    await executeQuery(sql, [
+      geohash5,
+      sample.observedAt.toISOString(),
+      sample.surfacePressureKpa,
+      sample.dewPointC,
+      sample.airTempC,
+      sample.source,
+    ]);
+    written++;
+  }
+  return written;
+}
+
+/**
+ * Recompute the robust baseline for a geohash from its stored window.
+ *
+ * Returns null when the window is empty — an absent baseline, not a zeroed one.
+ * A fabricated median here would propagate into every anomaly the location ever
+ * reports.
+ */
+export async function recomputeBaseline(
+  geohash5: string,
+  elevationM: number,
+  elevationBasis: string,
+  archiveSeeded: boolean,
+): Promise<BaselineRow | null> {
+  const { rows } = await executeQuery(buildSelectWindowObservations(), [
+    geohash5,
+    BASELINE_WINDOW_DAYS,
+  ]);
+  if (rows.length === 0) return null;
+
+  const pressures = rows.map((r: { surface_pressure_kpa: number }) => Number(r.surface_pressure_kpa));
+  const dewPoints = rows.map((r: { dew_point_c: number }) => Number(r.dew_point_c));
+
+  const pressureStat = robustStat(pressures);
+  const dewPointStat = robustStat(dewPoints);
+
+  // Distinct calendar days, not row count: an archive seed contributes many
+  // hours per day, and counting rows would overstate how much independent
+  // history actually stands behind the statistic.
+  const distinctDays = new Set(
+    rows.map((r: { observed_at: Date | string }) =>
+      new Date(r.observed_at).toISOString().slice(0, 10),
+    ),
+  ).size;
+
+  await executeQuery(buildUpsertBaseline(), [
+    geohash5,
+    elevationM,
+    elevationBasis,
+    pressureStat.median,
+    pressureStat.madSigma,
+    dewPointStat.median,
+    dewPointStat.madSigma,
+    distinctDays,
+    archiveSeeded,
+  ]);
+
+  return {
+    geohash5,
+    elevationM,
+    elevationBasis,
+    pressureMedianKpa: pressureStat.median,
+    pressureMadSigmaKpa: pressureStat.madSigma,
+    dewPointMedianC: dewPointStat.median,
+    dewPointMadSigmaC: dewPointStat.madSigma,
+    sampleDays: distinctDays,
+    archiveSeeded,
+    lastComputedAt: new Date(),
+  };
+}
+
+export async function getBaseline(geohash5: string): Promise<BaselineRow | null> {
+  const { rows } = await executeQuery(buildSelectBaseline(), [geohash5]);
+  if (rows.length === 0) return null;
+  const r = rows[0];
+  return {
+    geohash5: r.geohash5,
+    elevationM: Number(r.elevation_m),
+    elevationBasis: r.elevation_basis,
+    pressureMedianKpa: Number(r.pressure_median_kpa),
+    pressureMadSigmaKpa: Number(r.pressure_mad_sigma_kpa),
+    dewPointMedianC: Number(r.dew_point_median_c),
+    dewPointMadSigmaC: Number(r.dew_point_mad_sigma_c),
+    sampleDays: Number(r.sample_days),
+    archiveSeeded: Boolean(r.archive_seeded),
+    lastComputedAt: new Date(r.last_computed_at),
+  };
+}
+
+/**
+ * Seed a location's window from the ERA5 archive on first sight.
+ *
+ * Idempotent: a geohash that already holds archive rows is left alone, so a
+ * retried cron or a second user in the same cell does not re-fetch.
+ */
+export async function seedFromArchive(
+  latitude: number,
+  longitude: number,
+): Promise<BaselineRow | null> {
+  const geohash5 = encodeGeohash(latitude, longitude, ENVIRONMENT_GEOHASH_PRECISION);
+
+  const { rows: counts } = await executeQuery(buildCountObservations(), [
+    geohash5,
+    BASELINE_WINDOW_DAYS,
+  ]);
+  if (Number(counts[0]?.archive_count ?? 0) > 0) {
+    return getBaseline(geohash5);
+  }
+
+  // Elevation is resolved from the caller's real coordinate, not the geohash
+  // centroid — a ~5 km cell in rugged terrain spans enough elevation to move
+  // the boiling point by more than a degree.
+  const elevationM = await fetchElevation(latitude, longitude);
+
+  // ERA5 lags real time, so the window ends where the archive actually has data.
+  const end = new Date(Date.now() - ARCHIVE_LAG_DAYS * 86_400_000);
+  const start = new Date(end.getTime() - BASELINE_WINDOW_DAYS * 86_400_000);
+
+  const center = decodeGeohashCenter(geohash5);
+  const hourly = await fetchArchiveSamples(
+    center.latitude,
+    center.longitude,
+    elevationM,
+    toIsoDate(start),
+    toIsoDate(end),
+  );
+
+  const daily = reduceToDailyAtHour(hourly, sampleHourForGeohash(geohash5));
+  const written = await insertSamples(geohash5, daily);
+
+  void _logger.info("Seeded environmental baseline from archive", {
+    geohash5,
+    elevationM,
+    daysWritten: written,
+  });
+
+  return recomputeBaseline(geohash5, elevationM, "MEASURED", true);
+}
+
+/** Take today's live sample for one geohash and refresh its baseline. */
+export async function sampleGeohash(
+  geohash5: string,
+  elevationM: number,
+): Promise<{ written: number; baseline: BaselineRow | null }> {
+  const center = decodeGeohashCenter(geohash5);
+  const hourly = await fetchForecastSamples(center.latitude, center.longitude, elevationM);
+  const targetHour = sampleHourForGeohash(geohash5);
+
+  const daily = reduceToDailyAtHour(hourly, targetHour).filter(
+    (sample) => sample.observedAt.getTime() <= Date.now(),
+  );
+
+  const written = await insertSamples(geohash5, daily);
+  const existing = await getBaseline(geohash5);
+  const baseline = await recomputeBaseline(
+    geohash5,
+    elevationM,
+    existing?.elevationBasis ?? "MEASURED",
+    existing?.archiveSeeded ?? false,
+  );
+  return { written, baseline };
+}
+
+/** Geohashes due for sampling at the given UTC hour. */
+export async function getGeohashesDueForSampling(
+  utcHour: number,
+  limit: number,
+): Promise<Array<{ geohash5: string; elevationM: number }>> {
+  const { rows } = await executeQuery(buildSelectGeohashesDueForSampling(), [utcHour, limit]);
+  return rows.map((r: { geohash5: string; elevation_m: number }) => ({
+    geohash5: r.geohash5,
+    elevationM: Number(r.elevation_m),
+  }));
+}
+
+export interface IngestionSummary {
+  geohashCount: number;
+  archiveSeededCount: number;
+  /** Baselines with a full window behind them — the ones whose z-scores are trustworthy. */
+  matureCount: number;
+  minSampleDays: number;
+  maxSampleDays: number;
+  observationCount: number;
+  lastComputedAt: Date | null;
+  /**
+   * False until at least one baseline exists. The admin surface must render
+   * this as an honest "no source yet" rather than a healthy-looking zero.
+   */
+  live: boolean;
+}
+
+/** Fleet-wide ingestion health. Reports what is in the tables, never a shape. */
+export async function summarizeIngestion(): Promise<IngestionSummary> {
+  const { rows } = await executeQuery(buildSummarizeBaselines(), []);
+  const r = rows[0] ?? {};
+  const geohashCount = Number(r.geohash_count ?? 0);
+  return {
+    geohashCount,
+    archiveSeededCount: Number(r.archive_seeded_count ?? 0),
+    matureCount: Number(r.mature_count ?? 0),
+    minSampleDays: Number(r.min_sample_days ?? 0),
+    maxSampleDays: Number(r.max_sample_days ?? 0),
+    observationCount: Number(r.observation_count ?? 0),
+    lastComputedAt: r.last_computed_at ? new Date(r.last_computed_at) : null,
+    live: geohashCount > 0,
+  };
+}
+
+/** Retention sweep. Bounded per invocation; converges across runs. */
+export async function pruneOldObservations(batchLimit = 5_000): Promise<number> {
+  const result = await executeQuery(buildPruneObservations(), [
+    OBSERVATION_RETENTION_DAYS,
+    batchLimit,
+  ]);
+  return result.rowCount ?? 0;
+}

--- a/src/services/environmentalQueries.ts
+++ b/src/services/environmentalQueries.ts
@@ -1,0 +1,241 @@
+/**
+ * SQL builders for the environmental ingestion layer.
+ *
+ * ZERO runtime imports, deliberately. `scripts/checkEnvironmentalSqlParses.ts`
+ * imports this module and PREPAREs every statement it exports against a real
+ * PostgreSQL, so the gate checks exactly what ships and cannot drift from it.
+ * The moment this file imports something with side effects, that gate has to
+ * scrape strings instead — and a regex that stops matching reports "extracted
+ * nothing", not "the SQL changed".
+ *
+ * Every bind parameter carries an explicit cast. A parameter used in two places
+ * with two inferable types cannot be prepared at all (42P08), and that failure
+ * is invisible to any test that mocks the database.
+ *
+ * @file src/services/environmentalQueries.ts
+ */
+
+/**
+ * Idempotent insert of one reading.
+ *
+ * ON CONFLICT DO UPDATE so re-running the cron, or an archive backfill
+ * overlapping live samples, converges instead of throwing. A live 'forecast'
+ * reading is allowed to overwrite an 'archive' one for the same slot: the
+ * live sample is the better measurement of what actually happened.
+ *
+ * Params: $1 geohash5, $2 observed_at, $3 surface_pressure_kpa,
+ *         $4 dew_point_c, $5 air_temp_c, $6 source
+ */
+export function buildInsertObservation(): string {
+  return `
+    INSERT INTO environmental_observations (
+      geohash5, observed_at, surface_pressure_kpa, dew_point_c, air_temp_c, source
+    )
+    VALUES (
+      $1::varchar, $2::timestamptz, $3::numeric, $4::numeric, $5::numeric, $6::varchar
+    )
+    ON CONFLICT (geohash5, observed_at) DO UPDATE SET
+      surface_pressure_kpa = EXCLUDED.surface_pressure_kpa,
+      dew_point_c          = EXCLUDED.dew_point_c,
+      air_temp_c           = EXCLUDED.air_temp_c,
+      source               = EXCLUDED.source
+  `;
+}
+
+/**
+ * The trailing window for one geohash, newest first.
+ *
+ * Returns raw rows rather than aggregating in SQL: median and MAD are computed
+ * in TypeScript because MAD is a median OF deviations FROM a median, which is
+ * two passes Postgres has no single aggregate for. Bounded by the window, so
+ * this is at most ~30 rows.
+ *
+ * Params: $1 geohash5, $2 window_days
+ */
+export function buildSelectWindowObservations(): string {
+  return `
+    SELECT
+      observed_at,
+      surface_pressure_kpa,
+      dew_point_c,
+      air_temp_c,
+      source
+    FROM environmental_observations
+    WHERE geohash5 = $1::varchar
+      AND observed_at >= NOW() - ($2::integer * INTERVAL '1 day')
+    ORDER BY observed_at DESC
+  `;
+}
+
+/**
+ * Write the recomputed baseline.
+ *
+ * `created_at` is preserved on update so a location's first-seen date survives
+ * every recomputation.
+ *
+ * Params: $1 geohash5, $2 elevation_m, $3 elevation_basis,
+ *         $4 pressure_median_kpa, $5 pressure_mad_sigma_kpa,
+ *         $6 dew_point_median_c, $7 dew_point_mad_sigma_c,
+ *         $8 sample_days, $9 archive_seeded
+ */
+export function buildUpsertBaseline(): string {
+  return `
+    INSERT INTO environmental_baselines (
+      geohash5, elevation_m, elevation_basis,
+      pressure_median_kpa, pressure_mad_sigma_kpa,
+      dew_point_median_c, dew_point_mad_sigma_c,
+      sample_days, archive_seeded, last_computed_at
+    )
+    VALUES (
+      $1::varchar, $2::numeric, $3::varchar,
+      $4::numeric, $5::numeric,
+      $6::numeric, $7::numeric,
+      $8::integer, $9::boolean, NOW()
+    )
+    ON CONFLICT (geohash5) DO UPDATE SET
+      elevation_m            = EXCLUDED.elevation_m,
+      elevation_basis        = EXCLUDED.elevation_basis,
+      pressure_median_kpa    = EXCLUDED.pressure_median_kpa,
+      pressure_mad_sigma_kpa = EXCLUDED.pressure_mad_sigma_kpa,
+      dew_point_median_c     = EXCLUDED.dew_point_median_c,
+      dew_point_mad_sigma_c  = EXCLUDED.dew_point_mad_sigma_c,
+      sample_days            = EXCLUDED.sample_days,
+      archive_seeded         = EXCLUDED.archive_seeded,
+      last_computed_at       = NOW()
+  `;
+}
+
+/**
+ * Read one baseline. The request hot path touches this table only.
+ *
+ * Params: $1 geohash5
+ */
+export function buildSelectBaseline(): string {
+  return `
+    SELECT
+      geohash5,
+      elevation_m,
+      elevation_basis,
+      pressure_median_kpa,
+      pressure_mad_sigma_kpa,
+      dew_point_median_c,
+      dew_point_mad_sigma_c,
+      sample_days,
+      archive_seeded,
+      last_computed_at
+    FROM environmental_baselines
+    WHERE geohash5 = $1::varchar
+  `;
+}
+
+/**
+ * Geohashes due for sampling at the given UTC hour.
+ *
+ * Each geohash is sampled once a day at its own derived hour, which keeps the
+ * semidiurnal atmospheric tide out of the window's dispersion and spreads the
+ * fleet's ingestion across the day instead of stampeding one cron minute.
+ *
+ * The NOT EXISTS clause makes the sweep idempotent within the hour: a geohash
+ * already sampled today is skipped, so a retried or double-fired cron does not
+ * double-write.
+ *
+ * Params: $1 sample_hour, $2 limit
+ */
+export function buildSelectGeohashesDueForSampling(): string {
+  return `
+    SELECT b.geohash5, b.elevation_m
+    FROM environmental_baselines b
+    WHERE MOD(
+            ABS(('x' || SUBSTR(MD5(b.geohash5), 1, 8))::bit(32)::bigint),
+            24
+          ) = $1::integer
+      AND NOT EXISTS (
+        SELECT 1
+        FROM environmental_observations o
+        WHERE o.geohash5 = b.geohash5
+          AND o.source = 'forecast'
+          AND o.observed_at >= DATE_TRUNC('day', NOW())
+      )
+    ORDER BY b.last_computed_at ASC
+    LIMIT $2::integer
+  `;
+}
+
+/**
+ * Baselines whose statistics have gone stale relative to their observations.
+ *
+ * Params: $1 max_age_hours, $2 limit
+ */
+export function buildSelectStaleBaselines(): string {
+  return `
+    SELECT geohash5, elevation_m, sample_days
+    FROM environmental_baselines
+    WHERE last_computed_at < NOW() - ($1::integer * INTERVAL '1 hour')
+    ORDER BY last_computed_at ASC
+    LIMIT $2::integer
+  `;
+}
+
+/**
+ * 90-day retention sweep.
+ *
+ * Bounded by $2 so one cron invocation cannot lock the table for an unbounded
+ * span; the sweep converges across runs.
+ *
+ * Params: $1 retention_days, $2 batch_limit
+ */
+export function buildPruneObservations(): string {
+  return `
+    DELETE FROM environmental_observations
+    WHERE ctid IN (
+      SELECT ctid
+      FROM environmental_observations
+      WHERE observed_at < NOW() - ($1::integer * INTERVAL '1 day')
+      LIMIT $2::integer
+    )
+  `;
+}
+
+/**
+ * Fleet-wide summary for the admin surface.
+ *
+ * Reports what is actually in the tables — never a fabricated healthy-looking
+ * shape. An empty fleet returns zeros, which the panel must render as an honest
+ * "no source yet" rather than dressing up as live.
+ *
+ * No parameters.
+ */
+export function buildSummarizeBaselines(): string {
+  return `
+    SELECT
+      COUNT(*)::integer                                              AS geohash_count,
+      COUNT(*) FILTER (WHERE archive_seeded)::integer                AS archive_seeded_count,
+      COUNT(*) FILTER (WHERE sample_days >= 30)::integer             AS mature_count,
+      COALESCE(MIN(sample_days), 0)::integer                         AS min_sample_days,
+      COALESCE(MAX(sample_days), 0)::integer                         AS max_sample_days,
+      MAX(last_computed_at)                                          AS last_computed_at,
+      (SELECT COUNT(*)::integer FROM environmental_observations)     AS observation_count
+    FROM environmental_baselines
+  `;
+}
+
+/**
+ * Whether a geohash has ever been seeded, and how much history it holds.
+ *
+ * Drives the archive-seed decision on first sight. COUNT over a bounded window
+ * with the covering index, so this stays cheap.
+ *
+ * Params: $1 geohash5, $2 window_days
+ */
+export function buildCountObservations(): string {
+  return `
+    SELECT
+      COUNT(*)::integer                                        AS total,
+      COUNT(*) FILTER (WHERE source = 'archive')::integer      AS archive_count,
+      MIN(observed_at)                                         AS earliest,
+      MAX(observed_at)                                         AS latest
+    FROM environmental_observations
+    WHERE geohash5 = $1::varchar
+      AND observed_at >= NOW() - ($2::integer * INTERVAL '1 day')
+  `;
+}

--- a/src/types/environmentalResponseSchema.ts
+++ b/src/types/environmentalResponseSchema.ts
@@ -1,0 +1,540 @@
+import { z } from "zod";
+
+/**
+ * Environmental Thermodynamics — canonical contracts.
+ *
+ * Implements the Dual-Baseline Engine: an elevation-derived *climatic baseline*
+ * (permanent, geographic) plus a *daily anomaly* (transient, weather-driven).
+ * Absolute physics sets the trunk; the anomaly drives the daily advisory.
+ *
+ * Three rules govern every number in this file:
+ *
+ *  1. Every coefficient names its `basis` and a `source` a reader can re-derive it
+ *     from. No value exists because it "felt right".
+ *  2. Physics identities (Boyle, Clausius–Clapeyron) carry `tunable: false`. They are
+ *     not free parameters and must never be fitted.
+ *  3. Advisories are gated on the *computed effect size*, never on the driver
+ *     magnitude. A 1.5 kPa front is a large pressure anomaly and a ~1.5% leavening
+ *     effect; only one of those is worth telling a user about.
+ */
+
+// ============================================================================
+// 1. Canonical method key-space  (Q14A)
+// ============================================================================
+
+/**
+ * The single canonical method key-space. Supersedes four divergent registries:
+ *   - `CookingMethod` union            (src/types/shared.ts — 18 keys, kebab-case, has a
+ *                                       literal "method_name" placeholder)
+ *   - `COOKING_METHOD_PILLAR_MAPPING`  (src/constants/alchemicalPillars.ts — 27 keys)
+ *   - `COOKING_METHOD_KINETIC_PROFILES`(src/utils/cookingMethodKinetics.ts — 28 keys)
+ *   - `METHOD_PHYSICAL_REFERENCE`      (src/data/cooking/physicalReference.ts)
+ *
+ * snake_case throughout. Every registry must be total over this list; the
+ * coverage test is the enforcement point.
+ */
+export const CANONICAL_COOKING_METHODS = [
+  "baking",
+  "boiling",
+  "braising",
+  "broiling",
+  "ceviche",
+  "cryo_cooking",
+  "curing",
+  "dehydrating",
+  "distilling",
+  "emulsification",
+  "fermentation",
+  "foam",
+  "frying",
+  "gelification",
+  "grilling",
+  "infusing",
+  "marinating",
+  "pickling",
+  "poaching",
+  "pressure_cooking",
+  "raw",
+  "roasting",
+  "sauteing",
+  "simmering",
+  "smoking",
+  "sous_vide",
+  "spherification",
+  "steaming",
+  "stewing",
+  "stir_frying",
+  "tilt_skillet",
+] as const;
+
+export const cookingMethodKeySchema = z.enum(CANONICAL_COOKING_METHODS);
+export type CookingMethodKey = z.infer<typeof cookingMethodKeySchema>;
+
+/**
+ * Legacy spellings → canonical key. Read-only migration aid: normalize at the
+ * registry boundary, never persist a legacy key.
+ */
+export const COOKING_METHOD_KEY_ALIASES: Readonly<Record<string, CookingMethodKey>> = {
+  "stir-frying": "stir_frying",
+  "tilt-skillet": "tilt_skillet",
+  fermenting: "fermentation",
+  drying: "dehydrating",
+  sous_vide: "sous_vide",
+  "sous-vide": "sous_vide",
+  "pressure-cooking": "pressure_cooking",
+};
+
+// ============================================================================
+// 2. Value basis  (defensible-values standard)
+// ============================================================================
+
+export const valueBasisSchema = z.enum([
+  /** Read from an instrument or a published measurement. `source` cites it. */
+  "MEASURED",
+  /** Follows from a physical law + stated constants. `source` gives the formula. */
+  "DERIVED",
+  /** Produced by this engine from MEASURED/DERIVED inputs at request time. */
+  "COMPUTED",
+  /** No trustworthy input. The dependent advisory must be suppressed, not defaulted. */
+  "ABSENT",
+]);
+export type ValueBasis = z.infer<typeof valueBasisSchema>;
+
+/**
+ * A physical coefficient with its provenance attached. `source` must be
+ * sufficient to reconstruct `value` without reading this file's git history.
+ */
+export const physicalCoefficientSchema = z.object({
+  value: z.number(),
+  /** Explicit units, e.g. "degC/kPa", "fraction_per_kPa", "fraction_per_degC_dewpoint". */
+  unit: z.string(),
+  basis: valueBasisSchema,
+  source: z.string().describe("Formula with constants, or a literature citation."),
+  /**
+   * false for physics identities that must never be fitted (Boyle's law, the
+   * Clausius–Clapeyron slope). true for empirical culinary coefficients that
+   * may be calibrated against observed outcomes.
+   */
+  tunable: z.boolean(),
+});
+export type PhysicalCoefficient = z.infer<typeof physicalCoefficientSchema>;
+
+// ============================================================================
+// 3. Regimes and response channels  (Q13C, plus the surface/interior split)
+// ============================================================================
+
+export const cookingRegimeSchema = z.enum([
+  /** Temperature ceiling is the medium's boiling point. Pressure is first-order. */
+  "saturation_limited",
+  /** Temperature is set by equipment. Pressure ~0 effect; humidity acts on the surface. */
+  "setpoint_limited",
+  /** Rate is set by vapour-pressure deficit. Humidity is first-order. */
+  "evaporation_limited",
+  /** Target is a solute concentration, read out via boiling point. Both drivers shift the readout. */
+  "concentration_limited",
+  /** Rate/extent is set by gas-phase expansion against ambient pressure. */
+  "leavening_limited",
+  /** No applied heat. Drivers act only through storage and biological rate. */
+  "ambient_limited",
+]);
+export type CookingRegime = z.infer<typeof cookingRegimeSchema>;
+
+/**
+ * Response channels.
+ *
+ * A method is not one number. Humidity moves a roast's surface and its interior
+ * in *opposite* directions: higher ambient moisture slows surface drying (browning
+ * is delayed) while raising the wet-bulb plateau (the interior stalls less). A
+ * single per-method scalar cannot express that, and would silently pick a side.
+ */
+export const responseChannelSchema = z.enum([
+  /** The cooking medium's own state — water's boiling point, oil temp, cavity air. */
+  "medium",
+  /** Crust, browning front, surface dehydration. */
+  "surface",
+  /** Core temperature, time-to-doneness. */
+  "interior",
+  /** Gas-phase expansion — yeast and chemical leaveners. */
+  "leavening",
+  /** Pre-cook hygroscopic state of dry stores (the Pantry Hydration Index). */
+  "ingredient",
+]);
+export type ResponseChannel = z.infer<typeof responseChannelSchema>;
+
+/** The knob a channel turns. One channel writes exactly one axis. */
+export const adjustmentAxisSchema = z.enum([
+  "time_multiplier",
+  "temperature_delta_c",
+  "hydration_multiplier",
+  "expansion_multiplier",
+]);
+export type AdjustmentAxis = z.infer<typeof adjustmentAxisSchema>;
+
+/**
+ * Which humidity clock a channel reads.
+ *
+ * Exposed sugar work equilibrates with room air in minutes; flour in a sealed bin
+ * takes days to weeks. Driving the Pantry Hydration Index off *today's* dew point
+ * would claim an effect that the physical process has not had time to produce.
+ */
+export const humidityClockSchema = z.enum([
+  /** Today's reading. Exposed surfaces, open-air cooking, live cavity air. */
+  "instant",
+  /** Exponentially-weighted trend. Bulk dry stores reaching sorption equilibrium. */
+  "lagged",
+]);
+export type HumidityClock = z.infer<typeof humidityClockSchema>;
+
+// ============================================================================
+// 4. Per-channel response
+// ============================================================================
+
+export const driverResponseSchema = z.object({
+  coefficient: physicalCoefficientSchema,
+  axis: adjustmentAxisSchema,
+  /**
+   * Effect-size floor, in the units of `axis`. Below this the advisory is
+   * suppressed as physically trivial — the gate is on the computed effect, not
+   * on the driver. e.g. 0.03 on `time_multiplier` suppresses anything under 3%.
+   */
+  minimumEffect: z.number().nonnegative(),
+  /**
+   * Statistical floor, in MAD-sigmas. Second half of the dual gate: an advisory
+   * fires only when |z| ≥ minimumZ AND effect ≥ minimumEffect.
+   *
+   * Both are required. Z alone would fire on rare-but-trivial days; effect alone
+   * would ignore that "unusual here" is what makes a daily tip worth reading.
+   */
+  minimumZ: z.number().nonnegative(),
+  /** Hard clamp on |effect|. Prevents extrapolating a local linearization. */
+  maximumEffect: z.number().positive(),
+});
+export type DriverResponse = z.infer<typeof driverResponseSchema>;
+
+export const channelResponseSchema = z.object({
+  channel: responseChannelSchema,
+  regime: cookingRegimeSchema,
+  /**
+   * How much of the *outdoor* anomaly actually reaches this channel, 0–1.
+   *
+   * This is the field that keeps the engine honest. A closed oven's cavity
+   * humidity is dominated by the food's own moisture release and the vent, not
+   * by intake air — coupling ~0.15. An offset smoker breathes ambient air —
+   * ~0.95. A deep fryer's oil does not care about outdoor humidity at all — ~0.05.
+   * Without this term, "crank your oven because it's humid outside" is fabricated.
+   */
+  ambientCoupling: physicalCoefficientSchema,
+  pressure: driverResponseSchema.nullable(),
+  humidity: driverResponseSchema.nullable(),
+  humidityClock: humidityClockSchema,
+  /** Plain-language mechanism. Feeds `causal_chain[].effect`; never invented downstream. */
+  mechanism: z.string(),
+});
+export type ChannelResponse = z.infer<typeof channelResponseSchema>;
+
+// ============================================================================
+// 5. ENVIRONMENTAL_RESPONSE_PROFILE registry  (Q12B)
+// ============================================================================
+
+/**
+ * Joined to `COOKING_METHOD_KINETIC_PROFILES` and `COOKING_METHOD_PILLAR_MAPPING`
+ * at calc time by `CookingMethodKey`. Deliberately not merged into
+ * `CookingMethodData`, which is already ~40 optional fields deep.
+ */
+export const environmentalResponseProfileSchema = z.object({
+  method: cookingMethodKeySchema,
+  /** The regime that governs when no channel qualifies. Drives the score vector. */
+  primaryRegime: cookingRegimeSchema,
+  /**
+   * Ordered, at least one. Bread carries `leavening` + `ingredient` + `surface`;
+   * a roast carries `surface` + `interior` pulling opposite ways.
+   */
+  channels: z.array(channelResponseSchema).min(1),
+  /**
+   * Set when the method supplies its own pressure vessel. Absolute pressure is
+   * ambient + gauge, so altitude propagates *through* the appliance rather than
+   * being cancelled by it: 15 psi gauge in Denver is ~117 °C, not 121 °C.
+   */
+  vesselPressure: z
+    .object({
+      regulation: z.enum([
+        /** Weight/spring valve holds a fixed gauge pressure. Altitude carries through. */
+        "fixed_gauge",
+        /** Electric controller, typically ~10–11.6 psi and often lower than stovetop. */
+        "electronic",
+        /** Sealed but unregulated. */
+        "passive",
+      ]),
+      gaugeKpa: physicalCoefficientSchema,
+      /** Surface a USDA dial-gauge altitude note when canning is implied. */
+      canningAdvisory: z.boolean(),
+    })
+    .nullable(),
+  notes: z.string().optional(),
+});
+export type EnvironmentalResponseProfile = z.infer<typeof environmentalResponseProfileSchema>;
+
+export const environmentalResponseRegistrySchema = z.record(
+  cookingMethodKeySchema,
+  environmentalResponseProfileSchema,
+);
+export type EnvironmentalResponseRegistry = z.infer<typeof environmentalResponseRegistrySchema>;
+
+// ============================================================================
+// 6. Regime kinetics  (Q3C — per-regime activation energies)
+// ============================================================================
+
+/**
+ * ΔT_medium → time multiplier, per regime.
+ *
+ * Stated as activation energy rather than Q10, because Q10 is not a constant:
+ * Q10 = 2 is ~53 kJ/mol at room temperature and ~81 kJ/mol at boiling. Quoting
+ * a bare "Q10 = 2" hides which one you meant. `q10AtReference` is printed for
+ * intuition only and must be recomputed from `activationEnergyKjMol`, never
+ * stored independently of it.
+ */
+export const regimeKineticsSchema = z.object({
+  regime: cookingRegimeSchema,
+  activationEnergyKjMol: physicalCoefficientSchema,
+  /** Kelvin. The temperature the Arrhenius linearization is centred on. */
+  referenceTemperatureK: z.number().positive(),
+  /** Display-only. exp(Ea/R · (1/T − 1/(T+10))) at `referenceTemperatureK`. */
+  q10AtReference: z.number().positive(),
+  /**
+   * Set for regimes carrying a food-safety consequence. Microbial lethality
+   * follows a z-value, not the softening kinetics, and must not be collapsed
+   * into the comfort-time multiplier.
+   */
+  lethalityZValueC: z.number().positive().nullable(),
+});
+export type RegimeKinetics = z.infer<typeof regimeKineticsSchema>;
+
+// ============================================================================
+// 7. Environment reading — the Dual-Baseline state  (Q2B, Q4B, Q9B, Q11C, Q16)
+// ============================================================================
+
+/**
+ * Robust location + dispersion for one driver over the trailing window.
+ *
+ * Median and MAD rather than mean and σ, because the events worth flagging are
+ * precisely the outliers — and a classical σ lets a storm inflate the denominator
+ * that would have detected it, suppressing the next month of alerts.
+ */
+export const robustStatSchema = z.object({
+  median: z.number(),
+  /** MAD × 1.4826 — a σ-equivalent that outliers cannot inflate. Denominator for z. */
+  madSigma: z.number().nonnegative(),
+  unit: z.string(),
+  basis: valueBasisSchema,
+});
+export type RobustStat = z.infer<typeof robustStatSchema>;
+
+export const climaticBaselineSchema = z.object({
+  /** Elevation-derived via the ISA barometric formula. The permanent trunk. */
+  pressureKpa: physicalCoefficientSchema,
+  /** Trailing-30d robust stats. These are the z-score denominators. */
+  surfacePressure: robustStatSchema,
+  dewPoint: robustStatSchema,
+  /**
+   * Days of observation actually behind the stats above. MAD over a handful of
+   * samples is close to meaningless, so this gates the confidence basis.
+   */
+  sampleDays: z.number().int().nonnegative(),
+  /**
+   * Resolved at full DEM fidelity — deliberately NOT the p5 geohash cell centroid.
+   * A ~5 km cell in rugged terrain can span enough elevation to move the boiling
+   * point by more than a degree, and elevation is the dominant term.
+   */
+  elevationM: z.number(),
+  elevationBasis: valueBasisSchema,
+  /** True while the window was seeded from the archive rather than sampled live. */
+  archiveSeeded: z.boolean(),
+});
+
+export const liveReadingSchema = z.object({
+  /**
+   * Station pressure. NEVER `pressure_msl`.
+   *
+   * Sea-level-adjusted pressure has the altitude signal removed by construction:
+   * feed it to a boiling-point solver and Denver returns ~100 °C. Open-Meteo's
+   * `surface_pressure` is correct here; its `pressure_msl` is not.
+   */
+  surfacePressureKpa: physicalCoefficientSchema,
+  dewPointC: physicalCoefficientSchema,
+  /** Lagged dew point for the `ingredient` channel. Null until the EMA has warmed up. */
+  dewPointEmaC: physicalCoefficientSchema.nullable(),
+  /** Time constant behind `dewPointEmaC`, in days. */
+  emaTimeConstantDays: z.number().positive(),
+  outdoorAirTempC: physicalCoefficientSchema,
+  observedAt: z.string().datetime(),
+  /** Age gate. Past the TTL, degrade to climatic baseline and suppress humidity. */
+  stale: z.boolean(),
+});
+
+/**
+ * Indoor state. Dew point transports across the wall largely unchanged; relative
+ * humidity does not (80% RH at 10 °C outdoors is drier air than 40% RH at 22 °C
+ * indoors). So RH is always *recomputed* here from the transported dew point,
+ * never carried in from the API.
+ */
+export const indoorStateSchema = z.object({
+  assumedAirTempC: z.number(),
+  assumedAirTempBasis: valueBasisSchema,
+  /** Magnus–Tetens (Alduchov–Eskridge a=17.625, b=243.04), ±0.4 °C over −45…60 °C. */
+  relativeHumidityPct: physicalCoefficientSchema,
+  /** True once a user profile supplies it (e.g. "no A/C"). */
+  userOverridden: z.boolean(),
+});
+
+/**
+ * The daily anomaly, in both physical and statistical units.
+ *
+ * Physical Δ says how much the cooking changes; z says how unusual today is for
+ * THIS location. Neither substitutes for the other — a −1.8 kPa swing is routine
+ * on the Gulf coast in hurricane season and a 3σ event in Denver, while a 3σ event
+ * in a very calm climate can still be a physically trivial half-percent.
+ */
+export const anomalyVectorSchema = z.object({
+  /** live.surfacePressureKpa − baseline.surfacePressure.median */
+  pressureKpa: z.number(),
+  /** live.dewPointC − baseline.dewPoint.median */
+  dewPointC: z.number(),
+  /** live.dewPointEmaC − baseline.dewPoint.median. Drives the `ingredient` channel. */
+  dewPointLaggedC: z.number().nullable(),
+  /** pressureKpa / baseline.surfacePressure.madSigma */
+  pressureZ: z.number(),
+  /** dewPointC / baseline.dewPoint.madSigma */
+  dewPointZ: z.number(),
+  dewPointLaggedZ: z.number().nullable(),
+});
+export type AnomalyVector = z.infer<typeof anomalyVectorSchema>;
+
+export const environmentReadingSchema = z.object({
+  geohash: z.string(),
+  climaticBaseline: climaticBaselineSchema,
+  live: liveReadingSchema.nullable(),
+  indoor: indoorStateSchema,
+  anomaly: anomalyVectorSchema.nullable(),
+  /**
+   * Q11C. When live data is unavailable the baseline physics stands on its own
+   * and only the humidity-driven advisories go dark.
+   */
+  degradation: z
+    .enum(["none", "live_unavailable", "live_stale", "humidity_unavailable", "no_location"])
+    .default("none"),
+});
+export type EnvironmentReading = z.infer<typeof environmentReadingSchema>;
+
+// ============================================================================
+// 8. Stitch payload  (Q17B + Q18, Q19B, Q20D)
+// ============================================================================
+// snake_case across the service boundary, matching tiltSkilletSchema.
+
+/** One hop of the causal chain. Stitch composes UI from these; it never does physics. */
+export const causalStepSchema = z.object({
+  factor: z.string().describe("e.g. 'surface_pressure', 'indoor_dew_point'"),
+  from: z.number(),
+  to: z.number(),
+  unit: z.string(),
+  /** The mechanism this hop expresses, lifted from `ChannelResponse.mechanism`. */
+  effect: z.string(),
+  /** Signed, in the units of the axis this hop writes. */
+  magnitude: z.number(),
+  axis: adjustmentAxisSchema,
+  channel: responseChannelSchema,
+  basis: valueBasisSchema,
+});
+export type CausalStep = z.infer<typeof causalStepSchema>;
+
+/** Q18: full spectrum, so the UI can isolate the daily delta from the geography. */
+export const mediumStateSchema = z.object({
+  boiling_point_c: z.object({
+    sea_level: z.number(),
+    climatic_baseline: z.number(),
+    today: z.number(),
+    /** today − climatic_baseline. The number the daily tip is actually about. */
+    anomaly_delta: z.number(),
+    /** climatic_baseline − sea_level. The number the geography tip is about. */
+    elevation_delta: z.number(),
+  }),
+  /** Present only when `vesselPressure` is set. Absolute = ambient + gauge. */
+  vessel_absolute_kpa: z.number().nullable(),
+  vessel_boiling_point_c: z.number().nullable(),
+});
+
+export const adjustmentsSchema = z.object({
+  time_multiplier: z.number().nullable(),
+  temperature_delta_c: z.number().nullable(),
+  hydration_multiplier: z.number().nullable(),
+  expansion_multiplier: z.number().nullable(),
+});
+
+/**
+ * Q19B: per-regime, not a scalar. Denver is punishing for beans and unremarkable
+ * for roasting; one number cannot say both.
+ */
+export const regimeScoreVectorSchema = z.record(cookingRegimeSchema, z.number().min(0).max(100));
+
+export const advisoryScoresSchema = z.object({
+  /** Q20D. Against sea-level standard conditions. Educates on geography; stable. */
+  absolute: regimeScoreVectorSchema,
+  /** Q20D. Against this location's own climatic baseline. The daily hook; mean-reverting to ~50. */
+  relative: regimeScoreVectorSchema,
+  composite_absolute: z.number().min(0).max(100),
+  composite_relative: z.number().min(0).max(100),
+});
+
+/**
+ * Backend-composed prose. Kept alongside the structured chain — not instead of it —
+ * and generated *from* the computed magnitudes so the copy cannot drift from the
+ * math. Stitch may render this verbatim or build its own from `causal_chain`.
+ */
+export const narrativeChainSchema = z.object({
+  trigger: z.string(),
+  mechanism: z.string(),
+  action: z.string(),
+});
+
+export const environmentalAdvisoryPayloadSchema = z.object({
+  schema_version: z.literal("1.0.0"),
+  method: cookingMethodKeySchema,
+  regime: cookingRegimeSchema,
+
+  location: z.object({
+    geohash: z.string(),
+    elevation_m: z.number(),
+    elevation_basis: valueBasisSchema,
+  }),
+
+  environmental_factors: z.object({
+    pressure_anomaly_kpa: z.number().nullable(),
+    dew_point_anomaly_c: z.number().nullable(),
+    /** How unusual today is for THIS location, in MAD-sigmas. Drives "rarest in 30 days" copy. */
+    pressure_anomaly_z: z.number().nullable(),
+    dew_point_anomaly_z: z.number().nullable(),
+    surface_pressure_kpa: z.number(),
+    indoor_relative_humidity_pct: z.number().nullable(),
+    observed_at: z.string().datetime().nullable(),
+    /** Days behind the baseline. Stitch should soften its copy when this is low. */
+    baseline_sample_days: z.number().int().nonnegative(),
+  }),
+
+  medium: mediumStateSchema,
+  adjustments: adjustmentsSchema,
+  causal_chain: z.array(causalStepSchema),
+  narrative: narrativeChainSchema.nullable(),
+  scores: advisoryScoresSchema,
+
+  /**
+   * True when every channel's effect fell under `minimumEffect`. The payload is
+   * still complete and still correct — there is simply nothing worth saying today.
+   * Stitch renders a calm state, not an empty one.
+   */
+  advisory_suppressed: z.boolean(),
+  suppression_reason: z.string().nullable(),
+  /** Mirrors `EnvironmentReading.degradation` so the UI can be honest about gaps. */
+  degradation: z.string(),
+  /** Lowest basis across every input feeding `adjustments`. ABSENT ⇒ show nothing. */
+  confidence_basis: valueBasisSchema,
+});
+export type EnvironmentalAdvisoryPayload = z.infer<typeof environmentalAdvisoryPayloadSchema>;

--- a/vercel.json
+++ b/vercel.json
@@ -68,6 +68,10 @@
     {
       "path": "/api/cron/chain-reconcile",
       "schedule": "45 * * * *"
+    },
+    {
+      "path": "/api/cron/environmental-ingest",
+      "schedule": "10 * * * *"
     }
   ],
   "env": {


### PR DESCRIPTION
Step 1 of a 5-step environmental thermodynamics sequence. **Ingestion only** — this starts the 30-day baseline clock. No calc engine, no public API, no UI.

## Why a dual baseline

A single "live weather" input conflates two very different things. Elevation sets a location's permanent pressure baseline; weather only perturbs it.

| | Δ vs sea level |
|---|---|
| Denver, 1609 m | **−17.9 kPa** |
| Hurricane at sea level (950 hPa) | −6.3 kPa |
| Routine daily swing | ~±1.5 kPa |

Geography outweighs even extreme weather ~3:1, and a normal day by an order of magnitude. So anomalies are measured against a **per-geohash climatic baseline**, never a global constant.

## The failure mode this guards hardest against

`[MEASURED 2026-07-30]` Open-Meteo, Denver (39.7392, −104.9903, 1599 m), same timestamp:

```
surface_pressure   840.4 hPa  →  boiling 94.9 °C
pressure_msl      1006.0 hPa  →  boiling 99.8 °C
```

Sea-level-adjusted pressure has the altitude signal removed *by construction*. Ingesting it yields a **4.9 °C error** that looks entirely plausible and is wrong everywhere except the coast. `assertStationPressure` refuses it at the boundary.

The check is **discriminative, not a tolerance band** — a band wide enough to admit a real hurricane is too wide to catch MSLP. It asks "is this closer to sea level than to where elevation says it should be?", and explicitly declines to judge below ~600 m where the two hypotheses are genuinely indistinguishable, rather than inventing a verdict.

## Design notes

- **Archive-seeded** on first sight, so anomalies are valid on day one rather than after a month of accumulation.
- **Geohash p5 (~5 km)** keys the weather cache; finer is false precision against an ~11 km model grid. Elevation is resolved *separately* at full DEM fidelity — a p5 cell in rugged terrain spans more than a degree of boiling point.
- **One sample per geohash per day at its own derived UTC hour.** Fixing the hour keeps the semidiurnal atmospheric tide (~1–2 hPa) out of the window's dispersion instead of inflating MAD and desensitizing every z-score. It also spreads the fleet across the day rather than stampeding one cron minute.
- **Robust statistics** (median + MAD×1.4826), not mean/σ. The outliers are what this engine exists to detect, and a classical σ lets a storm inflate the very denominator that would have caught it.
- **90 days raw** against a 30-day window, so the statistic stays recomputable and auditable. Robust stats cannot be updated incrementally.

Absent values stay absent throughout: empty samples throw rather than returning zero, a degenerate MAD yields a `null` z rather than `Infinity`, and null hours are dropped rather than interpolated.

## Admin seed endpoint

`POST/GET /api/admin/environment/seed`. The hourly cron only samples geohashes that already have a baseline row, and nothing creates that first row until the public API lands in step 5. The baseline window is a wall-clock dependency, so it needs a manual trigger now. Coordinates travel in the POST body and are coarsened to ~5 km before anything is logged or stored. `GET` returns `live: false` on an empty fleet rather than a healthy-looking zero.

## Gates

- **`scripts/checkEnvironmentalSqlParses.ts`** PREPAREs all 9 builders against real PostgreSQL, self-provisioning migration 74 inside a rolled-back transaction. It therefore runs *before* the migration is applied anywhere, and verifies the migration and the queries agree. Three controls guard against a vacuous pass: it proves it can reject a broken statement, every exported builder must be exercised, and the statement count is asserted.
- **24 golden vectors** pin the physics to values outside this repo — the ISA standard atmosphere, published geohash vectors, and the live Denver reading above, including a regression test for the MSLP trap.

Verified against prod: **9/9 prepare, rollback confirmed to have persisted nothing.** Typecheck 0 errors, lint clean, 24/24 tests.

## Not in this PR

Migration 74 is **not applied** anywhere — the gate only ever creates it inside a rolled-back transaction. Applying it is a deploy step.

Also carries the schema contracts (types + 5 worked response profiles) as inert types for step 5; nothing imports them yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)