### PR TITLE
chore(adr-009): disarm the nightly production writer, and cover main.py's weighting

### DIFF
--- a/.github/workflows/monica-backfill.yml
+++ b/.github/workflows/monica-backfill.yml
@@ -34,11 +34,45 @@
 #   * schedule + manual dispatch ONLY. Never on push or pull_request: a workflow
 #     that writes to production must not be triggerable by opening a PR.
 
+# ── ⚠️ DISARMED 2026-08-01 for the ADR-009 scale migration ──────────────────
+#
+# The nightly schedule is commented out, NOT deleted. Manual dispatch still
+# works, so a deliberate, watched run is still one click away.
+#
+# WHY: ADR-009 unifies five per-planet weight scales onto the inertial scale.
+# The moment that lands, every weight-derived monica recomputes to a different
+# value — and this script rewrites what it recomputes. The UPDATEs at
+# scripts/backfillMonicaPerConstruction.ts:310, :326 and :342 are keyed only on
+# `WHERE up.user_id = v.user_id`, with no `monica_method IS NULL` guard, and the
+# script says so itself at :104-106: "it does not care what is currently
+# stored".
+#
+# `--max-new` does NOT hold this back. It bounds the count of NEW ARRIVALS
+# (`monica_method IS NULL`, :108-112). Already-classified rows are not new, so
+# they are not counted, not bounded, and rewritten anyway. On the first night
+# after the migration deploys, that is all 469 two-body and 71 full-chart rows,
+# unreviewed, at 06:45.
+#
+# It gets worse in combination: `scripts/checkAgentMonicaDrift.ts` will already
+# be red at 07:15, reporting those same rows as defects that "cannot happen
+# through ordinary operation" (:368-372), and its remediation text at :434-447
+# tells the operator to run THIS script. So the alarm points at the thing that
+# would silently make the alarm stop.
+#
+# RE-ARM WHEN: the migration has deployed, the intended backfill has run, and
+# its result is verified against the DEPLOYED SHA (not local git). Uncomment the
+# two `schedule` lines below — nothing else changed.
+#
+# The queue does not rot meanwhile: ~50 agents/night arrive unclassified and
+# simply wait. Clear them with a manual dispatch if the backlog matters before
+# the migration lands.
+# ────────────────────────────────────────────────────────────────────────────
+
 name: Monica Backfill
 
 on:
-  schedule:
-    - cron: "45 6 * * *"
+  # schedule:
+  #   - cron: "45 6 * * *"
   workflow_dispatch:
     inputs:
       max_new:

--- a/.github/workflows/monica-integrity.yml
+++ b/.github/workflows/monica-integrity.yml
@@ -93,6 +93,19 @@ jobs:
           python -m pip install --quiet pytest
           python -m pytest backend/tests/test_kalchm_parity.py -q
 
+      - name: Deployed-server planet weighting (Python)
+        # backend/alchm_kitchen/main.py is what Railway actually serves, and it
+        # carries an INLINE copy of the orbital-period weight table that PR #697
+        # deleted from backend/utils/. Until test_main_planet_weighting.py it had
+        # NO coverage at all — the inverse risk of the parity gate above: nothing
+        # would break when it moved, and nothing would say it had moved.
+        #
+        # That test reads main.py's SOURCE and extracts the weighting with `ast`
+        # rather than importing it, precisely so this step keeps the pytest-only
+        # install described above. If it ever needs fastapi, the extraction has
+        # been replaced by an import and the same warning applies.
+        run: python -m pytest backend/tests/test_main_planet_weighting.py -q
+
   # ---------------------------------------------------------------------------
   # PRE-MERGE. The two gates a PULL REQUEST DIFF can actually break, run BEFORE
   # the code reaches master.

--- a/backend/tests/test_main_planet_weighting.py
+++ b/backend/tests/test_main_planet_weighting.py
@@ -1,0 +1,155 @@
+"""The weighting the DEPLOYED FastAPI server actually uses.
+
+`backend/alchm_kitchen/main.py` is the module Railway serves (Procfile:
+`uvicorn backend.alchm_kitchen.main:app`). It carries its own INLINE copy of the
+orbital-period weight table — the same table PR #697 deleted from
+`backend/utils/planetary_alchemy.py` — and until this file existed, **nothing
+tested it**. `test_kalchm_parity.py:21-24` explains why: importing
+`backend.alchm_kitchen.main` pulls in fastapi/sqlalchemy/pyswisseph, and CI
+installs only pytest, so a suite that imports it could not be COLLECTED at all.
+
+That left the riskiest surface in the physics stack with the opposite failure
+mode from everything around it: nothing would break when it moved, and nothing
+would say it had moved.
+
+── How this tests it without importing it ──────────────────────────────────
+
+The weighting is a pure table plus a pure function with no imports beyond
+`math`. So instead of importing the app, this reads main.py's SOURCE, pulls out
+exactly those definitions with `ast`, and executes them in an isolated
+namespace. That is the real source, not a transcription — a copy here is
+precisely how `main.py` and `planetary_alchemy.py` drifted apart in the first
+place. Requires only the stdlib, so it runs under CI's pytest-only install.
+
+── What this pins, and why the numbers look "wrong" ────────────────────────
+
+It pins the period scale **as it is deployed today**, including the parts
+ADR-009 rules to be defects (Pluto heaviest, Sun at half of Pluto). That is
+deliberate and is the same device as the `normalizePlanetWeight` positive
+controls in `esmsConformance.test.ts`: pinning the current, wrong behaviour is
+what makes changing it VISIBLE instead of silent.
+
+**ADR-009 decision 4 will make this file fail.** That is the intended signal,
+not a regression. The migration PR flips `EXPECTED_SCALE` to "inertial" and the
+assertions follow. If you are reading this because CI went red on a scale
+change: good — that is the gate doing the one job it was written for.
+"""
+import ast
+import math
+from pathlib import Path
+
+import pytest
+
+from backend.utils.planetary_alchemy import get_inertial_mass_weight
+
+MAIN_PY = Path(__file__).resolve().parents[1] / "alchm_kitchen" / "main.py"
+
+# Flip to "inertial" in the ADR-009 decision-4 PR, together with main.py itself.
+EXPECTED_SCALE = "period"
+
+WEIGHTING_NAMES = {"PLANET_ALCHM_PERIODS", "PERIOD_LOG_MIN", "PERIOD_LOG_MAX"}
+WEIGHTING_FUNCS = {"normalize_alchm_weight"}
+
+
+def _extract_weighting():
+    """Execute ONLY the weighting definitions out of main.py's real source."""
+    tree = ast.parse(MAIN_PY.read_text())
+    wanted = []
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            names = {t.id for t in node.targets if isinstance(t, ast.Name)}
+            if names & WEIGHTING_NAMES:
+                wanted.append(node)
+        elif isinstance(node, ast.FunctionDef) and node.name in WEIGHTING_FUNCS:
+            wanted.append(node)
+    ns = {"math": math}
+    exec(compile(ast.Module(body=wanted, type_ignores=[]), str(MAIN_PY), "exec"), ns)
+    return ns
+
+
+@pytest.fixture(scope="module")
+def weighting():
+    return _extract_weighting()
+
+
+def test_the_weighting_definitions_are_still_where_we_think(weighting):
+    """POSITIVE CONTROL on the extractor itself.
+
+    Everything below reads whatever this pulled out of main.py. If a rename or a
+    move made the extractor find nothing, every other assertion would vacuously
+    pass against an empty namespace — a green suite proving nothing, which is the
+    exact failure this file was written to end.
+    """
+    for name in WEIGHTING_NAMES | WEIGHTING_FUNCS:
+        assert name in weighting, f"{name} not found in {MAIN_PY.name} — extractor is stale"
+    assert len(weighting["PLANET_ALCHM_PERIODS"]) == 11
+
+
+def test_the_extracted_weighting_is_actually_called_by_the_server(weighting):
+    """A definition nobody calls would pin nothing. Prove the call sites exist."""
+    tree = ast.parse(MAIN_PY.read_text())
+    calls = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "normalize_alchm_weight"
+    ]
+    # calculate_local_alchemize and calculate_local_philosophers_stone.
+    assert len(calls) >= 2, f"expected >=2 live call sites, found {len(calls)}"
+
+
+@pytest.mark.skipif(EXPECTED_SCALE != "period", reason="migrated to the inertial scale")
+def test_deployed_server_still_runs_the_orbital_period_scale(weighting):
+    """The divergence ADR-009 exists to remove, pinned so it cannot move quietly.
+
+    MEASURED against production 2026-08-01 at deployed SHA a2425ca6: the live
+    /api/philosophers-stone/positions response returns exactly these values in
+    its per-planet `alchmWeight` field.
+    """
+    w = lambda p: weighting["normalize_alchm_weight"](weighting["PLANET_ALCHM_PERIODS"][p])
+
+    assert w("Pluto") == pytest.approx(1.0, abs=1e-12)
+    assert w("Sun") == pytest.approx(0.5130695808579581, abs=1e-12)
+    assert w("Moon") == pytest.approx(0.2842944773527886, abs=1e-9)
+
+    # Pluto is the HEAVIEST body on this scale and the Sun barely half of it.
+    # Inverted against every other engine in the repo; that is the defect.
+    assert w("Pluto") > w("Sun")
+    assert w("Sun") / w("Pluto") == pytest.approx(0.513, abs=1e-3)
+
+
+@pytest.mark.skipif(EXPECTED_SCALE != "period", reason="migrated to the inertial scale")
+def test_the_two_python_scales_disagree_and_by_how_much(weighting):
+    """Both scales live in the same deployed process, split by endpoint.
+
+    /alchemize and /philosophers-stone use the inline period table; /api/user/
+    onboarding imports the inertial one. This pins the size of the gap so the
+    migration's effect is a known quantity rather than a surprise.
+    """
+    w = lambda p: weighting["normalize_alchm_weight"](weighting["PLANET_ALCHM_PERIODS"][p])
+
+    period_ratio = w("Sun") / w("Pluto")
+    inertial_ratio = get_inertial_mass_weight("Sun") / get_inertial_mass_weight("Pluto")
+
+    assert period_ratio == pytest.approx(0.513, abs=1e-3)
+    assert inertial_ratio == pytest.approx(9.180, abs=1e-3)
+    # ~17.9x apart, and rank-inverted: the scales disagree about which body in
+    # the chart is heaviest, not merely by how much.
+    assert inertial_ratio / period_ratio == pytest.approx(17.9, abs=0.1)
+
+
+@pytest.mark.skipif(EXPECTED_SCALE != "inertial", reason="still on the period scale")
+def test_deployed_server_runs_the_inertial_scale(weighting):
+    """Post-migration shape. Inert until EXPECTED_SCALE flips, by design.
+
+    Written now, with decision 4, so the migration PR has a green target to aim
+    at rather than inventing its own assertions after the fact.
+    """
+    for body in ("Sun", "Moon", "Mercury", "Venus", "Mars", "Jupiter", "Saturn",
+                 "Uranus", "Neptune", "Pluto"):
+        assert weighting["weight_for"](body) == pytest.approx(
+            get_inertial_mass_weight(body), abs=1e-12
+        ), f"{body} does not match the canonical inertial scale"
+    assert weighting["weight_for"]("Sun") == 1.0
+    assert weighting["weight_for"]("Pluto") > 0.1  # no body is annihilated


### PR DESCRIPTION
ADR-009 **Step 0** — the safety net that must exist before decisions 1–3 touch any weight scale. No behaviour changes.

## 1. `monica-backfill.yml` disarmed

The nightly 06:45 schedule is **commented out, not deleted**; `workflow_dispatch` is untouched, so a deliberate watched run is still one click away.

It is the only workflow in the repo that writes to production. When ADR-009 lands, every weight-derived monica recomputes to a different value — and this script rewrites what it recomputes. The UPDATEs at `backfillMonicaPerConstruction.ts:310`, `:326` and `:342` are keyed only on `WHERE up.user_id = v.user_id`, with no `monica_method IS NULL` guard. The script says so itself at `:104-106`: *"it does not care what is currently stored"*.

**I checked the workflow's own safety claim, and it does not hold.** Its header lists `--max-new` as the guard against exactly this scenario. It isn't: `--max-new` bounds the count of **new arrivals** (`monica_method IS NULL`, `:108-112`). Already-classified rows are not new, so they are neither counted nor bounded — and are rewritten regardless. That's all 469 two-body and 71 full-chart rows on the first night, unreviewed.

The combination is the real hazard: `checkAgentMonicaDrift` will already be red at 07:15 reporting those same rows as defects that *"cannot happen through ordinary operation"*, and its remediation text points the operator at this very script. **The alarm points at the thing that silently stops the alarm.**

## 2. `main.py`'s weighting is now tested

`backend/alchm_kitchen/main.py` is what Railway serves, it carries the inline copy of the orbital-period table #697 deleted from `backend/utils/`, and **nothing tested it**. That's the inverse risk from everything around it: nothing breaks when it moves, and nothing tells you it moved.

It can't simply be imported — `test_kalchm_parity.py:21-24` documents why (fastapi/sqlalchemy/pyswisseph would break collection), and CI installs **only pytest** by design. Confirmed locally: `fastapi`, `sqlalchemy` and `pydantic` are all absent.

So the test reads main.py's **source** and extracts the table and normalizer with `ast`, executing them in an isolated namespace. That's the real source, not a transcription — a copy is precisely how `main.py` and `planetary_alchemy.py` drifted apart. Stdlib only, so the pytest-only install is preserved.

### What it pins, and why the numbers look wrong

It pins the period scale **as deployed**, including the parts ADR-009 rules to be defects (Pluto heaviest at 1.0, Sun at 0.513). Deliberate, and the same device as the `normalizePlanetWeight` positive controls in `esmsConformance.test.ts`: pinning current wrong behaviour is what makes changing it visible.

**Decision 4 will make this file fail. That is the signal, not a regression.** A skipped post-migration test is included so the migration PR has a green target to aim at rather than inventing assertions after the fact — flip `EXPECTED_SCALE` to `"inertial"`.

### Guards against the test proving nothing

- A **positive control** that the extractor still finds the definitions — otherwise every assertion passes vacuously against an empty namespace, which is the exact failure this file exists to end.
- An **AST check for ≥2 live call sites** — a definition nobody calls pins nothing.

### Negative controls, run

| control | result |
|---|---|
| edit the period table | 2 assertions fail — change detected |
| rename the table | extractor control fails **first**, nothing passes vacuously |
| restore | green again |

Wired into `monica-integrity.yml` beside the parity gate. An unrun test is no gate.

## Gates

- `pytest backend/tests/` — 66 passed, 1 skipped (the post-migration test, correctly inert)
- Both workflow files parse; `monica-backfill` resolves to `workflow_dispatch` only, `monica-integrity` keeps its 07:15 schedule

## After this merges

Step 0 is complete: row cardinality measured (64), `HONO_API_URL` confirmed unset, production writer disarmed, Python weighting covered. Decisions 1–3 become safe to start — and will need the calibration constants re-derived a **third** time, since they change `aggregateEnhancedZodiacElementals`, which feeds the calibration population.

🤖 Generated with [Claude Code](https://claude.com/claude-code)