### PR TITLE
fix(physics): gate abstract bodies out of the served Python engine

### DIFF
--- a/backend/alchm_kitchen/main.py
+++ b/backend/alchm_kitchen/main.py
@@ -507,6 +507,55 @@ class PhilosophersStonePositionsResponse(BaseModel):
 # finally share one scale.
 
 
+# Bodies excluded from the alchemical universe — abstract geometric points and
+# minor bodies, not physical masses. Byte-for-byte the same membership as
+# EXCLUDED_ASPECT_BODIES in src/services/RealAlchemizeService.ts, matched the
+# same way (lowercased, whitespace stripped), because the two runtimes must
+# answer this question identically.
+#
+# ── What this fixes, MEASURED against production 2026-08-02 ─────────────────
+#
+# TypeScript gated these bodies out; this module never did. So a live sky
+# carrying North Node, South Node and MC put THREE phantom bodies into the
+# elemental totals of every /alchemize and /api/philosophers-stone/positions
+# response — 14 units of element mass where there should have been 11.
+#
+# Note where the damage was and was NOT. Their ESMS was already exactly zero,
+# because `PLANETARY_ALCHEMY.get(planet)` returns None for them and the ESMS sum
+# sits behind `if alchemy:`. The elemental lines had no such guard: they add a
+# flat 0.6 + 0.4 with NO mass weighting at all. So the fabricated
+# get_inertial_mass_weight fallback (unknown body -> Earth's mass, 0.3984) was
+# never the mechanism — zeroing that weight would have left this untouched,
+# because the elemental blend does not read it. Only momentum did.
+#
+# The 0.4 is the worse half: get_planetary_sect_element returns "Air" for any
+# body it does not know (:587), so each phantom pushed 0.4 of PURE AIR. That is
+# why Air is the element that moves most when they are removed:
+#
+#   Air -3.51pp · Water +2.34pp · Fire +1.95pp · Earth -0.78pp
+#
+# Same divergence class as ADR-009 decision 4 (#712): a fix landed in TypeScript
+# and the served Python module kept running the old behaviour.
+EXCLUDED_ASPECT_BODIES = frozenset(
+    {
+        "northnode",
+        "southnode",
+        "truenode",
+        "meannode",
+        "chiron",
+        "lilith",
+        "vertex",
+        "parsfortune",
+        "mc",
+    }
+)
+
+
+def is_excluded_aspect_body(planet: str) -> bool:
+    """True for abstract points that must not contribute mass or element."""
+    return "".join(str(planet).lower().split()) in EXCLUDED_ASPECT_BODIES
+
+
 PLANETARY_ALCHEMY = {
     "Sun": {"Spirit": 1, "Essence": 0, "Matter": 0, "Substance": 0},
     "Moon": {"Spirit": 0, "Essence": 1, "Matter": 1, "Substance": 0},
@@ -645,6 +694,11 @@ def calculate_local_alchemize(request: AlchemizeRequest) -> Dict[str, Any]:
             continue
         sign = str(position.get("sign", "")).lower()
         if not sign:
+            continue
+        # Abstract points contribute NOTHING — not ESMS, not element, not
+        # momentum, not modality. Must precede the elemental blend below, which
+        # is unguarded and unweighted.
+        if is_excluded_aspect_body(planet):
             continue
 
         alchemy = PLANETARY_ALCHEMY.get(planet)
@@ -795,6 +849,12 @@ def calculate_local_philosophers_stone(
             continue
         sign_raw = str(position.get("sign", "Aries"))
         sign_lower = sign_raw.lower() or "aries"
+        # Same gate as calculate_local_alchemize. Additionally keeps abstract
+        # points out of `per_planet`, whose consumers reasonably assume its keys
+        # are real bodies — an MC entry carried populated `elements` and a
+        # fabricated `alchmWeight` beside all-zero `esms`.
+        if is_excluded_aspect_body(planet):
+            continue
 
         # get_inertial_mass_weight special-cases the Ascendant to the RULED
         # vessel weight 1.0 itself, so no conditional is needed here.

--- a/backend/tests/test_main_excluded_bodies.py
+++ b/backend/tests/test_main_excluded_bodies.py
@@ -1,0 +1,187 @@
+"""Abstract geometric points must not contribute mass or element.
+
+`backend/alchm_kitchen/main.py` is the module Railway serves. It had no
+exclusion gate at all, while `src/services/RealAlchemizeService.ts` has had one
+for months — so every /alchemize and /api/philosophers-stone/positions response
+blended North Node, South Node and MC into its elemental totals as if they were
+bodies. Same divergence class as ADR-009 decision 4: a fix landed on one runtime
+and the served module on the other kept the old behaviour.
+
+── What was actually wrong ─────────────────────────────────────────────────
+
+NOT the mass. Their ESMS was already exactly 0.0, because PLANETARY_ALCHEMY has
+no entry for them and the ESMS sum sits behind `if alchemy:`. The elemental
+lines are the unguarded ones, and they are also UNWEIGHTED — a flat 0.6 + 0.4
+that never reads alchm_weight. So assigning these bodies a weight of 0.0 would
+have fixed nothing: the distortion does not read the weight. Only the gate does.
+
+The 0.4 is the worse half: get_planetary_sect_element returns "Air" for unknown
+bodies, so each phantom pushed 0.4 of pure Air, which is why Air moves most
+(-3.51pp) when they are removed.
+
+── How this tests it without importing it ──────────────────────────────────
+
+Importing main.py pulls in fastapi/sqlalchemy/pyswisseph and CI installs only
+pytest (see test_kalchm_parity.py:21-24), so this reads main.py's SOURCE and
+inspects it with `ast`. The gate itself is pure stdlib — a frozenset and string
+ops — so it is EXTRACTED AND EXECUTED for the behavioural tests below.
+"""
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+MAIN_PY = REPO / "backend" / "alchm_kitchen" / "main.py"
+TS_SERVICE = REPO / "src" / "services" / "RealAlchemizeService.ts"
+
+WEIGHTED_FUNCS = ("calculate_local_alchemize", "calculate_local_philosophers_stone")
+
+
+def _tree():
+    return ast.parse(MAIN_PY.read_text())
+
+
+def _extract_gate():
+    """Execute ONLY the gate definitions out of main.py's real source."""
+    wanted = []
+    for node in _tree().body:
+        if isinstance(node, ast.Assign):
+            names = {t.id for t in node.targets if isinstance(t, ast.Name)}
+            if "EXCLUDED_ASPECT_BODIES" in names:
+                wanted.append(node)
+        elif isinstance(node, ast.FunctionDef) and node.name == "is_excluded_aspect_body":
+            wanted.append(node)
+    assert len(wanted) == 2, f"expected the set and the predicate, found {len(wanted)}"
+    ns = {"frozenset": frozenset}
+    exec(compile(ast.Module(body=wanted, type_ignores=[]), str(MAIN_PY), "exec"), ns)
+    return ns
+
+
+def _func(name):
+    for node in _tree().body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found in main.py")
+
+
+def test_main_py_parses_and_the_targets_exist():
+    """POSITIVE CONTROL for every assertion below — they all read this one file.
+
+    If the path were wrong or the parse empty, the structural assertions would
+    pass vacuously against nothing.
+    """
+    tree = _tree()
+    assert len(tree.body) > 100, "main.py parsed to almost nothing — path or parse is wrong"
+    for name in WEIGHTED_FUNCS:
+        assert _func(name) is not None
+
+
+# ── The gate's behaviour ────────────────────────────────────────────────────
+
+
+def test_the_gate_matches_every_spelling_the_backend_can_emit():
+    is_excluded = _extract_gate()["is_excluded_aspect_body"]
+    # The Swiss-Ephemeris backend emits node keys WITH a space; other callers
+    # use the squashed form. Both must match, in any case.
+    for spelling in [
+        "North Node", "NorthNode", "north node", "NORTHNODE",
+        "South Node", "SouthNode",
+        "True Node", "Mean Node", "MC", "mc",
+        "Chiron", "Lilith", "Vertex", "Pars Fortune", "ParsFortune",
+    ]:
+        assert is_excluded(spelling), f"{spelling!r} should be excluded"
+
+
+def test_the_gate_does_NOT_swallow_real_bodies():
+    """The failure mode that would be far worse than the bug being fixed."""
+    is_excluded = _extract_gate()["is_excluded_aspect_body"]
+    for planet in [
+        "Sun", "Moon", "Mercury", "Venus", "Mars",
+        "Jupiter", "Saturn", "Uranus", "Neptune", "Pluto", "Ascendant",
+    ]:
+        assert not is_excluded(planet), f"{planet!r} must NOT be excluded"
+
+
+def test_the_python_set_is_IDENTICAL_to_the_typescript_one():
+    """The parity check that would have caught this divergence.
+
+    TypeScript gated these bodies and Python did not, and nothing compared the
+    two. Membership is asserted equal, not merely overlapping, so adding an
+    entry on one side alone fails here.
+    """
+    ts_src = TS_SERVICE.read_text()
+    block = re.search(
+        r"EXCLUDED_ASPECT_BODIES\s*=\s*new Set\(\[(.*?)\]\)", ts_src, re.S
+    )
+    assert block, "could not find EXCLUDED_ASPECT_BODIES in RealAlchemizeService.ts"
+    ts_set = set(re.findall(r'"([^"]+)"', block.group(1)))
+    # POSITIVE CONTROL — a regex that silently matched nothing would make the
+    # comparison below trivially true against two empty sets.
+    assert len(ts_set) >= 5, f"TS set parsed to {ts_set} — the regex is stale"
+
+    py_set = set(_extract_gate()["EXCLUDED_ASPECT_BODIES"])
+    assert py_set == ts_set, (
+        f"runtimes disagree — only in Python: {sorted(py_set - ts_set)}; "
+        f"only in TypeScript: {sorted(ts_set - py_set)}"
+    )
+
+
+# ── The gate's placement ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("func_name", WEIGHTED_FUNCS)
+def test_the_gate_runs_BEFORE_the_unguarded_elemental_blend(func_name):
+    """Order is the whole fix.
+
+    The ESMS sum is already guarded by `if alchemy:`, so a gate placed after the
+    elemental lines would look correct, pass any ESMS assertion, and still leak
+    0.4 of pure Air per phantom body into the totals. Asserted by line number
+    rather than by presence.
+    """
+    fn = _func(func_name)
+
+    gate_lines = [
+        n.lineno
+        for n in ast.walk(fn)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "is_excluded_aspect_body"
+    ]
+    assert len(gate_lines) == 1, f"{func_name}: expected exactly one gate, got {len(gate_lines)}"
+
+    # The elemental blend: the augmented assignments adding the 0.6/0.4 split.
+    blend_lines = [
+        n.lineno
+        for n in ast.walk(fn)
+        if isinstance(n, ast.AugAssign)
+        and isinstance(n.op, ast.Add)
+        and isinstance(n.value, ast.Constant)
+        and n.value.value in (0.6, 0.4)
+    ]
+    assert len(blend_lines) == 2, f"{func_name}: expected the 0.6/0.4 pair, got {blend_lines}"
+
+    assert gate_lines[0] < min(blend_lines), (
+        f"{func_name}: gate at line {gate_lines[0]} runs AFTER the elemental "
+        f"blend at {min(blend_lines)} — phantom bodies still reach the totals"
+    )
+
+
+@pytest.mark.parametrize("func_name", WEIGHTED_FUNCS)
+def test_the_gate_precedes_the_weight_lookup_too(func_name):
+    """So an excluded body never even reaches get_inertial_mass_weight, whose
+    unknown-body fallback silently returns Earth's mass (0.3984)."""
+    fn = _func(func_name)
+    gate = [
+        n.lineno for n in ast.walk(fn)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        and n.func.id == "is_excluded_aspect_body"
+    ]
+    weight = [
+        n.lineno for n in ast.walk(fn)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        and n.func.id == "get_inertial_mass_weight"
+    ]
+    assert gate and weight
+    assert gate[0] < min(weight)

--- a/docs/adr/009-one-planetary-weight-scale.md
+++ b/docs/adr/009-one-planetary-weight-scale.md
@@ -199,6 +199,46 @@ Note the fallback hazard on the way out: on the period scale `?? 1.0` means
 `:278-279`. On Scale A the same `?? 1.0` means "unknown → Earth's mass" (0.3984).
 Neither is acceptable; the migration should make unknown bodies throw.
 
+📌 **Follow-up `[MEASURED 2026-08-02]`: the fabricated weight was NOT the
+mechanism.** Chasing this fallback in the served Python module found the real
+defect somewhere else, and the obvious fix would have missed it.
+
+`main.py` had **no exclusion gate at all**, while `RealAlchemizeService.ts` has
+gated nine abstract bodies for months. So every `/alchemize` and
+`/api/philosophers-stone/positions` response blended North Node, South Node and
+MC into its elemental totals — 14 units of raw element mass where there should
+have been 11. Same divergence class as decision 4.
+
+But their ESMS was **already exactly 0.0**, because `PLANETARY_ALCHEMY.get()`
+returns `None` for them and the ESMS sum sits behind `if alchemy:`. The
+*elemental* lines were the unguarded ones — and they are also **unweighted**, a
+flat `+= 0.6` / `+= 0.4` that never reads `alchm_weight`. So assigning these
+bodies weight 0.0 would have changed **nothing** about the distortion: the
+elemental blend does not read the weight, and momentum was the only path that
+did. The mechanism was a missing gate, not a wrong number.
+
+The worse half is the 0.4: `get_planetary_sect_element` returns `"Air"` for any
+unknown body (`:587`), so each phantom pushed 0.4 of *pure Air*. Hence Air is the
+element that moves most when they are removed — the signature of that fallback:
+
+| | Fire | Water | Earth | Air |
+|---|---|---|---|---|
+| shift on removal | +1.95pp | +2.34pp | −0.78pp | **−3.51pp** |
+
+Downstream, recomputed from production's own captured payload with the real
+`thermo_quotient` / `compute_kalchm_monica` (the model reproduces the served
+response to 1e-9 on all six metrics, so the deltas are trustworthy): heat
+**+11.6%**, entropy **−10.7%**, reactivity −0.7%, gregsEnergy **+14.1%**, monica
+**−13.5%** — and **kalchm exactly 0.0%**, which independently confirms the
+phantoms contributed no ESMS.
+
+Fixed by porting the gate, with a test asserting the Python and TypeScript
+membership sets are **identical** rather than merely overlapping, and asserting
+by line number that the gate runs BEFORE the elemental blend — a gate placed
+after it still compiles, still passes every ESMS assertion, and still leaks the
+Air. The `?? 1.0` fallback itself remains (now unreachable from these two served
+paths); making unknown bodies throw is still open.
+
 ⚠️ **RULED: decision 5 ships as its own PR, after 1–4 have landed.** Retiring
 Scale C invalidates constants that the B→A move does not touch —
 `FALLBACK_METRICS`, the 1821-sample `alchemicalSamples.json` they were measured


### PR DESCRIPTION
Checklist item 1 — but **not the fix that was specified**, because measurement showed that fix wouldn't have worked.

## Zeroing the weight would have changed nothing

The proposal was to assign Nodes/MC a weight of 0.0 so they stop inflating the ESMS baseline. They aren't inflating it. Their ESMS is **already exactly 0.0** — `PLANETARY_ALCHEMY.get(planet)` returns `None` for them and the ESMS sum sits behind `if alchemy:`. Live payload confirms: all three report `esmsSum` of `0.000000`, and per-planet ESMS sums to the top-level value to the last digit.

| path | reads `alchm_weight`? | effect of weight → 0.0 |
|---|---|---|
| ESMS | yes, but already zero via `if alchemy:` | **nothing** |
| **elements** | **no** — flat `+= 0.6` / `+= 0.4`, unweighted | **nothing** ← the real distortion |
| momentum | yes | only this |

The distortion is real, but it isn't mass. `main.py` had **no exclusion gate at all**, while `RealAlchemizeService.ts` has gated nine abstract bodies for months — so three phantom bodies entered the elemental totals of every `/alchemize` and `/api/philosophers-stone/positions` response. 14 units of raw element mass where there should be 11.

Same divergence class as decision 4 (#712): a fix landed in TypeScript, the served Python module never got it.

## The Air signature

`get_planetary_sect_element` returns `"Air"` for any body it doesn't know (`:587`), so each phantom pushed 0.4 of **pure Air**:

| | Fire | Water | Earth | Air |
|---|---|---|---|---|
| shift on removal | +1.95pp | +2.34pp | −0.78pp | **−3.51pp** |

Air moving most is that fallback's fingerprint.

## Live shift

Recomputed from production's own captured payload using the **real** `thermo_quotient` and `compute_kalchm_monica` — imported, not replicated. My first pass replicated `num / max(den, 0.01)`, which is the exact form `thermo_quotient` was written to replace; it happened to agree here because every denominator was far above the floor, but importing is the right way.

| metric | with phantoms | gated | change |
|---|---|---|---|
| heat | 0.079594 | 0.088837 | **+11.6%** |
| entropy | 0.273473 | 0.244163 | **−10.7%** |
| reactivity | 2.718089 | 2.699902 | −0.7% |
| gregsEnergy | −0.663730 | −0.570378 | **+14.1%** |
| kalchm | 152.793140 | 152.793140 | **+0.0%** |
| monica | 0.048556 | 0.042007 | **−13.5%** |

The model reproduces the served response to **1e-9 on all six metrics**, so the deltas are trustworthy. `kalchm` landing at exactly 0.0% independently confirms the phantoms contributed no ESMS — the same conclusion, from the other direction.

## The tests

**Membership is asserted identical to TypeScript**, not merely overlapping, by parsing `RealAlchemizeService.ts`. That's the check whose absence let the runtimes diverge in the first place. It carries its own positive control, since a stale regex matching nothing would compare two empty sets.

**Placement is asserted by line number**, in both loops. This matters more than it looks: a gate placed *after* the elemental blend still compiles, still passes every ESMS assertion, and still leaks the Air. Verified by moving it there — 2 tests fail while the file compiles fine.

Also pinned: the gate precedes `get_inertial_mass_weight` so excluded bodies never reach the fabricating fallback, and real bodies are **not** swallowed — which would be worse than the bug.

## Gates

`py_compile` clean · **75 passed, 2 skipped** · both negative controls fire (dropping `"mc"` from the Python set fails parity; misplacing the gate fails ordering). No TypeScript changed.

## Still open

The `?? 1.0` fallback itself remains — now unreachable from these two served paths, but still live for any other caller. Making unknown bodies throw is the real fix and is its own change.

Railway service: verify against the deployed SHA after merge rather than assuming.