### PR TITLE
feat(physics): derive the oscillator — ω is the Venus synodic cycle, measured

### DIFF
--- a/docs/physics/ESMS_WAVE_FUNCTION_SPECIFICATION.md
+++ b/docs/physics/ESMS_WAVE_FUNCTION_SPECIFICATION.md
@@ -170,6 +170,16 @@ $$\hat{H} = \frac{\hat{p}^2}{2m} + \frac{1}{2} m \omega^2 (x - \bar{x}_{\text{se
 - **Current Λ**: total swing ±155,724; the residual spectrum concentrates in the 25–40 d lunar band (synodic 29.53 d: 6.5×10⁹; anomalistic 27.55 d: 1.9×10⁹) — i.e. under the shipped tensor, the oscillator **is** the Moon's distance cycle and nothing else.
 - **Under option C**: |x| ≤ 16.9; dominant peaks move to the annual/Venus-synodic scale (~2.5×10³ at ≈1 yr) with Mercury's 115.9 d synodic clearly resolved (4.6×10²) and the lunar months present but proportionate (~0.3–0.5).
 
+**`[MEASURED 2026-08-01 — ω DERIVED under the ruled Λ = C]`** §7 is ruled and shipped; the derivation ran per item 1 below, over the required ≥2-synodic epoch (item 2): daily series, noon UTC, 2026-01-01 → 2033-12-31 (2922 samples, **5.0 Venus synodic cycles**), sect-demodulated, bodies only (the sky has no observer, so no vessel term).
+
+- **Fundamental**: T = **586.30 d (diurnal) / 585.90 d (nocturnal)** — within **0.4% of the Venus synodic period (583.92 d)** and sect-independent to 0.07%. The oscillator *is* the Venus distance cycle, whose $(\bar r/r)^2$ factor spans 0.35–13.9×, the largest modulation in the tensor.
+- **Harmonic series**: 291.5 d ≈ T/2 and 146 d ≈ T/4 — the $(\bar r/r)^2$ waveform is non-sinusoidal.
+- **Mercury synodic**: resolved at 115.0–116.5 d (true 115.88 d), exactly as predicted above.
+- **Ruled single ω**: T = 586.10 d (mean of the sect fundamentals, 0.07% apart — per-sect ω would be precision theater), so **ω = 2π/586.10 = 1.07203×10⁻² rad/day**.
+- **Equilibria**: $\bar{x}_{\text{diurnal}} = 6.5245$, $\bar{x}_{\text{nocturnal}} = -4.0937$ (epoch means).
+
+Implementation: `src/utils/esmsOscillator.ts` (constants + $\hat H$ + the coherent transport rule); `esmsOscillator.test.ts` re-derives every constant from the ephemeris on each run, and pins the Venus identification so a Λ change that moves the fundamental off the Venus line fails loudly.
+
 **Consequences for implementation, once §7 is ruled:**
 1. ω must be re-derived against the ruled Λ — deriving it now would calibrate a constant against a defect.
 2. The Venus synodic period (584 d) exceeds a 1-year window; the ω-derivation epoch must span ≥ 2 synodic cycles (**2026–2029**).

--- a/src/__tests__/physics/esmsOscillator.test.ts
+++ b/src/__tests__/physics/esmsOscillator.test.ts
@@ -1,0 +1,163 @@
+/**
+ * The oscillator constants are MEASURED, and this is where they are re-measured.
+ *
+ * ω, the sect fundamentals, and the equilibria x̄ in `esmsOscillator.ts` are
+ * literals; this suite rebuilds the exact 8-year sect-demodulated series from
+ * the ephemeris and re-derives all of them. If astronomy-engine, the Λ tensor,
+ * the sectarian table, or the epoch definition changes, THIS FAILS and names
+ * the cause — the constants can never drift into being comments.
+ */
+import * as Astronomy from "astronomy-engine";
+import {
+  coherentPacketCenter,
+  ESMS_OSCILLATOR_EPOCH,
+  OSCILLATOR_BODIES,
+  OSCILLATOR_FUNDAMENTAL_DAYS,
+  OSCILLATOR_OMEGA_RAD_PER_DAY,
+  OSCILLATOR_PERIOD_DAYS,
+  OSCILLATOR_X_BAR,
+  oscillatorCoordinate,
+  oscillatorEnergy,
+} from "@/utils/esmsOscillator";
+
+const ASTRO_BODY: Record<string, Astronomy.Body> = {
+  Sun: Astronomy.Body.Sun, Moon: Astronomy.Body.Moon, Mercury: Astronomy.Body.Mercury,
+  Venus: Astronomy.Body.Venus, Mars: Astronomy.Body.Mars, Jupiter: Astronomy.Body.Jupiter,
+  Saturn: Astronomy.Body.Saturn, Uranus: Astronomy.Body.Uranus, Neptune: Astronomy.Body.Neptune,
+  Pluto: Astronomy.Body.Pluto,
+};
+
+/** The exact epoch series, rebuilt from the ephemeris. */
+function buildSeries(): { diurnal: number[]; nocturnal: number[] } {
+  const start = Date.parse(ESMS_OSCILLATOR_EPOCH.startUtc);
+  const stepMs = ESMS_OSCILLATOR_EPOCH.stepHours * 3600 * 1000;
+  const out = { diurnal: [] as number[], nocturnal: [] as number[] };
+  for (let i = 0; i < ESMS_OSCILLATOR_EPOCH.samples; i++) {
+    const t = Astronomy.MakeTime(new Date(start + i * stepMs));
+    const dist: Record<string, number> = {};
+    for (const body of OSCILLATOR_BODIES) {
+      const v = Astronomy.GeoVector(ASTRO_BODY[body], t, true);
+      dist[body] = Math.hypot(v.x, v.y, v.z);
+    }
+    out.diurnal.push(oscillatorCoordinate(dist, true));
+    out.nocturnal.push(oscillatorCoordinate(dist, false));
+  }
+  return out;
+}
+
+/** Periodogram argmax over [Tlo, Thi] at the derivation's own grid step. */
+function fundamentalDays(x: number[], Tlo: number, Thi: number, step: number): number {
+  const mean = x.reduce((s, v) => s + v, 0) / x.length;
+  const dm = x.map((v) => v - mean);
+  let bestT = 0;
+  let bestP = -1;
+  for (let T = Tlo; T <= Thi; T += step) {
+    let c = 0;
+    let s = 0;
+    for (let i = 0; i < dm.length; i++) {
+      const ph = (2 * Math.PI * i) / T;
+      c += dm[i] * Math.cos(ph);
+      s += dm[i] * Math.sin(ph);
+    }
+    const P = (c * c + s * s) / dm.length;
+    if (P > bestP) {
+      bestP = P;
+      bestT = T;
+    }
+  }
+  return bestT;
+}
+
+const series = buildSeries();
+
+describe("ESMS oscillator calibration (§8)", () => {
+  it("re-derives the sect equilibria x̄ from the ephemeris", () => {
+    for (const sect of ["diurnal", "nocturnal"] as const) {
+      const x = series[sect];
+      expect(x).toHaveLength(ESMS_OSCILLATOR_EPOCH.samples);
+      const mean = x.reduce((s, v) => s + v, 0) / x.length;
+      expect(mean).toBeCloseTo(OSCILLATOR_X_BAR[sect], 10);
+    }
+  });
+
+  it("re-derives the periodogram fundamentals per sect", () => {
+    for (const sect of ["diurnal", "nocturnal"] as const) {
+      const T = fundamentalDays(series[sect], 500, 700, 0.05);
+      expect(T).toBeCloseTo(OSCILLATOR_FUNDAMENTAL_DAYS[sect], 6);
+    }
+  });
+
+  it("identifies the fundamental as the Venus synodic cycle, sect-independently", () => {
+    // The INTERPRETATION pin: the measured period sits within 0.5% of the Venus
+    // synodic period (583.92 d) — Venus's (r̄/r)² spans 0.35–13.9×, the largest
+    // modulation in the tensor. If a Λ change moves the fundamental off the
+    // Venus line, the physical story in the module doc is stale and this fails.
+    const VENUS_SYNODIC_DAYS = 583.92;
+    for (const sect of ["diurnal", "nocturnal"] as const) {
+      const rel = Math.abs(OSCILLATOR_FUNDAMENTAL_DAYS[sect] - VENUS_SYNODIC_DAYS) / VENUS_SYNODIC_DAYS;
+      expect(rel).toBeLessThan(0.005);
+    }
+    // Sect independence: the two fundamentals agree to 0.1% — the basis for
+    // ruling a SINGLE ω instead of per-sect precision theater.
+    const relSect =
+      Math.abs(OSCILLATOR_FUNDAMENTAL_DAYS.diurnal - OSCILLATOR_FUNDAMENTAL_DAYS.nocturnal) /
+      OSCILLATOR_FUNDAMENTAL_DAYS.diurnal;
+    expect(relSect).toBeLessThan(0.001);
+  });
+
+  it("derives ω from the ruled period, never assigns it", () => {
+    expect(OSCILLATOR_PERIOD_DAYS).toBeCloseTo(
+      (OSCILLATOR_FUNDAMENTAL_DAYS.diurnal + OSCILLATOR_FUNDAMENTAL_DAYS.nocturnal) / 2,
+      10,
+    );
+    expect(OSCILLATOR_OMEGA_RAD_PER_DAY).toBe((2 * Math.PI) / OSCILLATOR_PERIOD_DAYS);
+  });
+});
+
+describe("oscillator coordinate and Hamiltonian", () => {
+  const meanSky: Record<string, number> = {
+    Sun: 1.0001517506922113, Moon: 0.002571016680904456, Mercury: 1.0527771261580632,
+    Venus: 1.0162138470401183, Mars: 1.9442585501420186, Jupiter: 5.429789190115696,
+    Saturn: 9.484384119258557, Uranus: 19.49876988921305, Neptune: 29.88354939796314,
+    Pluto: 35.52718536398905,
+  };
+
+  it("throws on a partial or malformed sky rather than measuring a different observable", () => {
+    const { Pluto: _dropped, ...partial } = meanSky;
+    expect(() => oscillatorCoordinate(partial, true)).toThrow(/Pluto/);
+    expect(() => oscillatorCoordinate({ ...meanSky, Moon: NaN }, true)).toThrow(/Moon/);
+    expect(() => oscillatorCoordinate({ ...meanSky, Venus: 0 }, true)).toThrow(/Venus/);
+    expect(() => oscillatorCoordinate({ ...meanSky, Venus: -1 }, false)).toThrow(/Venus/);
+  });
+
+  it("has its energy minimum exactly at the sect equilibrium", () => {
+    for (const diurnal of [true, false]) {
+      const xBar = diurnal ? OSCILLATOR_X_BAR.diurnal : OSCILLATOR_X_BAR.nocturnal;
+      expect(oscillatorEnergy(xBar, 0, diurnal)).toBe(0);
+      expect(oscillatorEnergy(xBar + 1, 0, diurnal)).toBeGreaterThan(0);
+      expect(oscillatorEnergy(xBar - 1, 0, diurnal)).toBe(oscillatorEnergy(xBar + 1, 0, diurnal));
+      expect(oscillatorEnergy(xBar, 0.1, diurnal)).toBeCloseTo(0.005, 12);
+    }
+    expect(() => oscillatorEnergy(NaN, 0, true)).toThrow(TypeError);
+    expect(() => oscillatorEnergy(0, Infinity, true)).toThrow(TypeError);
+  });
+
+  it("transports the coherent packet center on the measured coordinate, not a model", () => {
+    // The transport rule IS the identity on the measured coordinate — pinned so
+    // nobody swaps in x̄ + A·cos(ωt) and calls it transport.
+    expect(coherentPacketCenter(meanSky, true)).toBe(oscillatorCoordinate(meanSky, true));
+    // Endpoint pins to the ephemeris: first and last epoch samples.
+    for (const idx of [0, ESMS_OSCILLATOR_EPOCH.samples - 1]) {
+      const t = Astronomy.MakeTime(
+        new Date(Date.parse(ESMS_OSCILLATOR_EPOCH.startUtc) + idx * ESMS_OSCILLATOR_EPOCH.stepHours * 3600 * 1000),
+      );
+      const dist: Record<string, number> = {};
+      for (const body of OSCILLATOR_BODIES) {
+        const v = Astronomy.GeoVector(ASTRO_BODY[body], t, true);
+        dist[body] = Math.hypot(v.x, v.y, v.z);
+      }
+      expect(coherentPacketCenter(dist, true)).toBe(series.diurnal[idx]);
+      expect(coherentPacketCenter(dist, false)).toBe(series.nocturnal[idx]);
+    }
+  });
+});

--- a/src/utils/esmsOscillator.ts
+++ b/src/utils/esmsOscillator.ts
@@ -1,0 +1,155 @@
+/**
+ * The ESMS harmonic oscillator — §8 of the wave-function spec, RULED destination.
+ *
+ * The oscillator coordinate is x = ln(kalchm) of the INTEGRATED sky vector K
+ * under the RULED Λ = diag(M̂·(r̄/r)²) tensor. It genuinely oscillates about a
+ * sect-conditional equilibrium — unlike planetary longitudes, which circulate
+ * and would need an invented ω.
+ *
+ *   Ĥ = p²/2m + ½ m ω² (x − x̄_sect)²
+ *
+ * ── Every constant below is MEASURED, and re-measured by test ───────────────
+ *
+ * Epoch: daily series (noon UTC), 2026-01-01 → 2033-12-31 (2922 samples, 5.0
+ * Venus synodic cycles — §8 requires ≥ 2). Sect-DEMODULATED: the day/night ESMS
+ * reallocation is a 1-day square wave that would bury the distance physics, so
+ * x(t) is computed at fixed sect, both sects. Bodies only, no Ascendant vessel:
+ * the sky has no observer, so the OSCILLATOR series carries no vessel term
+ * (natal charts do — this module is about the sky's time dynamics).
+ *
+ * MEASURED spectrum (periodogram, both sects):
+ *   fundamental  T = 586.30 d (diurnal) / 585.90 d (nocturnal)
+ *                — within 0.4% of the VENUS SYNODIC PERIOD (583.92 d), and
+ *                sect-independent to 0.07%. The oscillator is the Venus
+ *                distance cycle: Venus's (r̄/r)² factor spans 0.35–13.9×, the
+ *                largest modulation in the tensor by an order of magnitude.
+ *   harmonics    291.5 d ≈ T/2, 146 d ≈ T/4 — the (r̄/r)² waveform is
+ *                non-sinusoidal, so the Venus line carries a harmonic series.
+ *   Mercury      115.0–116.5 d — Mercury's synodic period (115.88 d), resolved
+ *                exactly where §8 predicted it.
+ *
+ * ω is the mean of the two sect fundamentals (they differ by 0.07%, so a
+ * per-sect ω would be precision theater): T = 586.10 d.
+ *
+ * `esmsOscillator.test.ts` re-derives the fundamentals, the equilibria, and the
+ * Venus identification from the ephemeris on every run.
+ *
+ * ── RULED conventions (choices, named as such) ──────────────────────────────
+ *   m = 1           — the oscillator mass has no measured basis; H is used only
+ *                     for RELATIVE energies, where m cancels out of comparisons.
+ *   coherent only   — the shipped Gaussian packets have fixed σ, which IS the
+ *                     coherent state (σ = σ₀, no spreading). Squeezed states
+ *                     (width breathing at 2ω) stay OUT OF SCOPE until a
+ *                     measurable basis for σ-dynamics exists; a breathing width
+ *                     with an assigned rate would be a fabricated constant
+ *                     wearing physics clothing (§8.4).
+ */
+
+import { calculateKalchm } from "@/data/unified/alchemicalCalculations";
+import type { AlchemicalProperties } from "@/types/celestial";
+import {
+  getGravitationalInertia,
+  PLANETARY_SECTARIAN_ESMS,
+} from "./planetaryAlchemyMapping";
+
+/** The measured oscillator epoch — stated as data so the test rebuilds it exactly. */
+export const ESMS_OSCILLATOR_EPOCH = {
+  /** Noon UTC of the first daily sample. */
+  startUtc: "2026-01-01T12:00:00.000Z",
+  /** Daily samples: 8 years, 5.0 Venus synodic cycles. */
+  samples: 2922,
+  stepHours: 24,
+} as const;
+
+/** MEASURED periodogram fundamentals per sect, days. */
+export const OSCILLATOR_FUNDAMENTAL_DAYS = {
+  diurnal: 586.3,
+  nocturnal: 585.9,
+} as const;
+
+/** The RULED single period: mean of the sect fundamentals (0.07% apart). */
+export const OSCILLATOR_PERIOD_DAYS = 586.1;
+
+/** ω = 2π / T, rad/day. DERIVED from OSCILLATOR_PERIOD_DAYS — never assigned. */
+export const OSCILLATOR_OMEGA_RAD_PER_DAY = (2 * Math.PI) / OSCILLATOR_PERIOD_DAYS;
+
+/**
+ * MEASURED sect equilibria x̄ — the epoch means of x(t). The well minima of the
+ * two sect potentials. Re-derived by test.
+ */
+export const OSCILLATOR_X_BAR = {
+  diurnal: 6.524452527444266,
+  nocturnal: -4.093659600581897,
+} as const;
+
+/** The ten oscillator bodies — the charted set, no vessel (see module note). */
+export const OSCILLATOR_BODIES = [
+  "Sun", "Moon", "Mercury", "Venus", "Mars",
+  "Jupiter", "Saturn", "Uranus", "Neptune", "Pluto",
+] as const;
+
+export interface OscillatorBodyState {
+  /** Geocentric distance in AU. Required — the oscillator IS distance dynamics. */
+  distanceAu: number;
+}
+
+/**
+ * The oscillator coordinate x = ln(kalchm(K)) for a sky described by per-body
+ * geocentric distances, at a fixed sect.
+ *
+ * THROWS on a missing body or non-finite/non-positive distance — an oscillator
+ * coordinate from a partial sky would be a silently different observable, not a
+ * degraded one (§18k k7).
+ */
+export function oscillatorCoordinate(
+  bodyDistancesAu: Record<string, number>,
+  isDiurnal: boolean,
+): number {
+  const sect = isDiurnal ? "diurnal" : "nocturnal";
+  const K: AlchemicalProperties = { Spirit: 0, Essence: 0, Matter: 0, Substance: 0 };
+  for (const body of OSCILLATOR_BODIES) {
+    const r = bodyDistancesAu[body];
+    if (!Number.isFinite(r) || r <= 0) {
+      throw new TypeError(
+        `oscillatorCoordinate: body "${body}" needs a positive finite distance, got ${String(r)}`,
+      );
+    }
+    const inertia = getGravitationalInertia(body, r);
+    const se = PLANETARY_SECTARIAN_ESMS[body][sect];
+    K.Spirit += se.Spirit * inertia;
+    K.Essence += se.Essence * inertia;
+    K.Matter += se.Matter * inertia;
+    K.Substance += se.Substance * inertia;
+  }
+  return Math.log(calculateKalchm(K));
+}
+
+/**
+ * The Hamiltonian: H(x, p) = p²/2 + ½ ω² (x − x̄_sect)², with the RULED m = 1.
+ * Total energy of an oscillator state; the well minimum (p = 0, x = x̄) is 0.
+ */
+export function oscillatorEnergy(x: number, p: number, isDiurnal: boolean): number {
+  if (!Number.isFinite(x) || !Number.isFinite(p)) {
+    throw new TypeError(`oscillatorEnergy: x and p must be finite, got x=${String(x)} p=${String(p)}`);
+  }
+  const xBar = isDiurnal ? OSCILLATOR_X_BAR.diurnal : OSCILLATOR_X_BAR.nocturnal;
+  const d = x - xBar;
+  return (p * p) / 2 + 0.5 * OSCILLATOR_OMEGA_RAD_PER_DAY * OSCILLATOR_OMEGA_RAD_PER_DAY * d * d;
+}
+
+/**
+ * Coherent-state transport: the packet CENTER at time t is the measured
+ * oscillator coordinate itself — centers ride the real ephemeris, never a
+ * modeled trajectory (§8.3: "endpoints pinned to astronomy-engine — the
+ * transport rule is the only new machinery, no invented positions"). The
+ * classical analogy (packet sloshing in the well at ω) is the INTERPRETATION of
+ * that motion, not its source; using x̄ + A·cos(ωt) would replace measurement
+ * with model. This function is the SpacetimeDB live-layer interpolant's anchor:
+ * interpolate BETWEEN two measured coordinates, never extrapolate a cosine.
+ */
+export function coherentPacketCenter(
+  bodyDistancesAu: Record<string, number>,
+  isDiurnal: boolean,
+): number {
+  return oscillatorCoordinate(bodyDistancesAu, isDiurnal);
+}


### PR DESCRIPTION
Implements the §8 Hamiltonian on the RULED coordinate **x = ln(kalchm)** under the shipped Λ=C tensor (#685). Every constant is **measured, and re-measured from the ephemeris on every test run**.

## The derivation

Daily series, noon UTC, 2026-01-01 → 2033-12-31 — 2922 samples, **5.0 Venus synodic cycles** (§8 requires ≥2). Sect-demodulated (the day/night ESMS reallocation is a 1-day square wave that would bury the distance physics). Bodies only — the sky has no observer, so the oscillator series carries no vessel term.

| | |
|---|---|
| Fundamental | **586.30 d** (diurnal) / **585.90 d** (nocturnal) |
| Identification | within **0.4% of the Venus synodic period (583.92 d)**, sect-independent to 0.07% |
| Harmonics | 291.5 d ≈ T/2, 146 d ≈ T/4 — the (r̄/r)² waveform is non-sinusoidal |
| Mercury synodic | resolved at 116.4 d (true 115.88 d), exactly where §8 predicted |
| **ω** | T = 586.10 d (mean of sect fundamentals) → **ω = 2π/586.10 = 1.07203×10⁻² rad/day** |
| Equilibria | x̄ = 6.5245 (diurnal), −4.0937 (nocturnal) |

The oscillator **is** the Venus distance cycle — Venus's (r̄/r)² factor spans 0.35–13.9×, the largest modulation in the tensor by an order of magnitude.

## What ships

- `src/utils/esmsOscillator.ts` — constants, `H(x,p) = p²/2 + ½ω²(x−x̄_sect)²` with the RULED m=1 convention, and the **coherent transport rule**: the packet center at time t *is* the measured coordinate. Pinned by test so nobody swaps in `x̄ + A·cos(ωt)` and calls it transport — interpolate between measured coordinates, never extrapolate a cosine. This is the SpacetimeDB live-layer anchor.
- `esmsOscillator.test.ts` — re-derives the fundamentals, the equilibria, and ω from the ephemeris on every run (~4s), and pins the **Venus identification**: if a future Λ change moves the fundamental off the Venus line, the physical story fails loudly instead of going stale.

**Squeezed states stay out of scope** per §8.4 — σ-dynamics has no measurable basis yet; a breathing width with an assigned rate would be a fabricated constant wearing physics clothing.

## Checks

TS 190/190 (1777 tests, 7 oscillator) · `tsc` clean. Spec §8 updated from "destination" to MEASURED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)