### PR TITLE
fix(cooking-methods): one normalizer, zero renames — close the key-space fracture

### DIFF
--- a/src/__tests__/cookingMethodKeyspace.test.ts
+++ b/src/__tests__/cookingMethodKeyspace.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Registry totality and normalization guards for the cooking-method key space.
+ *
+ * `[MEASURED 2026-07-31]` an audit found at least 27 registries and alias maps
+ * keying cooking methods, four distinct types named `CookingMethod`, and five
+ * different normalization rules. Six of the 27 servable methods resolved no
+ * pillar and therefore rendered with untransformed ESMS.
+ *
+ * The fix deliberately renames NOTHING. Method keys are persisted in three
+ * Postgres surfaces read by exact string equality — most sharply
+ * `user_profiles.taste_corrections.methods`, where a stored
+ * `{"stir-frying": "block"}` is a user saying *never this*, applied by exact key
+ * match with no normalization and no backfill hook anywhere in database/init/.
+ * Renaming that key silently revokes the user's choice.
+ *
+ * So every guard here is written against BOTH old and new spellings: the point
+ * is that both resolve, permanently.
+ *
+ * These are runtime tests by necessity. Both registries are read through
+ * `Record<string, …>` index signatures, so TypeScript cannot see a missing key.
+ *
+ * @file src/__tests__/cookingMethodKeyspace.test.ts
+ */
+
+import { getCookingMethodPillar } from "@/constants/alchemicalPillars";
+import {
+  CANONICAL_COOKING_METHOD_KEYS,
+  REGISTRY_ONLY_COOKING_METHOD_KEYS,
+  SERVABLE_COOKING_METHOD_KEYS,
+  normalizeCookingMethodKey,
+  normalizeSlug,
+  resolveRegistryKey,
+  toCanonicalCookingMethodKey,
+} from "@/constants/cookingMethodKeys";
+import { allCookingMethods } from "@/data/cooking/methods";
+import { METHOD_PHYSICAL_REFERENCE } from "@/data/cooking/physicalReference";
+import { getKineticProfile } from "@/utils/cookingMethodKinetics";
+
+describe("the canonical list matches the live registry", () => {
+  it("lists exactly the ids allCookingMethods serves", () => {
+    expect([...SERVABLE_COOKING_METHOD_KEYS].sort()).toEqual(
+      Object.keys(allCookingMethods).sort(),
+    );
+  });
+
+  it("keeps registry-only keys separate from servable ones", () => {
+    // `baking` has a pillar entry AND a kinetic profile but no data file — a
+    // real catalog gap. Naming it here keeps "no profile" distinct from
+    // "no method".
+    for (const key of REGISTRY_ONLY_COOKING_METHOD_KEYS) {
+      expect(Object.keys(allCookingMethods)).not.toContain(key);
+    }
+    expect(REGISTRY_ONLY_COOKING_METHOD_KEYS).toContain("baking");
+  });
+
+  it("unions both sets into the canonical vocabulary", () => {
+    expect(CANONICAL_COOKING_METHOD_KEYS).toHaveLength(
+      SERVABLE_COOKING_METHOD_KEYS.length + REGISTRY_ONLY_COOKING_METHOD_KEYS.length,
+    );
+  });
+});
+
+describe("every servable method resolves in every registry", () => {
+  it.each([...SERVABLE_COOKING_METHOD_KEYS])("%s resolves a pillar", (id) => {
+    expect(getCookingMethodPillar(id)).toBeDefined();
+  });
+
+  it.each([...SERVABLE_COOKING_METHOD_KEYS])("%s resolves a kinetic profile", (id) => {
+    // getKineticProfile now returns null rather than six fabricated 0.50s, so a
+    // null here is a genuine registry gap.
+    expect(getKineticProfile(id)).not.toBeNull();
+  });
+
+  it.each([...SERVABLE_COOKING_METHOD_KEYS])("%s resolves a physical reference", (id) => {
+    const physical: Record<string, unknown> = METHOD_PHYSICAL_REFERENCE;
+    expect(resolveRegistryKey(id, Object.keys(physical))).not.toBeNull();
+  });
+});
+
+describe("every declared method name resolves — the data/registry seam", () => {
+  // This is the seam the registry-only tests cannot see: a registry can be
+  // perfectly total over its own keys while the strings the data files actually
+  // declare miss every one of them.
+  it.each(Object.entries(allCookingMethods).map(([id, m]) => [id, String((m as { name?: string }).name ?? "")]))(
+    "%s declares name %p, which normalizes onto its record key",
+    (id, declaredName) => {
+      if (!declaredName) return;
+      expect(normalizeCookingMethodKey(declaredName)).toBe(normalizeCookingMethodKey(id));
+    },
+  );
+
+  it.each(Object.values(allCookingMethods).map((m) => String((m as { name?: string }).name ?? "")))(
+    "the declared name %p resolves a pillar",
+    (declaredName) => {
+      if (!declaredName) return;
+      expect(getCookingMethodPillar(declaredName)).toBeDefined();
+    },
+  );
+});
+
+describe("old spellings keep resolving — nothing was renamed", () => {
+  // Each pair is (legacy spelling still stored somewhere, modern spelling).
+  const PAIRS: Array<[string, string]> = [
+    ["fermenting", "fermentation"],
+    ["drying", "dehydrating"],
+    ["stir-frying", "stir_frying"],
+  ];
+
+  it.each(PAIRS)("%s and %s both resolve a pillar", (legacy, modern) => {
+    expect(getCookingMethodPillar(legacy)).toBeDefined();
+    expect(getCookingMethodPillar(modern)).toBeDefined();
+  });
+
+  it.each(PAIRS)("%s and %s resolve to the SAME pillar", (legacy, modern) => {
+    expect(getCookingMethodPillar(legacy)?.id).toBe(getCookingMethodPillar(modern)?.id);
+  });
+});
+
+describe("normalization tolerates every spelling in the data", () => {
+  it("collapses separators and case", () => {
+    for (const input of ["Pressure Cooking", "pressure-cooking", "PRESSURE_COOKING"]) {
+      expect(getCookingMethodPillar(input)).toBeDefined();
+    }
+  });
+
+  it("folds accents", () => {
+    // "Sautéing" is a persisted picker option in FoodLabBook and appears in
+    // several cuisine files; without folding it never meets the key `sauteing`.
+    expect(normalizeCookingMethodKey("Sautéing")).toBe("sauteing");
+    expect(getCookingMethodPillar("Sautéing")).toBeDefined();
+  });
+
+  it("returns undefined for a genuine non-method rather than guessing", () => {
+    expect(getCookingMethodPillar("not_a_cooking_method_xyz")).toBeUndefined();
+    expect(toCanonicalCookingMethodKey("not_a_cooking_method_xyz")).toBeNull();
+  });
+});
+
+describe("the slug rule is derived from the key rule", () => {
+  it("composes: slug = strip(normalizeCookingMethodKey(x))", () => {
+    for (const key of CANONICAL_COOKING_METHOD_KEYS) {
+      expect(normalizeSlug(key)).toBe(
+        normalizeCookingMethodKey(key).replace(/[^a-z0-9]/g, ""),
+      );
+    }
+  });
+
+  it("maps every URL spelling the techniques route used to accept", () => {
+    const cases: Array<[string, string]> = [
+      ["stirfrying", "stir_frying"],
+      ["stir-frying", "stir_frying"],
+      ["sousvide", "sous_vide"],
+      ["pressurecooking", "pressure_cooking"],
+      ["Pressure Cooking", "pressure_cooking"],
+      ["cryocooking", "cryo_cooking"],
+    ];
+    const ids = Object.keys(allCookingMethods);
+    for (const [url, expected] of cases) {
+      const q = normalizeSlug(url);
+      expect(ids.find((k) => normalizeSlug(k) === q)).toBe(expected);
+    }
+  });
+
+  it("produces a collision-free slug space across all canonical keys", () => {
+    const slugs = CANONICAL_COOKING_METHOD_KEYS.map(normalizeSlug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+});
+
+describe("the kinetic fallback no longer fabricates", () => {
+  it("returns null for an unregistered method instead of six 0.50s", () => {
+    const result = getKineticProfile("a_method_that_does_not_exist");
+    expect(result).toBeNull();
+  });
+
+  it("still honours an explicitly supplied data profile", () => {
+    const supplied = {
+      voltage: 0.1,
+      current: 0.2,
+      resistance: 0.3,
+      velocityFactor: 0.4,
+      momentumRetention: 0.5,
+      forceImpact: 0.6,
+    };
+    expect(getKineticProfile("a_method_that_does_not_exist", supplied)).toBe(supplied);
+  });
+});

--- a/src/app/api/techniques/[name]/route.ts
+++ b/src/app/api/techniques/[name]/route.ts
@@ -1,26 +1,34 @@
 import { NextResponse } from "next/server";
+import { normalizeSlug } from "@/constants/cookingMethodKeys";
 import { allCookingMethods } from "@/data/cooking/methods";
 import { rateLimit } from "@/lib/rateLimit";
 
 export const dynamic = "force-dynamic";
 
-function normalize(s: string): string {
-  return s.toLowerCase().replace(/[^a-z0-9]/g, "").trim();
-}
-
-// Common verb → canonical cooking method name
+/**
+ * Common verb → CANONICAL COOKING METHOD KEY.
+ *
+ * The values here are canonical keys, not URL slugs. They used to be written in
+ * the stripped slug spelling (`"stirfrying"`, `"sousvide"`, `"pressurecooking"`),
+ * which made this a hand-maintained parallel list that drifts the moment a
+ * method is added or its key changes.
+ *
+ * Matching now runs both sides through `normalizeSlug`, which is derived from
+ * the canonical key normalizer — so these values stay correct without anyone
+ * remembering to restrip them.
+ */
 const VERB_ALIASES: Record<string, string> = {
   roast: "roasting",
   roasted: "roasting",
   bake: "roasting",
   baked: "roasting",
   baking: "roasting",
-  saute: "stirfrying",
-  sauteed: "stirfrying",
-  sear: "stirfrying",
-  seared: "stirfrying",
-  stirfry: "stirfrying",
-  stirfried: "stirfrying",
+  saute: "stir_frying",
+  sauteed: "stir_frying",
+  sear: "stir_frying",
+  seared: "stir_frying",
+  stirfry: "stir_frying",
+  stirfried: "stir_frying",
   fry: "frying",
   fried: "frying",
   deepfry: "frying",
@@ -40,8 +48,8 @@ const VERB_ALIASES: Record<string, string> = {
   braised: "braising",
   stew: "stewing",
   stewed: "stewing",
-  sousvide: "sousvide",
-  pressurecook: "pressurecooking",
+  sousvide: "sous_vide",
+  pressurecook: "pressure_cooking",
   ferment: "fermentation",
   fermented: "fermentation",
   pickle: "pickling",
@@ -68,21 +76,26 @@ export async function GET(
   try {
     const { name } = await props.params;
     const queryRaw = decodeURIComponent(name);
-    const query = normalize(queryRaw);
+    const query = normalizeSlug(queryRaw);
 
-    // Try direct key match first
+    // Both sides go through normalizeSlug, so the registry's own spelling never
+    // has to match the URL's. `pressure_cooking`, `Pressure Cooking` and
+    // `pressurecooking` all reduce to the same string.
     const keys = Object.keys(allCookingMethods);
-    let match = keys.find((k) => normalize(k) === query);
+    let match = keys.find((k) => normalizeSlug(k) === query);
 
-    // Try alias
+    // Alias values are canonical keys, so they are slugged the same way rather
+    // than being stored pre-stripped.
     if (!match && VERB_ALIASES[query]) {
-      const aliasTarget = VERB_ALIASES[query];
-      match = keys.find((k) => normalize(k) === aliasTarget);
+      const aliasTarget = normalizeSlug(VERB_ALIASES[query]);
+      match = keys.find((k) => normalizeSlug(k) === aliasTarget);
     }
 
-    // Try substring
+    // Substring, last resort.
     if (!match) {
-      match = keys.find((k) => normalize(k).includes(query) || query.includes(normalize(k)));
+      match = keys.find(
+        (k) => normalizeSlug(k).includes(query) || query.includes(normalizeSlug(k)),
+      );
     }
 
     if (!match) {

--- a/src/components/recommendations/EnhancedCookingMethodRecommender.tsx
+++ b/src/components/recommendations/EnhancedCookingMethodRecommender.tsx
@@ -569,12 +569,19 @@ export default function EnhancedCookingMethodRecommender({ onDoubleClickMethod }
         )
         : null;
 
-      const methodPowerProxy = Math.max(0, Math.min(1, kProfile.voltage * kProfile.current * (1 - kProfile.resistance)));
+      // Null when the method has no registered kinetic profile. The lookup used
+      // to return six 0.50 midpoints on a miss, which produced a real-looking
+      // power proxy for a method the registry knows nothing about.
+      const methodPowerProxy = kProfile
+        ? Math.max(0, Math.min(1, kProfile.voltage * kProfile.current * (1 - kProfile.resistance)))
+        : null;
       const currentPowerProxy = currentMoment
         ? Math.max(0, Math.min(1, Math.abs(currentMoment.circuit.power) * 20))
         : null;
       const kineticAlignmentScore =
-        currentPowerProxy === null ? null : Math.max(0, 100 - Math.abs(methodPowerProxy - currentPowerProxy) * 100);
+        currentPowerProxy === null || methodPowerProxy === null
+          ? null
+          : Math.max(0, 100 - Math.abs(methodPowerProxy - currentPowerProxy) * 100);
 
       // Calculate Harmony Index via Resonance Gap model
       const duration = method.duration || method.time_range;
@@ -951,27 +958,33 @@ export default function EnhancedCookingMethodRecommender({ onDoubleClickMethod }
     return (
       <div className="space-y-4">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="rounded-xl border border-white/10 bg-transparent p-5 shadow-sm">
-            <h4 className="text-sm font-bold text-gray-300 mb-3">P=IV Circuit Profile</h4>
-            <div className="flex justify-center">
-              <KineticRadar profile={kProfile} size={180} />
+          {/* Rendered only when the method has a registered kinetic profile.
+              The lookup used to substitute six 0.50 midpoints on a miss, so this
+              panel would display a full circuit readout for a method the
+              registry knows nothing about. Absent is now absent. */}
+          {kProfile && (
+            <div className="rounded-xl border border-white/10 bg-transparent p-5 shadow-sm">
+              <h4 className="text-sm font-bold text-gray-300 mb-3">P=IV Circuit Profile</h4>
+              <div className="flex justify-center">
+                <KineticRadar profile={kProfile} size={180} />
+              </div>
+              <div className="mt-3 grid grid-cols-3 gap-2 text-center">
+                {[
+                  { label: "Voltage", value: kProfile.voltage, unit: "V" },
+                  { label: "Current", value: kProfile.current, unit: "I" },
+                  { label: "Resistance", value: kProfile.resistance, unit: "R" },
+                  { label: "Velocity", value: kProfile.velocityFactor, unit: "v" },
+                  { label: "Momentum", value: kProfile.momentumRetention, unit: "p" },
+                  { label: "Force", value: kProfile.forceImpact, unit: "F" },
+                ].map(({ label, value, unit }) => (
+                  <div key={label} className="text-xs">
+                    <div className="text-gray-400">{label}</div>
+                    <div className="font-bold text-gray-300">{value.toFixed(2)} <span className="text-gray-400 text-[10px]">{unit}</span></div>
+                  </div>
+                ))}
+              </div>
             </div>
-            <div className="mt-3 grid grid-cols-3 gap-2 text-center">
-              {[
-                { label: "Voltage", value: kProfile.voltage, unit: "V" },
-                { label: "Current", value: kProfile.current, unit: "I" },
-                { label: "Resistance", value: kProfile.resistance, unit: "R" },
-                { label: "Velocity", value: kProfile.velocityFactor, unit: "v" },
-                { label: "Momentum", value: kProfile.momentumRetention, unit: "p" },
-                { label: "Force", value: kProfile.forceImpact, unit: "F" },
-              ].map(({ label, value, unit }) => (
-                <div key={label} className="text-xs">
-                  <div className="text-gray-400">{label}</div>
-                  <div className="font-bold text-gray-300">{value.toFixed(2)} <span className="text-gray-400 text-[10px]">{unit}</span></div>
-                </div>
-              ))}
-            </div>
-          </div>
+          )}
 
           {kinetics && (
             <div className="rounded-xl border border-white/10 bg-transparent p-5 shadow-sm">

--- a/src/constants/alchemicalPillars.ts
+++ b/src/constants/alchemicalPillars.ts
@@ -1,5 +1,6 @@
 // src/constants/alchemicalPillars.ts
 
+import { normalizeCookingMethodKey } from "@/constants/cookingMethodKeys";
 import { seasonalElements } from "@/data/seasons";
 import type { Season, ElementalProperties, QuantityScaledProperties } from "@/types/alchemy";
 import type { AlchemicalProperty, Element, LunarPhase} from "@/types/celestial";
@@ -338,6 +339,49 @@ export const COOKING_METHOD_PILLAR_MAPPING = {
   raw: 9, // Purification
   ceviche: 1, // Solution
   marinating: 4, // Distillation (flavor extraction)
+
+  // ── Methods that had no pillar under any spelling ────────────────────────
+  //
+  // `[MEASURED 2026-08-01]` 6 of the 27 servable methods resolved no pillar,
+  // so they rendered with UNTRANSFORMED ESMS and shared an identical kalchm.
+  //
+  // These are ADDED, never renamed. Method keys are persisted in three Postgres
+  // surfaces read by exact string equality — `user_profiles.taste_corrections
+  // .methods` most sharply, where a stored `{"stir-frying": "block"}` is a user
+  // saying *never this*. Renaming a key silently revokes that, and there is no
+  // backfill hook anywhere in database/init/. So `drying` and `dehydrating`
+  // both resolve, `fermenting` and `fermentation` both resolve, and every test
+  // and stored value that worked before still works.
+
+  // Same referent as `drying: 3` above; both spellings are live in the data.
+  dehydrating: 3, // Evaporation
+  // Same referent as `fermenting: 11` above.
+  fermentation: 11, // Fermentation
+  // Same referent as `"stir-frying": 5` above; the data files use stir_frying.
+  stir_frying: 5, // Separation
+
+  // Distillation by name and by mechanism — separation of volatiles by
+  // evaporation and condensation, which is pillar 4's own description.
+  distilling: 4, // Distillation
+  // Flavour extraction into a carrier liquid. Follows the in-repo precedent
+  // set by `marinating: 4 // Distillation (flavor extraction)` above.
+  infusing: 4, // Distillation (flavor extraction)
+
+  // Fire-primary with a substantial Water component from the lidded braise
+  // phase (tilt-skillet.ts elementalEffect Fire 0.55 / Water 0.25 / Earth 0.12,
+  // and profiles/dry.ts: "the lid converts dry conduction into moist
+  // convection: Fire recedes, Water rises"). That moist phase rules out
+  // Calcination's open-heat volatile loss, leaving pillar 5, whose
+  // elementalAssociations are Fire primary / Water secondary.
+  tilt_skillet: 5, // Separation
+
+  // Ruled 13 by the project owner. Recorded for the reader: an adversarial
+  // review argued for 11 (Fermentation) on element order, a suitable_for list
+  // identical to braising and stewing, Mars planetary overlap, and Spirit
+  // direction — pressure cooking retains volatiles ("nothing escapes the
+  // lock"), which argues Spirit +1 rather than pillar 1's Spirit -1.
+  // 13 and 11 differ in Spirit, so this is a real ESMS difference, not cosmetic.
+  pressure_cooking: 13, // Multiplication
 };
 
 /**
@@ -435,7 +479,22 @@ export function getCookingMethodPillar(
   // a bounds-checked `Record` for the dynamic lookup below (same pattern used
   // in monicaKalchmCalculations.ts).
   const pillarMapping: Record<string, number> = COOKING_METHOD_PILLAR_MAPPING;
-  const pillerId = pillarMapping[cookingMethod.toLowerCase()];
+
+  // This used to be a bare `.toLowerCase()`, which collapsed no separators and
+  // folded no accents. "Pressure Cooking" became "pressure cooking" (a space),
+  // "Cryo-Cooking" kept its hyphen, and "Sautéing" kept its accent — none of
+  // which is a key here. Normalizing tolerates every spelling in the data
+  // without renaming a single stored key.
+  const normalized = normalizeCookingMethodKey(cookingMethod);
+  const pillerId =
+    pillarMapping[normalized] ??
+    // Registry keys are not all in normalized form (e.g. "stir-frying"), so
+    // fall back to comparing normalized forms on both sides.
+    pillarMapping[
+      Object.keys(pillarMapping).find(
+        (key) => normalizeCookingMethodKey(key) === normalized,
+      ) ?? ""
+    ];
   if (!pillerId) return undefined;
   return ALCHEMICAL_PILLARS.find((pillar) => pillar.id === pillerId);
 }

--- a/src/constants/cookingMethodKeys.ts
+++ b/src/constants/cookingMethodKeys.ts
@@ -1,0 +1,176 @@
+/**
+ * Canonical cooking-method key space.
+ *
+ * ── Why this exists ─────────────────────────────────────────────────────────
+ *
+ * `[MEASURED 2026-07-31]` an audit found at least 27 registries and alias maps
+ * keying cooking methods, four distinct types named `CookingMethod`, and five
+ * different normalization rules. Under the two live rules, 6 of the 27 real
+ * methods fail to resolve a pillar.
+ *
+ * The fix is deliberately NOT a rename. Method keys are persisted in three
+ * Postgres surfaces read by exact string equality — most sharply
+ * `user_profiles.taste_corrections.methods`, where a stored `{"stir-frying":
+ * "block"}` is a user saying *never this*. Renaming the key silently revokes
+ * that, and there is no backfill hook anywhere in `database/init/`.
+ *
+ * So: registries keep their existing keys, and every reader normalizes instead.
+ * Both `fermenting` and `fermentation` resolve, forever.
+ *
+ * ── Two normalizers, tethered ───────────────────────────────────────────────
+ *
+ * `normalizeCookingMethodKey` — the data-layer rule. Collapses separators to
+ *   underscores so `"Pressure Cooking"`, `"pressure-cooking"` and
+ *   `"pressure_cooking"` are one key.
+ *
+ * `normalizeSlug` — the URL rule. Strips to bare alphanumerics so a route can
+ *   accept `/techniques/pressurecooking`.
+ *
+ * They do genuinely different jobs, but the slug is DERIVED from the key form
+ * rather than maintained beside it. That is the whole point: a hand-written
+ * parallel list of slugs drifts the moment a method is added, and the route's
+ * alias table had already drifted into storing slug spellings as its values.
+ *
+ * @file src/constants/cookingMethodKeys.ts
+ */
+
+/**
+ * Every cooking method with a data file, i.e. the keys of `allCookingMethods`.
+ *
+ * `[MEASURED 2026-08-01]` these 27 are the ids the /cooking-methods routes and
+ * /api/techniques actually serve. Registry totality is asserted against THIS
+ * list, because a method the app cannot serve cannot be missing a profile.
+ */
+export const SERVABLE_COOKING_METHOD_KEYS = [
+  "boiling",
+  "braising",
+  "broiling",
+  "cryo_cooking",
+  "curing",
+  "dehydrating",
+  "distilling",
+  "emulsification",
+  "fermentation",
+  "frying",
+  "gelification",
+  "grilling",
+  "infusing",
+  "marinating",
+  "pickling",
+  "poaching",
+  "pressure_cooking",
+  "raw",
+  "roasting",
+  "simmering",
+  "smoking",
+  "sous_vide",
+  "spherification",
+  "steaming",
+  "stewing",
+  "stir_frying",
+  "tilt_skillet",
+] as const;
+
+export type ServableCookingMethodKey = (typeof SERVABLE_COOKING_METHOD_KEYS)[number];
+
+/**
+ * Keys that appear in a registry but have no data file, so nothing can be
+ * served for them.
+ *
+ * `[MEASURED 2026-08-01]` `baking` carries both a pillar entry and a kinetic
+ * profile yet has no method data — a real catalog gap, not a naming artifact.
+ * `sauteing`, `foam` and `ceviche` are pillar-only. They are named here rather
+ * than quietly dropped so the difference between "we have no profile" and "we
+ * have no method" stays visible.
+ */
+export const REGISTRY_ONLY_COOKING_METHOD_KEYS = [
+  "baking",
+  "ceviche",
+  "foam",
+  "sauteing",
+] as const;
+
+/**
+ * Every method key the system names, servable or not.
+ *
+ * This is the vocabulary a schema should validate against; totality checks over
+ * the registries use {@link SERVABLE_COOKING_METHOD_KEYS} instead.
+ */
+export type CanonicalCookingMethodKey =
+  | ServableCookingMethodKey
+  | (typeof REGISTRY_ONLY_COOKING_METHOD_KEYS)[number];
+
+export const CANONICAL_COOKING_METHOD_KEYS: readonly CanonicalCookingMethodKey[] =
+  [...SERVABLE_COOKING_METHOD_KEYS, ...REGISTRY_ONLY_COOKING_METHOD_KEYS].sort();
+
+const CANONICAL_SET: ReadonlySet<string> = new Set<string>([
+  ...SERVABLE_COOKING_METHOD_KEYS,
+  ...REGISTRY_ONLY_COOKING_METHOD_KEYS,
+]);
+
+/**
+ * Data-layer key normalization.
+ *
+ * lowercase → fold accents → collapse runs of whitespace and hyphens to a
+ * single underscore.
+ *
+ * Accent folding matters and is not decorative: `"Sautéing"` appears in a
+ * persisted picker option (`FoodLabBook.tsx`), a type union, and several cuisine
+ * files, and without folding it never meets the registry key `sauteing`.
+ *
+ * This function is total and never throws — an unrecognised string normalizes
+ * to something that simply will not be found, which callers handle as absence.
+ */
+export function normalizeCookingMethodKey(input: string): string {
+  return input
+    .normalize("NFD")
+    // Strip combining diacritical marks (U+0300–U+036F).
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .trim()
+    .replace(/[\s-]+/g, "_");
+}
+
+/**
+ * URL-slug normalization, derived from the key form.
+ *
+ * Composition is the contract: `normalizeSlug = stripNonAlphanumeric ∘
+ * normalizeCookingMethodKey`. A change to the key rule propagates here
+ * automatically, so the two can never disagree about what a method is called.
+ *
+ * `normalizeSlug("Pressure Cooking") === normalizeSlug("pressure_cooking")
+ *  === normalizeSlug("pressurecooking") === "pressurecooking"`
+ */
+export function normalizeSlug(input: string): string {
+  return normalizeCookingMethodKey(input).replace(/[^a-z0-9]/g, "");
+}
+
+/** Narrow an arbitrary string to a canonical key, or null if it is not one. */
+export function toCanonicalCookingMethodKey(
+  input: string,
+): CanonicalCookingMethodKey | null {
+  const normalized = normalizeCookingMethodKey(input);
+  return CANONICAL_SET.has(normalized)
+    ? (normalized as CanonicalCookingMethodKey)
+    : null;
+}
+
+/**
+ * Resolve an arbitrary user- or data-supplied string against a registry's own
+ * keys, tolerating any spelling on either side.
+ *
+ * This is how a reader consults a registry without that registry being
+ * renamed: the registry keeps `drying` and `fermenting`, and a caller asking for
+ * `dehydrating` or `fermentation` still has to miss — normalization alone cannot
+ * bridge two genuinely different words. Those cases are fixed by ADDING the
+ * second spelling to the registry, not by renaming the first.
+ *
+ * @returns the registry's own key, so the caller indexes it directly.
+ */
+export function resolveRegistryKey(
+  input: string,
+  registryKeys: readonly string[],
+): string | null {
+  const target = normalizeCookingMethodKey(input);
+  return registryKeys.find((key) => normalizeCookingMethodKey(key) === target) ?? null;
+}

--- a/src/data/cooking/physicalReference.ts
+++ b/src/data/cooking/physicalReference.ts
@@ -151,4 +151,28 @@ export const METHOD_PHYSICAL_REFERENCE: Record<string, MethodPhysicalReference> 
         temperatureF: { low: 34, high: 70, ideal: 40, note: "Refrigerated diffusion and acid/salt-driven denaturation for safety + controlled uptake." },
         pressure: { mode: "ambient", gaugePsi: "0", absoluteKPa: "~101", note: "Typically atmospheric unless vacuum tumbling/compression is used." },
     },
+
+    // ── Servable methods that had no physical reference ──────────────────────
+    // [MEASURED 2026-08-01] `stewing` and `raw` were the only two of the 27
+    // servable methods with no entry here, so their temperature and pressure
+    // block was silently omitted from the /cooking-methods surfaces.
+    stewing: {
+        temperatureF: {
+            low: 180, high: 205, ideal: 190,
+            note: "Held just below a boil so collagen converts to gelatin without the agitation that shreds fibres; the same sub-simmer window as simmering, sustained far longer.",
+        },
+        pressure: { mode: "ambient", gaugePsi: "0", absoluteKPa: "~101", note: "Covered vessel at atmospheric pressure; the lid limits evaporation, not pressure." },
+    },
+    raw: {
+        temperatureF: {
+            low: 34, high: 70, ideal: 40,
+            note: "No applied heat. The range is storage and service temperature, bounded below by freezing and above by the food-safety danger zone.",
+            proteins: {
+                seafood: { temp: 34, note: "Held as close to freezing as possible; raw seafood is the least forgiving on time-temperature." },
+                redMeat: { temp: 38, note: "Refrigerated service for tartare and carpaccio." },
+                vegetable: { temp: 55, note: "Cool but not cold — full aromatic expression is lost at refrigerator temperature." },
+            },
+        },
+        pressure: { mode: "ambient", gaugePsi: "0", absoluteKPa: "~101", note: "Atmospheric throughout; no thermal or pressure processing is applied." },
+    },
 };

--- a/src/types/environmentalResponseSchema.ts
+++ b/src/types/environmentalResponseSchema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { CANONICAL_COOKING_METHOD_KEYS } from "@/constants/cookingMethodKeys";
 
 /**
  * Environmental Thermodynamics — canonical contracts.
@@ -33,41 +34,15 @@ import { z } from "zod";
  * snake_case throughout. Every registry must be total over this list; the
  * coverage test is the enforcement point.
  */
-export const CANONICAL_COOKING_METHODS = [
-  "baking",
-  "boiling",
-  "braising",
-  "broiling",
-  "ceviche",
-  "cryo_cooking",
-  "curing",
-  "dehydrating",
-  "distilling",
-  "emulsification",
-  "fermentation",
-  "foam",
-  "frying",
-  "gelification",
-  "grilling",
-  "infusing",
-  "marinating",
-  "pickling",
-  "poaching",
-  "pressure_cooking",
-  "raw",
-  "roasting",
-  "sauteing",
-  "simmering",
-  "smoking",
-  "sous_vide",
-  "spherification",
-  "steaming",
-  "stewing",
-  "stir_frying",
-  "tilt_skillet",
-] as const;
+// The canonical key space now lives in src/constants/cookingMethodKeys.ts, which
+// owns the cooking-method domain. It was duplicated here; two hand-maintained
+// lists of the same 31 strings is the exact fracture this schema was written to
+// describe.
+export const CANONICAL_COOKING_METHODS = CANONICAL_COOKING_METHOD_KEYS;
 
-export const cookingMethodKeySchema = z.enum(CANONICAL_COOKING_METHODS);
+export const cookingMethodKeySchema = z.enum(
+  CANONICAL_COOKING_METHOD_KEYS as unknown as [string, ...string[]],
+);
 export type CookingMethodKey = z.infer<typeof cookingMethodKeySchema>;
 
 /**

--- a/src/utils/cookingMethodKinetics.ts
+++ b/src/utils/cookingMethodKinetics.ts
@@ -12,6 +12,7 @@
  * "Sous Vide" (low power, low entropy, high stability).
  */
 
+import { normalizeCookingMethodKey } from "@/constants/cookingMethodKeys";
 import type { Element } from "@/types/celestial";
 import type { CookingMethodKineticProfile } from "@/types/cookingMethod";
 import type { AspectPhase, KineticMetrics } from "@/types/kinetics";
@@ -299,21 +300,31 @@ interface MethodKineticsInput {
 export function getKineticProfile(
   methodId: string,
   dataProfile?: CookingMethodKineticProfile,
-): CookingMethodKineticProfile {
+): CookingMethodKineticProfile | null {
   if (dataProfile) return dataProfile;
 
-  // Normalize method name for lookup
-  const normalized = methodId.toLowerCase().replace(/[\s-]+/g, "_");
+  const normalized = normalizeCookingMethodKey(methodId);
 
-  return COOKING_METHOD_KINETIC_PROFILES[normalized] ?? {
-    // Fallback for unknown methods
-    voltage: 0.50,
-    current: 0.50,
-    resistance: 0.50,
-    velocityFactor: 0.50,
-    momentumRetention: 0.50,
-    forceImpact: 0.50,
-  };
+  const direct = COOKING_METHOD_KINETIC_PROFILES[normalized];
+  if (direct) return direct;
+
+  // Registry keys are not all in normalized form, so compare normalized forms
+  // on both sides before giving up.
+  const matched = Object.keys(COOKING_METHOD_KINETIC_PROFILES).find(
+    (key) => normalizeCookingMethodKey(key) === normalized,
+  );
+  if (matched) return COOKING_METHOD_KINETIC_PROFILES[matched];
+
+  // Returns null rather than six fabricated 0.50s.
+  //
+  // The old fallback handed back a full profile of midpoints for any unknown
+  // method. Downstream, a 0.50 voltage from this fallback is indistinguishable
+  // from a 0.50 voltage that was actually authored — so a method silently
+  // missing from the registry scored as though it had been measured.
+  //
+  // A coverage test asserts every servable method resolves here, so null means
+  // a genuine gap that a caller must handle, not a routine miss.
+  return null;
 }
 
 /**
@@ -392,6 +403,16 @@ export function calculateMethodSpecificKinetics(
   } = input;
 
   const profile = getKineticProfile(methodId, dataProfile);
+  if (!profile) {
+    // Throws rather than substituting midpoints. A coverage test asserts every
+    // servable method resolves a profile, so reaching this means an
+    // unregistered method id — a programming error that must be visible, not a
+    // recommendation quietly scored on six invented 0.50s.
+    throw new Error(
+      `No kinetic profile for cooking method "${methodId}". ` +
+        `Register it in COOKING_METHOD_KINETIC_PROFILES or pass a dataProfile.`,
+    );
+  }
   const planetaryBoost = getPlanetaryElementBoost(elementalEffect, planetaryPositions);
   const monicaValue = monica ?? 1.0;
 

--- a/src/utils/methodAlchemicalSnapshot.ts
+++ b/src/utils/methodAlchemicalSnapshot.ts
@@ -60,7 +60,12 @@ export interface MethodAlchemicalSnapshot {
   kalchm: number;
   monica: number | null;
   kinetics: KineticMetrics | null;
-  kProfile: CookingMethodKineticProfile;
+  /**
+   * Null when the method has no registered kinetic profile. Previously this was
+   * non-null because the lookup substituted six 0.50 midpoints on a miss, which
+   * consumers could not distinguish from authored values.
+   */
+  kProfile: CookingMethodKineticProfile | null;
   harmony: HarmonyResult;
 }
 

--- a/src/utils/tiltSkilletCircuit.ts
+++ b/src/utils/tiltSkilletCircuit.ts
@@ -144,7 +144,9 @@ export function computeStageCircuit(
     thermodynamics: { heat: thermo.heat, entropy: thermo.entropy, reactivity: thermo.reactivity },
     gregsEnergy: thermo.gregsEnergy,
     monica: Number.isFinite(thermo.monica) ? thermo.monica : null,
-    kineticProfile: getKineticProfile("tilt_skillet"),
+    // tilt_skillet is a registered profile, so this never resolves null; the
+    // bridge exists because the field is optional rather than nullable.
+    kineticProfile: getKineticProfile("tilt_skillet") ?? undefined,
     planetaryPositions,
   });
 


### PR DESCRIPTION
`[MEASURED 2026-07-31]` an audit found **at least 27 registries and alias maps** keying cooking methods, **four** distinct types named `CookingMethod`, and **five** different normalization rules. 6 of the 27 servable methods resolved no pillar and rendered with untransformed ESMS, sharing an identical kalchm.

## Nothing is renamed — and that is the central decision

Adversarial verification of the original rename-based plan returned **`safe: false`**.

Method keys are persisted in three Postgres surfaces read by **exact string equality**, with no backfill hook anywhere in `database/init/`:

| Surface | Why it matters |
|---|---|
| `user_profiles.taste_corrections.methods` | A stored `{"stir-frying":"block"}` is a user saying *never this*, applied by exact key match at `userInteractionsService.ts:193-204` |
| `user_interactions.payload` | Taste-graph history aggregated by exact string |
| `food_lab_entries.cooking_method` | Stores Title Case, including `'Sautéing'` |

**Renaming a key silently revokes a user's explicit blocklist.**

The same review also found the rename would fix only 3 of 7 unmapped methods (*"the proposal's premise is 43% true"*), break a currently-passing test, 404 every multiword alias on `/api/techniques`, and orphan 26 committed WebP assets.

So readers normalize, and registries **gain** spellings instead of losing them.

## What changed

**`src/constants/cookingMethodKeys.ts`** (new) — two deliberately distinct lists: `SERVABLE_COOKING_METHOD_KEYS` (27, have a data file; totality is asserted against these) and `REGISTRY_ONLY_COOKING_METHOD_KEYS`. `baking` has a pillar entry *and* a kinetic profile but **no method data** — a real catalog gap, now named rather than silently absent.

**`normalizeCookingMethodKey`** — lowercase → fold accents → collapse `[\s-]+` to `_`. Accent folding is load-bearing: `'Sautéing'` is a persisted picker option and without folding never meets the key `sauteing`.

**`normalizeSlug` is derived, not parallel** — `normalizeSlug = stripNonAlphanumeric ∘ normalizeCookingMethodKey`. The route's 48 `VERB_ALIASES` *values* were written in stripped slug spelling (`"stirfrying"`, `"sousvide"`), a hand-maintained list that drifts. Values are now canonical keys, slugged on the fly.

**6 pillar entries added alongside the existing ones**, so both spellings resolve:

```
dehydrating: 3   (beside drying: 3)        distilling: 4
fermentation: 11 (beside fermenting: 11)   infusing: 4
stir_frying: 5   (beside "stir-frying": 5) tilt_skillet: 5
pressure_cooking: 13
```

Each carries its evidence in-code. `pressure_cooking` is ruled **13** by you; an adversarial review argued **11** on five independent lines, and that argument is recorded at the mapping — 13 and 11 differ in Spirit, so it is a real ESMS difference, not cosmetic.

**The kinetic fallback is gone.** `getKineticProfile` returned six fabricated `0.50` midpoints on a miss, indistinguishable downstream from authored values. It now returns `null`, and `calculateMethodSpecificKinetics` **throws with the offending method id** rather than scoring a recommendation on invented physics.

**`stewing` and `raw`** were the only servable methods with no `METHOD_PHYSICAL_REFERENCE` entry, so their temperature/pressure block was silently omitted from the UI. Both added.

**`CANONICAL_COOKING_METHODS`** was duplicated into `environmentalResponseSchema.ts` by #680; it now imports from the module that owns the domain.

## Tests — 152

Runtime by necessity: both registries are read through `Record<string, …>` index signatures, so TypeScript cannot see a missing key.

The highest-value ones cover the **data/registry seam**: every `name:` string the data files declare must normalize onto its own record key *and* resolve a pillar. A registry can be perfectly total over its own keys while every string the data actually declares misses all of them.

Old spellings are asserted to keep working **and to resolve to the same pillar** as their modern twin — the regression that would revoke a user's blocklist.

Controls verified: dropping `pressure_cooking` fails 3 tests; dropping the added `fermentation` spelling fails 4.

Typecheck 0 errors, lint clean, **180/180** across the affected suites.

Depends on nothing; #689 touches adjacent files but not the same lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)