### PR TITLE
fix(cuisine): calibrate thermodynamic affinity over production's cuisine ESMS

### DIFF
--- a/src/__tests__/thermodynamicAffinityCalibration.test.ts
+++ b/src/__tests__/thermodynamicAffinityCalibration.test.ts
@@ -47,7 +47,10 @@ import {
   thermoStateDistance,
   type ThermoState,
 } from "@/data/unified/thermodynamicAffinity";
-import { CUISINE_ELEMENTAL_MAP } from "@/services/restaurantScoring";
+import {
+  CUISINE_ELEMENTAL_MAP,
+  deriveCuisineAlchemical,
+} from "@/services/restaurantScoring";
 import {
   getAccuratePlanetaryPositions,
   isCurrentSkyDiurnal,
@@ -67,31 +70,36 @@ function capitalizeSign(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
 }
 
-/** One cuisine's thermodynamic state at a given sect. */
+/**
+ * One cuisine's thermodynamic state at a given sect — built through the SAME
+ * call production uses.
+ *
+ * This used to build a one-hot single-ruler vector from
+ * `PLANETARY_SECTARIAN_ALCHEMICAL[profile.planetaryRuler]`, which is the shape
+ * #700 deliberately retired: cuisine ESMS is now mass-weighted over ALL of the
+ * cuisine's ruling planets, which is what takes kalchm off the binary lattice.
+ * The derivation never followed production there, so these constants were
+ * calibrated against a population the scorer had stopped producing — and the
+ * suite stayed green the whole time, because it re-derives and pins its OWN
+ * output and is therefore self-consistent no matter which population it uses.
+ *
+ * Calling `deriveCuisineAlchemical` rather than re-implementing it is the point:
+ * a copy here is exactly how the two drifted apart the first time.
+ * `scoreCuisineAgainstMoment` (restaurantScoring.ts:197) pairs it with the same
+ * `CUISINE_ELEMENTAL_MAP` elementals used below, so this now matches production
+ * on both halves of the state.
+ */
 function cuisineState(
   cuisine: keyof typeof CUISINE_ELEMENTAL_MAP,
   diurnal: boolean,
 ): Full {
   const profile = CUISINE_ELEMENTAL_MAP[cuisine];
-  const entry =
-    PLANETARY_SECTARIAN_ALCHEMICAL[
-      profile.planetaryRuler as keyof typeof PLANETARY_SECTARIAN_ALCHEMICAL
-    ];
-  const sect = diurnal ? entry.diurnal : entry.nocturnal;
-  return calculateThermodynamics(
-    {
-      Spirit: sect.Spirit,
-      Essence: sect.Essence,
-      Matter: sect.Matter,
-      Substance: sect.Substance,
-    },
-    {
-      Fire: profile.Fire,
-      Water: profile.Water,
-      Earth: profile.Earth,
-      Air: profile.Air,
-    },
-  ) as Full;
+  return calculateThermodynamics(deriveCuisineAlchemical(cuisine, diurnal), {
+    Fire: profile.Fire,
+    Water: profile.Water,
+    Earth: profile.Earth,
+    Air: profile.Air,
+  }) as Full;
 }
 
 /** The sky on the epoch grid, exactly as the discovery service reads it. */
@@ -284,9 +292,15 @@ describe("thermodynamic affinity calibration", () => {
       }
     }
     const pct = share.map((s) => (100 * s) / total);
-    expect(pct[0]).toBeCloseTo(32.9, 1); // heat
-    expect(pct[1]).toBeCloseTo(62.1, 1); // entropy
-    expect(pct[2]).toBeCloseTo(5.0, 1); // reactivity
+    // Pinned to 2 decimals at precision 1 (an absolute ±0.05 bound) rather than
+    // to a 1-decimal figure. entropy lands on 63.95, and the nearest 1-decimal
+    // pin (64.0) would sit 0.0465 from the measured value — inside the bound,
+    // but with only 7% headroom, which is how a pin becomes flaky under an ULP
+    // change. Pinning the measured 2-decimal value keeps the same tolerance and
+    // restores the margin.
+    expect(pct[0]).toBeCloseTo(29.39, 1); // heat
+    expect(pct[1]).toBeCloseTo(63.95, 1); // entropy
+    expect(pct[2]).toBeCloseTo(6.66, 1); // reactivity
   });
 
   itPinnedConstant("confirms equal weighting IS the first principal component", () => {

--- a/src/data/unified/thermodynamicAffinity.ts
+++ b/src/data/unified/thermodynamicAffinity.ts
@@ -163,14 +163,14 @@ export const THERMO_AFFINITY_EPOCH = {
  * population. BASIS: MEASURED — re-derived by
  * `thermodynamicAffinityCalibration.test.ts` on every run.
  *
- * Whitening is not cosmetic. Unwhitened, reactivity's asinh spread (2.334) would
- * outweigh heat's (0.342) by nearly 7:1 on scale alone — an unexamined emphasis of
+ * Whitening is not cosmetic. Unwhitened, reactivity's asinh spread (2.333) would
+ * outweigh heat's (0.333) by 7:1 on scale alone — an unexamined emphasis of
  * exactly the kind the old `Math.abs(a - b) / 2` divisor smuggled in.
  */
 export const THERMO_AFFINITY_SD: Readonly<ThermoState> = {
-  heat: 0.34242341216623884,
-  entropy: 0.38791946880722994,
-  reactivity: 2.3335058155938997,
+  heat: 0.3328000991150603,
+  entropy: 0.37031863162603695,
+  reactivity: 2.3331310334971707,
 };
 
 /**
@@ -178,15 +178,25 @@ export const THERMO_AFFINITY_SD: Readonly<ThermoState> = {
  * all 21900 REACHABLE cuisine↔moment distances (see the epoch note above). Not
  * chosen; re-derived by the calibration test.
  *
- * Distance quantiles for reference: p10 0.305, p25 0.517, MEDIAN 1.904,
- * p75 2.585, p90 3.559, max 5.053. The upper tail CONTRACTED when cuisine
- * ESMS went mass-weighted (Strategy A): weighted multi-ruler sums sit closer
- * to real skies than the old one-hot unit vectors did (old max 5.548).
+ * Distance quantiles for reference: p10 0.265, p25 0.380, MEDIAN 1.100,
+ * p75 1.766, p90 2.772, max 4.873.
+ *
+ * The whole distribution CONTRACTED — not just the tail — when the derivation
+ * was finally pointed at the mass-weighted cuisine ESMS production actually
+ * uses (#706). Weighted multi-ruler sums sit much closer to real skies than
+ * one-hot unit vectors, so the MEDIAN fell 1.904 → 1.100 (−42%) and the max
+ * fell 5.053 → 4.873.
+ *
+ * Note this contraction was ASSERTED here before it was ever MEASURED: the
+ * previous version of this comment already credited Strategy A with pulling the
+ * tail in, while the derivation was still building one-hot states. The effect
+ * was real and the direction was right; the magnitude was understated because
+ * nothing had measured it. That gap is the defect #706 closed.
  *
  * D0 depends on `THERMO_AFFINITY_SD`, so the two must be re-derived together —
  * the calibration test fails on both if either is edited alone.
  */
-export const THERMO_AFFINITY_D0 = 1.903549175561494;
+export const THERMO_AFFINITY_D0 = 1.0997692434132713;
 
 /**
  * Whitened, asinh-space Euclidean distance between two thermodynamic states.

--- a/src/services/restaurantScoring.ts
+++ b/src/services/restaurantScoring.ts
@@ -492,11 +492,16 @@ function buildMatchReasons(input: {
     reasons.push(`Elemental harmony with the moment (${Math.round(elementalMatch * 100)}%)`);
   }
 
-  // 0.85 affinity is d ≤ −D0·ln(0.85) = 0.3094 in whitened units, between p10
-  // (0.305) and p25 (0.517) of the measured reachable distribution — see
-  // `thermodynamicAffinity.ts`. The old copy keyed off a monica score that was
-  // identical for every cuisine at any given moment, so it fired for all fifteen
-  // or none, which is not a per-restaurant reason.
+  // 0.85 affinity is d ≤ −D0·ln(0.85) = 0.1787 in whitened units. MEASURED: it
+  // fires for 4.57% of reachable cuisine↔moment pairs, down from ~10.3% before
+  // #706 re-derived the constants against production's mass-weighted cuisine
+  // ESMS. The band tightened because the distribution changed SHAPE, not just
+  // scale: the lower tail contracted less than the median (p10 ×0.87 vs median
+  // ×0.58), so the same affinity cut now sits further out in D0 units. This
+  // reason is deliberately rarer than the 0.8 elemental one above it.
+  // See `thermodynamicAffinity.ts`. The old copy keyed off a monica score that
+  // was identical for every cuisine at any given moment, so it fired for all
+  // fifteen or none, which is not a per-restaurant reason.
   if (thermodynamicAffinity >= 0.85) {
     reasons.push("Thermodynamic state closely matches this moment");
   }


### PR DESCRIPTION
Closes #706.

## The defect

`thermodynamicAffinityCalibration.test.ts` built its cuisine population from a **one-hot single-ruler** vector — the shape #700 deliberately retired. Production uses `deriveCuisineAlchemical`, mass-weighted over **all** of a cuisine's ruling planets, which is the whole point of getting kalchm off the binary lattice. The derivation never followed production there.

So `THERMO_AFFINITY_SD` and `THERMO_AFFINITY_D0` — both declaring `BASIS: MEASURED` — were measured over a population the scorer had stopped producing.

**It stayed green the entire time**, and that is the part worth internalizing: the suite re-derives the constants and pins its *own* output. Self-consistency holds no matter which population it uses, so a passing calibration proved only that the test agreed with itself. This is a green gate that verified nothing.

## The fix

`cuisineState` now **calls** `deriveCuisineAlchemical` instead of re-implementing it. That is deliberate — a local copy is precisely how the two drifted apart in the first place. The elemental half already matched production (`CUISINE_ELEMENTAL_MAP`), so only the ESMS half moves.

## Re-derived constants

Regenerated by the suite, never hand-edited:

| constant | before | after |
|---|---|---|
| `SD.heat` | 0.34242341216623884 | 0.3328000991150603 |
| `SD.entropy` | 0.38791946880722994 | 0.37031863162603695 |
| `SD.reactivity` | 2.3335058155938997 | 2.3331310334971707 |
| **`D0`** | 1.903549175561494 | **1.0997692434132713** (−42%) |
| axis influence | 32.9 / 62.1 / 5.0 | 29.39 / 63.95 / 6.66 |

⚠️ **This needed two passes, and the intermediate value is a trap.** `D0` and the axis shares are measured in *whitened* units, so they depend on `SD` — deriving them against the old `SD` produces a number that is wrong the instant `SD` lands. `SD` itself derives independently of both, so it is a fixed point after one pass. The first-pass `D0` was **1.0658**, which is not the answer; the settled value is **1.0998**. Anyone re-running this should expect the same two-step convergence.

## A measured behaviour change

The distribution changed **shape**, not just scale: p10 contracted ×0.87 while the median contracted ×0.58. So the same affinity cut now sits further out in `D0` units, and the `0.85` reason in `restaurantScoring` fires for a measured **4.57% of reachable pairs, down from ~10.3%**.

That comment has **no test guarding it**, so it is updated by hand with the measured rate rather than left to rot.

## A claim that preceded its measurement

The `D0` doc comment already credited Strategy A with contracting the tail — while the derivation was still building one-hot states. The direction was right and the magnitude understated (real max 4.873, not the claimed 5.053). Corrected, and the ADR-009 note about asserted-vs-measured now has a concrete instance.

## Pin robustness

Axis pins moved to 2-decimal values at precision 1 (the ±0.05 absolute bound is unchanged). `entropy` lands on 63.95, and the nearest 1-decimal pin (64.0) would sit 0.0465 from the measured value — inside the bound, but with 7% headroom, which is how a pin becomes flaky under an ULP change.

## Relationship to ADR-009 (#705)

This lands **first**, by design. ADR-009 also requires re-deriving these constants, for the independent reason that they are fitted over Scale-B elementals. Doing this one first means the scale migration is measured against a correct cuisine population instead of compounding two derivation errors.

## Gates

- `bunx tsc --noEmit` — clean
- `jest` — 197/197 suites, 1976 passed, 9 skipped
- `eslint` — clean on every changed line. The single `import/order` warning in `restaurantScoring.ts:33` is **pre-existing on master** (verified against a clean master worktree) and this diff changes no import lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)