### PR TITLE
fix(physics): remove the THIRD divergent pole policy — kalchmEngine's invented 0.5

### DIFF
--- a/src/__tests__/thermodynamicDegenerateCharacterisation.test.ts
+++ b/src/__tests__/thermodynamicDegenerateCharacterisation.test.ts
@@ -166,3 +166,53 @@ describe("§14d — the three monica implementations are unified", () => {
     });
   });
 });
+
+// ─── kalchmEngine's ratio poles: canonical policy, not a fabricated 0.5 ──────
+//
+// Until 2026-08-01, calculateHeat/calculateEntropy/calculateReactivity in
+// src/calculations/core/kalchmEngine.ts each carried
+// `if (denominator === 0) return 0.5;` — a flat invented ratio, the THIRD
+// divergent pole policy in the repo (canonical substitutes THERMO_DEN_FLOOR at
+// a true pole; the second engine's `: 0` pole was removed in #679). Reachable
+// from production via menu-planner's NutritionalDashboard → nutritionalCalculator.
+describe("kalchmEngine ratio poles follow the canonical thermoQuotient", () => {
+  const kalchmEngine = jest.requireActual("@/calculations/core/kalchmEngine");
+  const { thermoQuotient, THERMO_DEN_FLOOR } = jest.requireActual(
+    "@/data/unified/alchemicalCalculations",
+  );
+  const ZERO = {
+    Spirit: 0, Essence: 0, Matter: 0, Substance: 0,
+    Fire: 0, Water: 0, Earth: 0, Air: 0,
+  };
+
+  it("returns the pole substitution at a true pole — never the invented 0.5", () => {
+    // All-zero input: every denominator is 0, every numerator is 0. Canonical
+    // policy: 0 / THERMO_DEN_FLOOR = 0 (a true zero, honestly reported).
+    expect(kalchmEngine.calculateHeat(ZERO)).toBe(0);
+    expect(kalchmEngine.calculateEntropy(ZERO)).toBe(0);
+    expect(kalchmEngine.calculateReactivity(ZERO)).toBe(0);
+    // A pole with a NONZERO numerator gets the published substitution, which is
+    // emphatically not 0.5 for these inputs.
+    const spiritOnly = { ...ZERO, Spirit: 2 };
+    expect(kalchmEngine.calculateReactivity(spiritOnly)).toBe(
+      thermoQuotient(4, 0),
+    );
+    expect(thermoQuotient(4, 0)).toBe(4 / THERMO_DEN_FLOOR);
+    expect(thermoQuotient(4, 0)).not.toBe(0.5);
+  });
+
+  it("propagates NaN for malformed input instead of inventing a confident ratio", () => {
+    const malformed = { ...ZERO, Spirit: NaN };
+    expect(Number.isNaN(kalchmEngine.calculateHeat(malformed))).toBe(true);
+  });
+
+  it("is exact and unchanged on healthy input", () => {
+    const healthy = {
+      Spirit: 4, Essence: 7, Matter: 6, Substance: 2,
+      Fire: 1.2, Water: 0.9, Earth: 0.8, Air: 1.1,
+    };
+    const num = 4 ** 2 + 1.2 ** 2;
+    const den = (2 + 7 + 6 + 0.9 + 1.1 + 0.8) ** 2;
+    expect(kalchmEngine.calculateHeat(healthy)).toBe(num / den);
+  });
+});

--- a/src/calculations/core/kalchmEngine.ts
+++ b/src/calculations/core/kalchmEngine.ts
@@ -8,6 +8,7 @@
 import {
   calculateKalchm as canonicalCalculateKalchm,
   calculateMonica,
+  thermoQuotient,
 } from "@/data/unified/alchemicalCalculations";
 import type { ElementalProperties, PlanetaryPosition } from "@/types/alchemy";
 import type { AlchemicalProperties } from "@/types/celestial";
@@ -83,9 +84,13 @@ export function calculateHeat(
     2,
   );
 
-  // Prevent division by zero
-  if (denominator === 0) return 0.5;
-  return numerator / denominator;
+  // Canonical pole handling (§18k k7/k30): exact wherever the ratio is defined,
+  // the published THERMO_DEN_FLOOR substitution at a true pole, NaN propagation
+  // for malformed input. The old `denominator === 0 ? 0.5` was a k12-class
+  // fabrication — a flat invented ratio indistinguishable from a measurement,
+  // and a THIRD divergent pole policy after canonical's and the second
+  // engine's (#679 removed that one).
+  return thermoQuotient(numerator, denominator);
 }
 
 /**
@@ -113,9 +118,13 @@ export function calculateEntropy(
     2,
   );
 
-  // Prevent division by zero
-  if (denominator === 0) return 0.5;
-  return numerator / denominator;
+  // Canonical pole handling (§18k k7/k30): exact wherever the ratio is defined,
+  // the published THERMO_DEN_FLOOR substitution at a true pole, NaN propagation
+  // for malformed input. The old `denominator === 0 ? 0.5` was a k12-class
+  // fabrication — a flat invented ratio indistinguishable from a measurement,
+  // and a THIRD divergent pole policy after canonical's and the second
+  // engine's (#679 removed that one).
+  return thermoQuotient(numerator, denominator);
 }
 
 /**
@@ -142,9 +151,13 @@ export function calculateReactivity(
     Math.pow(Water, 2);
   const denominator = Math.pow((Matter || 0) + (Earth || 0), 2);
 
-  // Prevent division by zero
-  if (denominator === 0) return 0.5;
-  return numerator / denominator;
+  // Canonical pole handling (§18k k7/k30): exact wherever the ratio is defined,
+  // the published THERMO_DEN_FLOOR substitution at a true pole, NaN propagation
+  // for malformed input. The old `denominator === 0 ? 0.5` was a k12-class
+  // fabrication — a flat invented ratio indistinguishable from a measurement,
+  // and a THIRD divergent pole policy after canonical's and the second
+  // engine's (#679 removed that one).
+  return thermoQuotient(numerator, denominator);
 }
 
 /**


### PR DESCRIPTION
`src/calculations/core/kalchmEngine.ts` carried `if (denominator === 0) return 0.5;` in `calculateHeat`, `calculateEntropy`, and `calculateReactivity` — a flat invented ratio at the pole, indistinguishable from a measurement (§18k k12 class). It was the repo's **third** pole policy for the same three ratios: canonical substitutes `THERMO_DEN_FLOOR` at a true pole and propagates NaN; the second engine's `: 0` pole was removed in #679; this one survived because its module did.

**Reachable from production**: menu-planner's `NutritionalDashboard` → `nutritionalCalculator` → these three functions, plus `calculateKalchmResults` via the calculations barrel.

All three sites now route through the canonical `thermoQuotient` (the module already imports from the canonical engine — no new dependency, no cycle).

## Behavioral shift, deliberate and pinned

| input | before | after |
|---|---|---|
| all-zero | `0.5` (invented) | `0` (a true zero, honestly reported) |
| nonzero numerator, zero denominator | `0.5` | `numerator / THERMO_DEN_FLOOR` |
| NaN input | `0.5` (confident fabrication) | `NaN` (propagated) |
| healthy input | — | bit-identical, unchanged |

New pins in `thermodynamicDegenerateCharacterisation.test.ts`; the existing three-implementation monica agreement suite still passes.

## Checks

193/193 suites (1953 tests) · `tsc` clean · no overlap with the unified-engine session's files (that session owns the *canonical* module's future; this PR only consumes its existing export).

🤖 Generated with [Claude Code](https://claude.com/claude-code)