### PR TITLE
feat(economy): implement the §6 token quantization contract — the mainnet gate

### DIFF
--- a/backend/tests/test_esms_conformance.py
+++ b/backend/tests/test_esms_conformance.py
@@ -9,6 +9,12 @@ import json
 import math
 import os
 import unittest
+from backend.utils.esms_quantization import (
+    ESMS_K_MAX,
+    format_micro_esms,
+    parse_micro_esms,
+    quantize_esms,
+)
 from backend.utils.natal_alchemy import calculate_natal_alchemical_quantities
 from backend.utils.planetary_alchemy import (
     ASCENDANT_VESSEL_WEIGHT,
@@ -147,6 +153,87 @@ class TestEsmsConformance(unittest.TestCase):
         at_perigee = get_gravitational_inertia("Moon", 0.002384073736896684)
         self.assertLess(at_perigee, 0.25)   # ~0.19 * 1.163 — O(weight), not 43,043
         self.assertGreater(at_perigee, get_inertial_mass_weight("Moon"))  # perigee amplifies
+
+    def test_quantized_goldens_byte_identical(self):
+        """§6 mainnet gate: quantize the engine's full-precision K and match the
+        fixture's expected_micro integers EXACTLY. The TS suite asserts the same
+        integers from the TS quantizer — byte-identical across runtimes."""
+        fixture = load_conformance_fixture()
+        for chart in fixture["charts"]:
+            res = calculate_natal_alchemical_quantities(
+                chart["planetary_positions"], is_diurnal=chart.get("is_diurnal", True)
+            )
+            for coin, want in chart["expected_micro"].items():
+                got = quantize_esms(res[coin])
+                self.assertEqual(got, want, f"[{chart['id']}] {coin}: {got} != {want}")
+                self.assertIsInstance(got, int)
+
+    def test_quantization_conservation(self):
+        """§6 rule 4: sum(q(parts)) <= q(whole), MEASURED over the golden set.
+
+        Parts are the raw per-body coin contributions (sect ESMS x inertia, the
+        vessel as its own part) — the same primitives the engine sums — so the
+        whole is exactly the float sum of the parts, no correction terms. Note
+        the mathematical property holds for exact reals; with float sums an
+        adversarial all-integer-micro portfolio could violate it by one ulp, so
+        this is pinned over the REACHABLE parts, not claimed universally.
+        """
+        from backend.utils.planetary_alchemy import (
+            ESMS_PLANETS,
+            PLANETARY_SECTARIAN_ESMS,
+            calculate_positional_ascendant_vessel,
+        )
+        fixture = load_conformance_fixture()
+        checked = 0
+        for chart in fixture["charts"]:
+            positions = chart["planetary_positions"]
+            sect = "diurnal" if chart.get("is_diurnal", True) else "nocturnal"
+            parts = {"Spirit": [], "Essence": [], "Matter": [], "Substance": []}
+            for body, pos in positions.items():
+                clean = body.strip().title()
+                if clean not in ESMS_PLANETS:
+                    continue
+                inertia = get_gravitational_inertia(clean, pos.get("distance"))
+                for coin, val in PLANETARY_SECTARIAN_ESMS[clean][sect].items():
+                    parts[coin].append(val * inertia)
+            asc = positions.get("Ascendant", {"sign": "aries", "degree": 0})
+            vessel = calculate_positional_ascendant_vessel(asc["sign"], asc.get("degree", 0))
+            asc_inertia = get_gravitational_inertia("Ascendant")
+            for coin in parts:
+                parts[coin].append(vessel[coin] * asc_inertia)
+                whole = sum(parts[coin])
+                self.assertLessEqual(
+                    sum(quantize_esms(p) for p in parts[coin]),
+                    quantize_esms(whole),
+                    f"[{chart['id']}] {coin}: parts quantize above the whole",
+                )
+                checked += 1
+        self.assertEqual(checked, 80)
+
+    def test_quantizer_floor_and_guards(self):
+        """Floor never round; malformed input throws instead of minting."""
+        self.assertEqual(quantize_esms(1.9999999), 1_999_999)  # floor, not round
+        self.assertEqual(quantize_esms(0.0), 0)
+        for bad in (float("nan"), float("inf"), -0.001, ESMS_K_MAX + 1):
+            with self.assertRaises(TypeError):
+                quantize_esms(bad)
+
+    def test_no_float_dequantize_and_exact_round_trip(self):
+        """AMENDMENT to §6 rule 5, with its measurement.
+
+        NEGATIVE CONTROL — the drafted float idempotence is impossible with
+        floor: q=249's float representative multiplies back to 248.99…, so
+        floor loses a micro. This is why there is NO float dequantize.
+        """
+        self.assertEqual(math.floor((249 / 1e6) * 1e6), 248)  # the measured trap
+        # The exact decimal path is lossless for every integer.
+        for q in list(range(0, 2000)) + [249, 999_999, 1_000_000, 4_560_831, 10**8]:
+            self.assertEqual(parse_micro_esms(format_micro_esms(q)), q)
+        self.assertEqual(format_micro_esms(249), "0.000249")
+        fixture = load_conformance_fixture()
+        for chart in fixture["charts"]:
+            for q in chart["expected_micro"].values():
+                self.assertEqual(parse_micro_esms(format_micro_esms(q)), q)
 
     def test_sect_changes_the_result(self):
         """is_diurnal must matter: the onboarding route used to omit it entirely,

--- a/backend/utils/esms_quantization.py
+++ b/backend/utils/esms_quantization.py
@@ -1,0 +1,70 @@
+"""
+ESMS token quantization - the RULED §6 contract (mainnet gate).
+
+Mirror of src/lib/economy/esmsQuantization.ts. 1 on-chain unit = 1e-6 K-units
+("micro-ESMS"); on-chain amounts are integers only. quantize_esms is the ONE
+quantization boundary in this runtime, applied once at mint/settlement to the
+FULL-PRECISION float64 K the engine returns.
+
+Floor, never round: a quantizer can only under-credit (the mint-cost-pole rule
+- economic errors favor the ledger). Conservation: sum(q(parts)) <= q(whole).
+
+Cross-runtime determinism: MEASURED - all 80 unrounded K values over the 20
+golden charts are BIT-IDENTICAL across runtimes, so math.floor(k * 1e6) here
+and Math.floor(k * 1e6) in TS agree exactly. The fixture's expected_micro
+integers are the shared witness; both conformance suites assert equality.
+
+AMENDMENT to §6 rule 5 (idempotence), with its measurement: the drafted pin
+quantize(dequantize(q)) == q is UNSATISFIABLE with pure floor - q/1e6 is
+inexact in binary, and when it rounds low the EXACT product with 1e6 is
+already below q, so floor loses a micro. MEASURED: 1.48% of the reachable
+integer range violates it (first violator q=249 -> 248), identically in both
+runtimes. There is therefore NO float dequantize: format_micro_esms renders
+the exact decimal via integer math, parse_micro_esms inverts it exactly, and
+quantized integers never re-enter the quantizer as floats.
+"""
+
+import math
+import re
+
+# RULED §6: 1 K-unit = 1e6 micro-ESMS.
+MICRO_ESMS_PER_K = 1_000_000
+
+# Upper guard for a single coin's K. BASIS: max reachable coin over the golden
+# set is 8.81 (chart_20, all bodies at measured 2026 minimum distances); 100 is
+# over an order of magnitude above any reachable K.
+ESMS_K_MAX = 100
+
+
+def quantize_esms(k: float) -> int:
+    """THE quantization boundary: full-precision K -> integer micro-ESMS, floor.
+
+    Raises on malformed input rather than inventing an amount (§18k k7):
+    non-finite, negative, or beyond ESMS_K_MAX.
+    """
+    if not isinstance(k, (int, float)) or isinstance(k, bool) or not math.isfinite(k):
+        raise TypeError(f"quantize_esms: K must be finite, got {k!r}")
+    if k < 0:
+        raise TypeError(f"quantize_esms: K must be non-negative, got {k!r}")
+    if k > ESMS_K_MAX:
+        raise TypeError(f"quantize_esms: K={k!r} exceeds ESMS_K_MAX={ESMS_K_MAX} - malformed input, not physics")
+    return math.floor(k * MICRO_ESMS_PER_K)
+
+
+def format_micro_esms(q: int) -> str:
+    """Exact decimal rendering of integer micro-ESMS via integer math only."""
+    if not isinstance(q, int) or isinstance(q, bool) or q < 0:
+        raise TypeError(f"format_micro_esms: expected a non-negative integer, got {q!r}")
+    whole, frac = divmod(q, MICRO_ESMS_PER_K)
+    return f"{whole}.{frac:06d}"
+
+
+_MICRO_RE = re.compile(r"^(\d+)\.(\d{6})$")
+
+
+def parse_micro_esms(s: str) -> int:
+    """Exact inverse of format_micro_esms - integer parsing only."""
+    m = _MICRO_RE.match(s if isinstance(s, str) else "")
+    if not m:
+        raise TypeError(f'parse_micro_esms: expected "<int>.<6 digits>", got {s!r}')
+    return int(m.group(1)) * MICRO_ESMS_PER_K + int(m.group(2))

--- a/backend/utils/natal_alchemy.py
+++ b/backend/utils/natal_alchemy.py
@@ -97,11 +97,16 @@ def calculate_natal_alchemical_quantities(
     else:
         elemental_balance = {"Fire": 0.25, "Earth": 0.25, "Air": 0.25, "Water": 0.25}
 
-    # Absolute ESMS scores
-    spirit = round(esms_totals["Spirit"], 4)
-    essence = round(esms_totals["Essence"], 4)
-    matter = round(esms_totals["Matter"], 4)
-    substance = round(esms_totals["Substance"], 4)
+    # Absolute ESMS scores — FULL PRECISION, deliberately un-rounded.
+    # §6 rule 2 of the quantization contract: all upstream math stays float64,
+    # and display roundings MUST NOT feed the quantizer. The old round(..., 4)
+    # here silently pre-quantized every downstream consumer at 1e-4 — including
+    # the mint boundary — and capped cross-runtime parity checks at 5e-4.
+    # Display formatting is the caller's concern.
+    spirit = esms_totals["Spirit"]
+    essence = esms_totals["Essence"]
+    matter = esms_totals["Matter"]
+    substance = esms_totals["Substance"]
 
     # Reactivity: Strictly (Matter + Earth)^2
     earth_val = elemental_balance.get("Earth", 0.25)

--- a/docs/physics/esms_conformance.json
+++ b/docs/physics/esms_conformance.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.1.0",
-  "description": "ESMS 2.0 golden conformance charts under the RULED Lambda tensor diag(Mhat*(rbar/r)^2) \u2014 spec \u00a77 option C. Every planetary position carries a REAL geocentric distance: the per-body 2026 epoch mean by default, with themed charts at measured 2026 minima (perigee/opposition), and chart_20 with ALL bodies at minima as the numeric stress case. The old fixture pinned Moon/Mercury distance at 1.0 \u2014 a sanitized regime production never ran (spec \u00a77). 'expected' blocks are the Python engine's output (calculate_natal_alchemical_quantities) at the chart's stated sect; the TS suite asserts the same values from the TS functions, making this file the cross-runtime parity witness. 'epoch_mean_geocentric_au' and 'mass_weights' pin the source tables in both runtimes.",
+  "version": "2.2.0",
+  "description": "ESMS 2.0 golden conformance charts under the RULED Lambda tensor diag(Mhat*(rbar/r)^2) \u2014 spec \u00a77 option C. Every planetary position carries a REAL geocentric distance: the per-body 2026 epoch mean by default, with themed charts at measured 2026 minima (perigee/opposition), and chart_20 with ALL bodies at minima as the numeric stress case. The old fixture pinned Moon/Mercury distance at 1.0 \u2014 a sanitized regime production never ran (spec \u00a77). 'expected' blocks are the Python engine's output (calculate_natal_alchemical_quantities) at the chart's stated sect; the TS suite asserts the same values from the TS functions, making this file the cross-runtime parity witness. 'epoch_mean_geocentric_au' and 'mass_weights' pin the source tables in both runtimes. v2.2.0: `expected` blocks are FULL-PRECISION float64 (the engine's display rounding was removed per \u00a76 rule 2 \u2014 display must not feed the quantizer); MEASURED bit-identical across runtimes, so both suites assert exact equality. `expected_micro` blocks are the \u00a76 quantized integers floor(K*1e6) \u2014 the byte-identical mainnet gate.",
   "charts": [
     {
       "id": "chart_01_diurnal_standard",
@@ -63,10 +63,16 @@
         }
       },
       "expected": {
-        "spirit": 3.5461,
-        "essence": 2.5386,
+        "spirit": 3.5461423156931646,
+        "essence": 2.5386466622173223,
         "matter": 0.6,
         "substance": 0.75
+      },
+      "expected_micro": {
+        "spirit": 3546142,
+        "essence": 2538646,
+        "matter": 600000,
+        "substance": 750000
       }
     },
     {
@@ -131,9 +137,15 @@
       },
       "expected": {
         "spirit": 1.5,
-        "essence": 1.771,
-        "matter": 2.8697,
-        "substance": 1.2941
+        "essence": 1.7709903949001067,
+        "matter": 2.8697218312199757,
+        "substance": 1.2940767517904042
+      },
+      "expected_micro": {
+        "spirit": 1500000,
+        "essence": 1770990,
+        "matter": 2869721,
+        "substance": 1294076
       }
     },
     {
@@ -173,9 +185,15 @@
       },
       "expected": {
         "spirit": 1.6,
-        "essence": 1.671,
-        "matter": 2.8733,
+        "essence": 1.6709903949001066,
+        "matter": 2.873266673866234,
         "substance": 0.5
+      },
+      "expected_micro": {
+        "spirit": 1600000,
+        "essence": 1670990,
+        "matter": 2873266,
+        "substance": 500000
       }
     },
     {
@@ -209,10 +227,16 @@
         }
       },
       "expected": {
-        "spirit": 2.2612,
-        "essence": 1.1101,
+        "spirit": 2.261210882140804,
+        "essence": 1.1101260556406423,
         "matter": 0.6,
         "substance": 0.75
+      },
+      "expected_micro": {
+        "spirit": 2261210,
+        "essence": 1110126,
+        "matter": 600000,
+        "substance": 750000
       }
     },
     {
@@ -253,8 +277,14 @@
       "expected": {
         "spirit": 1.5,
         "essence": 1.1,
-        "matter": 1.342,
-        "substance": 0.7612
+        "matter": 1.3419813600939976,
+        "substance": 0.7612108821408041
+      },
+      "expected_micro": {
+        "spirit": 1500000,
+        "essence": 1100000,
+        "matter": 1341981,
+        "substance": 761210
       }
     },
     {
@@ -283,10 +313,16 @@
         }
       },
       "expected": {
-        "spirit": 2.6452,
-        "essence": 0.8887,
+        "spirit": 2.645249059410167,
+        "essence": 0.8887471726885867,
         "matter": 0.6,
         "substance": 1.0
+      },
+      "expected_micro": {
+        "spirit": 2645249,
+        "essence": 888747,
+        "matter": 600000,
+        "substance": 1000000
       }
     },
     {
@@ -309,6 +345,12 @@
         "essence": 0.5,
         "matter": 0.6,
         "substance": 0.75
+      },
+      "expected_micro": {
+        "spirit": 2000000,
+        "essence": 500000,
+        "matter": 600000,
+        "substance": 750000
       }
     },
     {
@@ -329,8 +371,14 @@
       "expected": {
         "spirit": 0.5,
         "essence": 0.6,
-        "matter": 1.1904,
+        "matter": 1.190355649255737,
         "substance": 0.75
+      },
+      "expected_micro": {
+        "spirit": 500000,
+        "essence": 600000,
+        "matter": 1190355,
+        "substance": 750000
       }
     },
     {
@@ -352,7 +400,13 @@
         "spirit": 0.6,
         "essence": 1.0,
         "matter": 0.75,
-        "substance": 1.0329
+        "substance": 1.0328658696496
+      },
+      "expected_micro": {
+        "spirit": 600000,
+        "essence": 1000000,
+        "matter": 750000,
+        "substance": 1032865
       }
     },
     {
@@ -376,10 +430,16 @@
         }
       },
       "expected": {
-        "spirit": 2.1139,
+        "spirit": 2.1139410386522535,
         "essence": 0.6,
         "matter": 1.0,
         "substance": 0.75
+      },
+      "expected_micro": {
+        "spirit": 2113941,
+        "essence": 600000,
+        "matter": 1000000,
+        "substance": 750000
       }
     },
     {
@@ -405,8 +465,14 @@
       "expected": {
         "spirit": 0.5,
         "essence": 1.1,
-        "matter": 1.3291,
+        "matter": 1.3291028219443237,
         "substance": 0.5
+      },
+      "expected_micro": {
+        "spirit": 500000,
+        "essence": 1100000,
+        "matter": 1329102,
+        "substance": 500000
       }
     },
     {
@@ -430,10 +496,16 @@
         }
       },
       "expected": {
-        "spirit": 2.421,
+        "spirit": 2.4209903949001066,
         "essence": 0.5,
         "matter": 0.6,
         "substance": 1.0
+      },
+      "expected_micro": {
+        "spirit": 2420990,
+        "essence": 500000,
+        "matter": 600000,
+        "substance": 1000000
       }
     },
     {
@@ -459,8 +531,14 @@
       "expected": {
         "spirit": 0.5,
         "essence": 1.1,
-        "matter": 1.233,
+        "matter": 1.233049993505948,
         "substance": 0.5
+      },
+      "expected_micro": {
+        "spirit": 500000,
+        "essence": 1100000,
+        "matter": 1233049,
+        "substance": 500000
       }
     },
     {
@@ -485,9 +563,15 @@
       },
       "expected": {
         "spirit": 1.5,
-        "essence": 1.0868,
+        "essence": 1.0868290893409467,
         "matter": 1.1,
         "substance": 0.75
+      },
+      "expected_micro": {
+        "spirit": 1500000,
+        "essence": 1086829,
+        "matter": 1100000,
+        "substance": 750000
       }
     },
     {
@@ -513,8 +597,14 @@
       "expected": {
         "spirit": 0.5,
         "essence": 1.0,
-        "matter": 1.0404,
-        "substance": 1.0329
+        "matter": 1.0403556492557369,
+        "substance": 1.0328658696496
+      },
+      "expected_micro": {
+        "spirit": 500000,
+        "essence": 1000000,
+        "matter": 1040355,
+        "substance": 1032865
       }
     },
     {
@@ -539,9 +629,15 @@
       },
       "expected": {
         "spirit": 1.75,
-        "essence": 0.7089,
+        "essence": 0.7089313665880494,
         "matter": 0.5,
         "substance": 1.0
+      },
+      "expected_micro": {
+        "spirit": 1750000,
+        "essence": 708931,
+        "matter": 500000,
+        "substance": 1000000
       }
     },
     {
@@ -575,10 +671,16 @@
         }
       },
       "expected": {
-        "spirit": 2.2612,
-        "essence": 1.0791,
+        "spirit": 2.261210882140804,
+        "essence": 1.0791028219443237,
         "matter": 0.6,
         "substance": 0.75
+      },
+      "expected_micro": {
+        "spirit": 2261210,
+        "essence": 1079102,
+        "matter": 600000,
+        "substance": 750000
       }
     },
     {
@@ -607,10 +709,16 @@
         }
       },
       "expected": {
-        "spirit": 2.671,
-        "essence": 0.7927,
+        "spirit": 2.6709903949001066,
+        "essence": 0.7926943442502112,
         "matter": 0.6,
         "substance": 0.75
+      },
+      "expected_micro": {
+        "spirit": 2670990,
+        "essence": 792694,
+        "matter": 600000,
+        "substance": 750000
       }
     },
     {
@@ -641,8 +749,14 @@
       "expected": {
         "spirit": 0.5,
         "essence": 1.1,
-        "matter": 1.3291,
-        "substance": 1.0329
+        "matter": 1.3291028219443237,
+        "substance": 1.0328658696496
+      },
+      "expected_micro": {
+        "spirit": 500000,
+        "essence": 1100000,
+        "matter": 1329102,
+        "substance": 1032865
       }
     },
     {
@@ -706,10 +820,16 @@
         }
       },
       "expected": {
-        "spirit": 4.5608,
-        "essence": 8.8073,
+        "spirit": 4.560831181041339,
+        "essence": 8.807260963043165,
         "matter": 0.5,
         "substance": 1.0
+      },
+      "expected_micro": {
+        "spirit": 4560831,
+        "essence": 8807260,
+        "matter": 500000,
+        "substance": 1000000
       }
     }
   ],

--- a/src/__tests__/physics/esmsConformance.test.ts
+++ b/src/__tests__/physics/esmsConformance.test.ts
@@ -2,6 +2,12 @@ import * as Astronomy from "astronomy-engine";
 import fixture from "../../../docs/physics/esms_conformance.json";
 import { PLANET_WEIGHTS, normalizePlanetWeight } from "@/data/planets";
 import {
+  ESMS_K_MAX,
+  formatMicroEsms,
+  parseMicroEsms,
+  quantizeEsms,
+} from "@/lib/economy/esmsQuantization";
+import {
   ASCENDANT_VESSEL_WEIGHT,
   calculatePositionalAscendantVessel,
   getGravitationalInertia,
@@ -87,18 +93,53 @@ describe("ESMS 2.0 Unified Physics Model Conformance Suite", () => {
       expect(substance).toBeGreaterThan(0);
 
       // CROSS-RUNTIME PARITY — the fixture's `expected` blocks are the PYTHON
-      // engine's output (calculate_natal_alchemical_quantities, rounded 4dp).
-      // The TS functions must reproduce them; before this, both suites asserted
-      // only finiteness, which is how a 2x mass-basis divergence stayed green.
-      // Tolerance covers Python's 4dp rounding (5e-5) plus float noise; a basis
-      // divergence is O(0.1+) and cannot hide under it.
+      // engine's FULL-PRECISION output (its 4dp display rounding was removed
+      // per §6 rule 2). MEASURED: all 80 values are BIT-IDENTICAL across
+      // runtimes (same summation order, IEEE-754 float64 in both), so this is
+      // EXACT equality, not a tolerance. Before this, both suites asserted only
+      // finiteness — which is how a 2x mass-basis divergence stayed green.
       const expected = (chart as { expected?: Record<string, number> }).expected;
       expect(expected).toBeDefined();
-      expect(spirit).toBeCloseTo(expected!.spirit, 3);
-      expect(essence).toBeCloseTo(expected!.essence, 3);
-      expect(matter).toBeCloseTo(expected!.matter, 3);
-      expect(substance).toBeCloseTo(expected!.substance, 3);
+      expect(spirit).toBe(expected!.spirit);
+      expect(essence).toBe(expected!.essence);
+      expect(matter).toBe(expected!.matter);
+      expect(substance).toBe(expected!.substance);
+
+      // §6 MAINNET GATE — the TS quantizer must reproduce the fixture's
+      // expected_micro integers byte-identically. Python asserts the same
+      // integers from its quantizer.
+      const micro = (chart as { expected_micro?: Record<string, number> }).expected_micro;
+      expect(micro).toBeDefined();
+      expect(quantizeEsms(spirit)).toBe(micro!.spirit);
+      expect(quantizeEsms(essence)).toBe(micro!.essence);
+      expect(quantizeEsms(matter)).toBe(micro!.matter);
+      expect(quantizeEsms(substance)).toBe(micro!.substance);
     });
+  });
+
+  it("quantizer: floor never round, and malformed input throws", () => {
+    expect(quantizeEsms(1.9999999)).toBe(1_999_999); // floor, not round
+    expect(quantizeEsms(0)).toBe(0);
+    for (const bad of [NaN, Infinity, -Infinity, -0.001, ESMS_K_MAX + 1]) {
+      expect(() => quantizeEsms(bad)).toThrow(TypeError);
+    }
+  });
+
+  it("quantizer: no float dequantize — the exact-decimal path is the round trip", () => {
+    // NEGATIVE CONTROL, the measured §6 rule-5 amendment: pure floor cannot
+    // round-trip a float dequantize (q=249's representative multiplies back to
+    // 248.99…), so dequantized floats must never re-enter the quantizer.
+    expect(Math.floor((249 / 1e6) * 1e6)).toBe(248);
+    // The integer-math decimal path is lossless for every integer.
+    expect(formatMicroEsms(249)).toBe("0.000249");
+    for (let q = 0; q < 2000; q++) {
+      expect(parseMicroEsms(formatMicroEsms(q))).toBe(q);
+    }
+    for (const chart of fixture.charts as Array<{ expected_micro?: Record<string, number> }>) {
+      for (const q of Object.values(chart.expected_micro ?? {})) {
+        expect(parseMicroEsms(formatMicroEsms(q))).toBe(q);
+      }
+    }
   });
 
   it("pins the source tables to the fixture — the shared parity witness", () => {

--- a/src/lib/economy/esmsQuantization.ts
+++ b/src/lib/economy/esmsQuantization.ts
@@ -1,0 +1,106 @@
+/**
+ * ESMS token quantization — the RULED §6 contract (mainnet gate).
+ *
+ * 1 on-chain unit = 10⁻⁶ K-units ("micro-ESMS"). On-chain amounts are integers
+ * only. `quantizeEsms` is the ONE quantization boundary per runtime — it is
+ * applied once, at mint/settlement, to the FULL-PRECISION float64 K the engine
+ * returns. Display roundings must never feed it (natal_alchemy's old
+ * `round(…, 4)` was removed for exactly this reason).
+ *
+ * ── Rounding: floor, never round ────────────────────────────────────────────
+ * A quantizer can only under-credit. This mirrors the mint-cost-pole rule
+ * (PR #676): every economic error must favor the ledger, not the minter.
+ *
+ * ── Conservation ────────────────────────────────────────────────────────────
+ * floor gives Σₖ q(Kₖ) ≤ q(ΣₖKₖ): a portfolio of parts can never quantize to
+ * more than the whole. Pinned per golden chart by the conformance suites.
+ *
+ * ── Cross-runtime determinism ───────────────────────────────────────────────
+ * TS and Python MUST produce byte-identical integers. MEASURED basis: over the
+ * 20 golden charts all 80 unrounded K values are BIT-IDENTICAL across runtimes
+ * (same summation order, IEEE-754 float64 in both), so `Math.floor(k * 1e6)`
+ * and `math.floor(k * 1e6)` agree exactly. The fixture's `expected_micro`
+ * integers are the shared witness; both conformance suites assert `===`.
+ *
+ * ── AMENDMENT to §6 rule 5 (idempotence), with its measurement ──────────────
+ * The drafted pin `quantize(dequantize(q)) === q` is UNSATISFIABLE with pure
+ * floor: `q / 1e6` is inexact in binary, and when it rounds low the EXACT
+ * product `dequantize(q) · 10⁶` is already below q — so floor must lose a
+ * micro. MEASURED: 1,478,721 of the 10⁸ integers in the reachable range
+ * violate it (1.48%; first violator q = 249 → 248), identically in both
+ * runtimes. This is floor-composition mathematics, not float noise, so no
+ * implementation of float-dequantize can satisfy the drafted rule.
+ *
+ * The intent — no ledger information loss, no double-quantization drift — is
+ * kept by construction instead:
+ *   • there is NO float dequantize. `formatMicroEsms` renders an integer as its
+ *     EXACT decimal K-string via integer math (q·10⁻⁶ is always exact in
+ *     decimal), and `parseMicroEsms` inverts it exactly. Round-trip is
+ *     lossless for every integer, pinned by test.
+ *   • quantized integers therefore cannot re-enter the quantizer as floats;
+ *     the negative control `floor((249/1e6)·1e6) === 248` is pinned in the
+ *     conformance suites as the reason the door stays shut.
+ */
+
+/** RULED §6: 1 K-unit = 10⁶ micro-ESMS. */
+export const MICRO_ESMS_PER_K = 1_000_000;
+
+/**
+ * Upper guard for a single coin's K. BASIS: the maximum reachable coin over the
+ * golden set is 8.81 (chart_20, every body at its measured 2026 minimum
+ * distance); 100 is more than an order of magnitude above any reachable K, so
+ * crossing it is malformed input, not physics.
+ */
+export const ESMS_K_MAX = 100;
+
+/**
+ * THE quantization boundary: full-precision K → integer micro-ESMS, floor.
+ * THROWS on malformed input rather than inventing an amount (§18k k7):
+ * non-finite, negative, or beyond ESMS_K_MAX. Negative K is not mintable by
+ * construction (sect allocations and weights are non-negative), so a negative
+ * here means an upstream invariant broke.
+ */
+export function quantizeEsms(k: number): number {
+  if (!Number.isFinite(k)) {
+    throw new TypeError(`quantizeEsms: K must be finite, got ${String(k)}`);
+  }
+  if (k < 0) {
+    throw new TypeError(`quantizeEsms: K must be non-negative, got ${k}`);
+  }
+  if (k > ESMS_K_MAX) {
+    throw new TypeError(
+      `quantizeEsms: K=${k} exceeds ESMS_K_MAX=${ESMS_K_MAX} — malformed input, not physics`,
+    );
+  }
+  return Math.floor(k * MICRO_ESMS_PER_K);
+}
+
+/**
+ * Exact decimal rendering of an integer micro-ESMS amount, via integer math
+ * only — no float division, so no representation loss. `formatMicroEsms(249)`
+ * is exactly "0.000249".
+ */
+export function formatMicroEsms(q: number): string {
+  if (!Number.isSafeInteger(q) || q < 0) {
+    throw new TypeError(`formatMicroEsms: expected a non-negative integer, got ${String(q)}`);
+  }
+  const whole = Math.floor(q / MICRO_ESMS_PER_K);
+  const frac = q % MICRO_ESMS_PER_K;
+  return `${whole}.${String(frac).padStart(6, "0")}`;
+}
+
+/**
+ * Exact inverse of `formatMicroEsms` — integer parsing only.
+ * `parseMicroEsms(formatMicroEsms(q)) === q` for every valid q, pinned by test.
+ */
+export function parseMicroEsms(s: string): number {
+  const m = /^(\d+)\.(\d{6})$/.exec(s);
+  if (!m) {
+    throw new TypeError(`parseMicroEsms: expected "<int>.<6 digits>", got ${JSON.stringify(s)}`);
+  }
+  const q = Number(m[1]) * MICRO_ESMS_PER_K + Number(m[2]);
+  if (!Number.isSafeInteger(q)) {
+    throw new TypeError(`parseMicroEsms: ${JSON.stringify(s)} exceeds safe integer range`);
+  }
+  return q;
+}


### PR DESCRIPTION
Implements the **ratified §6 contract** in both runtimes. Both blockers were resolved by #685.

## The contract, as shipped

- `quantizeEsms(K) = ⌊K·10⁶⌋` — the **one** quantization boundary per runtime, applied to the engine's full-precision K. **Floor, never round**: a quantizer can only under-credit (the mint-cost-pole rule — economic errors favor the ledger). Throws on non-finite / negative / `K > ESMS_K_MAX = 100` (an order of magnitude above the max reachable coin, 8.81 on the all-minima stress chart).
- `natal_alchemy`'s `round(…, 4)` on the four coins is **removed** (§6 rule 2: display must not feed the quantizer). MEASURED consequence: **all 80 golden K values are bit-identical across runtimes**, so the float goldens are now asserted with *exact equality* — the old 5e-4 tolerance existed only to absorb that rounding.
- **Fixture v2.2.0**: `expected` at full precision + new `expected_micro` integer blocks. Python asserts them from its quantizer, TS from its own — **byte-identical integers over 20 charts × 4 coins is the mainnet gate, enforced in CI on both runtimes.**
- **Conservation** (rule 4) pinned 80/80 over the golden set's per-body parts — as MEASURED over reachable parts, not claimed universally (with float sums, an adversarial all-integer-micro portfolio could violate the exact-real property by one ulp).

## ⚠️ Amendment to rule 5 (idempotence) — measured, not argued

The drafted pin `quantize(dequantize(q)) === q` is **unsatisfiable with pure floor**: `q/1e6` is inexact in binary, and when it rounds low the *exact* product with 10⁶ is already below q — floor must lose a micro. MEASURED: **1,478,721 of the 10⁸ reachable integers violate it** (1.48%; first violator `249 → 248`), identically in both runtimes. This is floor-composition mathematics, not float noise.

The intent (no ledger information loss, no double-quantization drift) is kept **by construction**: there is **no float dequantize**. `formatMicroEsms` renders the exact decimal via integer math (`q·10⁻⁶` is always exact in decimal), `parseMicroEsms` inverts it exactly (round-trip pinned), and the negative control `⌊(249/1e6)·1e6⌋ === 248` is pinned in both suites as the reason the door stays shut.

## Scope

Contract + functions + gates only. **Wiring into mint/settlement routes is a follow-up** with its own blast-radius survey.

## Checks

TS 188/188 (1767 tests, 28 conformance) · Python conformance 12/12 · `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)