### PR TITLE
fix(recipe-nft): make the on-chain commitment commit, while the ledger is still empty

### DIFF
--- a/database/init/57-recipe-nft-content-envelope.sql
+++ b/database/init/57-recipe-nft-content-envelope.sql
@@ -1,0 +1,18 @@
+-- database/init/57-recipe-nft-content-envelope.sql
+-- The exact content envelope the on-chain contentHash commits to, persisted at
+-- mint time. The content route serves THIS verbatim for minted recipes.
+--
+-- Why: the envelope embeds the alchemical fingerprint, which depends on the
+-- live ingredient catalog. Recomputing it at serve time meant any catalog edit
+-- changed the served bytes out from under the hash in the URL — while the
+-- route's Cache-Control said `immutable`. An on-chain commitment must resolve
+-- to stored bytes, not to a function of mutable inputs.
+--
+-- Nullable: rows minted before this migration (none exist — the table is 0
+-- rows at migration time) and the featured pre-mint recipe recompute instead.
+
+ALTER TABLE recipe_nft_mints
+    ADD COLUMN IF NOT EXISTS content_json JSONB;
+
+COMMENT ON COLUMN recipe_nft_mints.content_json IS
+    'The exact content envelope contentHash commits to (schema v2+). Served verbatim by /api/recipes/nft/content/{hash}; never recomputed from the live catalog.';

--- a/src/__tests__/recipeNftContentCommitment.test.ts
+++ b/src/__tests__/recipeNftContentCommitment.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Recipe-NFT content commitment — schema v2 identity and integrity pins.
+ *
+ * Four defects fixed together while `recipe_nft_mints` is still 0 rows (the
+ * last cheap window before anything is committed on-chain):
+ *   1. `id` was inside the contentHash envelope, so the SAME dish minted again
+ *      under a different client-chosen id produced a different hash and walked
+ *      straight past the UNIQUE(content_hash) dedupe.
+ *   2. User-visible content (tags, finishing/serving, leftovers, vitamins,
+ *      minerals) was NOT committed — silently mutable post-mint.
+ *   3. The content route recomputed the fingerprint from the live ingredient
+ *      catalog while claiming `Cache-Control: immutable` (served bytes drifted
+ *      from the hash in the URL whenever the catalog changed). Now the mint
+ *      stores the exact envelope and the route serves it verbatim.
+ *   4. A mint with on-chain enabled could commit a localhost/protected-preview
+ *      contentURI permanently — now refused via isPublicCommitmentBase.
+ */
+import {
+  buildRecipeNftContent,
+  computeCommitments,
+  CONTENT_SCHEMA_VERSION,
+} from "@/lib/recipe-nft/content";
+import { computeRecipeFingerprint } from "@/lib/recipe-nft/fingerprint";
+import { parseRecipeForMint, type MintableRecipe } from "@/lib/recipe-nft/mintableRecipe";
+import { featuredRecipe } from "@/data/featuredRecipe";
+import { isPublicCommitmentBase } from "@/utils/urlUtils";
+
+const baseRecipe = (): MintableRecipe =>
+  JSON.parse(JSON.stringify(featuredRecipe)) as MintableRecipe;
+
+const hashesOf = (r: MintableRecipe) => computeCommitments(r, computeRecipeFingerprint(r));
+
+describe("content envelope schema v2", () => {
+  it("pins the schema version", () => {
+    expect(CONTENT_SCHEMA_VERSION).toBe(2);
+  });
+
+  it("keeps the client-chosen id OUT of the identity", () => {
+    const a = baseRecipe();
+    const b = baseRecipe();
+    b.id = "totally-different-client-id";
+    // THE DEFECT: under v1 these differed, so re-minting the same dish under a
+    // fresh id bypassed the UNIQUE(content_hash) dedupe.
+    expect(hashesOf(a).contentHash).toBe(hashesOf(b).contentHash);
+    // POSITIVE CONTROL — the hash still discriminates real content: change one
+    // ingredient quantity and every commitment that embeds content moves.
+    const c = baseRecipe();
+    c.ingredients[0].quantity = String(Number(c.ingredients[0].quantity || "1") + 1);
+    expect(hashesOf(a).contentHash).not.toBe(hashesOf(c).contentHash);
+    // And the envelope itself carries no id key at all.
+    const envelope = buildRecipeNftContent(a, computeRecipeFingerprint(a));
+    expect("id" in envelope).toBe(false);
+  });
+
+  it("commits the user-visible content v1 left mutable", () => {
+    const recipe = baseRecipe();
+    const envelope = buildRecipeNftContent(recipe, computeRecipeFingerprint(recipe)) as Record<
+      string,
+      unknown
+    >;
+    // Fields present on the recipe must land in the envelope (stableStringify
+    // skips undefined, so optional-absent stays stable).
+    for (const key of [
+      "tags",
+      "finishing_and_serving",
+      "leftovers_and_storage",
+      "vitamins",
+      "minerals",
+    ] as const) {
+      if ((recipe as Record<string, unknown>)[key] !== undefined) {
+        expect(envelope[key]).toEqual((recipe as Record<string, unknown>)[key]);
+      }
+    }
+    // Moment-relative evaluations stay OUT: they grade fit-to-request, not the
+    // recipe, and would make the same dish hash differently by mood.
+    expect("alignment_score" in envelope).toBe(false);
+    expect("alignment_notes" in envelope).toBe(false);
+  });
+
+  it("changes the hash when committed-but-previously-mutable content changes", () => {
+    const a = baseRecipe();
+    const b = baseRecipe();
+    (b as Record<string, unknown>).finishing_and_serving = "Serve cold, garnish with regret.";
+    expect(hashesOf(a).contentHash).not.toBe(hashesOf(b).contentHash);
+  });
+
+  it("round-trips the featured recipe through the mint parser", () => {
+    // The stored-envelope path serves parseRecipeForMint(recipe_json)'s output;
+    // if the featured recipe cannot round-trip, the ledger path is broken.
+    const parsed = parseRecipeForMint(featuredRecipe);
+    expect(parsed.ok).toBe(true);
+  });
+});
+
+describe("isPublicCommitmentBase — no dead contentURIs on-chain", () => {
+  const OLD = { ...process.env };
+  afterEach(() => {
+    process.env.VERCEL_URL = OLD.VERCEL_URL;
+    process.env.VERCEL_PROJECT_PRODUCTION_URL = OLD.VERCEL_PROJECT_PRODUCTION_URL;
+  });
+
+  it("refuses localhost and loopback", () => {
+    expect(isPublicCommitmentBase("http://localhost:3000")).toBe(false);
+    expect(isPublicCommitmentBase("http://127.0.0.1:3000")).toBe(false);
+    expect(isPublicCommitmentBase("http://app.localhost:3000")).toBe(false);
+    expect(isPublicCommitmentBase("not a url")).toBe(false);
+  });
+
+  it("accepts the production site", () => {
+    expect(isPublicCommitmentBase("https://alchm.kitchen")).toBe(true);
+  });
+
+  it("refuses a Deployment-Protection-gated Vercel deployment URL", () => {
+    process.env.VERCEL_URL = "wten-abc123-team.vercel.app";
+    process.env.VERCEL_PROJECT_PRODUCTION_URL = "alchm.kitchen";
+    // The deployment URL returns 401 to the public — committing it on-chain
+    // permanently points the token at a door that never opens.
+    expect(isPublicCommitmentBase("https://wten-abc123-team.vercel.app")).toBe(false);
+    // The production alias itself stays fine even when it IS the deployment.
+    process.env.VERCEL_URL = "alchm.kitchen";
+    expect(isPublicCommitmentBase("https://alchm.kitchen")).toBe(true);
+  });
+});

--- a/src/app/api/recipes/mint/route.ts
+++ b/src/app/api/recipes/mint/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { gateDemoOrAuth } from "@/lib/auth/demoAccess";
 import { getCurrentSwapRates } from "@/lib/economy/swapRates";
 import { getPrivyWallet } from "@/lib/privy/server";
-import { buildMetadata, computeCommitments } from "@/lib/recipe-nft/content";
+import { buildMetadata, buildRecipeNftContent, computeCommitments } from "@/lib/recipe-nft/content";
 import { recipeNftEnabled } from "@/lib/recipe-nft/contract";
 import { baseMintCost, elementToCoin, redistributeTowardDominant } from "@/lib/recipe-nft/cost";
 import { computeRecipeFingerprint } from "@/lib/recipe-nft/fingerprint";
@@ -14,7 +14,7 @@ import { subscriptionService } from "@/services/subscriptionService";
 import { tokenEconomy } from "@/services/TokenEconomyService";
 import { getCapitalizedNatalPositions } from "@/utils/astrology/chartDataUtils";
 import { getDominantElementFromPositions } from "@/utils/astrology/signElement";
-import { getSelfBaseUrl } from "@/utils/urlUtils";
+import { getSelfBaseUrl, isPublicCommitmentBase } from "@/utils/urlUtils";
 import type { NextRequest } from "next/server";
 import type { Address } from "viem";
 
@@ -126,18 +126,38 @@ export async function POST(request: NextRequest) {
 
   // Pin display metadata: generate the hero image (live nanobanana, cached) and
   // build absolute content/metadata URIs served from our own infra (no IPFS).
-  const imageUrl =
+  // KEEP null when generation fails — the ledger stores absence, and the
+  // metadata route regenerates on absence. Coalescing to "" here permanently
+  // pinned a blank image on every mint whose generation had a transient failure.
+  const imageUrl: string | null =
     (await generateRecipeImage({
       id: recipe.id,
       title: recipe.title,
       description: recipe.short_description,
       cuisine: recipe.cuisine,
       elemental: fingerprint.elemental,
-    })) ?? "";
+    })) ?? null;
   const base = getSelfBaseUrl();
+  // A real on-chain mint commits these URIs permanently. Refuse to anchor the
+  // token to a base the public can never fetch (localhost fallback, or a
+  // Deployment-Protection-gated Vercel deployment URL) — a misconfigured env
+  // must be a 503 now, not a dead contentURI forever.
+  if (recipeNftEnabled() && !isPublicCommitmentBase(base)) {
+    return NextResponse.json(
+      {
+        error: "mint_unavailable",
+        detail:
+          "On-chain minting is enabled but no public site URL is configured (set NEXT_PUBLIC_SITE_URL). Refusing to commit a non-public contentURI on-chain.",
+      },
+      { status: 503 },
+    );
+  }
   const contentURI = `${base}/api/recipes/nft/content/${commitments.contentHash}`;
   const metadataURI = `${base}/api/recipes/nft/metadata/${commitments.contentHash}`;
-  const metadata = buildMetadata(recipe, fingerprint, { imageUrl, externalUrl: `${base}/recipe-builder` });
+  const metadata = buildMetadata(recipe, fingerprint, {
+    imageUrl: imageUrl ?? undefined,
+    externalUrl: `${base}/recipe-builder`,
+  });
 
   // Recipient = the user's own linked Base wallet when known, else the rights
   // holder (custody, matching the gas-free claim-mint model). Resolved purely
@@ -209,6 +229,9 @@ export async function POST(request: NextRequest) {
     chainResult,
     metadataUri: metadataURI,
     recipeJson: recipe,
+    // The EXACT envelope contentHash commits to — served verbatim by the
+    // content route so catalog edits can never drift the bytes from the hash.
+    contentJson: buildRecipeNftContent(recipe, fingerprint),
     imageUrl,
   };
   let record = await recipeNftMintService.recordMint(ledgerRow);

--- a/src/app/api/recipes/nft/content/[id]/route.ts
+++ b/src/app/api/recipes/nft/content/[id]/route.ts
@@ -7,8 +7,17 @@ export const runtime = "nodejs";
 
 /**
  * The canonical recipe content envelope (the exact object the on-chain
- * `contentHash` commits) — the `contentURI` target. Deterministic and immutable
- * for a given recipe + engine version, so it's cache-forever.
+ * `contentHash` commits) — the `contentURI` target.
+ *
+ * For MINTED recipes this serves the envelope STORED at mint time (migration
+ * 57), verbatim. It used to recompute the fingerprint from the live ingredient
+ * catalog on every request — while sending `Cache-Control: immutable` — so any
+ * catalog edit (e.g. PR #686's potency corrections) silently changed the served
+ * bytes out from under the hash in the URL. An on-chain commitment must resolve
+ * to stored bytes, not to a function of mutable inputs.
+ *
+ * The featured recipe (pre-mint, no ledger row) still recomputes: its URL is
+ * always derived from the CURRENT hash, so content and address move together.
  */
 export async function GET(
   _req: Request,
@@ -20,10 +29,19 @@ export async function GET(
     return NextResponse.json({ error: "Recipe not found" }, { status: 404 });
   }
 
+  if (resolved.storedContent != null) {
+    return NextResponse.json(resolved.storedContent, {
+      headers: { "Cache-Control": "public, max-age=31536000, immutable" },
+    });
+  }
+
   const fingerprint = computeRecipeFingerprint(resolved.recipe);
   const content = buildRecipeNftContent(resolved.recipe, fingerprint);
 
   return NextResponse.json(content, {
-    headers: { "Cache-Control": "public, max-age=31536000, immutable" },
+    // No `immutable` on the recomputed path: without a stored envelope this
+    // response tracks the live catalog, and a year-long immutable cache would
+    // freeze whichever version a CDN saw first.
+    headers: { "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400" },
   });
 }

--- a/src/app/api/recipes/nft/metadata/[id]/route.ts
+++ b/src/app/api/recipes/nft/metadata/[id]/route.ts
@@ -28,16 +28,19 @@ export async function GET(
 
   const { recipe, storedImageUrl } = resolved;
   const fingerprint = computeRecipeFingerprint(recipe);
+  // `||` deliberately, NOT `??`: a stored empty string means image generation
+  // failed at mint time, and it must trigger regeneration here — `??` would
+  // pin the blank image forever.
   const imageUrl =
-    storedImageUrl ??
-    (await generateRecipeImage({
+    storedImageUrl ||
+    ((await generateRecipeImage({
       id: recipe.id,
       title: recipe.title,
       description: recipe.short_description,
       cuisine: recipe.cuisine,
       elemental: fingerprint.elemental,
     })) ??
-    "";
+      "");
   const externalUrl = `${getSelfBaseUrl()}/recipe-builder`;
 
   const metadata = buildMetadata(recipe, fingerprint, { imageUrl, externalUrl });

--- a/src/lib/recipe-nft/content.ts
+++ b/src/lib/recipe-nft/content.ts
@@ -12,8 +12,23 @@ import { ALCHM_RECIPE_LICENSE } from "./contract";
 import type { MintableRecipe } from "./mintableRecipe";
 import type { RecipeFingerprint } from "./types";
 
-/** Schema version of the NFT content envelope (separate from the alchemical engine version). */
-export const CONTENT_SCHEMA_VERSION = 1;
+/**
+ * Schema version of the NFT content envelope (separate from the alchemical
+ * engine version).
+ *
+ * v2 (2026-08-01, while recipe_nft_mints is still 0 rows):
+ *   • `id` REMOVED from the envelope. It is a client-supplied handle, not
+ *     content — and because the mint dedupe keys on contentHash, a client could
+ *     mint the SAME dish arbitrarily many times by varying only `id`. Identity
+ *     now commits to what the recipe IS, not what the client called it.
+ *   • ADDED the user-visible content that v1 left uncommitted (and therefore
+ *     silently mutable post-mint): `tags`, `finishing_and_serving`,
+ *     `leftovers_and_storage`, `vitamins`, `minerals`.
+ *   • `alignment_score` / `alignment_notes` stay OUT deliberately: they grade
+ *     the recipe's fit to a particular moment/request, not the recipe itself —
+ *     committing them would make the same dish hash differently by mood.
+ */
+export const CONTENT_SCHEMA_VERSION = 2;
 
 /** Deterministic JSON with recursively sorted object keys. */
 function stableStringify(value: unknown): string {
@@ -35,7 +50,6 @@ export function buildRecipeNftContent(
   return {
     schemaVersion: CONTENT_SCHEMA_VERSION,
     engineVersion: fingerprint.engineVersion,
-    id: recipe.id,
     title: recipe.title,
     short_description: recipe.short_description,
     category: recipe.category,
@@ -43,10 +57,15 @@ export function buildRecipeNftContent(
     difficulty: recipe.difficulty,
     yields: recipe.yields,
     total_time: recipe.total_time,
+    tags: recipe.tags,
     ingredients: recipe.ingredients,
     steps: recipe.steps,
+    finishing_and_serving: recipe.finishing_and_serving,
+    leftovers_and_storage: recipe.leftovers_and_storage,
     elementalBalance: recipe.elementalBalance,
     nutrition: recipe.nutrition,
+    vitamins: recipe.vitamins,
+    minerals: recipe.minerals,
     astro_explanation: recipe.astro_explanation,
     // The alchemical fingerprint travels with the content.
     fingerprint,

--- a/src/lib/recipe-nft/resolve.ts
+++ b/src/lib/recipe-nft/resolve.ts
@@ -17,6 +17,13 @@ export interface ResolvedNftRecipe {
   recipe: MintableRecipe;
   /** A durable image URL stored at mint time, if any (else generate on demand). */
   storedImageUrl: string | null;
+  /**
+   * The exact committed content envelope stored at mint time (migration 57).
+   * When present, the content route serves THIS verbatim — never a live
+   * recomputation, whose fingerprint drifts with the ingredient catalog.
+   * Null for the featured pre-mint recipe and legacy rows.
+   */
+  storedContent: unknown | null;
 }
 
 let _featuredContentHash: string | null = null;
@@ -33,7 +40,7 @@ export async function resolveNftRecipe(id: string): Promise<ResolvedNftRecipe | 
 
   // 1. The featured recipe — by id or by its content hash (serveable pre-mint).
   if (key === featuredRecipe.id || lower === featuredContentHash()) {
-    return { recipe: featuredRecipe, storedImageUrl: null };
+    return { recipe: featuredRecipe, storedImageUrl: null, storedContent: null };
   }
 
   // 2. Any minted recipe — by content hash from the ledger.
@@ -42,7 +49,11 @@ export async function resolveNftRecipe(id: string): Promise<ResolvedNftRecipe | 
     if (stored) {
       const parsed = parseRecipeForMint(stored.recipeJson);
       if (parsed.ok && parsed.recipe) {
-        return { recipe: parsed.recipe, storedImageUrl: stored.imageUrl };
+        return {
+          recipe: parsed.recipe,
+          storedImageUrl: stored.imageUrl,
+          storedContent: stored.contentJson,
+        };
       }
     }
   }

--- a/src/services/recipeNftMintService.ts
+++ b/src/services/recipeNftMintService.ts
@@ -25,6 +25,12 @@ export interface RecordMintInput {
   metadataUri?: string;
   /** Validated recipe payload, so the metadata/content routes can rebuild the token JSON. */
   recipeJson?: unknown;
+  /**
+   * The EXACT content envelope `contentHash` commits to. The content route
+   * serves this verbatim; recomputing from the live catalog made the served
+   * bytes drift from the hash in the URL (migration 57).
+   */
+  contentJson?: unknown;
   imageUrl?: string | null;
 }
 
@@ -37,8 +43,8 @@ export const recipeNftMintService = {
            (user_id, recipe_id, title, source, content_hash, computation_hash,
             ingredient_catalog_root, engine_version, aggregation_mode, a_sharp,
             cost, transaction_group_id, status, chain, token_id, tx_hash, metadata_uri,
-            recipe_json, image_url, minted_at)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,
+            recipe_json, content_json, image_url, minted_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,
                  CASE WHEN $13 = 'minted' THEN now() ELSE NULL END)
          ON CONFLICT (content_hash) DO NOTHING
          RETURNING id`,
@@ -61,7 +67,12 @@ export const recipeNftMintService = {
           input.chainResult.txHash ?? null,
           input.metadataUri ?? null,
           input.recipeJson != null ? JSON.stringify(input.recipeJson) : null,
-          input.imageUrl ?? null,
+          input.contentJson != null ? JSON.stringify(input.contentJson) : null,
+          // NOTE `|| null`, not `?? null`: an empty string here means "image
+          // generation failed at mint time" — storing "" would permanently pin
+          // a blank image, because the metadata route regenerates only when the
+          // stored value is absent.
+          input.imageUrl || null,
         ],
       );
       const id = res.rows?.[0]?.id;
@@ -89,15 +100,21 @@ export const recipeNftMintService = {
   /** Fetch a minted recipe's stored payload (for the metadata/content routes). */
   async getByContentHash(
     contentHash: string,
-  ): Promise<{ recipeJson: unknown; imageUrl: string | null } | null> {
+  ): Promise<{ recipeJson: unknown; contentJson: unknown; imageUrl: string | null } | null> {
     try {
       const res = await executeQuery(
-        `SELECT recipe_json, image_url FROM recipe_nft_mints WHERE content_hash = $1 LIMIT 1`,
+        `SELECT recipe_json, content_json, image_url FROM recipe_nft_mints WHERE content_hash = $1 LIMIT 1`,
         [contentHash],
       );
       const row = res.rows?.[0];
       if (!row?.recipe_json) return null;
-      return { recipeJson: row.recipe_json, imageUrl: row.image_url ?? null };
+      return {
+        recipeJson: row.recipe_json,
+        contentJson: row.content_json ?? null,
+        // `|| null` deliberately: a legacy "" must read as absent so the
+        // metadata route regenerates instead of serving a blank image forever.
+        imageUrl: row.image_url || null,
+      };
     } catch {
       return null;
     }

--- a/src/utils/urlUtils.ts
+++ b/src/utils/urlUtils.ts
@@ -87,3 +87,30 @@ export const getSelfBaseUrl = (): string => {
   const port = process.env.PORT || "3000";
   return `http://localhost:${port}`;
 };
+
+/**
+ * Is `base` safe to commit into a PERMANENT public reference (an on-chain
+ * `contentURI`/`metadataURI`)? False for localhost/loopback, and false for a
+ * bare Vercel DEPLOYMENT URL that differs from the production alias — those are
+ * Deployment-Protection-gated and return 401 to the public, so committing one
+ * on-chain permanently points the token at a door that will never open.
+ */
+export const isPublicCommitmentBase = (base: string): boolean => {
+  let host: string;
+  try {
+    host = new URL(base).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  if (host === "localhost" || host === "127.0.0.1" || host === "::1" || host.endsWith(".localhost")) {
+    return false;
+  }
+  const deployment = process.env.VERCEL_URL?.trim().replace(/^https?:\/\//, "").toLowerCase();
+  const productionAlias = process.env.VERCEL_PROJECT_PRODUCTION_URL?.trim()
+    .replace(/^https?:\/\//, "")
+    .toLowerCase();
+  if (deployment && host === deployment && host !== productionAlias) {
+    return false;
+  }
+  return true;
+};


### PR DESCRIPTION
Four defects in the `contentHash` pipeline, fixed in the last cheap window — `recipe_nft_mints` is 0 rows and nothing is committed on-chain.

## 1. Identity bypass (dedupe defeated by a client string)

`id` — a client-supplied handle — was inside the committed envelope, so the **same dish re-submitted under a fresh id got a fresh contentHash** and walked past the `UNIQUE(content_hash)` dedupe: one recipe, unlimited "unique" NFTs. Removed from the envelope (`CONTENT_SCHEMA_VERSION` 1→2). Pinned: same dish + different id → same hash, with an ingredient-change positive control.

## 2. Partial commitment

`tags`, `finishing_and_serving`, `leftovers_and_storage`, `vitamins`, `minerals` are user-visible recipe content but were **not hashed** — silently mutable post-mint. Now committed. `alignment_score`/`alignment_notes` stay out deliberately: they grade fit-to-a-moment, not the recipe.

## 3. `immutable` URI, mutable bytes

The content route **recomputed the fingerprint from the live ingredient catalog** on every request while sending `Cache-Control: immutable` — any catalog edit (e.g. #686's potency corrections) changed the served bytes out from under the hash in the URL. The mint now persists the exact committed envelope (`content_json`, migration 57) and the route serves it **verbatim**; the recomputed fallback (featured, pre-mint) drops `immutable`.

## 4. Permanent-blank-image and dead-URI guards

- `imageUrl ?? ""` at mint stored `""` forever, and the metadata route's `storedImageUrl ?? regenerate` never regenerated (`??` passes `""` through). Absence is now `NULL` end-to-end; the route uses `||` deliberately, with the reasoning in place.
- With on-chain minting enabled, a misconfigured env could commit a **localhost or Deployment-Protection-gated contentURI permanently**. `isPublicCommitmentBase()` refuses both with a diagnosable 503.

## Checks

193/193 suites (1950 tests) incl. new commitment pins · `tsc` clean · eslint clean · zero file overlap with the unified-engine session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)