### PR TITLE
fix(physics): un-zero the Ascendant vessel, and thread sect through onboarding

### DIFF
--- a/backend/alchm_kitchen/main.py
+++ b/backend/alchm_kitchen/main.py
@@ -365,8 +365,19 @@ async def user_onboarding(
         if not chart_data or "positions" not in chart_data:
              raise HTTPException(status_code=500, detail="Failed to calculate natal chart")
 
-        # Calculate Alchemical Quantities
-        alchemy_stats = calculate_natal_alchemical_quantities(chart_data["positions"])
+        # Calculate Alchemical Quantities.
+        # Sect MUST come from the birth moment: this call previously omitted
+        # is_diurnal, so it defaulted to True and every user onboarded here got a
+        # DAY-chart ESMS regardless of birth time. `is_sect_diurnal` is the same
+        # 06:00-18:00 wall-clock approximation the TS side uses
+        # (isSectDiurnalForBirth), so the two runtimes agree on sect for a birth.
+        birth_moment = datetime(
+            b_date.year, b_date.month, b_date.day, b_time.hour, b_time.minute
+        )
+        alchemy_stats = calculate_natal_alchemical_quantities(
+            chart_data["positions"],
+            is_diurnal=is_sect_diurnal(birth_moment),
+        )
 
         # Return the comprehensive profile
         return {

--- a/backend/tests/test_esms_conformance.py
+++ b/backend/tests/test_esms_conformance.py
@@ -6,9 +6,17 @@ over all 20 golden test charts to verify zero-drift performance using standard u
 """
 
 import json
+import math
 import os
 import unittest
 from backend.utils.natal_alchemy import calculate_natal_alchemical_quantities
+from backend.utils.planetary_alchemy import (
+    ASCENDANT_VESSEL_WEIGHT,
+    get_gravitational_inertia,
+    get_normalized_alchm_weight,
+    _PERIOD_LOG_MIN,
+    _PERIOD_LOG_MAX,
+)
 
 CONF_FILE = os.path.join(
     os.path.dirname(__file__), "..", "..", "docs", "physics", "esms_conformance.json"
@@ -41,6 +49,52 @@ class TestEsmsConformance(unittest.TestCase):
             # Elemental balance sums to 1.0
             elem_sum = sum(res["elemental_balance"].values())
             self.assertAlmostEqual(elem_sum, 1.0, places=3, msg=f"[{chart_id}] Elemental balance sum != 1.0")
+
+    def test_vessel_actually_contributes_no_day_chart_collapse(self):
+        """The grounding vessel must land in every chart.
+
+        REGRESSION: before ASCENDANT_VESSEL_WEIGHT, get_normalized_alchm_weight
+        ("Ascendant") returned exactly 0.0 (the period table's 0.003 entry IS the
+        log-scale minimum), so the vessel was multiplied by zero and 11/20 of
+        these charts — every diurnal one — collapsed to Matter = Substance = 0.
+        The finiteness assertions above passed throughout; only a value
+        assertion can see this defect.
+        """
+        fixture = load_conformance_fixture()
+        for chart in fixture["charts"]:
+            res = calculate_natal_alchemical_quantities(
+                chart["planetary_positions"],
+                is_diurnal=chart.get("is_diurnal", True),
+            )
+            cid = chart["id"]
+            # Vessel components are >= 0.5 and the vessel weight is 1.0, so every
+            # coin must clear this floor no matter the sect.
+            self.assertGreater(res["matter"], 0.0, f"[{cid}] Matter collapsed to 0 — vessel inert")
+            self.assertGreater(res["substance"], 0.0, f"[{cid}] Substance collapsed to 0 — vessel inert")
+
+    def test_ascendant_weight_is_ruled_not_derived(self):
+        """The Ascendant weight is the RULED anchor 1.0, bypassing the period scale."""
+        self.assertEqual(get_normalized_alchm_weight("Ascendant"), ASCENDANT_VESSEL_WEIGHT)
+        self.assertEqual(ASCENDANT_VESSEL_WEIGHT, 1.0)
+        self.assertEqual(get_gravitational_inertia("Ascendant"), 1.0)  # r = 1.0 AU
+        # POSITIVE CONTROL — the trap this ruling dodges is real: feeding the
+        # Ascendant's own period entry (0.003) through the normalizer returns
+        # exactly 0.0, because it is the scale's minimum.
+        raw = (math.log10(0.003) - _PERIOD_LOG_MIN) / (_PERIOD_LOG_MAX - _PERIOD_LOG_MIN)
+        self.assertEqual(raw, 0.0)
+
+    def test_sect_changes_the_result(self):
+        """is_diurnal must matter: the onboarding route used to omit it entirely,
+        silently giving every user a day chart."""
+        fixture = load_conformance_fixture()
+        positions = fixture["charts"][0]["planetary_positions"]
+        day = calculate_natal_alchemical_quantities(positions, is_diurnal=True)
+        night = calculate_natal_alchemical_quantities(positions, is_diurnal=False)
+        self.assertNotEqual(
+            (day["spirit"], day["essence"], day["matter"], day["substance"]),
+            (night["spirit"], night["essence"], night["matter"], night["substance"]),
+            "day and night sect produced identical ESMS — sect is not being applied",
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/utils/planetary_alchemy.py
+++ b/backend/utils/planetary_alchemy.py
@@ -119,8 +119,26 @@ PLANET_MEAN_DISTANCES: Dict[str, float] = {
 _PERIOD_LOG_MIN = math.log10(0.003)    # Ascendant (1 day)
 _PERIOD_LOG_MAX = math.log10(247.94)   # Pluto
 
+# The Ascendant is the "Physical Vessel" grounding anchor, not an orbiting body.
+# RULED weight 1.0 — the SAME special case TypeScript applies on every period-scale
+# path (src/utils/planetaryAlchemyMapping.ts `calculateESMSWithDegrees`:
+# "fixed (+1) to anchor the system"; RealAlchemizeService.ts twice). This port
+# originally DROPPED that special case, and because the period table's 0.003 entry
+# IS the log-scale minimum, the normalizer returned exactly 0.0 for the Ascendant.
+# The vessel — the mechanism that exists to prevent day-chart Matter/Substance
+# collapse — was silently multiplied by zero, and 11/20 golden conformance charts
+# (every diurnal one) collapsed to Matter = Substance = 0 (MEASURED 2026-07-31).
+# Never derive this weight from the period table: an extremum-anchored scale
+# annihilates whatever sits at its extremum.
+ASCENDANT_VESSEL_WEIGHT = 1.0
+
 def get_normalized_alchm_weight(planet: str) -> float:
-    """Computes logarithmic weight [0, 1] based on orbital period."""
+    """Computes logarithmic weight [0, 1] based on orbital period.
+
+    The Ascendant bypasses the period scale entirely — see ASCENDANT_VESSEL_WEIGHT.
+    """
+    if planet == "Ascendant":
+        return ASCENDANT_VESSEL_WEIGHT
     period = PLANET_ALCHM_PERIODS.get(planet, 1.0)
     log_val = math.log10(max(period, 1e-9))
     return (log_val - _PERIOD_LOG_MIN) / (_PERIOD_LOG_MAX - _PERIOD_LOG_MIN)

--- a/src/__tests__/physics/esmsConformance.test.ts
+++ b/src/__tests__/physics/esmsConformance.test.ts
@@ -1,5 +1,7 @@
 import fixture from "../../../docs/physics/esms_conformance.json";
+import { PLANET_WEIGHTS, normalizePlanetWeight } from "@/data/planets";
 import {
+  ASCENDANT_VESSEL_WEIGHT,
   calculatePositionalAscendantVessel,
   getGravitationalInertia,
   getTidalPull,
@@ -73,6 +75,25 @@ describe("ESMS 2.0 Unified Physics Model Conformance Suite", () => {
       const lnArg = (spirit + essence + 0.05) / (matter + substance + 0.05);
       const monica = 1.618 * Math.log(Math.max(lnArg, 1e-6));
       expect(Number.isFinite(monica)).toBe(true);
+
+      // REGRESSION — the vessel must actually LAND. The Python port zeroed the
+      // Ascendant weight (its period entry is that scale's log-minimum) and
+      // every diurnal chart collapsed to Matter = Substance = 0 while all the
+      // finiteness assertions above kept passing. Only a value assertion sees it.
+      expect(matter).toBeGreaterThan(0);
+      expect(substance).toBeGreaterThan(0);
     });
+  });
+
+  it("pins the Ascendant vessel weight to the RULED anchor 1.0 in both runtimes", () => {
+    // test_esms_conformance.py pins the identical value on the Python side.
+    expect(ASCENDANT_VESSEL_WEIGHT).toBe(1.0);
+    expect(getGravitationalInertia("Ascendant")).toBe(1.0); // r = 1.0 AU
+    expect(getTidalPull("Ascendant")).toBe(1.0);
+    // POSITIVE CONTROL — what the accidental `?? 1.0` fallback used to produce:
+    // Earth's relative MASS through the mass normalizer, ≈ 0.3249, not a ruling.
+    expect(PLANET_WEIGHTS["Ascendant" as keyof typeof PLANET_WEIGHTS]).toBeUndefined();
+    expect(normalizePlanetWeight(1.0)).toBeCloseTo(0.3248835368415509, 12);
+    expect(normalizePlanetWeight(1.0)).not.toBe(ASCENDANT_VESSEL_WEIGHT);
   });
 });

--- a/src/utils/planetaryAlchemyMapping.ts
+++ b/src/utils/planetaryAlchemyMapping.ts
@@ -254,12 +254,34 @@ export const PLANET_MEAN_DISTANCES: Record<string, number> = {
 };
 
 /**
+ * The Ascendant is the "Physical Vessel" grounding anchor, not an orbiting body.
+ * RULED weight 1.0 — the same special case every period-scale path in this repo
+ * already applies (`calculateESMSWithDegrees` below: "fixed (+1) to anchor the
+ * system"; RealAlchemizeService.ts twice). The inertia functions here previously
+ * had NO special case, so "Ascendant" fell through `?? 1.0` to Earth's relative
+ * MASS and came out as normalizePlanetWeight(1.0) ≈ 0.3249 — an accident of the
+ * fallback, not a ruling. The Python port was worse: its period scale is
+ * min-anchored AT the Ascendant, so the same lookup returned exactly 0.0 and the
+ * vessel was inert (11/20 golden charts collapsed to Matter = Substance = 0).
+ * Both runtimes now pin THIS constant; `esmsConformance.test.ts` and
+ * `test_esms_conformance.py` each assert it.
+ */
+export const ASCENDANT_VESSEL_WEIGHT = 1.0;
+
+function inertialMass(planet: string): number {
+  if (planet === "Ascendant") return ASCENDANT_VESSEL_WEIGHT;
+  // NOTE: unknown bodies still fall back to Earth's relative mass (1.0). That is
+  // a silent-fabrication hazard kept only because every caller filters to the
+  // known-body set first; tightening it to a throw is out of scope here.
+  return normalizePlanetWeight(PLANET_WEIGHTS[planet] ?? 1.0);
+}
+
+/**
  * Computes true gravitational inertia M / r^2.
  * Uses log-normalized weight for mass M, and geocentric distance r in AU.
  */
 export function getGravitationalInertia(planet: string, distanceAu?: number): number {
-  const relMass = PLANET_WEIGHTS[planet] ?? 1.0;
-  const mass = normalizePlanetWeight(relMass);
+  const mass = inertialMass(planet);
   const r = (distanceAu !== undefined && distanceAu > 0) ? distanceAu : (PLANET_MEAN_DISTANCES[planet] ?? 1.0);
   return mass / (r * r);
 }
@@ -268,8 +290,7 @@ export function getGravitationalInertia(planet: string, distanceAu?: number): nu
  * Computes tidal pull M / r^3.
  */
 export function getTidalPull(planet: string, distanceAu?: number): number {
-  const relMass = PLANET_WEIGHTS[planet] ?? 1.0;
-  const mass = normalizePlanetWeight(relMass);
+  const mass = inertialMass(planet);
   const r = (distanceAu !== undefined && distanceAu > 0) ? distanceAu : (PLANET_MEAN_DISTANCES[planet] ?? 1.0);
   return mass / (r * r * r);
 }


### PR DESCRIPTION
## Two live defects, one root pattern

Both confirmed **running in production** (Railway deployment `c713de76` = commit `0647e6d6`) and measured against the 20-chart golden fixture.

### 1. The grounding vessel was inert in Python

`calculate_positional_ascendant_vessel` exists precisely to prevent day-chart Matter/Substance collapse — and its output is correct (`Matter: 1.0` for Taurus 15°). But it was multiplied by `get_normalized_alchm_weight("Ascendant")`, which returns **exactly 0.0**: the Ascendant's period entry (0.003) *is* the log scale's minimum, so the normalizer annihilates it.

**MEASURED: 11/20 golden charts — every diurnal one — collapsed to Matter = Substance = 0**, with the whole conformance suite green, because it asserted finiteness and never values. Combined with defect 2, every user onboarded through `/onboarding` since the deploy got `matter = substance = 0`.

The ruling already existed in-repo: every TS period-scale path special-cases the Ascendant to the fixed anchor **1.0** (*"Physical Vessel … fixed (+1) to anchor the system"* — `calculateESMSWithDegrees`, `RealAlchemizeService` twice). The Python port dropped the special case. Restored as a named `ASCENDANT_VESSEL_WEIGHT = 1.0` in **both** runtimes — TS's own inertia functions had the sibling accident (`?? 1.0` fell through to Earth's *mass*, ≈ 0.3249 — a fallback artifact, not a ruling).

### 2. `/onboarding` never passed `is_diurnal`

It defaulted to `True`: every user got a day-chart ESMS regardless of birth time. Sect now comes from the birth moment via the existing `is_sect_diurnal` — the same 06:00–18:00 wall-clock approximation TS uses in `isSectDiurnalForBirth`, so the runtimes agree on a birth's sect.

## After the fix

| | before | after |
|---|---|---|
| golden charts with M = Σ = 0 | **11/20** | **0/20** |
| chart_01 day | M=0, Σ=0 | M=0.6, Σ=0.75 |
| sect at onboarding | always day | from birth time |

## Regression tests (both runtimes)

- **The vessel must land**: `matter > 0 && substance > 0` on every golden chart — the value assertion that would have caught this.
- **The weight is ruled, not derived**: pinned to 1.0 in both suites, with a positive control showing the period-scale trap really returns 0.0.
- **Sect must matter**: day vs night ESMS on the same positions must differ.

## The general lesson

An extremum-anchored normalization annihilates whatever sits at its extremum. Python's period scale zeroes the **Ascendant**; the TS mass scale zeroes **Pluto** the same way (`normalizePlanetWeight(0.0022) = 0`). The Pluto zero is **not** fixed here — it belongs to the ruled mass-basis unification (physical mass in both runtimes), tracked separately.

## Checks

`tsc --noEmit` clean · **187/187 TS suites, 1744 tests** · Python conformance 4/4 (local `test_kalchm_parity` can't import — no local pytest, known limitation; CI runs it).

Note for rollout: users onboarded between the `0647e6d6` deploy and this fix carry collapsed `matter=0, substance=0` profiles — they may need a recompute backfill once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)