### PR TITLE
fix(cuisine): separate Indian and Korean elementalAlignment (measured corpus)

### DIFF
--- a/src/__tests__/cuisineFlavorProfileBasis.test.ts
+++ b/src/__tests__/cuisineFlavorProfileBasis.test.ts
@@ -1,0 +1,100 @@
+/**
+ * cuisineFlavorProfiles.elementalAlignment basis pins.
+ *
+ * korean and indian shipped the byte-identical literal
+ * { Fire: 0.5, Earth: 0.3, Water: 0.1, Air: 0.1 } — the same Indian≡Korean
+ * copy-paste that PR #699 killed in CUISINE_ELEMENTAL_MAP. Both now read
+ * their own corpus row LIVE from cuisineSignatures.generated.ts, so there is
+ * no transcribed decimal that can drift (a copied `toPrecision()` print is
+ * how three irreproducible scales shipped once before).
+ *
+ * These pins guard:
+ * 1. Both MEASURED rows round-trip exactly from the corpus artifact.
+ * 2. They stay separated, and each stays a normalized recipe mean.
+ * 3. The 14 hand-authored rows stay an explicit, exhaustive list — migrating
+ *    one, or adding a new unbased row, must be a conscious act.
+ */
+import { cuisineFlavorProfiles } from "@/data/cuisineFlavorProfiles";
+import { CUISINE_SIGNATURES } from "@/utils/cuisineSignatures.generated";
+
+/** profile key → corpus `cuisine` key it is measured from. */
+const MEASURED_ROWS: Record<string, string> = {
+  korean: "Korean",
+  indian: "Indian",
+};
+
+const ELEMENTS = ["Fire", "Water", "Earth", "Air"] as const;
+
+describe("cuisineFlavorProfiles elementalAlignment basis", () => {
+  it("every measured row round-trips from the corpus artifact", () => {
+    for (const [profileKey, corpusKey] of Object.entries(MEASURED_ROWS)) {
+      const corpus = CUISINE_SIGNATURES.find((s) => s.cuisine === corpusKey);
+      expect(corpus).toBeDefined();
+      const alignment = cuisineFlavorProfiles[profileKey].elementalAlignment;
+      for (const el of ELEMENTS) {
+        expect(alignment[el]).toBe(corpus!.averageElementals[el]);
+      }
+    }
+  });
+
+  it("measured rows are normalized recipe means (each sums to ~1)", () => {
+    for (const profileKey of Object.keys(MEASURED_ROWS)) {
+      const row = cuisineFlavorProfiles[profileKey].elementalAlignment;
+      const sum = row.Fire + row.Water + row.Earth + row.Air;
+      expect(sum).toBeGreaterThan(0.999);
+      expect(sum).toBeLessThan(1.001);
+    }
+  });
+
+  it("indian and korean are no longer the same cuisine", () => {
+    // The defect this file exists to kill: both rows were the byte-identical
+    // literal { Fire: 0.5, Earth: 0.3, Water: 0.1, Air: 0.1 }.
+    const indian = cuisineFlavorProfiles.indian.elementalAlignment;
+    const korean = cuisineFlavorProfiles.korean.elementalAlignment;
+    const differs = ELEMENTS.some((el) => indian[el] !== korean[el]);
+    expect(differs).toBe(true);
+    // POSITIVE CONTROL — the comparison machinery detects sameness where
+    // sameness is real: a row always equals itself.
+    expect(ELEMENTS.some((el) => indian[el] !== indian[el])).toBe(false);
+  });
+
+  it("the two measured rows disagree on their dominant element", () => {
+    // Not merely unequal decimals — the corpus separates them on the axis
+    // consumers actually branch on (restaurantDiscoveryService renders a
+    // dominant-element badge). Korean is Fire-dominant, Indian Earth-dominant.
+    const dominant = (profileKey: string) =>
+      ELEMENTS.slice().sort(
+        (a, b) =>
+          cuisineFlavorProfiles[profileKey].elementalAlignment[b] -
+          cuisineFlavorProfiles[profileKey].elementalAlignment[a],
+      )[0];
+    expect(dominant("korean")).toBe("Fire");
+    expect(dominant("indian")).toBe("Earth");
+  });
+
+  it("only the unmigrated rows are hand-authored", () => {
+    const handAuthored = Object.keys(cuisineFlavorProfiles).filter(
+      (k) => !(k in MEASURED_ROWS),
+    );
+    // UNBASED (pre-existing) rows, exhaustively. These are hand-authored
+    // decimals with no recorded derivation, left untouched by the conflation
+    // fix. Migrating one to the corpus means deleting it from this list —
+    // which is the point: it cannot happen silently.
+    expect(handAuthored.sort()).toEqual([
+      "african",
+      "american",
+      "cantonese",
+      "chinese",
+      "french",
+      "greek",
+      "italian",
+      "japanese",
+      "mexican",
+      "middleEastern",
+      "russian",
+      "sichuanese",
+      "thai",
+      "vietnamese",
+    ]);
+  });
+});

--- a/src/data/cuisineFlavorProfiles.ts
+++ b/src/data/cuisineFlavorProfiles.ts
@@ -3,6 +3,7 @@ import { _logger } from "@/lib/logger";
 import { log } from "@/services/LoggingService";
 import type { ElementalProperties } from "@/types/alchemy";
 import type { Recipe } from "@/types/unified";
+import { CUISINE_SIGNATURES } from "@/utils/cuisineSignatures.generated";
 import { compatibilityToMatchPercentage } from "@/utils/enhancedCompatibilityScoring";
 
 export interface CuisineFlavorProfile {
@@ -35,6 +36,63 @@ export interface CuisineFlavorProfile {
   culturalContext?: string;
 }
 
+/**
+ * MEASURED elemental alignment — the corpus mean of a cuisine's own recipes,
+ * read LIVE from cuisineSignatures.generated.ts (regenerate with
+ * `bun run cuisines:process-all`). Nothing is copied into this file, so there
+ * is no transcribed decimal that can drift away from its basis.
+ *
+ * `elementalAlignment` is compared element-wise against recipe
+ * `elementalProperties` (see getRecipesForCuisineMatch below), so the corpus
+ * mean is the only value in the right units for that comparison.
+ */
+const corpusElementalAlignment = (corpusCuisine: string): ElementalProperties => {
+  const row = CUISINE_SIGNATURES.find((s) => s.cuisine === corpusCuisine);
+  if (!row) {
+    // Loud by design: a silent fallback here would fabricate an alignment.
+    // cuisineFlavorProfileBasis.test.ts pins every corpus row this file
+    // reads, so a green build cannot reach this throw.
+    throw new Error(
+      `cuisineFlavorProfiles: corpus row missing for ${corpusCuisine}`,
+    );
+  }
+  const { Fire, Water, Earth, Air } = row.averageElementals;
+  return { Fire, Water, Earth, Air };
+};
+
+/**
+ * BASIS of `elementalAlignment`, per row:
+ *
+ * - MEASURED — korean and indian only. These two shipped the byte-identical
+ *   literal { Fire: 0.5, Earth: 0.3, Water: 0.1, Air: 0.1 }: the same
+ *   Indian≡Korean copy-paste that PR #699 killed in CUISINE_ELEMENTAL_MAP.
+ *   Identical values also made the pair's relative rank an artifact of object
+ *   key order — every tie resolved to korean, so indian sat ~2 places lower
+ *   for no culinary reason. Both now read their own corpus row.
+ *
+ * - UNBASED (pre-existing) — the other 14 rows are hand-authored decimals
+ *   carried over from the file's original authoring with no recorded
+ *   derivation. They are NOT relabelled "RULED" here, because a ruling needs
+ *   a rationale and these have none on record. They are left byte-for-byte
+ *   untouched; this change does not launder them.
+ *
+ * Known consequence of the mixed basis: corpus means are flatter than the
+ * hand values (mean max-min spread 0.20 vs 0.37), and the recommender's
+ * mean(1 - |diff|) similarity favours flat profiles across a diverse user
+ * population. Swept over 286 user elemental states, korean and indian gain
+ * ~2.4 and ~1.9 mean rank places against the 14 unmigrated rows versus where
+ * a fully-migrated set puts them. That is a smaller distortion than "these
+ * two cuisines are literally the same cuisine", so it ships — but migrating
+ * the remaining 12 corpus-backed rows is the fix that removes it. See the
+ * follow-up issue linked in the PR.
+ *
+ * Only `elementalAlignment` was conflated. The pair's other fields were
+ * checked field-by-field and are already distinct (flavorProfiles differ on
+ * sour/bitter/umami; techniques, ingredients, meal patterns, planetary
+ * resonance and dietary suitability all differ). `seasonalPreference:
+ * ["all"]` matches, but it matches six other cuisines too — that is a real
+ * "no seasonal skew" value, not a copy-paste twin.
+ */
 export const cuisineFlavorProfiles: Record<string, CuisineFlavorProfile> = {
   // Mediterranean Cuisines
   greek: {
@@ -189,12 +247,8 @@ export const cuisineFlavorProfiles: Record<string, CuisineFlavorProfile> = {
       salty: 0.6,
       umami: 0.7,
     },
-    elementalAlignment: {
-      Fire: 0.5,
-      Earth: 0.3,
-      Water: 0.1,
-      Air: 0.1,
-    },
+    // MEASURED — corpus mean, 43 Korean recipes. Was byte-identical to indian.
+    elementalAlignment: corpusElementalAlignment("Korean"),
     signatureTechniques: ["fermentation", "grilling", "stewing"],
     signatureIngredients: [
       "gochujang",
@@ -423,12 +477,9 @@ export const cuisineFlavorProfiles: Record<string, CuisineFlavorProfile> = {
       salty: 0.6,
       umami: 0.4,
     },
-    elementalAlignment: {
-      Fire: 0.5,
-      Earth: 0.3,
-      Water: 0.1,
-      Air: 0.1,
-    },
+    // MEASURED — corpus mean, 39 Indian recipes. Was byte-identical to korean.
+    // Dominant element moves Fire → Earth (Earth .322 > Fire .299).
+    elementalAlignment: corpusElementalAlignment("Indian"),
     signatureTechniques: [
       "tempering",
       "slow cooking",

--- a/src/data/cuisineFlavorProfiles.ts
+++ b/src/data/cuisineFlavorProfiles.ts
@@ -83,8 +83,7 @@ const corpusElementalAlignment = (corpusCuisine: string): ElementalProperties =>
  * ~2.4 and ~1.9 mean rank places against the 14 unmigrated rows versus where
  * a fully-migrated set puts them. That is a smaller distortion than "these
  * two cuisines are literally the same cuisine", so it ships — but migrating
- * the remaining 12 corpus-backed rows is the fix that removes it. See the
- * follow-up issue linked in the PR.
+ * the remaining 12 corpus-backed rows is the fix that removes it (#704).
  *
  * Only `elementalAlignment` was conflated. The pair's other fields were
  * checked field-by-field and are already distinct (flavorProfiles differ on


### PR DESCRIPTION
## The defect

`src/data/cuisineFlavorProfiles.ts` shipped the **byte-identical** literal `{ Fire: 0.5, Earth: 0.3, Water: 0.1, Air: 0.1 }` for both `korean` and `indian` — the same Indian≡Korean copy-paste that #699 killed in `CUISINE_ELEMENTAL_MAP`. This is the second home of that conflation.

There was a second-order effect worth naming: because the two values were *equal*, the recommender's `sort` resolved every korean/indian tie by object key order. `korean` is declared first, so it won every tie, and `indian` sat ~2 mean rank places lower than an identically-valued cuisine for no culinary reason at all.

## The fix

Both rows now read their own corpus mean **live** from `cuisineSignatures.generated.ts`, matching the helper pattern #699 established in `restaurantScoring.ts`. Nothing is transcribed into this file, so there is no copied decimal that can drift from its basis.

| | Fire | Water | Earth | Air | n | dominant |
|---|---|---|---|---|---|---|
| korean | .3209 | .2709 | .2895 | .1186 | 43 | Fire (unchanged) |
| indian | .2987 | .2538 | .3218 | .1256 | 39 | **Fire → Earth** |

Indian's dominant element flip is user-visible: `restaurantDiscoveryService` renders it as the restaurant's dominant-element badge.

**BASIS: MEASURED** — corpus mean of each cuisine's own recipes. This is also the semantically correct value for the field, not just the defensible one: `getRecipesForCuisineMatch` compares `elementalAlignment` element-wise against recipe `elementalProperties`, so the corpus mean is the only value in the right units for that comparison.

## Scope: only `elementalAlignment` was conflated

I diffed the two entries field-by-field at runtime. Everything else is already distinct — `flavorProfiles` differ on sour/bitter/umami, and techniques, ingredients, meal patterns, planetary resonance and dietary suitability all differ. `seasonalPreference: ["all"]` matches, but it matches six other cuisines too; that is a real "no seasonal skew" value, not a copy-paste twin. Neither entry has `flavorIntensities`.

## The other 14 rows: left alone, labelled honestly

They keep their hand-authored decimals byte-for-byte and are documented as **UNBASED (pre-existing)** — not relabelled `RULED`, because a ruling needs a rationale and these have none on record. This change does not launder them.

## Known consequence, measured

Fixing two rows in a 16-row set leaves a mixed basis, and that is not free. Corpus means are flatter than the hand values (mean max−min spread **0.20 vs 0.37**), and the recommender's `mean(1 - |diff|)` similarity favours flat profiles across a diverse user population.

Swept over 286 user elemental states (a simplex grid), against a fully-migrated set as the reference:

| | status quo | this PR | all 14 migrated | distortion |
|---|---|---|---|---|
| korean | 7.80 | 5.96 | 8.31 | **−2.35** |
| indian | 9.98 | 6.06 | 7.99 | **−1.93** |

So this PR over-favours both cuisines by ~2 rank places relative to a consistent basis. I shipped it anyway because that is a strictly smaller error than *"these two cuisines are literally the same cuisine"*, and it also removes the key-order artifact — but it is real, it is documented in the file, and **migrating the remaining 12 corpus-backed rows is the fix that removes it.** That is a deliberate 12-cuisine behavior change across the homepage recommenders, so it belongs in its own PR rather than smuggled into a conflation fix. Happy to do it as a follow-up if you want it.

(`sichuanese` and `cantonese` have no corpus row. They can't take a parent-`chinese` proxy either — that would make them identical to each other, which is the exact defect being fixed here.)

## Consumer audit

All 8 consumers checked; **nothing pinned the old values** (no `.snap` files exist in the repo, no test imported `cuisineFlavorProfiles`).

- `restaurantDiscoveryService` — the only discrete change: Indian's dominant-element badge flips Fire→Earth.
- `cuisineRecommender` util, `recipes.ts` — continuous score shifts, no thresholds crossed.
- `CuisineCard`, `cuisineSauceProfiler` — read `flavorProfiles`/metadata only, never `elementalAlignment`. No-ops.
- `CuisineRecommender.tsx` — scores off context elementals, not this field.
- `ElementalCalculator` — its `> 0.5` gate never fired before (old max was exactly `0.5`) and does not fire now.
- `flavorProfileMigration` — reads a non-existent `elementalState` field behind an `as unknown as any`, so every cuisine silently gets the 0.25 neutral fallback today. Pre-existing, untouched, flagged for follow-up.

## Tests

New `src/__tests__/cuisineFlavorProfileBasis.test.ts`, mirroring `cuisineElementalMapBasis.test.ts`: round-trip from the artifact, sum-to-1, the pair stays separated (with a positive control that the comparison detects real sameness), the two dominant elements disagree, and the hand-authored list stays exhaustive so migrating or adding a row cannot happen silently.

**Verified discriminating, not inert:** with the old literal reintroduced on both rows, 3 of its 5 tests fail. Restored and green.

## Gates

- `bunx tsc --noEmit` — clean
- `jest` — 197/197 suites, 1972 passed, 13 skipped (worktree run with `--testPathIgnorePatterns` minus `/.worktrees/`)
- `eslint` — clean, `.eslintcache` removed first

🤖 Generated with [Claude Code](https://claude.com/claude-code)