### PR TITLE
refactor(physics): disambiguate spec-Φ from canonical monica — internal rename + dual-emit

### DIFF
--- a/backend/alchm_kitchen/main.py
+++ b/backend/alchm_kitchen/main.py
@@ -379,7 +379,11 @@ async def user_onboarding(
             is_diurnal=is_sect_diurnal(birth_moment),
         )
 
-        # Return the comprehensive profile
+        # Return the comprehensive profile.
+        # alchemical_quantities dual-emits the spec-Φ observable under BOTH
+        # "phi" (code name) and "monica" (frozen legacy wire key) — see
+        # backend/utils/natal_alchemy.py. That quantity is NOT the canonical
+        # thermodynamic monica served by /alchemize and philosophers-stone.
         return {
             "user_id": user.get("sub"),
             "birth_data": data.dict(),

--- a/backend/tests/test_esms_conformance.py
+++ b/backend/tests/test_esms_conformance.py
@@ -61,8 +61,9 @@ class TestEsmsConformance(unittest.TestCase):
             
             res = calculate_natal_alchemical_quantities(positions, is_diurnal=is_diurnal)
             
-            # Assert keys exist
-            for key in ["spirit", "essence", "matter", "substance", "reactivity", "inertia", "monica"]:
+            # Assert keys exist ("monica" and "phi" are the same spec-Φ quantity:
+            # phi is the code name, monica the frozen legacy wire key)
+            for key in ["spirit", "essence", "matter", "substance", "reactivity", "inertia", "monica", "phi"]:
                 self.assertIn(key, res, f"[{chart_id}] Missing key {key}")
                 val = res[key]
                 self.assertIsNotNone(val, f"[{chart_id}] Key {key} is None")
@@ -71,6 +72,26 @@ class TestEsmsConformance(unittest.TestCase):
             # Elemental balance sums to 1.0
             elem_sum = sum(res["elemental_balance"].values())
             self.assertAlmostEqual(elem_sum, 1.0, places=3, msg=f"[{chart_id}] Elemental balance sum != 1.0")
+
+    def test_phi_disambiguation_dual_emit(self):
+        """Spec-Φ dual-emit: the natal dict carries BOTH keys with the SAME value.
+
+        `phi` is the code name for the Monica Equilibrium Observable
+        Φ = 1.618·ln((S+E+ε)/(M+Σ+ε)); `monica` is its frozen legacy wire key
+        (persisted/wire compatibility). Canonical thermodynamic monica
+        (−gregsEnergy/(reactivity·ln kalchm)) is a DIFFERENT quantity and keeps
+        its name — this test pins the Φ path only.
+        """
+        fixture = load_conformance_fixture()
+        for chart in fixture["charts"]:
+            res = calculate_natal_alchemical_quantities(
+                chart["planetary_positions"],
+                is_diurnal=chart.get("is_diurnal", True),
+            )
+            cid = chart["id"]
+            self.assertIn("phi", res, f"[{cid}] missing phi key")
+            self.assertIn("monica", res, f"[{cid}] missing legacy monica key")
+            self.assertEqual(res["phi"], res["monica"], f"[{cid}] phi != monica (dual-emit must carry one value)")
 
     def test_vessel_actually_contributes_no_day_chart_collapse(self):
         """The grounding vessel must land in every chart.

--- a/backend/utils/natal_alchemy.py
+++ b/backend/utils/natal_alchemy.py
@@ -96,10 +96,15 @@ def calculate_natal_alchemical_quantities(
     reactivity_denom = (matter + earth_val) ** 2
     reactivity = round(reactivity_denom, 4)
 
-    # Continuous Monica Equilibrium calculation
-    # Monica phi equilibrium = 1.618; non-zero signed continuous readout
+    # Monica Equilibrium Observable Phi (spec: ESMS_WAVE_FUNCTION_SPECIFICATION.md §4)
+    #   Phi = 1.618 · ln((Spirit+Essence+ε)/(Matter+Substance+ε))
+    # DISAMBIGUATION: this is spec-Φ, NOT canonical monica. Canonical monica
+    # (−gregsEnergy / (reactivity · ln kalchm), thermodynamics.compute_kalchm_monica)
+    # is a DIFFERENT quantity that keeps the name `monica`. This quantity's code
+    # name is `phi`; its historical wire key "monica" is frozen for compatibility
+    # and the response dual-emits both keys with the same value.
     ln_arg = (spirit + essence + 0.05) / (matter + substance + 0.05)
-    monica = round(1.618 * math.log(max(ln_arg, 1e-6)), 4)
+    phi = round(1.618 * math.log(max(ln_arg, 1e-6)), 4)
 
     return {
         "spirit": spirit,
@@ -110,6 +115,7 @@ def calculate_natal_alchemical_quantities(
         "reactivity": reactivity,
         "inertia": round(total_inertia, 4),
         "tidal_pull": round(total_tidal_pull, 4),
-        "monica": monica,
+        "monica": phi,  # legacy serialization — the wire key "monica" is frozen; value IS spec-Φ
+        "phi": phi,
         "is_diurnal": is_diurnal,
     }

--- a/docs/physics/ESMS_WAVE_FUNCTION_SPECIFICATION.md
+++ b/docs/physics/ESMS_WAVE_FUNCTION_SPECIFICATION.md
@@ -102,6 +102,8 @@ Derived non-linear physical observables are calculated as expectations:
 2. **Monica Equilibrium Observable $\Phi(\mathbf{\Psi})$**:
    $$\Phi(\mathbf{\Psi}) = 1.618 \cdot \ln\left( \frac{(\mathbf{e}_S + \mathbf{e}_E)^T \mathbf{K} + \epsilon}{(\mathbf{e}_M + \mathbf{e}_\Sigma)^T \mathbf{K} + \epsilon} \right)$$
 
+   *Naming*: the code name for $\Phi$ is `phi` (`backend/utils/natal_alchemy.py`). Its historical wire/DB serialization key is `monica` — that key is **frozen** for compatibility, and API responses dual-emit both `monica` (legacy) and `phi` with the same value. Canonical thermodynamic monica, $-E_{greg} / (R \cdot \ln K_{alchm})$, is a **different quantity** and keeps the name `monica` throughout the codebase.
+
 ---
 
 ## 5. Discrete Equivalence & Code Parity
@@ -143,7 +145,7 @@ $\mathbf{\Lambda} = \operatorname{diag}(M_k / r_k^2)$ divides a **dimensionless 
 |---|---|---|
 | Moon inertia | 0.284 | **43,043** (Sun: 0.51) |
 | day-chart ESMS | mixed | Essence ≈ 43,045 (99.99% Moon) |
-| monica | continuous | sect binary: **+16.72 / −16.07** |
+| Φ (code `phi`; wire key `monica`) | continuous | sect binary: **+16.72 / −16.07** |
 | reactivity (night) | O(1) | **1.85 × 10⁹** |
 | canonical kalchm | finite | **overflows** → fallback 1.0 → monica φ |
 


### PR DESCRIPTION
## Summary

Two different live formulas have shared the name "monica": canonical monica (`−gregsEnergy/(reactivity·ln kalchm)`) and the spec's Φ observable (`1.618·ln((S+E+ε)/(M+Σ+ε))`), shipped by the natal engine under the key `"monica"`. This resolves the collision per ruling: **code adopts the spec symbol for the spec quantity** — the natal quantity's internal name becomes `phi`, canonical monica keeps its name everywhere, and no persisted key changes.

## Changes

- `backend/utils/natal_alchemy.py` — the sole computation site of Φ (verified by formula fingerprint: `1.618·log` occurs exactly once across src/ + backend/): internal identifier renamed `phi`, with a disambiguation comment naming both formulas; the response **dual-emits** `"monica": phi` (frozen legacy wire key, commented as such) and `"phi": phi`.
- `backend/alchm_kitchen/main.py` — comment marking the dual-emit at `/api/user/onboarding` (the only Φ-serving API; it serializes the natal dict directly).
- `backend/tests/test_esms_conformance.py` — new `test_phi_disambiguation_dual_emit` pins `monica == phi` across all 20 conformance charts; key-presence list extended.
- Spec §4/§7 — naming note: code name `phi`, wire key `monica` frozen, canonical monica is a different quantity.

## Census result worth recording

The scout flagged 9 TS + 5 Python response surfaces as dual-emit candidates. Verification against each one showed **every TS route and 4 of the 5 Python routes serve canonical monica or persisted `monicaConstant` blobs — never Φ**. Only the onboarding endpoint serves the Φ quantity, so only it dual-emits; adding `phi` to the others would have attached the wrong name to the wrong formula. No ambiguous identifiers remained.

Deliberately untouched: `user_profiles` monica columns/constraints, migrations, the conformance fixture (its generator never writes monica/phi), request/input keys, `MONICA_LN_EPSILON`/`MONICA_REACTIVITY_FLOOR`/`MONICA_EQUILIBRIUM`, golden-vector keys, and the Monica companion persona. Note for the future TS Φ port (`esmsWaveFunction.ts`, uncommitted in another session): name the identifier `phi` from day one and reuse this dual-emit contract.

## Verification

Python conformance 15/15 (`OK`); tsc clean; jest 196/196 suites (1971 passed, 9 skipped pre-existing). Rebased onto post-#701 master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)