### PR TITLE
fix(physics): weight natal elementals on the inertial-mass scale, not orbital period

### DIFF
--- a/backend/tests/test_esms_conformance.py
+++ b/backend/tests/test_esms_conformance.py
@@ -23,9 +23,6 @@ from backend.utils.planetary_alchemy import (
     calculate_alchemical_from_planets,
     get_gravitational_inertia,
     get_inertial_mass_weight,
-    get_normalized_alchm_weight,
-    _PERIOD_LOG_MIN,
-    _PERIOD_LOG_MAX,
 )
 
 CONF_FILE = os.path.join(
@@ -98,15 +95,34 @@ class TestEsmsConformance(unittest.TestCase):
             self.assertGreater(res["substance"], 0.0, f"[{cid}] Substance collapsed to 0 — vessel inert")
 
     def test_ascendant_weight_is_ruled_not_derived(self):
-        """The Ascendant weight is the RULED anchor 1.0, bypassing the period scale."""
-        self.assertEqual(get_normalized_alchm_weight("Ascendant"), ASCENDANT_VESSEL_WEIGHT)
+        """The Ascendant weight is the RULED anchor 1.0, off any derived scale."""
+        self.assertEqual(get_inertial_mass_weight("Ascendant"), ASCENDANT_VESSEL_WEIGHT)
         self.assertEqual(ASCENDANT_VESSEL_WEIGHT, 1.0)
         self.assertEqual(get_gravitational_inertia("Ascendant"), 1.0)  # r = 1.0 AU
-        # POSITIVE CONTROL — the trap this ruling dodges is real: feeding the
-        # Ascendant's own period entry (0.003) through the normalizer returns
-        # exactly 0.0, because it is the scale's minimum.
-        raw = (math.log10(0.003) - _PERIOD_LOG_MIN) / (_PERIOD_LOG_MAX - _PERIOD_LOG_MIN)
-        self.assertEqual(raw, 0.0)
+        # ANTI-ANNIHILATION CONTROL — the period scale (deleted with its last
+        # caller when elementals unified onto the inertial-mass scale) zeroed
+        # its extremum body, the Ascendant. The inertial scale anchors one
+        # decade BELOW Pluto precisely so its extremum body survives.
+        self.assertGreater(get_inertial_mass_weight("Pluto"), 0.1)
+
+    def test_elementals_and_esms_share_one_scale(self):
+        """The mixed-scale defect must stay dead.
+
+        REGRESSION: natal elementals were weighted by the orbital-period scale
+        (Pluto = 1.0 max, Sun ~ 0.513) while the ESMS vector in the SAME
+        function used the inertial-mass scale (Sun = 1.0, Pluto ~ 0.109) — two
+        roughly anti-correlated weightings in one output. Pin one ratio the two
+        scales order OPPOSITELY: a Sun sign must now outweigh a Pluto sign in
+        the elemental balance.
+        """
+        res = calculate_natal_alchemical_quantities({
+            "Sun": {"sign": "aries", "degree": 0, "exactLongitude": 0},
+            "Pluto": {"sign": "cancer", "degree": 0, "exactLongitude": 90},
+        })
+        balance = res["elemental_balance"]
+        # Sun (aries -> Fire) carries weight 1.0; Pluto (cancer -> Water) ~0.109.
+        # Under the deleted period scale this ordering was INVERTED.
+        self.assertGreater(balance["Fire"], balance["Water"])
 
     def test_golden_expected_values(self):
         """The engine must reproduce the fixture's expected ESMS exactly.

--- a/backend/utils/natal_alchemy.py
+++ b/backend/utils/natal_alchemy.py
@@ -11,7 +11,7 @@ from typing import Dict, Any
 from backend.utils.planetary_alchemy import (
     ESMS_PLANETS,
     ZODIAC_ELEMENTS,
-    get_normalized_alchm_weight,
+    get_inertial_mass_weight,
     get_gravitational_inertia,
     get_tidal_pull,
     calculate_alchemical_from_planets,
@@ -54,9 +54,13 @@ def calculate_natal_alchemical_quantities(
             except (ValueError, TypeError):
                 distance_au = None
 
-        # Elemental placement
+        # Elemental placement, on the SAME inertial-mass scale as the ESMS
+        # vector above. This function used to weight elementals by the orbital-
+        # period scale while its ESMS came from the inertial-mass scale — two
+        # roughly ANTI-correlated scales in one output (period privileges outer
+        # planets, mass privileges Sun/Jupiter).
         element = ZODIAC_ELEMENTS.get(sign, "Earth")
-        alchm_weight = get_normalized_alchm_weight(body_clean)
+        alchm_weight = get_inertial_mass_weight(body_clean)
         inertia = get_gravitational_inertia(body_clean, distance_au)
         tidal_pull = get_tidal_pull(body_clean, distance_au)
         

--- a/backend/utils/planetary_alchemy.py
+++ b/backend/utils/planetary_alchemy.py
@@ -92,21 +92,6 @@ ZODIAC_ELEMENTS: Dict[str, str] = {
     "sagittarius": "Fire", "capricorn": "Earth", "aquarius": "Air", "pisces": "Water",
 }
 
-# Orbital Period Weights for Alchm Thermodynamics (log10 normalized)
-PLANET_ALCHM_PERIODS: Dict[str, float] = {
-    "Pluto":      247.94,
-    "Neptune":    164.79,
-    "Uranus":      84.01,
-    "Saturn":      29.46,
-    "Jupiter":     11.86,
-    "Mars":         1.88,
-    "Sun":          1.00,
-    "Venus":        0.615,
-    "Mercury":      0.241,
-    "Moon":         0.075,
-    "Ascendant":    0.003, # 1 day physical vessel anchor
-}
-
 # Relative masses (Earth = 1.0) — ported verbatim from src/data/planets.ts
 # PLANET_WEIGHTS. The RULED canonical mass basis for the Lambda(r) tensor
 # ("physical mass, both runtimes" — spec §7). The old inertia here was
@@ -144,9 +129,6 @@ PLANET_MEAN_GEOCENTRIC_AU: Dict[str, float] = {
     "Pluto":   35.52718536398905,
 }
 
-_PERIOD_LOG_MIN = math.log10(0.003)    # Ascendant (1 day)
-_PERIOD_LOG_MAX = math.log10(247.94)   # Pluto
-
 # The Ascendant is the "Physical Vessel" grounding anchor, not an orbiting body.
 # RULED weight 1.0 — the SAME special case TypeScript applies on every period-scale
 # path (src/utils/planetaryAlchemyMapping.ts `calculateESMSWithDegrees`:
@@ -156,20 +138,11 @@ _PERIOD_LOG_MAX = math.log10(247.94)   # Pluto
 # The vessel — the mechanism that exists to prevent day-chart Matter/Substance
 # collapse — was silently multiplied by zero, and 11/20 golden conformance charts
 # (every diurnal one) collapsed to Matter = Substance = 0 (MEASURED 2026-07-31).
-# Never derive this weight from the period table: an extremum-anchored scale
-# annihilates whatever sits at its extremum.
+# Never derive this weight from an extremum-anchored scale: it annihilates
+# whatever sits at its extremum. (The Python period scale itself was DELETED
+# when elementals unified onto the inertial-mass scale — its last caller was
+# natal_alchemy's elemental loop.)
 ASCENDANT_VESSEL_WEIGHT = 1.0
-
-def get_normalized_alchm_weight(planet: str) -> float:
-    """Computes logarithmic weight [0, 1] based on orbital period.
-
-    The Ascendant bypasses the period scale entirely — see ASCENDANT_VESSEL_WEIGHT.
-    """
-    if planet == "Ascendant":
-        return ASCENDANT_VESSEL_WEIGHT
-    period = PLANET_ALCHM_PERIODS.get(planet, 1.0)
-    log_val = math.log10(max(period, 1e-9))
-    return (log_val - _PERIOD_LOG_MIN) / (_PERIOD_LOG_MAX - _PERIOD_LOG_MIN)
 
 # The inertial mass scale — physical mass, log-normalized, zero anchored OFF the
 # charted set (RULED: one decade below Pluto, so no charted body is annihilated


### PR DESCRIPTION
## Summary

Closes the last mixed-scale function in the Python natal engine. `calculate_natal_alchemical_quantities` computed its ESMS vector on the canonical inertial-mass scale (post #685/#695) while still weighting its **elemental balance** by the orbital-period scale — two roughly anti-correlated weightings in one output (period makes Pluto the max at 1.0 with Sun ≈ 0.513; mass makes Sun 1.0 with Pluto ≈ 0.109).

## Changes

- `backend/utils/natal_alchemy.py` — the elemental loop now uses `get_inertial_mass_weight`, same scale as the ESMS vector above it.
- `backend/utils/planetary_alchemy.py` — the period scale (`PLANET_ALCHM_PERIODS`, `_PERIOD_LOG_MIN/MAX`, `get_normalized_alchm_weight`) lost its last production caller and is **deleted**. `ASCENDANT_VESSEL_WEIGHT` stays — it is the inertial scale's RULED anchor.
- `backend/tests/test_esms_conformance.py` — Ascendant pin repointed to `get_inertial_mass_weight`; new regression test pins the Sun-outweighs-Pluto elemental ordering that the period scale inverted; anti-annihilation control pins Pluto > 0.1 on the inertial scale.

## Fixture impact: none

The conformance fixture stores no elemental values — `expected`/`expected_micro` ESMS goldens are byte-identical and **no regeneration is needed** (verified: 14/14 Python conformance tests pass against the unchanged v2.3.0 fixture).

## What shifts

Onboarding-response `elemental_balance` shares move (per-planet weight ratios invert), and `reactivity = (matter + Earth-share)²` moves with the Earth share. Spirit/essence/matter/substance, monica, inertia, and tidal_pull are unchanged.

## Observed, deliberately NOT touched (flagged for a future ruling)

- TS has two elemental scales of its own (`aggregateZodiacElementals` on Pluto-anchored `normalizePlanetWeight`; `natalAlchemy.ts` on a 0.6·astro + 0.4·mass blend) — cross-runtime elemental unification is a modeling decision beyond this fix's ruling.
- `backend/alchm_kitchen/main.py` carries its own `PLANET_ALCHM_PERIODS` copy for separate endpoints — out of scope here.
- Python's elemental loop excludes the Ascendant (not in `ESMS_PLANETS`) while TS's natal path includes it — pre-existing, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)