### PR TITLE
docs(physics): re-anchor the aspect-dignity note, and enforce it with tests

### DIFF
--- a/src/__tests__/utils/agentMonicaTwoBody.test.ts
+++ b/src/__tests__/utils/agentMonicaTwoBody.test.ts
@@ -38,6 +38,11 @@ import {
   parseAgentPlacement,
   twoBodyMonicaFromName,
 } from "@/utils/agentMonicaResolver";
+import {
+  DIGNITY_POINTS,
+  toLegacyEsmsScale,
+} from "@/calculations/dignityManifest";
+import { inertialMassWeight } from "@/utils/planetaryAlchemyMapping";
 
 const SIGNS = [
   "Aries", "Taurus", "Gemini", "Cancer", "Leo", "Virgo",
@@ -206,11 +211,20 @@ describe("ASPECT_DIGNITY — [DERIVED] from aspectCalculator.ts", () => {
     expect(ASPECT_DIGNITY.sesquisquare).toBeCloseTo(-3.75, 10);
   });
 
-  it("keeps the sanity property: ±10 are the domicile/fall anchors and square sits between detriment and fall", () => {
+  it("keeps the sanity property: ±10 are single-fold anchors and square sits between the two debilities", () => {
     expect(Math.abs(ASPECT_DIGNITY.conjunction)).toBe(10);
     expect(Math.abs(ASPECT_DIGNITY.opposition)).toBe(10);
-    expect(ASPECT_DIGNITY.square).toBeLessThan(-7); // past detriment
-    expect(ASPECT_DIGNITY.square).toBeGreaterThan(-10); // not past fall
+    // Bounds come from the manifest's single folds, not from retired literals.
+    // This test used to read `< -7 // past detriment` and `> -10 // not past
+    // fall`, which were the SIGN-LEVEL scale's values. Under the manifest those
+    // two swapped: detriment alone is −10 and fall alone is −8, so the same
+    // −8.75 now sits past fall and short of detriment. The assertions were
+    // numerically unchanged and silently passed while their comments inverted —
+    // deriving the bounds keeps that from recurring.
+    expect(ASPECT_DIGNITY.square).toBeLessThan(toLegacyEsmsScale(DIGNITY_POINTS.fall));
+    expect(ASPECT_DIGNITY.square).toBeGreaterThan(
+      toLegacyEsmsScale(DIGNITY_POINTS.detriment),
+    );
   });
 });
 
@@ -647,5 +661,64 @@ describe("twoBodyMonicaFromName — the resolver seam", () => {
     expect(() =>
       twoBodyMonicaFromName("Blorp Moon in Cancer 0 Degree"),
     ).toThrow(UnknownMoonPhaseError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The aspect-dignity anchor — enforcing the module note in section 5
+// ---------------------------------------------------------------------------
+
+describe("ASPECT_DIGNITY is anchored to a single dignity FOLD, not to the stack", () => {
+  // These exist because the range gap between the Moon (−18…+22) and the Sun
+  // (±10) reads as "the Sun was left behind on the retired sign-level scale"
+  // and invites a well-meaning rescale. It is not a defect. The module note in
+  // section 5 argues why; this turns that argument into assertions, so a
+  // rescale fails here and is pointed at the note instead of shipping.
+
+  const fold = (k: keyof typeof DIGNITY_POINTS) => toLegacyEsmsScale(DIGNITY_POINTS[k]);
+
+  it("keeps ±10 on real single-fold anchors — domicile and DETRIMENT", () => {
+    // The anchor never moved. What moved is WHICH debility carries it: fall
+    // alone is −8 under the manifest, detriment alone is −10.
+    expect(fold("domicile")).toBe(10);
+    expect(fold("detriment")).toBe(-10);
+    expect(fold("fall")).toBe(-8);
+
+    expect(ASPECT_DIGNITY.conjunction).toBe(fold("domicile"));
+    expect(ASPECT_DIGNITY.opposition).toBe(fold("detriment"));
+  });
+
+  it("keeps square between the two debilities rather than off the end", () => {
+    // −10 < −8.75 < −8. The gap it falls into is now fall…detriment, where on
+    // the sign-level scale it was detriment (−7)…fall (−10).
+    expect(ASPECT_DIGNITY.square).toBeGreaterThan(fold("detriment"));
+    expect(ASPECT_DIGNITY.square).toBeLessThan(fold("fall"));
+  });
+
+  it("stays symmetric, because conjunction and opposition share an orb budget", () => {
+    // The stacked manifest range is ASYMMETRIC (+22 / −18) because Mercury
+    // uniquely rules AND is exalted in one sign. Aspect dignity cannot inherit
+    // that: equal orb budgets force equal magnitudes.
+    expect(ASPECT_ORB_BUDGET.conjunction).toBe(ASPECT_ORB_BUDGET.opposition);
+    expect(ASPECT_DIGNITY.conjunction).toBe(-ASPECT_DIGNITY.opposition);
+  });
+
+  it("gives the Sun MORE absolute leverage than the Moon, despite the narrower band", () => {
+    // Range is not leverage — each dignity multiplies its own body's ESMS,
+    // which is mass-weighted. This is the measurement that retires the
+    // "solar under-weighting" reading of the range gap.
+    const STACK_MAX = toLegacyEsmsScale(11); // +22, Mercury in Virgo
+    const STACK_MIN = toLegacyEsmsScale(-9); // −18, Mercury in Pisces
+    expect([STACK_MAX, STACK_MIN]).toEqual([22, -18]);
+
+    const sunSwing =
+      inertialMassWeight("Sun") *
+      ((1 + ASPECT_DIGNITY.conjunction / 100) - (1 + ASPECT_DIGNITY.opposition / 100));
+    const moonSwing =
+      inertialMassWeight("Moon") * ((1 + STACK_MAX / 100) - (1 + STACK_MIN / 100));
+
+    expect(sunSwing).toBeCloseTo(0.2, 12);
+    expect(moonSwing).toBeCloseTo(0.0761, 4);
+    expect(sunSwing).toBeGreaterThan(moonSwing * 2.5);
   });
 });

--- a/src/utils/agentMonicaTwoBody.ts
+++ b/src/utils/agentMonicaTwoBody.ts
@@ -94,21 +94,49 @@
  *     thing, `× (1 + dignity/100)` on its own body's ESMS. Neither touches the
  *     shared vessel (see 2).
  *
- *     ⚠️ **RANGE ASYMMETRY, OPEN.** This note used to read "each is a ±10-scale
- *     number", and that stopped being true when the Moon moved to the 5-fold
- *     manifest. The Moon's position dignity now spans −18…+22 (summed folds over
- *     50), while the Sun's ASPECT_DIGNITY is still anchored to the retired
- *     ±10 sign-level scale — conjunction +10, opposition −10, chosen precisely
- *     because "±10 land exactly on the domicile/fall anchors of the existing
- *     dignity scale" (see the provenance note below). Those anchors moved.
+ *     ⚠️ **THE RANGE GAP IS NOT A DEFECT — MEASURED, DO NOT "FIX" IT.**
  *
- *     The APPLICATION is still symmetric and each dignity still has exactly one
- *     point of leverage, so this is not the two-points-of-leverage defect fixed
- *     above. But the Moon now carries roughly twice the Sun's dynamic range in
- *     a calculation whose whole premise is a two-body RELATIONSHIP. Rescaling
- *     ASPECT_DIGNITY to the new anchors is a model change to how minor aspects
- *     are valued, so it is NOT done here — recorded as an open decision rather
- *     than silently introduced.
+ *     The Moon's position dignity spans −18…+22 while the Sun's ASPECT_DIGNITY
+ *     spans ±10, and that gap looks like the Sun was left behind on the retired
+ *     sign-level scale when the Moon moved to the 5-fold manifest. It was not.
+ *     This note is here because that reading was flagged once already and is
+ *     wrong on three counts.
+ *
+ *     1. ±10 IS STILL AN EXACT ANCHOR. On the manifest's percentage scale the
+ *        SINGLE folds are domicile +10, exaltation +8, triplicity +6, term +4,
+ *        face +2, detriment −10, fall −8. Domicile is still exactly +10 and
+ *        detriment exactly −10 — the same numbers the aspect magnitude was
+ *        anchored to. Only WHICH state carries the negative anchor moved: it is
+ *        detriment now, not fall (fall alone is −8). See the provenance note.
+ *
+ *     2. −18…+22 IS A STACKING ARTIFACT, NOT A WIDER UNIT. It is reachable only
+ *        because essential-dignity folds COMBINE — Mercury in Virgo takes
+ *        domicile +5, exaltation +4 and its own term +2 for +11, being the one
+ *        body that rules AND is exalted in a single sign. An aspect is one
+ *        relationship between one pair; nothing stacks. Stretching ±10 to that
+ *        range would import a combinatorial artifact of essential dignity into
+ *        aspect space. It is also ASYMMETRIC (+22 / −18) for the same reason,
+ *        while aspect dignity is structurally symmetric: conjunction and
+ *        opposition share an orb budget of 8, so the derivation below FORCES
+ *        their magnitudes equal.
+ *
+ *     3. THE LEVERAGE WORRY INVERTS WHEN MEASURED. Range is not leverage —
+ *        each dignity multiplies its own body's ESMS, which is mass-weighted.
+ *        MEASURED 2026-08-03, inertialMassWeight Sun 1.0, Moon 0.19035564925573695:
+ *
+ *            Sun   ±10        → 1.0     × 0.20 = 0.200 absolute ESMS swing
+ *            Moon  −18…+22    → 0.19036 × 0.40 = 0.076 absolute ESMS swing
+ *
+ *        The Sun already carries 2.6× the Moon's actual leverage despite the
+ *        narrower band. There is no solar under-weighting to correct.
+ *
+ *     What WOULD be a real question — and is NOT settled by any of the above —
+ *     is whether one aspect should be commensurate with one FOLD or with a whole
+ *     STACK. That is a physics ruling with an argument on both sides, and it
+ *     would need the two-body grid measured under both. It is not a units fix,
+ *     and geometry cannot answer it: the derivation below already supplies
+ *     everything geometry can (polarity and the orbBudget/8 shape, both read
+ *     from live code), and magnitude is dimensionless.
  *
  * ── Provenance of the numbers ───────────────────────────────────────────────
  *
@@ -123,9 +151,17 @@
  *                   _sesquiquadrate 3
  *
  * giving conjunction +10, opposition −10, square −8.75, semisquare −3.75,
- * sesquisquare −3.75. Sanity property: ±10 land exactly on the domicile/fall
- * anchors of the existing dignity scale, and square falls between detriment
- * (−7) and fall (−10) rather than off the end.
+ * sesquisquare −3.75.
+ *
+ * Sanity property, RE-ANCHORED for the 5-fold dignity manifest: ±10 still land
+ * exactly on single-fold anchors, but on **domicile (+10) and DETRIMENT (−10)**
+ * — not domicile/fall as this note read while Layer 2 was the sign-level
+ * +10/+7/0/−7/−10 scale. Under the manifest fall alone is −8 and detriment
+ * alone is −10, so the two debilities swapped which one sits at the anchor.
+ * Square (−8.75) still lands between them rather than off the end; the gap it
+ * falls into is now fall (−8) … detriment (−10), where it used to be detriment
+ * (−7) … fall (−10). The magnitude is unchanged and needs no recalibration —
+ * see the range-gap note in section 5 above before concluding otherwise.
  *
  * ⚠️ **Giving semisquare / sesquisquare a nonzero dignity is a MODEL CHANGE,
  * not a gap-fill.** `aspectCalculator.ts:209-215` assigns `influence = 0` to


### PR DESCRIPTION
Corrects a claim I introduced in #722, and turns the corrected version into assertions so it can't rot.

#722's docstring recorded the range gap between the Moon's position dignity (−18…+22) and the Sun's `ASPECT_DIGNITY` (±10) as an **open asymmetry**, reading it as the Sun having been left behind on the retired sign-level scale. Measurement says otherwise on three counts.

## 1. ±10 is still an exact anchor

On the manifest's percentage scale the **single** folds are:

```
domicile   +10      detriment  −10
exaltation  +8      fall        −8
triplicity  +6
term        +4
face        +2
```

Domicile is still exactly **+10** and detriment exactly **−10** — the same numbers the aspect magnitude was anchored to. Only *which* debility carries the negative anchor moved: detriment now, not fall.

## 2. −18…+22 is a stacking artifact, not a wider unit

That range is reachable only because essential-dignity folds **combine** — Mercury in Virgo takes domicile +5, exaltation +4 and its own term +2 for +11, being the one body that rules *and* is exalted in a single sign. An aspect is one relationship between one pair; nothing stacks.

It's also **asymmetric** (+22/−18) for that same reason, while aspect dignity is structurally symmetric: conjunction and opposition share an orb budget of 8, which forces equal magnitudes.

## 3. The leverage worry inverts when measured

Range is not leverage — each dignity multiplies its own body's *mass-weighted* ESMS.

| Body | Range | `inertialMassWeight` | Absolute ESMS swing |
|---|---|---|---|
| Sun | ±10 | 1.0 | **0.200** |
| Moon | −18…+22 | 0.19035564925573695 | **0.076** |

The Sun already carries **2.6× the Moon's leverage** despite the narrower band. There is no solar under-weighting to correct, so `ASPECT_DIGNITY_MAGNITUDE` stays 10 and the recalibration branch isn't needed.

## What stays genuinely open

Whether one aspect should be commensurate with one **fold** or with a whole **stack**. That's a physics ruling needing the two-body grid measured under both — not a units fix. Geometry can't settle it either: the derivation already supplies everything geometry can (polarity and the `orbBudget/8` shape, both read from live code), and magnitude is dimensionless.

## Enforced, not just documented

Four assertions turn the argument into checks, so a well-meaning rescale fails and gets pointed at the note:

- conjunction/opposition equal the domicile/detriment **folds** (not typed literals)
- square stays between the two debilities
- `conjunction === -opposition`, given equal orb budgets
- the Sun's absolute swing exceeds the Moon's by >2.5×

## A test that was passing with inverted prose

`"±10 are the domicile/fall anchors…"` asserted `square < -7 // past detriment` and `> -10 // not past fall`. Both are **sign-level** values. Under the manifest they swapped — detriment is −10, fall is −8 — so the same −8.75 is now past *fall* and short of *detriment*. The numbers still passed while both comments were wrong. Bounds are now derived from `DIGNITY_POINTS` rather than typed.

## Verification

- TS: **2001 passed / 201 suites**, 9 skipped, 0 failed
- Python: **75 passed** (untouched)
- typecheck and eslint clean

No behaviour change — documentation and tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)