### PR TITLE
fix(physics): stop unknown bodies fabricating Earth's mass, in the aggregators too

### DIFF
--- a/backend/tests/test_main_excluded_bodies.py
+++ b/backend/tests/test_main_excluded_bodies.py
@@ -34,7 +34,7 @@ import pytest
 
 REPO = Path(__file__).resolve().parents[2]
 MAIN_PY = REPO / "backend" / "alchm_kitchen" / "main.py"
-TS_SERVICE = REPO / "src" / "services" / "RealAlchemizeService.ts"
+TS_SERVICE = REPO / "src" / "utils" / "planetaryAlchemyMapping.ts"
 
 WEIGHTED_FUNCS = ("calculate_local_alchemize", "calculate_local_philosophers_stone")
 
@@ -113,9 +113,9 @@ def test_the_python_set_is_IDENTICAL_to_the_typescript_one():
     """
     ts_src = TS_SERVICE.read_text()
     block = re.search(
-        r"EXCLUDED_ASPECT_BODIES\s*=\s*new Set\(\[(.*?)\]\)", ts_src, re.S
+        r"EXCLUDED_ASPECT_BODIES[^=]*=\s*new Set\(\[(.*?)\]\)", ts_src, re.S
     )
-    assert block, "could not find EXCLUDED_ASPECT_BODIES in RealAlchemizeService.ts"
+    assert block, "could not find EXCLUDED_ASPECT_BODIES in planetaryAlchemyMapping.ts"
     ts_set = set(re.findall(r'"([^"]+)"', block.group(1)))
     # POSITIVE CONTROL — a regex that silently matched nothing would make the
     # comparison below trivially true against two empty sets.

--- a/src/__tests__/thermodynamicAffinityCalibration.test.ts
+++ b/src/__tests__/thermodynamicAffinityCalibration.test.ts
@@ -293,14 +293,17 @@ describe("thermodynamic affinity calibration", () => {
     }
     const pct = share.map((s) => (100 * s) / total);
     // Pinned to 2 decimals at precision 1 (an absolute ±0.05 bound) rather than
-    // to a 1-decimal figure. entropy lands on 63.95, and the nearest 1-decimal
-    // pin (64.0) would sit 0.0465 from the measured value — inside the bound,
-    // but with only 7% headroom, which is how a pin becomes flaky under an ULP
-    // change. Pinning the measured 2-decimal value keeps the same tolerance and
-    // restores the margin.
-    expect(pct[0]).toBeCloseTo(29.57, 1); // heat
-    expect(pct[1]).toBeCloseTo(63.89, 1); // entropy
-    expect(pct[2]).toBeCloseTo(6.54, 1); // reactivity
+    // to a 1-decimal figure — a 1-decimal pin can land within 7% of the bound,
+    // which is how a pin becomes flaky under an ULP change. The measured
+    // 2-decimal value keeps the same tolerance and restores the margin.
+    //
+    // [RE-DERIVED 2026-08-02] Was 29.57 / 63.89 / 6.54. The moment population
+    // these are measured over changed: `aggregateEnhancedZodiacElementals` was
+    // handing NorthNode and SouthNode EARTH's mass (2920 fabricated calls in one
+    // suite run), and gating them out moved every sky in the epoch grid.
+    expect(pct[0]).toBeCloseTo(29.04, 1); // heat
+    expect(pct[1]).toBeCloseTo(64.76, 1); // entropy
+    expect(pct[2]).toBeCloseTo(6.21, 1); // reactivity
   });
 
   itPinnedConstant("confirms equal weighting IS the first principal component", () => {

--- a/src/__tests__/unknownBodyFabrication.test.ts
+++ b/src/__tests__/unknownBodyFabrication.test.ts
@@ -1,0 +1,143 @@
+import {
+  inertialMassWeight,
+  isExcludedAspectBody,
+  EXCLUDED_ASPECT_BODIES,
+  aggregateZodiacElementals,
+  aggregateEnhancedZodiacElementals,
+} from "@/utils/planetaryAlchemyMapping";
+import { PLANET_WEIGHTS } from "@/data/planets";
+
+/**
+ * The unknown-body fabrication, and the gate that ends it.
+ *
+ * `inertialMassWeight` read `PLANET_WEIGHTS[planet] ?? 1.0`, with a source note
+ * claiming the fallback was harmless because "every caller filters to the
+ * known-body set first". That claim was FALSE. Instrumenting the function across
+ * the full suite recorded **2920 calls with an unknown body** — NorthNode and
+ * SouthNode, 1460 each — every one silently given Earth's relative mass.
+ *
+ * Both leaks came from this module's own aggregators, which had no exclusion
+ * gate at all while `RealAlchemizeService` had one. Between them those two
+ * functions feed natalChartService, /api/user/charts, restaurantDiscoveryService,
+ * AstrologicalService, commensalDatabaseService and ChartComparisonService.
+ *
+ * ⚠️ The fabricated weight was uniquely hard to spot: `PLANET_WEIGHTS.Earth` is
+ * exactly 1.0 — the same literal the fallback used — so an unknown body produced
+ * a weight IDENTICAL to a legitimate "Earth" call, and heavier than Mars,
+ * Mercury, the Moon and Pluto.
+ */
+
+const NODE_SPELLINGS = [
+  "North Node", "NorthNode", "north node", "SOUTHNODE",
+  "South Node", "True Node", "Mean Node", "MC", "mc",
+  "Chiron", "Lilith", "Vertex", "Pars Fortune", "ParsFortune",
+];
+
+const REAL_BODIES = [
+  "Sun", "Moon", "Mercury", "Venus", "Mars",
+  "Jupiter", "Saturn", "Uranus", "Neptune", "Pluto",
+];
+
+describe("unknown bodies can no longer fabricate a mass", () => {
+  it("POSITIVE CONTROL: the known bodies all still resolve", () => {
+    // Without this, a gate that swallowed everything would pass every assertion
+    // below by making the throw unreachable.
+    for (const b of REAL_BODIES) {
+      expect(inertialMassWeight(b)).toBeGreaterThan(0);
+    }
+    expect(inertialMassWeight("Ascendant")).toBe(1.0);
+    expect(inertialMassWeight("Sun")).toBe(1.0);
+  });
+
+  it("THROWS instead of returning Earth's mass", () => {
+    for (const b of ["ZZ_NOT_A_BODY", "Ceres", "Eris", ""]) {
+      expect(() => inertialMassWeight(b)).toThrow(/no mass for/);
+    }
+  });
+
+  it("names the excluded case specifically, so the fix is obvious from the message", () => {
+    expect(() => inertialMassWeight("North Node")).toThrow(/EXCLUDED body/);
+    expect(() => inertialMassWeight("ZZ_NOT_A_BODY")).toThrow(/Unknown body/);
+  });
+
+  it("would have returned EARTH's weight — the value that used to be fabricated", () => {
+    // Pins what the old fallback produced, so the severity stays legible: 0.3984
+    // is heavier than four real planets.
+    const earth = inertialMassWeight("Earth");
+    expect(earth).toBeCloseTo(0.3984248957794913, 12);
+    for (const lighter of ["Mars", "Mercury", "Moon", "Pluto"]) {
+      expect(inertialMassWeight(lighter)).toBeLessThan(earth);
+    }
+  });
+
+  it("recognises every spelling the backends emit", () => {
+    for (const s of NODE_SPELLINGS) expect(isExcludedAspectBody(s)).toBe(true);
+    for (const b of [...REAL_BODIES, "Ascendant"]) {
+      expect(isExcludedAspectBody(b)).toBe(false);
+    }
+    expect(EXCLUDED_ASPECT_BODIES.size).toBe(9);
+  });
+});
+
+describe("both aggregators gate abstract bodies out", () => {
+  const REAL_SKY: Record<string, string> = {
+    Sun: "Leo", Moon: "Pisces", Mercury: "Cancer", Venus: "Virgo",
+    Mars: "Gemini", Jupiter: "Leo", Saturn: "Aries", Uranus: "Gemini",
+    Neptune: "Aries", Pluto: "Aquarius",
+  };
+  // Nodes and MC placed in Fire signs, so an ungated run would visibly skew Fire.
+  const WITH_PHANTOMS: Record<string, string> = {
+    ...REAL_SKY,
+    "North Node": "Aries", "South Node": "Leo", MC: "Sagittarius",
+  };
+
+  it("aggregateZodiacElementals ignores them entirely", () => {
+    const a = aggregateZodiacElementals(REAL_SKY);
+    const b = aggregateZodiacElementals(WITH_PHANTOMS);
+    for (const k of ["Fire", "Water", "Earth", "Air"] as const) {
+      expect(b[k]).toBeCloseTo(a[k], 12);
+    }
+  });
+
+  it("aggregateEnhancedZodiacElementals ignores them entirely, in both sects", () => {
+    for (const diurnal of [true, false]) {
+      const a = aggregateEnhancedZodiacElementals(REAL_SKY, diurnal);
+      const b = aggregateEnhancedZodiacElementals(WITH_PHANTOMS, diurnal);
+      for (const k of ["Fire", "Water", "Earth", "Air"] as const) {
+        expect(b[k]).toBeCloseTo(a[k], 12);
+      }
+    }
+  });
+
+  it("NEGATIVE CONTROL: an identical NON-excluded key in the same sign DOES move it", () => {
+    // Guards against a vacuous pass. If this fixture were element-insensitive,
+    // the two tests above would pass without the gate doing anything.
+    //
+    // The A/B is exact: same sign, same shape, one extra key either way. "Earth"
+    // is a real PLANET_WEIGHTS entry and is NOT excluded; "North Node" is
+    // excluded. Only the gate separates them.
+    //
+    // (An earlier version of this control moved Jupiter Leo -> Sagittarius and
+    // asserted the totals shifted. They did not: both are FIRE signs, so the
+    // "control" changed nothing and failed — correctly.)
+    const base = aggregateZodiacElementals(REAL_SKY);
+    const withExcluded = aggregateZodiacElementals({ ...REAL_SKY, "North Node": "Aries" });
+    const withIncluded = aggregateZodiacElementals({ ...REAL_SKY, Earth: "Aries" });
+
+    const moved = (x: typeof base) =>
+      (["Fire", "Water", "Earth", "Air"] as const).some(
+        (k) => Math.abs(x[k] - base[k]) > 1e-9,
+      );
+
+    expect(moved(withExcluded)).toBe(false); // gated
+    expect(moved(withIncluded)).toBe(true); // weighted, so the fixture IS sensitive
+  });
+
+  it("PLANET_WEIGHTS still has no entry for any excluded body", () => {
+    // The gate and the table must not disagree: an excluded body that ALSO had a
+    // mass entry would be silently weighted by whichever check ran first.
+    for (const s of NODE_SPELLINGS) {
+      expect(PLANET_WEIGHTS[s]).toBeUndefined();
+    }
+  });
+});

--- a/src/data/unified/thermodynamicAffinity.ts
+++ b/src/data/unified/thermodynamicAffinity.ts
@@ -168,9 +168,9 @@ export const THERMO_AFFINITY_EPOCH = {
  * exactly the kind the old `Math.abs(a - b) / 2` divisor smuggled in.
  */
 export const THERMO_AFFINITY_SD: Readonly<ThermoState> = {
-  heat: 0.32988662169162397,
-  entropy: 0.3689024420258162,
-  reactivity: 2.3088816101488434,
+  heat: 0.32637481885352243,
+  entropy: 0.3600556169710307,
+  reactivity: 2.282714354733683,
 };
 
 /**
@@ -195,8 +195,25 @@ export const THERMO_AFFINITY_SD: Readonly<ThermoState> = {
  *
  * D0 depends on `THERMO_AFFINITY_SD`, so the two must be re-derived together —
  * the calibration test fails on both if either is edited alone.
+ *
+ * ⚠️ RE-DERIVED [MEASURED 2026-08-02], and NOT because the metric changed. The
+ * MOMENT POPULATION underneath it did: `aggregateEnhancedZodiacElementals` was
+ * handing NorthNode and SouthNode EARTH's mass via an unknown-body fallback
+ * (2920 fabricated calls in one suite run), so every sky in the 1460-sample
+ * epoch grid carried two phantom bodies. Gating them out moved all of it.
+ *
+ *   SD.heat        0.32988662169162397 -> 0.32637481885352243
+ *   SD.entropy     0.3689024420258162  -> 0.3600556169710307
+ *   SD.reactivity  2.3088816101488434  -> 2.282714354733683
+ *   D0             1.0934456889925421  -> 1.0904241489725401
+ *   axis influence 29.57/63.89/6.54    -> 29.04/64.76/6.21
+ *
+ * ⚠️ Derived in the ORDER the dependency requires: SD first, then D0 re-measured
+ * AGAINST the new SD. Taking both from one pass gives D0 = 1.0708780888185956 —
+ * wrong by 0.02, because D0 is measured in whitened units and the whitening had
+ * not landed yet. Same trap as #707 and #710; it is now three for three.
  */
-export const THERMO_AFFINITY_D0 = 1.0934456889925421;
+export const THERMO_AFFINITY_D0 = 1.0904241489725401;
 
 /**
  * Whitened, asinh-space Euclidean distance between two thermodynamic states.

--- a/src/services/RealAlchemizeService.ts
+++ b/src/services/RealAlchemizeService.ts
@@ -16,6 +16,7 @@ import {
   getPlanetarySectElement,
   calculateAlchemicalFromPlanetsDetailed,
   inertialMassWeight,
+  isExcludedAspectBody,
   type AlchemicalPlanetPositions,
 } from "@/utils/planetaryAlchemyMapping";
 
@@ -76,21 +77,11 @@ function computeDominantModality(
  * Normalizing closes this gap and any future one in the same shape, rather
  * than chasing spellings one at a time.
  */
-const EXCLUDED_ASPECT_BODIES = new Set([
-  "northnode",
-  "southnode",
-  "truenode",
-  "meannode",
-  "chiron",
-  "lilith",
-  "vertex",
-  "parsfortune",
-  "mc",
-]);
-
-function isExcludedAspectBody(planet: string): boolean {
-  return EXCLUDED_ASPECT_BODIES.has(planet.toLowerCase().replace(/\s+/g, ""));
-}
+// EXCLUDED_ASPECT_BODIES and isExcludedAspectBody moved to
+// @/utils/planetaryAlchemyMapping (imported below) so there is ONE canonical set
+// per runtime. This module had the only copy, while the two aggregators in
+// planetaryAlchemyMapping had NO gate at all and were handing nodes Earth's mass
+// — a duplicate that existed here could not protect them.
 
 /**
  * Real Alchemize Service

--- a/src/utils/planetaryAlchemyMapping.ts
+++ b/src/utils/planetaryAlchemyMapping.ts
@@ -296,12 +296,66 @@ export const ASCENDANT_VESSEL_WEIGHT = 1.0;
 const _INERTIAL_LOG_MIN = Math.log10(0.0022 / 10); // one decade below Pluto — RULED
 const _INERTIAL_LOG_MAX = Math.log10(333054.2532); // Sun
 
+/**
+ * Bodies that carry no mass and must never reach a weighting function —
+ * abstract geometric points (nodes, MC) and minor bodies with no entry in
+ * PLANET_WEIGHTS.
+ *
+ * ⚠️ CANONICAL. This set is mirrored EXACTLY in `backend/alchm_kitchen/main.py`
+ * as `EXCLUDED_ASPECT_BODIES`, and `backend/tests/test_main_excluded_bodies.py`
+ * asserts the two are IDENTICAL, not merely overlapping. Add here and there
+ * together, or that test fails — which is the point: the two runtimes drifted
+ * apart on exactly this question once already (ADR-009 decision 4, #712) and the
+ * Python side served phantom bodies for a month.
+ *
+ * Matched case- and whitespace-insensitively, because the Swiss-Ephemeris
+ * backend emits "North Node" with a space while other callers use "NorthNode".
+ */
+export const EXCLUDED_ASPECT_BODIES: ReadonlySet<string> = new Set([
+  "northnode",
+  "southnode",
+  "truenode",
+  "meannode",
+  "chiron",
+  "lilith",
+  "vertex",
+  "parsfortune",
+  "mc",
+]);
+
+/** True for bodies that must contribute no mass and no element. */
+export function isExcludedAspectBody(planet: string): boolean {
+  return EXCLUDED_ASPECT_BODIES.has(String(planet).toLowerCase().replace(/\s+/g, ""));
+}
+
 export function inertialMassWeight(planet: string): number {
   if (planet === "Ascendant") return ASCENDANT_VESSEL_WEIGHT;
-  // NOTE: unknown bodies still fall back to Earth's relative mass (1.0). That is
-  // a silent-fabrication hazard kept only because every caller filters to the
-  // known-body set first; tightening it to a throw is out of scope here.
-  const relMass = PLANET_WEIGHTS[planet] ?? 1.0;
+
+  // ⚠️ THROWS on an unknown body. It used to be `PLANET_WEIGHTS[planet] ?? 1.0`,
+  // with a note claiming the fallback was safe because "every caller filters to
+  // the known-body set first". That claim was FALSE, and measurably so:
+  // instrumenting this function across the full suite recorded 2920 calls with
+  // NorthNode / SouthNode (1460 each), every one silently handed Earth's mass.
+  //
+  // The fabricated value is especially hard to spot because PLANET_WEIGHTS.Earth
+  // is exactly 1.0 — the same number the fallback used — so an unknown body
+  // produced a weight (0.3984) indistinguishable from a legitimate "Earth" call,
+  // and heavier than Mars, Mercury, the Moon and Pluto.
+  //
+  // Callers that legitimately see abstract bodies must filter with
+  // `isExcludedAspectBody` BEFORE calling this, exactly as the two aggregators
+  // below and RealAlchemizeService do. Anything else reaching here is a real bug
+  // and should be loud (ADR-009: "the migration should make unknown bodies
+  // throw").
+  const relMass = PLANET_WEIGHTS[planet];
+  if (relMass === undefined) {
+    const why = isExcludedAspectBody(planet)
+      ? "It is an EXCLUDED body — the caller must filter with isExcludedAspectBody() first."
+      : "Unknown body: add it to PLANET_WEIGHTS, or exclude it.";
+    throw new Error(
+      `inertialMassWeight: no mass for ${JSON.stringify(planet)}. ${why}`,
+    );
+  }
   return (Math.log10(Math.max(relMass, 1e-9)) - _INERTIAL_LOG_MIN) / (_INERTIAL_LOG_MAX - _INERTIAL_LOG_MIN);
 }
 
@@ -716,6 +770,13 @@ export function aggregateZodiacElementals(planetaryPositions: {
       continue;
     }
 
+    // Abstract points (nodes, MC, Chiron, ...) carry no mass and no element.
+    // Without this they reached inertialMassWeight and were silently handed
+    // EARTH's mass (0.3984) — heavier than Mars, Mercury, the Moon and Pluto.
+    // MEASURED: 2920 such calls in one suite run, all NorthNode/SouthNode.
+    if (isExcludedAspectBody(planet)) continue;
+
+
     // Weight elemental contribution by the planet's inertial mass — the SAME
     // scale the ESMS half of this module uses (ADR-009). This was
     // `normalizePlanetWeight`, which anchors AT Pluto and so gave Pluto a weight
@@ -776,6 +837,13 @@ export function aggregateEnhancedZodiacElementals(
     if (!signElement || !sectElement) {
       continue;
     }
+
+    // Abstract points (nodes, MC, Chiron, ...) carry no mass and no element.
+    // Without this they reached inertialMassWeight and were silently handed
+    // EARTH's mass (0.3984) — heavier than Mars, Mercury, the Moon and Pluto.
+    // MEASURED: 2920 such calls in one suite run, all NorthNode/SouthNode.
+    if (isExcludedAspectBody(planet)) continue;
+
 
     // Inertial mass — same scale as the ESMS half of this module (ADR-009).
     // See the note in `aggregateZodiacElementals` above for what the previous


### PR DESCRIPTION
The last open item from ADR-009. `inertialMassWeight` read `PLANET_WEIGHTS[planet] ?? 1.0`, with a source note claiming the fallback was harmless because *"every caller filters to the known-body set first."*

**That claim was false.** Instrumenting the function across the full suite recorded **2920 calls with an unknown body** — `NorthNode` and `SouthNode`, 1460 each — every one silently handed Earth's relative mass.

## Where they came from

This module's **own two aggregators**. Neither had an exclusion gate, while `RealAlchemizeService` had one — a duplicate set living there could not protect them. `aggregateEnhancedZodiacElementals` guards only on an *unresolvable sign*, and nodes have perfectly good signs, so they passed straight through to the weighting.

Those two functions feed `natalChartService`, `/api/user/charts`, `restaurantDiscoveryService`, `AstrologicalService`, `commensalDatabaseService`, `ChartComparisonService`, `agentTelemetryService` and `hierarchicalRecipeCalculations`.

Same defect class as #715 on the Python side, with one difference that made it worse here: Python added a flat **unweighted** 0.6/0.4; this added a **mass-weighted** contribution at **0.3984** — heavier than Mars, Mercury, the Moon and Pluto.

⚠️ Why it stayed invisible: `PLANET_WEIGHTS.Earth` is exactly `1.0`, the same literal the fallback used, so an unknown body produced a weight **indistinguishable from a legitimate "Earth" call**.

## The fix

- `EXCLUDED_ASPECT_BODIES` + `isExcludedAspectBody` move **into** `planetaryAlchemyMapping` — one canonical set per runtime. `RealAlchemizeService` imports it rather than keeping its own copy (no cycle: it already imports this module, not the reverse). `backend/tests/test_main_excluded_bodies.py` is repointed and still asserts the TS and Python sets are **identical**.
- Both aggregators gate excluded bodies **before** any weighting.
- `inertialMassWeight` **throws** on an unknown body, naming whether it's excluded (caller must filter) or genuinely unknown (add it, or exclude it). ADR-009 asked for exactly this: *"the migration should make unknown bodies throw."*

## The calibration had to be re-derived

The affinity constants are measured over the 1460-sample epoch grid, and every sky in it carried the two phantoms:

| constant | before | after |
|---|---|---|
| `SD.heat` | 0.32988662169162397 | 0.32637481885352243 |
| `SD.entropy` | 0.3689024420258162 | 0.3600556169710307 |
| `SD.reactivity` | 2.3088816101488434 | 2.282714354733683 |
| `D0` | 1.0934456889925421 | 1.0904241489725401 |
| axis influence | 29.57 / 63.89 / 6.54 | 29.04 / 64.76 / 6.21 |

⚠️ Derived in the order the dependency requires: **SD first, then D0 re-measured against the new SD.** Taking both from one pass gives `D0 = 1.0708780888185956` — wrong by 0.02, because D0 is measured in whitened units and the whitening hadn't landed. Same trap as #707 and #710; three for three now.

## Tests

The full suite passing is itself the proof that no unknown body reaches the weight any more — it would throw. Pinned explicitly too, with a **positive control** (real bodies still resolve, so a gate that swallowed everything can't pass) and a **negative control** that's a true A/B: same sign, same shape, `"North Node"` gated vs `"Earth"` weighted.

The first version of that control was **wrong and failed correctly** — it moved Jupiter Leo → Sagittarius and asserted the totals shifted, but both are Fire signs, so it changed nothing. That's recorded in the test.

## Gates

`tsc --noEmit` clean · **201/201 suites, 2000 passed, 9 skipped** · pytest **75 passed, 2 skipped** · eslint clean on a cleared cache.

## Note on the other "open item"

I'd flagged that `Agent monica drift + integrity` skips on PRs and so wouldn't have caught the 1054-row drift. **That was wrong** — the job's `if:` is `schedule || (push && master)`, it needs DB secrets, and it *did* fire: FAILURE on the master push at 08:22 (#717) and on the 09:18 cron, then success at 13:17 after the backfill. The PR-level skip is the documented two-job design so the static half can run on forks. No change needed there.