### PR TITLE
feat(physics): retire the period scale from momentum, and remeasure decision 5

### DIFF
--- a/docs/adr/009-one-planetary-weight-scale.md
+++ b/docs/adr/009-one-planetary-weight-scale.md
@@ -208,6 +208,77 @@ all-or-nothing across both the economy and the momentum paths. Decisions 1–4
 alone leave the system strictly more coherent than today, so they are a valid
 stopping point if 5 slips.
 
+### Decision 5, remeasured `[MEASURED 2026-08-02]`
+
+Decision 5 has **two halves with unrelated blast radii**, and the causality
+assumed above is wrong in one direction and understated in the other. Measured
+at deployed SHA `77bdfe34`:
+
+**5a — `RealAlchemizeService` momentum. Shipped.** Its private duplicate of the
+period table fed `planetaryMomentum` and *nothing else*: ESMS comes from
+`engine.totals` (canonical, already inertial) and the elementals from the flat
+0.6/0.4 sign/sect split. Momentum is display-only — two API responses and the
+`/quantities` tide readout — and is never persisted. Weights move a long way
+(Pluto 1.0 → 0.109, Sun 0.513 → 1.0, Uranus 0.904 → 0.525) but no stored value
+does.
+
+**`alchemicalSamples.json` and `FALLBACK_METRICS` are NOT invalidated by decision
+5. They were ALREADY stale before it.** Regenerating the file at its own anchor
+(`--anchor=2026-07-12T06:00:00.000Z`, values-only diff by construction) changed
+**1821/1821 samples on unmodified master** — the Sun's stored ESMS contribution
+moves 0.51307 (period × dignity) → 1.0 (inertial), and the dignity multipliers
+moved too, `{1, 1.15, 0.7, 0.85, 1.3}` → `{1, 1.1, 0.9, 0.93, 1.07}`. Cause: the
+ESMS engine unification that already shipped (#695/#710), not this decision.
+Regenerating the same file **with 5a applied is byte-identical** to regenerating
+without it (md5 `63f7ff4e…` both ways) — the file has no momentum field.
+
+The shipped `FALLBACK_METRICS` round-trip *exactly* against the committed
+samples (heat 0.067/0.037 vs measured 0.0669/0.0365), so the derivation was
+honest; it is the samples underneath that moved. Against current master those
+priors are off by roughly 2×:
+
+| prior      | shipped     | current master  | drift         |
+|------------|-------------|-----------------|---------------|
+| heat       | 0.067/0.037 | 0.1225/0.0763   | +83% / +106%  |
+| entropy    | 0.225/0.101 | 0.3929/0.2620   | +75% / +159%  |
+| reactivity | 6.54/6.91   | 14.4540/21.8652 | +121% / +216% |
+
+⚠️ This is a **live defect independent of ADR-009**: `projectZScoreTarget` is
+z-scoring compatibility against priors that no longer describe the engine's
+distribution. It needs its own PR — regenerate the samples, re-derive the priors
+from them — and must NOT be attributed to decision 5, which does not cause it.
+
+**5b — `agentMonicaTwoBody`. BLOCKED on a ruling, not merely deferred.** Swapping
+`alchmWeightOf` to the inertial scale moves **5184/5760 grid cells (90.0%)**,
+median relative shift 24.4%, p90 227%, and fails 6 tests across 2 suites. Two of
+those are not re-pinnable numbers but **design contracts**:
+
+- *"sits inside the single-body envelope"* — two-body |max| goes 2.8108 → 4.4166
+  against a limit of 3.8977. Inertial puts the two-body range OUTSIDE the
+  single-body envelope, which the suite states as an invariant.
+- *"still absorbs a real share of the grid (guard: not a no-op band)"* — the
+  degenerate band's canonical-only population falls to 0, neutering it.
+
+Plus a real constant to re-derive (Sacred-7 two-body scale 1.4054 → 2.2083, i.e.
+|max|/2) and **469 persisted phase-agent rows** (`monica_diurnal` /
+`monica_nocturnal`) that would desync — the module's own header already warns
+that a far smaller perturbation "would desync the 4280 rows already in
+production". So 5b is a model change requiring a ruling on the envelope, plus a
+backfill; it is not a mechanical scale swap. `src/data/planets.ts` therefore
+KEEPS `PLANET_ALCHM_PERIODS` / `normalizeAlchmWeight` until 5b lands — 5b is
+their last consumer.
+
+📌 Correction to the record: `agentMonicaTwoBody`'s header docstring quotes
+"median |monica| 0.2244 · p90 1.2434 · max 12.6756 · 304 cells (5.3%) resolve to
+φ". **All four are stale.** Re-measured over the same 5760-cell grid on current
+master (period scale, unchanged by this PR): median 0.2927 · p90 1.6180 · max
+2.8108 · 813 cells (14.1%) at φ. `agentMonicaTwoBody.test.ts:457` independently
+pins |max| to 2.8107786459098314, agreeing with the re-measurement — **the test
+is the accurate record; the docstring is stale.** Corrected in this PR.
+
+(Under the inertial scale those become median 0.3262 · p90 1.6180 · max 4.4166 ·
+576 cells (10.0%) — recorded here so 5b starts from measured numbers.)
+
 ## Consequences
 
 ### Chart-level output movement (TypeScript)

--- a/src/__tests__/realAlchemizeMomentumScale.test.ts
+++ b/src/__tests__/realAlchemizeMomentumScale.test.ts
@@ -1,0 +1,132 @@
+import fs from "fs";
+import path from "path";
+
+import { alchemizeDetailed } from "@/services/RealAlchemizeService";
+import { PLANET_ALCHM_PERIODS, normalizeAlchmWeight } from "@/data/planets";
+import { inertialMassWeight } from "@/utils/planetaryAlchemyMapping";
+
+/**
+ * ADR-009 decision 5 (partial): momentum's weight scale.
+ *
+ * RealAlchemizeService carried its OWN copy of PLANET_ALCHM_PERIODS /
+ * normalizeAlchmWeight, byte-identical to the one in src/data/planets.ts. A
+ * private duplicate is exactly how the two runtimes drifted apart before: PR
+ * #697 deleted the orbital-period table from Python's backend/utils/ and left
+ * main.py's inline copy running for a month, so production served two different
+ * weight scales split by endpoint (ADR-009 decision 4).
+ *
+ * Its only consumer here was `planetaryMomentum`. ESMS comes from the canonical
+ * inertial engine (`engine.totals`) and the elementals from the flat 0.6/0.4
+ * sign/sect split, so this migration moves momentum and nothing else.
+ *
+ * ── Why these tests are shaped this way ─────────────────────────────────────
+ *
+ * Momentum is not stored in any artifact: regenerating alchemicalSamples.json
+ * before and after this change produced BYTE-IDENTICAL files (MEASURED
+ * 2026-08-02, same --anchor). That is the correct result — the file has no
+ * momentum field — but it is also exactly what a change that never executed
+ * would produce. So the scale is asserted through the OUTPUT, recovering the
+ * weight from momentum itself, and a positive control proves the two scales
+ * actually disagree so the assertion can fail.
+ */
+
+const SIGNS = [
+  "aries", "taurus", "gemini", "cancer", "leo", "virgo",
+  "libra", "scorpio", "sagittarius", "capricorn", "aquarius", "pisces",
+];
+
+const BODIES = [
+  "Sun", "Moon", "Mercury", "Venus", "Mars",
+  "Jupiter", "Saturn", "Uranus", "Neptune", "Pluto", "Ascendant",
+];
+
+/** Every body moves by exactly this, so the ONLY thing separating their
+ *  momenta is the weight. */
+const DELTA_DEGREES = 2;
+
+function sky() {
+  const now: Record<string, any> = {};
+  const hist: Record<string, any> = {};
+  BODIES.forEach((b, i) => {
+    const lon = (i % 12) * 30 + 10;
+    now[b] = { sign: SIGNS[i % 12], degree: 10, minute: 0, exactLongitude: lon };
+    hist[b] = { sign: SIGNS[i % 12], degree: 8, minute: 0, exactLongitude: lon - DELTA_DEGREES };
+  });
+  return { now, hist };
+}
+
+/** The scale this module used to apply, kept here only to assert we no longer
+ *  land on it. Reads the still-live table in @/data/planets — two-body monica
+ *  still uses it, so decision 5 is only half done (see the ADR). */
+function periodWeight(planet: string): number {
+  return planet === "Ascendant"
+    ? 1.0
+    : normalizeAlchmWeight(PLANET_ALCHM_PERIODS[planet] ?? 1.0);
+}
+
+describe("ADR-009 decision 5 — momentum rides the inertial mass scale", () => {
+  it("POSITIVE CONTROL: the two scales genuinely disagree, so these tests can fail", () => {
+    const disagreeing = BODIES.filter(
+      (b) => Math.abs(inertialMassWeight(b) - periodWeight(b)) > 1e-6,
+    );
+    // Only the Ascendant coincides — it is the RULED vessel weight 1.0 under
+    // both. If this ever collapsed to zero disagreeing bodies, every assertion
+    // below would pass vacuously against two identical scales.
+    expect(disagreeing.length).toBe(BODIES.length - 1);
+    expect(disagreeing).not.toContain("Ascendant");
+  });
+
+  it("recovers the INERTIAL weight from momentum, for every body", () => {
+    const { now, hist } = sky();
+    const r = alchemizeDetailed(now, hist, new Date("2026-07-12T06:00:00.000Z"));
+
+    for (const b of BODIES) {
+      const m = r.planetaryMomentum[b];
+      expect(typeof m).toBe("number");
+      // momentum = delta * weight, and delta is 2 by construction.
+      expect(m / DELTA_DEGREES).toBeCloseTo(inertialMassWeight(b), 12);
+    }
+  });
+
+  it("does NOT land on the orbital-period weight", () => {
+    const { now, hist } = sky();
+    const r = alchemizeDetailed(now, hist, new Date("2026-07-12T06:00:00.000Z"));
+
+    // Every body EXCEPT the Ascendant, where the two scales legitimately agree.
+    for (const b of BODIES.filter((x) => x !== "Ascendant")) {
+      const recovered = r.planetaryMomentum[b] / DELTA_DEGREES;
+      expect(Math.abs(recovered - periodWeight(b))).toBeGreaterThan(1e-6);
+    }
+  });
+
+  it("puts the Sun above Pluto — the period scale had it inverted", () => {
+    const { now, hist } = sky();
+    const r = alchemizeDetailed(now, hist, new Date("2026-07-12T06:00:00.000Z"));
+    const sun = r.planetaryMomentum.Sun / DELTA_DEGREES;
+    const pluto = r.planetaryMomentum.Pluto / DELTA_DEGREES;
+
+    expect(sun).toBeGreaterThan(pluto);
+    // Pluto sits exactly one decade above the anchor by construction, so its
+    // weight is 1/range and the ratio IS the log range. Under the period scale
+    // this was 0.513 — Pluto the heaviest body in every chart.
+    expect(sun / pluto).toBeCloseTo(9.180092303273348, 9);
+  });
+
+  it("no longer keeps a PRIVATE copy of the period table", () => {
+    // Structural, because the cheapest way to undo this migration is to paste
+    // the table back in rather than to change a number.
+    const src = fs.readFileSync(
+      path.resolve(__dirname, "../services/RealAlchemizeService.ts"),
+      "utf8",
+    );
+    // POSITIVE CONTROL — the file was really read and is substantial, so the
+    // absence assertions below are real rather than a silent empty string.
+    expect(src.length).toBeGreaterThan(10_000);
+    expect(src).toContain("alchemizeDetailed");
+
+    // Declarations, not mentions: the REMOVED note deliberately names them.
+    expect(src).not.toMatch(/const\s+PLANET_ALCHM_PERIODS\s*:/);
+    expect(src).not.toMatch(/const\s+PERIOD_LOG_(MIN|MAX)\s*=/);
+    expect(src).not.toMatch(/function\s+normalizeAlchmWeight\s*\(/);
+  });
+});

--- a/src/services/RealAlchemizeService.ts
+++ b/src/services/RealAlchemizeService.ts
@@ -15,6 +15,7 @@ import {
 import {
   getPlanetarySectElement,
   calculateAlchemicalFromPlanetsDetailed,
+  inertialMassWeight,
   type AlchemicalPlanetPositions,
 } from "@/utils/planetaryAlchemyMapping";
 
@@ -44,29 +45,23 @@ function computeDominantModality(
   return top && top[1] > 0 ? top[0] : "Cardinal";
 }
 
-const PLANET_ALCHM_PERIODS: Record<string, number> = {
-  Pluto: 247.94,
-  Neptune: 164.79,
-  Uranus: 84.01,
-  Saturn: 29.46,
-  Jupiter: 11.86,
-  Mars: 1.88,
-  Sun: 1.0,
-  Venus: 0.615,
-  Mercury: 0.241,
-  Moon: 0.075,
-  Ascendant: 0.003,
-};
-
-const PERIOD_LOG_MIN = Math.log10(0.003);
-const PERIOD_LOG_MAX = Math.log10(247.94);
-
-function normalizeAlchmWeight(periodYears: number): number {
-  return (
-    (Math.log10(Math.max(periodYears, 1e-9)) - PERIOD_LOG_MIN) /
-    (PERIOD_LOG_MAX - PERIOD_LOG_MIN)
-  );
-}
+// REMOVED (ADR-009 decision 5): this module's PRIVATE copy of
+// PLANET_ALCHM_PERIODS / PERIOD_LOG_MIN / PERIOD_LOG_MAX / normalizeAlchmWeight.
+//
+// It was a byte-identical duplicate of the table in src/data/planets.ts, and a
+// duplicate is how the two runtimes drifted apart in the first place (PR #697
+// deleted the Python table from backend/utils/ and left main.py's private copy
+// running for a month — see ADR-009 decision 4).
+//
+// Its only consumer here was the momentum weight. ESMS and the elementals never
+// used it: ESMS comes from `engine.totals` (the canonical inertial-mass engine)
+// and the elementals from the flat SIGN_WEIGHT/SECT_WEIGHT split. So retiring it
+// moves `planetaryMomentum` and nothing else — momentum is a display quantity
+// (two API responses and the /quantities tide readout), never persisted.
+//
+// Momentum now uses `inertialMassWeight`, the one scale. The Ascendant special
+// case went with it: inertialMassWeight applies the RULED vessel weight 1.0
+// itself, so the local `=== "Ascendant" ? 1.0 :` conditional is redundant.
 
 /**
  * Bodies excluded from the ESMS aspect universe — not real planets, so they
@@ -275,19 +270,19 @@ export function alchemize(
     // does not know. A live sky carrying MC and both nodes therefore had three
     // phantom bodies each pushing 0.4 of pure Air into the totals, skewing
     // elementalProperties and everything derived from it (thermodynamics,
-    // monica). Their momentum was fabricated too: alchmWeight falls back to
-    // PLANET_ALCHM_PERIODS[planet] ?? 1.0, and 1.0 is Pluto's weight, so MC
-    // was being handed the heaviest alchemical mass in the system.
+    // monica). Their momentum was fabricated too: the weight lookup falls back
+    // to Pluto's period under the old scale (and to Earth's mass under the
+    // inertial one that replaced it — the fabrication survives the migration,
+    // only its magnitude changes), so MC was handed a mass it has no basis for.
+    // This gate, not the fallback, is what keeps them out.
     if (isExcludedAspectBody(planet)) {
       continue;
     }
     const canonicalPlanet = canonicalBodyByLower.get(planet.toLowerCase());
     if (!canonicalPlanet) continue;
-    // Momentum retains its orbital-period scale; ESMS is computed once, below,
-    // by the canonical inertial-mass engine.
-    const period = PLANET_ALCHM_PERIODS[canonicalPlanet] ?? 1.0;
-    const alchmWeight =
-      canonicalPlanet === "Ascendant" ? 1.0 : normalizeAlchmWeight(period);
+    // ONE scale (ADR-009 decision 5): momentum shares the inertial-mass weight
+    // with ESMS, which `engine.totals` already computes below.
+    const alchmWeight = inertialMassWeight(canonicalPlanet);
     // Elemental contribution — blend of zodiac sign element and sectarian element.
     // Sign element: the element of the sign the planet currently occupies.
     const signElement = getZodiacElement(position.sign);
@@ -518,9 +513,8 @@ export function alchemizeDetailed(
     const engineEntry = enginePerPlanetByLower.get(planet.toLowerCase());
     if (!engineEntry) continue;
     const { planet: canonicalPlanet, contribution } = engineEntry;
-    const period = PLANET_ALCHM_PERIODS[canonicalPlanet] ?? 1.0;
-    const momentumWeight =
-      canonicalPlanet === "Ascendant" ? 1.0 : normalizeAlchmWeight(period);
+    // ONE scale (ADR-009 decision 5) — same weight the engine used for ESMS.
+    const momentumWeight = inertialMassWeight(canonicalPlanet);
 
     const signElement = getZodiacElement(position.sign);
     const sectElement = getPlanetarySectElement(canonicalPlanet, diurnal);

--- a/src/utils/agentMonicaTwoBody.ts
+++ b/src/utils/agentMonicaTwoBody.ts
@@ -51,11 +51,21 @@
  *     That is expected, not a bug.
  *
  *  4. **Each body is weighted by `alchmWeight`** — the ORBITAL-PERIOD scale
- *     (`normalizeAlchmWeight(PLANET_ALCHM_PERIODS[planet])`), canonical in this
- *     engine. ⚠️ There is a second, mass-based scale (`normalizePlanetWeight`);
- *     planetaryAlchemyMapping.ts:528-533 records that the two disagree per
- *     planet and must never be transcribed between. This module uses the
- *     orbital-period one.
+ *     (`normalizeAlchmWeight(PLANET_ALCHM_PERIODS[planet])`).
+ *
+ *     ⚠️ `[2026-08-02]` This module is the LAST consumer of that scale, and the
+ *     only reason `src/data/planets.ts` still exports it. Everything else in
+ *     both runtimes now runs on inertial mass (`inertialMassWeight`) — ADR-009
+ *     decisions 1–4 plus 5a. An earlier version of this note warned about a
+ *     second, mass-based scale called `normalizePlanetWeight`; that function no
+ *     longer exists (deleted in decision 1 — it annihilated Pluto by anchoring
+ *     its log normalization ON Pluto).
+ *
+ *     Migrating this module is ADR-009 decision **5b**, and it is BLOCKED on a
+ *     ruling rather than merely pending: the swap moves 90.0% of the grid and
+ *     pushes |max| to 4.4166, OUTSIDE the 3.8977 single-body envelope this
+ *     suite asserts as an invariant. It also desyncs 469 persisted phase-agent
+ *     rows. See docs/adr/009 "Decision 5, remeasured".
  *
  *  5. **Dignity — the two bodies SOURCE it differently, but APPLY it identically.**
  *       • Moon → POSITION-based: its own essential dignity at its own sign,
@@ -122,8 +132,17 @@
  * numbers, so any earlier figure quoted elsewhere is stale by construction.
  *
  * **Full grid** (8 phases × 12 signs × 30 degrees × 2 sects = 5760):
- * 5760/5760 finite · median |monica| 0.2244 · p90 1.2434 · **max 12.6756** ·
- * 304 cells (5.3%) resolve to φ via the local band.
+ * 5760/5760 finite · median |monica| 0.2927 · p90 1.6180 · **max 2.8108** ·
+ * 813 cells (14.1%) resolve to φ via the local band.
+ *
+ * ⚠️ `[RE-MEASURED 2026-08-02]` — the four grid figures above previously read
+ * "median 0.2244 · p90 1.2434 · max 12.6756 · 304 cells (5.3%)". All four were
+ * stale: something moved the grid after 2026-07-21 and this block was not
+ * updated with it. The values now shown are re-measured over the same 5760-cell
+ * enumeration, and `agentMonicaTwoBody.test.ts:457` independently pins |max| to
+ * 2.8107786459098314 — it agreed with the code the whole time this comment did
+ * not. Prefer the test: a docstring cannot fail, so it drifts silently.
+ * (The 469-agent figures below are NOT re-measured — they need the live DB.)
  *
  * **All 469 production phase agents**: 0 unrecognised phase strings, 0
  * non-finite, **range [−5.4191, 1.8004]**, 221 distinct values, 16 φ.


### PR DESCRIPTION
ADR-009 **decision 5a**. `RealAlchemizeService`'s private copy of the orbital-period table is gone; momentum now rides `inertialMassWeight`.

I went in to execute decision 5 as ruled and measurement changed its shape. Reporting that first, because two of the findings are about the *other* items on the board.

## Decision 5 is two halves with unrelated blast radii

**5a — momentum. Shipped here.** The private table fed `planetaryMomentum` and nothing else: ESMS comes from `engine.totals` (canonical, already inertial), elementals from the flat 0.6/0.4 sign/sect split. Momentum is display-only — two API responses and the `/quantities` tide readout — never persisted. Weights move a long way (Pluto 1.0 → 0.109, Sun 0.513 → 1.0, Uranus 0.904 → 0.525); no stored value does.

**5b — `agentMonicaTwoBody`. BLOCKED on a ruling, not merely deferred.** The swap moves **5184/5760 grid cells (90.0%)** and fails 6 tests. Two are design contracts, not re-pinnable numbers:

- *"sits inside the single-body envelope"* — two-body |max| goes **2.8108 → 4.4166** against a **3.8977** limit. Inertial puts two-body OUTSIDE the envelope the suite asserts as an invariant.
- *"still absorbs a real share of the grid (not a no-op band)"* — the degenerate band's canonical-only population falls to **0**.

Plus a constant to re-derive (Sacred-7 two-body 1.4054 → 2.2083) and **469 persisted phase-agent rows** that desync — the module's own header warns a far smaller perturbation "would desync the 4280 rows already in production". That is a model change plus a backfill, not a scale swap. So `planets.ts` **keeps** `PLANET_ALCHM_PERIODS` — 5b is its last consumer.

## The ADR had the sample-file causality backwards

`alchemicalSamples.json` and `FALLBACK_METRICS` are **not** invalidated by decision 5. They were **already stale**.

Regenerating at the file's own anchor (values-only diff by construction) changed **1821/1821 samples on unmodified master** — the Sun's stored ESMS contribution moves `0.51307` (period × dignity) → `1.0` (inertial), and the dignity multipliers moved too. Cause: the ESMS unification that already shipped (#695/#710). Regenerating **with** 5a applied is **byte-identical** to regenerating without it (md5 `63f7ff4e` both ways) — the file has no momentum field.

The shipped priors round-trip *exactly* against the committed samples (heat 0.067/0.037 vs measured 0.0669/0.0365), so the derivation was honest — the samples moved underneath it:

| prior | shipped | current master | drift |
|---|---|---|---|
| heat | 0.067/0.037 | 0.1225/0.0763 | +83% / +106% |
| entropy | 0.225/0.101 | 0.3929/0.2620 | +75% / +159% |
| reactivity | 6.54/6.91 | 14.4540/21.8652 | +121% / +216% |

⚠️ **Live defect, independent of ADR-009**: `projectZScoreTarget` is z-scoring compatibility against priors ~2× off the engine's actual distribution. Needs its own PR — regenerate, re-derive — and should not be attributed to decision 5, which does not cause it.

## Why the test is shaped this way

Byte-identical regen is the correct result *and* exactly what a change that never executed would produce. So the scale is asserted through the **output**: recover the weight from momentum itself.

- **Positive control** — the two scales genuinely disagree on 10/11 bodies (only the Ascendant coincides, at the RULED 1.0), so the assertions can fail.
- **Negative control** — reverting the source fails 4/4 substantive tests while the positive control correctly still passes.
- **Structural** — the private table's *declarations* must be absent, since the cheapest way to undo this is to paste it back.

## A stale docstring, corrected

`agentMonicaTwoBody`'s header claimed "median 0.2244 · p90 1.2434 · max 12.6756 · 304 cells (5.3%) at φ". **All four were stale.** Re-measured over the same 5760 cells: **0.2927 / 1.6180 / 2.8108 / 813 (14.1%)**. `agentMonicaTwoBody.test.ts:457` pinned `2.8107786459098314` and agreed with the code the whole time the comment did not. It also warned about `normalizePlanetWeight`, deleted back in decision 1. A docstring cannot fail, so it drifts silently.

## Also verified

Decision 4 is confirmed live at deployed SHA `77bdfe34` — all **14/14** served `alchmWeight` values round-trip exactly against the canonical function. Two incidental findings: the Sun/Pluto ratio **is** the log range (9.180092303273348) because Pluto sits exactly one decade above the anchor by construction; and `North Node` / `South Node` / `MC` are not in the mass table, so `?? 1.0` hands them **Earth's mass** (0.3984) — heavier than Mars, Mercury, the Moon and Pluto. That fallback is live in production and survives the migration with only its magnitude changed.

## Gates

`tsc --noEmit` clean · **199/199 suites, 1980 passed, 9 skipped** · eslint clean on a cleared cache.

Momentum is user-visible on `/quantities` and two API responses — worth an eye after deploy.