### PR TITLE
docs(ops): record the 2026-08-03 monica-backfill disarm/re-arm cycle

### DIFF
--- a/.github/workflows/monica-backfill.yml
+++ b/.github/workflows/monica-backfill.yml
@@ -79,6 +79,56 @@
 # workflow_dispatch job: --max-new still bounds only NEW arrivals, so a future
 # engine change reopens exactly the same window. DISARM AGAIN before the next
 # one.
+#
+# ── ⚠️ 2026-08-03 — THE WINDOW REOPENED, EXACTLY AS PREDICTED ───────────────
+#
+# The sentence directly above is not hypothetical. It came true in eight days.
+#
+# PRs #721/#722 replaced Layer 2 with the degree-level 5-fold dignity manifest
+# in BOTH runtimes — a weight-derived-monica change of precisely the kind the
+# note warned about — and this workflow was NOT disarmed beforehand. It was
+# caught at 22:30 UTC with the 06:45 run ~8h away, while tracing write paths
+# for the follow-up backfill. Had it fired, all 5485 already-classified rows
+# would have been rewritten unattended, unbounded (--max-new gates only
+# `monica_method IS NULL`, and there were ZERO new arrivals that night, so it
+# would have bounded nothing at all).
+#
+# Disarmed via `gh workflow disable "Monica Backfill"` rather than a PR —
+# the CLI takes effect immediately, where a workflow-file change would not have
+# landed before 06:45. Use the CLI for the stop, a PR for the record.
+#
+# ── All three re-arm conditions met, 2026-08-03 ─────────────────────────────
+#
+#  1. DEPLOYED. Verified from each deployment's OWN commit SHA, never local git:
+#     Vercel production READY at 37240a492 (= origin/master HEAD); Railway
+#     service WhatToEatNext SUCCESS at b96a1e649 (#721). Railway showed #722 and
+#     #723 as SKIPPED — confirmed correct, not a failed deploy: both touched
+#     zero backend/ files, while #721 touched five.
+#  2. BACKFILL RAN. backfillMonicaPerConstruction.ts --write, one transaction,
+#     snapshot monica_preconstruction_20260803_225237. A SECOND, independent
+#     snapshot was taken first (snapshotAgentMonica.ts →
+#     agent_monica_snapshot_20260803_224249) so a crash during the migration's
+#     own initialisation could not leave us without a restore point.
+#  3. VERIFIED. checkAgentMonicaDrift.ts: 0 drift across all three populations
+#     (4358 single-body + 1056 two-body + 71 full-chart = 5485), accounting
+#     closed at 5541/5541 agents, every row matching a fresh computation to
+#     1e-5. §18o invariant re-checked post-write: monica_constant populated for
+#     single-body only, 0 for two-body and full-chart.
+#
+# POPULATION, RE-MEASURED. The two-body family is **1056** as of 2026-08-03.
+# It was 469 (2026-07-21), then 983 (2026-08-02), now 1056 — it has grown at
+# every single measurement, and every time some doc was still quoting the
+# previous figure. Do not quote this number either; run the dry run.
+#
+# One thing this cycle adds to the runbook: `alchemical_constitutions` was
+# deliberately NOT backfilled alongside. A control test (recompute with the OLD
+# dignity, compare to stored) FAILED on both recomputable rows, proving the
+# stored-vs-fresh gap was not attributable to the dignity change — it predates
+# it. Two of its four rows have no birth data at all. Backfilling it would have
+# applied unrelated physics drift, on degraded geometry (natal_chart.planets[]
+# carries no geocentric distance), under a "dignity backfill" label. Always
+# control a backfill against the OLD engine before attributing a delta to the
+# new one.
 # ────────────────────────────────────────────────────────────────────────────
 
 name: Monica Backfill

--- a/scripts/backfillPhaseMonica.ts
+++ b/scripts/backfillPhaseMonica.ts
@@ -7,8 +7,12 @@
  * ⚠️ POPULATION SIZE IS MEASURED, NOT ASSUMED. This docstring said "469" from
  * 2026-07-21 until 2026-08-02, when a dry run against production counted **983**
  * of 5399 agent rows in the phase family — the population had more than doubled
- * while every doc, PR body and ADR note kept quoting 469. Read the dry-run
- * report, never this sentence. A Moon
+ * while every doc, PR body and ADR note kept quoting 469.
+ *
+ * It went stale AGAIN within a day: the 2026-08-03 dry run counted **1056** of
+ * 5485. Three measurements, three different numbers, each one larger. This note
+ * proving its own point twice is the strongest argument for what it says —
+ * read the dry-run report, never this sentence. A Moon
  * phase is a Sun-Moon *relationship*, not a placement, so it gets a genuine
  * two-body construction rather than a single-body approximation. This writes
  * that value and stamps `monica_method = 'two-body-phase'`.

--- a/src/utils/agentMonicaTwoBody.ts
+++ b/src/utils/agentMonicaTwoBody.ts
@@ -4,8 +4,17 @@
  *
  * A phase agent ("First Quarter Moon in Cancer 0 Degree", "Moon Phase Dark Moon
  * 153") is not a placement. A phase is a Sun–Moon *relationship*, so it earns a
- * genuine two-body calculation rather than a scaled single-body one. 469 agent
- * rows are in this family. Until this lands they carry NULL in
+ * genuine two-body calculation rather than a scaled single-body one.
+ *
+ * ⚠️ POPULATION SIZE IS MEASURED, NOT ASSUMED — and this sentence has been
+ * wrong twice. It read "469 agent rows are in this family" from 2026-07-21
+ * until 2026-08-03. The true count was 983 by 2026-08-02 and **1056** by
+ * 2026-08-03: it has grown at every measurement, and each time the docs were
+ * still quoting the previous figure. Read the dry-run report of
+ * scripts/backfillPhaseMonica.ts or backfillMonicaPerConstruction.ts, never
+ * this number.
+ *
+ * Until the two-body work landed these rows carried NULL in
  * `monica_diurnal` / `monica_nocturnal` (the single-body backfill skipped them)
  * and the OLD FAKE `monica_constant` of 0.5 — not NULL. That fake sentinel is
  * what this replaces.


### PR DESCRIPTION
The workflow header warned that *"a future engine change reopens exactly the same window. **DISARM AGAIN before the next one.**"* That came true in eight days. The warning is only worth what the record behind it is worth, so this writes the cycle down.

Documentation only — no behaviour change.

## What happened

#721/#722 replaced Layer 2 with the degree-level 5-fold dignity manifest in both runtimes — a weight-derived-monica change of exactly the kind the note describes — and the nightly was **not** disarmed beforehand. Caught at 22:30 UTC with the 06:45 run ~8h out, while tracing write paths for the follow-up backfill.

Had it fired, all **5,485** already-classified rows would have been rewritten unattended and unbounded. `--max-new` gates only `monica_method IS NULL`, and there were **zero** new arrivals that night — so it would have bounded nothing whatsoever.

Disarmed with `gh workflow disable`, not a PR: the CLI takes effect immediately, where a workflow-file change could not have landed before 06:45. **CLI for the stop, PR for the record.** Now re-armed via `gh workflow enable`.

## The three re-arm conditions, recorded in full

1. **DEPLOYED** — verified from each deployment's *own* SHA, never local git. Vercel READY at `37240a492`; Railway SUCCESS at `b96a1e649`. Railway's `SKIPPED` on #722/#723 was confirmed correct watch-path behaviour (both touched zero `backend/` files; #721 touched five), not a failed deploy.
2. **BACKFILL RAN** — one transaction, snapshot `monica_preconstruction_20260803_225237`, preceded by an *independent* `snapshotAgentMonica.ts` run (`agent_monica_snapshot_20260803_224249`) so a crash during the migration's own initialisation couldn't leave us with no restore point.
3. **VERIFIED** — 0 drift across all three populations (4358 + 1056 + 71 = 5485), accounting closed at 5541/5541 agents, tolerance 1e-5. §18o invariant re-checked post-write: `monica_constant` populated for single-body only.

## Population re-measured; stale figures retired

The two-body family is **1,056**. It was **469** (07-21), then **983** (08-02), now **1,056** — larger at every single measurement, and every time some doc was still quoting the previous number.

- `agentMonicaTwoBody.ts` still said 469 → corrected, and now points at the dry-run report rather than stating a number.
- `backfillPhaseMonica.ts`'s "POPULATION SIZE IS MEASURED, NOT ASSUMED" note extended — it has now proven its own point **twice**.

## One addition to the runbook

`alchemical_constitutions` was deliberately **not** backfilled alongside. A control — recompute with the OLD dignity, compare to stored — **failed** on both recomputable rows, proving the stored-vs-fresh gap wasn't attributable to the dignity change; it predates it. Two of its four rows have no birth data at all.

Backfilling would have applied unrelated physics drift, on degraded geometry (`natal_chart.planets[]` carries no geocentric distance), under a "dignity backfill" label. The rule now written down: **control a backfill against the OLD engine before attributing any delta to the new one.**

## Verification

- Workflow change is comment-only: every added line is a comment, the trigger block is byte-unchanged, and `gh workflow view` still parses it.
- TS 2001 passed / 201 suites; typecheck and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)