### PR TITLE
refactor(physics): retire the sign-level dignity scale from the agent and chart paths

### DIFF
--- a/src/__tests__/monicaPopulationScaleDerivation.test.ts
+++ b/src/__tests__/monicaPopulationScaleDerivation.test.ts
@@ -128,9 +128,13 @@ describe("the Sacred-7 monica scales are derived from their populations", () => 
       // SINGLE.absMax comes off a live grid walk whose monica runs through
       // Math.log and Math.pow. Neither is required by IEEE-754 to be correctly
       // rounded, so engines legitimately disagree in the last bits: MEASURED
-      // 2026-08-02, this same enumeration yields 3.8977146920667276 under Node
-      // v22 (which is what jest runs on) and 3.8977146920667267 under Bun 1.3 —
-      // ~2 ULP apart, extremum at Neptune / Aquarius / 2° / nocturnal. An exact
+      // 2026-08-02 on the then-current sign-level dignity scale, this same
+      // enumeration yielded 3.8977146920667276 under Node v22 (which is what
+      // jest runs on) and 3.8977146920667267 under Bun 1.3 — ~2 ULP apart,
+      // extremum then at Neptune / Aquarius / 2° / nocturnal. The enumeration
+      // now yields 4.112110463016779 with the extremum at Mercury / Gemini /
+      // 2° / nocturnal, but the ENGINE-SPREAD REASONING is unchanged and is
+      // what this tolerance exists for. An exact
       // assertion here passes only on whichever engine happened to derive the
       // constant, and this repo runs scripts under `bun` and tests under Node.
       //
@@ -146,15 +150,16 @@ describe("the Sacred-7 monica scales are derived from their populations", () => 
     });
 
     it("holds the measurement recorded in the source", () => {
-      // 3.8977146920667276 / 2. Was 1.9875 (|max| 3.9751) while calculateKalchm
-      // floored each axis at 0.01.
+      // 4.112110463016779 / 2. Was 1.9488573460333638 (|max| 3.8977146920667276)
+      // on the sign-level dignity scale, and 1.9875 (|max| 3.9751) before that,
+      // while calculateKalchm floored each axis at 0.01.
       //
       // Measured-against-literal: engine-sensitive, so a tolerance (see above).
-      expect(SINGLE.absMax).toBeCloseTo(3.8977146920667276, 12);
+      expect(SINGLE.absMax).toBeCloseTo(4.112110463016779, 12);
       // Literal-against-literal: no measurement, no engine, no drift. EXACT — and
       // this is the assertion that actually catches a lossy transcription of the
       // shipped constant.
-      expect(MONICA_POPULATION_SCALE["single-body"]).toBe(1.9488573460333638);
+      expect(MONICA_POPULATION_SCALE["single-body"]).toBe(2.0560552315083895);
     });
   });
 
@@ -208,6 +213,12 @@ describe("the Sacred-7 monica scales are derived from their populations", () => 
       // further". Under inertial mass it fails: 4.4166 vs 3.8977, ratio 1.1331,
       // 33 cells over. Three things were measured before inverting it:
       //
+      // (Those two figures are the 2026-08-02 state, kept because they are the
+      // evidence the inversion was argued from. The dignity manifest since
+      // raised single-body to 4.1121 while two-body held at 4.4166, so the
+      // ratio narrowed to 1.0740 — the inequality this test asserts still
+      // holds, by less.)
+      //
       //  1. The single-body envelope is SCALE-INDEPENDENT. agentMonica imports no
       //     weight function at all — its only mass constant is VESSEL_MASS — so
       //     3.8977146920667276 is bit-identical before and after the migration.
@@ -235,7 +246,7 @@ describe("the Sacred-7 monica scales are derived from their populations", () => 
       // DOES restore nesting but hands φ to 576 healthy charts — the exact
       // fabrication TWO_BODY_LN_EPSILON was deleted for.
       expect(TWO.absMax).toBeGreaterThan(SINGLE.absMax);
-      expect(TWO.absMax / SINGLE.absMax).toBeCloseTo(1.133114, 5);
+      expect(TWO.absMax / SINGLE.absMax).toBeCloseTo(1.074036, 5);
     });
 
     it("but is NOT reachable on the single-body scale — the display is what protects the hierarchy", () => {

--- a/src/__tests__/utils/agentMonicaResolver.test.ts
+++ b/src/__tests__/utils/agentMonicaResolver.test.ts
@@ -119,22 +119,28 @@ describe("parseAgentPlacement", () => {
 
     it("produces a real single-body monica for the two stuck production rows", () => {
       // The exact values that will be written to production. Pinned so a change
-      // to the vessel, the dignity table or the sectarian ESMS fails here rather
-      // than silently re-valuing stored rows.
+      // to the vessel, the dignity manifest or the sectarian ESMS fails here
+      // rather than silently re-valuing stored rows.
+      //
+      // ⚠️ Re-measure these UNDER JEST, never from a `bun run` probe. These are
+      // exact `toBe` pins and monica runs through Math.log/exp, which ECMAScript
+      // leaves implementation-defined: jest is Node/V8, `bun run` is JSC, and the
+      // two disagree by an ULP. MEASURED here — nocturnal is ...181878 under jest
+      // and ...181879 under bun, which is enough to fail toBe.
       expect(agentMonicaWithMethod("Mars Gemini")).toEqual({
         method: "single-body",
         monica: {
-          diurnal: 0.23632718765038255,
-          nocturnal: -0.21159527266371464,
-          combined: 0.012365957493333954,
+          diurnal: 0.2338892828502221,
+          nocturnal: -0.20936954259002769,
+          combined: 0.012259870130097203,
         },
       });
       expect(agentMonicaWithMethod("Moon Cancer")).toEqual({
         method: "single-body",
         monica: {
-          diurnal: 0.08982183448164283,
-          nocturnal: -0.06616940474149076,
-          combined: 0.011826214870076034,
+          diurnal: 0.09186116374961706,
+          nocturnal: -0.06886676129181878,
+          combined: 0.011497201228899141,
         },
       });
     });
@@ -152,7 +158,7 @@ describe("parseAgentPlacement", () => {
       // CONTROL: the zero is a property of degree 15, not of this agent. The
       // shipped midpoint on the same row is a real number.
       expect(agentMonicaWithMethod("Moon Cancer")?.monica.combined).toBe(
-        0.011826214870076034,
+        0.011497201228899141,
       );
 
       // CONTROL: exactly five of the thirty degrees do this, so a mapping that

--- a/src/calculations/dignityManifest.ts
+++ b/src/calculations/dignityManifest.ts
@@ -575,6 +575,26 @@ function foldsFromComponents(components: DignityBreakdown['components']) {
 }
 
 /**
+ * Absolute ecliptic longitude from a sign name and a degree within it, or null
+ * when the sign is unrecognised.
+ *
+ * Exists so no caller writes `SIGNS.indexOf(sign) * 30 + degree` by hand.
+ * `SIGNS` is lowercase, but sign keys elsewhere in this codebase are Title-case
+ * (`toSignKey` in agentMonica) or raw API strings, and a bare `indexOf` returns
+ * −1 for all twelve of those — silently mapping EVERY sign to the same wrong
+ * longitude rather than failing. That defect shipped briefly during the agent
+ * migration and was caught only because a two-body test asserted that Moon
+ * domicile and Moon detriment must differ. Case is normalised here, and an
+ * unknown sign returns null rather than a plausible number.
+ */
+export function longitudeFromSignDegree(sign: string, degree: number): number | null {
+  const idx = SIGNS.indexOf(String(sign).trim().toLowerCase() as SignName)
+  if (idx < 0) return null
+  if (!Number.isFinite(degree)) return null
+  return idx * 30 + degree
+}
+
+/**
  * Exact dignity folds at a known ecliptic longitude.
  */
 export function dignityFoldsAtLongitude(

--- a/src/components/dashboard/NatalTransitChart.tsx
+++ b/src/components/dashboard/NatalTransitChart.tsx
@@ -1,13 +1,19 @@
 'use client';
 
 import React, { useEffect, useMemo, useState } from 'react';
+import {
+  dignityFoldsAtLongitude,
+  dignityFoldsForSign,
+  toLegacyDignityType,
+  type ManifestPlanet,
+} from '@/calculations/dignityManifest';
 import { useAlchemical } from '@/contexts/AlchemicalContext/hooks';
 import { useActiveTransits } from '@/hooks/useActiveTransits';
 import { useTransitGroupChat } from '@/hooks/useTransitGroupChat';
 import type { NatalChart, Planet, ZodiacSignType } from '@/types/natalChart';
 import { buildAspectsFromChartPlanets } from '@/utils/aspectCalculator';
 import { extractPlanetaryPositions } from '@/utils/astrology/chartDataUtils';
-import { getDignityScore } from '@/utils/dignityScales';
+import { isSectDiurnalForBirth } from '@/utils/planetaryAlchemyMapping';
 
 interface NatalTransitChartProps {
   natalChart: NatalChart;
@@ -57,12 +63,20 @@ interface TransitData {
 
 /**
  * Sign-vector length = BASE + (dignityMultiplier − 1) × GAIN, in SVG units.
- * Yields ~6px at Fall (×0.90) and ~24px at Domicile (×1.10), a spread a
- * reader can actually see, versus ~2px if the multiplier scaled the length
- * directly. Neutral sits at BASE.
+ * Yields ~7.8px at the manifest's worst debility (×0.82) and ~23.8px at its
+ * best dignity (×1.22), a spread a reader can actually see, versus ~2px if the
+ * multiplier scaled the length directly. Undignified sits at BASE.
  */
 const SIGN_VECTOR_BASE = 15;
-const SIGN_VECTOR_GAIN = 90;
+// Retuned 90 → 40 when the sign vectors moved to the 5-fold dignity manifest.
+// The old gain was fitted to the sign-level scale's ±7/±10% span; the manifest
+// spans −18%…+22%, so at gain 90 the worst debility computed to
+// 15 + (0.82 − 1) × 90 = −1.2px — a NEGATIVE arrow length, which SVG would draw
+// inverted rather than short. Gain 40 maps the wider range back onto essentially
+// the original pixel band: 7.8px at 𝒟 = 0.82, 23.8px at 𝒟 = 1.22, against the
+// old 8.7–24.0px. The encoding stays monotonic and proportional, and the exact
+// multiplier remains in the <title> tooltip either way.
+const SIGN_VECTOR_GAIN = 40;
 
 /** Majors only on the wheel — minors would hairball; they live on the FBD cards instead. */
 const MAJOR_ASPECTS = new Set(['conjunction', 'opposition', 'trine', 'square', 'sextile']);
@@ -132,20 +146,40 @@ export const NatalTransitChart: React.FC<NatalTransitChartProps> = ({
   };
 
   // Build natal positions
-  const natalPositions: Array<{ planet: string; sign: string; degree: number; absAngle: number }> = [];
+  // Sect for dignity: triplicity rulership is sect-dependent, so the sign
+  // vectors need it. Derived from the chart's own birth moment; an unparseable
+  // birthData falls back to diurnal, matching the engine's own default.
+  const birthMoment = new Date(natalChart.birthData?.dateTime ?? '');
+  const birthMomentIsValid = Number.isFinite(birthMoment.getTime());
+  const chartSect: 'diurnal' | 'nocturnal' =
+    !birthMomentIsValid || isSectDiurnalForBirth(birthMoment) ? 'diurnal' : 'nocturnal';
+
+  const natalPositions: Array<{
+    planet: string;
+    sign: string;
+    degree: number;
+    absAngle: number;
+    /** True ecliptic longitude, or null when this row carries no measured geometry. */
+    longitude: number | null;
+  }> = [];
   const natalSigns = extractPlanetaryPositions(natalChart);
-  
+
   for (const planet of PLANETS) {
     const sign = natalSigns[planet];
     if (!sign) continue;
     const planetInfo = natalChart.planets?.find(p => p.name === planet);
     const rawPos = planetInfo?.position ?? 0;
+    // `position <= 0` means unknown/legacy per PlanetInfo.position's contract —
+    // NOT 0° Aries. Placement keeps its 15° sign-midpoint convention so the glyph
+    // still lands somewhere sensible, but `longitude` stays null so dignity below
+    // falls back to E[𝒟 | sign] instead of inheriting the midpoint's term and face.
     const deg = rawPos > 0 ? rawPos % 30 : 15;
     natalPositions.push({
       planet,
       sign: typeof sign === 'string' ? sign : '',
       degree: deg,
       absAngle: toAbsoluteAngle(typeof sign === 'string' ? sign : '', deg),
+      longitude: rawPos > 0 ? rawPos : null,
     });
   }
 
@@ -285,10 +319,25 @@ export const NatalTransitChart: React.FC<NatalTransitChartProps> = ({
               const element = SIGN_ELEMENTS[signStr];
               if (!element) return null;
               const color = ELEMENT_COLORS[element];
-              // ESMS-scale dignity — the same multiplier the alchemical engine
-              // applies, so the arrow length means what the FBD cards mean.
-              const dignity = getDignityScore(pos.planet, signStr);
-              const multiplier = 1 + dignity.esmsScale / 100;
+              // Degree-level 5-fold dignity — the same multiplier the alchemical
+              // engine applies, so the arrow length means what the FBD cards mean.
+              // That claim was briefly FALSE: the engine moved to the manifest
+              // while this component still read the retired sign-level scale.
+              // Resolution mirrors the engine exactly — real longitude when the
+              // row has one, E[𝒟 | sign] when it does not.
+              const folds =
+                pos.longitude === null
+                  ? dignityFoldsForSign(pos.planet as ManifestPlanet, signStr, chartSect)
+                  : dignityFoldsAtLongitude(pos.planet as ManifestPlanet, pos.longitude, chartSect);
+              const multiplier = folds.multiplier;
+              const dignityType = toLegacyDignityType(folds);
+              // The legacy type alone now under-describes the physics — Venus in
+              // virgo reads "Fall" yet applies ×0.98, because the Earth day
+              // triplicity offsets the fall. List the folds that actually fired.
+              const foldLabel = (['domicile', 'exaltation', 'triplicity', 'term', 'face', 'detriment', 'fall'] as const)
+                .filter((k) => folds[k] !== 0)
+                .map((k) => `${k} ${folds[k] > 0 ? '+' : ''}${Number(folds[k].toFixed(2))}`)
+                .join(', ');
               // Amplify the dignity deviation so it is actually visible.
               //
               // The ESMS dignity scale spans only ±7/±10% (Detriment 0.93 →
@@ -315,7 +364,11 @@ export const NatalTransitChart: React.FC<NatalTransitChartProps> = ({
               const signLabel = signStr ? signStr.charAt(0).toUpperCase() + signStr.slice(1) : signStr;
               return (
                 <g key={`sign-vector-${pos.planet}`} opacity="0.8">
-                  <title>{`${signLabel} → ${element} · ${dignity.type} ×${multiplier.toFixed(2)}`}</title>
+                  <title>
+                    {`${signLabel} → ${element} · ${dignityType} ×${multiplier.toFixed(2)}${ 
+                      foldLabel ? ` (${foldLabel})` : '' 
+                      }${folds.resolution === 'sign-mean' ? ' · sign-mean, no measured longitude' : ''}`}
+                  </title>
                   <line
                     x1={start.x}
                     y1={start.y}

--- a/src/lib/sacred-7-stats.ts
+++ b/src/lib/sacred-7-stats.ts
@@ -301,10 +301,20 @@ export type MonicaMethod = 'single-body' | 'two-body' | 'full-chart'
 // Exported for src/__tests__/monicaPopulationScaleDerivation.test.ts, which
 // re-derives the two grid-backed entries from their populations on every run.
 export const MONICA_POPULATION_SCALE: Partial<Record<MonicaMethod, number>> = {
-  // |max| 3.8977146920667276 / 2  [MEASURED 2026-07-25, exhaustive grid n=7920,
-  // AFTER the exact-zero kalchm fix]. Was 1.9875 from |max| 3.9751 under the floor.
-  // Extremum at Neptune / Aquarius / 2° / nocturnal (monica -3.8977146920667276).
-  'single-body': 1.9488573460333638,
+  // |max| 4.112110463016779 / 2  [MEASURED 2026-08-03, exhaustive grid n=7920,
+  // AFTER agent monica moved to the degree-level 5-fold dignity manifest].
+  // Was 1.9488573460333638 from |max| 3.8977146920667276; before that 1.9875
+  // from |max| 3.9751 under the floor.
+  //
+  // ⚠️ The extremum CHANGED BODIES: Neptune / Aquarius / 2° / nocturnal →
+  // Mercury / Gemini / 2° / nocturnal (monica -4.112110463016779). Mercury in
+  // Gemini is the manifest's strongest Mercury — domicile +5, Air nocturnal
+  // triplicity +3, its own Egyptian term +2 → 𝒟 = 1.20 — and the old
+  // sign-level scale could only ever give it +10 → 1.10. A |max|-derived scale
+  // is hostage to whichever single row is most extreme, so record WHICH row:
+  // this one is now a well-dignified classical body rather than an outer
+  // planet, which is the more defensible anchor of the two.
+  'single-body': 2.0560552315083895,
   // |max| 2.810778645909833 / 2  [MEASURED 2026-07-25, exhaustive two-body grid
   // n=5760, AFTER the exact-zero kalchm fix AND the switch to a structural
   // degeneracy test]. Was 2.7095 from |max| 5.4191.

--- a/src/utils/agentMonica.ts
+++ b/src/utils/agentMonica.ts
@@ -19,7 +19,11 @@
  *              × (1 + dignity / 100)
  *
  * where the degree selects one of the 14 alchemical processes (§7a) and dignity
- * is the planet's own essential dignity at its sign (the +10/+7/-7/-10 scale).
+ * is the planet's own essential dignity at its DEGREE, from the 5-fold manifest
+ * (domicile/exaltation/triplicity/term/face, summed, as (𝒟−1)×100). It replaced
+ * the sign-level +10/+7/0/−7/−10 scale; the same degree that picks the process
+ * now also resolves the term and face, and sect matters because triplicity
+ * rulership is sect-dependent.
  * The sect-resolved ESMS plus the vessel goes through the canonical
  * data/unified thermodynamics. Both sects are returned — a position expresses
  * differently by day and night.
@@ -32,6 +36,12 @@
  * equilibrium band and correctly return φ regardless of dignity. Any all-zero /
  * unknown-planet input also resolves to φ, never NaN.
  */
+import {
+  dignityFoldsAtLongitude,
+  toLegacyEsmsScale,
+  longitudeFromSignDegree,
+  type ManifestPlanet,
+} from "@/calculations/dignityManifest";
 import { ALCHEMICAL_PILLARS } from "@/constants/alchemicalPillars";
 import {
   calculateKalchm,
@@ -39,7 +49,6 @@ import {
   calculateThermodynamics,
 } from "@/data/unified/alchemicalCalculations";
 import type { AlchemicalProperties } from "@/types/celestial";
-import { getDignityScore } from "@/utils/dignityScales";
 import {
   PLANETARY_SECTARIAN_ESMS,
   ZODIAC_ELEMENTS,
@@ -73,7 +82,11 @@ function toSignKey(sign: string): SignKey | null {
 
 /**
  * The process-shaped, dignity-scaled grounding vessel for a given degree.
- * `dignityEsmsScale` is the +10/+7/0/-7/-10 essential-dignity score.
+ * `dignityEsmsScale` is the percentage form of the applied dignity multiplier,
+ * (𝒟 − 1) × 100 — now sourced from the degree-level 5-fold manifest rather than
+ * the retired sign-level +10/+7/0/−7/−10 scale. The `/100` arithmetic below is
+ * unchanged because the field is still a percentage; only its resolution and
+ * range moved (±10% → −18%…+22%).
  *
  * Exported so the two-body phase calc (§18i) reuses this exact construction
  * rather than forking a second one — the §17c lesson was that a forked formula
@@ -129,7 +142,16 @@ export function agentMonicaForSect(
   const base: ESMS = sectTable ? { ...ZERO_ESMS, ...sectTable[sect] } : ZERO_ESMS;
 
   const signKey = toSignKey(sign);
-  const dignityScale = signKey ? getDignityScore(planet, signKey).esmsScale : 0;
+  // Degree-level 5-fold dignity. This call site already carries both the degree
+  // and the sect, so it resolves exactly — no sign-mean fallback is needed, and
+  // sect matters here because triplicity rulership is sect-dependent.
+  const dignityLongitude = signKey ? longitudeFromSignDegree(signKey, degree) : null;
+  const dignityScale =
+    dignityLongitude === null
+      ? 0
+      : toLegacyEsmsScale(
+          dignityFoldsAtLongitude(planet as ManifestPlanet, dignityLongitude, sect).score,
+        );
   const v = groundingVessel(degree, dignityScale);
 
   const esms: ESMS = {

--- a/src/utils/agentMonicaTwoBody.ts
+++ b/src/utils/agentMonicaTwoBody.ts
@@ -84,15 +84,31 @@
  *
  *  5. **Dignity — the two bodies SOURCE it differently, but APPLY it identically.**
  *       • Moon → POSITION-based: its own essential dignity at its own sign,
- *         the +10/+7/0/−7/−10 scale (`getDignityScore`).
+ *         the degree-level 5-fold dignity manifest (`dignityFoldsAtLongitude`).
  *       • Sun  → ASPECT-based, NOT position-based. Its longitude is *inferred*
  *         from the phase name, but the *aspect* is stated by the name with
  *         certainty. Scaling by a guessed position would compound an inference;
  *         reading dignity off the aspect uses the one thing the name guarantees.
  *
- *     Different SOURCES, identical APPLICATION: each is a ±10-scale number and
- *     each multiplies exactly one thing, `× (1 + dignity/100)` on its own body's
- *     ESMS. Neither touches the shared vessel (see 2).
+ *     Different SOURCES, identical APPLICATION: each multiplies exactly one
+ *     thing, `× (1 + dignity/100)` on its own body's ESMS. Neither touches the
+ *     shared vessel (see 2).
+ *
+ *     ⚠️ **RANGE ASYMMETRY, OPEN.** This note used to read "each is a ±10-scale
+ *     number", and that stopped being true when the Moon moved to the 5-fold
+ *     manifest. The Moon's position dignity now spans −18…+22 (summed folds over
+ *     50), while the Sun's ASPECT_DIGNITY is still anchored to the retired
+ *     ±10 sign-level scale — conjunction +10, opposition −10, chosen precisely
+ *     because "±10 land exactly on the domicile/fall anchors of the existing
+ *     dignity scale" (see the provenance note below). Those anchors moved.
+ *
+ *     The APPLICATION is still symmetric and each dignity still has exactly one
+ *     point of leverage, so this is not the two-points-of-leverage defect fixed
+ *     above. But the Moon now carries roughly twice the Sun's dynamic range in
+ *     a calculation whose whole premise is a two-body RELATIONSHIP. Rescaling
+ *     ASPECT_DIGNITY to the new anchors is a model change to how minor aspects
+ *     are valued, so it is NOT done here — recorded as an open decision rather
+ *     than silently introduced.
  *
  * ── Provenance of the numbers ───────────────────────────────────────────────
  *
@@ -217,6 +233,11 @@
  * 4280 rows already in production.
  */
 import {
+  dignityFoldsAtLongitude,
+  toLegacyEsmsScale,
+  longitudeFromSignDegree,
+} from "@/calculations/dignityManifest";
+import {
   MONICA_EQUILIBRIUM,
   calculateKalchm,
   calculateMonica,
@@ -229,7 +250,6 @@ import {
   type ESMS,
   type Sect,
 } from "@/utils/agentMonica";
-import { getDignityScore } from "@/utils/dignityScales";
 import {
   PLANETARY_SECTARIAN_ESMS,
   ZODIAC_ELEMENTS,
@@ -738,8 +758,15 @@ export function twoBodyState(
   const sunSignKey = toSignKey(sun.sign);
   if (!sunSignKey) return DEGENERATE_STATE;
 
-  // Moon: position-based essential dignity at its own sign.
-  const moonDignity = getDignityScore("Moon", moonSignKey).esmsScale;
+  // Moon: position-based essential dignity at its own DEGREE, from the 5-fold
+  // manifest. moonDegree is finite by the guard above, so this resolves exactly.
+  // Sect is passed because triplicity rulership is sect-dependent, and the Moon
+  // is the Water participating ruler in both sects.
+  const moonLongitude = longitudeFromSignDegree(moonSignKey, moonDegree);
+  if (moonLongitude === null) return DEGENERATE_STATE;
+  const moonDignity = toLegacyEsmsScale(
+    dignityFoldsAtLongitude("Moon", moonLongitude, sect).score,
+  );
   // Sun: aspect-based dignity, scaled by applying/separating.
   const sunDignity =
     ASPECT_DIGNITY[geometry.aspect] *


### PR DESCRIPTION
Follow-up to #721. That PR moved the ESMS engine to the degree-level 5-fold dignity manifest but left three call sites on the retired sign-level +10/+7/0/−7/−10 scale, so TypeScript was running **two dignity models side by side**. This closes that.

## Migrated

All three sites turned out to have exact geometry available, so none needed a fallback it couldn't justify:

| Site | Longitude | Sect |
|---|---|---|
| `agentMonica.ts:132` | `degree` already a parameter | `sect` already a parameter |
| `agentMonicaTwoBody.ts:742` | `moonDegree`, finite by the guard above | `sect` parameter |
| `NatalTransitChart.tsx:290` | `PlanetInfo.position` | derived from `birthData.dateTime` |

The chart honours `PlanetInfo.position`'s documented contract — `position <= 0` means unknown/legacy, **not** 0° Aries. Placement keeps its 15° sign-midpoint convention so the glyph still lands, but `longitude` stays null and dignity falls back to E[𝒟 | sign] rather than inheriting the midpoint's term and face.

## A bug an existing invariant caught

The first pass computed longitude as `SIGNS.indexOf(signKey) * 30 + degree`. `SIGNS` is lowercase; `toSignKey` returns **Title-case**. `indexOf` returned `-1` for all twelve signs, silently mapping every sign to one wrong longitude instead of failing.

It surfaced only because `agentMonicaTwoBody` asserts Moon-domicile and Moon-detriment must differ — and they had become identical. Fixed by adding `longitudeFromSignDegree`, which normalises case and returns `null` on an unknown sign, so no call site writes a raw `indexOf` again.

## A rendering bug the retune avoids

`SIGN_VECTOR_GAIN` 90 → 40. The old gain was fitted to the sign-level ±7/±10% span. At gain 90 the manifest's worst debility computes to `15 + (0.82 − 1) × 90 = −1.2px` — a **negative** arrow length, which SVG draws inverted rather than short. Gain 40 maps the wider range back onto essentially the original band (7.8–23.8px vs 8.7–24.0px).

## Re-derived

`MONICA_POPULATION_SCALE['single-body']`: 1.9488573460333638 → **2.0560552315083895**.

The extremum **changed bodies** — Neptune/Aquarius/2°/nocturnal → **Mercury/Gemini/2°/nocturnal**, |max| 3.8977146920667276 → 4.112110463016779. Mercury in Gemini is the manifest's strongest Mercury: domicile +5, Air nocturnal triplicity +3, its own Egyptian term +2 → 𝒟 = 1.20, where the old scale could only reach 1.10. A |max|-derived scale is hostage to one row, so *which* row is now recorded — and it's a well-dignified classical body rather than an outer planet.

Two-body |max| is unchanged at 4.416554679000386, so the two-body-exceeds-single-body inequality still holds, by less: ratio 1.1331 → 1.0740.

## Pinned values must be measured under jest

Monica runs through `Math.log`/`exp`, which ECMAScript leaves implementation-defined. Jest is Node/V8; `bun run` is JSC. **Measured:** `Moon Cancer` nocturnal is `...181878` under jest and `...181879` under bun — one ULP, enough to fail an exact `toBe`. This repo already documented that hazard for the population scale; the note is now attached to the resolver pins too.

## ⚠️ Open decision, deliberately not resolved here

`agentMonicaTwoBody` now has a **range asymmetry**. The Moon's position dignity spans −18…+22, while the Sun's `ASPECT_DIGNITY` is still anchored to the retired scale's ±10 — chosen precisely because "±10 land exactly on the domicile/fall anchors of the existing dignity scale". Those anchors moved.

Application stays symmetric and each dignity still has exactly one point of leverage, so this is **not** the two-points-of-leverage defect that module already fixed. But the Moon now carries roughly twice the Sun's dynamic range in a calculation whose premise is a two-body *relationship*. Rescaling `ASPECT_DIGNITY` is a model change to how minor aspects are valued, so it's recorded in the module docstring rather than silently introduced.

## Deploy note

Agent grid re-measured: 3600 cells, **all finite**, |combined| max 3.8339, 166 exact zeros. Stored single-body monica rows will disagree with live computation until backfilled — a post-deploy step, not a pre-deploy one, for the same reason #721 deferred its archetype backfill.

## Verification

- TS: **1997 passed / 201 suites**, 9 skipped, 0 failed
- Python: **75 passed** (untouched by this branch — it never used the TS sign-level scale)
- `bun run typecheck` clean, `eslint` clean (19 pre-existing warnings elsewhere, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)