### PR TITLE
docs: record the key-space and environmental-thermodynamics decisions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,34 @@
 - Verify: `bun run verify`
 - Test: `bun run test`
 
+## No fabricated values
+
+Every value must name a basis and be reproducible from it. Where none exists,
+return an explicit absent state — `null`, or a documented `ABSENT` basis — never
+a plausible-looking default.
+
+`Math.random()` is an **eslint error** in `src/constants`, `src/data`,
+`src/calculations` and `src/services` (`no-restricted-syntax` in
+`eslint.config.mjs`). A fabricated value in those layers is indistinguishable at
+the call site from a computed one. Components keep genuine visual randomness. A
+shrink-only ratchet list holds the pre-existing violations; **it may only lose
+entries**. If randomness is genuinely required (ids, nonces, jitter), add an
+`eslint-disable-next-line` naming why.
+
+The same rule applies to lookups. A miss must be visible:
+
+- Return `null` or throw — never a default object of midpoints. `getKineticProfile`
+  used to return six `0.50`s on a miss.
+- Never `catch { score = 0.5 }`. A swallowed error becomes a fabricated number
+  and keeps the real fault out of the logs.
+- Use `??`, not `||`, on numerics — `||` silently replaces a legitimate `0`.
+- A guard over an empty table (`if (lookup[key])` where the table has no keys)
+  reads as a working tier while never resolving anything.
+
+Registries here are read through `Record<string, …>` index signatures, so
+**TypeScript cannot see a missing key** — coverage must be a runtime test, and it
+must cover the data/registry seam, not just the registry against itself.
+
 ## Agent skills
 
 ### Issue tracker

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -96,9 +96,52 @@ none — not a number synthesized from their elements.
   elements as separate inputs. Combining the two axes in a formula is correct;
   deriving one from the other is not.
 
+## Cooking methods
+
+- **Method key** — the `snake_case` identifier a registry is keyed by, e.g.
+  `pressure_cooking`. Distinct from a method's **declared name** (`"Pressure
+  Cooking"`, the Title Case string in its data file) and from its **slug**
+  (`pressurecooking`, the URL form). All three normalize to the same key; only
+  the key is a lookup identity. See ADR-009.
+- **Servable method** — a method with a data file, i.e. a key of
+  `allCookingMethods` (27 of them). Registry totality is asserted against these.
+  Contrast **registry-only key** — present in a registry with no data file
+  (`baking`, `ceviche`, `foam`, `sauteing`), so nothing can be served for it.
+- **Pillar** — one of the 14 alchemical transformations a method maps to, which
+  supplies the ESMS delta the method applies. A method with no pillar renders
+  with *untransformed* ESMS — silently, since the lookup returns `undefined`.
+- **Method keys are never renamed.** They are persisted in
+  `user_profiles.taste_corrections.methods`, `user_interactions.payload` and
+  `food_lab_entries.cooking_method`, all read by exact string equality. Adding a
+  second spelling is correct; substituting one is a data migration. See ADR-009.
+
+## Environment
+
+- **Climatic baseline** — a location's *permanent* conditions: elevation-derived
+  pressure plus a trailing 30-day robust median and dispersion per geohash. The
+  trunk, not the variable.
+- **Daily anomaly** — today's reading minus the climatic baseline, carried in
+  both physical units **and** z-scores against that location's own dispersion.
+  Elevation outweighs weather by roughly an order of magnitude, so the anomaly is
+  the smaller term and is always expressed relative to the baseline, never
+  absolutely.
+- **Station pressure** — pressure measured *at* the location (Open-Meteo's
+  `surface_pressure`). Always this. **Never sea-level pressure** (MSLP / QNH /
+  `pressure_msl`), which has the altitude signal removed by construction: using
+  it puts Denver's boiling point at 99.8 °C instead of 94.9 °C. See ADR-010.
+- **Dew point, not relative humidity**, is the transported moisture variable. RH
+  is a ratio against a temperature-dependent saturation pressure and does not
+  survive the trip from outdoor air to indoor air; dew point does.
+- **Regime** — which physical constraint governs a method: `saturation_limited`
+  (boiling point caps it), `setpoint_limited` (equipment sets it),
+  `evaporation_limited` (vapour-pressure deficit sets the rate),
+  `concentration_limited`, `leavening_limited`, `ambient_limited`. The regime
+  decides whether pressure or humidity matters at all.
+
 ## Related
 
 - `docs/HIERARCHICAL_SYSTEM_IMPLEMENTATION.md` — tiering of what data holds what.
-- `docs/adr/` — architectural decisions.
+- `docs/adr/` — architectural decisions. ADR-009 (cooking-method key space),
+  ADR-010 (environmental thermodynamics).
 - `src/components/home/QuantitiesExplainer.tsx` — the user-facing framing of the
   two readings; the terminology anchor for copy.

--- a/docs/adr/009-cooking-method-key-space.md
+++ b/docs/adr/009-cooking-method-key-space.md
@@ -1,0 +1,121 @@
+# ADR-009: Cooking-method key space — normalize on read, never rename
+
+**Status:** Accepted
+**Date:** 2026-08-01
+**Implemented by:** #690 (and #689, which removed the fallbacks that hid the problem)
+
+## Context
+
+An audit on 2026-07-31 found the cooking-method key space fractured well beyond
+what any single registry suggests:
+
+- **At least 27 registries and alias maps** key cooking methods, plus two large
+  free-text vocabularies (recipe method tags, cuisine dish descriptions).
+- **Four distinct types named `CookingMethod`** — `types/shared.ts:237`,
+  `types/constants.ts:55`, `types/culinary.ts:632`, `types/alchemy.ts:599` — with
+  no relationship to each other.
+- **Five different normalization rules**, from a bare `.toLowerCase()` to one
+  that strips every non-alphanumeric character.
+
+The measurable consequence: **6 of the 27 servable methods resolved no
+alchemical pillar**, so they rendered with untransformed ESMS and shared an
+identical kalchm. Two more had no `METHOD_PHYSICAL_REFERENCE` entry, so their
+temperature and pressure block was silently omitted from the UI.
+
+The obvious fix — one canonical `snake_case` union, rename the divergent
+spellings, add a coverage test — was drafted and approved. Adversarial
+verification returned **`safe: false`**.
+
+### Why the rename was rejected
+
+Cooking-method keys are **persisted in three Postgres surfaces read by exact
+string equality**, with no backfill hook anywhere in `database/init/`:
+
+| Surface | Consequence of a rename |
+|---|---|
+| `user_profiles.taste_corrections.methods` | A stored `{"stir-frying":"block"}` is a user saying *never this*, applied by exact key match at `userInteractionsService.ts:193-204`. **The block silently stops working.** |
+| `user_interactions.payload` | Taste-graph history is aggregated by exact string; a rename splits one user's accumulated counts across two keys, and the top-5 shows both with neither carrying the full total. |
+| `food_lab_entries.cooking_method` | Stores Title Case from a picker (`'Fermenting'`, `'Sautéing'`); every stored row orphans. |
+
+The review also established the rename would fix **only 3 of the 7** unmapped
+methods (`tilt_skillet`, `pressure_cooking`, `infusing` and `distilling` have no
+pillar entry under *any* spelling), break a currently-passing test, 404 every
+multiword alias on `/api/techniques`, and orphan 26 committed WebP assets whose
+filenames follow the current spelling.
+
+## Decision
+
+**Readers normalize. Registries gain spellings. Nothing is renamed.**
+
+1. **`src/constants/cookingMethodKeys.ts` owns the key space.** It exports two
+   deliberately distinct lists:
+   - `SERVABLE_COOKING_METHOD_KEYS` (27) — methods with a data file. Registry
+     totality is asserted against these, because a method the app cannot serve
+     cannot be missing a profile.
+   - `REGISTRY_ONLY_COOKING_METHOD_KEYS` (`baking`, `ceviche`, `foam`,
+     `sauteing`) — present in a registry with no data file. `baking` carries both
+     a pillar entry and a kinetic profile yet has no method data: a real catalog
+     gap, named rather than silently absent.
+
+2. **One data-layer normalizer.** `normalizeCookingMethodKey` = lowercase → NFD
+   accent-fold → collapse `[\s-]+` to `_`. Accent folding is load-bearing, not
+   cosmetic: `'Sautéing'` is a persisted picker option and without folding never
+   meets the registry key `sauteing`.
+
+3. **The URL slug is derived, not parallel.**
+   `normalizeSlug = stripNonAlphanumeric ∘ normalizeCookingMethodKey`. The two
+   rules do genuinely different jobs — one collapses separators, one removes them
+   — but composing them means they cannot disagree about what a method is called.
+   The `/api/techniques` alias table had already drifted into storing slug
+   spellings (`"stirfrying"`, `"sousvide"`) as its *values*; those are canonical
+   keys now, slugged on the fly.
+
+4. **Missing entries are ADDED beside the old ones**, never substituted:
+   `dehydrating: 3` beside `drying: 3`, `fermentation: 11` beside
+   `fermenting: 11`, `stir_frying: 5` beside `"stir-frying": 5`. Both spellings
+   resolve, permanently. Plus `distilling: 4`, `infusing: 4`, `tilt_skillet: 5`,
+   `pressure_cooking: 13`, each carrying its evidence in-code.
+
+5. **Lookups that miss return absence, not a plausible value.**
+   `getKineticProfile` previously returned `?? { voltage: .5, current: .5,
+   resistance: .5, velocityFactor: .5, momentumRetention: .5, forceImpact: .5 }`
+   — six fabricated midpoints indistinguishable downstream from authored values.
+   It now returns `null`, and `calculateMethodSpecificKinetics` throws naming the
+   offending method id.
+
+## Consequences
+
+**Enforcement is a runtime test**, not a type. Both registries are read through
+`Record<string, …>` index signatures, so TypeScript cannot see a missing key —
+this is precisely why the fracture survived so long. `src/__tests__/cookingMethodKeyspace.test.ts`
+carries 152 cases, and the highest-value ones cover the **data/registry seam**:
+every `name:` string the data files declare must normalize onto its own record
+key *and* resolve a pillar. A registry can be perfectly total over its own keys
+while every string the data actually declares misses all of them.
+
+**Old spellings are asserted to keep resolving, and to resolve to the same
+pillar** as their modern twin. That test is the guard against a future
+"cleanup" reintroducing the revocation risk.
+
+**The key space is now larger, not smaller.** This is the intended trade. A
+smaller key space would require a data migration on user-authored preferences;
+a larger one costs an extra map entry.
+
+**Live behaviour shifts.** Six methods gain pillar effects they did not have,
+which re-orders the cooking-methods list and changes displayed kalchm. That is
+the bug being fixed, not a regression — but expect it rather than discover it.
+
+**Not addressed here, deliberately:**
+
+- `calculatePillarCompatibility` (sign-agreement scoring) and `esmsAlignment`
+  (normalised L1 distance) are two real, disagreeing compatibility formulas.
+  Choosing between them changes live recommendation output and belongs in its
+  own decision.
+- `pressure_cooking` is ruled **13 (Multiplication)** by the project owner. An
+  adversarial review argued **11 (Fermentation)** on element order,
+  `suitable_for` family, planetary overlap and Spirit direction. 13 and 11 differ
+  in Spirit, so this is a real ESMS difference; the argument is recorded in-code
+  at the mapping for any future reader.
+- The remaining ~24 registries and alias maps are untouched. This ADR fixes the
+  four that feed the alchemical engine; the rest were catalogued but not
+  consolidated.

--- a/docs/adr/010-environmental-thermodynamics.md
+++ b/docs/adr/010-environmental-thermodynamics.md
@@ -1,0 +1,122 @@
+# ADR-010: Environmental thermodynamics — the Dual-Baseline engine
+
+**Status:** Accepted, partially implemented (step 1 of 5)
+**Date:** 2026-08-01
+**Implemented by:** #680 (ingestion). Steps 2–5 outstanding.
+
+## Context
+
+Cooking recommendations should respond to where and when a user is cooking:
+atmospheric pressure sets the boiling point, and humidity governs evaporation.
+The naive design feeds "live weather" into the recommendation pipeline.
+
+That design is wrong in a way that is easy to miss. **Elevation dominates
+weather by roughly an order of magnitude:**
+
+| Condition | Absolute pressure | Boiling point | Δ vs sea level |
+|---|---|---|---|
+| Sea level, standard | 101.3 kPa | 100.0 °C | — |
+| Hurricane eyewall (950 hPa) | 95.0 kPa | 98.2 °C | −1.8 |
+| Denver, 1609 m | 83.4 kPa | 94.6 °C | **−5.4** |
+| La Paz, 3640 m | 64.0 kPa | 87.0 °C | −13.0 |
+
+The most violent weather on Earth is worth one third of Denver. A single "live
+pressure" input conflates a permanent geographic fact with a transient one, and
+the transient one is nearly always the smaller term.
+
+### The failure mode this subsystem exists to avoid
+
+Consumer weather APIs return **sea-level-adjusted pressure (MSLP/QNH)** by
+default — the station reading extrapolated down to sea level using an ISA lapse
+rate. `[MEASURED 2026-07-30]` Open-Meteo, Denver (39.7392, −104.9903, 1599 m),
+same timestamp:
+
+```
+surface_pressure   840.4 hPa  →  boiling 94.9 °C
+pressure_msl      1006.0 hPa  →  boiling 99.8 °C
+```
+
+**A 4.9 °C error from reading the adjacent field** — plausible-looking, and wrong
+everywhere except the coast.
+
+## Decision
+
+**Two baselines, not one.**
+
+1. **Climatic baseline** — elevation-derived pressure via the ISA barometric
+   formula, plus a trailing 30-day robust location/dispersion per geohash. This
+   is the permanent trunk.
+2. **Daily anomaly** — today's live reading minus that baseline, expressed in
+   **both** physical units and **z-scores** against the location's own
+   dispersion. A −1.8 kPa swing is routine on the Gulf coast and a 3σ event in
+   Denver; neither number substitutes for the other.
+
+**Supporting decisions:**
+
+- **`assertStationPressure` guards the MSLP trap at the ingestion boundary**, and
+  throws rather than clamping — a wrong-field reading would poison every baseline
+  computed from it. The check is **discriminative** ("is this closer to sea level
+  than to where elevation says it should be?"), not a tolerance band: a band wide
+  enough to admit a real hurricane is too wide to catch MSLP. Below ~600 m it
+  declines to judge, because the two hypotheses are genuinely indistinguishable
+  there — and that is also where the trap causes least harm.
+- **Robust statistics (median + MAD×1.4826), not mean/σ.** The events worth
+  flagging *are* the outliers, and a classical σ lets a storm inflate the very
+  denominator that would have detected it.
+- **Geohash p5 (~5 km) keys weather; elevation is resolved separately at full DEM
+  fidelity.** Finer than p5 is false precision against an ~11 km model grid, but
+  a p5 cell in rugged terrain spans more than a degree of boiling point.
+- **One sample per geohash per day at its own derived UTC hour.** Fixing the hour
+  keeps the semidiurnal atmospheric tide (~1–2 hPa, a real periodic signal) out
+  of the window's dispersion, and spreads the fleet across the day.
+- **Dew point, not relative humidity, is the transported variable.** RH is a ratio
+  against a temperature-dependent saturation pressure, so 80% RH at 10 °C outdoors
+  is *drier air* than 40% RH at 22 °C indoors. Dew point survives the trip
+  indoors; RH is recomputed at the indoor temperature when needed.
+- **Advisories fire on a dual gate:** `|z| ≥ minimumZ` **AND**
+  `effect ≥ minimumEffect`. Z alone fires on rare-but-physically-trivial days;
+  effect alone ignores that "unusual here" is what makes a daily tip worth
+  reading. Channels driven by the **elevation baseline rather than the anomaly**
+  carry `minimumZ: 0` — geography is not an anomaly and should not be statistically
+  gated.
+- **90 days raw retained against a 30-day window**, so the statistic stays
+  recomputable and auditable. Robust statistics cannot be updated incrementally
+  the way a mean can.
+- **Archive-seeded on first sight** (ERA5, ~6-day lag), so a new location has
+  valid anomalies on day one rather than after a month of accumulation.
+
+## Consequences
+
+**⚠️ The subsystem is currently inert.** `database/init/74-environmental-observations.sql`
+has not been applied to any database — the CI gate
+(`scripts/checkEnvironmentalSqlParses.ts`) only ever creates it inside a
+rolled-back transaction. With `environmental_baselines` empty, the hourly cron
+has nothing to sample. To bring it alive: apply migration 74, then
+`POST /api/admin/environment/seed`.
+
+**The response profiles are inert types.** `src/types/environmentalResponseSchema.ts`
+and `src/constants/environmentalResponseProfiles.ts` ship for step 5; only 5 of
+31 methods have profiles, chosen because each breaks a naive design — `roasting`
+(surface and interior respond to humidity in *opposite* directions), `pressure_cooking`
+(gauge pressure composes with ambient rather than cancelling it), `baking` (two
+humidity clocks), `dehydrating` (humidity first-order), `frying` (a negative
+control that should never fire a daily advisory).
+
+**`ambientCoupling` is the one unsourced axis.** How much of the outdoor anomaly
+reaches the cooking environment. The closed-oven value (0.03) is bounded by a
+mass balance — a 50 L cavity holds ~0.87 g of ambient water against 200–400 g
+released by a 2 kg roast — and open-air is 1.0 by definition. The middle values
+are reasoned, not measured, and are marked `tunable: true`.
+
+**Magnitudes are smaller than intuition suggests, and the schema enforces that.**
+Boyle's law gives a 1.8 kPa anomaly ~1.8% extra dough expansion, not the ~15%
+that "check your proofing 15 minutes early" would imply. Flour sorption justifies
+holding back ~2.6% of formula water for a +4 °C dew-point anomaly at full
+equilibration, not 10%. The `minimumEffect` floors exist to keep the engine
+silent rather than confidently wrong; `dehydrating` is where the daily anomaly
+regularly clears threshold.
+
+**Remaining steps:** (2) *done* — see ADR-009; (3) promote
+`METHOD_PHYSICAL_REFERENCE` to SI-typed canonical with a full Antoine/ISA solver;
+(4) derive the P=IV circuit model from ESMS + pillar effects; (5) calc engine,
+public API, and the remaining 26 response profiles.

--- a/docs/adr/010-environmental-thermodynamics.md
+++ b/docs/adr/010-environmental-thermodynamics.md
@@ -87,12 +87,22 @@ everywhere except the coast.
 
 ## Consequences
 
-**⚠️ The subsystem is currently inert.** `database/init/74-environmental-observations.sql`
-has not been applied to any database — the CI gate
-(`scripts/checkEnvironmentalSqlParses.ts`) only ever creates it inside a
-rolled-back transaction. With `environmental_baselines` empty, the hourly cron
-has nothing to sample. To bring it alive: apply migration 74, then
-`POST /api/admin/environment/seed`.
+**⚠️ The subsystem is currently inert — because nothing has been seeded, not
+because the schema is missing.** `[MEASURED 2026-08-01]` migration 74 **is**
+applied in production. Note the applier asymmetry that makes this easy to get
+wrong: migrations run from the **Railway Python backend container**
+(`backend/Dockerfile` invokes `run_init_migrations` before uvicorn), while
+Vercel's `buildCommand` is `next build` and never runs one. A Vercel deploy can
+therefore ship a cron that queries tables Railway has not created yet, and the CI
+gate cannot tell you either way — it applies the migration inside a transaction
+and rolls back, so a green gate is fully compatible with the table not existing.
+Check the database, not the gate.
+
+With `environmental_baselines` empty the hourly cron is a clean 200-OK no-op, and
+nothing in the ingestion layer can create the first row: `buildUpsertBaseline` is
+reached only via `seedFromArchive` (admin POST) or `sampleGeohash`, which the
+due-query only offers for geohashes that already have a baseline. To bring it
+alive: `POST /api/admin/environment/seed`.
 
 **The response profiles are inert types.** `src/types/environmentalResponseSchema.ts`
 and `src/constants/environmentalResponseProfiles.ts` ship for step 5; only 5 of
@@ -115,6 +125,15 @@ holding back ~2.6% of formula water for a +4 °C dew-point anomaly at full
 equilibration, not 10%. The `minimumEffect` floors exist to keep the engine
 silent rather than confidently wrong; `dehydrating` is where the daily anomaly
 regularly clears threshold.
+
+**Shipped with a defect, corrected in #696.** The sampling hour was derived
+twice — MD5 in SQL (deciding when a cell is due) and a `*31` charCode polynomial
+in TypeScript (deciding which hour's reading to keep). They disagreed for 489 of
+508 geohashes, and any cell whose TS hour fell later than its SQL hour would have
+written nothing, permanently, while the run reported success. The general lesson
+is recorded here because the shape recurs: **a value derived twice in two
+languages is invisible to every single-language check.**
+`scripts/checkSamplingHourAgrees.ts` now evaluates both against a real database.
 
 **Remaining steps:** (2) *done* — see ADR-009; (3) promote
 `METHOD_PHYSICAL_REFERENCE` to SI-typed canonical with a full Antoine/ISA solver;


### PR DESCRIPTION
Five PRs merged today — #680, #682, #686, #689, #690 — all fixing one defect class: **a value a caller cannot distinguish from a real one.** This records the decisions so they aren't re-derived or accidentally reversed.

## ADR-009 — cooking-method key space

Why the obvious fix (one canonical union, rename the divergent spellings) was **rejected**: method keys are persisted in three Postgres surfaces read by exact string equality, with no backfill hook anywhere in `database/init/`. Most sharply, a stored `{"stir-frying":"block"}` in `user_profiles.taste_corrections.methods` is a user saying *never this* — renaming the key silently revokes it.

Records the shipped design (normalize on read, **add** spellings) and the three things deliberately left open: the two competing compatibility formulas, the `pressure_cooking` pillar ruling with its counter-argument, and the ~24 registries catalogued but not consolidated.

## ADR-010 — environmental thermodynamics

Why there are **two** baselines rather than one live reading: elevation outweighs weather by roughly an order of magnitude (Denver −5.4 °C against a hurricane's −1.8 °C).

Records the MSLP trap with its measurement — `surface_pressure` 840.4 hPa vs `pressure_msl` 1006.0 hPa at the same Denver timestamp, a **4.9 °C error** — the discriminative guard that catches it, and why the subsystem is **currently inert** (migration 74 unapplied, no location seeded).

## CONTEXT.md

Glossary entries for the terms these introduce: method key vs declared name vs slug, servable vs registry-only key, climatic baseline, daily anomaly, station pressure vs sea-level pressure, regime.

States plainly that **method keys are never renamed** — the rule most likely to be broken by a well-intentioned cleanup.

## CLAUDE.md

A "no fabricated values" section covering the eslint rule and its shrink-only ratchet, plus the lookup rules these PRs established:

- return `null` or throw rather than a default object of midpoints
- never `catch { score = 0.5 }`
- `??` not `||` on numerics
- beware a guard over an empty table — it reads as a working tier while never resolving

And the reason coverage has to be a runtime test: registries here are read through `Record<string, …>` index signatures, so TypeScript cannot see a missing key.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)