### PR TITLE
fix(recipe-nft): remove the random potency poisoning contentHash

### DIFF
--- a/src/__tests__/recipeNftDeterminism.test.ts
+++ b/src/__tests__/recipeNftDeterminism.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Determinism guards for the Recipe-NFT fingerprint.
+ *
+ * `src/lib/recipe-nft/fingerprint.ts` documents computeRecipeFingerprint as
+ * "Deterministic for a given recipe + ingredient catalog, so it is safe to hash
+ * into `contentHash`". That claim was FALSE: herb potency was computed with
+ * Math.random() at module load, so the value differed per process and the
+ * contentHash — the mint deduplication key and the on-chain commitment — was
+ * not reproducible from the recipe it described.
+ *
+ * `[MEASURED 2026-07-31]` before the fix, three separate processes:
+ *   basil=6 mint=6 rosemary=5 curry_leaves=4 lemongrass=5 shiso=5
+ *   basil=4 mint=4 rosemary=5 curry_leaves=6 lemongrass=4 shiso=4
+ *   basil=3 mint=5 rosemary=6 curry_leaves=4 lemongrass=4 shiso=5
+ *
+ * The load-bearing tests here spawn a SEPARATE PROCESS and compare. An
+ * in-process test cannot catch this class of defect at all: a module-load
+ * random is computed once per process, so repeated calls within one test run
+ * agree with each other while disagreeing with every other process.
+ *
+ * @file src/__tests__/recipeNftDeterminism.test.ts
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO_ROOT = join(__dirname, "..", "..");
+
+/**
+ * Run a snippet in a fresh process against this repo, returning its stdout.
+ *
+ * The file is written INSIDE the repo so the "@/..." path alias resolves; it is
+ * removed afterwards regardless of outcome.
+ */
+function runInFreshProcess(snippet: string, label: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "nft-determinism-"));
+  const scriptPath = join(REPO_ROOT, `.determinism-${label}-${process.pid}.ts`);
+  try {
+    writeFileSync(scriptPath, snippet, "utf8");
+    return execFileSync("bunx", ["tsx", scriptPath], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 120_000,
+    }).trim();
+  } finally {
+    rmSync(scriptPath, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const POTENCY_SNIPPET = `
+import { herbs } from "@/data/ingredients/herbs";
+const names = ["basil", "mint", "rosemary", "curry_leaves", "lemongrass", "shiso"];
+const out: Record<string, unknown> = {};
+for (const n of names) out[n] = (herbs as Record<string, { potency?: number }>)[n]?.potency ?? null;
+console.log(JSON.stringify(out));
+`;
+
+const FINGERPRINT_SNIPPET = `
+import { computeRecipeFingerprint } from "@/lib/recipe-nft/fingerprint";
+const recipe = {
+  title: "Determinism Probe",
+  yields: 4,
+  // These three are the herbs that ACTUALLY reach the fingerprint through
+  // resolveIngredient. [MEASURED 2026-07-31] on unmodified master they varied
+  // per process — rosemary 3/6/5, curry_leaves 5/4/3, shiso 4/3/5 — while
+  // "basil" and "mint" resolve to fresh_basil / fresh_mint instead and were
+  // never affected. A fixture built from basil and mint passes whether or not
+  // the defect is present, which is how the first draft of this test fooled
+  // its own control.
+  ingredients: [
+    { name: "rosemary", quantity: "1", unit: "tsp" },
+    { name: "curry_leaves", quantity: "2", unit: "tbsp" },
+    { name: "shiso", quantity: "3", unit: "tbsp" },
+  ],
+};
+const fp = computeRecipeFingerprint(recipe as never);
+console.log(JSON.stringify({ totals: fp.totals, aSharp: fp.aSharp }));
+`;
+
+describe("herb potency is stable across processes", () => {
+  it("returns identical potency in two independent processes", () => {
+    const a = runInFreshProcess(POTENCY_SNIPPET, "pot-a");
+    const b = runInFreshProcess(POTENCY_SNIPPET, "pot-b");
+    expect(a).toBe(b);
+  }, 180_000);
+
+  it("keeps basil's authored potency rather than deriving one", () => {
+    // freshHerbs.ts:265 authors `potency: 7`. The index.ts entry shadows that
+    // record, so the authored figure is restored explicitly there.
+    const parsed = JSON.parse(runInFreshProcess(POTENCY_SNIPPET, "pot-c"));
+    expect(parsed.basil).toBe(7);
+  }, 180_000);
+
+  it("leaves unsourced herbs absent rather than inventing a number", () => {
+    // Absent resolves to NEUTRAL_POTENCY at fingerprint.ts, which is an honest
+    // "unknown". Filling these in by hand would fabricate the same values the
+    // random generator did, just more slowly.
+    const parsed = JSON.parse(runInFreshProcess(POTENCY_SNIPPET, "pot-d"));
+    for (const herb of ["mint", "rosemary", "curry_leaves", "lemongrass", "shiso"]) {
+      expect(parsed[herb]).toBeNull();
+    }
+  }, 180_000);
+});
+
+describe("recipe fingerprint is reproducible across processes", () => {
+  it("produces an identical fingerprint in two independent processes", () => {
+    // This is the property fingerprint.ts documents and that contentHash —
+    // the mint dedup key and the on-chain commitment — depends on.
+    const a = runInFreshProcess(FINGERPRINT_SNIPPET, "fp-a");
+    const b = runInFreshProcess(FINGERPRINT_SNIPPET, "fp-b");
+    expect(a).toBe(b);
+  }, 180_000);
+});
+
+describe("no fabricated values remain in the herbs module", () => {
+  it("contains no Math.random call", () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const source: string = require("node:fs").readFileSync(
+      join(REPO_ROOT, "src/data/ingredients/herbs/index.ts"),
+      "utf8",
+    );
+    // Strip line comments before checking: the file documents the removed
+    // Math.random() in prose, and that mention must not trip this guard.
+    const withoutComments = source
+      .split("\n")
+      .filter((line) => !line.trim().startsWith("//"))
+      .join("\n");
+    expect(withoutComments).not.toContain("Math.random");
+  });
+});

--- a/src/data/ingredients/herbs/index.ts
+++ b/src/data/ingredients/herbs/index.ts
@@ -26,54 +26,35 @@ const CUISINE_TYPES = {
   LEBANESE: "lebanese",
 } as const;
 
-// Helper function to generate meaningful herb values
-function generateHerbValues(
-  elementalProps: Record<string, number>,
-): Record<string, number> {
-  // Normalize elements to ensure they sum to 1
-  const totalElements = Object.values(elementalProps).reduce(
-    (sum, val) => sum + val,
-    0,
-  );
-  const normalized = Object.entries(elementalProps).reduce(
-    (acc, [key, val]) => {
-      acc[key] = val / (totalElements || 1);
-      return acc;
-    },
-    {} as Record<string, number>,
-  );
+// ---------------------------------------------------------------------------
+// `generateHerbValues` used to live here. It fabricated five numeric fields
+// with Math.random() at MODULE LOAD, so every process saw different values:
+//
+//   [MEASURED 2026-07-31] three separate processes, same code:
+//     basil=6 mint=6 rosemary=5 curry_leaves=4 lemongrass=5 shiso=5
+//     basil=4 mint=4 rosemary=5 curry_leaves=6 lemongrass=4 shiso=4
+//     basil=3 mint=5 rosemary=6 curry_leaves=4 lemongrass=4 shiso=5
+//
+// One of those fields, `potency`, is load-bearing. It flows through
+// resolveIngredient -> potencyFactor -> ingredient weight -> the recipe
+// fingerprint -> contentHash, which is the Recipe-NFT mint deduplication key
+// AND the on-chain commitment. A per-process hash defeats the "one token per
+// unique recipe content" check at api/recipes/mint/route.ts:78, and commits a
+// hash that cannot be reproduced from the recipe it claims to describe.
+//
+// The other four (`aromatics`, `flavorComplexity`, `preservationFactor`,
+// `infusion_speed`) are removed outright: a repo-wide search found ZERO readers
+// outside src/data/ingredients. `aromatics` additionally collided with the
+// unrelated `aromatics?: string[]` on the recipe types, so shipping a number
+// there was a latent type conflict as well.
+//
+// Potency is now authored or absent. Absent resolves to NEUTRAL_POTENCY (5) at
+// fingerprint.ts, which is an honest "unknown" rather than an invented number —
+// only two herbs in this directory have ever had a sourced potency, and
+// authoring six more would be fabricating the same values by hand.
+// ---------------------------------------------------------------------------
 
-  // Find dominant element
-  const dominant = Object.entries(normalized).sort(
-    ([, a], [, b]) => b - a,
-  )[0][0];
-
-  // Calculate unique values
-  const aromaticStrength = Math.round(
-    normalized["Air"] * 6 + normalized["Fire"] * 4 + Math.random() * 2,
-  );
-  const potency = Math.round(normalized[dominant] * 7 + Math.random() * 3);
-  const flavorComplexity = Math.round(
-    Object.keys(normalized).filter((k) => normalized[k] > 0.15).length * 2 +
-      Math.random() * 3,
-  );
-  const preservationFactor = Math.round(
-    normalized["Earth"] * 5 + normalized["Water"] * 3 + Math.random(),
-  );
-
-  return {
-    aromatics: Math.min(10, Math.max(1, aromaticStrength)),
-    potency: Math.min(10, Math.max(1, potency)),
-    flavorComplexity: Math.min(10, Math.max(1, flavorComplexity)),
-    preservationFactor: Math.min(10, Math.max(1, preservationFactor)),
-    infusion_speed: Math.min(
-      10,
-      Math.max(1, Math.round(10 - preservationFactor + Math.random() * 2)),
-    ),
-  };
-}
-
-// Helper function to standardize ingredient mappings with enhanced values
+// Helper function to standardize ingredient mappings
 function createIngredientMapping(
   id: string,
   properties: Partial<IngredientMapping>,
@@ -87,14 +68,10 @@ function createIngredientMapping(
     Air: 0.45,
   };
 
-  // Generate meaningful numeric values based on elemental properties
-  const herbValues = generateHerbValues(elementalProps);
-
   return {
     name: id,
     elementalProperties: elementalProps,
     category: properties.category || "",
-    ...herbValues,
     ...properties,
   } as IngredientMapping;
 }
@@ -113,6 +90,20 @@ export const herbs: Record<string, IngredientMapping> = fixIngredientMappings({
     elementalProperties: { Air: 0.43, Water: 0.27, Fire: 0.22, Earth: 0.08 },
     qualities: ["aromatic", "sweet", "peppery"],
     category: "culinary_herb",
+    // Restored from this repo's own authored value for basil,
+    // src/data/ingredients/herbs/freshHerbs.ts:265 (`potency: 7 // 1-10 scale`).
+    // This entry shadows that one in the `herbs` spread below, so the authored
+    // figure was already being lost before the random value replaced it.
+    //
+    // Note this does NOT feed the Recipe-NFT fingerprint: [MEASURED 2026-07-31]
+    // resolveIngredient maps the name "basil" to the catalog key `fresh_basil`,
+    // not to this record. It is restored because it is the correct value for
+    // this ingredient, not as part of the contentHash fix.
+    //
+    // The other five herbs built through createIngredientMapping have no sourced
+    // potency anywhere in the repo and are deliberately left absent, resolving
+    // to NEUTRAL_POTENCY rather than to an invented number.
+    potency: 7,
     varieties: {
       sweet_basil: {
         aroma: "clove-like, sweet",

--- a/src/lib/recipe-nft/fingerprint.ts
+++ b/src/lib/recipe-nft/fingerprint.ts
@@ -43,6 +43,26 @@ export const TARGET_ESMS = 20.0;
 
 const NEUTRAL_POTENCY = 5;
 
+/** Authored potency is documented as a 1-10 scale throughout src/data/ingredients. */
+const MIN_POTENCY = 1;
+const MAX_POTENCY = 10;
+
+/**
+ * Resolve a potency to use as a weighting factor.
+ *
+ * Absent, non-finite, or out-of-scale values fall back to NEUTRAL_POTENCY — an
+ * honest "unknown", not a measurement. Previously this was `potency || NEUTRAL`,
+ * which also swallowed a legitimate 0; `??` keeps 0 distinguishable from absent
+ * so the range check can reject it explicitly rather than silently rewriting it.
+ */
+function resolvePotency(potency: number | undefined): number {
+  const value = potency ?? NEUTRAL_POTENCY;
+  if (!Number.isFinite(value) || value < MIN_POTENCY || value > MAX_POTENCY) {
+    return NEUTRAL_POTENCY;
+  }
+  return value;
+}
+
 const DEFAULT_ESMS: CoinAmounts = { spirit: 0.25, essence: 0.3, matter: 0.25, substance: 0.2 };
 
 /** Curated per-unit ESMS + elemental + potency for ingredients absent from the catalog. */
@@ -259,7 +279,7 @@ export function computeRecipeFingerprint(recipe: MintableRecipe): RecipeFingerpr
   const rows = recipe.ingredients.map((ing) => {
     const r = resolveIngredient(ing.name);
     const { grams, estimated } = estimateMass(ing.quantity, ing.unit, ing.household_description);
-    const potencyFactor = clamp((r.potency || NEUTRAL_POTENCY) / NEUTRAL_POTENCY, 0.3, 2.5);
+    const potencyFactor = clamp(resolvePotency(r.potency) / NEUTRAL_POTENCY, 0.3, 2.5);
     const weight = grams * potencyFactor;
     return { ing, r, grams, estimated, potencyFactor, weight };
   });


### PR DESCRIPTION
`herbs/index.ts` computed five numeric fields with `Math.random()` **at module load**, so every process saw different values. One of them, `potency`, is load-bearing.

`[MEASURED 2026-07-31]` unmodified master — the potency that actually reaches `computeRecipeFingerprint`, three separate processes:

```
rosemary      3  6  5
curry_leaves  5  4  3
shiso         4  3  5
```

## The chain

```
herbs/index.ts:55  →  lookupIngredientFull      recipeAlchemicalQuantities.ts:331
  →  resolveIngredient                          fingerprint.ts:172
  →  potencyFactor                              fingerprint.ts:262
  →  ingredient weight                          fingerprint.ts:263
  →  fingerprint totals / aSharp / physics
  →  buildRecipeNftContent                      content.ts:52
  →  contentHash                                content.ts:88
```

`contentHash` is the mint **deduplication key** — `mint/route.ts:78` and `:274` enforce *"one token per unique recipe content"* — **and** the on-chain commitment and URI path (`:138-139`), immutable once minted. A hash that changes per process defeats the dedup and commits a value that cannot be reproduced from the recipe it describes.

It also falsified the docstring at `fingerprint.ts:253`: *"Deterministic for a given recipe + ingredient catalog, so it is safe to hash into `contentHash`."*

## Blast radius — corrected by measurement

**3–4 herbs, not the 6** that use `createIngredientMapping`. `"basil"` and `"mint"` resolve through `resolveIngredient` to catalog keys `fresh_basil` / `fresh_mint`, **not** to these records, and measured stable at 5 across processes. `rosemary`, `curry_leaves` and `shiso` resolve to their own records and did vary.

`[MEASURED 2026-07-31]` **`recipe_nft_mints` has 0 rows** — nothing has been minted from a randomised hash, so there is no on-chain remediation to do.

## The fix

- **Delete `generateHerbValues`.** Potency is now authored or absent; absent resolves to `NEUTRAL_POTENCY` (5), an honest *unknown*. Only two herbs in this directory ever had a sourced potency, so authoring six more by hand would fabricate the same numbers more slowly.
- **`basil` keeps `potency: 7`**, restored from this repo's own authored value at `freshHerbs.ts:265`, which this record shadows. Noted in-code that this does *not* feed the fingerprint.
- **Delete `aromatics` / `flavorComplexity` / `preservationFactor` / `infusion_speed`** — verified zero readers repo-wide outside `src/data/ingredients`. `aromatics` additionally collided with the unrelated `aromatics?: string[]` on the recipe types, so shipping a number there was a latent type conflict too.
- **`fingerprint.ts`**: `r.potency || NEUTRAL_POTENCY` silently swallowed a legitimate `0`. Replaced with `resolvePotency()` using `??` plus an explicit 1–10 range check, so `0` is rejected deliberately rather than rewritten to 5.

## Tests

They **spawn a separate process and compare**. An in-process test cannot catch this defect class at all — a module-load random is computed once per process, so repeated calls within one test run agree with each other while disagreeing with every other process.

Worth flagging: **the first draft of these tests fooled its own control.** The fingerprint fixture was built from `basil` and `mint` — exactly the two herbs that resolve elsewhere and were never affected — so it passed with the defect reintroduced. The fixture now uses `rosemary`, `curry_leaves`, `shiso`.

Control verified both ways: restoring master's `herbs/index.ts` fails **5/5**; the fix passes **5/5**.

Typecheck 0 errors, lint clean, **35/35** across the recipe-nft and ingredient suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)