### PR TITLE
fix(cooking-methods): close three lookups that could not fail loudly

### DIFF
--- a/src/__tests__/cookingMethodThermodynamicsFallback.test.ts
+++ b/src/__tests__/cookingMethodThermodynamicsFallback.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Guards for the three silent holes in cooking-method thermodynamics resolution.
+ *
+ * All three shared one shape: a lookup that could not fail loudly.
+ *
+ *   1. Tier 1 dereferenced `detailedCookingMethods[key].thermodynamicProperties`
+ *      with no guard, so a key miss threw TypeError instead of falling through.
+ *   2. `_COOKING_METHOD_THERMODYNAMICS` was `{}`, so its tier could never resolve
+ *      while its `if` guard made it read as a working priority tier.
+ *   3. The only caller wrapped the whole thing in
+ *      `catch { thermodynamicScore = 0.5 }`, converting the TypeError into a
+ *      fabricated mid-value that is indistinguishable from a computed 0.5.
+ *
+ * @file src/__tests__/cookingMethodThermodynamicsFallback.test.ts
+ */
+
+import { getMethodThermodynamics as getFromRecommender } from "@/utils/cookingMethodRecommender";
+import { getMethodThermodynamics as getFromRecommendation } from "@/utils/recommendation/methodRecommendation";
+
+/** Names whose `.toLowerCase()` does not match any `allCookingMethods` record key. */
+const UNMAPPED_NAMES = [
+  "Pressure Cooking", // -> "pressure cooking" (space), key is pressure_cooking
+  "Cryo-Cooking", // -> "cryo-cooking" (hyphen), key is cryo_cooking
+  "Tilt-Skillet",
+  "a method that does not exist at all",
+];
+
+const RESOLVERS: Array<[string, (m: unknown) => unknown]> = [
+  ["cookingMethodRecommender", getFromRecommender as (m: unknown) => unknown],
+  ["recommendation/methodRecommendation", getFromRecommendation as (m: unknown) => unknown],
+];
+
+describe.each(RESOLVERS)("%s.getMethodThermodynamics", (_label, resolve) => {
+  it("does not throw on a name that misses the detailed catalog", () => {
+    // This is the defect: the dereference was unguarded, so a miss threw.
+    for (const name of UNMAPPED_NAMES) {
+      expect(() => resolve({ name })).not.toThrow();
+    }
+  });
+
+  it("returns finite numbers for every unmapped name", () => {
+    for (const name of UNMAPPED_NAMES) {
+      const result = resolve({ name }) as Record<string, number>;
+      for (const key of ["heat", "entropy", "reactivity"]) {
+        expect(Number.isFinite(result[key])).toBe(true);
+      }
+    }
+  });
+
+  it("survives a method with no name at all", () => {
+    expect(() => resolve({})).not.toThrow();
+  });
+
+  it("routes an unmapped high-heat name to the heuristic tier, not a flat 0.5", () => {
+    // With the empty-registry tier removed, the keyword heuristic is the real
+    // last tier. A name containing "grill" must reach it and produce the
+    // documented high-heat profile — if this comes back 0.5 across the board,
+    // something is silently defaulting again.
+    const result = resolve({ name: "charcoal grilling technique" }) as Record<string, number>;
+    expect(result.heat).toBeGreaterThan(0.5);
+  });
+
+  it("differentiates high-heat from wet methods", () => {
+    // The whole point of the ladder is differentiation. A swallowed error or a
+    // universal default collapses these to the same value.
+    const hot = resolve({ name: "open flame grilling" }) as Record<string, number>;
+    const wet = resolve({ name: "gentle poaching" }) as Record<string, number>;
+    expect(hot.heat).toBeGreaterThan(wet.heat);
+  });
+});
+
+describe("the empty thermodynamics registry is gone", () => {
+  it("no longer exports _COOKING_METHOD_THERMODYNAMICS", async () => {
+    const alchemy = (await import("@/types/alchemy")) as Record<string, unknown>;
+    expect(alchemy).not.toHaveProperty("_COOKING_METHOD_THERMODYNAMICS");
+  });
+});

--- a/src/components/CookingMethods.tsx
+++ b/src/components/CookingMethods.tsx
@@ -11,8 +11,7 @@ import { cookingMethods } from '@/data/cooking/cookingMethods';
 import { molecularCookingMethods } from '@/data/cooking/molecularMethods';
 import type { Modality } from '@/data/ingredients/types';
 import { useAstrologicalState } from '@/hooks/useAstrologicalState';
-import type { ElementalProperties, ZodiacSign, BasicThermodynamicProperties } from '@/types/alchemy';
-import { _COOKING_METHOD_THERMODYNAMICS as COOKING_METHOD_THERMODYNAMICS } from '@/types/alchemy';
+import type { ElementalProperties, ZodiacSign } from '@/types/alchemy';
 import { _staticAlchemize as staticAlchemize } from '@/utils/alchemyInitializer';
 import { getCulturalCookingMethods } from '@/utils/culturalMethodsAggregator';
 import { elementalSignature } from '@/utils/elemental/signature';
@@ -359,13 +358,9 @@ export default function CookingMethods() {
       };
     }
 
-    // Look for the method in the COOKING_METHOD_THERMODYNAMICS constant
-    const thermoMap = COOKING_METHOD_THERMODYNAMICS as Record<string, ThermoTuple>;
-    for (const knownMethod of Object.keys(thermoMap)) {
-      if (methodName.includes(knownMethod)) {
-        return thermoMap[knownMethod];
-      }
-    }
+    // A lookup over COOKING_METHOD_THERMODYNAMICS used to sit here. That constant
+    // was `{}`, so `Object.keys(...)` was empty and the loop never ran a single
+    // iteration. See src/types/alchemy.ts.
 
     // Fallback values based on method characteristics
     if (methodName.includes('grill') || methodName.includes('roast') || methodName.includes('fry')) {
@@ -558,13 +553,9 @@ export default function CookingMethods() {
       return method[property as keyof typeof method] as number || 0;
     }
     
-    // Check COOKING_METHOD_THERMODYNAMICS constant
-    const methodName = method.name.toLowerCase();
-    const thermoMap = COOKING_METHOD_THERMODYNAMICS as Record<string, BasicThermodynamicProperties>;
-    if (thermoMap && thermoMap[methodName]) {
-      return thermoMap[methodName][property as keyof BasicThermodynamicProperties] || 0;
-    }
-    
+    // A COOKING_METHOD_THERMODYNAMICS lookup used to sit here. The constant was
+    // `{}`, so the guard was always false. See src/types/alchemy.ts.
+
     // Generate values based on method name keywords if no explicit values found
     // This ensures all methods have reasonable thermodynamic values
     const methodLower = method.name.toLowerCase();

--- a/src/types/alchemy.ts
+++ b/src/types/alchemy.ts
@@ -591,7 +591,18 @@ export type DignityType =
   | "Fall"
   | "Neutral";
 
-export const _COOKING_METHOD_THERMODYNAMICS = {};
+// `_COOKING_METHOD_THERMODYNAMICS` was declared here as `{}` — an empty object.
+//
+// Four call sites read it as tier 3 of a thermodynamics-resolution ladder, each
+// guarded by `if (constantThermoData)`. Because the object has no keys, that
+// guard was ALWAYS false: the tier could never hit, control always fell through
+// to the substring-heuristic tier below it, and the guard made a table that
+// cannot resolve anything read like a working priority tier.
+//
+// Removed rather than populated. The heuristic tier is what has actually been
+// deciding these values all along, and adding entries here would change live
+// behaviour under the guise of a cleanup. If a curated method→thermodynamics
+// table is wanted, it should be introduced deliberately with sourced values.
 
 // ========== MISSING TYPES FOR TS2305 FIXES ==========
 

--- a/src/utils/cookingMethodRecommender.ts
+++ b/src/utils/cookingMethodRecommender.ts
@@ -113,7 +113,6 @@ import type {
   MethodRecommendation,
   MethodRecommendationOptions,
 } from "@/types/alchemy";
-import { _COOKING_METHOD_THERMODYNAMICS } from "@/types/alchemy";
 // Removed unused, import: CookingMethodEnum
 import type { CookingMethod } from "@/types/cooking";
 import { calculateLunarPhase, getLunarPhaseName } from "@/utils/astrologyUtils";
@@ -303,10 +302,18 @@ const allCookingMethodsCombined: CookingMethodDictionary = {
 
 // --- Added Thermodynamic Helpers ---
 
-// Function to get thermodynamic properties for a method
-// PRIORITIZES detailedCookingMethods from src/data/cooking/cookingMethods.ts
-// FALLS BACK to _COOKING_METHOD_THERMODYNAMICS constant from src/data/cooking/thermodynamics.ts
-// FURTHER FALLS BACK to keyword-based logic
+// Function to get thermodynamic properties for a method.
+//
+// PRIORITIZES the detailed data source, then the method object's own
+// thermodynamicProperties, then keyword-based logic.
+//
+// The previous comment here claimed a fallback to `_COOKING_METHOD_THERMODYNAMICS`
+// "from src/data/cooking/thermodynamics.ts". Two things were wrong with that: the
+// constant lived in src/types/alchemy.ts, and it was an empty object, so the tier
+// it described could never resolve anything. Both are gone.
+//
+// Note the import below resolves to `allCookingMethods`, not to the legacy
+// src/data/cooking/cookingMethods.ts the old comment named.
 interface MethodWithThermodynamics {
   name?: string;
   thermodynamicProperties?: {
@@ -333,7 +340,10 @@ export function getMethodThermodynamics(
     detailedCookingMethods[
       methodNameLower as keyof typeof detailedCookingMethods
     ];
-  if (detailedMethodData.thermodynamicProperties) {
+  // Optional chain is load-bearing — see the twin in
+  // src/utils/recommendation/methodRecommendation.ts. Here the throw WAS
+  // reachable, and was swallowed by a catch that substituted a fabricated 0.5.
+  if (detailedMethodData?.thermodynamicProperties) {
     const thermoProps = detailedMethodData.thermodynamicProperties;
     return {
       heat: Number(thermoProps.heat) || 0.5,
@@ -355,17 +365,10 @@ export function getMethodThermodynamics(
     };
   }
 
-  // 3. Check the explicitly defined mapping constant (_COOKING_METHOD_THERMODYNAMICS)
-  // ✅ Pattern KK-1: Safe type conversion for thermodynamics lookup
-  const constantThermoData =
-    _COOKING_METHOD_THERMODYNAMICS[
-      methodNameLower as keyof typeof _COOKING_METHOD_THERMODYNAMICS
-    ];
-  if (constantThermoData) {
-    return constantThermoData;
-  }
-
-  // 4. Fallback logic based on method name characteristics - ENHANCED with more cooking methods
+  // 3. Fallback logic based on method name characteristics - ENHANCED with more cooking methods
+  //
+  // A tier reading the empty `_COOKING_METHOD_THERMODYNAMICS` used to sit above
+  // this one and could never resolve. See src/types/alchemy.ts.
   // ✅ Pattern KK-1: Direct string access since methodNameLower is already string
   const nameStr = methodNameLower;
   if (
@@ -998,18 +1001,20 @@ export async function getRecommendedCookingMethods(
     }
 
     // NEW: Thermodynamic compatibility (10% of score - creates better differentiation)
-    let thermodynamicScore = 0;
-    try {
-      const methodThermodynamics = getMethodThermodynamics(
-        method as unknown as CookingMethodProfile,
-      );
-      thermodynamicScore = calculateThermodynamicCompatibility(
-        elementalComposition,
-        methodThermodynamics,
-      );
-    } catch (_error) {
-      thermodynamicScore = 0.5; // Default if calculation fails
-    }
+    //
+    // No try/catch here any more. It used to swallow every error into
+    // `thermodynamicScore = 0.5` — a fabricated mid-value that is
+    // indistinguishable at the call site from a real computed 0.5, and which
+    // made the TypeError from the unguarded lookup above invisible in logs.
+    // getMethodThermodynamics now always returns a value via its heuristic tier,
+    // so an exception reaching here is a genuine defect and must surface.
+    const methodThermodynamics = getMethodThermodynamics(
+      method as unknown as CookingMethodProfile,
+    );
+    const thermodynamicScore = calculateThermodynamicCompatibility(
+      elementalComposition,
+      methodThermodynamics,
+    );
 
     // Astrological compatibility (25% of score)
     if (method.astrologicalInfluences) {

--- a/src/utils/recommendation/methodRecommendation.ts
+++ b/src/utils/recommendation/methodRecommendation.ts
@@ -9,7 +9,6 @@ import type {
   MethodRecommendationOptions,
   PlanetaryAspect
 } from "@/types/alchemy";
-import { _COOKING_METHOD_THERMODYNAMICS } from "@/types/alchemy";
 import type { AstrologicalState } from "@/types/celestial";
 import type { Ingredient, UnifiedIngredient } from "@/types/ingredient";
 import {
@@ -263,12 +262,19 @@ export function getMethodThermodynamics(
     String((method as unknown as Record<string, unknown>).name).toLowerCase() ||
     "";
 
-  // 1. Check the detailed data source first
+  // 1. Check the detailed data source first.
+  //
+  // The optional chain is load-bearing: this lookup MISSES for any method whose
+  // declared `name` differs from its record key, and the dereference below was
+  // unguarded, so a miss threw TypeError rather than falling through to tier 2.
+  // Production had not crashed on it only by accident — the aggregator upstream
+  // rewrites `name: id`, so the mismatched names never reached this path. Any
+  // caller passing a real method object hit it.
   const detailedMethodData =
     detailedCookingMethods[
     methodNameLower as keyof typeof detailedCookingMethods
     ];
-  if (detailedMethodData.thermodynamicProperties) {
+  if (detailedMethodData?.thermodynamicProperties) {
     return {
       heat: detailedMethodData.thermodynamicProperties.heat ?? 0.5,
       entropy: detailedMethodData.thermodynamicProperties._entropy ?? 0.5,
@@ -292,16 +298,12 @@ export function getMethodThermodynamics(
     };
   }
 
-  // 3. Check the explicitly defined mapping constant
-  const constantThermoData =
-    _COOKING_METHOD_THERMODYNAMICS[
-    methodNameLower as keyof typeof _COOKING_METHOD_THERMODYNAMICS
-    ];
-  if (constantThermoData) {
-    return constantThermoData;
-  }
-
-  // 4. Fallback logic based on method name characteristics - Safe string access
+  // 3. Fallback logic based on method name characteristics - Safe string access
+  //
+  // A tier reading `_COOKING_METHOD_THERMODYNAMICS` used to sit above this one.
+  // That constant was `{}`, so its `if` guard was never true and this heuristic
+  // has been the real tier 3 all along. See src/types/alchemy.ts for why it was
+  // removed rather than populated.
   if (
     methodNameLower.includes("grill") ||
     methodNameLower.includes("roast") ||


### PR DESCRIPTION
Three defects in cooking-method thermodynamics resolution, all the same shape: **a lookup that misses without saying so.**

## 1. Unguarded dereference

Tier 1 of `getMethodThermodynamics` read `detailedCookingMethods[key].thermodynamicProperties` with no guard — in **both** copies of the function. A key miss threw `TypeError` instead of falling through to tier 2.

The lookup misses whenever a method's declared `name` differs from its record key: `"Pressure Cooking"` lowercases to `"pressure cooking"` while the key is `pressure_cooking`.

In `recommendation/methodRecommendation.ts` the throw had not fired in production **only by accident** — an aggregator upstream rewrites `name: id` before the lookup, so the mismatched names never arrived. Any caller passing a real method object hit it. In `cookingMethodRecommender.ts` the throw *was* reachable, and was swallowed — see §3.

## 2. A registry that could never resolve

`_COOKING_METHOD_THERMODYNAMICS` was `{}`. Four call sites read it as tier 3, each behind `if (constantThermoData)`. With no keys that guard was **always false**, so the tier could never hit while reading like a working priority tier, and control always fell through to the keyword heuristic below it.

In `CookingMethods.tsx` the two uses iterated `Object.keys({})` — loops that never ran a single iteration.

**Removed rather than populated.** The heuristic tier is what has actually been deciding these values; adding entries would change live behaviour under the guise of a cleanup. If a curated table is wanted, it should be introduced deliberately with sourced values.

## 3. A swallowed TypeError

```ts
catch (_error) {
  thermodynamicScore = 0.5; // Default if calculation fails
}
```

That converted the throw from §1 into a fabricated mid-value — indistinguishable at the call site from a computed 0.5 — and kept the `TypeError` out of the logs entirely. Removed. `getMethodThermodynamics` now always returns via its heuristic tier, so an exception reaching that point is a genuine defect and must surface.

## Also

Corrected a comment that pointed readers at the wrong module for **both** the constant (it lived in `src/types/alchemy.ts`, not `src/data/cooking/thermodynamics.ts`) and the detailed catalog (the import resolves to `allCookingMethods`, not the legacy `src/data/cooking/cookingMethods.ts`).

## Verification

11 tests, run against **both** copies of the resolver via `describe.each` so the two cannot drift apart silently.

Control verified: restoring the unguarded dereference fails **10 of 11**.

Typecheck 0 errors, lint clean, 19/19 across the affected suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)