### PR TITLE
feat(cuisine): mass-weighted multi-ruler cuisine ESMS — off the binary lattice

### DIFF
--- a/src/__tests__/cuisineEsmsStrategyA.test.ts
+++ b/src/__tests__/cuisineEsmsStrategyA.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Strategy A pins: cuisine ESMS is a mass-weighted multi-ruler sum.
+ *
+ * The old derivation was a one-hot unit vector from a single planetary ruler,
+ * which pinned every cuisine to the {0,1}⁴ binary lattice where kalchm ≡ 1 —
+ * monica was the same constant for all 30 cuisine×sect states, and three
+ * Mars-ruled cuisines (Indian, Korean, Mexican) shared one identical ESMS.
+ * These pins keep the replacement honest:
+ *
+ * 1. Coverage — every scoring key resolves to rulers (the derivation throws
+ *    loudly instead of fabricating; this suite green-gates that throw).
+ * 2. Round-trip — the sum re-derives from its named inputs.
+ * 3. Lattice escape — kalchm ≠ 1 for every real cuisine, both sects.
+ * 4. Discriminant — pairwise-distinct ESMS across all real cuisines.
+ */
+import {
+  CUISINE_ELEMENTAL_MAP,
+  deriveCuisineAlchemical,
+} from "@/services/restaurantScoring";
+import { culinaryTraditions } from "@/data/cuisines/culinaryTraditions";
+import {
+  PLANETARY_SECTARIAN_ALCHEMICAL,
+  inertialMassWeight,
+} from "@/utils/planetaryAlchemyMapping";
+import { calculateKalchm } from "@/data/unified/alchemicalCalculations";
+
+const REAL_CUISINES = Object.keys(CUISINE_ELEMENTAL_MAP).filter(
+  (k) => k !== "Default",
+);
+const COINS = ["Spirit", "Essence", "Matter", "Substance"] as const;
+
+describe("cuisine ESMS Strategy A", () => {
+  it("every scoring key resolves to rulers and derives finite ESMS, both sects", () => {
+    for (const key of Object.keys(CUISINE_ELEMENTAL_MAP)) {
+      for (const diurnal of [true, false]) {
+        const esms = deriveCuisineAlchemical(key, diurnal);
+        for (const coin of COINS) {
+          expect(Number.isFinite(esms[coin])).toBe(true);
+          expect(esms[coin]).toBeGreaterThanOrEqual(0);
+        }
+        // A ruler set that contributed nothing would be a silent absence.
+        expect(COINS.reduce((s, c) => s + esms[c], 0)).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("round-trips from culinaryTraditions × inertialMassWeight × sect table", () => {
+    for (const key of ["Indian", "Japanese", "Spanish"]) {
+      const rulers = culinaryTraditions[
+        key.toLowerCase()
+      ].astrologicalProfile.rulingPlanets.map(
+        (p) => p.charAt(0).toUpperCase() + p.slice(1),
+      );
+      for (const diurnal of [true, false]) {
+        const expected = { Spirit: 0, Essence: 0, Matter: 0, Substance: 0 };
+        for (const ruler of rulers) {
+          const sectRow =
+            PLANETARY_SECTARIAN_ALCHEMICAL[
+              ruler as keyof typeof PLANETARY_SECTARIAN_ALCHEMICAL
+            ][diurnal ? "diurnal" : "nocturnal"];
+          const w = inertialMassWeight(ruler);
+          for (const coin of COINS) expected[coin] += sectRow[coin] * w;
+        }
+        expect(deriveCuisineAlchemical(key, diurnal)).toEqual(expected);
+      }
+    }
+  });
+
+  it("escapes the binary lattice: kalchm ≠ 1 for every real cuisine, both sects", () => {
+    // THE point of Strategy A. On the old one-hot vectors kalchm was
+    // identically 1 (x·ln x is zero at both 0 and 1), so monica collapsed to
+    // one constant across all cuisines.
+    for (const key of REAL_CUISINES) {
+      for (const diurnal of [true, false]) {
+        const k = calculateKalchm(deriveCuisineAlchemical(key, diurnal));
+        expect(Number.isFinite(k)).toBe(true);
+        expect(Math.abs(Math.log(k))).toBeGreaterThan(1e-6);
+      }
+    }
+    // POSITIVE CONTROL — the detector still sees the lattice: a one-hot
+    // integer vector really does give kalchm exactly 1.
+    expect(
+      calculateKalchm({ Spirit: 1, Essence: 0, Matter: 0, Substance: 0 }),
+    ).toBe(1);
+  });
+
+  it("Default alone stays the neutral Sun anchor (documented ABSENT sentinel)", () => {
+    // Sun's inertial weight is exactly 1.0 (the scale's anchor), so Default
+    // is a one-hot {Spirit: 1} in both sects — deliberately: it is the
+    // honest-absence row for unknown cuisines, not a cuisine.
+    for (const diurnal of [true, false]) {
+      expect(deriveCuisineAlchemical("Default", diurnal)).toEqual({
+        Spirit: 1,
+        Essence: 0,
+        Matter: 0,
+        Substance: 0,
+      });
+    }
+  });
+
+  it("is a discriminant: pairwise-distinct ESMS across real cuisines at fixed sect", () => {
+    // Old behavior: Indian, Korean and Mexican (all Mars one-hots) were
+    // byte-identical. Distinct ruler SETS now guarantee distinct sums.
+    for (const diurnal of [true, false]) {
+      const seen = new Map<string, string>();
+      for (const key of REAL_CUISINES) {
+        const esms = deriveCuisineAlchemical(key, diurnal);
+        const sig = COINS.map((c) => esms[c].toFixed(15)).join("|");
+        expect(seen.has(sig)).toBe(false);
+        seen.set(sig, key);
+      }
+    }
+  });
+
+  it("sect matters for cuisines with sect-flipping rulers", () => {
+    // Moon contributes Essence by day, Matter by night — Japanese
+    // [moon, mercury] must therefore differ across sects.
+    const day = deriveCuisineAlchemical("Japanese", true);
+    const night = deriveCuisineAlchemical("Japanese", false);
+    expect(day).not.toEqual(night);
+  });
+
+  it("the four RULED tradition entries hold the file's own invariants", () => {
+    for (const key of ["american", "greek", "spanish", "ethiopian"]) {
+      const entry = culinaryTraditions[key];
+      expect(entry).toBeDefined();
+      const sum = Object.values(entry.elementalAlignment).reduce(
+        (a, b) => a + b,
+        0,
+      );
+      expect(Math.abs(sum - 1.0)).toBeLessThan(0.001);
+      expect(entry.astrologicalProfile.favorableZodiac).toHaveLength(3);
+      for (const p of entry.astrologicalProfile.rulingPlanets) {
+        const cap = p.charAt(0).toUpperCase() + p.slice(1);
+        expect(PLANETARY_SECTARIAN_ALCHEMICAL).toHaveProperty(cap);
+      }
+    }
+    // No two entries in the WHOLE file may share a ruler list — a shared set
+    // is a shared ESMS profile, the Indian≡Korean conflation reborn.
+    const sets = Object.entries(culinaryTraditions).map(([k, v]) => [
+      k,
+      [...v.astrologicalProfile.rulingPlanets].sort().join(","),
+    ]);
+    const bySet = new Map<string, string>();
+    for (const [k, set] of sets) {
+      expect(bySet.has(set)).toBe(false);
+      bySet.set(set, k);
+    }
+  });
+});

--- a/src/data/cuisines/culinaryTraditions.ts
+++ b/src/data/cuisines/culinaryTraditions.ts
@@ -197,6 +197,88 @@ export const culinaryTraditions: Record<string, CuisineProfile> = {
       water_dominant: "Balance with coconut milk",
     },
   },
+
+  // ── RULED entries, authored 2026-08-01 ──────────────────────────────────
+  // The four cuisines below existed in restaurant scoring's
+  // CUISINE_ELEMENTAL_MAP with no tradition entry, so their ESMS derivation
+  // had nothing to read. There is no measurement for a cultural-astrological
+  // correspondence — every entry in this file is a RULED mapping — so these
+  // are authored to the same standard as the originals: rulers chosen from
+  // the cuisine's dominant culinary character, favorableZodiac from the
+  // rulers' domiciles, elementalAlignment summing to 1.0. Reviewed post-merge
+  // by explicit ruling (2026-08-01); amend freely, but keep each set distinct
+  // from every other entry — two cuisines sharing a ruler LIST would share an
+  // ESMS profile, which is the Indian≡Korean conflation all over again.
+  american: {
+    // Abundance and scale (Jupiter), grill and barbecue heat (Mars),
+    // comfort-sweet dairy tradition (Venus).
+    elementalAlignment: { Earth: 0.4, Fire: 0.3, Air: 0.2, Water: 0.1 },
+    astrologicalProfile: {
+      rulingPlanets: ["jupiter", "mars", "venus"],
+      favorableZodiac: ["sagittarius", "aries", "taurus"],
+      techniques: ["barbecue", "smoking", "deep_frying"],
+      aspectEnhancers: ["Jupiter trine Sun", "Mars sextile Venus"],
+    },
+    signatureModifications: {
+      fire_dominant: "Char over open hickory flame",
+      earth_dominant: "Anchor with cornbread and beans",
+      air_dominant: "Lighten with slaw and pickles",
+      water_dominant: "Braise low and slow in stock",
+    },
+  },
+  greek: {
+    // Sun-drenched olive-and-honey table (Sun), festive Venusian sweetness,
+    // seafaring Neptune. Distinct from mediterranean's [sun, mercury,
+    // neptune] — Greek is a NAMED cuisine here, not the meta-category.
+    elementalAlignment: { Fire: 0.35, Air: 0.25, Earth: 0.25, Water: 0.15 },
+    astrologicalProfile: {
+      rulingPlanets: ["sun", "venus", "neptune"],
+      favorableZodiac: ["leo", "taurus", "pisces"],
+      techniques: ["charcoal_grilling", "phyllo_layering", "olive_curing"],
+      aspectEnhancers: ["Sun trine Neptune", "Venus sextile Mercury"],
+    },
+    signatureModifications: {
+      fire_dominant: "Finish over charcoal with lemon",
+      earth_dominant: "Ground with chickpea and barley",
+      air_dominant: "Brighten with oregano and citrus",
+      water_dominant: "Enrich with yogurt and brine",
+    },
+  },
+  spanish: {
+    // Solar cuisine of saffron and plancha (Sun), pimentón fire and the
+    // tapas pulse (Mars), festive conviviality (Venus). Distinct from
+    // mexican's [sun, mars] by the Venus third.
+    elementalAlignment: { Fire: 0.4, Earth: 0.25, Water: 0.2, Air: 0.15 },
+    astrologicalProfile: {
+      rulingPlanets: ["sun", "mars", "venus"],
+      favorableZodiac: ["leo", "aries", "libra"],
+      techniques: ["a_la_plancha", "sofrito", "dry_curing"],
+      aspectEnhancers: ["Sun conjunct Mars", "Venus trine Jupiter"],
+    },
+    signatureModifications: {
+      fire_dominant: "Sear a la plancha with pimentón",
+      earth_dominant: "Deepen with jamón and beans",
+      air_dominant: "Lift with sherry vinegar",
+      water_dominant: "Simmer in saffron broth",
+    },
+  },
+  ethiopian: {
+    // Fermentation depth of injera and ancient highland tradition (Saturn),
+    // berbere heat (Mars), the shared communal plate and stews (Moon).
+    elementalAlignment: { Earth: 0.4, Fire: 0.3, Water: 0.2, Air: 0.1 },
+    astrologicalProfile: {
+      rulingPlanets: ["saturn", "mars", "moon"],
+      favorableZodiac: ["capricorn", "aries", "cancer"],
+      techniques: ["fermentation", "slow_stewing", "spice_blending"],
+      aspectEnhancers: ["Saturn trine Moon", "Mars sextile Sun"],
+    },
+    signatureModifications: {
+      fire_dominant: "Intensify the berbere bloom",
+      earth_dominant: "Serve on fresh injera",
+      air_dominant: "Cut with cardamom and clove",
+      water_dominant: "Slow the wat to a silk stew",
+    },
+  },
 };
 
 // Add validation to ensure all elementalAlignments sum to 1.0

--- a/src/services/restaurantScoring.ts
+++ b/src/services/restaurantScoring.ts
@@ -26,7 +26,11 @@ import type {
 import type { YelpBusiness, AlchmScoredRestaurant } from "@/types/yelp";
 import { calculateElementalMatch } from "@/utils/cuisineRecommender";
 import { CUISINE_SIGNATURES } from "@/utils/cuisineSignatures.generated";
-import { PLANETARY_SECTARIAN_ALCHEMICAL } from "@/utils/planetaryAlchemyMapping";
+import {
+  PLANETARY_SECTARIAN_ALCHEMICAL,
+  inertialMassWeight,
+} from "@/utils/planetaryAlchemyMapping";
+import { culinaryTraditions } from "@/data/cuisines/culinaryTraditions";
 
 // ─── Constants ─────────────────────────────────────────────────────────────
 
@@ -185,15 +189,12 @@ export function scoreCuisineAgainstMoment(
   // and monica was φ for all 30 cuisine × sect rows. The full derivation and the
   // replacement metric live in `@/data/unified/thermodynamicAffinity`.
   //
-  // Monica is deliberately NOT computed here any more, not even for display: it
-  // is the same constant for every cuisine, so surfacing it would present a
-  // constant as a per-cuisine measurement. It becomes meaningful again once
-  // cuisine ESMS is derived the way the moment's is (mass-weighted over the
-  // cuisine's ruling planets) — tracked separately.
-  const cuisineAlchemical = deriveCuisineAlchemical(
-    cuisineProfile.planetaryRuler,
-    diurnal,
-  );
+  // Monica is still deliberately NOT computed here for display. Cuisine ESMS
+  // is now mass-weighted over the cuisine's ruling planets (the correction
+  // this comment used to track), so kalchm is finally off the binary lattice
+  // and monica varies per cuisine — but surfacing it stays a recalibration-PR
+  // decision, made against the re-derived affinity constants, not here.
+  const cuisineAlchemical = deriveCuisineAlchemical(cuisineKey, diurnal);
   const thermodynamicAffinity = thermoAffinity(
     calculateThermodynamics(cuisineAlchemical, cuisineElement),
     calculateThermodynamics(momentAlchemical, momentElement),
@@ -301,27 +302,76 @@ function deriveMomentElemental(state: AstrologicalState): ElementalProperties {
   };
 }
 
+/** Capitalize a culinaryTraditions planet name into the engine key-space. */
+const capitalizePlanet = (p: string): string =>
+  p.charAt(0).toUpperCase() + p.slice(1).toLowerCase();
+
 /**
- * Derive the cuisine's alchemical (ESMS) profile from its planetary ruler
- * using the authoritative `PLANETARY_SECTARIAN_ALCHEMICAL` table.
+ * The cuisine's ruling planets, read from `culinaryTraditions` — normalize on
+ * read (the traditions file is lowercase-keyed; never rename its keys). The
+ * Default sentinel gets the single neutral Sun anchor and is the ONE profile
+ * allowed to stay on the binary lattice — it is the honest-absence row, not a
+ * cuisine.
  */
-function deriveCuisineAlchemical(
-  ruler: string,
+function cuisineRulingPlanets(cuisineKey: string): string[] {
+  if (cuisineKey === "Default") return ["Sun"];
+  const tradition = culinaryTraditions[cuisineKey.toLowerCase()];
+  const rulers = tradition?.astrologicalProfile?.rulingPlanets;
+  if (!rulers?.length) {
+    // Loud by design — a silent one-hot or flat fallback here would fabricate
+    // an ESMS profile. cuisineEsmsStrategyA.test.ts pins that every scoring
+    // key resolves, so a green build cannot reach this throw.
+    throw new Error(
+      `deriveCuisineAlchemical: no ruling planets for cuisine "${cuisineKey}"`,
+    );
+  }
+  return rulers.map(capitalizePlanet);
+}
+
+/**
+ * Derive the cuisine's alchemical (ESMS) profile the way the MOMENT's is
+ * derived: a mass-weighted sum over bodies, not a one-hot unit vector.
+ *
+ *     ESMS(cuisine, sect) = Σ over rulingPlanets of
+ *         PLANETARY_SECTARIAN_ALCHEMICAL[planet][sect] · inertialMassWeight(planet)
+ *
+ * The old single-ruler one-hot pinned every cuisine to the {0,1}⁴ binary
+ * lattice, where kalchm ≡ 1 for ANY vector — which is what collapsed monica
+ * to a constant across all cuisines (see `thermodynamicAffinity.ts`). The
+ * mass weights are the unified engine's inertial scale (Sun 1.0 … Pluto
+ * 0.109), so the sum is non-integer and off the lattice by construction. No
+ * dignity or distance terms: a cuisine has no chart, so there is no sign
+ * placement to score and no live distance to modulate — the factors the
+ * canonical moment engine adds on top of this same base are measurements of
+ * a sky, and a cuisine has none.
+ */
+export function deriveCuisineAlchemical(
+  cuisineKey: string,
   diurnal: boolean,
 ): AlchemicalProperties {
-  const entry = PLANETARY_SECTARIAN_ALCHEMICAL[
-    ruler as keyof typeof PLANETARY_SECTARIAN_ALCHEMICAL
-  ];
-  if (!entry) {
-    return { Spirit: 1, Essence: 1, Matter: 1, Substance: 1 };
-  }
-  const sect = diurnal ? entry.diurnal : entry.nocturnal;
-  return {
-    Spirit: sect.Spirit,
-    Essence: sect.Essence,
-    Matter: sect.Matter,
-    Substance: sect.Substance,
+  const totals: AlchemicalProperties = {
+    Spirit: 0,
+    Essence: 0,
+    Matter: 0,
+    Substance: 0,
   };
+  for (const ruler of cuisineRulingPlanets(cuisineKey)) {
+    const entry = PLANETARY_SECTARIAN_ALCHEMICAL[
+      ruler as keyof typeof PLANETARY_SECTARIAN_ALCHEMICAL
+    ];
+    if (!entry) {
+      throw new Error(
+        `deriveCuisineAlchemical: "${ruler}" is not in PLANETARY_SECTARIAN_ALCHEMICAL`,
+      );
+    }
+    const sect = diurnal ? entry.diurnal : entry.nocturnal;
+    const w = inertialMassWeight(ruler);
+    totals.Spirit += sect.Spirit * w;
+    totals.Essence += sect.Essence * w;
+    totals.Matter += sect.Matter * w;
+    totals.Substance += sect.Substance * w;
+  }
+  return totals;
 }
 
 /**


### PR DESCRIPTION
## Summary

Delivers the correction `restaurantScoring.ts`'s own Factor-3 comment has been tracking: cuisine ESMS is now derived **the way the moment's is** — a mass-weighted sum over bodies — instead of a one-hot unit vector from a single planetary ruler.

The one-hot pinned every cuisine to the {0,1}⁴ binary lattice, where kalchm ≡ 1 for *any* vector (x·ln x is zero at both 0 and 1): monica was a single constant across all 30 cuisine×sect states, and the three Mars-ruled cuisines (Indian, Korean, Mexican) shared one byte-identical ESMS.

## The model (as ratified)

```
ESMS(cuisine, sect) = Σ over rulingPlanets of
    PLANETARY_SECTARIAN_ALCHEMICAL[planet][sect] · inertialMassWeight(planet)
```

Same sect table and same inertial mass scale (Sun 1.0 … Pluto 0.109) as the unified moment engine — non-integer and off the lattice by construction. **No dignity or distance terms**: a cuisine has no chart, so there is no sign placement to score and no live distance to modulate.

## The four RULED entries

`culinaryTraditions` lacked entries for exactly **4** scoring cuisines (American, Greek, Spanish, Ethiopian — the campaign's "5" only held by counting the Default sentinel; census correction in the scout notes). Authored to the existing entries' standard with per-entry rationale comments, rulers chosen from culinary character, favorableZodiac from the rulers' domiciles, alignments summing to 1.0 — and each ruler **set** distinct from every other entry, because a shared set is a shared ESMS profile (the Indian≡Korean conflation reborn). These are cultural mappings; there is no measurement for them — RULED is the honest basis, and they're open to post-merge amendment per the merge-policy ruling.

Key-space: normalize-on-read (`Ethiopian` → `ethiopian` etc.); no traditions keys renamed. `Default` keeps a neutral single-Sun anchor and is the one profile allowed to remain on the lattice — it is the honest-absence row, not a cuisine. Missing rulers now **throw loudly** instead of returning the old fabricated `{1,1,1,1}` flat.

## Pins (`cuisineEsmsStrategyA.test.ts`)

Coverage (every scoring key, both sects), exact round-trip from named inputs, lattice escape (`|ln kalchm| > 1e-6` for every real cuisine×sect, with a positive control proving one-hots still give exactly 1), pairwise-distinct ESMS across all 14 real cuisines at fixed sect, sect sensitivity via Moon's day/night flip, and whole-file ruler-set uniqueness.

## Calibration

Affinity constants remain suspended (`RECALIBRATION_PENDING`, set in #699) — this PR changes the cuisine states those constants are measured over, which is exactly why the ruling batches one recalibration PR after it. That PR is next in the sequence.

## Verification

tsc clean; jest 196/196 suites (1967 passed, 13 skipped = 9 pre-existing + 4 ruled suspensions). Rebased onto post-#699 master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)