### PR TITLE
fix(cuisine): recalibrate thermodynamic affinity over the measured-map + Strategy A states

### DIFF
--- a/src/__tests__/thermodynamicAffinityCalibration.test.ts
+++ b/src/__tests__/thermodynamicAffinityCalibration.test.ts
@@ -197,7 +197,7 @@ describe("thermodynamic affinity calibration", () => {
   });
 
   // Tolerance note: `toBeCloseTo(x, n)` is an ABSOLUTE bound of 0.5e-n. Pinning at
-  // n=12 would be ~1e-13 relative on SD.reactivity ≈ 3.95 — tighter than this
+  // n=12 would be ~2e-13 relative on SD.reactivity ≈ 2.33 — tighter than this
   // population is actually stable. `Math.asinh`/`Math.log` are implementation-
   // defined in ECMAScript, so a V8 update can move a summand by an ULP, and
   // MEASURED: epoch sample 520 sits 2.474 SECONDS from a sect flip, so a change to
@@ -208,16 +208,14 @@ describe("thermodynamic affinity calibration", () => {
   const CALIBRATION_PRECISION = 6;
 
   // ── RECALIBRATION_PENDING ──────────────────────────────────────────────────
-  // CUISINE_ELEMENTAL_MAP moved to MEASURED corpus rows (fix/cuisine-map-
-  // measured), and Strategy A will move cuisine ESMS next. Both change the
-  // 30-state cuisine population these constants are measured over, so the
-  // pinned values in thermodynamicAffinity.ts are STALE BY RULING until the
-  // single recalibration PR re-derives and re-pins them (one constants churn,
-  // by explicit user ruling 2026-08-01). That PR flips this back to `it` and
-  // MUST be the next thing that touches this file. Structural invariants
-  // (population shape, gregsEnergy identity, decay-form choice, cuisine
-  // separation) stay live below — only the value pins are suspended.
-  const RECALIBRATION_PENDING = true;
+  // Set to true ONLY in a PR that changes the cuisine population these
+  // constants are measured over (map rows, cuisine ESMS derivation, sect
+  // rule, engine), when a ruling batches the recalibration into a later PR.
+  // While true, the four value pins below are suspended; structural
+  // invariants stay live. The recalibration PR re-derives the constants,
+  // re-pins them, and flips this back to false — as this one does (the
+  // 2026-08-01 measured-map + Strategy A batch, recalibrated here).
+  const RECALIBRATION_PENDING = false;
   const itPinnedConstant = RECALIBRATION_PENDING ? it.skip : it;
 
   itPinnedConstant("re-derives THERMO_AFFINITY_SD", () => {
@@ -286,9 +284,9 @@ describe("thermodynamic affinity calibration", () => {
       }
     }
     const pct = share.map((s) => (100 * s) / total);
-    expect(pct[0]).toBeCloseTo(26.3, 1); // heat
-    expect(pct[1]).toBeCloseTo(69.1, 1); // entropy
-    expect(pct[2]).toBeCloseTo(4.6, 1); // reactivity
+    expect(pct[0]).toBeCloseTo(32.9, 1); // heat
+    expect(pct[1]).toBeCloseTo(62.1, 1); // entropy
+    expect(pct[2]).toBeCloseTo(5.0, 1); // reactivity
   });
 
   itPinnedConstant("confirms equal weighting IS the first principal component", () => {

--- a/src/data/unified/thermodynamicAffinity.ts
+++ b/src/data/unified/thermodynamicAffinity.ts
@@ -117,6 +117,9 @@ export type ThermoState = Record<ThermoAffinityAxis, number>;
  *
  * Two parts, pooled:
  *   1. Every cuisine × sect in `CUISINE_ELEMENTAL_MAP` (30 states) — exhaustive.
+ *      Since the measured-map + Strategy A PRs, a cuisine state is MEASURED
+ *      corpus elementals + a mass-weighted multi-ruler ESMS (no longer a
+ *      one-hot), so all 28 non-Default states are pairwise distinct.
  *   2. The real sky on a 6-hour grid across the epoch year (1460 states), via
  *      `getAccuratePlanetaryPositions` → `calculateAlchemicalFromPlanets` +
  *      `aggregateEnhancedZodiacElementals`, with sect from `isCurrentSkyDiurnal`
@@ -129,9 +132,9 @@ export type ThermoState = Record<ThermoAffinityAxis, number>;
  *
  * `THERMO_AFFINITY_SD` is measured over all 1490 rows AS SAMPLED — which is
  * DWELL-TIME WEIGHTED, not one-row-per-distinct-state. MEASURED: those 1490 rows
- * hold 1484 distinct states (the aspect-bearing sky contributes 1460 distinct
- * states across 1460 samples), so repeated cuisine states still count in their
- * observed proportions.
+ * hold 1486 distinct states (Default is sect-invariant — its single Sun anchor
+ * has no day/night flip — and the sky contributes a few coincidences), so
+ * repeated states still count in their observed proportions.
  * That is deliberate: the scale exists to normalise states the scorer actually
  * meets at runtime, and an even grid over the year is the closest thing to a
  * traffic model this repo has. Deduplicating would upweight rare configurations
@@ -142,9 +145,9 @@ export type ThermoState = Record<ThermoAffinityAxis, number>;
  *
  * The epoch is NAMED and FIXED rather than "the current year" so the constants
  * are reproducible forever. The sky's spread does drift: re-deriving over 2040
- * gives SD.reactivity 2.683 vs 3.952 here (~32% narrower), while the PC1 loadings
- * stay put ([0.5829, 0.5749, 0.5742]). So the loadings are pinned tightly and the
- * scales are pinned to this epoch.
+ * (MEASURED under the original #681 population) moved SD.reactivity ~32%
+ * narrower while the PC1 loadings stayed put — so the loadings are pinned
+ * tightly and the scales are pinned to this epoch.
  */
 export const THERMO_AFFINITY_EPOCH = {
   /** UTC midnight of the first sample. */
@@ -160,14 +163,14 @@ export const THERMO_AFFINITY_EPOCH = {
  * population. BASIS: MEASURED — re-derived by
  * `thermodynamicAffinityCalibration.test.ts` on every run.
  *
- * Whitening is not cosmetic. Unwhitened, reactivity's asinh spread (2.338) would
- * outweigh heat's (0.343) by nearly 7:1 on scale alone — an unexamined emphasis of
+ * Whitening is not cosmetic. Unwhitened, reactivity's asinh spread (2.334) would
+ * outweigh heat's (0.342) by nearly 7:1 on scale alone — an unexamined emphasis of
  * exactly the kind the old `Math.abs(a - b) / 2` divisor smuggled in.
  */
 export const THERMO_AFFINITY_SD: Readonly<ThermoState> = {
-  heat: 0.3434003327775092,
-  entropy: 0.4121094628487977,
-  reactivity: 2.338113315559114,
+  heat: 0.34242341216623884,
+  entropy: 0.38791946880722994,
+  reactivity: 2.3335058155938997,
 };
 
 /**
@@ -175,13 +178,15 @@ export const THERMO_AFFINITY_SD: Readonly<ThermoState> = {
  * all 21900 REACHABLE cuisine↔moment distances (see the epoch note above). Not
  * chosen; re-derived by the calibration test.
  *
- * Distance quantiles for reference: p10 0.268, p25 0.499, MEDIAN 1.840,
- * p75 3.519, p90 4.390, max 5.548.
+ * Distance quantiles for reference: p10 0.305, p25 0.517, MEDIAN 1.904,
+ * p75 2.585, p90 3.559, max 5.053. The upper tail CONTRACTED when cuisine
+ * ESMS went mass-weighted (Strategy A): weighted multi-ruler sums sit closer
+ * to real skies than the old one-hot unit vectors did (old max 5.548).
  *
  * D0 depends on `THERMO_AFFINITY_SD`, so the two must be re-derived together —
  * the calibration test fails on both if either is edited alone.
  */
-export const THERMO_AFFINITY_D0 = 1.8397254332230344;
+export const THERMO_AFFINITY_D0 = 1.903549175561494;
 
 /**
  * Whitened, asinh-space Euclidean distance between two thermodynamic states.

--- a/src/services/restaurantScoring.ts
+++ b/src/services/restaurantScoring.ts
@@ -492,8 +492,8 @@ function buildMatchReasons(input: {
     reasons.push(`Elemental harmony with the moment (${Math.round(elementalMatch * 100)}%)`);
   }
 
-  // 0.85 affinity is d ≤ −D0·ln(0.85) = 0.2709 in whitened units, between p10
-  // (0.195) and p25 (0.314) of the measured reachable distribution — see
+  // 0.85 affinity is d ≤ −D0·ln(0.85) = 0.3094 in whitened units, between p10
+  // (0.305) and p25 (0.517) of the measured reachable distribution — see
   // `thermodynamicAffinity.ts`. The old copy keyed off a monica score that was
   // identical for every cuisine at any given moment, so it fired for all fifteen
   // or none, which is not a per-restaurant reason.


### PR DESCRIPTION
## Summary

The single batched recalibration that #699 (measured map) and #700 (Strategy A) deferred to, per the one-constants-churn ruling. All four suspended value pins are **live again and green**; `RECALIBRATION_PENDING` is back to `false` with its comment rewritten as a reusable mechanism note.

## New constants (all re-derived by the pinned calibration suite)

- **SD**: heat `0.34242341216623884`, entropy `0.38791946880722994`, reactivity `2.3335058155938997` — small drift; the 1490-row pool is sky-dominated.
- **D₀**: `1.903549175561494`. Worth recording: my first harvested value (1.8438) was measured under the **old** whitening — `reachableDistances()` whitens by the pinned SD, so D₀ must be derived *after* SD lands. The re-derivation pin caught exactly that procedure error before it shipped.
- **Axis influence**: 32.9 / 62.1 / 5.0 (was 26.3 / 69.1 / 4.6) — heat gained influence, entropy still dominates, deliberately pinned.
- **PC1**: loadings [0.5854, 0.5772, 0.5693], 95.6% explained — the equal-weight derivation **survives** the new cuisine population (all loadings within 0.008 of 1/√3).
- **Quantiles**: p10 0.305, p25 0.517, median 1.904, p75 2.585, p90 3.559, max 5.053. The upper tail *contracted* (old max 5.548): mass-weighted cuisine ESMS sits measurably closer to real skies than the one-hot unit vectors did.

## Also repaired in passing

- `buildMatchReasons` comment arithmetic (0.85 affinity ↔ d ≤ 0.3094, between p10 and p25) — stale since #695.
- Dwell-time doc: 1490 rows hold 1486 distinct states (Default is sect-invariant by design — its Sun anchor has no day/night flip).
- The 2040 drift note now attributes its measurement to the #681-era population instead of implying it re-derives against current constants.

## Verification

tsc clean; jest 196/196 suites, 1971 passed, 9 skipped (all pre-existing — the 4 ruled suspensions are ended). Rebased onto post-#700 master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)