### PR TITLE
feat(physics): unify the TypeScript weight scales onto inertial mass

### DIFF
--- a/src/__tests__/data/planets.test.ts
+++ b/src/__tests__/data/planets.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for data/planets.ts — planetary mass data and weight normalization.
  */
-import { PLANET_WEIGHTS, normalizePlanetWeight, planetaryData } from "@/data/planets";
+import { PLANET_WEIGHTS, planetaryData } from "@/data/planets";
 
 describe("PLANET_WEIGHTS", () => {
   const expectedPlanets = [
@@ -51,40 +51,18 @@ describe("PLANET_WEIGHTS", () => {
   });
 });
 
-describe("normalizePlanetWeight", () => {
-  it("normalizes Sun to approximately 1.0", () => {
-    const normalized = normalizePlanetWeight(PLANET_WEIGHTS.Sun);
-    expect(normalized).toBeCloseTo(1.0, 2);
-  });
-
-  it("normalizes Pluto to approximately 0.0", () => {
-    const normalized = normalizePlanetWeight(PLANET_WEIGHTS.Pluto);
-    expect(normalized).toBeCloseTo(0.0, 2);
-  });
-
-  it("returns values in [0, 1] for all planets", () => {
-    for (const [name, weight] of Object.entries(PLANET_WEIGHTS)) {
-      const normalized = normalizePlanetWeight(weight);
-      expect(normalized).toBeGreaterThanOrEqual(0);
-      expect(normalized).toBeLessThanOrEqual(1);
-    }
-  });
-
-  it("is monotonically increasing (heavier → higher normalized)", () => {
-    const sorted = Object.entries(PLANET_WEIGHTS)
-      .sort((a, b) => a[1] - b[1]);
-
-    for (let i = 1; i < sorted.length; i++) {
-      const prevNorm = normalizePlanetWeight(sorted[i - 1][1]);
-      const currNorm = normalizePlanetWeight(sorted[i][1]);
-      expect(currNorm).toBeGreaterThanOrEqual(prevNorm);
-    }
-  });
-
-  it("handles very small values gracefully", () => {
-    const result = normalizePlanetWeight(0.0001);
-    expect(typeof result).toBe("number");
-    expect(isNaN(result)).toBe(false);
+describe("the removed Pluto-anchored scale", () => {
+  it("stays removed — no mass normalizer may anchor at a member of its own set", () => {
+    // REGRESSION GUARD (ADR-009). `normalizePlanetWeight` anchored its minimum
+    // AT Pluto, so Pluto normalized to exactly 0 and contributed nothing to any
+    // chart it appeared in. The whole module is asserted to no longer export it,
+    // because the cheapest way to undo this migration is to add it back.
+    const planets = jest.requireActual("@/data/planets") as Record<string, unknown>;
+    expect(planets.normalizePlanetWeight).toBeUndefined();
+    // POSITIVE CONTROL — the module IS loaded and DOES export things, so the
+    // assertion above is a real absence rather than a failed import.
+    expect(typeof planets.PLANET_WEIGHTS).toBe("object");
+    expect(typeof planets.normalizeAlchmWeight).toBe("function");
   });
 });
 

--- a/src/__tests__/physics/esmsConformance.test.ts
+++ b/src/__tests__/physics/esmsConformance.test.ts
@@ -1,6 +1,6 @@
 import * as Astronomy from "astronomy-engine";
 import fixture from "../../../docs/physics/esms_conformance.json";
-import { PLANET_WEIGHTS, normalizePlanetWeight } from "@/data/planets";
+import { PLANET_WEIGHTS } from "@/data/planets";
 import {
   ESMS_K_MAX,
   formatMicroEsms,
@@ -101,10 +101,11 @@ describe("ESMS 2.0 Unified Physics Model Conformance Suite", () => {
   });
 
   it("annihilates no charted body on the inertial mass scale", () => {
-    // normalizePlanetWeight anchors AT Pluto, so Pluto is exactly 0 on that
-    // scale — the same extremum-annihilation that zeroed the Ascendant on the
-    // period scale (PR #683). POSITIVE CONTROL first: the trap is real.
-    expect(normalizePlanetWeight(PLANET_WEIGHTS.Pluto)).toBe(0);
+    // The trap this guards against: a mass scale anchored AT Pluto makes Pluto
+    // exactly 0 — a body in the chart contributing nothing. That scale
+    // (`normalizePlanetWeight`) was DELETED in ADR-009; `planets.test.ts` pins
+    // that it stays deleted, since re-adding it is the cheapest way to undo the
+    // migration. Here we assert the surviving scale's property directly.
     // The inertial scale anchors one decade below Pluto (RULED): all bodies > 0.
     expect(inertialMassWeight("Sun")).toBe(1.0);
     for (const body of Object.keys(PLANET_MEAN_GEOCENTRIC_AU)) {
@@ -162,10 +163,13 @@ describe("ESMS 2.0 Unified Physics Model Conformance Suite", () => {
     expect(ASCENDANT_VESSEL_WEIGHT).toBe(1.0);
     expect(getGravitationalInertia("Ascendant")).toBe(1.0); // r = 1.0 AU
     expect(getTidalPull("Ascendant")).toBe(1.0);
-    // POSITIVE CONTROL — what the accidental `?? 1.0` fallback used to produce:
-    // Earth's relative MASS through the mass normalizer, ≈ 0.3249, not a ruling.
+    // The Ascendant still has NO mass entry — it is not an orbiting body. Under
+    // the deleted Pluto-anchored scale that meant a `?? 1.0` fallback handed it
+    // EARTH's mass (≈0.3249), an accident of the fallback rather than a ruling.
+    // `inertialMassWeight` special-cases it instead, so the absence below is now
+    // harmless — but it is asserted because the fallback returns silently, and a
+    // future entry here would resurrect the accident without failing anything.
     expect(PLANET_WEIGHTS["Ascendant" as keyof typeof PLANET_WEIGHTS]).toBeUndefined();
-    expect(normalizePlanetWeight(1.0)).toBeCloseTo(0.3248835368415509, 12);
-    expect(normalizePlanetWeight(1.0)).not.toBe(ASCENDANT_VESSEL_WEIGHT);
+    expect(inertialMassWeight("Ascendant")).toBe(ASCENDANT_VESSEL_WEIGHT);
   });
 });

--- a/src/__tests__/thermodynamicAffinityCalibration.test.ts
+++ b/src/__tests__/thermodynamicAffinityCalibration.test.ts
@@ -298,9 +298,9 @@ describe("thermodynamic affinity calibration", () => {
     // but with only 7% headroom, which is how a pin becomes flaky under an ULP
     // change. Pinning the measured 2-decimal value keeps the same tolerance and
     // restores the margin.
-    expect(pct[0]).toBeCloseTo(29.39, 1); // heat
-    expect(pct[1]).toBeCloseTo(63.95, 1); // entropy
-    expect(pct[2]).toBeCloseTo(6.66, 1); // reactivity
+    expect(pct[0]).toBeCloseTo(29.57, 1); // heat
+    expect(pct[1]).toBeCloseTo(63.89, 1); // entropy
+    expect(pct[2]).toBeCloseTo(6.54, 1); // reactivity
   });
 
   itPinnedConstant("confirms equal weighting IS the first principal component", () => {

--- a/src/app/api/alchm-quantities/route.ts
+++ b/src/app/api/alchm-quantities/route.ts
@@ -5,7 +5,6 @@
  * - alchm-kinetics
  */
 import { NextResponse } from "next/server";
-import { PLANET_WEIGHTS, normalizePlanetWeight } from "@/data/planets";
 import { rateLimit } from "@/lib/rateLimit";
 import { getServiceUrlSafe } from "@/lib/serviceUrls";
 import { AlchmQuantitiesApiResponseSchema } from "@/lib/validation/apiSchemas";
@@ -14,7 +13,7 @@ import { alchemize, type PlanetaryPosition } from "@/services/RealAlchemizeServi
 import type { DegradedInfo } from "@/types/degraded";
 import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
 import { createLogger } from "@/utils/logger";
-import { PLANETARY_ALCHEMY } from "@/utils/planetaryAlchemyMapping";
+import { PLANETARY_ALCHEMY, inertialMassWeight } from "@/utils/planetaryAlchemyMapping";
 import {
   calculatePlanetaryPositions,
   calculatePlanetaryPositionsWithMeta,
@@ -386,9 +385,11 @@ export async function GET(request: Request) {
         const moiety1 = PLANET_MOIETIES[p1] ?? 3.0;
         const moiety2 = PLANET_MOIETIES[p2] ?? 3.0;
 
-        // Gravitational/alchemical physical mass coupling
-        const w1 = normalizePlanetWeight(PLANET_WEIGHTS[p1] ?? 1.0);
-        const w2 = normalizePlanetWeight(PLANET_WEIGHTS[p2] ?? 1.0);
+        // Gravitational/alchemical physical mass coupling, on the canonical
+        // inertial scale (ADR-009). Under the old Pluto-anchored scale a
+        // Pluto aspect contributed w=0 to the pair, i.e. nothing.
+        const w1 = inertialMassWeight(p1);
+        const w2 = inertialMassWeight(p2);
         const combinedWeight = (w1 + w2) / 2;
 
         for (const def of ASPECT_DEFS) {

--- a/src/calculations/kinetics.ts
+++ b/src/calculations/kinetics.ts
@@ -6,9 +6,9 @@
  * momentum, inertia, and aspect phase calculations.
  */
 
-import { PLANET_WEIGHTS, normalizePlanetWeight } from "@/data/planets";
 import type { Element } from "@/types/celestial";
 import type { AspectPhase, KineticMetrics } from "@/types/kinetics";
+import { inertialMassWeight } from "@/utils/planetaryAlchemyMapping";
 import { alchemize, planetInfo } from "./core/alchemicalEngine";
 
 export type { KineticMetrics } from "@/types/kinetics";
@@ -225,8 +225,7 @@ function aggregateAlchemicalProperties(
 
     // Weight each planet's contribution by its log-normalized physical mass.
     // Jupiter (w≈0.63) adds ~5× more than Mercury (w≈0.17) to alchemical totals.
-    const relMass = PLANET_WEIGHTS[planet] ?? 1.0;
-    const w = normalizePlanetWeight(relMass);
+    const w = inertialMassWeight(planet);
 
     // Sum mass-weighted alchemical properties
     totals.Spirit    += planetData.Alchemy.Spirit    * w;
@@ -277,11 +276,11 @@ function getElementFromSign(sign: string): Element | null {
  *   velocity × 0.15  — faster internal alchemical flow for massive planets
  *   current  × 0.15  — stronger energetic current from massive bodies
  *
- * Result range: ~1.01 (Pluto, w≈0) to ~1.25 (Sun, w=1.0) for force.
+ * Result range: ~1.03 (Pluto, w≈0.109) to ~1.25 (Sun, w=1.0) for force.
+ * ADR-009: was ~1.01 at the bottom, when Pluto's weight was exactly 0.
  */
 function getPlanetaryModifiers(planet: string) {
-  const relMass = PLANET_WEIGHTS[planet] ?? 1.0; // actual × Earth
-  const w = normalizePlanetWeight(relMass);       // 0 (Pluto) → 1 (Sun)
+  const w = inertialMassWeight(planet); // 0.109 (Pluto) → 1.0 (Sun)
 
   return {
     velocity: 1.0 + w * 0.15,

--- a/src/data/planets.ts
+++ b/src/data/planets.ts
@@ -28,15 +28,20 @@ export const PLANET_WEIGHTS: Record<string, number> = {
 };
 
 /**
- * Normalizes a relative-mass value to [0, 1] via log₁₀.
- * Pluto → 0.0, Sun → 1.0.
- * Used by food-recommendation scoring; not for Alchm thermodynamics.
+ * REMOVED (ADR-009): `normalizePlanetWeight`, the Pluto-anchored mass scale.
+ *
+ * It log-normalized with its minimum anchored AT Pluto, so Pluto's weight was
+ * identically 0 — a body in the chart contributing nothing — and the Ascendant,
+ * having no entry here, fell through a `?? 1.0` to EARTH's mass (0.3249) rather
+ * than the ruled vessel weight. Both are extremum-annihilation, the same defect
+ * PR #683 fixed for the Ascendant on the period scale.
+ *
+ * Every caller now uses `inertialMassWeight` from
+ * `@/utils/planetaryAlchemyMapping`, which takes a body NAME, pins the Ascendant
+ * to 1.0, and anchors its zero one decade BELOW the lightest charted body so no
+ * member can be annihilated. Do not reintroduce a mass normalizer anchored at a
+ * member of the set it normalizes.
  */
-const _MASS_LOG_MIN = Math.log10(0.0022);      // Pluto
-const _MASS_LOG_MAX = Math.log10(333054.2532); // Sun
-export function normalizePlanetWeight(relMass: number): number {
-  return (Math.log10(Math.max(relMass, 1e-9)) - _MASS_LOG_MIN) / (_MASS_LOG_MAX - _MASS_LOG_MIN);
-}
 
 /**
  * Orbital periods in Earth years.

--- a/src/data/unified/thermodynamicAffinity.ts
+++ b/src/data/unified/thermodynamicAffinity.ts
@@ -163,14 +163,14 @@ export const THERMO_AFFINITY_EPOCH = {
  * population. BASIS: MEASURED — re-derived by
  * `thermodynamicAffinityCalibration.test.ts` on every run.
  *
- * Whitening is not cosmetic. Unwhitened, reactivity's asinh spread (2.333) would
- * outweigh heat's (0.333) by 7:1 on scale alone — an unexamined emphasis of
+ * Whitening is not cosmetic. Unwhitened, reactivity's asinh spread (2.309) would
+ * outweigh heat's (0.330) by 7:1 on scale alone — an unexamined emphasis of
  * exactly the kind the old `Math.abs(a - b) / 2` divisor smuggled in.
  */
 export const THERMO_AFFINITY_SD: Readonly<ThermoState> = {
-  heat: 0.3328000991150603,
-  entropy: 0.37031863162603695,
-  reactivity: 2.3331310334971707,
+  heat: 0.32988662169162397,
+  entropy: 0.3689024420258162,
+  reactivity: 2.3088816101488434,
 };
 
 /**
@@ -178,8 +178,8 @@ export const THERMO_AFFINITY_SD: Readonly<ThermoState> = {
  * all 21900 REACHABLE cuisine↔moment distances (see the epoch note above). Not
  * chosen; re-derived by the calibration test.
  *
- * Distance quantiles for reference: p10 0.265, p25 0.380, MEDIAN 1.100,
- * p75 1.766, p90 2.772, max 4.873.
+ * Distance quantiles for reference: p10 0.262, p25 0.376, MEDIAN 1.093,
+ * p75 1.762, p90 2.787, max 4.893.
  *
  * The whole distribution CONTRACTED — not just the tail — when the derivation
  * was finally pointed at the mass-weighted cuisine ESMS production actually
@@ -196,7 +196,7 @@ export const THERMO_AFFINITY_SD: Readonly<ThermoState> = {
  * D0 depends on `THERMO_AFFINITY_SD`, so the two must be re-derived together —
  * the calibration test fails on both if either is edited alone.
  */
-export const THERMO_AFFINITY_D0 = 1.0997692434132713;
+export const THERMO_AFFINITY_D0 = 1.0934456889925421;
 
 /**
  * Whitened, asinh-space Euclidean distance between two thermodynamic states.

--- a/src/services/planetaryScoring.ts
+++ b/src/services/planetaryScoring.ts
@@ -6,7 +6,6 @@
  * planetary hours, critical degrees, and retrograde modifiers.
  */
 
-import { PLANET_WEIGHTS, normalizePlanetWeight } from "@/data/planets";
 import type {
   Planet,
   ZodiacSignType,
@@ -14,6 +13,7 @@ import type {
 } from "@/types/celestial";
 import type { Recipe } from "@/types/recipe";
 import { getAccuratePlanetaryPositions } from "@/utils/astrology/positions";
+import { inertialMassWeight } from "@/utils/planetaryAlchemyMapping";
 
 // Planets used for scoring (exclude Ascendant which isn't a planet)
 const SCORING_PLANETS: Planet[] = [
@@ -416,11 +416,11 @@ export class PlanetaryScoringService {
       components.planetaryHourBonus +
       components.criticalDegreeBonus;
 
-    // Ruling planet's physical mass as a soft weight. PLANET_WEIGHTS stores
-    // actual relative-to-Earth values; normalizePlanetWeight log-scales so
-    // Pluto → ≈0, Sun → 1.0. Floor at 0.5 keeps small bodies in play.
-    const relMass = PLANET_WEIGHTS[rulingPlanet] ?? 1.0;
-    const massScale = 0.5 + 0.5 * normalizePlanetWeight(relMass);
+    // Ruling planet's physical mass as a soft weight, on the canonical
+    // inertial scale (ADR-009): Pluto → 0.109, Sun → 1.0. The 0.5 floor stays —
+    // it kept small bodies in play back when Pluto normalized to exactly 0, and
+    // it still bounds how much mass alone can suppress a sky score.
+    const massScale = 0.5 + 0.5 * inertialMassWeight(rulingPlanet);
     const skyComponent = Math.min(
       skyBase * massScale * components.retrogradeModifier,
       1,

--- a/src/services/restaurantScoring.ts
+++ b/src/services/restaurantScoring.ts
@@ -492,12 +492,10 @@ function buildMatchReasons(input: {
     reasons.push(`Elemental harmony with the moment (${Math.round(elementalMatch * 100)}%)`);
   }
 
-  // 0.85 affinity is d ≤ −D0·ln(0.85) = 0.1787 in whitened units. MEASURED: it
-  // fires for 4.57% of reachable cuisine↔moment pairs, down from ~10.3% before
-  // #706 re-derived the constants against production's mass-weighted cuisine
-  // ESMS. The band tightened because the distribution changed SHAPE, not just
-  // scale: the lower tail contracted less than the median (p10 ×0.87 vs median
-  // ×0.58), so the same affinity cut now sits further out in D0 units. This
+  // 0.85 affinity is d ≤ −D0·ln(0.85) = 0.1777 in whitened units. MEASURED: it
+  // fires for 4.69% of reachable cuisine↔moment pairs (was 4.57% before
+  // ADR-009 moved the elementals onto the inertial scale, and ~10.3% before
+  // #706 re-derived against production's mass-weighted cuisine ESMS). This
   // reason is deliberately rarer than the 0.8 elemental one above it.
   // See `thermodynamicAffinity.ts`. The old copy keyed off a monica score that
   // was identical for every cuisine at any given moment, so it fired for all

--- a/src/utils/astrology/natalAlchemy.ts
+++ b/src/utils/astrology/natalAlchemy.ts
@@ -1,4 +1,3 @@
-import { PLANET_WEIGHTS, normalizePlanetWeight } from "@/data/planets";
 import { performAlchemicalAnalysis } from "@/data/unified/alchemicalCalculations";
 import type { ElementalProperties } from "@/types/alchemy";
 import type { AlchemicalProperties } from "@/types/celestial";
@@ -6,6 +5,7 @@ import type { NatalChart } from "@/types/natalChart";
 import type { AlchemicalState } from "@/utils/monica/types";
 import {
   calculateAlchemicalFromPlanets,
+  inertialMassWeight,
   isSectDiurnalForBirth,
 } from '@/utils/planetaryAlchemyMapping';
 
@@ -29,16 +29,43 @@ const PLANETARY_WEIGHTS_ASTRO: Record<string, number> = {
 };
 
 /**
- * Composite weight: 60% astrological tradition + 40% physical mass (log-normalized).
- * This grounds the scoring in physics while respecting astrological convention.
+ * Composite weight: 60% astrological tradition + 40% physical mass.
+ *
+ * BASIS of the 0.6 — RULED (ADR-009), not measured. With the astro table
+ * normalized below, 0.6 now means what it always claimed: astrological
+ * convention carries the larger share of a NATAL INTERPRETIVE weight, physical
+ * mass the smaller. That is a product judgement about what a natal chart is,
+ * and it is legitimately ruled rather than derived. It is deliberately NOT
+ * fitted: there is no target metric to fit it against, and inventing one would
+ * launder a hand value into a false "MEASURED".
+ *
+ * ⚠️ This 0.6 is NOT the 0.6/0.4 sign/sect split in planetaryAlchemyMapping,
+ * RealAlchemizeService or main.py. Same number, unrelated meaning. Do not
+ * "unify" them.
+ *
+ * Two defects fixed here (ADR-009 decision 3):
+ *
+ * 1. `PLANETARY_WEIGHTS_ASTRO` was UNNORMALIZED (0.8–1.5), so its term ran
+ *    0.48–0.90 while the mass term was capped at 0.40. The declared 60/40 was
+ *    in practice ~80/20 — and for Pluto exactly 100/0, because the old
+ *    Pluto-anchored mass scale returned 0 and the "physical grounding"
+ *    contributed literally nothing.
+ * 2. The mass term now comes from the canonical inertial scale, so no body is
+ *    annihilated and the Ascendant gets its ruled 1.0 instead of the 0.5
+ *    midpoint guess below.
+ *
+ * Normalized by MAX, deliberately, NOT min-max: min-max would map the lowest
+ * astro value (0.8 — Uranus, Neptune, Pluto) to exactly 0, reintroducing on the
+ * astro axis the precise annihilation this ADR removes. Divide-by-max preserves
+ * ratios and caps the astro term at exactly 0.6, as declared.
  */
+const _ASTRO_MAX = Math.max(...Object.values(PLANETARY_WEIGHTS_ASTRO));
+
 const NATAL_WEIGHTS: Record<string, number> = Object.fromEntries(
-  Object.entries(PLANETARY_WEIGHTS_ASTRO).map(([planet, astroWeight]) => {
-    const massWeight = PLANET_WEIGHTS[planet]
-      ? normalizePlanetWeight(PLANET_WEIGHTS[planet])
-      : 0.5; // Ascendant has no mass; use midpoint
-    return [planet, astroWeight * 0.6 + massWeight * 0.4];
-  })
+  Object.entries(PLANETARY_WEIGHTS_ASTRO).map(([planet, astroWeight]) => [
+    planet,
+    (astroWeight / _ASTRO_MAX) * 0.6 + inertialMassWeight(planet) * 0.4,
+  ])
 );
 
 // Define element and modality for each sign

--- a/src/utils/planetaryAlchemyMapping.ts
+++ b/src/utils/planetaryAlchemyMapping.ts
@@ -15,7 +15,7 @@
  * night. These sectarian elements drive the dynamic elemental profile of the sky.
  */
 
-import { PLANET_WEIGHTS, normalizePlanetWeight } from "@/data/planets";
+import { PLANET_WEIGHTS } from "@/data/planets";
 import type { DignityType, ElementalProperties } from "@/types/alchemy";
 import type { AlchemicalProperties } from "@/types/celestial";
 import { buildAspectsWithStrength } from "./aspectCalculator";
@@ -716,10 +716,17 @@ export function aggregateZodiacElementals(planetaryPositions: {
       continue;
     }
 
-    // Weight elemental contribution by planet's normalized physical mass.
-    // Jupiter in Sagittarius adds ~7× more Fire than Mercury in Sagittarius.
-    const relMass = PLANET_WEIGHTS[planet] ?? 1.0;
-    const w = normalizePlanetWeight(relMass);
+    // Weight elemental contribution by the planet's inertial mass — the SAME
+    // scale the ESMS half of this module uses (ADR-009). This was
+    // `normalizePlanetWeight`, which anchors AT Pluto and so gave Pluto a weight
+    // of exactly 0: it was in the chart and contributed nothing, and a
+    // Pluto-only positions map fell through the `count === 0` guard below to a
+    // flat 0.25 vector. The Ascendant fared no better — it has no mass entry, so
+    // `?? 1.0` handed it EARTH's mass (0.3249) rather than the ruled vessel
+    // weight. `inertialMassWeight` fixes both: it takes the body NAME, pins the
+    // Ascendant to 1.0, and anchors its zero one decade below the lightest
+    // charted body so no member is annihilated.
+    const w = inertialMassWeight(planet);
     totals[element] += w;
     count += w;
   }
@@ -770,9 +777,11 @@ export function aggregateEnhancedZodiacElementals(
       continue;
     }
 
-    // Weight elemental contribution by planet's normalized physical mass.
-    const relMass = PLANET_WEIGHTS[planet as PlanetName] ?? 1.0;
-    const w = normalizePlanetWeight(relMass);
+    // Inertial mass — same scale as the ESMS half of this module (ADR-009).
+    // See the note in `aggregateZodiacElementals` above for what the previous
+    // `normalizePlanetWeight` did to Pluto (exactly 0) and the Ascendant
+    // (Earth's mass, 0.3249, by fallback accident).
+    const w = inertialMassWeight(planet);
 
     // Blended elemental property
     totals[signElement] += w * 0.6;


### PR DESCRIPTION
ADR-009 **decisions 1–3**. Every TypeScript caller of the Pluto-anchored mass scale now uses the canonical inertial scale, and that scale is **deleted**.

## Decision 1 — Pluto-at-zero was an artifact

`normalizePlanetWeight` anchored its minimum **at** Pluto, so Pluto's weight was identically `0`: a body in the chart contributing nothing. Six call sites migrated to `inertialMassWeight` (Pluto 0.1089, Sun 1.0), which anchors one decade *below* the lightest charted body so no member can be annihilated.

| file | site |
|---|---|
| `planetaryAlchemyMapping.ts` | `aggregateZodiacElementals` + the enhanced variant |
| `natalAlchemy.ts` | `NATAL_WEIGHTS` mass term |
| `kinetics.ts` | `getPlanetaryModifiers` (×2) |
| `planetaryScoring.ts` | `massScale` |
| `alchm-quantities/route.ts` | aspect mass coupling (×2) |

The function and its anchors are then **removed**. Verified repo-wide (not just `src/`) that nothing outside comments, docs and tests referenced it. The migration isn't finished while the annihilating scale is still importable.

## Decision 2 — the Ascendant, for free

It has no mass entry, so `?? 1.0` handed it **Earth's** mass (0.3249) instead of the ruled vessel weight. `inertialMassWeight` special-cases it to 1.0, so every migrated site gets the fix at once — a **3.08× correction**, and the single largest driver of output movement.

## Decision 3 — `NATAL_WEIGHTS`

`PLANETARY_WEIGHTS_ASTRO` was unnormalized (0.8–1.5), so its term ran 0.48–0.90 against a mass term capped at 0.40. The declared "60% astro / 40% mass" was in practice ~80/20 — and for Pluto exactly **100/0**, because the old scale returned 0 and the "physical grounding" contributed literally nothing.

Now `astro/max * 0.6 + inertial * 0.4`. **Divide-by-max, not min-max**: min-max would map the lowest astro value (0.8 — Uranus, Neptune, Pluto) to exactly 0, reintroducing on the astro axis the precise annihilation this ADR removes.

The `0.6` is documented as **RULED** with its rationale, deliberately not promoted to MEASURED. It also carries a warning that it is **not** the sign/sect `0.6` in `planetaryAlchemyMapping` / `RealAlchemizeService` / `main.py` — same number, unrelated meaning. That coincidence is the same shape as the Indian≡Korean bug: one identical literal read as one shared meaning.

## Calibration re-derived — third time, and it needs two passes

Changing `aggregateEnhancedZodiacElementals` moves the calibration population. `D0` and the axis shares are measured in **whitened** units so they depend on `SD`; `SD` derives independently and is a fixed point after one pass. Deriving them together yields a value that is wrong the moment `SD` lands — the first-pass `D0` was 1.0863, the settled one is 1.0934.

| constant | before | after |
|---|---|---|
| `SD.heat` | 0.3328000991150603 | 0.32988662169162397 |
| `SD.entropy` | 0.37031863162603695 | 0.3689024420258162 |
| `SD.reactivity` | 2.3331310334971707 | 2.3088816101488434 |
| `D0` | 1.0997692434132713 | 1.0934456889925421 |
| axis influence | 29.39 / 63.95 / 6.66 | 29.57 / 63.89 / 6.54 |

The 0.85 affinity reason now fires for a measured **4.69%** of reachable pairs (4.57% before this, ~10.3% before #706). Comment updated by hand — no test guards it.

## Round-trip check on the memo itself

The shipped code reproduces ADR-009's predictions **exactly**: Pluto 0.1089, Ascendant 1.0000, and today's sky elementals Fire **0.4279** / Earth **0.0478** — the same figures the memo predicted before any of this code was written.

`planets.test.ts`'s `normalizePlanetWeight` block is replaced by a **removal guard** asserting the module no longer exports it, plus a positive control that the module still loads and exports its other members — so the absence is a real absence, not a failed import. Re-adding the function is the cheapest way to undo this migration; now it fails.

## Gates

- `tsc --noEmit` — clean
- `jest` — 198/198 suites, 1975 passed
- `pytest backend/tests/` — 66 passed (Python untouched here)
- `eslint` — clean; the one `restaurantScoring` `import/order` warning is pre-existing on master

## Deliberately NOT in this PR

**Decision 4** — the inline Python period table. Separate surface, and #709 already landed its test harness: flip `EXPECTED_SCALE` to `"inertial"` and the assertions are waiting.

**The `natal_chart.elementalBalance` backfill.** This PR changes that persisted value (~75 rows carry a real chart). Per ADR-009 Step 5 a backfill must run only *after* the new writer is live, verified against the deployed SHA — so it is an operational step, not a code change, and I would rather not ship a hastily-written production writer at the end of a long session. The recompute is `aggregateEnhancedZodiacElementals(positions, diurnal)` over `user_profiles.natal_chart` / `users.profile`.

**Decision 5** stays a separate PR as ruled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)