### PR TITLE
feat(physics): retire the last period scale, and the envelope that only held by accident

### DIFF
--- a/docs/adr/009-one-planetary-weight-scale.md
+++ b/docs/adr/009-one-planetary-weight-scale.md
@@ -239,6 +239,54 @@ after it still compiles, still passes every ESMS assertion, and still leaks the
 Air. The `?? 1.0` fallback itself remains (now unreachable from these two served
 paths); making unknown bodies throw is still open.
 
+### Decision 5b, RULED and shipped `[2026-08-02]`
+
+The envelope invariant was retired, not satisfied. Three ways of satisfying it
+were measured and rejected first:
+
+| approach | result |
+|---|---|
+| scalar damping coefficient λ on body mass | **unusable** — grid \|max\| is non-monotone in λ (0.6 → 17.35, 1.0 → 4.42, 2.0 → 1.68, 3.0 → 6.54); monica has poles wherever ln(kalchm) → 0 |
+| normalise the pair to unit mass (mirroring `ELEMENTAL_MASS`) | **worse**, 6.2563 — shrinking bodies toward the balanced vessel drives kalchm → 1 and monica diverges |
+| widen the degeneracy predicate to `vessel.Essence === 0` | restores nesting (\|max\| 1.6026) but hands φ to **576 healthy charts** — the exact fabrication `TWO_BODY_LN_EPSILON` was deleted for |
+
+The third was recommended and then withdrawn: it was measured to restore nesting
+but its collateral was not measured until afterwards. Restoring an invariant by
+fabricating sentinel values is not a fix.
+
+**What the measurements actually showed:**
+
+1. **The single-body envelope is SCALE-INDEPENDENT.** `agentMonica` imports no
+   weight function at all — its only mass constant is `VESSEL_MASS = 4` — so
+   3.8977146920667276 is bit-identical before and after the migration. There was
+   never a "period-scale ghost" to re-derive on that side.
+2. **The old nesting was an ARTIFACT.** The period scale weighted BOTH luminaries
+   below 1.0 (Sun 0.5131, Moon 0.2843, sum 0.7974), so the pair carried less mass
+   than one unweighted body. Inertial puts the Sun at exactly 1.0 and the pair at
+   1.1904. Two weighted bodies outweighing one, against the same mass-4 vessel,
+   is arithmetic.
+3. **The raw magnitudes never meet.** `normalizeMonicaForStats` selects the scale
+   by method, and each is its own population's `|max|/2`, so every extremum maps
+   to `tanh(2)` → **0.982014** regardless. That — not the raw comparison — is what
+   protects the phase-agent economy, and it is now asserted directly.
+
+**Shipped:** two-body weights → `inertialMassWeight`; `MONICA_POPULATION_SCALE`
+`'two-body'` re-derived 1.4053893229549166 → **2.208277339500193**
+(`|max|` 4.416554679000386 / 2, extremum at full / Aries / 8° / diurnal, 6-way
+tied); envelope assertions inverted to measured relationships; and
+`PLANET_ALCHM_PERIODS` / `normalizeAlchmWeight` **deleted** from
+`src/data/planets.ts` — this module was their last consumer, so **ADR-009 is
+closed**.
+
+The degeneracy predicate is UNCHANGED, so collateral is still exactly 0. A side
+effect worth recording: φ now accounts for exactly the 576 structurally
+degenerate cells and NOTHING from the engine-wide canonical band, because the
+inertial grid sits further from the pole — closest healthy cell |ln kalchm|
+0.1924 against a band edge of 0.1094, **1.758× clear**. That margin is asserted.
+
+⚠️ **Operational:** the 469 persisted phase-agent rows (`monica_diurnal` /
+`monica_nocturnal`) are stale by construction until the backfill runs.
+
 ⚠️ **RULED: decision 5 ships as its own PR, after 1–4 have landed.** Retiring
 Scale C invalidates constants that the B→A move does not touch —
 `FALLBACK_METRICS`, the 1821-sample `alchemicalSamples.json` they were measured

--- a/src/__tests__/data/planets.test.ts
+++ b/src/__tests__/data/planets.test.ts
@@ -62,7 +62,11 @@ describe("the removed Pluto-anchored scale", () => {
     // POSITIVE CONTROL — the module IS loaded and DOES export things, so the
     // assertion above is a real absence rather than a failed import.
     expect(typeof planets.PLANET_WEIGHTS).toBe("object");
-    expect(typeof planets.normalizeAlchmWeight).toBe("function");
+    // ADR-009 decision 5b: the orbital-period scale is gone too, so this module
+    // now exports NEITHER normalizer. `PLANET_WEIGHTS` above carries the
+    // positive-control job alone.
+    expect(planets.normalizeAlchmWeight).toBeUndefined();
+    expect(planets.PLANET_ALCHM_PERIODS).toBeUndefined();
   });
 });
 

--- a/src/__tests__/monicaPopulationScaleDerivation.test.ts
+++ b/src/__tests__/monicaPopulationScaleDerivation.test.ts
@@ -190,21 +190,66 @@ describe("the Sacred-7 monica scales are derived from their populations", () => 
     });
 
     it("holds the measurement recorded in the source", () => {
-      // 2.810778645909833 / 2. Was 2.7095 (|max| 5.4191) while the degeneracy
-      // band was an |ln kalchm| threshold instead of `esms.Essence === 0` — that
-      // threshold left 442 genuinely degenerate charts unbanded, and those were
-      // the ones producing the extremes.
-      expect(TWO.absMax).toBeCloseTo(2.810778645909833, 12);
+      // 4.416554679000386 / 2  [ADR-009 decision 5b — the two bodies moved from
+      // the orbital-period scale to inertial mass]. Was 1.4054 from |max| 2.8108,
+      // and before that 2.7095 from |max| 5.4191 while the degeneracy band was an
+      // |ln kalchm| threshold instead of a structural test.
+      expect(TWO.absMax).toBeCloseTo(4.416554679000386, 12);
       // Literal-against-literal — exact, and engine-independent.
-      expect(MONICA_POPULATION_SCALE["two-body"]).toBe(1.4053893229549166);
+      expect(MONICA_POPULATION_SCALE["two-body"]).toBe(2.208277339500193);
     });
 
-    it("sits inside the single-body envelope", () => {
-      // A two-body chart is a single-body chart plus one more body, so it should
-      // not reach further than the single-body population can. It DID before the
-      // structural degeneracy test (5.4191 > 3.8977) — that violation is what
-      // exposed the mis-banding, so this is a real regression guard, not a truism.
-      expect(TWO.absMax).toBeLessThanOrEqual(SINGLE.absMax);
+    it("exceeds the single-body raw maximum — and that is FINE, measured", () => {
+      // ⚠️ THIS ASSERTION WAS INVERTED BY ADR-009 decision 5b [2026-08-02], and
+      // the reasoning matters more than the number.
+      //
+      // It used to read `TWO.absMax <= SINGLE.absMax`, justified as "a two-body
+      // chart is a single-body chart plus one more body, so it should not reach
+      // further". Under inertial mass it fails: 4.4166 vs 3.8977, ratio 1.1331,
+      // 33 cells over. Three things were measured before inverting it:
+      //
+      //  1. The single-body envelope is SCALE-INDEPENDENT. agentMonica imports no
+      //     weight function at all — its only mass constant is VESSEL_MASS — so
+      //     3.8977146920667276 is bit-identical before and after the migration.
+      //     There was never a "period-scale ghost" to re-derive on that side.
+      //
+      //  2. The old nesting was an ARTIFACT. The period scale weighted BOTH
+      //     luminaries below 1.0 (Sun 0.5131, Moon 0.2843, sum 0.7974), so the
+      //     pair carried less mass than a single unweighted body. Inertial puts
+      //     the Sun at exactly 1.0 and the pair at 1.1904. Two weighted bodies
+      //     against the same mass-4 vessel outweighing one is arithmetic, not a
+      //     defect — the inequality only ever held by coincidence.
+      //
+      //  3. The raw magnitudes NEVER MEET. normalizeMonicaForStats picks the
+      //     scale by method, and each scale is its own population's |max|/2, so
+      //     every extremum maps to tanh(2) -> 0.982014 regardless. That is the
+      //     §18o point: these are different OBJECTS, not one quantity at three
+      //     scales. The test below asserts exactly that, and it is what actually
+      //     protects the phase-agent economy — this comparison never did.
+      //
+      // Rejected on measurement, recorded so they are not retried: a scalar
+      // damping coefficient (the grid |max| is violently non-monotone in it —
+      // lambda 0.6 -> 17.35 vs 1.0 -> 4.42, because monica has poles wherever
+      // ln(kalchm) -> 0); normalising the pair to unit mass (worse, 6.2563); and
+      // widening the degeneracy predicate to the vessel's zero Essence, which
+      // DOES restore nesting but hands φ to 576 healthy charts — the exact
+      // fabrication TWO_BODY_LN_EPSILON was deleted for.
+      expect(TWO.absMax).toBeGreaterThan(SINGLE.absMax);
+      expect(TWO.absMax / SINGLE.absMax).toBeCloseTo(1.133114, 5);
+    });
+
+    it("but is NOT reachable on the single-body scale — the display is what protects the hierarchy", () => {
+      // The claim item 3 of the ruling turned on, asserted rather than narrated:
+      // each population's extremum lands on the SAME display value, so a phase
+      // agent cannot outrank a single-body agent by carrying a bigger raw monica.
+      const twoOnOwn = normalizeMonicaForStats(TWO.absMax, "two-body");
+      const singleOnOwn = normalizeMonicaForStats(SINGLE.absMax, "single-body");
+      expect(twoOnOwn).toBeCloseTo(singleOnOwn, 10);
+
+      // NEGATIVE CONTROL: grading two-body on the single-body scale WOULD
+      // over-score it. That path does not exist — normalizeMonicaForStats
+      // selects by method — but if it ever did, this is the damage.
+      expect(normalizeMonicaForStats(TWO.absMax, "single-body")).toBeGreaterThan(singleOnOwn);
     });
   });
 

--- a/src/__tests__/realAlchemizeMomentumScale.test.ts
+++ b/src/__tests__/realAlchemizeMomentumScale.test.ts
@@ -2,7 +2,6 @@ import fs from "fs";
 import path from "path";
 
 import { alchemizeDetailed } from "@/services/RealAlchemizeService";
-import { PLANET_ALCHM_PERIODS, normalizeAlchmWeight } from "@/data/planets";
 import { inertialMassWeight } from "@/utils/planetaryAlchemyMapping";
 
 /**
@@ -55,13 +54,30 @@ function sky() {
   return { now, hist };
 }
 
-/** The scale this module used to apply, kept here only to assert we no longer
- *  land on it. Reads the still-live table in @/data/planets — two-body monica
- *  still uses it, so decision 5 is only half done (see the ADR). */
+/**
+ * The scale this module used to apply, kept ONLY to assert we no longer land on
+ * it. This imported from @/data/planets until ADR-009 decision 5b deleted the
+ * table outright (two-body monica was its last consumer), so it is now a FROZEN
+ * private copy — a historical record. Nothing may compute with it.
+ *
+ * Note the rank inversion it encodes: Pluto's 247.94 IS the log-scale maximum,
+ * so Pluto normalized to exactly 1.0 while the Sun sat at 0.5131.
+ */
+const RETIRED_PERIODS: Record<string, number> = {
+  Pluto: 247.94, Neptune: 164.79, Uranus: 84.01, Saturn: 29.46, Jupiter: 11.86,
+  Mars: 1.88, Sun: 1.0, Venus: 0.615, Mercury: 0.241, Moon: 0.075,
+  Ascendant: 0.003,
+};
+const RETIRED_LOG_MIN = Math.log10(0.003);
+const RETIRED_LOG_MAX = Math.log10(247.94);
+
 function periodWeight(planet: string): number {
-  return planet === "Ascendant"
-    ? 1.0
-    : normalizeAlchmWeight(PLANET_ALCHM_PERIODS[planet] ?? 1.0);
+  if (planet === "Ascendant") return 1.0;
+  const p = RETIRED_PERIODS[planet] ?? 1.0;
+  return (
+    (Math.log10(Math.max(p, 1e-9)) - RETIRED_LOG_MIN) /
+    (RETIRED_LOG_MAX - RETIRED_LOG_MIN)
+  );
 }
 
 describe("ADR-009 decision 5 — momentum rides the inertial mass scale", () => {

--- a/src/__tests__/sacred7MonicaMapping.test.ts
+++ b/src/__tests__/sacred7MonicaMapping.test.ts
@@ -178,9 +178,19 @@ describe("deriveStatsFromChart — the real monica range no longer clamps", () =
   it("a two-body agent and a single-body agent at the SAME monica differ", () => {
     // The whole point of §18o: the same number means different things depending
     // on which construction produced it.
-    expect(stats(0.8, "two-body").power).not.toBeCloseTo(
-      stats(0.8, "single-body").power,
-      6,
-    );
+    //
+    // Asserted on normalizeMonicaForStats rather than on `.power`, because that
+    // is where §18o actually lives. ADR-009 decision 5b moved the two scales
+    // much closer (1.9489 vs 2.2083, 13% apart; they were 39% apart when
+    // two-body ran on the orbital-period weights), and `power` rounds to a
+    // 0-100 integer — so at monica 0.8 both now land on exactly 75 while the
+    // underlying values still differ by 0.0208. The principle held; the probe
+    // had become too coarse to see it.
+    const two = normalizeMonicaForStats(0.8, "two-body");
+    const single = normalizeMonicaForStats(0.8, "single-body");
+    expect(two).not.toBeCloseTo(single, 6);
+    // MEASURED separation across the range, so this cannot silently decay to a
+    // rounding coincidence again.
+    expect(Math.abs(two - single)).toBeGreaterThan(0.01);
   });
 });

--- a/src/__tests__/utils/agentMonicaTwoBody.test.ts
+++ b/src/__tests__/utils/agentMonicaTwoBody.test.ts
@@ -448,14 +448,29 @@ describe("twoBodyMonica — the totality contract", () => {
       expect(localCollateral).toEqual([]);
     });
 
-    it("brings the two-body range INSIDE the single-body envelope", () => {
-      // Previously two-body reached 5.4191 against a single-body 3.9751, because
-      // 442 degenerate charts went unbanded and produced the extremes.
+    it("keeps every cell finite, and exceeds the single-body raw max — measured", () => {
+      // ⚠️ THE SECOND ASSERTION WAS INVERTED BY ADR-009 decision 5b [2026-08-02].
+      // It read `absMax < 3.8977…` on the reasoning that a two-body chart is a
+      // single-body chart plus one more body and so cannot reach further. Under
+      // inertial mass it does reach further, and that turned out to be correct
+      // rather than a regression:
+      //
+      //   • The single-body envelope is SCALE-INDEPENDENT — agentMonica imports
+      //     no weight function at all — so 3.8977… is bit-identical before and
+      //     after the migration. There was no period-scale ghost to re-derive.
+      //   • The old nesting was an ARTIFACT of the period scale weighting BOTH
+      //     luminaries below 1.0 (sum 0.7974, less than one unweighted body).
+      //     Inertial puts the Sun at exactly 1.0 and the pair at 1.1904.
+      //   • The raw magnitudes never meet in production: normalizeMonicaForStats
+      //     scales each population by its OWN |max|/2, so both extrema map to
+      //     tanh(2) -> 0.982014. See monicaPopulationScaleDerivation.test.ts.
+      //
+      // The TOTALITY half of this test is unchanged and still load-bearing.
       const finite = cells.map((c) => c.monica).filter((m) => Number.isFinite(m));
       expect(finite.length).toBe(cells.length);
       const absMax = Math.max(...finite.map(Math.abs));
-      expect(absMax).toBeCloseTo(2.8107786459098314, 10);
-      expect(absMax).toBeLessThan(3.8977146920667267); // single-body envelope
+      expect(absMax).toBeCloseTo(4.416554679000386, 10);
+      expect(absMax).toBeGreaterThan(3.8977146920667267);
     });
 
     it("still absorbs a real share of the grid (guard: not a no-op band)", () => {
@@ -471,8 +486,22 @@ describe("twoBodyMonica — the totality contract", () => {
       // Every φ cell is explained by exactly one of the two bands.
       expect(phi.length).toBe(structural.length + canonicalOnly.length);
       expect(structural.length).toBeGreaterThan(0);
-      expect(canonicalOnly.length).toBeGreaterThan(0);
       expect(phi.length).toBeLessThan(cells.length / 2); // not swallowing everything
+
+      // `canonicalOnly > 0` used to be asserted here, and ADR-009 decision 5b
+      // drove it to exactly 0 — NOT by weakening the local band, which is
+      // untouched, but because the inertial grid sits further from the pole.
+      // MEASURED: the closest healthy cell has |ln kalchm| 0.19236558565274994
+      // against a canonical band edge of 0.10939293407637272 — 1.758x clear. So
+      // no healthy cell NEEDS the engine-wide band any more. Asserting the
+      // margin is the honest form of the original guard: it still fails loudly
+      // if the grid drifts back toward the degenerate pole.
+      const healthyMinLnK = Math.min(
+        ...cells.filter((c) => !c.essenceZero).map((c) => c.absLnK),
+      );
+      expect(canonicalOnly.length).toBe(0);
+      expect(healthyMinLnK).toBeGreaterThan(MONICA_LN_EPSILON);
+      expect(healthyMinLnK / MONICA_LN_EPSILON).toBeGreaterThan(1.5);
     });
   });
 

--- a/src/data/planets.ts
+++ b/src/data/planets.ts
@@ -11,7 +11,10 @@
  * (ingredient scoring, recipe matching). It correctly privileges massive bodies
  * (Sun, Jupiter) because physical presence matters for culinary archetypes.
  *
- * For the ALCHM thermodynamic engine, use PLANET_ALCHM_PERIODS instead.
+ * For the ALCHM thermodynamic engine, use `inertialMassWeight` from
+ * `@/utils/planetaryAlchemyMapping` — it takes a body NAME and derives its
+ * weight from THIS table. (This line used to point at PLANET_ALCHM_PERIODS,
+ * deleted in ADR-009 decision 5b; see the note below.)
  */
 export const PLANET_WEIGHTS: Record<string, number> = {
   Sun:     333054.2532,  // 1.989 × 10³⁰ kg
@@ -44,45 +47,29 @@ export const PLANET_WEIGHTS: Record<string, number> = {
  */
 
 /**
- * Orbital periods in Earth years.
+ * REMOVED (ADR-009 decision 5b): `PLANET_ALCHM_PERIODS`, `_PERIOD_LOG_MIN`,
+ * `_PERIOD_LOG_MAX` and `normalizeAlchmWeight` — the orbital-period weight scale,
+ * and with it the LAST of the five scales ADR-009 set out to unify. Everything in
+ * both runtimes now uses `inertialMassWeight`.
  *
- * Used by the ALCHM thermodynamic engine (RealAlchemizeService, planetaryAlchemyMapping).
- * Slower planets carry higher "alchemical volume":
- *   - Pluto (P=248y) creates generational tides — highest weight
- *   - Moon  (P≈0.075y) creates personal ripples — lowest weight
+ * It was RANK-INVERTED against physical mass: Pluto normalized to exactly 1.0,
+ * the heaviest weight in the system, and the Sun to 0.5131, because a longer
+ * orbital period was read as greater "alchemical volume". The served Python
+ * endpoints ran on it until #712, so production really did hand Pluto nearly
+ * twice the Sun's weight in every chart it returned.
  *
- * Includes Ascendant as the "Physical Vessel" grounding constant (P=1 day ≈ 0.003y),
- * which anchors the reactivity denominator even in pure diurnal charts.
+ * It also ANNIHILATED whatever sat at its lower anchor. The Ascendant's 0.003
+ * entry IS the log-scale minimum, so `normalizeAlchmWeight(0.003)` returned
+ * exactly 0.0, and every caller had to special-case the Ascendant back to 1.0 by
+ * hand. One port forgot, and 11/20 golden conformance charts collapsed to
+ * Matter = Substance = 0. `inertialMassWeight` anchors one decade BELOW the
+ * lightest charted body precisely so no member can be zeroed this way.
  *
- * Source: NASA/IAU mean sidereal periods.
+ * Deleted rather than deprecated, because the cheapest way to undo a migration is
+ * to re-add the table. `src/__tests__/data/planets.test.ts` asserts its absence;
+ * `realAlchemizeMomentumScale.test.ts` keeps a frozen private copy for the sole
+ * purpose of asserting that momentum does NOT land on it.
  */
-export const PLANET_ALCHM_PERIODS: Record<string, number> = {
-  Pluto:      247.94,   // P=248y  — generational, deepest tide
-  Neptune:    164.79,   // P=165y
-  Uranus:      84.01,   // P=84y
-  Saturn:      29.46,   // P=29.5y
-  Jupiter:     11.86,   // P=12y
-  Mars:         1.88,   // P=1.9y
-  Sun:          1.00,   // P=1y   (solar year — ecliptic reference)
-  Venus:        0.615,  // P=225d
-  Mercury:      0.241,  // P=88d
-  Moon:         0.075,  // P=27.3d
-  Ascendant:    0.003,  // P=1d — Physical Vessel grounding constant
-};
-
-/**
- * Normalises an orbital-period value to [0, 1] via log₁₀.
- *
- * Moon (P=0.075y) → ≈ 0.0   (lowest alchemical volume)
- * Pluto (P=248y)  → ≈ 1.0   (highest alchemical volume)
- *
- * Used exclusively by the Alchm thermodynamic engine.
- */
-const _PERIOD_LOG_MIN = Math.log10(0.003);    // Ascendant (1 day)
-const _PERIOD_LOG_MAX = Math.log10(247.94);   // Pluto
-export function normalizeAlchmWeight(periodYears: number): number {
-  return (Math.log10(Math.max(periodYears, 1e-9)) - _PERIOD_LOG_MIN) / (_PERIOD_LOG_MAX - _PERIOD_LOG_MIN);
-}
 
 
 export const planetaryData = {

--- a/src/lib/sacred-7-stats.ts
+++ b/src/lib/sacred-7-stats.ts
@@ -320,9 +320,24 @@ export const MONICA_POPULATION_SCALE: Partial<Record<MonicaMethod, number>> = {
   // The |max| nearly HALVED because the old local |ln kalchm| threshold was
   // leaving 442 genuinely degenerate charts unbanded, and those were the ones
   // producing the extreme values. Testing `esms.Essence === 0` instead catches all
-  // of them, so the surviving range is [-0.292735, 2.81078] — now comfortably
-  // inside the single-body envelope of 3.8977, which it previously exceeded.
-  'two-body': 1.4053893229549166,
+  // of them.
+  //
+  // ⚠️ RE-DERIVED [MEASURED 2026-08-02] for ADR-009 decision 5b — was
+  // 1.4053893229549166 from |max| 2.810778645909833, when the two bodies were
+  // weighted by the orbital-period scale. They now use inertial mass, which
+  // moves the Moon 0.2843 -> 0.1904 (-33%) against a Sun that goes 0.5131 -> 1.0.
+  //
+  // |max| 4.416554679000386 / 2, over the same 5760-cell grid. Extremum at
+  // full / Aries / 8° / diurnal, 6-way tied. Range [-0.424203, 4.416554].
+  // The degeneracy predicate is UNCHANGED, so collateral is still exactly 0 —
+  // no healthy chart is handed φ.
+  //
+  // ⚠️ THIS SCALE IS |max|-DERIVED, and the warning above about extremum-derived
+  // constants applies to it directly: the 6-way tie is the whole basis. It is
+  // load-bearing only for DISPLAY, and the tie is structural (one vessel shape
+  // repeating across signs) rather than one anomalous row — but re-audit it, not
+  // just re-run it, after any change to kalchm or the vessel.
+  'two-body': 2.208277339500193,
   // ⚠️ RE-DERIVED. The first value shipped here was 0.016851, taken from
   // |max| 0.033702 / 2 across all 71 rows. That maximum was NOT a real agent's
   // monica: Carl Jung and Frida Kahlo share a byte-identical natal_positions

--- a/src/utils/agentMonicaTwoBody.ts
+++ b/src/utils/agentMonicaTwoBody.ts
@@ -25,9 +25,11 @@
  *
  *     ⚠️ Sharing the vessel does NOT put the two scales on top of each other.
  *     An earlier version of this note claimed it "lands on the same scale as a
- *     single-body one"; that was never measured and is false. See the measured
- *     behaviour section: the two-body grid reaches 12.6756 where single-body
- *     reaches 3.9751.
+ *     single-body one"; that was never measured and is false. MEASURED
+ *     2026-08-02: the two-body grid reaches 4.4166 where single-body reaches
+ *     3.8977. (This line previously quoted 12.6756 / 3.9751 — both stale, from
+ *     before the exact-zero kalchm fix; the figures were never updated with the
+ *     grid. See the measured-behaviour section.)
  *
  *     ► VESSEL-DIGNITY DECISION `[RULED 2026-07-21, revised]`: the shared vessel
  *       is **dignity-NEUTRAL** — `groundingVessel(moonDegree, 0)`. The Moon
@@ -50,22 +52,35 @@
  *     *all* sect variation comes from the Moon (day = Essence, night = Matter).
  *     That is expected, not a bug.
  *
- *  4. **Each body is weighted by `alchmWeight`** — the ORBITAL-PERIOD scale
- *     (`normalizeAlchmWeight(PLANET_ALCHM_PERIODS[planet])`).
+ *  4. **Each body is weighted by `alchmWeight`** — `inertialMassWeight`, the ONE
+ *     scale, since ADR-009 decision **5b** `[2026-08-02]`. This module was the
+ *     last consumer of the orbital-period scale in either runtime, so
+ *     `PLANET_ALCHM_PERIODS` / `normalizeAlchmWeight` were deleted from
+ *     `src/data/planets.ts` in the same change and ADR-009 is closed. (An older
+ *     version of this note also warned about a third scale,
+ *     `normalizePlanetWeight` — gone in decision 1, which started all this.)
  *
- *     ⚠️ `[2026-08-02]` This module is the LAST consumer of that scale, and the
- *     only reason `src/data/planets.ts` still exports it. Everything else in
- *     both runtimes now runs on inertial mass (`inertialMassWeight`) — ADR-009
- *     decisions 1–4 plus 5a. An earlier version of this note warned about a
- *     second, mass-based scale called `normalizePlanetWeight`; that function no
- *     longer exists (deleted in decision 1 — it annihilated Pluto by anchoring
- *     its log normalization ON Pluto).
+ *     ⚠️ Sun 0.5131 → 1.0, Moon 0.2843 → **0.1904 (−33%)**. The Moon losing a
+ *     third of its weight is what moves this grid, and it lands hardest at the
+ *     Comixion degrees, where the shared vessel contributes NO Essence and the
+ *     pair's entire Essence is therefore the Moon's weight alone.
  *
- *     Migrating this module is ADR-009 decision **5b**, and it is BLOCKED on a
- *     ruling rather than merely pending: the swap moves 90.0% of the grid and
- *     pushes |max| to 4.4166, OUTSIDE the 3.8977 single-body envelope this
- *     suite asserts as an invariant. It also desyncs 469 persisted phase-agent
- *     rows. See docs/adr/009 "Decision 5, remeasured".
+ *     Three fixes for the resulting envelope breach were measured and REJECTED,
+ *     recorded here so they are not retried. A scalar damping coefficient: the
+ *     grid |max| is violently NON-MONOTONE in it (λ 0.6 → 17.35, 1.0 → 4.42,
+ *     2.0 → 1.68, 3.0 → 6.54), because monica has poles wherever ln(kalchm) → 0
+ *     and moving mass sweeps cells through them. Normalising the pair to unit
+ *     mass, mirroring `ELEMENTAL_MASS`: worse, 6.2563 — shrinking bodies toward
+ *     the balanced vessel drives kalchm → 1 and monica diverges. Widening the
+ *     degeneracy predicate to the VESSEL's zero Essence: it does restore nesting
+ *     (|max| 1.6026), but hands φ to **576 healthy charts** — the exact
+ *     fabrication `TWO_BODY_LN_EPSILON` was deleted for.
+ *
+ *     What was ruled instead: the envelope was never an invariant. See the note
+ *     on the envelope test — the single-body bound is scale-INDEPENDENT, the old
+ *     nesting was an artifact of the period scale weighting both luminaries
+ *     below 1.0, and per-population display scaling means the raw magnitudes
+ *     never meet anyway.
  *
  *  5. **Dignity — the two bodies SOURCE it differently, but APPLY it identically.**
  *       • Moon → POSITION-based: its own essential dignity at its own sign,
@@ -132,17 +147,33 @@
  * numbers, so any earlier figure quoted elsewhere is stale by construction.
  *
  * **Full grid** (8 phases × 12 signs × 30 degrees × 2 sects = 5760):
- * 5760/5760 finite · median |monica| 0.2927 · p90 1.6180 · **max 2.8108** ·
- * 813 cells (14.1%) resolve to φ via the local band.
+ * 5760/5760 finite · median |monica| 0.3262 · p90 1.6180 · **max 4.4166**
+ * (full / Aries / 8° / diurnal, 6-way tied) · range [−0.424203, 4.416554] ·
+ * 576 cells (10.0%) resolve to φ, all of them structurally degenerate.
  *
- * ⚠️ `[RE-MEASURED 2026-08-02]` — the four grid figures above previously read
- * "median 0.2244 · p90 1.2434 · max 12.6756 · 304 cells (5.3%)". All four were
- * stale: something moved the grid after 2026-07-21 and this block was not
- * updated with it. The values now shown are re-measured over the same 5760-cell
- * enumeration, and `agentMonicaTwoBody.test.ts:457` independently pins |max| to
- * 2.8107786459098314 — it agreed with the code the whole time this comment did
- * not. Prefer the test: a docstring cannot fail, so it drifts silently.
- * (The 469-agent figures below are NOT re-measured — they need the live DB.)
+ * ⚠️ `[MEASURED 2026-08-02]` These moved TWICE in one day, for unrelated
+ * reasons, and both are worth knowing.
+ *
+ * First a correction: they had read "median 0.2244 · p90 1.2434 · max 12.6756 ·
+ * 304 cells (5.3%)" and ALL FOUR were stale — the grid moved after 2026-07-21
+ * and this block was never updated, while the test pinning |max| agreed with the
+ * code the whole time. Prefer the tests: a docstring cannot fail, so it drifts
+ * silently.
+ *
+ * Then decision 5b moved them legitimately, by putting the two bodies on the
+ * inertial-mass scale. Note that φ now accounts for exactly the structural band
+ * (576) with NOTHING from the engine-wide canonical band — the inertial grid
+ * sits further from the ln(kalchm) pole than the period grid did: the closest
+ * healthy cell is at |ln kalchm| 0.1924 against a band edge of 0.1094, 1.758×
+ * clear. That margin is asserted, not just recorded.
+ *
+ * ⚠️ |max| now EXCEEDS the single-body 3.8977, and that is expected rather than
+ * a regression — see the envelope note in `agentMonicaTwoBody.test.ts` and
+ * `monicaPopulationScaleDerivation.test.ts`. Each population is displayed on its
+ * own |max|/2 scale, so both extrema map to 0.982014 regardless.
+ *
+ * (The 469-agent figures below are NOT re-measured — they need the live DB, and
+ * they are stale BY CONSTRUCTION until the decision-5b backfill runs.)
  *
  * **All 469 production phase agents**: 0 unrecognised phase strings, 0
  * non-finite, **range [−5.4191, 1.8004]**, 221 distinct values, 16 φ.
@@ -185,7 +216,6 @@
  * after it perturbs single-body from 3.9751 to 3.9089, which would desync the
  * 4280 rows already in production.
  */
-import { PLANET_ALCHM_PERIODS, normalizeAlchmWeight } from "@/data/planets";
 import {
   MONICA_EQUILIBRIUM,
   calculateKalchm,
@@ -203,6 +233,7 @@ import { getDignityScore } from "@/utils/dignityScales";
 import {
   PLANETARY_SECTARIAN_ESMS,
   ZODIAC_ELEMENTS,
+  inertialMassWeight,
 } from "@/utils/planetaryAlchemyMapping";
 
 /** Zodiac signs in ecliptic order — index × 30 is the sign's start longitude. */
@@ -500,9 +531,17 @@ export function derivedSunPosition(
 
 // ─────────────────────────────── the calc ─────────────────────────────────
 
-/** Orbital-period ("alchm") weight for a body. NOT the mass scale. */
+/** Inertial-mass weight for a body — the ONE scale (ADR-009 decision 5b).
+ *
+ * This module was the LAST consumer of the orbital-period scale in either
+ * runtime, and the only reason src/data/planets.ts still exported it. Both are
+ * deleted in the same change, closing ADR-009.
+ *
+ * Sun 0.5131 -> 1.0 and Moon 0.2843 -> 0.1904. The Moon losing a third of its
+ * weight is what moves this module's grid; see the envelope note below.
+ */
 function alchmWeightOf(planet: string): number {
-  return normalizeAlchmWeight(PLANET_ALCHM_PERIODS[planet] ?? 1.0);
+  return inertialMassWeight(planet);
 }
 
 /**


### PR DESCRIPTION
**ADR-009 decision 5b, Option A.** `agentMonicaTwoBody` moves to `inertialMassWeight` — the last consumer of the orbital-period scale in either runtime — so `PLANET_ALCHM_PERIODS` and `normalizeAlchmWeight` are **deleted** from `src/data/planets.ts`. **ADR-009 is closed.**

> Stacked on #716 (base = `fix/monica-pins-engine-tolerance`). Merge that first.

Sun `0.5131 → 1.0`, Moon `0.2843 → 0.1904` (−33%).

## The envelope was retired, not satisfied

The swap pushes two-body `|max|` to 4.4166 against a single-body 3.8977, which a test asserted as an invariant. Three ways of *satisfying* it were measured first, and all three rejected:

| approach | result |
|---|---|
| scalar damping coefficient λ | **unusable** — `\|max\|` is non-monotone in λ (0.6 → **17.35**, 1.0 → 4.42, 2.0 → 1.68, 3.0 → **6.54**). monica has poles wherever `ln(kalchm) → 0`, and moving mass sweeps cells *through* them |
| normalise the pair to unit mass | **worse**, 6.2563 — shrinking bodies toward the balanced vessel drives kalchm → 1 and monica diverges |
| widen the predicate to `vessel.Essence === 0` | restores nesting (1.6026) but hands φ to **576 healthy charts** |

I recommended the third last round and then withdrew it. It *was* measured to restore nesting — but I hadn't measured its collateral, which is the thing that matters. Those 576 charts have `total Essence ≠ 0` and `|ln kalchm| ≈ 0.82` against a band of 0.109; they are nowhere near degenerate. That's the exact fabrication `TWO_BODY_LN_EPSILON` was deleted for, at twice the scale (it did it to 286).

## What the measurements showed instead

1. **The single-body envelope is scale-independent.** `agentMonica` imports no weight function at all — its only mass constant is `VESSEL_MASS`. So `3.8977146920667276` is bit-identical before and after the migration. There was never a period-scale ghost to re-derive on that side.
2. **The old nesting was an artifact.** The period scale weighted *both* luminaries below 1.0 (sum 0.7974), so the pair carried less mass than one unweighted body. Inertial puts the Sun at exactly 1.0 and the pair at 1.1904. Two weighted bodies outweighing one, against the same mass-4 vessel, is arithmetic.
3. **The raw magnitudes never meet.** `normalizeMonicaForStats` selects the scale by method, and each is its own population's `|max|/2`, so every extremum maps to `tanh(2)` → **0.982014**. That is what protects the phase-agent economy — the raw comparison never did. Now asserted directly, with a negative control showing what cross-scale grading *would* cost.

## Also in this PR

- `MONICA_POPULATION_SCALE['two-body']` re-derived `1.4053893229549166` → **`2.208277339500193`** (`|max|` 4.416554679000386 / 2; extremum `full / Aries / 8° / diurnal`, 6-way tied).
- **Degeneracy predicate unchanged**, so collateral is still exactly **0**.
- φ now accounts for exactly the 576 structurally degenerate cells and **nothing** from the engine-wide canonical band — the inertial grid sits *further* from the pole (closest healthy cell `|ln kalchm|` 0.1924 vs band edge 0.1094, **1.758× clear**). The old `canonicalOnly > 0` guard is replaced by that margin, which still fails loudly if the grid drifts back.
- §18o distinctness now asserts on `normalizeMonicaForStats` rather than `.power`: the scales are 13% apart (were 39%) and `power` rounds to a 0–100 integer, so both landed on 75 while the underlying values still differed by 0.0208. The principle held; the probe had gone too coarse.
- Corrected two more stale docstring figures (12.6756 / 3.9751) predating the exact-zero kalchm fix.
- `realAlchemizeMomentumScale.test.ts` keeps a **frozen private copy** of the retired table, purely to assert momentum does not land on it.

## ⚠️ Operational

The **469 persisted phase-agent rows** (`monica_diurnal` / `monica_nocturnal`) are stale by construction until the backfill runs.

## Gates

`tsc --noEmit` clean · **200/200 suites, 1991 passed, 9 skipped** · eslint clean on a cleared cache.