### PR TITLE
fix(astro): seal the timezone boundary, and give stored charts real geometry

### DIFF
--- a/backend/tests/aspect_effects_golden.json
+++ b/backend/tests/aspect_effects_golden.json
@@ -1,0 +1,387 @@
+{
+  "_comment": "Layer 3 aspect-ESMS effect tables. Shared golden for TS<->Python parity. Order: [Spirit, Essence, Matter, Substance].",
+  "axes": [
+    "Spirit",
+    "Essence",
+    "Matter",
+    "Substance"
+  ],
+  "dignityAnchors": {
+    "_comment": "Layer 2 anchors the Layer 3 magnitudes are ruled commensurate with.",
+    "domicileFoldPoints": 5,
+    "fullStackPoints": 11,
+    "dignityScoreDivisor": 50
+  },
+  "tables": {
+    "Jupiter-Mercury": {
+      "biquintile": [
+        0.2,
+        0,
+        0,
+        0.1
+      ],
+      "conjunction": [
+        0.4,
+        0,
+        0,
+        0.2
+      ],
+      "inconjunct": [
+        0,
+        0,
+        0,
+        0
+      ],
+      "opposition": [
+        0.1,
+        0,
+        0,
+        0.2
+      ],
+      "quincunx": [
+        0,
+        0,
+        0,
+        0
+      ],
+      "quintile": [
+        0.2,
+        0,
+        0,
+        0.1
+      ],
+      "semi-sextile": [
+        0.1,
+        0,
+        0,
+        0
+      ],
+      "semisquare": [
+        0,
+        0,
+        0,
+        -0.05
+      ],
+      "sesquisquare": [
+        0,
+        0,
+        0,
+        -0.05
+      ],
+      "sextile": [
+        0.2,
+        0,
+        0,
+        0.1
+      ],
+      "square": [
+        -0.1,
+        0,
+        0,
+        -0.1
+      ],
+      "trine": [
+        0.3,
+        0,
+        0,
+        0.1
+      ]
+    },
+    "Mars-Venus": {
+      "biquintile": [
+        0,
+        0.2,
+        0.1,
+        0
+      ],
+      "conjunction": [
+        0,
+        0.4,
+        0.2,
+        0
+      ],
+      "inconjunct": [
+        0,
+        0,
+        0,
+        0.1
+      ],
+      "opposition": [
+        0,
+        -0.2,
+        0,
+        0.2
+      ],
+      "quincunx": [
+        0,
+        0,
+        0,
+        0.1
+      ],
+      "quintile": [
+        0,
+        0.2,
+        0.1,
+        0
+      ],
+      "semi-sextile": [
+        0,
+        0.1,
+        0,
+        0
+      ],
+      "semisquare": [
+        0,
+        0,
+        0.1,
+        0
+      ],
+      "sesquisquare": [
+        0,
+        0,
+        0.1,
+        0
+      ],
+      "sextile": [
+        0,
+        0.2,
+        0.1,
+        0
+      ],
+      "square": [
+        0,
+        -0.1,
+        0.3,
+        0
+      ],
+      "trine": [
+        0,
+        0.3,
+        0.1,
+        0
+      ]
+    },
+    "Moon-Sun": {
+      "biquintile": [
+        0.1,
+        0.05,
+        0,
+        0
+      ],
+      "conjunction": [
+        -0.5,
+        -0.5,
+        0,
+        0
+      ],
+      "inconjunct": [
+        0,
+        0,
+        0,
+        0.1
+      ],
+      "opposition": [
+        0.3,
+        0.3,
+        0,
+        0
+      ],
+      "quincunx": [
+        0,
+        0,
+        0,
+        0.1
+      ],
+      "quintile": [
+        0.1,
+        0.05,
+        0,
+        0
+      ],
+      "semi-sextile": [
+        0,
+        0.05,
+        0,
+        0
+      ],
+      "semisquare": [
+        0,
+        0,
+        0.1,
+        0
+      ],
+      "sesquisquare": [
+        0,
+        0,
+        0.1,
+        0
+      ],
+      "sextile": [
+        0.1,
+        0.1,
+        0,
+        0
+      ],
+      "square": [
+        -0.1,
+        -0.1,
+        0.2,
+        0
+      ],
+      "trine": [
+        0.2,
+        0.2,
+        0,
+        0
+      ]
+    },
+    "Saturn-Sun": {
+      "biquintile": [
+        0.1,
+        0,
+        0.2,
+        0
+      ],
+      "conjunction": [
+        -0.3,
+        0,
+        0.4,
+        0.2
+      ],
+      "inconjunct": [
+        0,
+        0,
+        0.1,
+        0.1
+      ],
+      "opposition": [
+        0,
+        0,
+        0.2,
+        0.3
+      ],
+      "quincunx": [
+        0,
+        0,
+        0.1,
+        0.1
+      ],
+      "quintile": [
+        0.1,
+        0,
+        0.2,
+        0
+      ],
+      "semi-sextile": [
+        0,
+        0,
+        0.1,
+        0
+      ],
+      "semisquare": [
+        -0.1,
+        0,
+        0.1,
+        0
+      ],
+      "sesquisquare": [
+        -0.1,
+        0,
+        0.1,
+        0
+      ],
+      "sextile": [
+        0.1,
+        0,
+        0.2,
+        0.1
+      ],
+      "square": [
+        -0.2,
+        0,
+        0.3,
+        0
+      ],
+      "trine": [
+        0.1,
+        0,
+        0.3,
+        0.2
+      ]
+    },
+    "__DEFAULT__": {
+      "biquintile": [
+        0.05,
+        0,
+        0,
+        0
+      ],
+      "conjunction": [
+        0.1,
+        0.1,
+        0,
+        0
+      ],
+      "inconjunct": [
+        0,
+        0,
+        0,
+        0.05
+      ],
+      "opposition": [
+        0,
+        0,
+        0.1,
+        0
+      ],
+      "quincunx": [
+        0,
+        0,
+        0,
+        0.05
+      ],
+      "quintile": [
+        0.05,
+        0,
+        0,
+        0
+      ],
+      "semi-sextile": [
+        0,
+        0,
+        0,
+        0
+      ],
+      "semisquare": [
+        0,
+        0,
+        0.05,
+        0
+      ],
+      "sesquisquare": [
+        0,
+        0,
+        0.05,
+        0
+      ],
+      "sextile": [
+        0.05,
+        0,
+        0,
+        0
+      ],
+      "square": [
+        0,
+        0,
+        0.1,
+        0
+      ],
+      "trine": [
+        0.05,
+        0.05,
+        0,
+        0
+      ]
+    }
+  }
+}

--- a/backend/tests/test_aspect_effects_parity.py
+++ b/backend/tests/test_aspect_effects_parity.py
@@ -1,0 +1,128 @@
+"""Cross-runtime parity for the Layer 3 aspect-ESMS effect tables.
+
+ESMS 2.0 RULED 2026-08-03, lambda = 1: the aspect layer is ratified AS MEASURED.
+A typical aspect is worth about one dignity FOLD; an exceptional one about a
+full dignity STACK. No global rescale was applied, because measurement showed
+the relationship already held. See the BASIS block in
+`backend/utils/aspect_esms_effects.py`.
+
+Layer 3 is a hand-authored per-planet-pair table duplicated in two runtimes.
+Nothing in either type system stops one from being edited without the other,
+and a one-sided edit is invisible: both runtimes keep computing, just different
+physics. The only real defence is that both must reproduce the same golden file
+-- backend/tests/aspect_effects_golden.json. The TypeScript half of this pair is
+src/__tests__/aspectDignityCommensurability.test.ts.
+
+DIVISION OF LABOUR, stated so nobody assumes this file checks more than it does:
+
+  * THIS file enforces TABLE PARITY -- the values, the aspect types, and the set
+    of authored pairs, plus the dignity anchors the ruling is stated against.
+  * The TypeScript half additionally enforces the DISTRIBUTIONAL ruling (median
+    aspect ~ one fold, p90 ~ one full stack), because that measurement needs an
+    ephemeris to generate real skies and this suite deliberately imports no
+    ephemeris. Table parity here plus the distribution there covers the ruling:
+    identical tables through an identical accumulator cannot produce different
+    distributions.
+
+Assertions are `==` on floats, deliberately, matching test_kalchm_parity.py.
+These are authored constants, not computed results -- there is no accumulated
+floating-point error to tolerate, and `pytest.approx` would wave through a
+table edit in the 4th decimal, which is exactly what this gate exists to catch.
+"""
+import json
+import os
+
+import pytest
+
+# Imports the effect tables, NOT the FastAPI app. Importing
+# backend.alchm_kitchen.main would pull in fastapi/sqlalchemy/pyswisseph and
+# this suite could not be COLLECTED without them -- a parity gate that cannot
+# run is worse than no gate, because its absence reads as a pass.
+from backend.utils.aspect_esms_effects import (
+    DEFAULT_ASPECT_EFFECTS,
+    PLANET_PAIR_ASPECT_EFFECTS,
+)
+from backend.utils.dignity_manifest import DIGNITY_POINTS, DIGNITY_SCORE_DIVISOR
+
+GOLDEN_PATH = os.path.join(os.path.dirname(__file__), "aspect_effects_golden.json")
+
+with open(GOLDEN_PATH) as handle:
+    GOLDEN = json.load(handle)
+
+TABLES = GOLDEN["tables"]
+AXES = GOLDEN["axes"]
+
+#: The measured ceiling of the summed 5-fold dignity score: Mercury 0-7 deg
+#: Virgo (domicile +5, exaltation +4, term +2). See DIGNITY_SCORE_DIVISOR.
+FULL_STACK_POINTS = 11
+
+
+def _normalize_pair(pair: str) -> str:
+    return "-".join(sorted(p[:1].upper() + p[1:].lower() for p in pair.split("-")))
+
+
+def _python_tables() -> dict:
+    return {
+        _normalize_pair(pair): {
+            aspect_type: [float(x) for x in effect]
+            for aspect_type, effect in by_type.items()
+        }
+        for pair, by_type in PLANET_PAIR_ASPECT_EFFECTS.items()
+    }
+
+
+def test_axis_order_matches_golden():
+    """The tables are positional tuples in Python and named fields in TS.
+
+    If the axis order ever disagrees, every value would still compare equal in
+    aggregate while Spirit silently became Essence. Pin the order explicitly.
+    """
+    assert AXES == ["Spirit", "Essence", "Matter", "Substance"]
+
+
+@pytest.mark.parametrize(
+    "pair", sorted(k for k in TABLES if k != "__DEFAULT__")
+)
+def test_authored_pair_table_matches_golden(pair):
+    tables = _python_tables()
+    assert pair in tables, f"Python is missing the authored pair {pair}"
+    for aspect_type, expected in TABLES[pair].items():
+        assert aspect_type in tables[pair], (
+            f"Python {pair} is missing aspect type {aspect_type}"
+        )
+        assert tables[pair][aspect_type] == expected, (
+            f"{pair}/{aspect_type} drifted from the TypeScript runtime"
+        )
+
+
+def test_default_fallback_table_matches_golden():
+    for aspect_type, expected in TABLES["__DEFAULT__"].items():
+        assert aspect_type in DEFAULT_ASPECT_EFFECTS, (
+            f"Python DEFAULT is missing aspect type {aspect_type}"
+        )
+        assert [float(x) for x in DEFAULT_ASPECT_EFFECTS[aspect_type]] == expected, (
+            f"DEFAULT/{aspect_type} drifted from the TypeScript runtime"
+        )
+
+
+def test_authors_exactly_the_pairs_the_golden_records():
+    """Catches an ADDED pair table, which the per-pair parametrization cannot see."""
+    expected = sorted(k for k in TABLES if k != "__DEFAULT__")
+    assert sorted(_python_tables()) == expected
+
+
+def test_every_authored_pair_covers_every_default_aspect_type():
+    """A pair table missing a type silently falls back to DEFAULT in TS
+    (`pairEffects[aspectType]` is undefined -> DEFAULT) but raises KeyError in
+    Python. Same input, different behaviour -- so require full coverage.
+    """
+    types = set(DEFAULT_ASPECT_EFFECTS)
+    for pair, by_type in _python_tables().items():
+        assert set(by_type) == types, f"{pair} does not cover every aspect type"
+
+
+def test_dignity_anchors_the_ruling_is_stated_against():
+    anchors = GOLDEN["dignityAnchors"]
+    assert anchors["domicileFoldPoints"] == DIGNITY_POINTS["domicile"]
+    assert anchors["fullStackPoints"] == FULL_STACK_POINTS
+    assert anchors["dignityScoreDivisor"] == DIGNITY_SCORE_DIVISOR

--- a/backend/utils/aspect_esms_effects.py
+++ b/backend/utils/aspect_esms_effects.py
@@ -4,6 +4,54 @@ Python port of ``src/utils/aspectCalculator.ts`` plus
 ``src/utils/aspectESMSEffects.ts``. Aspect geometry is derived from absolute
 longitudes (or sign + degree), then the strongest in-orb aspect per pair is
 scaled by the same cosine bell and archetypal ESMS table as TypeScript.
+
+ASPECT-DIGNITY COMMENSURABILITY
+===============================
+``[RULED 2026-08-03, lambda = 1]`` -- the aspect layer is ratified AS MEASURED.
+A single aspect is commensurate with a single dignity FOLD at the median and
+with a full dignity STACK at the tail. No scaling constant is applied.
+
+BASIS: MEASURED over 48 fixed skies (1970-2025), 1743 aspects. Reproduce with
+``src/__tests__/aspectDignityCommensurability.test.ts``. Additivity residual
+``|sum(parts) - total|`` was exactly 0, so the layer decomposition is valid.
+
+The two layers are not the same kind of quantity, which is why this needed
+ruling at all: Layer 2 (dignity) is a per-planet MULTIPLIER, ``D = 1 + score/50``
+(``dignity_manifest.py``), while Layer 3 (this module) is an ADDITIVE term on
+the chart totals. Nothing structurally ties them together.
+
+Measured, in gross ESMS units summed over all four axes:
+
+===========================================  ========  =======  ========
+quantity                                     value     x fold   x stack
+===========================================  ========  =======  ========
+one domicile fold (+5), D=1.10               0.0468    1.00     0.45
+full stack (+11, Mercury 0-7 deg Virgo)      0.1029    2.20     1.00
+single aspect, p50                           0.0352    0.75     0.34
+single aspect, mean                          0.0514    1.10     0.50
+single aspect, p90                           0.1000    2.14     0.97
+single aspect, p100                          0.8998    19.2     8.75
+===========================================  ========  =======  ========
+
+The distribution is already BRACKETED by the two dignity anchors: the median
+aspect sits just below one fold and p90 lands on the full-stack ceiling. That
+is the commensurability the ruling wanted, so lambda = 1 changes no number.
+
+REJECTED -- stack-commensurate scaling (lambda = 2.0012, making the MEAN aspect
+equal a full stack). It doubles the layer and moves ESMS shares by up to
+10.98 percentage points, which would move every threshold stabilised under
+ADR-009. This is the same magnitude argument that rejected DIGNITY_SCORE_DIVISOR
+= 10 in favour of 50 (see ``dignity_manifest.py``). For reference the other
+modelled options were: exact fold parity, lambda = 0.9102 -> 1.25pp; per-aspect
+cap at the stack ceiling -> 8.27pp (7.6% of aspects capped); aspects off -> 17.97pp.
+
+KNOWN, NOT FIXED: 7.6% of aspects exceed a full dignity stack, topping out at
+8.75x (the Sun-Moon conjunction at +/-0.5 per axis). Capping the tail was
+modelled and deliberately not adopted -- at 8.27pp it costs nearly as much as
+the rescale it would prevent.
+
+Enforced by ``backend/tests/test_aspect_effects_parity.py`` (table parity) and
+the TypeScript suite above (the distributional ruling).
 """
 
 import math

--- a/backend/utils/celestial_calculations.py
+++ b/backend/utils/celestial_calculations.py
@@ -330,8 +330,18 @@ def calculate_planetary_positions_pyephem(
                 lon_deg = math.degrees(float(ecl_now.lon)) % 360
                 lat_deg = math.degrees(float(ecl_now.lat))
                 # pyephem reports earth_distance in AU for all bodies (including Moon).
+                #
+                # When it is absent, emit None rather than a literal 1.0. A
+                # fabricated 1.0 is INDISTINGUISHABLE from a real measurement
+                # downstream, so it defeats every mean-distance fallback that
+                # exists to handle a missing range: get_gravitational_inertia
+                # here, and resolveGeocentricDistanceAu in the TypeScript
+                # runtime, both substitute the body's own rbar when the distance
+                # is absent but accept any positive number as measured truth.
+                # 1.0 AU would put Pluto (rbar 35.53) at Earth's orbit.
+                # Every reader already uses .get("distance", None).
                 dist_au = float(planet_obj.earth_distance) \
-                    if hasattr(planet_obj, "earth_distance") else 1.0
+                    if hasattr(planet_obj, "earth_distance") else None
 
                 # Finite-difference velocity at t + 1 hour
                 future_planet = type(planet_obj)()
@@ -340,12 +350,19 @@ def calculate_planetary_positions_pyephem(
                 lon_next = math.degrees(float(ecl_next.lon)) % 360
                 lat_next = math.degrees(float(ecl_next.lat))
                 dist_next = float(future_planet.earth_distance) \
-                    if hasattr(future_planet, "earth_distance") else dist_au
+                    if hasattr(future_planet, "earth_distance") else None
 
                 d_lon = ((lon_next - lon_deg + 540) % 360) - 180  # wrap to (-180, 180]
                 longitude_speed = d_lon / DT_DAYS
                 latitude_speed = (lat_next - lat_deg) / DT_DAYS
-                distance_speed = (dist_next - dist_au) / DT_DAYS
+                # Absent either endpoint there is no rate to report. None, not
+                # 0.0: a zero here would read as "range is not changing", which
+                # is a measurement, whereas None is the honest "not measured".
+                distance_speed = (
+                    (dist_next - dist_au) / DT_DAYS
+                    if dist_au is not None and dist_next is not None
+                    else None
+                )
 
                 is_retrograde = (
                     longitude_speed < 0

--- a/scripts/backfillChartGeocentricDistance.ts
+++ b/scripts/backfillChartGeocentricDistance.ts
@@ -1,0 +1,289 @@
+#!/usr/bin/env bun
+/**
+ * One-off backfill: add true geocentric distances to stored natal charts.
+ *
+ * ── SCOPE IS 4 CHARTS, NOT ~73 (measured against prod 2026-08-04) ───────────
+ *
+ * `user_profiles` holds 5498 rows. 75 have a non-empty `natal_chart`, and 0 of
+ * them carry a distance on any planet. But those 75 are TWO different shapes:
+ *
+ *   71 rows  {aspects, planets}  planets is an OBJECT   <- NOT backfillable
+ *    4 rows  full NatalChart     planets is an ARRAY    <- the real target
+ *
+ * The 71 are placeholder profiles, not user geometry, and backfilling them
+ * would fabricate precision rather than recover it:
+ *   - every one belongs to an AGENT (`users.is_agent`); zero humans;
+ *   - they share ONE birth instant — 1900-01-01T12:00:00.000Z (50 rows) or
+ *     null (21) — at the hardcoded 40.7498/-73.7976 "Fallback NY" coordinate,
+ *     so all 71 would receive byte-identical distances;
+ *   - their planet entries are `{sign, house, degree, retrograde}` with NO
+ *     longitude anywhere (0 of 71 mention one), so a precise AU distance would
+ *     be the only exact field on an otherwise sign-only chart. `chartDataUtils`
+ *     would then feed that precision into `getGravitationalInertia` while
+ *     dignity still resolves at sign-mean. Incoherent, and worse than the
+ *     honest absence it replaces.
+ *
+ * This script therefore refuses the object-shaped rows by construction and
+ * reports them, rather than silently counting them as "done".
+ *
+ * ── THIS IS A LIVE PHYSICS CHANGE, NOT METADATA ─────────────────────────────
+ *
+ * The field is written as `distance` (NOT `distanceAu`): `chartDataUtils`
+ * forwards `planets[].distance` into the positions record that reaches
+ * `getGravitationalInertia`, and drops any other spelling. Inertia is
+ * M̂·(r̄/r)², so a chart with no distance uses r = r̄ and gets exactly 1; with a
+ * real distance it gets the true ratio.
+ *
+ * MEASURED consequence, taken from the applied run (2026-08-04) by scoring the
+ * pre-apply snapshot and the committed chart through the SAME read path:
+ *
+ *   user        ESMS before      after          max Δshare  archetype
+ *   2ee5eb05    36/40/17/7   ->  33/44/16/7     4.85pp      unchanged
+ *   32ad3b88    37/33/20/10  ->  33/39/19/9     5.25pp      Root Alchemist -> Lunar Adept
+ *   5f40a6e5    23/22/38/17  ->  23/19/38/20    3.25pp      unchanged
+ *   ce117d50    37/33/20/10  ->  33/39/19/9     5.25pp      Root Alchemist -> Lunar Adept
+ *
+ * Neither flipped account has an `alchemical_constitutions` row, so no STORED
+ * archetype or balance moved; the shift is only in what the read path derives.
+ *
+ * ⚠ The pre-apply estimate for this same change predicted "no archetype
+ * changes" and was WRONG for 2 of 4. It was produced with
+ * `getAccuratePlanetaryPositions` — freshly recomputed astronomy-engine
+ * geometry — rather than the STORED astrologize longitudes the read path
+ * actually consumes. Different position source, different baseline, different
+ * side of the archetype boundary. Predict a data change through the path
+ * production reads, never through one that merely resembles it.
+ *
+ * The ESMS_BASELINE constants are NOT affected: they are generated from a
+ * synthetic uniform sample that supplies no distances, so the baseline sits at
+ * r = r̄ before and after. Verified — `scripts/generate-esms-baseline.ts`
+ * reproduces the committed block byte-for-byte.
+ *
+ * ── USAGE ───────────────────────────────────────────────────────────────────
+ *
+ *   bun run scripts/backfillChartGeocentricDistance.ts            # dry run
+ *   bun run scripts/backfillChartGeocentricDistance.ts --apply    # one txn
+ *
+ * Raw `pg`, no ORM. Distances are TZ-independent: they are computed from the
+ * absolute birth instant, so unlike the astrologize payload this needs no UTC
+ * guard.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import * as Astronomy from "astronomy-engine";
+import pg from "pg";
+
+import { PLANET_MEAN_GEOCENTRIC_AU } from "@/utils/planetaryAlchemyMapping";
+
+const APPLY = process.argv.slice(2).includes("--apply");
+
+// ─────────────────────────────── plumbing ───────────────────────────────
+
+function loadEnvFile(file: string): Record<string, string> {
+  const abs = path.resolve(process.cwd(), file);
+  if (!fs.existsSync(abs)) return {};
+  const out: Record<string, string> = {};
+  for (const line of fs.readFileSync(abs, "utf8").split("\n")) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)$/);
+    if (m) out[m[1]] = m[2].replace(/^["']|["']$/g, "").trim();
+  }
+  return out;
+}
+
+function resolveConnectionString(): string {
+  const env = { ...loadEnvFile(".env.development.local"), ...loadEnvFile(".env.local") };
+  const url =
+    process.env.DATABASE_PUBLIC_URL || env.DATABASE_PUBLIC_URL || env.DATABASE_URL;
+  if (!url) {
+    console.error(
+      "FATAL: no DATABASE_PUBLIC_URL / DATABASE_URL available.\n" +
+        "Run from the repo root so .env.development.local resolves.",
+    );
+    process.exit(1);
+  }
+  return url;
+}
+
+const ASTRONOMY_BODIES: Record<string, Astronomy.Body> = {
+  Sun: Astronomy.Body.Sun,
+  Moon: Astronomy.Body.Moon,
+  Mercury: Astronomy.Body.Mercury,
+  Venus: Astronomy.Body.Venus,
+  Mars: Astronomy.Body.Mars,
+  Jupiter: Astronomy.Body.Jupiter,
+  Saturn: Astronomy.Body.Saturn,
+  Uranus: Astronomy.Body.Uranus,
+  Neptune: Astronomy.Body.Neptune,
+  Pluto: Astronomy.Body.Pluto,
+};
+
+/**
+ * True geocentric range in AU, or null for a body with no distance concept
+ * (Ascendant, lunar nodes). Null means "leave the field off" — never invent a
+ * placeholder, because a fabricated distance is indistinguishable downstream
+ * from a measured one and defeats the r̄ fallback that exists for absence.
+ */
+function geocentricDistanceAu(planet: string, instant: Date): number | null {
+  const body = ASTRONOMY_BODIES[planet];
+  if (!body) return null;
+  const v = Astronomy.GeoVector(body, new Astronomy.AstroTime(instant), true);
+  return Math.hypot(v.x, v.y, v.z);
+}
+
+interface Row {
+  user_id: string;
+  email: string | null;
+  natal_chart: any;
+  planets_type: string | null;
+  birth_dt: string | null;
+  jsonb_chart_has_planets: boolean;
+}
+
+// ──────────────────────────────── main ────────────────────────────────
+
+async function main(): Promise<void> {
+  const pool = new pg.Pool({
+    connectionString: resolveConnectionString(),
+    ssl: { rejectUnauthorized: false },
+    max: 2,
+  });
+  const client = await pool.connect();
+
+  try {
+    const { rows } = await client.query<Row>(`
+      SELECT
+        up.user_id::text                                   AS user_id,
+        u.email                                            AS email,
+        up.natal_chart                                     AS natal_chart,
+        jsonb_typeof(up.natal_chart->'planets')            AS planets_type,
+        COALESCE(up.birth_data->>'dateTime',
+                 u.profile->'birthData'->>'dateTime')      AS birth_dt,
+        (jsonb_typeof(u.profile->'natalChart'->'planets') = 'array')
+                                                           AS jsonb_chart_has_planets
+      FROM user_profiles up
+      LEFT JOIN users u ON u.id = up.user_id
+      WHERE up.natal_chart IS NOT NULL
+        AND up.natal_chart::text NOT IN ('{}','null')
+      ORDER BY up.user_id
+    `);
+
+    const arrayShaped = rows.filter((r) => r.planets_type === "array");
+    const objectShaped = rows.filter((r) => r.planets_type === "object");
+    const otherShaped = rows.filter(
+      (r) => r.planets_type !== "array" && r.planets_type !== "object",
+    );
+
+    console.log(`\nStored charts scanned: ${rows.length}`);
+    console.log(`  planets[] array  (backfillable) : ${arrayShaped.length}`);
+    console.log(`  planets{} object (placeholder)  : ${objectShaped.length}  — SKIPPED, see header`);
+    if (otherShaped.length > 0) {
+      console.log(`  other/absent shape             : ${otherShaped.length}  — SKIPPED`);
+    }
+
+    console.log(`\n━━━ ${APPLY ? "APPLY" : "DRY RUN"} ━━━`);
+
+    const planned: Array<{ row: Row; chart: any; added: number; instant: string }> = [];
+
+    for (const row of arrayShaped) {
+      if (!row.birth_dt || Number.isNaN(Date.parse(row.birth_dt))) {
+        console.log(`  ${row.user_id}  SKIP — no usable birth instant; distance is a function of it`);
+        continue;
+      }
+      const instant = new Date(row.birth_dt);
+      const chart = structuredClone(row.natal_chart);
+      const planets: any[] = chart.planets ?? [];
+
+      let added = 0;
+      let alreadyHad = 0;
+      const detail: string[] = [];
+      for (const planet of planets) {
+        if (typeof planet?.distance === "number" && planet.distance > 0) {
+          alreadyHad++;
+          continue;
+        }
+        const d = geocentricDistanceAu(planet?.name, instant);
+        if (d === null) continue; // Ascendant & friends: no distance concept
+        planet.distance = d;
+        added++;
+        const rBar = PLANET_MEAN_GEOCENTRIC_AU[planet.name];
+        if (rBar !== undefined) {
+          detail.push(`${planet.name} r=${d.toFixed(4)} (r̄/r)²=${((rBar / d) ** 2).toFixed(3)}`);
+        }
+      }
+
+      if (added === 0) {
+        console.log(`  ${row.user_id}  nothing to add (${alreadyHad} already had a distance)`);
+        continue;
+      }
+
+      chart.geometryBasis = {
+        distance: "DERIVED — astronomy-engine GeoVector |(x,y,z)| at the birth instant",
+        distanceUnits: "AU",
+        instant: instant.toISOString(),
+        backfilledAt: new Date().toISOString(),
+      };
+
+      console.log(`\n  ${row.user_id}  (${row.email ?? "no email"})`);
+      console.log(`    instant  : ${instant.toISOString()}`);
+      console.log(`    planets  : ${planets.length}, +${added} distances (${planets.length - added} have no distance concept)`);
+      console.log(`    sample   : ${detail.slice(0, 3).join("  ")}`);
+      console.log(`    mirror   : users.profile.natalChart ${row.jsonb_chart_has_planets ? "also updated" : "has no planets[] — column only"}`);
+
+      planned.push({ row, chart, added, instant: instant.toISOString() });
+    }
+
+    if (planned.length === 0) {
+      console.log("\n  Nothing to write.");
+      return;
+    }
+
+    if (!APPLY) {
+      console.log(`\n  (dry run — ${planned.length} chart(s) would be updated, no write)`);
+      return;
+    }
+
+    // ONE transaction for the whole set: these charts are a physics cohort, and
+    // a partial apply would leave some users on distance-aware inertia and
+    // others on the r̄ fallback with nothing recording which is which.
+    await client.query("BEGIN");
+    try {
+      for (const { row, chart } of planned) {
+        const res = await client.query(
+          `UPDATE user_profiles
+             SET natal_chart = $2::jsonb, updated_at = CURRENT_TIMESTAMP
+           WHERE user_id = $1::uuid`,
+          [row.user_id, JSON.stringify(chart)],
+        );
+        if (res.rowCount !== 1) {
+          throw new Error(`expected 1 user_profiles row for ${row.user_id}, got ${res.rowCount}`);
+        }
+
+        // Mirror into the users.profile JSONB. Updating only one of the two
+        // surfaces is exactly how the constitution rows diverged — see
+        // scripts/healConstitutionGeometry.ts. Guarded so we only touch rows
+        // that actually carry a planets[] there.
+        if (row.jsonb_chart_has_planets) {
+          await client.query(
+            `UPDATE users
+               SET profile = jsonb_set(profile, '{natalChart}', $2::jsonb, true),
+                   updated_at = CURRENT_TIMESTAMP
+             WHERE id = $1::uuid`,
+            [row.user_id, JSON.stringify(chart)],
+          );
+        }
+      }
+      await client.query("COMMIT");
+      console.log(`\n  ✔ committed ${planned.length} chart(s) in one transaction`);
+    } catch (err) {
+      await client.query("ROLLBACK");
+      console.error("\n  ROLLED BACK:", (err as Error).message);
+      process.exitCode = 1;
+    }
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+await main();

--- a/scripts/healConstitutionGeometry.ts
+++ b/scripts/healConstitutionGeometry.ts
@@ -1,0 +1,523 @@
+#!/usr/bin/env bun
+/**
+ * One-off recovery: heal `alchemical_constitutions` rows whose natal geometry
+ * was never persisted to the canonical `user_profiles` columns.
+ *
+ * ── WHAT IS ACTUALLY BROKEN (measured 2026-08-03 against prod) ──────────────
+ *
+ * `alchemical_constitutions` has NO `natal_chart` column — it stores four
+ * scalar balances plus an archetype. The geometry lives in `user_profiles`
+ * (`birth_data`, `natal_chart`), dual-written by `userDatabase.updateUserProfile`.
+ *
+ * Of the 4 constitution rows, 2 are broken — but NOT by "missing distances":
+ *
+ *   user_id     esms          user_profiles          users.profile->birthData
+ *   ─────────────────────────────────────────────────────────────────────────
+ *   2ee5eb05…   30/46/14/9    chart, 11 planets      present        HEALTHY
+ *   5f40a6e5…   16/16/47/21   chart, 11 planets      present        HEALTHY
+ *   3de96e89…   25/25/25/25   birth_data={}, no chart  PRESENT      BROKEN
+ *   5e813bbf…   25/25/25/25   birth_data={}, no chart  PRESENT      BROKEN
+ *
+ * The two broken rows carry a flat 25/25/25/25 ESMS under the "Solar Forager"
+ * archetype — the degenerate signature of a constitution computed with no
+ * chart. Their birth data survives ONLY in the `users.profile` JSONB, because
+ * the write landed there but never reached the normalized columns. That JSONB
+ * is the recovery source, and it is why these rows are healable at all.
+ *
+ * Geocentric distance is a SEPARATE, population-wide gap, not row staleness:
+ * 0 of 75 stored charts carry a distance on any planet, because
+ * `calculateNatalChart` emits `{name, sign, position}` and the astrologize
+ * response type has no distance field. Backfilling 2 rows cannot close it.
+ * `--with-distance` enriches the rebuilt charts from astronomy-engine (see the
+ * flag's docs below); it is opt-in precisely because it is a physics change.
+ *
+ * ── WHY TZ=UTC IS ENFORCED ──────────────────────────────────────────────────
+ *
+ * `fetchPlanetaryPositions` builds the astrologize payload with LOCAL-time
+ * getters (`getFullYear`/`getHours`/…) on a UTC instant, and ignores
+ * `birthData.timezone` entirely. The stored charts were computed on UTC
+ * infrastructure. Measured: re-igniting 2ee5eb05 reproduces the stored Sun
+ * bit-exact (91.63304700590142 vs 91.6330470059014) under TZ=UTC, and drifts
+ * to 91.474 under TZ=America/New_York — 0.16° of pure harness artifact. A
+ * backfill run under the operator's local clock silently writes a different
+ * chart, so this script refuses to run outside UTC.
+ *
+ * ── USAGE ───────────────────────────────────────────────────────────────────
+ *
+ *   # 1. Control gate only — proves the pipeline reproduces known-good rows.
+ *   TZ=UTC ALCHM_MCP_BACKEND_URL=https://alchm.kitchen \
+ *     bun run scripts/healConstitutionGeometry.ts --control
+ *
+ *   # 2. Dry run (default) — control gate, then the full diff, no writes.
+ *   TZ=UTC ALCHM_MCP_BACKEND_URL=https://alchm.kitchen \
+ *     bun run scripts/healConstitutionGeometry.ts
+ *
+ *   # 3. Apply — same as above, then one transaction per healed user.
+ *   TZ=UTC ALCHM_MCP_BACKEND_URL=https://alchm.kitchen \
+ *     bun run scripts/healConstitutionGeometry.ts --apply
+ *
+ * Raw `pg` only, no ORM. Reads DATABASE_PUBLIC_URL (prod) from the environment
+ * or `.env.development.local`.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import pg from "pg";
+import * as Astronomy from "astronomy-engine";
+
+import { calculateNatalChart } from "@/services/natalChartService";
+import { toEsmsShares, selectArchetype } from "@/utils/alchemicalConstitution";
+import { isSectDiurnalForBirth } from "@/utils/planetaryAlchemyMapping";
+
+// ───────────────────────────────── flags ─────────────────────────────────
+
+const ARGV = new Set(process.argv.slice(2));
+const CONTROL_ONLY = ARGV.has("--control");
+const APPLY = ARGV.has("--apply");
+/**
+ * Enrich each rebuilt planet with its true geocentric distance in AU.
+ *
+ * The field MUST be named `distance` (not `distanceAu`): `chartDataUtils`
+ * forwards `planets[].distance` into the positions record that reaches
+ * `getGravitationalInertia`, and drops any other spelling. That makes this a
+ * live physics change — inertia goes from M̂·(r̄/r)²=M̂ (the missing-distance
+ * fallback) to the real ratio — so it is opt-in and reported separately.
+ *
+ * Basis: DERIVED — astronomy-engine GeoVector at the birth instant, |(x,y,z)|.
+ * All four birth dates are 1984–2021, well clear of the pre-1600 regime where
+ * astronomy-engine diverges from JPL by up to 0.53°.
+ */
+const WITH_DISTANCE = ARGV.has("--with-distance");
+/**
+ * Also recompute the rows that already have a chart, bringing all four onto the
+ * current engine. Off by default: those rows are not broken, they are merely
+ * old, and silently rewriting healthy production data is a bigger decision than
+ * healing rows that carry no chart at all. The control gate reports when this
+ * would matter.
+ */
+const RECOMPUTE_ALL = ARGV.has("--recompute-all");
+
+// ─────────────────────────────── guardrails ───────────────────────────────
+
+function assertUtc(): void {
+  const tz = process.env.TZ;
+  const offset = new Date().getTimezoneOffset();
+  if (offset !== 0) {
+    console.error(
+      `FATAL: this script must run under UTC (TZ=${tz ?? "<unset>"}, offset ${offset}min).\n` +
+        "The astrologize payload is built from local-time getters, so a non-UTC\n" +
+        "clock silently produces a different chart than the one prod stored.\n" +
+        "Re-run with: TZ=UTC bun run scripts/healConstitutionGeometry.ts …",
+    );
+    process.exit(1);
+  }
+}
+
+function loadEnvFile(file: string): Record<string, string> {
+  const abs = path.resolve(process.cwd(), file);
+  if (!fs.existsSync(abs)) return {};
+  const out: Record<string, string> = {};
+  for (const line of fs.readFileSync(abs, "utf8").split("\n")) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)$/);
+    if (m) out[m[1]] = m[2].replace(/^["']|["']$/g, "").trim();
+  }
+  return out;
+}
+
+function resolveConnectionString(): string {
+  const env = { ...loadEnvFile(".env.development.local"), ...loadEnvFile(".env.local") };
+  const url =
+    process.env.DATABASE_PUBLIC_URL || env.DATABASE_PUBLIC_URL || env.DATABASE_URL;
+  if (!url) {
+    console.error("FATAL: no DATABASE_PUBLIC_URL / DATABASE_URL available.");
+    process.exit(1);
+  }
+  return url;
+}
+
+// ──────────────────────────────── types ────────────────────────────────
+
+interface BirthData {
+  dateTime: string;
+  latitude: number;
+  longitude: number;
+  timezone?: string;
+}
+
+interface CandidateRow {
+  user_id: string;
+  email: string | null;
+  base_archetype: string | null;
+  stored_esms: [number, number, number, number];
+  profile_planet_count: number;
+  profile_birth_data: BirthData | Record<string, never> | null;
+  jsonb_birth_data: BirthData | null;
+  users_profile: Record<string, unknown> | null;
+  stored_chart: any | null;
+}
+
+function isUsableBirthData(b: unknown): b is BirthData {
+  if (!b || typeof b !== "object") return false;
+  const d = b as Partial<BirthData>;
+  return (
+    typeof d.dateTime === "string" &&
+    !Number.isNaN(Date.parse(d.dateTime)) &&
+    typeof d.latitude === "number" &&
+    Number.isFinite(d.latitude) &&
+    typeof d.longitude === "number" &&
+    Number.isFinite(d.longitude)
+  );
+}
+
+// ───────────────────────────── the pipeline ─────────────────────────────
+
+const ASTRONOMY_BODIES: Record<string, Astronomy.Body> = {
+  Sun: Astronomy.Body.Sun,
+  Moon: Astronomy.Body.Moon,
+  Mercury: Astronomy.Body.Mercury,
+  Venus: Astronomy.Body.Venus,
+  Mars: Astronomy.Body.Mars,
+  Jupiter: Astronomy.Body.Jupiter,
+  Saturn: Astronomy.Body.Saturn,
+  Uranus: Astronomy.Body.Uranus,
+  Neptune: Astronomy.Body.Neptune,
+  Pluto: Astronomy.Body.Pluto,
+};
+
+/** True geocentric range in AU at `instant`, or null for bodies with no such concept. */
+function geocentricDistanceAu(planet: string, instant: Date): number | null {
+  const body = ASTRONOMY_BODIES[planet];
+  if (!body) return null; // Ascendant, nodes, …
+  const v = Astronomy.GeoVector(body, new Astronomy.AstroTime(instant), true);
+  return Math.hypot(v.x, v.y, v.z);
+}
+
+/**
+ * Re-ignite: rebuild the chart from the external astrologize source and derive
+ * the constitution with the canonical engine. This is the same sequence
+ * `/api/agent-forge/ignite` runs, minus auth, geocoding and recipe generation.
+ */
+async function reignite(birthData: BirthData) {
+  const chart: any = await calculateNatalChart(birthData);
+
+  if (WITH_DISTANCE) {
+    const instant = new Date(birthData.dateTime);
+    for (const planet of chart.planets ?? []) {
+      const d = geocentricDistanceAu(planet.name, instant);
+      if (d !== null) planet.distance = d;
+    }
+    chart.geometryBasis = {
+      distance: "DERIVED — astronomy-engine GeoVector |(x,y,z)| at birth instant",
+      distanceUnits: "AU",
+      enrichedAt: new Date().toISOString(),
+    };
+  }
+
+  const shares = toEsmsShares(chart.alchemicalProperties);
+  const diurnal = isSectDiurnalForBirth(new Date(birthData.dateTime));
+  const { baseArchetype } = selectArchetype(shares, diurnal);
+
+  return {
+    chart,
+    esms: [
+      Math.round(shares.spirit),
+      Math.round(shares.essence),
+      Math.round(shares.matter),
+      Math.round(shares.substance),
+    ] as [number, number, number, number],
+    baseArchetype,
+  };
+}
+
+// ────────────────────────────── control gate ──────────────────────────────
+
+/**
+ * STORED vs CONTROL on the rows that are already healthy.
+ *
+ * The point is not to check that the healthy rows are fine — it is to prove
+ * that THIS script, on THIS machine, against THIS upstream, reproduces charts
+ * prod already wrote. If the control drifts, every "healed" value the script
+ * would write on the broken rows is the harness talking, not the fix.
+ *
+ * The control is split in two, because the two halves fail for different
+ * reasons and only one of them is the harness's fault:
+ *
+ *   GEOMETRY (blocking) — sign + longitude per planet. This is the astrologize
+ *     round-trip and the TZ handling. It MUST be bit-exact; a drift here means
+ *     the re-ignition is producing a different sky than prod recorded.
+ *
+ *   ESMS (informational) — the quantities derived FROM that geometry. This is
+ *     NOT expected to match: 14 engine commits landed between the oldest
+ *     constitution row (2026-05-28) and today, including the degree-level
+ *     dignity manifest (#721), the retirement of the sign-level dignity scale
+ *     (#722), the inertial-mass unification (#710) and the aspect-bearing
+ *     engine (#695). Measured drift on identical geometry: 30/46/14/9 →
+ *     36/39/18/7 and 16/16/47/21 → 22/22/40/17. That delta belongs to the
+ *     engine, not to this script, so it is reported rather than gated on —
+ *     blocking on it would only ever mean "the physics improved".
+ */
+async function runControl(healthy: CandidateRow[]): Promise<boolean> {
+  console.log("\n━━━ CONTROL GATE ━━━");
+  if (healthy.length === 0) {
+    console.log("  No healthy rows to control against — cannot verify. Refusing.");
+    return false;
+  }
+
+  let geometryClean = true;
+  const esmsDrifted: string[] = [];
+  for (const row of healthy) {
+    const birth = isUsableBirthData(row.profile_birth_data)
+      ? row.profile_birth_data
+      : row.jsonb_birth_data;
+    if (!isUsableBirthData(birth)) {
+      console.log(`  ${row.user_id}  SKIP — no usable birth data`);
+      geometryClean = false;
+      continue;
+    }
+
+    const { chart: control, esms } = await reignite(birth);
+    const storedPlanets: any[] = row.stored_chart?.planets ?? [];
+    const controlPlanets: any[] = control.planets ?? [];
+
+    const diffs: string[] = [];
+    for (const sp of storedPlanets) {
+      const cp = controlPlanets.find((p) => p.name === sp.name);
+      if (!cp) {
+        diffs.push(`${sp.name}: absent from control`);
+        continue;
+      }
+      if (cp.sign !== sp.sign) diffs.push(`${sp.name}: sign ${sp.sign} → ${cp.sign}`);
+      const dl = Math.abs(Number(cp.position) - Number(sp.position));
+      if (!(dl < 1e-9)) {
+        diffs.push(`${sp.name}: longitude Δ${dl.toExponential(3)}°`);
+      }
+    }
+
+    const esmsStored = row.stored_esms.join("/");
+    const esmsControl = esms.join("/");
+
+    if (diffs.length === 0) {
+      console.log(
+        `  ${row.user_id}  ✔ GEOMETRY bit-exact (${storedPlanets.length} planets: sign + longitude)`,
+      );
+    } else {
+      geometryClean = false;
+      console.log(`  ${row.user_id}  ✘ GEOMETRY DRIFT`);
+      for (const d of diffs.slice(0, 12)) console.log(`      ${d}`);
+      if (diffs.length > 12) console.log(`      … and ${diffs.length - 12} more`);
+    }
+
+    if (esmsStored === esmsControl) {
+      console.log(`      ESMS unchanged under the current engine: ${esmsStored}`);
+    } else {
+      console.log(
+        `      ESMS engine drift (expected): stored ${esmsStored} → current ${esmsControl}`,
+      );
+      esmsDrifted.push(row.user_id);
+    }
+  }
+
+  console.log(
+    geometryClean
+      ? "  GATE PASSED — re-ignition reproduces prod's own geometry bit-exact."
+      : "  GATE FAILED — do NOT apply; the re-ignited sky differs from what prod recorded.",
+  );
+  if (esmsDrifted.length > 0) {
+    console.log(
+      `\n  NOTE: ${esmsDrifted.length} healthy row(s) hold ESMS from a superseded engine.\n` +
+        "  Healing the broken rows writes CURRENT-engine values, so the table will\n" +
+        "  mix engine generations until those rows are recomputed too. Pass\n" +
+        "  --recompute-all to bring every row onto the current engine in the same run.",
+    );
+  }
+  return geometryClean;
+}
+
+// ─────────────────────────────── the write ───────────────────────────────
+
+/**
+ * Mirrors `userDatabase.updateUserProfile`'s dual-write exactly: the
+ * `users.profile` JSONB AND the normalized `user_profiles` columns, plus the
+ * constitution row — all inside ONE transaction. Writing only one of the two
+ * profile surfaces is the original defect; reproducing it here would re-break
+ * the rows in the other direction.
+ */
+async function healRow(
+  client: pg.PoolClient,
+  row: CandidateRow,
+  birth: BirthData,
+  rebuilt: Awaited<ReturnType<typeof reignite>>,
+): Promise<void> {
+  const mergedProfile = {
+    ...(row.users_profile ?? {}),
+    userId: row.user_id,
+    birthData: birth,
+    natalChart: rebuilt.chart,
+    onboardingComplete: true,
+  };
+  const name = (mergedProfile as any).name ?? "";
+
+  await client.query("BEGIN");
+  try {
+    await client.query(
+      `UPDATE users SET profile = $2, updated_at = CURRENT_TIMESTAMP WHERE id = $1::uuid`,
+      [row.user_id, JSON.stringify(mergedProfile)],
+    );
+
+    await client.query(
+      `INSERT INTO user_profiles (user_id, name, birth_data, natal_chart, onboarding_completed)
+       VALUES ($1::uuid, $2, $3::jsonb, $4::jsonb, true)
+       ON CONFLICT (user_id) DO UPDATE SET
+         name = COALESCE(NULLIF(EXCLUDED.name, ''), user_profiles.name),
+         birth_data = EXCLUDED.birth_data,
+         natal_chart = EXCLUDED.natal_chart,
+         onboarding_completed = true,
+         onboarding_completed_at = COALESCE(user_profiles.onboarding_completed_at, CURRENT_TIMESTAMP),
+         updated_at = CURRENT_TIMESTAMP`,
+      [row.user_id, name, JSON.stringify(birth), JSON.stringify(rebuilt.chart)],
+    );
+
+    const res = await client.query(
+      `UPDATE alchemical_constitutions SET
+         spirit_balance = $2, essence_balance = $3,
+         matter_balance = $4, substance_balance = $5,
+         base_archetype = $6, last_transit_sync = NOW(), updated_at = NOW()
+       WHERE user_id = $1::uuid`,
+      [row.user_id, ...rebuilt.esms, rebuilt.baseArchetype],
+    );
+    if (res.rowCount !== 1) {
+      throw new Error(`expected to update exactly 1 constitution row, got ${res.rowCount}`);
+    }
+
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  }
+}
+
+// ──────────────────────────────── main ────────────────────────────────
+
+async function main(): Promise<void> {
+  assertUtc();
+
+  if (!process.env.ALCHM_MCP_BACKEND_URL?.trim()) {
+    console.error(
+      "FATAL: set ALCHM_MCP_BACKEND_URL=https://alchm.kitchen so the re-ignition\n" +
+        "reaches the real astrologize backend rather than a non-existent localhost.",
+    );
+    process.exit(1);
+  }
+
+  const pool = new pg.Pool({
+    connectionString: resolveConnectionString(),
+    ssl: { rejectUnauthorized: false },
+    max: 2,
+  });
+  const client = await pool.connect();
+
+  try {
+    // 1. IDENTIFY — every constitution row, with both profile surfaces.
+    const { rows } = await client.query<CandidateRow>(`
+      SELECT
+        ac.user_id::text                       AS user_id,
+        u.email                                AS email,
+        ac.base_archetype,
+        ARRAY[ac.spirit_balance, ac.essence_balance,
+              ac.matter_balance, ac.substance_balance] AS stored_esms,
+        jsonb_array_length(COALESCE(up.natal_chart->'planets', '[]'::jsonb)) AS profile_planet_count,
+        up.birth_data                          AS profile_birth_data,
+        u.profile -> 'birthData'               AS jsonb_birth_data,
+        u.profile                              AS users_profile,
+        up.natal_chart                         AS stored_chart
+      FROM alchemical_constitutions ac
+      LEFT JOIN users u          ON u.id = ac.user_id
+      LEFT JOIN user_profiles up ON up.user_id = ac.user_id
+      ORDER BY ac.created_at
+    `);
+
+    const healthy = rows.filter((r) => Number(r.profile_planet_count) > 0);
+    const broken = rows.filter((r) => Number(r.profile_planet_count) === 0);
+
+    console.log(`\nScanned ${rows.length} constitution rows.`);
+    console.log(`  healthy (chart present): ${healthy.length}`);
+    console.log(`  broken  (no chart)     : ${broken.length}`);
+    console.log(`  distance enrichment    : ${WITH_DISTANCE ? "ON (--with-distance)" : "off"}`);
+
+    // 2. CONTROL — must reproduce prod's own output before touching anything.
+    const gatePassed = await runControl(healthy);
+    if (CONTROL_ONLY) {
+      process.exitCode = gatePassed ? 0 : 1;
+      return;
+    }
+    if (!gatePassed && APPLY) {
+      console.error("\nRefusing --apply: control gate failed.");
+      process.exitCode = 1;
+      return;
+    }
+
+    // 3. RE-IGNITE + 4. UPDATE
+    console.log(`\n━━━ ${APPLY ? "APPLY" : "DRY RUN"} ━━━`);
+    const targets = RECOMPUTE_ALL ? [...broken, ...healthy] : broken;
+    if (targets.length === 0) {
+      console.log("  Nothing to heal.");
+      return;
+    }
+    if (RECOMPUTE_ALL) {
+      console.log(`  --recompute-all: ${broken.length} broken + ${healthy.length} healthy rows`);
+    }
+
+    for (const row of targets) {
+      const birth = isUsableBirthData(row.profile_birth_data)
+        ? row.profile_birth_data
+        : row.jsonb_birth_data;
+
+      if (!isUsableBirthData(birth)) {
+        console.log(
+          `  ${row.user_id}  UNHEALABLE — no usable birth data in either surface. ` +
+            "Requires the user to re-onboard; a chart cannot be invented for them.",
+        );
+        continue;
+      }
+
+      const source = isUsableBirthData(row.profile_birth_data)
+        ? "user_profiles.birth_data"
+        : "users.profile->birthData (RECOVERED)";
+
+      let rebuilt: Awaited<ReturnType<typeof reignite>>;
+      try {
+        rebuilt = await reignite(birth);
+      } catch (err) {
+        console.log(`  ${row.user_id}  FAILED to re-ignite: ${(err as Error).message}`);
+        continue;
+      }
+
+      const withDist = (rebuilt.chart.planets ?? []).filter(
+        (p: any) => typeof p.distance === "number",
+      ).length;
+
+      console.log(`\n  ${row.user_id}  (${row.email ?? "no email"})`);
+      console.log(`    birth source : ${source}`);
+      console.log(`    birth instant: ${birth.dateTime}  @ ${birth.latitude}, ${birth.longitude}`);
+      console.log(`    ESMS         : ${row.stored_esms.join("/")} → ${rebuilt.esms.join("/")}`);
+      console.log(`    archetype    : ${row.base_archetype} → ${rebuilt.baseArchetype}`);
+      console.log(
+        `    chart        : ${rebuilt.chart.planets?.length ?? 0} planets` +
+          (WITH_DISTANCE ? `, ${withDist} with geocentric distance` : ""),
+      );
+
+      if (!APPLY) {
+        console.log("    (dry run — no write)");
+        continue;
+      }
+
+      await healRow(client, row, birth, rebuilt);
+      console.log("    ✔ committed (users.profile + user_profiles + constitution)");
+    }
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+await main();

--- a/src/__tests__/aspectDignityCommensurability.test.ts
+++ b/src/__tests__/aspectDignityCommensurability.test.ts
@@ -1,0 +1,218 @@
+/**
+ * ESMS 2.0 — Layer 3 (aspects) vs Layer 2 (essential dignity) commensurability.
+ *
+ * RULED 2026-08-03, λ = 1: the aspect layer is ratified AS MEASURED. A typical
+ * aspect is worth about one dignity FOLD; an exceptional one about a full
+ * dignity STACK. No global rescale is applied, because measurement showed the
+ * relationship the ruling wanted already holds — see the BASIS block in
+ * `src/utils/aspectESMSEffects.ts`.
+ *
+ * This suite is the enforcement half of that ruling. It exists because the
+ * relationship is EMERGENT — it is not written down in any constant. Layer 2 is
+ * a per-planet MULTIPLIER (𝒟 = 1 + score/50) and Layer 3 is an ADDITIVE term
+ * from a hand-authored per-pair table; nothing structurally ties them together,
+ * so either side can drift out of commensurability without a single test
+ * failing anywhere else in the repo.
+ *
+ * The pinned quantity is a distributional relationship between two layers, not
+ * a float, so the bounds are ranges rather than a `toBeCloseTo` that would fail
+ * on an innocuous ephemeris bump. They are nonetheless tight enough to fail the
+ * ×2 / ÷2 class of change that actually moves the economy — VERIFIED by
+ * mutation: doubling every value in the effect tables (Scenario B, λ=2.0012,
+ * measured at 10.98pp of share movement) fails this suite. An earlier, wider
+ * set of bounds passed that mutation, which is the whole reason these are
+ * stated as measured-ratio ± a margin rather than as round numbers.
+ */
+
+import { calculateAlchemicalFromPlanetsDetailed } from "@/utils/planetaryAlchemyMapping";
+import { buildAspectsWithStrength } from "@/utils/aspectCalculator";
+import { getAspectESMSEffect, PLANET_PAIR_ASPECT_EFFECTS } from "@/utils/aspectESMSEffects";
+import {
+  getAccuratePlanetaryPositions,
+  isCurrentSkyDiurnal,
+} from "@/utils/astrology/positions";
+import { DIGNITY_POINTS, DIGNITY_SCORE_DIVISOR } from "@/calculations/dignityManifest";
+import golden from "../../backend/tests/aspect_effects_golden.json";
+
+const AXES = ["Spirit", "Essence", "Matter", "Substance"] as const;
+
+/** The measured ceiling of the summed 5-fold dignity score: Mercury 0°–7° Virgo
+ *  (domicile +5, exaltation +4, term +2). See DIGNITY_SCORE_DIVISOR's docs. */
+const FULL_STACK_POINTS = 11;
+
+/**
+ * A fixed, deterministic spread of skies. Fixed so the suite cannot go green or
+ * red on the wall clock, and spread so the statistics are not read off one
+ * accidental configuration.
+ */
+const SAMPLE_SKIES: Date[] = [];
+for (let year = 1970; year <= 2025; year += 5) {
+  for (const month of [0, 3, 6, 9]) {
+    SAMPLE_SKIES.push(new Date(Date.UTC(year, month, 15, 12, 0, 0)));
+  }
+}
+
+interface Measured {
+  perAspectGross: number[];
+  meanPlanetContribution: number;
+  worstAdditivityResidual: number;
+}
+
+function measure(): Measured {
+  const perAspectGross: number[] = [];
+  const planetContributions: number[] = [];
+  let worstAdditivityResidual = 0;
+
+  for (const when of SAMPLE_SKIES) {
+    const positions = getAccuratePlanetaryPositions(when);
+    const detailed = calculateAlchemicalFromPlanetsDetailed(
+      positions as never,
+      isCurrentSkyDiurnal(when),
+    );
+
+    for (const axis of AXES) {
+      const summed =
+        Object.values(detailed.perPlanet).reduce(
+          (acc: number, p: { esms: Record<string, number> }) => acc + p.esms[axis],
+          0,
+        ) + detailed.aspectModifications[axis];
+      worstAdditivityResidual = Math.max(
+        worstAdditivityResidual,
+        Math.abs(summed - detailed.totals[axis]),
+      );
+    }
+
+    for (const p of Object.values(detailed.perPlanet) as Array<{
+      esms: Record<string, number>;
+    }>) {
+      planetContributions.push(AXES.reduce((s, k) => s + p.esms[k], 0));
+    }
+
+    const rich = Object.fromEntries(
+      Object.entries(positions).filter(
+        ([, p]) => typeof p === "object" && p !== null,
+      ),
+    );
+    for (const a of buildAspectsWithStrength(rich as never)) {
+      const effect = getAspectESMSEffect(a.planet1, a.planet2, a.type);
+      if (!effect) continue;
+      const gross =
+        AXES.reduce((s, k) => s + Math.abs((effect as Record<string, number>)[k]), 0) *
+        (a.strength ?? 1);
+      perAspectGross.push(gross);
+    }
+  }
+
+  return {
+    perAspectGross: perAspectGross.sort((x, y) => x - y),
+    meanPlanetContribution:
+      planetContributions.reduce((x, y) => x + y, 0) / planetContributions.length,
+    worstAdditivityResidual,
+  };
+}
+
+const m = measure();
+const percentile = (q: number): number =>
+  m.perAspectGross[Math.floor(q * (m.perAspectGross.length - 1))];
+
+// Anchors are DERIVED here from the manifest's own constants and the measured
+// mean planet contribution — never hardcoded from a previous print, so the
+// numbers round-trip from their basis rather than from a transcript.
+const foldAnchor =
+  m.meanPlanetContribution * (DIGNITY_POINTS.domicile / DIGNITY_SCORE_DIVISOR);
+const stackAnchor =
+  m.meanPlanetContribution * (FULL_STACK_POINTS / DIGNITY_SCORE_DIVISOR);
+
+describe("Layer 3 ↔ Layer 2 commensurability (RULED λ=1, 2026-08-03)", () => {
+  it("decomposes additively — Σ per-planet + aspect mods === totals", () => {
+    // Guards the premise of every ratio below. If the layers do not sum to the
+    // total, the "aspect share" being measured is not the aspect layer.
+    expect(m.worstAdditivityResidual).toBeLessThan(1e-9);
+  });
+
+  it("samples enough geometry to be distributional", () => {
+    expect(SAMPLE_SKIES.length).toBe(48);
+    expect(m.perAspectGross.length).toBeGreaterThan(1000);
+    expect(m.meanPlanetContribution).toBeGreaterThan(0);
+  });
+
+  it("prices a TYPICAL aspect at roughly one dignity FOLD", () => {
+    // MEASURED 2026-08-03: p50 = 0.0352 = 0.75× the fold anchor.
+    // Upper bound sits below the 1.51 a doubled aspect layer would produce.
+    const ratio = percentile(0.5) / foldAnchor;
+    expect(ratio).toBeGreaterThan(0.5);
+    expect(ratio).toBeLessThan(1.2);
+  });
+
+  it("prices an EXCEPTIONAL aspect at roughly one full dignity STACK", () => {
+    // MEASURED 2026-08-03: p90 = 0.1000 = 0.97× the stack anchor.
+    // Upper bound sits below the 1.94 a doubled aspect layer would produce.
+    const ratio = percentile(0.9) / stackAnchor;
+    expect(ratio).toBeGreaterThan(0.7);
+    expect(ratio).toBeLessThan(1.4);
+  });
+
+  it("keeps the mean aspect below the full-stack ceiling", () => {
+    // The ruling in one line: a typical aspect lives in the interval the
+    // dignity layer defines, and does not reach the ceiling a single planet's
+    // maximum dignity stack sets. MEASURED mean = 0.0514 (fold 0.0468,
+    // stack 0.1029); a doubled layer means 0.1028 and breaches this.
+    const mean =
+      m.perAspectGross.reduce((x, y) => x + y, 0) / m.perAspectGross.length;
+    expect(mean).toBeGreaterThan(foldAnchor * 0.7);
+    expect(mean).toBeLessThan(stackAnchor * 0.8);
+  });
+
+  it("holds the whole aspect layer to a minority of the chart", () => {
+    // Layer 3 gross was 25.8% of the Layer 1×2 total when ruled. A layer that
+    // grew to dominate the chart would be a different physics model, whatever
+    // the per-aspect ratios said.
+    const grossPerChart =
+      m.perAspectGross.reduce((x, y) => x + y, 0) / SAMPLE_SKIES.length;
+    const chartTotal = m.meanPlanetContribution * 11; // 11 bodies incl. Ascendant
+    expect(grossPerChart / chartTotal).toBeLessThan(0.5);
+  });
+});
+
+describe("Layer 3 cross-runtime parity (TS half)", () => {
+  // The Python half is backend/tests/test_aspect_effects_parity.py. Both read
+  // backend/tests/aspect_effects_golden.json, so a one-sided edit to either
+  // table fails on that side rather than drifting silently.
+  const tables = golden.tables as Record<string, Record<string, number[]>>;
+
+  it("reproduces every authored planet-pair table", () => {
+    for (const [pair, byType] of Object.entries(tables)) {
+      if (pair === "__DEFAULT__") continue;
+      const [a, b] = pair.split("-");
+      for (const [type, expected] of Object.entries(byType)) {
+        const effect = getAspectESMSEffect(a, b, type as never) as Record<string, number>;
+        expect(AXES.map((k) => effect[k])).toEqual(expected);
+      }
+    }
+  });
+
+  it("reproduces the DEFAULT fallback table for unauthored pairs", () => {
+    for (const [type, expected] of Object.entries(tables.__DEFAULT__)) {
+      const effect = getAspectESMSEffect("Uranus", "Neptune", type as never) as Record<
+        string,
+        number
+      >;
+      expect(AXES.map((k) => effect[k])).toEqual(expected);
+    }
+  });
+
+  it("authors exactly the pairs the golden records", () => {
+    // Catches an ADDED pair table, which the per-pair loop above cannot see.
+    const authored = Object.keys(PLANET_PAIR_ASPECT_EFFECTS).sort();
+    const expected = Object.keys(tables)
+      .filter((k) => k !== "__DEFAULT__")
+      .sort();
+    expect(authored).toEqual(expected);
+  });
+
+  it("pins the dignity anchors the ruling is stated against", () => {
+    expect(golden.dignityAnchors.domicileFoldPoints).toBe(DIGNITY_POINTS.domicile);
+    expect(golden.dignityAnchors.fullStackPoints).toBe(FULL_STACK_POINTS);
+    expect(golden.dignityAnchors.dignityScoreDivisor).toBe(DIGNITY_SCORE_DIVISOR);
+  });
+});

--- a/src/__tests__/services/natalChartTimezoneBoundary.test.ts
+++ b/src/__tests__/services/natalChartTimezoneBoundary.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment node
+ *
+ * The astrologize payload boundary must be timezone-invariant.
+ *
+ * `/api/astrologize` reconstructs the instant with
+ * `Date.UTC(year, month - 1, date, hour, minute)`, so `fetchPlanetaryPositions`
+ * has to hand it the UTC components of the birth instant. It used to read them
+ * with LOCAL getters, which made the caller's timezone part of the physics:
+ * MEASURED 2026-08-03, re-igniting a stored chart (birth 1991-06-23T14:24:00Z)
+ * returned the stored Sun bit-exact at 91.63304700590142 under TZ=UTC but
+ * 91.47408219086523 under TZ=America/New_York -- 0.159 degrees of drift with no
+ * error raised anywhere.
+ *
+ * This file forces a non-UTC zone BEFORE importing the service, so a revert to
+ * local getters fails here rather than only on a developer's laptop.
+ */
+
+// Must precede any import that captures the zone. Chosen to be on the far side
+// of the date line from UTC, so a local-getter regression shifts the DATE and
+// not merely the hour -- a same-day hour shift can hide inside a wide orb.
+process.env.TZ = "Pacific/Auckland";
+
+import { describe, expect, it, jest, beforeEach, afterAll } from "@jest/globals";
+
+const ORIGINAL_FETCH = global.fetch;
+
+/** A minimal astrologize response — only the fields the service reads. */
+function stubResponse() {
+  const body = (label: string, deg: number) => ({
+    key: label.toLowerCase(),
+    label,
+    Sign: { key: label.toLowerCase(), zodiac: label, label: "Cancer" },
+    ChartPosition: {
+      Ecliptic: {
+        DecimalDegrees: deg,
+        ArcDegrees: { degrees: Math.floor(deg), minutes: 0, seconds: 0 },
+      },
+    },
+    isRetrograde: false,
+  });
+  return {
+    _celestialBodies: {
+      all: [],
+      sun: body("Sun", 91.5),
+      moon: body("Moon", 120.5),
+      mercury: body("Mercury", 100.5),
+      venus: body("Venus", 110.5),
+      mars: body("Mars", 130.5),
+      jupiter: body("Jupiter", 140.5),
+      saturn: body("Saturn", 150.5),
+      uranus: body("Uranus", 160.5),
+      neptune: body("Neptune", 170.5),
+      pluto: body("Pluto", 180.5),
+    },
+    ascendant: { sign: "cancer", degree: 5, minute: 0, exactLongitude: 95.0 },
+  };
+}
+
+let capturedPayload: Record<string, unknown> | null = null;
+
+beforeEach(() => {
+  capturedPayload = null;
+  global.fetch = jest.fn(async (_url: unknown, init: unknown) => {
+    const body = (init as { body?: string })?.body;
+    capturedPayload = body ? JSON.parse(body) : null;
+    return {
+      ok: true,
+      statusText: "OK",
+      json: async () => stubResponse(),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+});
+
+afterAll(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+describe("astrologize payload timezone boundary", () => {
+  it("runs under a non-UTC zone, or this suite proves nothing", () => {
+    // A guard on the guard: if the runner ignores process.env.TZ, every
+    // assertion below would pass trivially against a UTC clock.
+    expect(new Date("1991-06-23T14:24:00.000Z").getTimezoneOffset()).not.toBe(0);
+  });
+
+  it("sends the UTC components of the birth instant, not the local ones", async () => {
+    const { calculateNatalChart } = await import("@/services/natalChartService");
+    await calculateNatalChart({
+      dateTime: "1991-06-23T14:24:00.000Z",
+      latitude: 40.6526006,
+      longitude: -73.9497211,
+      timezone: "America/New_York",
+    });
+
+    expect(capturedPayload).toMatchObject({
+      year: 1991,
+      month: 6,
+      date: 23,
+      hour: 14,
+      minute: 24,
+    });
+  });
+
+  it("round-trips exactly through the reconstruction the API performs", async () => {
+    // getUTC* -> Date.UTC is an identity. Local getters are not, and that
+    // asymmetry is the whole defect.
+    const { calculateNatalChart } = await import("@/services/natalChartService");
+    const instant = "1996-10-21T10:28:00.000Z";
+    await calculateNatalChart({
+      dateTime: instant,
+      latitude: 40.7956894,
+      longitude: -73.6989103,
+    });
+
+    const p = capturedPayload as Record<string, number>;
+    const reconstructed = new Date(
+      Date.UTC(p.year, p.month - 1, p.date, p.hour, p.minute),
+    );
+    expect(reconstructed.toISOString()).toBe(instant);
+  });
+
+  it("crosses the date line without dragging the calendar day with it", async () => {
+    // Auckland is +12/+13. An instant just before UTC midnight reads as the
+    // NEXT day locally, so a local-getter regression changes `date` here.
+    const { calculateNatalChart } = await import("@/services/natalChartService");
+    await calculateNatalChart({
+      dateTime: "2001-03-14T23:50:00.000Z",
+      latitude: 0,
+      longitude: 0,
+    });
+
+    expect(capturedPayload).toMatchObject({
+      year: 2001,
+      month: 3,
+      date: 14,
+      hour: 23,
+      minute: 50,
+    });
+  });
+
+  it("refuses an unparseable instant instead of charting the epoch", async () => {
+    const { calculateNatalChart } = await import("@/services/natalChartService");
+    await expect(
+      calculateNatalChart({
+        dateTime: "not-a-date",
+        latitude: 0,
+        longitude: 0,
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/src/__tests__/services/natalChartTimezoneBoundary.test.ts
+++ b/src/__tests__/services/natalChartTimezoneBoundary.test.ts
@@ -12,18 +12,56 @@
  * 91.47408219086523 under TZ=America/New_York -- 0.159 degrees of drift with no
  * error raised anywhere.
  *
- * This file forces a non-UTC zone BEFORE importing the service, so a revert to
- * local getters fails here rather than only on a developer's laptop.
+ * ── WHY THIS DOES NOT SET process.env.TZ ────────────────────────────────────
+ *
+ * The obvious test is "force a non-UTC zone, then check the payload". It does
+ * not work, and its first version shipped broken: setting `process.env.TZ` in a
+ * test module does not reliably relatch Node's zone, because jest's setup files
+ * have already constructed Dates by then. On a developer machine that is
+ * invisible -- the ambient zone is non-UTC anyway, so the assertions pass for
+ * the wrong reason -- and on a UTC CI runner the local and UTC getters AGREE,
+ * so a local-getter regression sails straight through.
+ *
+ * So the zone is not used as the lever at all. Instead the LOCAL getters are
+ * poisoned: any call to `getFullYear`/`getMonth`/`getDate`/`getHours`/
+ * `getMinutes` returns a value that cannot occur in a correct payload. A
+ * correct implementation never touches them and is unaffected; a regression
+ * reads poison and fails. That holds in EVERY timezone, including UTC, which is
+ * exactly where the timezone-based version was blind.
  */
-
-// Must precede any import that captures the zone. Chosen to be on the far side
-// of the date line from UTC, so a local-getter regression shifts the DATE and
-// not merely the hour -- a same-day hour shift can hide inside a wide orb.
-process.env.TZ = "Pacific/Auckland";
 
 import { describe, expect, it, jest, beforeEach, afterAll } from "@jest/globals";
 
 const ORIGINAL_FETCH = global.fetch;
+
+/**
+ * Sentinel values for the local-time getters — deliberately impossible for the
+ * instants under test, so a poisoned read is unmistakable in the diff.
+ */
+const POISON = {
+  getFullYear: 1888,
+  getMonth: 10, // would surface as month 11
+  getDate: 28,
+  getHours: 7,
+  getMinutes: 55,
+} as const;
+
+/**
+ * Run `fn` with the local-time getters poisoned. Scoped as tightly as possible
+ * and always restored, since Date.prototype is global and jest itself uses it.
+ */
+async function withPoisonedLocalGetters<T>(fn: () => Promise<T>): Promise<T> {
+  const spies = (Object.keys(POISON) as Array<keyof typeof POISON>).map((name) =>
+    jest
+      .spyOn(Date.prototype, name as never)
+      .mockReturnValue(POISON[name] as never),
+  );
+  try {
+    return await fn();
+  } finally {
+    for (const s of spies) s.mockRestore();
+  }
+}
 
 /** A minimal astrologize response — only the fields the service reads. */
 function stubResponse() {
@@ -77,20 +115,34 @@ afterAll(() => {
 });
 
 describe("astrologize payload timezone boundary", () => {
-  it("runs under a non-UTC zone, or this suite proves nothing", () => {
-    // A guard on the guard: if the runner ignores process.env.TZ, every
-    // assertion below would pass trivially against a UTC clock.
-    expect(new Date("1991-06-23T14:24:00.000Z").getTimezoneOffset()).not.toBe(0);
+  it("poisoning the local getters actually bites, or this suite proves nothing", () => {
+    // A guard on the guard. The previous version of this check asserted the
+    // runner was in a non-UTC zone; CI is UTC, so it failed there and correctly
+    // reported that every other assertion in the file was passing vacuously.
+    // This replacement is about the mechanism, not the ambient zone, so it holds
+    // identically on a laptop and on a UTC runner.
+    const probe = new Date("1991-06-23T14:24:00.000Z");
+    expect(probe.getUTCFullYear()).toBe(1991);
+    return withPoisonedLocalGetters(async () => {
+      expect(probe.getFullYear()).toBe(POISON.getFullYear);
+      expect(probe.getHours()).toBe(POISON.getHours);
+      // UTC getters must be untouched by the poison, or the tests below would
+      // be asserting against a mocked value rather than the real instant.
+      expect(probe.getUTCFullYear()).toBe(1991);
+      expect(probe.getUTCHours()).toBe(14);
+    });
   });
 
   it("sends the UTC components of the birth instant, not the local ones", async () => {
     const { calculateNatalChart } = await import("@/services/natalChartService");
-    await calculateNatalChart({
-      dateTime: "1991-06-23T14:24:00.000Z",
-      latitude: 40.6526006,
-      longitude: -73.9497211,
-      timezone: "America/New_York",
-    });
+    await withPoisonedLocalGetters(() =>
+      calculateNatalChart({
+        dateTime: "1991-06-23T14:24:00.000Z",
+        latitude: 40.6526006,
+        longitude: -73.9497211,
+        timezone: "America/New_York",
+      }),
+    );
 
     expect(capturedPayload).toMatchObject({
       year: 1991,
@@ -106,11 +158,13 @@ describe("astrologize payload timezone boundary", () => {
     // asymmetry is the whole defect.
     const { calculateNatalChart } = await import("@/services/natalChartService");
     const instant = "1996-10-21T10:28:00.000Z";
-    await calculateNatalChart({
-      dateTime: instant,
-      latitude: 40.7956894,
-      longitude: -73.6989103,
-    });
+    await withPoisonedLocalGetters(() =>
+      calculateNatalChart({
+        dateTime: instant,
+        latitude: 40.7956894,
+        longitude: -73.6989103,
+      }),
+    );
 
     const p = capturedPayload as Record<string, number>;
     const reconstructed = new Date(
@@ -119,15 +173,18 @@ describe("astrologize payload timezone boundary", () => {
     expect(reconstructed.toISOString()).toBe(instant);
   });
 
-  it("crosses the date line without dragging the calendar day with it", async () => {
-    // Auckland is +12/+13. An instant just before UTC midnight reads as the
-    // NEXT day locally, so a local-getter regression changes `date` here.
+  it("keeps an instant near UTC midnight on its own calendar day", async () => {
+    // The case a zone shift mangles worst: 23:50 UTC is already the NEXT day
+    // anywhere east of the meridian, so a local-getter regression moves `date`
+    // rather than merely `hour` — and an hour shift can hide inside a wide orb.
     const { calculateNatalChart } = await import("@/services/natalChartService");
-    await calculateNatalChart({
-      dateTime: "2001-03-14T23:50:00.000Z",
-      latitude: 0,
-      longitude: 0,
-    });
+    await withPoisonedLocalGetters(() =>
+      calculateNatalChart({
+        dateTime: "2001-03-14T23:50:00.000Z",
+        latitude: 0,
+        longitude: 0,
+      }),
+    );
 
     expect(capturedPayload).toMatchObject({
       year: 2001,

--- a/src/__tests__/utils/geocentricVectors.test.ts
+++ b/src/__tests__/utils/geocentricVectors.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Guards the geocentric distance fallback.
+ *
+ * `positionVec` used to resolve a missing distance to a flat 1 AU for every
+ * body. That is an invented geometry, not a neutral default: it placed Pluto at
+ * Earth's own orbital radius, ~35x too close, and the error flowed into both the
+ * position vector and the chain-rule velocity that scales with `r`.
+ *
+ * It was the LIVE path, not an edge case — no stored natal chart in production
+ * carries a distance on any planet (0 of 75 measured 2026-08-03), because
+ * `calculateNatalChart` emits `{name, sign, position}` only.
+ */
+
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  magnitude,
+  positionVec,
+  resolveGeocentricDistanceAu,
+} from "@/utils/astrology/geocentricVectors";
+import { PLANET_MEAN_GEOCENTRIC_AU } from "@/utils/planetaryAlchemyMapping";
+
+/** The shape every stored chart actually has: longitude, no distance. */
+const NO_DISTANCE = { exactLongitude: 300.25, isRetrograde: false };
+
+describe("resolveGeocentricDistanceAu", () => {
+  it("falls back to Pluto's own mean range, not 1 AU", () => {
+    // The regression this file exists for. Expectations are read from the
+    // table rather than hardcoded, so the pin round-trips from its basis.
+    const r = resolveGeocentricDistanceAu("Pluto", NO_DISTANCE);
+    expect(r).toBe(PLANET_MEAN_GEOCENTRIC_AU.Pluto);
+    expect(r).toBeGreaterThan(35);
+    expect(r).not.toBe(1);
+  });
+
+  it("falls back to each body's own mean range", () => {
+    for (const [planet, rBar] of Object.entries(PLANET_MEAN_GEOCENTRIC_AU)) {
+      expect(resolveGeocentricDistanceAu(planet, NO_DISTANCE)).toBe(rBar);
+    }
+  });
+
+  it("prefers a real supplied distance over the mean", () => {
+    expect(
+      resolveGeocentricDistanceAu("Pluto", { ...NO_DISTANCE, distance: 30.7389 }),
+    ).toBeCloseTo(30.7389, 6);
+  });
+
+  it("rejects a non-positive distance rather than collapsing to the origin", () => {
+    // `toFinite` passes a literal 0 straight through, so finiteness alone is not
+    // enough of a guard — 0 AU is impossible for every body here and would send
+    // the 1/r^2 coupling to its clamp.
+    for (const bad of [0, -1, Number.NaN, undefined, null, "nonsense"]) {
+      expect(
+        resolveGeocentricDistanceAu("Pluto", { ...NO_DISTANCE, distance: bad }),
+      ).toBe(PLANET_MEAN_GEOCENTRIC_AU.Pluto);
+    }
+  });
+
+  it("uses unit radius only for bodies with no distance concept", () => {
+    // The Ascendant is a chart angle, not an orbiting body — it has no entry in
+    // the mean-distance table, the same special case getGravitationalInertia
+    // applies when rBar is undefined.
+    expect(PLANET_MEAN_GEOCENTRIC_AU.Ascendant).toBeUndefined();
+    expect(resolveGeocentricDistanceAu("Ascendant", NO_DISTANCE)).toBe(1);
+    expect(resolveGeocentricDistanceAu("NotABody", NO_DISTANCE)).toBe(1);
+  });
+});
+
+describe("positionVec", () => {
+  it("places a distance-less Pluto at its mean range, not 1 AU", () => {
+    const { r } = positionVec("Pluto", NO_DISTANCE);
+    expect(magnitude(r)).toBeCloseTo(PLANET_MEAN_GEOCENTRIC_AU.Pluto, 9);
+    // The pre-fix behaviour, stated explicitly so a revert cannot pass quietly.
+    expect(magnitude(r)).not.toBeCloseTo(1, 3);
+  });
+
+  it("separates the outer planets instead of stacking them on one shell", () => {
+    // Under the old fallback every body sat at |r| = 1, so the whole solar
+    // system collapsed onto a single sphere and the 1/r^2 coupling was uniform.
+    const radii = ["Moon", "Sun", "Mars", "Jupiter", "Saturn", "Neptune", "Pluto"].map(
+      (p) => magnitude(positionVec(p, NO_DISTANCE).r),
+    );
+    for (let i = 1; i < radii.length; i++) {
+      expect(radii[i]).toBeGreaterThan(radii[i - 1]);
+    }
+    expect(new Set(radii.map((v) => v.toFixed(6))).size).toBe(radii.length);
+  });
+
+  it("scales the 1/r^2 coupling by the corrected range", () => {
+    // What the route computes per body. Pluto's coupling must be ~1/35.53^2,
+    // not the 1.0 a unit radius produced.
+    const coupling = (planet: string): number => {
+      const m = magnitude(positionVec(planet, NO_DISTANCE).r);
+      return 1 / Math.max(m * m, 0.01);
+    };
+    expect(coupling("Pluto")).toBeCloseTo(
+      1 / PLANET_MEAN_GEOCENTRIC_AU.Pluto ** 2,
+      12,
+    );
+    expect(coupling("Pluto")).toBeLessThan(coupling("Sun") / 1000);
+  });
+
+  it("scales the chain-rule velocity by the corrected range too", () => {
+    // The defect corrupted velocity as well as position: every term except the
+    // radial one carries a factor of r.
+    const moving = { ...NO_DISTANCE, longitudeSpeed: 0.01 };
+    const v = positionVec("Pluto", moving).v;
+    const expected = PLANET_MEAN_GEOCENTRIC_AU.Pluto * 0.01 * (Math.PI / 180);
+    expect(magnitude(v)).toBeCloseTo(expected, 9);
+  });
+
+  it("keeps a zero radial rate neutral rather than inventing one", () => {
+    // distanceSpeed's 0 default is a genuine neutral, unlike the distance one:
+    // it drops the rDot terms and leaves the body moving tangentially.
+    const still = positionVec("Pluto", NO_DISTANCE);
+    expect(magnitude(still.v)).toBe(0);
+    const radial = positionVec("Pluto", { ...NO_DISTANCE, distanceSpeed: 0.5 });
+    expect(magnitude(radial.v)).toBeCloseTo(0.5, 9);
+  });
+});

--- a/src/app/api/alchm-quantities/route.ts
+++ b/src/app/api/alchm-quantities/route.ts
@@ -11,6 +11,12 @@ import { AlchmQuantitiesApiResponseSchema } from "@/lib/validation/apiSchemas";
 import { getCachedHistoricalStats } from "@/services/HistoricalStatsService";
 import { alchemize, type PlanetaryPosition } from "@/services/RealAlchemizeService";
 import type { DegradedInfo } from "@/types/degraded";
+import {
+  DEG2RAD,
+  magnitude,
+  positionVec,
+  type Vec3,
+} from "@/utils/astrology/geocentricVectors";
 import { isCurrentSkyDiurnal } from "@/utils/astrology/positions";
 import { createLogger } from "@/utils/logger";
 import { PLANETARY_ALCHEMY, inertialMassWeight } from "@/utils/planetaryAlchemyMapping";
@@ -233,7 +239,6 @@ export async function GET(request: Request) {
     // separating aspects as inductive (resistance to change). The elemental
     // mix becomes resistive impedance R. Net reactance X = ωL − 1/(ωC).
     // -----------------------------------------------------------------------
-    interface Vec3 { x: number; y: number; z: number }
     const ZERO_VEC: Vec3 = { x: 0, y: 0, z: 0 };
     const addVec = (a: Vec3, b: Vec3): Vec3 => ({
       x: a.x + b.x,
@@ -245,51 +250,15 @@ export async function GET(request: Request) {
       y: v.y * s,
       z: v.z * s,
     });
-    const magnitude = (v: Vec3): number =>
-      Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
     const roundVec = (v: Vec3, digits = 6): Vec3 => ({
       x: round(v.x, digits),
       y: round(v.y, digits),
       z: round(v.z, digits),
     });
 
-    const DEG2RAD = Math.PI / 180;
-
-    // Build 3D ecliptic Cartesian + velocity for a position record.
-    // Distance defaults to 1 AU when the source didn't provide it.
-    const positionVec = (pos: any): { r: Vec3; v: Vec3 } => {
-      const lon = toFinite(pos?.exactLongitude) * DEG2RAD;
-      const lat = toFinite(pos?.eclipticLatitude) * DEG2RAD;
-      const r = toFinite(pos?.distance, 1);
-      const lonDot = toFinite(pos?.longitudeSpeed) * DEG2RAD; // rad/day
-      const latDot = toFinite(pos?.latitudeSpeed) * DEG2RAD; // rad/day
-      const rDot = toFinite(pos?.distanceSpeed); // AU/day
-
-      const cosLat = Math.cos(lat);
-      const sinLat = Math.sin(lat);
-      const cosLon = Math.cos(lon);
-      const sinLon = Math.sin(lon);
-
-      const position: Vec3 = {
-        x: r * cosLat * cosLon,
-        y: r * cosLat * sinLon,
-        z: r * sinLat,
-      };
-      // dP/dt by chain rule
-      const velocity: Vec3 = {
-        x:
-          rDot * cosLat * cosLon -
-          r * sinLat * latDot * cosLon -
-          r * cosLat * sinLon * lonDot,
-        y:
-          rDot * cosLat * sinLon -
-          r * sinLat * latDot * sinLon +
-          r * cosLat * cosLon * lonDot,
-        z: rDot * sinLat + r * cosLat * latDot,
-      };
-      return { r: position, v: velocity };
-    };
-
+    // `positionVec` now lives in @/utils/astrology/geocentricVectors — it takes
+    // the body NAME as well as the position, because a missing distance must
+    // fall back to that body's own mean geocentric range, not to a flat 1 AU.
     // ESMS vector field: sum planet velocities weighted by alchemical contribution.
     // Result is the directional "flow" of each ESMS axis through 3D space.
     const esmsVectors: Record<EsmsKey, Vec3> = {
@@ -308,7 +277,7 @@ export async function GET(request: Request) {
     for (const [planet, pos] of Object.entries(nowPositions)) {
       const alch = (PLANETARY_ALCHEMY as any)[planet];
       if (!alch) continue;
-      const { r, v } = positionVec(pos);
+      const { r, v } = positionVec(planet, pos);
       // Force magnitude scales with 1/r² (inverse-square coupling),
       // direction along velocity (motion = force-of-becoming).
       const coupling = 1 / Math.max(magnitude(r) * magnitude(r), 0.01);

--- a/src/services/astrologizeApi.ts
+++ b/src/services/astrologizeApi.ts
@@ -148,12 +148,21 @@ function calculateApproximateAscendant(
     "libra", "scorpio", "sagittarius", "capricorn", "aquarius", "pisces",
   ] as const;
 
+  // UTC getters, deliberately — same boundary rule as
+  // `natalChartService.fetchPlanetaryPositions`. These components are handed
+  // straight to `Date.UTC(year, month - 1, day, hour, minute)` below, so reading
+  // them with LOCAL getters shifted "now" by the caller's UTC offset and then
+  // reinterpreted the shifted wall clock as UTC — a double-counted offset.
+  //
+  // This path is worse than the natal one because it also runs in the BROWSER,
+  // where the offset is the visitor's own zone rather than the server's. A user
+  // in UTC+13 got an Ascendant computed for an instant 13 hours off, silently.
   const now = new Date();
-  const year = requestData.year ?? now.getFullYear();
-  const month = requestData.month ?? (now.getMonth() + 1);
-  const day = requestData.date ?? now.getDate();
-  const hour = requestData.hour ?? now.getHours();
-  const minute = requestData.minute ?? now.getMinutes();
+  const year = requestData.year ?? now.getUTCFullYear();
+  const month = requestData.month ?? (now.getUTCMonth() + 1);
+  const day = requestData.date ?? now.getUTCDate();
+  const hour = requestData.hour ?? now.getUTCHours();
+  const minute = requestData.minute ?? now.getUTCMinutes();
   const longitude = requestData.longitude ?? DEFAULT_LOCATION.longitude;
   const latitude = requestData.latitude ?? DEFAULT_LOCATION.latitude;
 

--- a/src/services/natalChartService.ts
+++ b/src/services/natalChartService.ts
@@ -200,13 +200,44 @@ async function fetchPlanetaryPositions(
 ): Promise<Record<Planet, PositionWithLongitude>> {
   try {
     const date = new Date(birthData.dateTime);
+    if (Number.isNaN(date.getTime())) {
+      throw new Error(
+        `Unparseable birthData.dateTime: ${JSON.stringify(birthData.dateTime)}. ` +
+          "Refusing to compute a chart from an invalid instant.",
+      );
+    }
 
+    // UTC getters, deliberately — this is the timezone boundary.
+    //
+    // `/api/astrologize` reconstructs the instant with
+    // `Date.UTC(year, month - 1, date, hour, minute)` (see that route). So the
+    // components it wants are the UTC components of this instant, and
+    // getUTC* -> Date.UTC is an exact round-trip on any machine.
+    //
+    // The local-time getters this replaces made the CALLER'S timezone part of
+    // the physics. MEASURED 2026-08-03 re-igniting a stored chart (birth
+    // 1991-06-23T14:24:00Z): TZ=UTC reproduced the stored Sun bit-exact at
+    // 91.63304700590142, while TZ=America/New_York returned 91.47408219086523
+    // -- 0.159 degrees of pure harness drift, small enough to read as rounding.
+    // Prod runs on UTC infrastructure, so every stored chart was computed on the
+    // UTC branch; these getters make that the behaviour everywhere instead of an
+    // accident of deployment.
+    //
+    // NOTE: `birthData.timezone` is still not applied, and that is deliberate,
+    // not an oversight. `dateTime` is built from a `datetime-local` input via
+    // `new Date(dob).toISOString()`, so it holds the user's WALL-CLOCK birth
+    // time labelled UTC, not the true UTC instant of their birth. Interpreting
+    // it through `timezone` would be more astronomically correct but would
+    // re-date every chart already stored (5 hours for a New York birth) and the
+    // stored zone strings are not uniformly IANA ("America/New_York" alongside
+    // "UTC-5"). That is a physics ruling with a migration attached, not a
+    // boundary fix -- see the session notes accompanying this change.
     const payload = {
-      year: date.getFullYear(),
-      month: date.getMonth() + 1, // 1-indexed
-      date: date.getDate(),
-      hour: date.getHours(),
-      minute: date.getMinutes(),
+      year: date.getUTCFullYear(),
+      month: date.getUTCMonth() + 1, // 1-indexed
+      date: date.getUTCDate(),
+      hour: date.getUTCHours(),
+      minute: date.getUTCMinutes(),
       latitude: birthData.latitude,
       longitude: birthData.longitude,
       zodiacSystem: "tropical" as const,

--- a/src/utils/aspectESMSEffects.ts
+++ b/src/utils/aspectESMSEffects.ts
@@ -11,6 +11,62 @@
  *
  * Aspects are scaled by their strength (tightness of orb) to ensure
  * closer aspects have more impact than wider aspects.
+ *
+ * ── ASPECT–DIGNITY COMMENSURABILITY ────────────────────────────────────────
+ *
+ * `[RULED 2026-08-03, λ = 1]` — the aspect layer is ratified AS MEASURED. A
+ * single aspect is commensurate with a single dignity FOLD at the median and
+ * with a full dignity STACK at the tail. There is deliberately NO scaling
+ * constant in this module; λ = 1 is the ruling, not an omission.
+ *
+ * BASIS: MEASURED over 48 fixed skies (1970–2025), 1743 aspects. Reproduce with
+ * `src/__tests__/aspectDignityCommensurability.test.ts`, which recomputes every
+ * number below from the manifest's own constants rather than reading them off
+ * this comment. Additivity residual |Σparts − total| was exactly 0, so the
+ * layer decomposition the ratios rest on is valid.
+ *
+ * The two layers are not the same kind of quantity, which is why this needed
+ * ruling at all: Layer 2 (dignity) is a per-planet MULTIPLIER, 𝒟 = 1 + score/50
+ * (`src/calculations/dignityManifest.ts`), while Layer 3 (this module) is an
+ * ADDITIVE term on the chart totals. Nothing structurally ties them together,
+ * so either can drift out of commensurability silently.
+ *
+ * Measured, in gross ESMS units summed over all four axes:
+ *
+ *   quantity                                   value    ×fold   ×stack
+ *   ───────────────────────────────────────────────────────────────────
+ *   one domicile fold (+5), 𝒟=1.10             0.0468   1.00    0.45
+ *   full stack (+11, Mercury 0–7° Virgo)       0.1029   2.20    1.00
+ *   single aspect, p50                         0.0352   0.75    0.34
+ *   single aspect, mean                        0.0514   1.10    0.50
+ *   single aspect, p90                         0.1000   2.14    0.97
+ *   single aspect, p100                        0.8998   19.2    8.75
+ *
+ * The distribution is already BRACKETED by the two dignity anchors: the median
+ * aspect sits just below one fold and p90 lands on the full-stack ceiling. That
+ * IS the commensurability the ruling sought, so λ = 1 changes no number. Layer 3
+ * gross is 25.8% of the Layer 1×2 chart total.
+ *
+ * REJECTED — stack-commensurate scaling (λ = 2.0012, making the MEAN aspect
+ * equal a full stack). It doubles this layer and moves ESMS shares by up to
+ * 10.98 percentage points, which would move every threshold stabilised under
+ * ADR-009 — the same magnitude argument that rejected DIGNITY_SCORE_DIVISOR = 10
+ * in favour of 50. The other modelled options: exact fold parity (λ = 0.9102) →
+ * 1.25pp; per-aspect cap at the stack ceiling → 8.27pp (7.6% of aspects capped);
+ * aspects off (λ = 0) → 17.97pp.
+ *
+ * ⚠ Shares do NOT absorb a rescale the way a uniform mass change does. Aspects
+ * are additive and asymmetric across axes, so scaling this layer genuinely moves
+ * the shares the economy reads (balances, archetype, yield) — it is not a
+ * normalisation that cancels.
+ *
+ * KNOWN, NOT FIXED: 7.6% of aspects exceed a full dignity stack, topping out at
+ * 8.75× (the Sun–Moon conjunction at ±0.5 per axis). Capping the tail was
+ * modelled and deliberately not adopted — at 8.27pp it costs nearly as much as
+ * the rescale it would prevent.
+ *
+ * Python parity half: `backend/utils/aspect_esms_effects.py`, enforced through
+ * the shared golden `backend/tests/aspect_effects_golden.json`.
  */
 
 import type { AspectType } from "@/types/alchemy";

--- a/src/utils/astrology/geocentricVectors.ts
+++ b/src/utils/astrology/geocentricVectors.ts
@@ -1,0 +1,106 @@
+/**
+ * Geocentric ecliptic Cartesian position/velocity vectors for a celestial body.
+ *
+ * Reference frame: GEOCENTRIC ecliptic of date — x toward 0° Aries, y toward
+ * 90° Cancer, z toward the north ecliptic pole. All inputs are measured with
+ * Earth at the origin, the only frame astrology recognises.
+ *
+ * Extracted from `src/app/api/alchm-quantities/route.ts` so the geometry can be
+ * asserted directly. Inside the route it was reachable only through a four-way
+ * alchemically-weighted sum, which is why the distance defect below survived:
+ * no test could see a single body's vector.
+ */
+
+import { PLANET_MEAN_GEOCENTRIC_AU } from "@/utils/planetaryAlchemyMapping";
+
+export interface Vec3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export const DEG2RAD = Math.PI / 180;
+
+export const magnitude = (v: Vec3): number =>
+  Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+
+function toFinite(value: unknown, fallback = 0): number {
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/**
+ * Resolve the geocentric range in AU for a body.
+ *
+ * `[FIXED 2026-08-03]` This used to be `toFinite(pos?.distance, 1)` — a flat
+ * 1 AU for EVERY body whose position record carried no distance. That is not a
+ * neutral default, it is an invented geometry: it places Pluto (r̄ = 35.53 AU)
+ * at Earth's own orbital radius, ~35× too close, and the error propagates into
+ * both the position vector and the chain-rule velocity that depends on `r`.
+ *
+ * The fallback was the LIVE path, not an edge case: no stored natal chart in
+ * production carries a distance on any planet (0 of 75 measured 2026-08-03),
+ * because `calculateNatalChart` emits `{name, sign, position}` and the
+ * astrologize response has no distance field.
+ *
+ * The correct fallback is the body's own MEAN geocentric distance, matching
+ * `getGravitationalInertia` (planetaryAlchemyMapping.ts), where substituting r̄
+ * yields a neutral (r̄/r)² = 1 instead of a wrong position. A body with no
+ * distance concept at all (Ascendant, or an unknown key) has no r̄ and falls
+ * back to unit radius — the same special case the inertia path applies.
+ *
+ * Guards on `> 0` rather than mere finiteness: `toFinite` passes a literal 0
+ * straight through, and a 0 AU range is physically impossible for every body
+ * here — it would collapse the vector to the origin and send the 1/r² coupling
+ * to its clamp.
+ */
+export function resolveGeocentricDistanceAu(planet: string, pos: unknown): number {
+  const raw = toFinite((pos as { distance?: unknown } | null)?.distance, 0);
+  if (raw > 0) return raw;
+  return PLANET_MEAN_GEOCENTRIC_AU[planet] ?? 1;
+}
+
+/**
+ * Build the 3D geocentric position and its time derivative for one body.
+ *
+ * `distanceSpeed` still defaults to 0, and that IS a neutral default unlike the
+ * distance one: a zero radial rate drops the `rDot` terms and leaves the body
+ * moving tangentially at its (mean) radius. It biases nothing in the way a
+ * wrong `r` does — it only omits a component nobody supplied.
+ */
+export function positionVec(
+  planet: string,
+  pos: unknown,
+): { r: Vec3; v: Vec3 } {
+  const p = pos as Record<string, unknown> | null;
+  const lon = toFinite(p?.exactLongitude) * DEG2RAD;
+  const lat = toFinite(p?.eclipticLatitude) * DEG2RAD;
+  const r = resolveGeocentricDistanceAu(planet, pos);
+  const lonDot = toFinite(p?.longitudeSpeed) * DEG2RAD; // rad/day
+  const latDot = toFinite(p?.latitudeSpeed) * DEG2RAD; // rad/day
+  const rDot = toFinite(p?.distanceSpeed); // AU/day
+
+  const cosLat = Math.cos(lat);
+  const sinLat = Math.sin(lat);
+  const cosLon = Math.cos(lon);
+  const sinLon = Math.sin(lon);
+
+  const position: Vec3 = {
+    x: r * cosLat * cosLon,
+    y: r * cosLat * sinLon,
+    z: r * sinLat,
+  };
+  // dP/dt by chain rule
+  const velocity: Vec3 = {
+    x:
+      rDot * cosLat * cosLon -
+      r * sinLat * latDot * cosLon -
+      r * cosLat * sinLon * lonDot,
+    y:
+      rDot * cosLat * sinLon -
+      r * sinLat * latDot * sinLon +
+      r * cosLat * cosLon * lonDot,
+    z: rDot * sinLat + r * cosLat * latDot,
+  };
+  return { r: position, v: velocity };
+}


### PR DESCRIPTION
> ⚠️ **The branch name is misleading.** `docs/monica-runbook-0803` previously carried #724 (docs, merged). This PR is a substantive physics + data change on top of it — please don't skim it as documentation.

> ⚠️ **A production write has already been executed** as part of this work: 4 rows in `user_profiles` (and their `users.profile` mirror) were backfilled with geocentric distances, under explicit operator authorisation, in a single transaction. Details and verification below. The scripts themselves are dry-run by default.

Closes the cleanup sweep that fell out of fixing the 1 AU distance fallback.

## Task 1 — timezone seal

`/api/astrologize` reconstructs the birth instant with `Date.UTC(year, month-1, date, hour, minute)`, but `fetchPlanetaryPositions` read those components with **local** getters. `getUTC*` → `Date.UTC` is an exact round-trip; local getters are not, so the caller's timezone became part of the physics.

MEASURED on a stored chart (birth `1991-06-23T14:24:00Z`):

| TZ | Sun longitude | vs stored `91.6330470059014` |
|---|---|---|
| `UTC` | 91.63304700590142 | bit-exact ✅ |
| `America/New_York` | 91.47408219086523 | 0.159° drift ❌ |

Small enough to read as rounding, with no error raised anywhere. Prod runs on UTC, so every stored chart came off the UTC branch — this makes that the behaviour everywhere rather than an accident of deployment.

The same defect is fixed in `astrologizeApi.calculateApproximateAscendant`, which was **worse**: it also runs in the browser, so the offset was the *visitor's* zone. A user in UTC+13 got an Ascendant computed for an instant 13 hours off.

Now bit-exact and identical under UTC, `America/New_York` and `Pacific/Auckland`.

## Task 2 — stored chart geometry

Two one-off scripts. Bun, raw `pg`, no ORM, dry-run by default.

**`backfillChartGeocentricDistance.ts`** — scope is **4 charts, not the ~73** the row count implies. Of 75 non-empty `natal_chart` values, only 4 have `planets` as an **array**. The other **71 have it as an object** and are agent placeholders: all belong to `is_agent` users, all share **one** birth instant (`1900-01-01T12:00:00Z` at the hardcoded fallback NY coordinate), and **none contains a longitude anywhere**. Backfilling them would put an exact AU distance on an otherwise sign-only chart, so the script refuses them by construction and reports the count rather than silently claiming them done.

**`healConstitutionGeometry.ts`** — repairs constitution rows whose geometry never reached the canonical `user_profiles` columns. Gates on **geometry parity only**: re-ignition reproduces prod's own charts bit-exact, while ESMS legitimately differs because 14 engine commits landed since those rows were written. Blocking on that would only ever mean "the physics improved".

Both write `distance`, never `distanceAu` — `chartDataUtils` forwards `planets[].distance` into `getGravitationalInertia` and drops any other spelling, which makes this a live physics change rather than metadata.

## Also included

- **Layer 3 ↔ Layer 2 commensurability RULED at λ = 1**, ratified as measured. Over 48 skies / 1743 aspects the median aspect is 0.75× a domicile fold and p90 lands on the full +11 stack — the aspect layer is already bracketed by the dignity anchors, so no rescale is warranted. Stack parity would need λ = 2.0 and move shares up to 10.98pp. Enforced by a golden shared with the Python runtime (tables verified **byte-identical**) plus a suite in each.
- **`geocentricVectors.ts`** extracts `positionVec` out of the `alchm-quantities` route, where it was reachable only through a four-way weighted sum and therefore untestable.
- **`celestial_calculations.py`** now emits `None` instead of a literal `1.0` when pyephem has no `earth_distance`. Both runtimes already fall back to the body's mean range when a distance is *absent*, but a fabricated `1.0` is indistinguishable from a measurement and sails straight past all of them.

## What was deliberately NOT done

- **No ESMS baseline recalibration.** The premise that the 1 AU fix shifted mass weights is false: `positionVec` feeds only the vector/force payload, while `getGravitationalInertia` (which does compute mass weights) was already correct and `planetaryAlchemyMapping.ts` is untouched by this PR. `generate-esms-baseline.ts` reproduces the committed `ESMS_BASELINE` **byte-for-byte** and its drift guard passes. Recalibrating would have shifted Web3 proof-of-balance thresholds for no reason.
- **`birthData.timezone` is still not applied.** `dateTime` holds the user's wall-clock birth time *labelled* UTC, so interpreting it through the zone would re-date every stored chart (5h for a New York birth), and the stored strings are not uniformly IANA (`"America/New_York"` beside `"UTC-5"`). Parked as known architectural debt needing its own migration strategy.

## Correction worth reviewing

My pre-apply estimate predicted **"no archetype changes."** Measured on the actual stored charts through the real read path, **2 of 4 archetypes changed** (Root Alchemist → Lunar Adept):

| user | ESMS before → after | max Δ | archetype |
|---|---|---|---|
| `2ee5eb05` | 36/40/17/7 → 33/44/16/7 | 4.85pp | unchanged |
| `32ad3b88` | 37/33/20/10 → 33/39/19/9 | 5.25pp | **changed** |
| `5f40a6e5` | 23/22/38/17 → 23/19/38/20 | 3.25pp | unchanged |
| `ce117d50` | 37/33/20/10 → 33/39/19/9 | 5.25pp | **changed** |

The estimate used `getAccuratePlanetaryPositions` (freshly recomputed geometry) rather than the stored astrologize longitudes the read path consumes. **Impact is contained:** neither flipped account has an `alchemical_constitutions` row, so no *stored* archetype or balance moved — the shift exists only in what the read path derives live. The script header now records the verified numbers and the methodology lesson.

## Verification

- Typecheck clean; **full suite run under `TZ=UTC` to match CI — 204 suites, 2026 passed, 9 skipped**; **84 Python tests**.
- The timezone guard initially FAILED CI, caught by its own guard-on-the-guard. It keyed off the ambient zone via `process.env.TZ`, which does not reliably relatch Node's zone; on a non-UTC laptop it passed for the wrong reason, and on a UTC runner local and UTC getters agree so a regression was invisible. Rewritten in `72bab850` to poison the LOCAL getters instead, which is zone-independent and strictly stronger: mutation-verified failing under **both** UTC and Pacific/Auckland, the UTC half being exactly what the previous version could not detect.
- **Mutation-verified guards** (a test that cannot fail is worth nothing):
  - timezone — reverting to local getters fails 3/5
  - distance fallback — reverting to `1` fails 7/10
  - commensurability — doubling the effect tables fails 6/10 in TS; a single `-0.5 → -0.55` edit fails Python
  - An earlier, wider set of commensurability bounds *passed* the ×2 mutation despite its own docstring claiming to catch it — caught only by running the mutation, and tightened.
- **Post-apply verification of the production write**, independent of the script's own success message: every distance re-derived bit-exact from astronomy-engine; no other field mutated (field-by-field diff vs a pre-apply snapshot); `users.profile` mirror byte-identical to the column; the 71 placeholders untouched (0 carry a distance); `alchemical_constitutions` untouched. A pre-apply snapshot was retained for rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

