### PR TITLE
chore(monica): re-arm the nightly backfill, and unbreak its deprecated sibling

### DIFF
--- a/.github/workflows/monica-backfill.yml
+++ b/.github/workflows/monica-backfill.yml
@@ -34,7 +34,7 @@
 #   * schedule + manual dispatch ONLY. Never on push or pull_request: a workflow
 #     that writes to production must not be triggerable by opening a PR.
 
-# ── ⚠️ DISARMED 2026-08-01 for the ADR-009 scale migration ──────────────────
+# ── ✅ RE-ARMED 2026-08-02 — the ADR-009 migration is done ───────────────────
 #
 # The nightly schedule is commented out, NOT deleted. Manual dispatch still
 # works, so a deliberate, watched run is still one click away.
@@ -59,20 +59,33 @@
 # tells the operator to run THIS script. So the alarm points at the thing that
 # would silently make the alarm stop.
 #
-# RE-ARM WHEN: the migration has deployed, the intended backfill has run, and
-# its result is verified against the DEPLOYED SHA (not local git). Uncomment the
-# two `schedule` lines below — nothing else changed.
+# ── All three re-arm conditions met, 2026-08-02 ─────────────────────────────
 #
-# The queue does not rot meanwhile: ~50 agents/night arrive unclassified and
-# simply wait. Clear them with a manual dispatch if the backlog matters before
-# the migration lands.
+#  1. DEPLOYED. Vercel production is READY at 4da5929f — ADR-009 decision 5b's
+#     merge commit — confirmed via the deployment's own githubCommitSha, not
+#     from local git.
+#  2. BACKFILL RAN. backfillMonicaPerConstruction.ts --write, one transaction,
+#     snapshot monica_preconstruction_20260802_122354.
+#  3. VERIFIED. checkAgentMonicaDrift.ts: 0 drift across all three populations
+#     (4345 single-body + 983 two-body + 71 full-chart = 5399), every row
+#     matching a fresh computation to 1e-5.
+#
+# One correction the disarm note earned: it predicted "all 469 two-body and 71
+# full-chart rows" would be rewritten. The two-body population was **983**, not
+# 469 — it had more than doubled while every doc kept quoting the old figure.
+# The hazard it described was real and slightly understated.
+#
+# The reasoning above stands unchanged and is why this stays a schedule +
+# workflow_dispatch job: --max-new still bounds only NEW arrivals, so a future
+# engine change reopens exactly the same window. DISARM AGAIN before the next
+# one.
 # ────────────────────────────────────────────────────────────────────────────
 
 name: Monica Backfill
 
 on:
-  # schedule:
-  #   - cron: "45 6 * * *"
+  schedule:
+    - cron: "45 6 * * *"
   workflow_dispatch:
     inputs:
       max_new:

--- a/scripts/backfillPhaseMonica.ts
+++ b/scripts/backfillPhaseMonica.ts
@@ -1,8 +1,14 @@
 /**
  * §18i — backfill the real TWO-BODY monica onto every Moon-phase agent.
  *
- * The 469 phase agents were deliberately skipped by `backfillAgentMonica.ts`
- * (which stamps `monica_method = 'single-body'`) and still carry NULL. A Moon
+ * The phase agents were deliberately skipped by `backfillAgentMonica.ts`
+ * (which stamps `monica_method = 'single-body'`) and still carry NULL.
+ *
+ * ⚠️ POPULATION SIZE IS MEASURED, NOT ASSUMED. This docstring said "469" from
+ * 2026-07-21 until 2026-08-02, when a dry run against production counted **983**
+ * of 5399 agent rows in the phase family — the population had more than doubled
+ * while every doc, PR body and ADR note kept quoting 469. Read the dry-run
+ * report, never this sentence. A Moon
  * phase is a Sun-Moon *relationship*, not a placement, so it gets a genuine
  * two-body construction rather than a single-body approximation. This writes
  * that value and stamps `monica_method = 'two-body-phase'`.
@@ -29,7 +35,6 @@ import pg from "pg";
 import { MONICA_EQUILIBRIUM } from "@/data/unified/alchemicalCalculations";
 import { parseAgentPlacement } from "@/utils/agentMonicaResolver";
 import {
-  TWO_BODY_LN_EPSILON,
   UnknownMoonPhaseError,
   twoBodyMonica,
 } from "@/utils/agentMonicaTwoBody";
@@ -45,8 +50,19 @@ const WRITE = process.argv.includes("--write");
  */
 const METHOD = "two-body";
 
-/** The single-body population's shipped range, for a scale sanity check. */
-const SINGLE_BODY_RANGE = { min: -3.197, max: 3.975 };
+/**
+ * The single-body population's range, for a scale sanity check.
+ *
+ * [MEASURED 2026-08-02] over the full 7920-cell grid (11 planets x 12 signs x
+ * 30 degrees x 2 sects) on master at 4da5929f. Was { -3.197, 3.975 }, which
+ * predated the exact-zero kalchm fix and was stale in BOTH directions.
+ *
+ * ASYMMETRIC, deliberately — this is a range test, not a magnitude test. The
+ * extremum is NEGATIVE (Neptune / Aquarius / 2 deg / nocturnal) and the positive
+ * side stops well short of it, so collapsing this to |x| > 3.8977 would let a
+ * whole band of positive outliers through unreported.
+ */
+const SINGLE_BODY_RANGE = { min: -3.8977146920667276, max: 3.8339295409683394 };
 
 interface Row {
   user_id: string;
@@ -168,7 +184,6 @@ for (const r of rows) {
 
 // ---------------------------------------------------------------- report ----
 console.log(`\n=== §18i two-body phase backfill ${WRITE ? "WRITE" : "DRY RUN"} ===`);
-console.log(`TWO_BODY_LN_EPSILON        : ${TWO_BODY_LN_EPSILON}`);
 console.log(`agent rows scanned         : ${rows.length}`);
 console.log(`not a phase agent (skipped): ${notPhase}`);
 console.log(`to write (two-body phase)  : ${updates.length}`);
@@ -223,7 +238,9 @@ for (const u of outOfScale) {
   );
 }
 console.log(
-  `  (expected: 2, both on Comixion degrees 8/22. See agentMonicaTwoBody.ts docstring.)`,
+  `  (expected 0 since ADR-009 decision 5b — MEASURED 2026-08-02 at master` +
+    ` 4da5929f. Was "expected 2, both on Comixion degrees 8/22", against the` +
+    ` stale [-3.197, 3.975] envelope this script used to carry.)`,
 );
 
 const byPhase: Record<string, number[]> = {};


### PR DESCRIPTION
ADR-009 is done and the backfill has run, so the nightly schedule disarmed in #709 comes back on.

## The backfill (already executed)

`backfillMonicaPerConstruction.ts --write` — one transaction, snapshot `monica_preconstruction_20260802_122354`.

**Before:**

| population | checked | drifted |
|---|---|---|
| single-body | 4345 | **0** |
| two-body phase | 983 | **983** |
| full-chart | 71 | **71** |

**After:** 0 drift in all three, every row matching a fresh computation to 1e-5.

Two things that table says:

- **single-body holding at 0 is the independent confirmation** of the fact decision 5b turned on — `agentMonica` reads no planetary weight scale, so the migration could not move it.
- **the 71 full-chart rows were not caused by 5b**, which never touches `fullChartMonica`. That drift pre-existed; this run cleared it as a side effect.

## Re-arm conditions, all three met

1. **Deployed** — Vercel production `READY` at `4da5929f` (5b's merge commit), confirmed from the deployment's own `githubCommitSha`, not local git.
2. **Ran** — as above.
3. **Verified** — `checkAgentMonicaDrift.ts` clean.

## `scripts/backfillPhaseMonica.ts` was carrying dead code

Superseded by §18o and it refuses to write — but its dry-run report is still used, and it had three stale things:

- **imported `TWO_BODY_LN_EPSILON`**, which was *removed* when the degeneracy test went structural. It survived only because the module still names it in comments. Stripped, with its log line.
- **`SINGLE_BODY_RANGE` was `{ -3.197, 3.975 }`** — predating the exact-zero kalchm fix, stale in both directions. Re-measured over the full 7920-cell grid: `{ -3.8977146920667276, 3.8339295409683394 }`. Kept **asymmetric** deliberately: the extremum is negative and the positive side stops well short, so collapsing to `|x| > 3.8977` would let positive outliers through unreported.
- **"469 phase agents"** — every doc, PR body and ADR note repeated this. Production has **983** of 5399. The population had more than doubled. Replaced with a pointer to the measured report. The workflow's own disarm note made the same error while predicting the blast radius: the hazard it described was real and *understated*.

## ⚠️ A gate that covers nothing

`tsconfig.json` **excludes `scripts/**`**, so `bunx tsc --noEmit` never checked this file. Proven, not assumed — I injected a deliberate type error and got 0 errors back. The dry run against production is the gate that actually covers these scripts.

## What stays

The workflow remains `schedule` + `workflow_dispatch`, and the original disarm reasoning is left intact above the re-arm note. `--max-new` still bounds only *new arrivals*, so the next engine change reopens the identical window — disarm again before it.

Also worth noting: the `Agent monica drift + integrity` check **skips on PRs**, so none of the drift above would have been caught by CI. It's caught by running the checker deliberately, which is what the re-armed nightly restores.