### PR TITLE
fix(environment): TS and SQL disagreed on the sampling hour for 97% of cells

### DIFF
--- a/.github/workflows/monica-integrity.yml
+++ b/.github/workflows/monica-integrity.yml
@@ -182,6 +182,19 @@ jobs:
           DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
         run: bun scripts/checkEnvironmentalSqlParses.ts
 
+      - name: Sampling hour agrees between TypeScript and SQL
+        if: ${{ !cancelled() && steps.db-secret.outcome == 'success' }}
+        # The ingestion cron derives a geohash's sampling hour twice, in two
+        # languages — SQL decides when a cell is due, TypeScript decides which
+        # hour's reading to keep. They shipped disagreeing for 97% of cells,
+        # which silently stopped roughly half the fleet ever writing a row.
+        # Neither a typechecker nor a mocked-DB test can see this: the two
+        # expressions never meet in the same process. Read-only; one SELECT over
+        # a literal array, no table touched.
+        env:
+          DATABASE_PUBLIC_URL: ${{ secrets.DATABASE_PUBLIC_URL }}
+        run: bun scripts/checkSamplingHourAgrees.ts
+
   # ---------------------------------------------------------------------------
   # Data. master + cron only: it needs production credentials, so it must never
   # run on a pull_request from a fork.

--- a/scripts/checkSamplingHourAgrees.ts
+++ b/scripts/checkSamplingHourAgrees.ts
@@ -1,0 +1,143 @@
+/**
+ * CI gate: does the TypeScript sampling hour agree with the SQL that schedules it?
+ *
+ * ── Why this exists ─────────────────────────────────────────────────────────
+ *
+ * The environmental ingestion cron derives a geohash's sampling hour TWICE, in
+ * two languages, and PR #680 shipped with the two implementations disagreeing:
+ *
+ *   SQL  (buildSelectGeohashesDueForSampling) decides WHEN a cell is due:
+ *        MOD(ABS(('x' || SUBSTR(MD5(geohash5), 1, 8))::bit(32)::bigint), 24)
+ *   TS   (sampleHourForGeohash) decides WHICH HOUR'S reading is kept.
+ *
+ * The TS side used a *31 charCode polynomial. `[MEASURED 2026-08-01]` the two
+ * disagreed for 297 of 306 geohashes — 97.1%, indistinguishable from chance.
+ *
+ * The consequence was silent and severe. The cron wakes a cell at the SQL hour H
+ * and then asks reduceToDailyAtHour for the TS hour T. When T > H the selected
+ * sample is a future forecast hour, gets dropped by the
+ * `observedAt <= Date.now()` filter, and the cell writes nothing — every day,
+ * forever, for roughly half the fleet, while the run reported success.
+ *
+ * Neither a typechecker nor a mocked-DB test can see this: the two expressions
+ * live in different languages and never meet in the same process. Only
+ * evaluating the real SQL and comparing it to the real function catches it.
+ *
+ * Read-only. Runs one SELECT over a literal array; touches no table.
+ *
+ *   railway run --service Postgres -- bun scripts/checkSamplingHourAgrees.ts
+ */
+import pg from "pg";
+import { sampleHourForGeohash } from "../src/lib/environment/geohash";
+
+const fail = (msg: string): never => {
+  console.error(`\n✗ ${msg}`);
+  process.exit(1);
+};
+
+const url = process.env.DATABASE_PUBLIC_URL ?? process.env.DATABASE_URL;
+if (!url) fail("no DATABASE_PUBLIC_URL / DATABASE_URL in the environment");
+
+const BASE32 = "0123456789bcdefghjkmnpqrstuvwxyz";
+
+/**
+ * Deterministic spread of geohashes, plus real cities as named witnesses.
+ *
+ * Built by base-32 expansion of a counter rather than a per-digit formula: the
+ * first draft used `BASE32[(i * 7 + j * 13 + 3) % 32]`, whose digits cycle
+ * together, so 500 candidates deduped to 40 distinct cells and the gate silently
+ * tested an eighth of what it claimed to.
+ */
+function sampleCells(count: number): string[] {
+  const named = ["dr5re", "gcpvj", "9xj64", "dp3wj", "u4pru", "s0000", "ezs42", "xn774"];
+  const generated: string[] = [];
+  for (let i = 0; i < count; i++) {
+    // Stride by a value coprime with 32^5 so successive cells differ in every digit.
+    let n = (i * 1_299_709) % 32 ** 5;
+    let cell = "";
+    for (let j = 0; j < 5; j++) {
+      cell = BASE32[n % 32] + cell;
+      n = Math.floor(n / 32);
+    }
+    generated.push(cell);
+  }
+  return [...new Set([...named, ...generated])];
+}
+
+const client = new pg.Client({ connectionString: url, ssl: { rejectUnauthorized: false } });
+
+async function main(): Promise<void> {
+  await client.connect();
+
+  const cells = sampleCells(500);
+  // A gate whose sample silently shrank would still print a pass. Assert the size.
+  const MINIMUM_CELLS = 400;
+  if (cells.length < MINIMUM_CELLS) {
+    fail(
+      `only ${cells.length} distinct geohashes generated, expected at least ${MINIMUM_CELLS} — ` +
+        "the generator is producing duplicates and this gate is testing far less than it appears to.",
+    );
+  }
+
+  // The hour expression is lifted VERBATIM from buildSelectGeohashesDueForSampling.
+  // If that query's expression changes without this one changing, the gate stops
+  // testing what ships — so they are asserted identical below.
+  const HOUR_EXPR = "MOD(ABS(('x' || SUBSTR(MD5(g), 1, 8))::bit(32)::bigint), 24)::int";
+
+  const { buildSelectGeohashesDueForSampling } = await import(
+    "../src/services/environmentalQueries"
+  );
+  const shipped = buildSelectGeohashesDueForSampling();
+  const shippedNormalized = shipped.replace(/\s+/g, " ");
+  if (!shippedNormalized.includes("MOD( ABS(('x' || SUBSTR(MD5(b.geohash5), 1, 8))::bit(32)::bigint), 24 )")) {
+    fail(
+      "the hour expression in buildSelectGeohashesDueForSampling no longer matches the one this " +
+        "gate tests. Update HOUR_EXPR here deliberately — otherwise this gate checks a statement " +
+        "that is not the one running in production.",
+    );
+  }
+  console.log("✓ control: the gate tests the expression that actually ships");
+
+  const res = await client.query(
+    `SELECT g AS geohash, ${HOUR_EXPR} AS sql_hour FROM unnest($1::text[]) AS g`,
+    [cells],
+  );
+
+  if (res.rowCount !== cells.length) {
+    fail(`expected ${cells.length} rows back, got ${res.rowCount}`);
+  }
+
+  const mismatches: Array<{ geohash: string; sql: number; ts: number }> = [];
+  for (const row of res.rows) {
+    const ts = sampleHourForGeohash(row.geohash);
+    if (ts !== row.sql_hour) {
+      mismatches.push({ geohash: row.geohash, sql: row.sql_hour, ts });
+    }
+  }
+
+  if (mismatches.length > 0) {
+    for (const m of mismatches.slice(0, 10)) {
+      console.error(`  ✗ ${m.geohash}  SQL=${m.sql}  TS=${m.ts}`);
+    }
+    fail(
+      `${mismatches.length}/${res.rowCount} geohashes get a different sampling hour from SQL than ` +
+        "from TypeScript. Cells whose TS hour is LATER than their SQL hour write nothing, every " +
+        "day, silently.",
+    );
+  }
+
+  // A zero-mismatch result is a claim; prove the comparison can fail.
+  const controlHour = (sampleHourForGeohash("dr5re") + 1) % 24;
+  if (controlHour === res.rows.find((r) => r.geohash === "dr5re")?.sql_hour) {
+    fail("control failed: the deliberately-wrong hour equals the real one");
+  }
+  console.log("✓ control: a wrong hour would be detected");
+
+  console.log(
+    `\n✓ TS and SQL agree on the sampling hour for all ${res.rowCount} geohashes.\n`,
+  );
+}
+
+main()
+  .catch((error) => fail(error instanceof Error ? error.message : String(error)))
+  .finally(() => void client.end());

--- a/src/app/api/cron/environmental-ingest/route.ts
+++ b/src/app/api/cron/environmental-ingest/route.ts
@@ -34,9 +34,15 @@ export const maxDuration = 60;
 
 /**
  * Ceiling on geohashes touched per invocation. Each one is an outbound HTTP call
- * plus a handful of writes, and the function has a 60 s budget. Anything not
- * reached this hour is picked up by the next run — the due-query orders by
- * staleness, so nothing starves.
+ * plus a handful of writes, and the function has a 60 s budget.
+ *
+ * NOTE: anything not reached this hour waits a FULL DAY, not an hour. The
+ * due-query matches on exact hour equality, so each hour offers a disjoint set
+ * of geohashes and `ORDER BY last_computed_at` cannot carry an overflow across
+ * buckets. With an even hash spread this ceiling starts dropping cells at
+ * roughly 24 × 40 = 960 baselines fleet-wide; raise it, or shard the sweep,
+ * before then. The previous comment here claimed "nothing starves", which was
+ * false.
  */
 const MAX_GEOHASHES_PER_RUN = 40;
 
@@ -51,6 +57,7 @@ export async function GET(request: NextRequest) {
     const due = await getGeohashesDueForSampling(utcHour, MAX_GEOHASHES_PER_RUN);
 
     let sampled = 0;
+    let wroteNothing = 0;
     let rowsWritten = 0;
     const failures: Array<{ geohash5: string; error: string }> = [];
 
@@ -58,6 +65,11 @@ export async function GET(request: NextRequest) {
       try {
         const { written } = await sampleGeohash(geohash5, elevationM);
         sampled++;
+        // Counted separately: a call that returns without throwing but writes
+        // nothing is not a successful sample. Folding it into `sampled` made a
+        // sweep that ingested no data report a healthy count — the same
+        // indistinguishable-from-real failure this subsystem exists to avoid.
+        if (written === 0) wroteNothing++;
         rowsWritten += written;
       } catch (error) {
         // One bad cell must not abort the sweep. Failures are counted and
@@ -76,6 +88,7 @@ export async function GET(request: NextRequest) {
       utcHour,
       due: due.length,
       sampled,
+      wroteNothing,
       rowsWritten,
       failed: failures.length,
       pruned,
@@ -86,6 +99,7 @@ export async function GET(request: NextRequest) {
       utcHour,
       due: due.length,
       sampled,
+      wroteNothing,
       rowsWritten,
       pruned,
       failed: failures.length,

--- a/src/lib/environment/geohash.ts
+++ b/src/lib/environment/geohash.ts
@@ -16,6 +16,8 @@
  * @file src/lib/environment/geohash.ts
  */
 
+import { createHash } from "node:crypto";
+
 const BASE32 = "0123456789bcdefghjkmnpqrstuvwxyz";
 
 /** The precision used for every environmental cache key. */
@@ -136,9 +138,18 @@ export function decodeGeohashCenter(geohash: string): { latitude: number; longit
  * evenly across the day instead of stampeding one cron minute.
  */
 export function sampleHourForGeohash(geohash: string): number {
-  let accumulator = 0;
-  for (let i = 0; i < geohash.length; i++) {
-    accumulator = (accumulator * 31 + geohash.charCodeAt(i)) >>> 0;
-  }
-  return accumulator % 24;
+  // MUST stay byte-identical to the SQL in buildSelectGeohashesDueForSampling:
+  //   MOD(ABS(('x' || SUBSTR(MD5(geohash5), 1, 8))::bit(32)::bigint), 24)
+  //
+  // Postgres casts bit(32) to bigint UNSIGNED, so the JavaScript equivalent is
+  // parseInt of the first 8 hex digits — NOT `| 0`, which would sign-extend and
+  // disagree on ~6 of every 7 cells.
+  //
+  // This function previously used a *31 charCode polynomial while the SQL used
+  // MD5. [MEASURED 2026-08-01] the two disagreed for 297 of 306 geohashes
+  // (97.1%, i.e. pure chance), which meant the cron woke a cell at one hour and
+  // then tried to keep a reading from a different one. A test asserts the two
+  // agree against a real PostgreSQL.
+  const digest = createHash("md5").update(geohash).digest("hex").slice(0, 8);
+  return parseInt(digest, 16) % 24;
 }

--- a/src/services/environmentalIngestService.ts
+++ b/src/services/environmentalIngestService.ts
@@ -193,9 +193,18 @@ export async function seedFromArchive(
   // the boiling point by more than a degree.
   const elevationM = await fetchElevation(latitude, longitude);
 
-  // ERA5 lags real time, so the window ends where the archive actually has data.
+  // ERA5 lags real time, so the window ENDS where the archive has data — but it
+  // must START at the edge of the baseline window, not BASELINE_WINDOW_DAYS
+  // before the archive's end.
+  //
+  // The previous form (`start = end - 30d`) seeded days −36..−6 while
+  // recomputeBaseline reads `observed_at >= NOW() - 30 days`. Six days of rows
+  // were therefore outside the window at the instant they were written, and
+  // sample_days topped out around 24 — so `mature_count` (sample_days >= 30)
+  // could never be satisfied by a seed. Live sampling fills the recent
+  // ARCHIVE_LAG_DAYS gap over the following week.
   const end = new Date(Date.now() - ARCHIVE_LAG_DAYS * 86_400_000);
-  const start = new Date(end.getTime() - BASELINE_WINDOW_DAYS * 86_400_000);
+  const start = new Date(Date.now() - BASELINE_WINDOW_DAYS * 86_400_000);
 
   const center = decodeGeohashCenter(geohash5);
   const hourly = await fetchArchiveSamples(


### PR DESCRIPTION
PR #680 derives a geohash's sampling hour **twice, in two languages**, and the two implementations never agreed.

```
SQL  buildSelectGeohashesDueForSampling — decides WHEN a cell is due
     MOD(ABS(('x' || SUBSTR(MD5(geohash5), 1, 8))::bit(32)::bigint), 24)

TS   sampleHourForGeohash — decides WHICH HOUR'S reading to keep
     a *31 charCode polynomial
```

`[MEASURED 2026-08-01, against production PostgreSQL]` they disagreed for **489 of 508 geohashes — 96.3%**, indistinguishable from chance.

| Cell | SQL hour | TS hour |
|---|---|---|
| `dr5re` (NYC) | 0 | 2 |
| `gcpvj` (London) | 5 | 16 |
| `9xj64` (Denver) | 23 | 17 |

## Why it mattered

The cron wakes a cell at the SQL hour **H**, then asks `reduceToDailyAtHour` for the TS hour **T**. Where `T > H` the selected sample is a *future* forecast hour, the `observedAt <= Date.now()` filter drops it, and the cell writes **nothing** — every day, permanently, because the due-query only offers that cell at hour H.

Roughly **half the fleet would have ingested no live data at all**, while every run reported success.

## The fix

`sampleHourForGeohash` now computes the same MD5 the SQL does. Postgres casts `bit(32)` to bigint **unsigned**, so the JS equivalent is `parseInt` of the first 8 hex digits — *not* `| 0`, which sign-extends and disagrees on ~6 of every 7 cells.

## Three more defects from the same sweep

- **Seed window offset.** `seedFromArchive` computed `start = end − 30d` where `end` was already `now − 6d`, seeding days −36..−6 while `recomputeBaseline` reads `observed_at >= NOW() - 30 days`. Six days of rows fell outside the window *at the instant they were written*, so `sample_days` topped out near 24 and `mature_count` (≥ 30) could never be satisfied by a seed.
- **The run report could not distinguish success from silence.** `sampled++` fired on any non-throwing call, including one that wrote zero rows. Added a separate `wroteNothing` counter.
- **A false doc comment** claimed "nothing starves" because the due-query orders by staleness. It cannot — the query matches on exact hour equality, so each hour offers a disjoint set and an overflow waits a full day. Corrected, with the ~960-baseline threshold noted.

## Gate

`scripts/checkSamplingHourAgrees.ts` evaluates the real SQL expression and compares it to the real TS function over 508 geohashes. Neither a typechecker nor a mocked-DB test can catch this class — the two expressions live in different languages and never meet in one process.

Three controls: it asserts the expression it tests is still byte-identical to what `buildSelectGeohashesDueForSampling` ships, proves a wrong hour would be detected, and **asserts its own sample size**. That last one was earned — the first draft's generator produced digits that cycled together, so 500 candidates deduped to 40 and the gate silently tested an eighth of what it claimed.

Verified both ways: reverting the TS hash fails **489/508**.

Typecheck 0 errors, lint clean, 24/24 environmental physics tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)