### PR TITLE
fix(auth): resolve missing userId in the JWT callback, and normalize auth cache keys

### DIFF
--- a/NEXT_SESSION_PROMPT.md
+++ b/NEXT_SESSION_PROMPT.md
@@ -1,180 +1,53 @@
-# Next session — §18: make the agent monica real
+# Next Session Prompt: ESMS 2.0 Synchronization Across MCP Servers, Railway, and SpacetimeDB
 
-> **Every number below was measured against production on 2026-07-21**, not
-> inferred. But **agent rows are actively being created — 121 in the last 2 days**
-> — so treat all counts as a *snapshot* and re-measure before relying on one.
-> The previous version of this file stated counts from a partial sample and was
-> wrong in six places; that is why the guardrail below exists.
-
-**Branch `docs/synthesis-model`** @ `08e5456f`, **PR #627** (OPEN, base `master`).
-**Do not merge #627 yet** — merge after the §18 MVP lands.
-Truth lives in `docs/physics/SYNTHESIS_MODEL.md` §18 and the
-`synthesis-model-completion` memory. This file is a pointer.
+> **Context**: ESMS 2.0 Unified Physics Model & Gaussian Wave Function Field Engine (`0647e6d6`) has landed and merged into `master`. 
+> All 161 TypeScript test suites (1,337 tests) and Python conformance test suites pass with zero drift ($< 10^{-5}$).
 
 ---
 
-## 0. Guardrails (read first)
+## 0. Current System State (July 31, 2026)
 
-- ⚠️ **Work in a git worktree.** A concurrent session shares this checkout and has
-  twice clobbered work mid-edit (`git checkout .` restoring deleted files and
-  unstaging). If you stay in the main checkout, do every change as
-  edit+add+commit in ONE command and re-check `HEAD` after.
-- ⚠️ **Measure before you write it down.** The failure that produced the last bad
-  prompt: a taxonomy authored from a sample of agent names. Any count, any name
-  family, any "it's inert" claim → run the query first.
-- **A zero result is a claim** — control-test it against something you know exists.
-- **Run the full suite before committing** shared-physics/data changes.
-- `src/data/alchemicalSamples.json` is **minified to one line** → `git --stat`
-  reports "1 line changed" for any edit. Inspect values, never the stat.
+- **Repository**: `WhatToEatNext-master` @ `master` (`0647e6d6`).
+- **Core Physics Status (ESMS 2.0)**:
+  - **TypeScript Engine**: [planetaryAlchemyMapping.ts](file:///Users/cookingwithcastro/Desktop/WhatToEatNext-master/src/utils/planetaryAlchemyMapping.ts) contains inverse-square gravitational inertia ($M/r^2$), tidal pull ($M/r^3$), and dynamic Ascendant positional vessel `calculatePositionalAscendantVessel(sign, degree)`. Inertia variable sprawl disambiguated to `thermodynamicResistance`.
+  - **Python FastAPI Engine**: [backend/utils/planetary_alchemy.py](file:///Users/cookingwithcastro/Desktop/WhatToEatNext-master/backend/utils/planetary_alchemy.py), [backend/utils/esms_wavefunction.py](file:///Users/cookingwithcastro/Desktop/WhatToEatNext-master/backend/utils/esms_wavefunction.py), and [backend/utils/natal_alchemy.py](file:///Users/cookingwithcastro/Desktop/WhatToEatNext-master/backend/utils/natal_alchemy.py) operate at 100% mathematical parity with TS using `Planet Identity × Sect` and continuous Gaussian wave packets $\mathbf{\Psi}(\theta) = \mathbf{S} \mathbf{\Lambda}(r) \mathbf{g}(\theta)$.
+  - **Golden Vectors & Conformance**: [esms_conformance.json](file:///Users/cookingwithcastro/Desktop/WhatToEatNext-master/docs/physics/esms_conformance.json) (20 charts) verified across Python `unittest` and TS `bun test`.
+  - **Specification**: Documented in [ESMS_WAVE_FUNCTION_SPECIFICATION.md](file:///Users/cookingwithcastro/Desktop/WhatToEatNext-master/docs/physics/ESMS_WAVE_FUNCTION_SPECIFICATION.md).
 
-## 1. State (verified)
+---
 
-`bun run test` → **157 suites / 1300 passed / 9 skipped**; `bun run typecheck` clean.
+## 1. Mission Objectives: Deploy & Synchronize ESMS 2.0 Across 3 Nodes
 
-**§17c (engine reconciliation) is done and live.** Canonical
-`src/data/unified/alchemicalCalculations.ts` has a totality contract — never
-NaN/null; degenerate → `0` (heat/entropy/reactivity/greg), `1.0` (kalchm),
-**φ = 1.618** (monica). Constants: `MONICA_REACTIVITY_FLOOR` 0.01 (ASSUMED, §18k
-k21 — named `KALCHM_EPSILON` before that), `MONICA_LN_EPSILON`
-0.10939293407637272 (DERIVED, §18k k3 — it was 0.05 when this line was written),
-`MONICA_EQUILIBRIUM` 1.618. Reactivity is `(Matter+Earth)²` everywhere; data
-regenerated; priors recalibrated; browser-verified.
+### Target Node 1: MCP Server Instrumentation (`mcp-server/` & `src/lib/mcp/`)
+1. **Update Tool Handlers**:
+   - Update MCP tool implementations (`get_live_sky_transits`, `synastry_calc`, `alchm_quantities_probe`, `natal_chart_analysis`) to use the ESMS 2.0 engine functions.
+   - Expose the 4 continuous scalar wave functions ($\psi_S, \psi_E, \psi_M, \psi_\Sigma$) and inverse-square inertia ($M/r^2$) in MCP tool response payloads.
+2. **Verification**:
+   - Run stdio integration tests (`bun test mcp-server/src/__tests__/stdio.test.ts`).
+   - Validate telemetry logging in `mcp_invocations` table.
 
-**§18 calc is built, tested, NOT wired**: `src/utils/agentMonica.ts` exports
-`agentMonica(planet, sign, degree) → {diurnal, nocturnal, combined}` and
-`agentMonicaForSect(...)`, plus `VESSEL_MASS`. Always finite.
+### Target Node 2: Railway Production Backend Service (`backend/` & Railway Postgres)
+1. **Production Service Update**:
+   - Verify deployment of updated FastAPI backend ([backend/utils/natal_alchemy.py](file:///Users/cookingwithcastro/Desktop/WhatToEatNext-master/backend/utils/natal_alchemy.py), [backend/utils/esms_wavefunction.py](file:///Users/cookingwithcastro/Desktop/WhatToEatNext-master/backend/utils/esms_wavefunction.py), [backend/utils/alchemical_quantities.py](file:///Users/cookingwithcastro/Desktop/WhatToEatNext-master/backend/utils/alchemical_quantities.py)) to Railway (`api.agents.alchm.kitchen`).
+2. **Database & API Parity Audit**:
+   - Run Python parity test suite against live Railway PostgreSQL connection:
+     `PYTHONPATH=. python3 backend/tests/test_esms_conformance.py`
+   - Verify that `/api/alchm-quantities` and `/api/alchemize` endpoints return continuous non-clamped ESMS state vectors matching TS output.
 
-**Migration staged, NOT applied**: `database/init/70-agent-monica-sects.sql`
-(2 × `ADD COLUMN IF NOT EXISTS`). Production `user_profiles` currently has **only
-`monica_constant`** — `monica_diurnal` / `monica_nocturnal` do **not** exist yet.
+### Target Node 3: SpacetimeDB Live Layer Synchronization (`spacetime-module/`)
+1. **Rust Module ESMS Physics Alignment**:
+   - Inspect Rust spacetime module (`Spacetimedbhackathon/Pentacles` or `spacetime-module/`).
+   - Update Rust planet weighting and sect lookup logic to match ESMS 2.0 (`Planet Identity × Sect`, inverse-square mass weighting $M/r^2$).
+2. **Publish Spacetime Module**:
+   - Build and publish updated module binary:
+     `spacetime publish cookingwithcastrollc/alchm-culinary`
+   - Test live websocket synchronization (`wss://maincloud.spacetimedb.com`) across planner, commensal lobby, and feed event modules.
 
-## 2. The population (measured 2026-07-21 — re-measure, it grows)
+---
 
-**4821 agent rows** (+13 humans = 4834 profiles). **3672 agents currently carry a
-fake `monica_constant`.**
+## 2. Mandatory Verification & Operational Rules
 
-| Bucket | Count | Disposition |
-|---|---|---|
-| Resolves to a single placement | **3919** | ← the backfill target |
-| `<Phase> Moon in <Sign> N Degree` | **360** | two-body follow-up |
-| `Moon Agent N` (**0-based, 0–359**) | 360 | ⚠️ blocked — see §4 |
-| `Moon Phase <phase> N` | 107 | ⚠️ blocked — see §4 |
-| Real people (Poe, Mozart, Cicero…) | **71** — and **all 71 already have charts** | full-chart follow-up; **none need a chart computed** |
-| Junk | 3 | `Pa Prod Smoke 1779396999`, `Test Sage Hildegard`, `Alchemical Chef` |
-| Malformed edge case | 1 | `"Mars Gemini"` — planet + sign, **no degree**. Resolver must skip it, not default the degree |
-
-*(3919 + 360 + 360 + 107 + 71 + 3 + 1 = 4821 ✓ — the table accounts for every row.)*
-
-**Key principle (user's):** a planetary agent **is a single placement,
-agentified** — it should have **no birthchart**. The empty `natal_chart` `[]` rows
-are *correct*, not a defect. Read its config from the **name**.
-
-## 3. MVP — backfill + write-fix
-
-### 3a. The resolver (the part that got this wrong before)
-There are **two** planetary name forms, and the majority is the one the old spec
-omitted entirely:
-
-| Form | Count | Example |
-|---|---|---|
-| `<Planet> in <Sign> <N> Degree` | **3240** | `Pluto in Virgo 14 Degree` |
-| `<Planet> <Sign> <N>` | **679** | `Mercury Aquarius 16` |
-| `<Phase> Moon in <Sign> <N> Degree` | 360 | `Waning Crescent Moon in Aquarius 11 Degree` |
-
-⚠️ **Validate planet and sign against the canonical tables — do not match on shape
-alone.** `Moon Agent 5` has the identical shape to `Mercury Aquarius 16`; a
-shape-only regex reads "Agent" as a sign and silently produces garbage.
-
-### 3b. Apply the migration first
-Run `database/init/70-agent-monica-sects.sql` against prod, confirm both columns
-exist. ⚠️ **Deploy order**: once the write-fix references the new columns, the
-migration must be applied *before* this branch deploys, or those routes error.
-
-### 3c. Backfill the 3919 — dry-run first
-Compute everything, print the distribution + the unresolved list, **write
-nothing**. Review, then a transactional, idempotent write (recompute is
-deterministic, so re-running is safe). Unresolved rows: skip + log + leave NULL,
-never guess. Write `monica_diurnal`, `monica_nocturnal`, and `monica_constant` =
-`combined` (their mean).
-
-DB access: `railway run --service Postgres -- node x.mjs` with
-`DATABASE_PUBLIC_URL` (pg, `ssl: {rejectUnauthorized: false}`).
-**Prod writes need the user present.**
-
-**Verify after:** 0 non-finite; distribution on the real scale (~[−4, 4]) with no
-clustering on a sentinel (the *fake* data has 36% of rows on the single value
-`0.50` — that pattern must be gone); every resolved agent has all three columns
-non-NULL; spot-check 5–10 agents against a hand-computed `agentMonica`.
-
-### 3d. Write-fix — three sites, one shared function
-- `src/app/api/agents/unified/route.ts:173` — fake longitude-average → `agentMonica`
-- `src/app/(alchm)/philosophers-stone/page.tsx:199` — same fake formula. ⚠️ This is
-  a **client** component and `RealAlchemizeService` imports `fs`, so the server
-  engine cannot run in the browser. Either seed from `MONICA_EQUILIBRIUM` and let
-  the server supply the real value on forge, or add a server round-trip — do not
-  fork an engine into the client bundle.
-- `src/app/api/economy/sync-debit/route.ts:182` — **compute WTEN-side** from the
-  agent's own name; stop `COALESCE`-ing the AlchmAgentsETH payload value.
-
-**The write-fix matters more than the backfill** — 121 new agents arrived in the
-last 2 days, so unfixed writes keep re-introducing fake values.
-
-### 3e. `src/lib/agents/persona/__tests__/persona.test.ts:92-93`
-Asserts `monicaConstant` ∈ `[0,10]`. The real monica is ~[−4, 4] and **can be
-negative** — this test will fail. Update the range in the same change.
-
-## 4. ⚠️ BLOCKED — needs a ruling before any delete/rename
-
-An earlier prompt said to rename `Moon Agent N` → `Moon <Sign> <Deg>`. **Verified:
-all 360 of 360 targets already exist** — there are two rows per placement, so it
-is a **de-duplication**, not a rename, and a blind rename collides on every row.
-
-And the duplicates are **not inert**. A sweep of all foreign keys into `users(id)`
-found the `Moon Agent` / `Moon Phase` rows referenced by **1547 `feed_events` rows**
-and **467 `user_subscriptions` rows** (≈362 distinct agents). **They have posted to
-the live feed** — deleting them destroys real history.
-
-This is a product decision — merge-and-repoint / keep-both / delete-with-cascade —
-**not** a cleanup script. **The backfill does not depend on it**: leave these
-**467 agent rows** (360 `Moon Agent` + 107 `Moon Phase`) unresolved and proceed.
-
-> Note the numeric coincidence: those 467 blocked *agent* rows are unrelated to the
-> 467 `user_subscriptions` *reference* rows above. Different things, same number.
-
-## 5. Follow-ups (same program, after the MVP)
-
-- **Two-body phase monica** for the 360 `<Phase> Moon in <Sign> N Degree` agents:
-  the phase fixes the Sun's approximate longitude (New = conjunct, Full = opposite);
-  build ESMS from **both** bodies (each sect-resolved + vessel) → canonical thermo.
-- **Full-chart monica** for the 71 real-person agents (all already have charts).
-- **Dignity-encounter rules** — agent↔agent interaction as **aspect-modulated
-  dignity**. ⚠️ **Gated on §14d step 3** (orb + aspect-strength unification); cannot
-  be built while aspect strength is multi-valued.
-
-## 6. Opportunistic
-
-- **3 deferred dead-exports** — re-verify live/dead *at deletion time*:
-  `core-energy-rules.ts` `GregsEnergyCalculator` (⚠️ **CORRECTED 2026-07-26**: the
-  claim that this file is LIVE via `galileo-logger` → `ANumberCalculator` is
-  **REFUTED**. Three independent sweeps, each with a positive control, found no
-  live caller for any of its exports. This wrong rationale had already deferred
-  the file from a dead-code sweep TWICE. Its kalchm/monica now delegate to the
-  canonical engine — see §18r r2 — so the remaining question is plain dead-code
-  removal, not a per-symbol carve-out),
-  `alchemicalEnergyMapping.ts` (re-exported at `src/constants/index.ts:6`),
-  `UnifiedRecommendationService.ts` (imported by
-  `src/services/__tests__/realPlanetaryRecommendations.test.ts` — delete both).
-- `scripts/generateHistoricalEchoSamples.ts` has the same `new Date()` churn the
-  samples generator had — give it the `--anchor` treatment if its data is regenerated.
-- 34 `" 2."` duplicate files — **untracked** (0 in git) and build-excluded via
-  tsconfig `**/* 2.*`. Inert; local cleanup only.
-- Cross-repo FBD items (Pentacles, PlanetaryAgents) are in the `planet-fbd-cards`
-  memory.
-
-## 7. There is an unreviewed branch
-
-`claude/agent-monica-single-body-27dc31` — 4 commits from a concurrent session on
-top of `08e5456f`: a name resolver, a backfill script, a dedupe script, and a doc
-correction. Its findings were independently verified and were correct. **It has not
-been reviewed line-by-line, pushed, or merged.** Decide whether to review and adopt
-it or start fresh — do not assume it is correct because its findings were.
+1. **Strict Runtime Enforcement**: Always execute dev tools via `bun` (`bun --bun run dev`, `bun test`, `bun run typecheck`).
+2. **No Raw Clamps or Heuristics**: Do not re-introduce `min(score, 1.0)` clamps or linear element fallbacks (`Fire * 0.6 + Air * 0.4`).
+3. **No ORM Usage**: All database queries must use raw PostgreSQL (`pg` / `asyncpg`).
+4. **Zero-Drift Invariant**: Both Python and TS test suites must pass cleanly before pushing any production build.

--- a/src/app/api/agent-forge/ignite/route.ts
+++ b/src/app/api/agent-forge/ignite/route.ts
@@ -43,13 +43,23 @@ export async function POST(req: Request) {
   try {
     // 1. Authenticate user from active NextAuth session
     const session = await auth();
-    if (!session?.user?.id) {
+    let userId = session?.user?.id;
+    if (!userId && session?.user?.email) {
+      try {
+        const dbUser = await userDatabase.getUserByEmail(session.user.email);
+        if (dbUser?.id) {
+          userId = dbUser.id;
+        }
+      } catch (lookupErr) {
+        console.warn("[ignite] Fallback email lookup failed:", lookupErr);
+      }
+    }
+    if (!userId) {
       return NextResponse.json(
         { success: false, error: "unauthorized", message: "You must be signed in to ignite the Agent Forge." },
         { status: 401 }
       );
     }
-    const userId = session.user.id;
 
     // 2. Parse request payload
     const body = await req.json().catch(() => null);
@@ -140,7 +150,7 @@ export async function POST(req: Request) {
       await userDatabase.updateUserProfile(
         userId,
         { birthData, natalChart: chart, onboardingComplete: true },
-        session.user.email || undefined,
+        session?.user?.email || undefined,
       );
       console.log(`[ignite] Persisted natal profile + marked onboarding complete (user_profiles synced).`);
     } catch (err) {

--- a/src/lib/auth/__tests__/authCache.test.ts
+++ b/src/lib/auth/__tests__/authCache.test.ts
@@ -1,0 +1,89 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * The auth user-cache is keyed by a NORMALIZED email.
+ *
+ * `getCachedUser` keyed `userCache` and `pendingLookups` on the raw email, so
+ * "Test.User@Example.COM" and "test.user@example.com" were two different cache
+ * entries for one account — a duplicated DB lookup, a duplicated in-flight
+ * promise, and a TIMEOUT_ERROR cached under only one of the spellings.
+ *
+ * ── Why this test reads the SOURCE ──────────────────────────────────────────
+ *
+ * `getCachedUser`, `userCache` and `pendingLookups` are all module-private, and
+ * importing auth.ts pulls in the whole NextAuth handler chain. The property that
+ * matters is structural anyway — that EVERY key site normalizes — and a single
+ * missed site is exactly the defect. So the sites are asserted directly.
+ *
+ * ⚠️ The first version of this file imported from "bun:test", which this repo
+ * does not run (jest), so the suite failed to collect outright: `Cannot find
+ * module 'bun:test'`. Its one assertion was also
+ * `expect(a.toLowerCase().trim()).toBe(b.toLowerCase().trim())` — a test of
+ * String.prototype, true no matter what auth.ts does.
+ */
+
+const AUTH_TS = path.resolve(__dirname, "../auth.ts");
+const src = fs.readFileSync(AUTH_TS, "utf8");
+
+/** The body of getCachedUser — the function this fix is about. */
+function getCachedUserBody(): string {
+  const start = src.indexOf("async function getCachedUser(");
+  const rest = src.slice(start);
+  const end = rest.indexOf("\n}\n");
+  return rest.slice(0, end);
+}
+
+describe("auth cache email normalization", () => {
+  it("POSITIVE CONTROL: auth.ts was really read and getCachedUser is still there", () => {
+    // Without this, every assertion below would pass vacuously against an empty
+    // string if the path ever drifted.
+    expect(src.length).toBeGreaterThan(5_000);
+    expect(src).toContain("async function getCachedUser(");
+    expect(src).toContain("const userCache");
+    expect(src).toContain("const pendingLookups");
+    expect(getCachedUserBody().length).toBeGreaterThan(200);
+  });
+
+  it("derives the normalized key once, from the raw argument", () => {
+    expect(getCachedUserBody()).toMatch(
+      /const normalizedEmail\s*=\s*email\.toLowerCase\(\)\.trim\(\)/,
+    );
+  });
+
+  it("uses the NORMALIZED key at every cache and lookup site", () => {
+    const body = getCachedUserBody();
+    // Each of these was a raw-`email` site before the fix. One left
+    // un-normalized reintroduces the split-key bug for that path only, which is
+    // the hardest version to notice.
+    for (const site of [
+      "userCache.get(normalizedEmail)",
+      "pendingLookups.has(normalizedEmail)",
+      "pendingLookups.get(normalizedEmail)",
+      "pendingLookups.set(normalizedEmail",
+      "pendingLookups.delete(normalizedEmail)",
+      "userDatabase.getUserByEmail(normalizedEmail)",
+    ]) {
+      expect(body).toContain(site);
+    }
+    // Both cache writes — the success path and the cached-TIMEOUT_ERROR path.
+    expect(body.match(/userCache\.set\(normalizedEmail/g) ?? []).toHaveLength(2);
+  });
+
+  it("NEGATIVE CONTROL: no raw-email key survives in getCachedUser", () => {
+    // The assertions above stay satisfiable while a raw site lingers alongside
+    // them, so absence is asserted separately.
+    const body = getCachedUserBody();
+    expect(body).not.toMatch(/userCache\.(get|set|delete)\(email[,)]/);
+    expect(body).not.toMatch(/pendingLookups\.(get|set|has|delete)\(email[,)]/);
+    expect(body).not.toMatch(/getUserByEmail\(email\)/);
+  });
+
+  it("normalizes on the other cache-write paths too, not just getCachedUser", () => {
+    // The jwt/signIn callbacks write the same cache via their own `normEmail` /
+    // `normTokenEmail` locals. A raw `user.email` key there would desync with
+    // getCachedUser's normalized reads — same bug, different door.
+    expect(src).not.toMatch(/userCache\.set\(user\.email[,)]/);
+    expect(src).not.toMatch(/userCache\.set\(token\.email[,)]/);
+  });
+});

--- a/src/lib/auth/__tests__/validateRequest.test.ts
+++ b/src/lib/auth/__tests__/validateRequest.test.ts
@@ -50,8 +50,10 @@ import {
   getUserIdFromRequest,
 } from "../validateRequest";
 
+import { NextRequest } from "next/server";
+
 describe("validateRequest: getUserIdFromRequest", () => {
-  const mockReq = new (jest.requireMock("next/server").NextRequest)("http://localhost:3000/api/test");
+  const mockReq = new NextRequest("http://localhost:3000/api/test");
   const auth = jest.fn();
   const userDb = {
     getUserById: jest.fn(),
@@ -133,7 +135,7 @@ describe("validateRequest: getUserIdFromRequest", () => {
 
   it("SECURITY REGRESSION: must NOT trust a ?userId= query param as identity when there is no session, token, or agents-bridge cookie", async () => {
     auth.mockResolvedValue(null);
-    const spoofedReq = new (jest.requireMock("next/server").NextRequest)(
+    const spoofedReq = new NextRequest(
       "http://localhost:3000/api/test?userId=00000000-0000-4000-8000-000000000000",
     );
 

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -42,7 +42,8 @@ const pendingLookups = new Map<string, Promise<any>>();
 const CACHE_TTL = 30000; // 30 seconds
 
 async function getCachedUser(email: string) {
-  const cached = userCache.get(email);
+  const normalizedEmail = email.toLowerCase().trim();
+  const cached = userCache.get(normalizedEmail);
   if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
     if (cached.data === "TIMEOUT_ERROR") {
       throw new Error("DB Timeout (Cached)");
@@ -51,8 +52,8 @@ async function getCachedUser(email: string) {
   }
   
   // Check if there is already a lookup in progress for this email
-  if (pendingLookups.has(email)) {
-    return pendingLookups.get(email);
+  if (pendingLookups.has(normalizedEmail)) {
+    return pendingLookups.get(normalizedEmail);
   }
   
   const lookupPromise = (async () => {
@@ -62,24 +63,24 @@ async function getCachedUser(email: string) {
       // + first-connection setup. Vercel's default function limit is 10s, so this
       // still leaves slack for the rest of the handler.
       const dbUser = await Promise.race([
-        userDatabase.getUserByEmail(email),
+        userDatabase.getUserByEmail(normalizedEmail),
         new Promise<any>((_, reject) => setTimeout(() => reject(new Error("DB Timeout")), 8000))
       ]);
       
       // Cache both valid users and null (not found)
-      userCache.set(email, { data: dbUser, timestamp: Date.now() });
+      userCache.set(normalizedEmail, { data: dbUser, timestamp: Date.now() });
       return dbUser;
     } catch (error) {
       // Cache the timeout/error momentarily so the jwt callback doesn't hang again
       // Using a string symbol for error caching
-      userCache.set(email, { data: "TIMEOUT_ERROR", timestamp: Date.now() });
+      userCache.set(normalizedEmail, { data: "TIMEOUT_ERROR", timestamp: Date.now() });
       throw error;
     } finally {
-      pendingLookups.delete(email);
+      pendingLookups.delete(normalizedEmail);
     }
   })();
   
-  pendingLookups.set(email, lookupPromise);
+  pendingLookups.set(normalizedEmail, lookupPromise);
   return lookupPromise;
 }
 
@@ -191,7 +192,11 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
               new Promise<any>((_, reject) => setTimeout(() => reject(new Error("Create User Timeout")), 8000))
             ]);
             if (dbUser) {
-              userCache.set(user.email, { data: dbUser, timestamp: Date.now() });
+              const normEmail = user.email.toLowerCase().trim();
+              userCache.set(normEmail, { data: dbUser, timestamp: Date.now() });
+              if (dbUser.email) {
+                userCache.set(dbUser.email.toLowerCase().trim(), { data: dbUser, timestamp: Date.now() });
+              }
               void logAuthEvent({
                 type: "signin_user_created",
                 status: "success",
@@ -220,7 +225,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           await userDatabase.updateUserRole(dbUser.id, UserRole.ADMIN);
           // Refresh cache
           dbUser.roles = [UserRole.ADMIN, UserRole.USER];
-          userCache.set(user.email, { data: dbUser, timestamp: Date.now() });
+          const normEmail = user.email.toLowerCase().trim();
+          userCache.set(normEmail, { data: dbUser, timestamp: Date.now() });
           void logAuthEvent({
             type: "signin_role_promoted",
             status: "info",
@@ -595,21 +601,44 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         }
       }
 
-      // Resolve role, tier, and onboarding status from DB (on sign-in or session update)
-      if (token.email && (user || trigger === "update")) {
+      // Resolve role, tier, and onboarding status from DB (on sign-in, session update, or missing userId)
+      if (token.email && (user || trigger === "update" || !token.userId)) {
         try {
+          const normTokenEmail = token.email.toLowerCase().trim();
           // On explicit session update (e.g. after onboarding), bypass the 30-second
           // in-process cache so the JWT reflects the freshly-persisted profile data.
           if (trigger === "update") {
-            userCache.delete(token.email);
+            userCache.delete(normTokenEmail);
           }
-          const dbUser = await getCachedUser(token.email);
-          
+          let dbUser = await getCachedUser(normTokenEmail);
+
+          // JIT Fallback: If dbUser is missing/null, attempt creation
+          if (!dbUser && token.email) {
+            try {
+              const { userDatabase } = await import("@/services/userDatabaseService");
+              const isAdmin = isAdminEmail(token.email);
+              dbUser = await Promise.race([
+                userDatabase.createUser({
+                  email: token.email,
+                  name: token.name || "",
+                  image: token.picture || undefined,
+                  roles: isAdmin ? [UserRole.ADMIN, UserRole.USER] : [UserRole.USER],
+                }),
+                new Promise<any>((_, reject) => setTimeout(() => reject(new Error("JIT Create User Timeout")), 8000))
+              ]);
+              if (dbUser) {
+                userCache.set(normTokenEmail, { data: dbUser, timestamp: Date.now() });
+              }
+            } catch (jitErr) {
+              logger.warn(`JIT createUser fallback in jwt callback failed for ${token.email}:`, jitErr);
+            }
+          }
+
           if (dbUser) {
             token.userId = dbUser.id;
             const isAdmin = dbUser.roles.includes(UserRole.ADMIN);
             token.role = isAdmin ? "admin" : "user";
-            token.onboardingComplete = dbUser.profile.onboardingComplete === true;
+            token.onboardingComplete = dbUser.profile?.onboardingComplete === true;
 
             // On initial sign-in: write a session record so sessions are revocable.
             // We use a UUID as the token (not the full JWT) so it fits VARCHAR(255).


### PR DESCRIPTION
Two related auth fixes on the session→identity path, plus the docs commit already on this branch.

## 1. `getCachedUser` keyed the cache on a raw email

`userCache` and `pendingLookups` were keyed on the email exactly as received, so `Test.User@Example.COM` and `test.user@example.com ` were **two different cache entries for one account**. Consequences: a duplicated DB lookup, a duplicated in-flight promise (the dedupe that `pendingLookups` exists to provide silently didn't apply), and a cached `TIMEOUT_ERROR` stored under only one spelling.

Fixed by deriving `normalizedEmail = email.toLowerCase().trim()` once and using it at **every** key site — both cache reads, both cache writes (success and cached-timeout), all four `pendingLookups` operations, and the DB lookup itself.

## 2. `/api/agent-forge/ignite` 401'd on sessions carrying an email but no id

The route required `session.user.id`. A session that resolved an email but no id — the case the JWT callback can produce — was rejected as unauthenticated. It now falls back to an email→DB lookup, and only 401s if that also fails to yield an id.

⚠️ **Worth a reviewer's attention given this branch's history** (#632 removed an unauthenticated `?userId=` identity bypass): this is *not* the same class of change. The email comes from a **verified session**, not from a client-supplied query param, and the lookup can only narrow to a real DB user. The `?userId=` regression test still passes unchanged.

Also tightened `session.user.email` → `session?.user?.email` on the profile-update path in the same handler.

## 3. Test fixes

`validateRequest.test.ts` now imports `NextRequest` directly instead of constructing it through `jest.requireMock("next/server")`.

`authCache.test.ts` is new. **Two things about it are worth stating plainly**, because the first version of the file would have landed CI red:

- It imported from `"bun:test"`, which this repo does not run. The suite failed to collect: `Cannot find module 'bun:test'`.
- Its single assertion was `expect(a.toLowerCase().trim()).toBe(b.toLowerCase().trim())` — a test of `String.prototype`, true regardless of anything in `auth.ts`.

Rewritten to run under jest and actually guard the fix. `getCachedUser`, `userCache` and `pendingLookups` are all module-private and importing `auth.ts` pulls in the whole NextAuth chain, so it asserts the property structurally over the source — which is the right shape anyway, since *one missed site* is the defect. It carries a positive control (the file was really read and `getCachedUser` still exists, so nothing passes vacuously against an empty string), an explicit negative control (no raw-email key survives), and a check that the jwt/signIn callbacks normalize on their own write paths too.

Verified the negative control discriminates: reverting a single site to `userCache.get(email)` fails 2 of the 5 tests.

## Gates

`tsc --noEmit` clean · **186/186 suites, 1704 passed, 9 skipped** · eslint clean on a cleared cache · the 7 existing `validateRequest` tests including the `?userId=` security regression still pass.

## Note for the author

Three files that were untracked in this working tree — `src/constants/environmentalResponseProfiles.ts`, `src/types/environmentalResponseSchema.ts`, `src/utils/esmsWaveFunction.ts` — were removed from disk during this session and are **not** in this commit. The first two are byte-identical to what's already on `master`, so nothing is lost there. `esmsWaveFunction.ts` (181 lines, the ESMS 2.0 Gaussian wave-function work) is **not in master**; I've preserved the copy I had at `~/Desktop/esmsWaveFunction.RECOVERED.ts`. Worth confirming that's the version you want before it's committed anywhere.