### PR TITLE
fix(scoring): rank restaurants on thermodynamic state, not a collapsed monica

### DIFF
--- a/src/__tests__/thermodynamicAffinityCalibration.test.ts
+++ b/src/__tests__/thermodynamicAffinityCalibration.test.ts
@@ -1,0 +1,439 @@
+/**
+ * The thermodynamic-affinity calibration is MEASURED, and this is where it is
+ * re-measured.
+ *
+ * `THERMO_AFFINITY_SD` and `THERMO_AFFINITY_D0` are stored as literals in
+ * `@/data/unified/thermodynamicAffinity` because deriving them there would need
+ * `CUISINE_ELEMENTAL_MAP` (a service) and `getAccuratePlanetaryPositions` — a
+ * layering inversion and an import cycle. So the derivation lives here and runs
+ * on every test run. If the cuisine table, the sectarian ESMS, the planet
+ * weights, the sect rule, or the engine change, the calibration moves and THIS
+ * FAILS — which is the point. Without it the constants would be comments
+ * asserting a measurement nobody re-checks.
+ *
+ * ── The population, stated exactly ──────────────────────────────────────────
+ *
+ * Built the way `restaurantDiscoveryService.buildAstrologicalState` builds a
+ * moment, so the calibration reflects production and not a convenient
+ * approximation of it:
+ *   - sect from `isCurrentSkyDiurnal` (real solar altitude at the New York
+ *     observer), NOT a 06:00–18:00 UTC rule;
+ *   - zodiac signs CAPITALIZED before aggregation, because `ZODIAC_ELEMENTS` is
+ *     capitalized and a lowercase key silently falls through to the flat
+ *     0.25/0.25/0.25/0.25 fallback.
+ *
+ * SCALES (`THERMO_AFFINITY_SD`) are measured over all 1490 SAMPLED rows: the 30
+ * cuisine × sect states (exhaustive) pooled with 1460 sky samples. Those 1490
+ * rows hold only 300 DISTINCT states, so the scale is dwell-time weighted by the
+ * grid — deliberately. The scorer always runs at "now", and "now" is uniform in
+ * time, so a time-uniform grid is the production-faithful measure. Deduplicating
+ * to 300 would whiten against a distribution no user experiences (and MEASURED,
+ * it moves SD by +3.2%/+13.1%/−3.6% and inverts 60 of 4200 pair orderings).
+ *
+ * D0 is measured over PRODUCTION-FAITHFUL PAIRS: a cuisine is always scored at
+ * the moment's own sect, so diurnal-cuisine × nocturnal-moment pairs are
+ * unreachable and are excluded. 15 cuisines × 1460 moments = 21900 pairs.
+ */
+import {
+  calculateThermodynamics,
+  calculateKalchm,
+  calculateMonica,
+  MONICA_EQUILIBRIUM,
+} from "@/data/unified/alchemicalCalculations";
+import {
+  THERMO_AFFINITY_AXES,
+  THERMO_AFFINITY_D0,
+  THERMO_AFFINITY_EPOCH,
+  THERMO_AFFINITY_SD,
+  thermoAffinity,
+  thermoStateDistance,
+  type ThermoState,
+} from "@/data/unified/thermodynamicAffinity";
+import { CUISINE_ELEMENTAL_MAP } from "@/services/restaurantScoring";
+import {
+  getAccuratePlanetaryPositions,
+  isCurrentSkyDiurnal,
+} from "@/utils/astrology/positions";
+import {
+  PLANETARY_SECTARIAN_ALCHEMICAL,
+  aggregateEnhancedZodiacElementals,
+  calculateAlchemicalFromPlanets,
+} from "@/utils/planetaryAlchemyMapping";
+
+type Full = ThermoState & { gregsEnergy: number };
+
+// ─── Population construction ────────────────────────────────────────────────
+
+/** Exactly `buildAstrologicalState`'s capitalization. */
+function capitalizeSign(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+}
+
+/** One cuisine's thermodynamic state at a given sect. */
+function cuisineState(
+  cuisine: keyof typeof CUISINE_ELEMENTAL_MAP,
+  diurnal: boolean,
+): Full {
+  const profile = CUISINE_ELEMENTAL_MAP[cuisine];
+  const entry =
+    PLANETARY_SECTARIAN_ALCHEMICAL[
+      profile.planetaryRuler as keyof typeof PLANETARY_SECTARIAN_ALCHEMICAL
+    ];
+  const sect = diurnal ? entry.diurnal : entry.nocturnal;
+  return calculateThermodynamics(
+    {
+      Spirit: sect.Spirit,
+      Essence: sect.Essence,
+      Matter: sect.Matter,
+      Substance: sect.Substance,
+    },
+    {
+      Fire: profile.Fire,
+      Water: profile.Water,
+      Earth: profile.Earth,
+      Air: profile.Air,
+    },
+  ) as Full;
+}
+
+/** The sky on the epoch grid, exactly as the discovery service reads it. */
+function buildMomentPopulation(): Array<{ state: Full; diurnal: boolean }> {
+  const start = Date.parse(THERMO_AFFINITY_EPOCH.startUtc);
+  const stepMs = THERMO_AFFINITY_EPOCH.stepHours * 3600 * 1000;
+  const out: Array<{ state: Full; diurnal: boolean }> = [];
+
+  for (let i = 0; i < THERMO_AFFINITY_EPOCH.samples; i++) {
+    const when = new Date(start + i * stepMs);
+    const positions = getAccuratePlanetaryPositions(when);
+    const signs: Record<string, string> = {};
+    for (const [planet, data] of Object.entries(positions)) {
+      const sign = (data as { sign?: unknown }).sign;
+      if (typeof sign === "string" && sign.length > 0) {
+        signs[planet] = capitalizeSign(sign);
+      }
+    }
+    const diurnal = isCurrentSkyDiurnal(when);
+    out.push({
+      state: calculateThermodynamics(
+        calculateAlchemicalFromPlanets(signs, diurnal),
+        aggregateEnhancedZodiacElementals(signs, diurnal),
+      ) as Full,
+      diurnal,
+    });
+  }
+  return out;
+}
+
+const CUISINES = Object.keys(CUISINE_ELEMENTAL_MAP) as Array<
+  keyof typeof CUISINE_ELEMENTAL_MAP
+>;
+
+const moments = buildMomentPopulation();
+/** Every distinct reachable cuisine state: 15 cuisines × 2 sects. */
+const cuisineStates = CUISINES.flatMap((c) => [
+  cuisineState(c, true),
+  cuisineState(c, false),
+]);
+/** Each distinct reachable state, counted once. */
+const pooled: Full[] = [...cuisineStates, ...moments.map((m) => m.state)];
+
+const asinhRow = (s: ThermoState) => THERMO_AFFINITY_AXES.map((a) => Math.asinh(s[a]));
+
+function derivedSd(): number[] {
+  const rows = pooled.map(asinhRow);
+  return THERMO_AFFINITY_AXES.map((_, j) => {
+    const mean = rows.reduce((acc, r) => acc + r[j], 0) / rows.length;
+    const varr = rows.reduce((acc, r) => acc + (r[j] - mean) ** 2, 0) / rows.length;
+    return Math.sqrt(varr);
+  });
+}
+
+/** Every distance the scorer can actually produce: cuisine at the moment's sect. */
+function reachableDistances(): number[] {
+  const out: number[] = [];
+  for (const m of moments) {
+    for (const c of CUISINES) {
+      out.push(thermoStateDistance(cuisineState(c, m.diurnal), m.state));
+    }
+  }
+  return out.sort((a, b) => a - b);
+}
+
+/** Leading eigenvector of the correlation matrix, by power iteration. */
+function pc1(rows: number[][]): { loadings: number[]; explained: number } {
+  const k = rows[0].length;
+  const mean = Array.from({ length: k }, (_, j) => rows.reduce((a, r) => a + r[j], 0) / rows.length);
+  const sd = Array.from({ length: k }, (_, j) =>
+    Math.sqrt(rows.reduce((a, r) => a + (r[j] - mean[j]) ** 2, 0) / rows.length),
+  );
+  const z = rows.map((r) => r.map((x, j) => (x - mean[j]) / sd[j]));
+  const cov = Array.from({ length: k }, (_, i) =>
+    Array.from({ length: k }, (_, j) => z.reduce((a, r) => a + r[i] * r[j], 0) / z.length),
+  );
+  let v = Array<number>(k).fill(1);
+  for (let it = 0; it < 1000; it++) {
+    const next = cov.map((row) => row.reduce((a, c, j) => a + c * v[j], 0));
+    const norm = Math.hypot(...next);
+    v = next.map((x) => x / norm);
+  }
+  const lambda = v.reduce((a, x, i) => a + x * cov[i].reduce((t, c, j) => t + c * v[j], 0), 0);
+  return { loadings: v.map(Math.abs), explained: lambda / k };
+}
+
+// ─── The calibration ────────────────────────────────────────────────────────
+
+describe("thermodynamic affinity calibration", () => {
+  it("re-derives the population the constants are measured over", () => {
+    expect(cuisineStates).toHaveLength(30);
+    expect(moments).toHaveLength(THERMO_AFFINITY_EPOCH.samples);
+    expect(pooled).toHaveLength(1490);
+    // POSITIVE CONTROL on the sky sampler. If the elementals ever come back flat,
+    // the sign keys stopped resolving and every scale below is measuring the
+    // fallback rather than the sky — which is exactly how a lowercase-sign bug
+    // hid itself during derivation.
+    const distinctReactivity = new Set(moments.map((m) => m.state.reactivity.toFixed(10)));
+    expect(distinctReactivity.size).toBeGreaterThan(100);
+    // Both sects must be represented, or the D0 pairing is only half measured.
+    expect(moments.filter((m) => m.diurnal).length).toBeGreaterThan(100);
+    expect(moments.filter((m) => !m.diurnal).length).toBeGreaterThan(100);
+  });
+
+  // Tolerance note: `toBeCloseTo(x, n)` is an ABSOLUTE bound of 0.5e-n. Pinning at
+  // n=12 would be ~1e-13 relative on SD.reactivity ≈ 3.95 — tighter than this
+  // population is actually stable. `Math.asinh`/`Math.log` are implementation-
+  // defined in ECMAScript, so a V8 update can move a summand by an ULP, and
+  // MEASURED: epoch sample 520 sits 2.474 SECONDS from a sect flip, so a change to
+  // astronomy-engine could flip one of 1460 rows outright. n=6 still catches any
+  // real recalibration by four orders of magnitude — a genuine change to the
+  // cuisine table, the sect rule or the engine moves these by ≥1e-2 (deduplicating
+  // the pool, the nearest plausible mistake, moves SD.entropy by 13%).
+  const CALIBRATION_PRECISION = 6;
+
+  it("re-derives THERMO_AFFINITY_SD", () => {
+    const sd = derivedSd();
+    THERMO_AFFINITY_AXES.forEach((axis, j) => {
+      expect(sd[j]).toBeCloseTo(THERMO_AFFINITY_SD[axis], CALIBRATION_PRECISION);
+    });
+  });
+
+  it("re-derives THERMO_AFFINITY_D0 as the median reachable distance", () => {
+    const d = reachableDistances();
+    expect(d).toHaveLength(CUISINES.length * moments.length);
+    expect(d[Math.floor(0.5 * (d.length - 1))]).toBeCloseTo(
+      THERMO_AFFINITY_D0,
+      CALIBRATION_PRECISION,
+    );
+  });
+
+  it("reports how close the epoch grid sits to a sect flip", () => {
+    // Diagnostic, not decoration. The sect boolean is the one DISCRETE input to
+    // the population, so a sample near a flip is the only way a tiny upstream
+    // change can move the constants discontinuously. If astronomy-engine ever
+    // shifts enough to flip sample 520, THIS test names the cause instead of
+    // leaving an opaque constant mismatch.
+    const start = Date.parse(THERMO_AFFINITY_EPOCH.startUtc);
+    const stepMs = THERMO_AFFINITY_EPOCH.stepHours * 3600 * 1000;
+    let closestMs = Infinity;
+    for (let i = 0; i < THERMO_AFFINITY_EPOCH.samples; i++) {
+      const t = start + i * stepMs;
+      const sect = isCurrentSkyDiurnal(new Date(t));
+      for (const dir of [-1, 1]) {
+        if (isCurrentSkyDiurnal(new Date(t + dir * stepMs)) === sect) continue;
+        let lo = 0;
+        let hi = stepMs;
+        for (let k = 0; k < 45; k++) {
+          const mid = (lo + hi) / 2;
+          if (isCurrentSkyDiurnal(new Date(t + dir * mid)) === sect) lo = mid;
+          else hi = mid;
+        }
+        closestMs = Math.min(closestMs, lo);
+      }
+    }
+    // MEASURED 2.474 s. Pinned loosely: the point is to notice a flip, not the
+    // exact margin. A flip would drive this to ~0 from the other side.
+    expect(closestMs).toBeGreaterThan(0.5 * 1000);
+    expect(closestMs).toBeLessThan(60 * 1000);
+  });
+
+  it("pins how much each axis actually contributes to the reachable distance", () => {
+    // Equal WEIGHTS after whitening is not equal INFLUENCE. Entropy dominates
+    // because cuisine and sky genuinely differ most there. That is a deliberate
+    // property (see the module's "Equal WEIGHTS is not equal INFLUENCE" note), so
+    // it is pinned rather than left to drift silently.
+    const share = THERMO_AFFINITY_AXES.map(() => 0);
+    let total = 0;
+    for (const m of moments) {
+      for (const c of CUISINES) {
+        const cuisine = cuisineState(c, m.diurnal);
+        THERMO_AFFINITY_AXES.forEach((axis, j) => {
+          const term =
+            ((Math.asinh(cuisine[axis]) - Math.asinh(m.state[axis])) /
+              THERMO_AFFINITY_SD[axis]) ** 2;
+          share[j] += term;
+          total += term;
+        });
+      }
+    }
+    const pct = share.map((s) => (100 * s) / total);
+    expect(pct[0]).toBeCloseTo(25.4, 1); // heat
+    expect(pct[1]).toBeCloseTo(65.2, 1); // entropy
+    expect(pct[2]).toBeCloseTo(9.4, 1); // reactivity
+  });
+
+  it("confirms equal weighting IS the first principal component", () => {
+    const { loadings, explained } = pc1(pooled.map(asinhRow));
+    const equal = 1 / Math.sqrt(THERMO_AFFINITY_AXES.length);
+    // Equal weights are DERIVED, not chosen: PC1 loads within 0.02 of 1/sqrt(3)
+    // on every axis. If this drifts, the equal-weight justification is gone and
+    // the metric needs re-arguing, not silently re-tuning.
+    loadings.forEach((l) => expect(Math.abs(l - equal)).toBeLessThan(0.02));
+    expect(explained).toBeGreaterThan(0.9);
+  });
+
+  it("keeps gregsEnergy OUT of the distance, because it is not independent", () => {
+    // The justification for three axes rather than four. Exact, not approximate.
+    const maxResidual = Math.max(
+      ...pooled.map((s) => Math.abs(s.gregsEnergy - (s.heat - s.entropy * s.reactivity))),
+    );
+    expect(maxResidual).toBe(0);
+  });
+
+  it("prefers exponential decay over rational decay, by measurement", () => {
+    const spread = (decay: (d: number) => number) => {
+      const widths = moments
+        .filter((_, i) => i % 37 === 0)
+        .map((m) => {
+          const scores = CUISINES.map((c) =>
+            decay(thermoStateDistance(cuisineState(c, m.diurnal), m.state)),
+          );
+          return Math.max(...scores) - Math.min(...scores);
+        });
+      return widths.reduce((a, x) => a + x, 0) / widths.length;
+    };
+    const exponential = spread((d) => Math.exp(-d / THERMO_AFFINITY_D0));
+    const rational = spread((d) => 1 / (1 + d / THERMO_AFFINITY_D0));
+    expect(exponential).toBeGreaterThan(rational);
+  });
+});
+
+// ─── What the calibration is FOR ────────────────────────────────────────────
+
+describe("thermodynamic affinity restores discriminant signal", () => {
+  it("separates cuisines at every sampled moment", () => {
+    // The defect this replaces: the monica factor produced ONE value for all 15
+    // cuisines, so its 0.20 weight was a constant offset. Any spread beats that,
+    // but pin a real floor so a future change cannot quietly re-flatten it.
+    const widths = moments
+      .filter((_, i) => i % 37 === 0)
+      .map((m) => {
+        const scores = CUISINES.map((c) =>
+          thermoAffinity(cuisineState(c, m.diurnal), m.state),
+        );
+        return Math.max(...scores) - Math.min(...scores);
+      });
+    expect(Math.min(...widths)).toBeGreaterThan(0.1);
+  });
+
+  it("pins the degeneracy that motivated this, so we notice when it is fixed", () => {
+    // Cuisine monica is φ for every cuisine and sect — the reason the old factor
+    // carried no signal. When cuisine ESMS is finally derived the way the
+    // moment's is, this FAILS, and that is the signal to revisit monica's role.
+    const monicas = new Set<number>();
+    for (const c of CUISINES) {
+      for (const diurnal of [true, false]) {
+        const profile = CUISINE_ELEMENTAL_MAP[c];
+        const entry =
+          PLANETARY_SECTARIAN_ALCHEMICAL[
+            profile.planetaryRuler as keyof typeof PLANETARY_SECTARIAN_ALCHEMICAL
+          ];
+        const sect = diurnal ? entry.diurnal : entry.nocturnal;
+        const esms = {
+          Spirit: sect.Spirit,
+          Essence: sect.Essence,
+          Matter: sect.Matter,
+          Substance: sect.Substance,
+        };
+        const t = cuisineState(c, diurnal);
+        monicas.add(calculateMonica(t.gregsEnergy, t.reactivity, calculateKalchm(esms)));
+      }
+    }
+    expect(monicas.size).toBe(1);
+    expect([...monicas][0]).toBe(MONICA_EQUILIBRIUM);
+  });
+
+  it("is degenerate on the whole binary lattice, not merely on sparse vectors", () => {
+    // Why 'give cuisines more ruling planets' is NOT a fix on its own: f(x)=x·ln x
+    // is zero at both 0 and 1, so any {0,1} vector lands on kalchm 1.
+    for (const v of [
+      { Spirit: 1, Essence: 0, Matter: 0, Substance: 0 },
+      { Spirit: 0, Essence: 1, Matter: 1, Substance: 0 },
+      { Spirit: 1, Essence: 1, Matter: 0, Substance: 0 },
+      { Spirit: 1, Essence: 1, Matter: 1, Substance: 1 },
+      { Spirit: 0, Essence: 0, Matter: 0, Substance: 0 },
+    ]) {
+      expect(calculateKalchm(v)).toBe(1);
+    }
+    // POSITIVE CONTROL: it moves the moment values leave the lattice.
+    expect(calculateKalchm({ Spirit: 0.5, Essence: 0, Matter: 0, Substance: 0 })).toBeCloseTo(
+      0.7071067811865476,
+      12,
+    );
+  });
+});
+
+// ─── Metric behaviour ───────────────────────────────────────────────────────
+
+describe("thermoStateDistance / thermoAffinity", () => {
+  const a: ThermoState = { heat: 1.5, entropy: 3, reactivity: 7 };
+  const b: ThermoState = { heat: 0.02, entropy: 0.4, reactivity: 120 };
+
+  it("is zero for identical states and gives affinity exactly 1", () => {
+    expect(thermoStateDistance(a, a)).toBe(0);
+    expect(thermoAffinity(a, a)).toBe(1);
+  });
+
+  it("is symmetric", () => {
+    expect(thermoStateDistance(a, b)).toBe(thermoStateDistance(b, a));
+  });
+
+  it("keeps affinity inside (0, 1]", () => {
+    const far: ThermoState = { heat: 0, entropy: 0, reactivity: 1e12 };
+    const v = thermoAffinity(a, far);
+    expect(v).toBeGreaterThan(0);
+    expect(v).toBeLessThan(1);
+  });
+
+  it("ignores gregsEnergy even when it is supplied", () => {
+    const withG = { ...a, gregsEnergy: -999 } as ThermoState;
+    expect(thermoStateDistance(withG, b)).toBe(thermoStateDistance(a, b));
+  });
+
+  it("THROWS on a non-finite axis rather than inventing a distance", () => {
+    for (const bad of [NaN, Infinity, -Infinity, undefined as unknown as number]) {
+      expect(() => thermoStateDistance({ ...a, reactivity: bad }, b)).toThrow(
+        /axis "reactivity" is not finite/,
+      );
+      expect(() => thermoStateDistance(a, { ...b, heat: bad })).toThrow(
+        /axis "heat" is not finite/,
+      );
+    }
+  });
+
+  it("does not let one axis dominate on raw scale alone", () => {
+    // Whitening check: a 1-SD move on heat and a 1-SD move on reactivity must
+    // contribute equally. Without it, reactivity would outweigh heat ~8:1.
+    const base: ThermoState = { heat: 1, entropy: 1, reactivity: 1 };
+    const heatMoved: ThermoState = {
+      ...base,
+      heat: Math.sinh(Math.asinh(1) + THERMO_AFFINITY_SD.heat),
+    };
+    const reactMoved: ThermoState = {
+      ...base,
+      reactivity: Math.sinh(Math.asinh(1) + THERMO_AFFINITY_SD.reactivity),
+    };
+    expect(thermoStateDistance(base, heatMoved)).toBeCloseTo(
+      thermoStateDistance(base, reactMoved),
+      12,
+    );
+  });
+});

--- a/src/data/unified/thermodynamicAffinity.ts
+++ b/src/data/unified/thermodynamicAffinity.ts
@@ -1,0 +1,240 @@
+/**
+ * Thermodynamic state affinity — how close two alchemical states are.
+ *
+ * ── Why this exists ─────────────────────────────────────────────────────────
+ *
+ * `src/services/restaurantScoring.ts` used to rank cuisines by the distance
+ * between two `monica` constants. That factor carried a 0.20 weight and
+ * MEASURED ZERO discriminating signal, for a structural reason:
+ *
+ *   kalchm = (S^S · E^E) / (M^M · Sub^Sub)
+ *   ln(kalchm) = f(S) + f(E) − f(M) − f(Sub),  where f(x) = x·ln(x), f(0) ≡ 0
+ *
+ * `f(x) = x ln x` is zero at BOTH x = 0 and x = 1, so every ESMS vector on the
+ * binary lattice {0,1}⁴ gives `ln(kalchm) = 0` exactly. Cuisine ESMS came from a
+ * single unweighted entry of `PLANETARY_SECTARIAN_ALCHEMICAL`, which is always a
+ * one-hot unit vector — so `kalchm ≡ 1`, `|ln(kalchm)| < MONICA_LN_EPSILON`, and
+ * `calculateMonica` returned `MONICA_EQUILIBRIUM` (φ) for EVERY cuisine.
+ *
+ * MEASURED: all 30 cuisine × sect combinations produced kalchm 1 and monica
+ * 1.618 — 1 distinct value out of 30.
+ *
+ * Be precise about what that did and did not imply. The old factor was NOT a
+ * fixed number: over the epoch below it took 275 distinct values spanning
+ * 0.106 → 0.579, because `momentMonica` moves with the sky. What it never did was
+ * distinguish CUISINES. MEASURED: at every one of the 1460 sampled moments the
+ * factor's spread across all 15 cuisines was exactly `0.0000000000`. A ranking
+ * signal has to vary across the things being ranked; this one varied only across
+ * time, so its 0.20 weight shifted every restaurant's score together and ordered
+ * nothing. It is not a bug in the physics; the physics is right. The scorer was
+ * reading the one coordinate that collapses.
+ *
+ * Note the degeneracy is NOT about sparsity. `{0,1,1,0}`, `{1,1,1,1}` and
+ * `{1,1,0,0}` all give kalchm 1 as well (MEASURED). Adding ruling planets as raw
+ * unit vectors does not escape it; only NON-INTEGER ESMS does.
+ *
+ * ── What this replaces it with ──────────────────────────────────────────────
+ *
+ * Distance over the thermodynamic state itself, which does vary: across the same
+ * 30 rows `gregsEnergy` takes 24 distinct values and reactivity spans 0.04 → 129.
+ * The signal was always being computed; monica discarded it.
+ *
+ *   d(a, b) = sqrt( (1/3) · Σ_axis ( (asinh(a_axis) − asinh(b_axis)) / SD_axis )² )
+ *   affinity = exp(−d / D0)  ∈ (0, 1]
+ *
+ * ── Three axes, not four ────────────────────────────────────────────────────
+ *
+ * `gregsEnergy` is EXCLUDED because it is not an independent coordinate:
+ * `calculateThermodynamics` defines it as `heat − entropy · reactivity`.
+ * MEASURED: `max |gregsEnergy − (heat − entropy·reactivity)| = 0` — exactly
+ * zero — over the full 1490-row calibration population. Including it alongside
+ * the three quantities it is built from silently double-weights that contrast,
+ * the same defect class as the Earth double-count removed in §18k.
+ *
+ * It remains a first-class output of the engine and a fine display value; it is
+ * only excluded from the DISTANCE.
+ *
+ * ── Why asinh ───────────────────────────────────────────────────────────────
+ *
+ * The axes span six orders of magnitude over the calibration population
+ * (reactivity 4.0e-2 → 5.9e4; heat 2.8e-3 → 3.2; entropy 6.2e-3 → 13.9).
+ * `asinh(x) = ln(x + sqrt(x² + 1))` is defined on all of ℝ including 0 and
+ * negatives, is linear near the origin and logarithmic in the tails, and needs NO
+ * epsilon floor — one less unfounded constant than a guarded `log(x + ε)`.
+ *
+ * ── Why equal weights ───────────────────────────────────────────────────────
+ *
+ * They are DERIVED, not chosen. After whitening, the first principal component of
+ * the calibration population loads
+ *   [0.5840, 0.5775, 0.5705]   vs exactly-equal 1/sqrt(3) = 0.5774
+ * and explains 95.82% of variance. Equal weighting IS the dominant direction of
+ * the data, to within 0.007 on every axis.
+ *
+ * That does NOT make the weighting irrelevant. Collapsing to a single axis
+ * changes the ranking materially and can invert it — Spearman rho against the
+ * three-axis ranking, over 40 real moments:
+ *   entropy only       mean 0.873  min  0.686   <- strongest single axis
+ *   heat only          mean 0.689  min  0.493
+ *   gregsEnergy only   mean 0.371  min −0.300
+ *   reactivity only    mean 0.191  min −0.557
+ * Three axes are load-bearing; the exact weights among multi-axis schemes are
+ * not (equal-3 vs equal-4: mean rho 0.972).
+ *
+ * ── Equal WEIGHTS is not equal INFLUENCE, and that is deliberate ────────────
+ *
+ * Whitening equalises how much each axis VARIES across states. It does not
+ * equalise how much each axis contributes to the distances the scorer actually
+ * computes. MEASURED share of the summed squared reachable distance:
+ *   heat 25.4%   entropy 65.2%   reactivity 9.4%
+ * Entropy dominates because cuisine and sky genuinely differ more on entropy,
+ * relative to how much entropy varies at all, than they do on reactivity.
+ *
+ * That asymmetry was NOT normalised away, and the alternative was tested rather
+ * than dismissed. Whitening by the RMS of the pairwise DIFFERENCES instead forces
+ * the split to exactly 33.3/33.3/33.3 — but it does so by dividing out the very
+ * contrast being measured, it disagrees with this metric's ranking at only
+ * rho 0.864 (min 0.525), and under it PC1 becomes [0.6504, 0.6433, 0.4039], so
+ * equal weighting would no longer be DERIVED from anything. Suppressing the axis
+ * that discriminates in order to make a table look symmetric is the wrong trade.
+ * The 25/65/9 split is pinned by the calibration test so it cannot drift unnoticed.
+ *
+ * `thermodynamicAffinityCalibration.test.ts` re-derives every constant below on
+ * every run. If the cuisine table, the sectarian ESMS, the planet weights or the
+ * engine change, the calibration moves and that test FAILS — which is the point.
+ */
+
+/** The three INDEPENDENT thermodynamic coordinates. See "Three axes" above. */
+export const THERMO_AFFINITY_AXES = ["heat", "entropy", "reactivity"] as const;
+
+export type ThermoAffinityAxis = (typeof THERMO_AFFINITY_AXES)[number];
+
+/** The minimum shape this metric needs — any `ThermodynamicMetrics` satisfies it. */
+export type ThermoState = Record<ThermoAffinityAxis, number>;
+
+/**
+ * The population the calibration below is measured over. Stated as data so the
+ * test can rebuild it exactly rather than re-describing it in prose.
+ *
+ * Two parts, pooled:
+ *   1. Every cuisine × sect in `CUISINE_ELEMENTAL_MAP` (30 states) — exhaustive.
+ *   2. The real sky on a 6-hour grid across the epoch year (1460 states), via
+ *      `getAccuratePlanetaryPositions` → `calculateAlchemicalFromPlanets` +
+ *      `aggregateEnhancedZodiacElementals`, with sect from `isCurrentSkyDiurnal`
+ *      and signs CAPITALIZED — exactly as
+ *      `restaurantDiscoveryService.buildAstrologicalState` does it. Faithfulness
+ *      matters here: `isCurrentSkyDiurnal` is a real solar-altitude test, not a
+ *      06:00–18:00 UTC rule (the epoch splits 750 diurnal / 710 nocturnal), and a
+ *      lowercase sign key falls through to a flat 0.25/0.25/0.25/0.25 elemental
+ *      fallback that would have calibrated the scales against nothing.
+ *
+ * `THERMO_AFFINITY_SD` is measured over all 1490 rows AS SAMPLED — which is
+ * DWELL-TIME WEIGHTED, not one-row-per-distinct-state. MEASURED: those 1490 rows
+ * hold only 300 distinct states (the sky contributes 276 distinct states across
+ * 1460 samples), so states the sky occupies for longer count proportionally more.
+ * That is deliberate: the scale exists to normalise states the scorer actually
+ * meets at runtime, and an even grid over the year is the closest thing to a
+ * traffic model this repo has. Deduplicating would upweight rare configurations
+ * for no stated reason. `THERMO_AFFINITY_D0` is measured over PRODUCTION-FAITHFUL PAIRS
+ * instead: a cuisine is always scored at the moment's own sect, so
+ * diurnal-cuisine × nocturnal-moment pairs are unreachable and excluded
+ * (15 × 1460 = 21900 pairs).
+ *
+ * The epoch is NAMED and FIXED rather than "the current year" so the constants
+ * are reproducible forever. The sky's spread does drift: re-deriving over 2040
+ * gives SD.reactivity 2.683 vs 3.952 here (~32% narrower), while the PC1 loadings
+ * stay put ([0.5829, 0.5749, 0.5742]). So the loadings are pinned tightly and the
+ * scales are pinned to this epoch.
+ */
+export const THERMO_AFFINITY_EPOCH = {
+  /** UTC midnight of the first sample. */
+  startUtc: "2026-01-01T00:00:00.000Z",
+  /** Number of samples: 365 days × 4 per day. */
+  samples: 1460,
+  /** Hours between samples. */
+  stepHours: 6,
+} as const;
+
+/**
+ * Per-axis standard deviation in asinh space, over the pooled calibration
+ * population. BASIS: MEASURED — re-derived by
+ * `thermodynamicAffinityCalibration.test.ts` on every run.
+ *
+ * Whitening is not cosmetic. Unwhitened, reactivity's asinh spread (3.952) would
+ * outweigh heat's (0.485) by 8:1 on scale alone — an unexamined emphasis of
+ * exactly the kind the old `Math.abs(a - b) / 2` divisor smuggled in.
+ */
+export const THERMO_AFFINITY_SD: Readonly<ThermoState> = {
+  heat: 0.4848944178705814,
+  entropy: 0.5710238245845198,
+  reactivity: 3.9518811669576164,
+};
+
+/**
+ * The decay scale, in whitened-distance units. BASIS: MEASURED — the MEDIAN of
+ * all 21900 REACHABLE cuisine↔moment distances (see the epoch note above). Not
+ * chosen; re-derived by the calibration test.
+ *
+ * Distance quantiles for reference: p10 0.195, p25 0.314, MEDIAN 1.667,
+ * p75 2.200, p90 3.107, max 3.889.
+ *
+ * D0 depends on `THERMO_AFFINITY_SD`, so the two must be re-derived together —
+ * the calibration test fails on both if either is edited alone.
+ */
+export const THERMO_AFFINITY_D0 = 1.6671237497708582;
+
+/**
+ * Whitened, asinh-space Euclidean distance between two thermodynamic states.
+ * Zero when identical; unbounded above. Symmetric.
+ *
+ * THROWS on a non-finite axis rather than substituting one. Both arguments come
+ * from `calculateThermodynamics`, which already refuses malformed input — so a
+ * non-finite value here means an upstream invariant broke, and inventing a
+ * distance would hide it. §18k k7.
+ */
+export function thermoStateDistance(a: ThermoState, b: ThermoState): number {
+  let sumSq = 0;
+  for (const axis of THERMO_AFFINITY_AXES) {
+    const av = a[axis];
+    const bv = b[axis];
+    if (!Number.isFinite(av) || !Number.isFinite(bv)) {
+      throw new TypeError(
+        `thermoStateDistance: axis "${axis}" is not finite (a=${String(av)}, b=${String(bv)}). ` +
+          "Both states must come from calculateThermodynamics.",
+      );
+    }
+    const delta = (Math.asinh(av) - Math.asinh(bv)) / THERMO_AFFINITY_SD[axis];
+    sumSq += delta * delta;
+  }
+  return Math.sqrt(sumSq / THERMO_AFFINITY_AXES.length);
+}
+
+/**
+ * Map two thermodynamic states to a compatibility score in (0, 1].
+ * 1.0 when identical, decaying with distance. ABSOLUTE, not set-relative: the
+ * same cuisine at the same moment scores the same regardless of what else is in
+ * the result set, so scores are comparable across searches and cacheable.
+ *
+ * ⚠️ (0, 1] is the range of THIS FUNCTION, not of the serialised
+ * `AlchmScoredRestaurant.thermodynamicAffinity` field. A restaurant that never
+ * got scored — no cosmic state, or `scoreCuisineAgainstMoment` threw — is
+ * annotated with a literal 0 by `restaurantDiscoveryService`, alongside
+ * `alchmScore: 0`. Readers must treat 0 as "unscored", not as "maximally
+ * distant"; `alchmScore > 0` is the existing liveness check the UI already uses.
+ *
+ * Note also that the throw below does NOT surface as a 500. Its only production
+ * caller wraps `scoreCuisineAgainstMoment` in a bare `catch {}` and falls through
+ * to the unscored annotation, so a malformed state costs one restaurant its
+ * score rather than failing the whole search. That predates this metric and is
+ * left as-is deliberately: failing an entire discovery request because one
+ * restaurant has a bad cuisine mapping would be a worse trade.
+ *
+ * Exponential decay was picked over the rational alternative `1/(1 + d/D0)` by
+ * MEASUREMENT, not taste: mean within-moment spread across the 15 cuisines is
+ * 0.581 for `exp(−d/D0)` vs 0.430 for `1/(1 + d/D0)` (40 real moments), and the
+ * worst moment still spreads 0.253. Both beat the 0.000 the monica factor
+ * delivered. The calibration test re-checks that ordering so it cannot silently
+ * invert.
+ */
+export function thermoAffinity(a: ThermoState, b: ThermoState): number {
+  return Math.exp(-thermoStateDistance(a, b) / THERMO_AFFINITY_D0);
+}

--- a/src/services/restaurantDiscoveryService.ts
+++ b/src/services/restaurantDiscoveryService.ts
@@ -909,7 +909,7 @@ interface AnnotateOptions {
     alchmScore?: number;
     elementalMatch?: number;
     planetaryAlignment?: number;
-    monicaCompatibility?: number;
+    thermodynamicAffinity?: number;
   };
 }
 
@@ -941,7 +941,7 @@ function annotateWithPartner(opts: AnnotateOptions): AlchmScoredRestaurant {
     alchmScore: scores.alchmScore ?? 0,
     elementalMatch: scores.elementalMatch ?? 0,
     planetaryAlignment: scores.planetaryAlignment ?? 0,
-    monicaCompatibility: scores.monicaCompatibility ?? 0,
+    thermodynamicAffinity: scores.thermodynamicAffinity ?? 0,
     dominantElement,
     matchReasons: partnerReasons,
     cuisineElement,

--- a/src/services/restaurantScoring.ts
+++ b/src/services/restaurantScoring.ts
@@ -15,7 +15,8 @@
  * elemental match or Monica calculation.
  */
 
-import { performAlchemicalAnalysis } from "@/data/unified/alchemicalCalculations";
+import { calculateThermodynamics } from "@/data/unified/alchemicalCalculations";
+import { thermoAffinity } from "@/data/unified/thermodynamicAffinity";
 import type { ElementalProperties } from "@/types/alchemy";
 import type {
   AstrologicalState,
@@ -71,7 +72,14 @@ const ZODIAC_ELEMENT: Record<string, Element> = {
 export const SCORING_WEIGHTS = {
   elemental: 0.35,
   planetary: 0.25,
-  monica: 0.20,
+  /**
+   * Was `monica`, and RENAMED rather than repurposed: the factor now measures
+   * thermodynamic state distance, not monica distance. Keeping the old key while
+   * changing what it means would leave every reader silently wrong. The 0.20
+   * value is unchanged — this change restores signal to the existing weight, it
+   * does not re-argue the weighting.
+   */
+  thermodynamic: 0.20,
   zodiac: 0.10,
   lunar: 0.10,
 } as const;
@@ -84,13 +92,17 @@ export const SCORING_WEIGHTS = {
  *
  * Reuses existing scoring primitives:
  *   - `calculateElementalMatch`   (cuisineRecommender)
- *   - `performAlchemicalAnalysis` (data/unified/alchemicalCalculations) — real Monica
+ *   - `calculateThermodynamics`   (data/unified/alchemicalCalculations)
+ *   - `thermoAffinity`            (data/unified/thermodynamicAffinity)
  *
  * Cuisine ESMS is derived from the cuisine's planetary ruler via
  * `PLANETARY_SECTARIAN_ALCHEMICAL`, so it represents an authentic
  * planet-derived alchemical profile rather than an elemental approximation.
+ * ⚠️ That profile is a single unweighted UNIT VECTOR, unlike the moment's
+ * mass-weighted multi-body sum. It is why the old monica factor collapsed; see
+ * `thermodynamicAffinity.ts`. Fixing it is a separate, queued data correction.
  *
- * Final score: weighted sum of elemental, planetary, monica, zodiac, lunar.
+ * Final score: weighted sum of elemental, planetary, thermodynamic, zodiac, lunar.
  *
  * Note: requires `astrologicalState.domElements` and `zodiacSign` to be present
  * (the discovery orchestrator's `buildAstrologicalState` always populates them).
@@ -132,23 +144,25 @@ export function scoreCuisineAgainstMoment(
     astrologicalState,
   );
 
-  // ── Factor 3: Monica compatibility ──
-  // Both Monica values come from `performAlchemicalAnalysis` so they
-  // are computed from the authoritative formula:
-  //   Monica = -GregsEnergy / (Reactivity * ln(Kalchm))
+  // ── Factor 3: Thermodynamic state affinity ──
+  // Was a distance between two `monica` constants. That carried MEASURED ZERO
+  // signal: cuisine ESMS is a one-hot unit vector, so kalchm ≡ 1, ln(kalchm) = 0,
+  // and monica was φ for all 30 cuisine × sect rows. The full derivation and the
+  // replacement metric live in `@/data/unified/thermodynamicAffinity`.
+  //
+  // Monica is deliberately NOT computed here any more, not even for display: it
+  // is the same constant for every cuisine, so surfacing it would present a
+  // constant as a per-cuisine measurement. It becomes meaningful again once
+  // cuisine ESMS is derived the way the moment's is (mass-weighted over the
+  // cuisine's ruling planets) — tracked separately.
   const cuisineAlchemical = deriveCuisineAlchemical(
     cuisineProfile.planetaryRuler,
     diurnal,
   );
-  const cuisineMonica = performAlchemicalAnalysis(
-    cuisineAlchemical,
-    cuisineElement,
-  ).monica;
-  const momentMonica = performAlchemicalAnalysis(
-    momentAlchemical,
-    momentElement,
-  ).monica;
-  const monicaCompatibility = normalizeMonicaDistance(cuisineMonica, momentMonica);
+  const thermodynamicAffinity = thermoAffinity(
+    calculateThermodynamics(cuisineAlchemical, cuisineElement),
+    calculateThermodynamics(momentAlchemical, momentElement),
+  );
 
   // ── Factor 4: Zodiac alignment ──
   const zodiacScore = scoreZodiacAlignment(
@@ -163,7 +177,7 @@ export function scoreCuisineAgainstMoment(
   const alchmScore =
     elementalMatch * SCORING_WEIGHTS.elemental +
     planetaryAlignment * SCORING_WEIGHTS.planetary +
-    monicaCompatibility * SCORING_WEIGHTS.monica +
+    thermodynamicAffinity * SCORING_WEIGHTS.thermodynamic +
     zodiacScore * SCORING_WEIGHTS.zodiac +
     lunarScore * SCORING_WEIGHTS.lunar;
 
@@ -175,7 +189,7 @@ export function scoreCuisineAgainstMoment(
     dominantElement,
     elementalMatch,
     planetaryAlignment,
-    monicaCompatibility,
+    thermodynamicAffinity,
     astrologicalState,
   });
 
@@ -184,7 +198,7 @@ export function scoreCuisineAgainstMoment(
     alchmScore: clamp01(alchmScore),
     elementalMatch: clamp01(elementalMatch),
     planetaryAlignment: clamp01(planetaryAlignment),
-    monicaCompatibility: clamp01(monicaCompatibility),
+    thermodynamicAffinity: clamp01(thermodynamicAffinity),
     dominantElement,
     matchReasons,
     cuisineElement,
@@ -293,17 +307,6 @@ function scorePlanetaryAlignment(
 }
 
 /**
- * Map two Monica constants to a 0–1 compatibility score.
- * Smaller absolute distance ⇒ higher compatibility.
- */
-function normalizeMonicaDistance(a: number, b: number): number {
-  if (!Number.isFinite(a) || !Number.isFinite(b)) return 0.5;
-  const distance = Math.abs(a - b);
-  // Empirical scaling: Monica values typically span O(1); 2.0 distance ≈ 0.
-  return clamp01(1 - Math.min(distance / 2, 1));
-}
-
-/**
  * Zodiac alignment: 1.0 when the zodiac's element is the cuisine's dominant
  * element, 0.7 when the cuisine has meaningful presence (≥0.25) of that
  * element, 0.5 otherwise.
@@ -368,7 +371,7 @@ function buildMatchReasons(input: {
   dominantElement: Element;
   elementalMatch: number;
   planetaryAlignment: number;
-  monicaCompatibility: number;
+  thermodynamicAffinity: number;
   astrologicalState: AstrologicalState;
 }): string[] {
   const reasons: string[] = [];
@@ -378,7 +381,7 @@ function buildMatchReasons(input: {
     dominantElement,
     elementalMatch,
     planetaryAlignment,
-    monicaCompatibility,
+    thermodynamicAffinity,
     astrologicalState,
   } = input;
 
@@ -404,8 +407,13 @@ function buildMatchReasons(input: {
     reasons.push(`Elemental harmony with the moment (${Math.round(elementalMatch * 100)}%)`);
   }
 
-  if (monicaCompatibility >= 0.85) {
-    reasons.push("Monica constant optimized for this moment");
+  // 0.85 affinity is d ≤ −D0·ln(0.85) = 0.2709 in whitened units, between p10
+  // (0.195) and p25 (0.314) of the measured reachable distribution — see
+  // `thermodynamicAffinity.ts`. The old copy keyed off a monica score that was
+  // identical for every cuisine at any given moment, so it fired for all fifteen
+  // or none, which is not a per-restaurant reason.
+  if (thermodynamicAffinity >= 0.85) {
+    reasons.push("Thermodynamic state closely matches this moment");
   }
 
   if (reasons.length === 0) {

--- a/src/types/yelp.ts
+++ b/src/types/yelp.ts
@@ -58,7 +58,17 @@ export interface AlchmScoredRestaurant {
   alchmScore: number;
   elementalMatch: number;
   planetaryAlignment: number;
-  monicaCompatibility: number;
+  /**
+   * Closeness of the cuisine's thermodynamic state to the moment's, in (0, 1]
+   * when scored — or exactly `0` when the entry was never scored (no cosmic
+   * state available, or scoring threw). Pair it with `alchmScore > 0` to tell
+   * the two apart; 0 does NOT mean "maximally distant".
+   *
+   * Renamed from `monicaCompatibility`: that field held a distance between two
+   * monica constants, which was MEASURED to be identical for every cuisine at
+   * any given moment. See `@/data/unified/thermodynamicAffinity`.
+   */
+  thermodynamicAffinity: number;
   dominantElement: "Fire" | "Water" | "Earth" | "Air";
   matchReasons: string[];
   cuisineElement: {


### PR DESCRIPTION
## The defect

Best Match gave **0.20 weight** to the distance between two `monica` constants. That factor could not order anything.

Cuisine ESMS is a single one-hot unit vector from `PLANETARY_SECTARIAN_ALCHEMICAL`, so `kalchm === 1` exactly, `|ln(kalchm)|` falls inside `MONICA_LN_EPSILON`, and `calculateMonica` returns φ for **all 30** cuisine × sect rows.

The degeneracy is **not sparsity** — that matters, because it kills the obvious fix. `ln(kalchm) = f(S)+f(E)−f(M)−f(Sub)` with `f(x) = x·ln x`, and `f` is zero at **both** 0 and 1. So every ESMS vector on the binary lattice `{0,1}⁴` lands on `kalchm = 1`:

| ESMS | kalchm |
|---|---|
| `1/0/0/0` | 1 |
| `0/1/1/0` | 1 |
| `1/1/0/0` | 1 |
| `1/1/1/1` | 1 |

Adding ruling planets as raw unit vectors does not escape it. Only non-integer ESMS does.

**A correction to how this was first characterised.** The old factor was not a fixed number — over the epoch it took **275 distinct values spanning 0.106–0.579** as the sky moved. What it never did was distinguish *cuisines*: at every one of 1460 sampled moments its spread across all 15 cuisines was exactly `0.0000000000`. It varied only in time, so its weight moved every restaurant together and ranked nothing. Its `Math.abs(a-b)/2` divisor was justified by a comment claiming *"Monica values typically span O(1)"*; real moment monica is O(1e-3).

## The replacement

Absolute, whitened, asinh-space distance over the three **independent** thermodynamic axes, scored `exp(−d/D₀)`.

`gregsEnergy` is excluded: `calculateThermodynamics` defines it as `heat − entropy·reactivity`, and **max residual = 0 exactly** over all 1490 calibration rows. Weighting it beside its own constituents is the Earth double-count defect in a new place.

`asinh` over a guarded `log`: defined on all of ℝ, linear near zero, logarithmic in the tails, **no ε floor** — one less unfounded constant.

## Every constant is measured and re-derived on each run

| | |
|---|---|
| `SD` | `[0.4848944178705814, 0.5710238245845198, 3.9518811669576164]` |
| `D₀` | `1.6671237497708582` — median of the **21900 reachable** pairs |
| weights | **derived**: 3-axis PC1 loads `[0.5840, 0.5775, 0.5705]` vs `1/√3 = 0.5774`, explaining 95.82% |
| decay | exponential beat rational on measured within-moment spread (0.581 vs 0.430) |

The population is built exactly as `buildAstrologicalState` does it — sect from `isCurrentSkyDiurnal` (a **real solar-altitude test**, not a 06:00–18:00 UTC rule; the epoch splits 750/710) and **capitalized** signs, since a lowercase key silently returns the flat `0.25` elemental fallback and would have calibrated the scales against nothing. D₀ counts only reachable pairs — a cuisine is always scored at the moment's own sect, so half the grid never occurs.

## Equal weights is not equal influence — deliberately

Measured share of reachable squared distance: **heat 25.4% / entropy 65.2% / reactivity 9.4%**. Entropy dominates because cuisine and sky genuinely differ most there.

The alternative was tested, not dismissed. Difference-space whitening forces 33/33/33 — but by dividing out the contrast being measured. It agrees with this ranking at only ρ 0.864 (min 0.525), and under it PC1 becomes `[0.6504, 0.6433, 0.4039]`, so equal weighting would no longer be derived from anything. The split is pinned by test instead.

Single-axis collapse is not safe either (Spearman vs the 3-axis ranking, 40 real moments): entropy 0.873, heat 0.689, gregsEnergy 0.371 (**min −0.300**), reactivity 0.191 (**min −0.557**).

## Live effect

At `2026-07-30T18:00Z`: **15 distinct affinities where there was 1**, spread 0.274, factor contribution 0.053–0.107 instead of a flat value, and the achievable `alchmScore` ceiling rises from ~0.84 to ~0.91.

## Renamed, not repurposed

`SCORING_WEIGHTS.monica` → `.thermodynamic` (0.20 unchanged, set still sums to 1.0) and `AlchmScoredRestaurant.monicaCompatibility` → `.thermodynamicAffinity`. Changing a field's meaning under its old name leaves every reader silently wrong. No UI reads the field — only `alchmScore`.

Monica is **not** surfaced for display either: it is the same constant for every cuisine, so showing it would present a constant as a per-cuisine measurement.

## Checks

`tsc --noEmit` clean · eslint clean · **186/186 suites, 1716 tests** · rebased onto ESMS 2.0 (`0647e6d6`) with the calibration re-deriving identically, which is the proof the constants are independent of it.

## Known and deliberately not fixed here

- `calculateAlchemicalFromPlanets` **ignores its zodiac-sign argument** — 199 distinct skies over 2026 produce **2** distinct moment ESMS (day/night). The elemental channel is healthy (277 distinct), which is what this metric rides.
- Cuisine ESMS should be derived the way the moment's is (mass-weighted over ruling planets). That's what makes monica meaningful again; the calibration test fails when it lands, by design.
- `Indian` and `Korean` are **byte-identical** rows in `CUISINE_ELEMENTAL_MAP`, so they score identically by construction.
- The throw does **not** surface as a 500: the caller's bare `catch {}` degrades one restaurant to unscored. Documented rather than changed — failing a whole search over one bad cuisine mapping would be worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)