### PR TITLE
fix(astro): store the true birth instant, not the wall clock wearing a Z

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,7 @@
         "suncalc": "^1.9.0",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "3.4.19",
+        "tz-lookup": "^6.1.25",
         "viem": "^2.52.2",
         "web-push": "^3.6.7",
         "ws": "^8.20.0",
@@ -4000,6 +4001,8 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "typescript-eslint": ["typescript-eslint@8.59.2", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.2", "@typescript-eslint/parser": "8.59.2", "@typescript-eslint/typescript-estree": "8.59.2", "@typescript-eslint/utils": "8.59.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ=="],
+
+    "tz-lookup": ["tz-lookup@6.1.25", "", {}, "sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg=="],
 
     "ua-parser-js": ["ua-parser-js@1.0.41", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug=="],
 

--- a/database/init/76-birth-instant-dual-storage.sql
+++ b/database/init/76-birth-instant-dual-storage.sql
@@ -1,0 +1,91 @@
+-- Temporal migration: separate the birth WALL CLOCK from the birth INSTANT.
+--
+-- `birth_data->>'dateTime'` holds a wall-clock time labelled `Z`. It is produced
+-- by `new Date(<datetime-local>).toISOString()`, so "born 14:24 in Brooklyn" is
+-- stored as `1991-06-23T14:24:00.000Z` — a string that claims to be a UTC
+-- instant and is not one. The true instant is 18:24Z. Every stored natal chart
+-- was computed for the wrong sky by exactly the birthplace's UTC offset: four
+-- hours of Moon motion (~2.2 deg) and of Ascendant motion (~60 deg, two whole signs).
+--
+-- The two quantities are NOT interchangeable and the engine needs both:
+--
+--   * the INSTANT drives the ephemeris — which sky was overhead;
+--   * the WALL CLOCK drives sect — `isSectDiurnal` is a 06:00-18:00 window,
+--     i.e. a local-clock predicate. MEASURED 2026-08-04: feeding it the true
+--     instant instead flips day<->night on 6 of the 8 human rows, which per
+--     `isSectDiurnalForBirth`'s own docs swings the profile from ~32/49/9/9 to
+--     ~14/16/47/22 and rewrites the archetype. That flip would be manufactured
+--     entirely by this migration, not discovered by it.
+--
+-- Storing only one and deriving the other is what got us here, so both are
+-- persisted, alongside the zone and the BASIS on which that zone was decided.
+--
+-- ── MEASURED 2026-08-04 against production ─────────────────────────────────
+--
+--   users.profile->'birthData'   60 rows   |  user_profiles.birth_data   4 rows
+--
+-- Of the 60: 52 are agent placeholders stamped `1900-01-01T12:00:00.000Z`, a
+-- sentinel rather than a birth, and are deliberately NOT migrated (their
+-- true_utc_instant stays NULL). 8 are human. Of those 8:
+--
+--   * 2 carry `40.7498, -73.7976` bit-exact — the retired `ignite` route's
+--     "Fallback NY" literal. Their birthplace was never geocoded, so no instant
+--     can be derived from it. NOT migratable; flagged for re-onboarding.
+--   * 2 carry the raw offset `UTC-5` on NY-metro pins, both born inside EDT,
+--     where the true offset is -4. Taking the string literally is an hour wrong.
+--   * 1 carries `America/New_York` on coordinates 2.82, -60.67 — Boa Vista,
+--     Brazil. A valid IANA string on the wrong continent.
+--
+-- which is why the zone is RULED to come from coordinates, never from the
+-- stored string. See `src/utils/astrology/birthTimezone.ts`.
+--
+-- Every column below is NULLable with no default, deliberately: NULL means
+-- "no defensible instant for this row", which is a state 54 of the 60 rows are
+-- genuinely in. A default would fabricate an instant for all of them at once.
+
+ALTER TABLE user_profiles
+  ADD COLUMN IF NOT EXISTS birth_local_wall_time TIMESTAMP WITHOUT TIME ZONE,
+  ADD COLUMN IF NOT EXISTS birth_true_utc_instant TIMESTAMP WITH TIME ZONE,
+  ADD COLUMN IF NOT EXISTS birth_timezone TEXT,
+  ADD COLUMN IF NOT EXISTS birth_timezone_basis TEXT,
+  ADD COLUMN IF NOT EXISTS birth_instant_migrated_at TIMESTAMP WITH TIME ZONE;
+
+COMMENT ON COLUMN user_profiles.birth_local_wall_time IS
+  'Wall-clock time at the birthplace. WITHOUT TIME ZONE deliberately: it is a clock reading, not an instant, and Postgres must not attach a zone to it. Drives sect (isSectDiurnal is a 06:00-18:00 local window). Equals the legacy birth_data->>''dateTime'' with its bogus Z stripped.';
+
+COMMENT ON COLUMN user_profiles.birth_true_utc_instant IS
+  'The absolute instant of birth = local_wall_time interpreted in birth_timezone. Drives the ephemeris query. NULL when no defensible instant exists (agent sentinel, fabricated pin, or unresolvable zone) — never fabricated.';
+
+COMMENT ON COLUMN user_profiles.birth_timezone IS
+  'IANA zone name, e.g. America/New_York. Never a raw UTC+-N offset: those cannot express daylight saving and are an hour wrong for any DST birth.';
+
+COMMENT ON COLUMN user_profiles.birth_timezone_basis IS
+  'How birth_timezone was decided: DERIVED_FROM_COORDINATES (normal), STORED_IANA_STRING (no usable pin), or ABSENT. Recorded so a zone can never be mistaken for a user statement when it was inferred.';
+
+COMMENT ON COLUMN user_profiles.birth_instant_migrated_at IS
+  'When backfillBirthInstant.ts wrote the three columns above. NULL = never migrated, which is distinct from migrated-and-found-unresolvable (that row has this set and true_utc_instant NULL).';
+
+-- The basis is a closed set; anything else means a writer invented a value.
+-- NOT VALID would let existing rows skip the check, but there are no existing
+-- rows to grandfather (the columns are new), so it is validated immediately.
+ALTER TABLE user_profiles
+  DROP CONSTRAINT IF EXISTS user_profiles_birth_timezone_basis_check;
+ALTER TABLE user_profiles
+  ADD CONSTRAINT user_profiles_birth_timezone_basis_check
+  CHECK (birth_timezone_basis IS NULL
+         OR birth_timezone_basis IN ('DERIVED_FROM_COORDINATES', 'STORED_IANA_STRING', 'ABSENT'));
+
+-- A true instant is meaningless without the zone that produced it: the pair is
+-- what makes the wall clock recoverable. Reject half-written rows outright.
+ALTER TABLE user_profiles
+  DROP CONSTRAINT IF EXISTS user_profiles_birth_instant_needs_zone_check;
+ALTER TABLE user_profiles
+  ADD CONSTRAINT user_profiles_birth_instant_needs_zone_check
+  CHECK (birth_true_utc_instant IS NULL
+         OR (birth_timezone IS NOT NULL AND birth_local_wall_time IS NOT NULL));
+
+-- Readers ask "which profiles still have no defensible birth instant?" — the
+-- backfill's own progress query, and the degrade check on the chart path.
+CREATE INDEX IF NOT EXISTS idx_user_profiles_birth_instant_missing
+  ON user_profiles (user_id)
+  WHERE birth_true_utc_instant IS NULL;

--- a/package.json
+++ b/package.json
@@ -224,6 +224,7 @@
     "suncalc": "^1.9.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "3.4.19",
+    "tz-lookup": "^6.1.25",
     "viem": "^2.52.2",
     "web-push": "^3.6.7",
     "ws": "^8.20.0",

--- a/scripts/backfillBirthInstant.ts
+++ b/scripts/backfillBirthInstant.ts
@@ -1,0 +1,637 @@
+#!/usr/bin/env bun
+/**
+ * Temporal migration: derive each user's TRUE UTC birth instant from the
+ * wall-clock time we have been storing as though it were UTC, and persist both.
+ *
+ * ── WHAT IS WRONG ───────────────────────────────────────────────────────────
+ *
+ * `birthData.dateTime` is `new Date(<datetime-local>).toISOString()`, so a
+ * Brooklyn birth at 14:24 is stored `1991-06-23T14:24:00.000Z`. That is a wall
+ * clock wearing a `Z`. The true instant is 18:24Z, and every stored natal chart
+ * was computed for the sky at 14:24Z — four hours early.
+ *
+ * ── SCOPE, MEASURED 2026-08-04 AGAINST PRODUCTION ───────────────────────────
+ *
+ * The canonical surface is `users.profile->'birthData'` (60 rows), NOT
+ * `user_profiles.birth_data` (4 rows). Both are written by
+ * `userDatabase.updateUserProfile`; only the JSONB is populated at scale, so a
+ * migration scoped to the normalized column would touch 4 of 60. This script
+ * reads the JSONB and writes BOTH, because writing one is the original defect.
+ *
+ *   60 rows with birthData
+ *   ├── 52 agent placeholders @ 1900-01-01T12:00:00.000Z ... SKIPPED (sentinel,
+ *   │      not a birth; re-dating it to 17:00Z would be churn on a fiction)
+ *   └──  8 human
+ *        ├── 2 @ 40.7498,-73.7976 bit-exact ............... REFUSED (that is the
+ *        │      retired `ignite` route's "Fallback NY" literal; these users'
+ *        │      birthplace was never geocoded, so no instant can be derived)
+ *        └── 6 migratable
+ *
+ * ── THE SECT TRAP ───────────────────────────────────────────────────────────
+ *
+ * `isSectDiurnal` is a 06:00-18:00 window: a LOCAL-clock predicate. Feeding it
+ * the true instant flips day<->night on 6 of the 8 rows (14:24 local reads
+ * diurnal; 18:24Z reads nocturnal because `18 < 18` is false), which per
+ * `isSectDiurnalForBirth`'s docs swings the profile from ~32/49/9/9 to
+ * ~14/16/47/22 and rewrites the archetype. That flip is manufactured by the
+ * migration, not discovered by it. Sect therefore keeps reading the WALL CLOCK
+ * in both the control and the new value; only the ephemeris moves. `--show-trap`
+ * prints what the naive reading would have done, to keep the hazard visible.
+ *
+ * ── WHY THREE COLUMNS AND NOT TWO ───────────────────────────────────────────
+ *
+ * STORED is what the constitution row holds. It was computed by an engine 14
+ * commits older, so STORED != CONTROL is expected and is NOT this migration's
+ * doing. CONTROL re-runs today's engine on today's (wall-clock-as-UTC) instant;
+ * NEW re-runs today's engine on the TRUE instant. Only CONTROL -> NEW is
+ * attributable to the temporal migration, and that is the delta reported as the
+ * archetype flip count. Reading STORED -> NEW instead would credit this change
+ * with a year of unrelated engine drift.
+ *
+ * ── USAGE ───────────────────────────────────────────────────────────────────
+ *
+ *   # Dry run (default) — full diff + archetype flip sizing, no writes.
+ *   TZ=UTC ALCHM_MCP_BACKEND_URL=https://alchm.kitchen \
+ *     bun run scripts/backfillBirthInstant.ts
+ *
+ *   # Same, plus what the naive (sect-from-instant) reading would have done.
+ *   TZ=UTC ALCHM_MCP_BACKEND_URL=https://alchm.kitchen \
+ *     bun run scripts/backfillBirthInstant.ts --show-trap
+ *
+ *   # Zone normalization only — no chart calls, no backend needed.
+ *   bun run scripts/backfillBirthInstant.ts --zones-only
+ *
+ *   # Apply — one transaction per user, both profile surfaces + the columns.
+ *   TZ=UTC ALCHM_MCP_BACKEND_URL=https://alchm.kitchen \
+ *     bun run scripts/backfillBirthInstant.ts --apply
+ *
+ * Raw `pg`, no ORM. Reads DATABASE_PUBLIC_URL from the environment or
+ * `.env.development.local`.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import pg from "pg";
+
+import { calculateNatalChart } from "@/services/natalChartService";
+import { toEsmsShares, selectArchetype } from "@/utils/alchemicalConstitution";
+import { isSectDiurnal } from "@/utils/planetaryAlchemyMapping";
+import {
+  resolveBirthZone,
+  wallClockToInstant,
+  isFabricatedFallbackPin,
+  type ResolvedZone,
+  type WallClockResolution,
+} from "@/utils/astrology/birthTimezone";
+
+// ───────────────────────────────── flags ─────────────────────────────────
+
+const ARGV = new Set(process.argv.slice(2));
+const APPLY = ARGV.has("--apply");
+const ZONES_ONLY = ARGV.has("--zones-only");
+const SHOW_TRAP = ARGV.has("--show-trap");
+/**
+ * Also process the 52 agent placeholders. Off by default and expected to stay
+ * off: `1900-01-01T12:00:00.000Z` is a sentinel, so "correcting" it to 17:00Z
+ * produces a more precise fiction, not a more accurate birth.
+ */
+const INCLUDE_AGENTS = ARGV.has("--include-agents");
+
+/** The sentinel every agent placeholder carries. */
+const AGENT_SENTINEL_DATETIME = "1900-01-01T12:00:00.000Z";
+
+// ─────────────────────────────── guardrails ───────────────────────────────
+
+function assertUtc(): void {
+  if (new Date().getTimezoneOffset() !== 0) {
+    console.error(
+      `FATAL: run under UTC (TZ=${process.env.TZ ?? "<unset>"}, offset ` +
+        `${new Date().getTimezoneOffset()}min).\n` +
+        "`isSectDiurnalForBirth` still reads LOCAL getters, so sect — and with it\n" +
+        "the archetype — depends on the operator's clock. The control column would\n" +
+        "measure this laptop rather than production.\n" +
+        "Re-run with: TZ=UTC bun run scripts/backfillBirthInstant.ts …",
+    );
+    process.exit(1);
+  }
+}
+
+function loadEnvFile(file: string): Record<string, string> {
+  const abs = path.resolve(process.cwd(), file);
+  if (!fs.existsSync(abs)) return {};
+  const out: Record<string, string> = {};
+  for (const line of fs.readFileSync(abs, "utf8").split("\n")) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)$/);
+    if (m) out[m[1]] = m[2].replace(/^["']|["']$/g, "").trim();
+  }
+  return out;
+}
+
+function resolveConnectionString(): string {
+  const env = { ...loadEnvFile(".env.development.local"), ...loadEnvFile(".env.local") };
+  const url = process.env.DATABASE_PUBLIC_URL || env.DATABASE_PUBLIC_URL || env.DATABASE_URL;
+  if (!url) {
+    console.error("FATAL: no DATABASE_PUBLIC_URL / DATABASE_URL available.");
+    process.exit(1);
+  }
+  return url;
+}
+
+// ──────────────────────────────── types ────────────────────────────────
+
+interface BirthData {
+  dateTime: string;
+  latitude: number;
+  longitude: number;
+  timezone?: string;
+  [k: string]: unknown;
+}
+
+interface Row {
+  user_id: string;
+  email: string | null;
+  is_agent: boolean;
+  jsonb_birth: BirthData | null;
+  users_profile: Record<string, unknown> | null;
+  up_birth: BirthData | Record<string, never> | null;
+  base_archetype: string | null;
+  has_constitution: boolean;
+  stored_esms: [number, number, number, number] | null;
+}
+
+type Disposition =
+  | "MIGRATABLE"
+  | "SKIP_AGENT_SENTINEL"
+  | "REFUSE_FABRICATED_PIN"
+  | "REFUSE_NO_ZONE"
+  | "REFUSE_UNUSABLE_BIRTHDATA";
+
+interface Plan {
+  row: Row;
+  disposition: Disposition;
+  reason?: string;
+  birth?: BirthData;
+  zone?: ResolvedZone;
+  wallClock?: Date;
+  trueInstant?: Date;
+  offsetMinutes?: number;
+  resolution?: WallClockResolution;
+}
+
+function isUsableBirthData(b: unknown): b is BirthData {
+  if (!b || typeof b !== "object") return false;
+  const d = b as Partial<BirthData>;
+  return (
+    typeof d.dateTime === "string" &&
+    !Number.isNaN(Date.parse(d.dateTime)) &&
+    typeof d.latitude === "number" &&
+    Number.isFinite(d.latitude) &&
+    typeof d.longitude === "number" &&
+    Number.isFinite(d.longitude)
+  );
+}
+
+// ───────────────────────────── planning ─────────────────────────────
+
+function planRow(row: Row): Plan {
+  const birth = row.jsonb_birth;
+
+  if (!isUsableBirthData(birth)) {
+    return {
+      row,
+      disposition: "REFUSE_UNUSABLE_BIRTHDATA",
+      reason: "birthData lacks a parseable dateTime or finite coordinates",
+    };
+  }
+
+  if (!INCLUDE_AGENTS && (row.is_agent || birth.dateTime === AGENT_SENTINEL_DATETIME)) {
+    return {
+      row,
+      disposition: "SKIP_AGENT_SENTINEL",
+      reason: `placeholder birth ${birth.dateTime}`,
+      birth,
+    };
+  }
+
+  if (isFabricatedFallbackPin(birth.latitude, birth.longitude)) {
+    return {
+      row,
+      disposition: "REFUSE_FABRICATED_PIN",
+      reason:
+        "coordinates are the retired `ignite` route's Fallback NY literal — the " +
+        "birthplace was never geocoded, so no instant can be derived from it",
+      birth,
+    };
+  }
+
+  const zone = resolveBirthZone(birth);
+  if (!zone.zone) {
+    return {
+      row,
+      disposition: "REFUSE_NO_ZONE",
+      reason: `no IANA zone resolvable (stored: ${birth.timezone ?? "<none>"})`,
+      birth,
+      zone,
+    };
+  }
+
+  const wallClock = new Date(birth.dateTime);
+  const { instant, offsetMinutes, resolution } = wallClockToInstant(wallClock, zone.zone);
+
+  return {
+    row,
+    disposition: "MIGRATABLE",
+    birth,
+    zone,
+    wallClock,
+    trueInstant: instant,
+    offsetMinutes,
+    resolution,
+  };
+}
+
+// ─────────────────────── archetype impact sizing ───────────────────────
+
+/**
+ * Derive the constitution the way `/api/agent-forge/ignite` does.
+ *
+ * ⚠️ The ephemeris instant is supplied via `utcInstant`, NEVER by overriding
+ * `dateTime`. This function did the latter at first and it was wrong in a way
+ * that is worth spelling out, because it is the same trap this whole migration
+ * exists to avoid, sprung one level down:
+ *
+ *   `calculateNatalChart` derives sect INTERNALLY from `birthData.dateTime`
+ *   (natalChartService.ts:407) and folds it into `alchemicalProperties`.
+ *   Overwriting `dateTime` with 18:24Z therefore flipped the chart's own sect to
+ *   nocturnal, while `selectArchetype` below was still being handed `diurnal`
+ *   from the wall clock — an internally inconsistent constitution, half day and
+ *   half night. MEASURED: it moved 2ee5eb05 from 37/33/19/10 to 20/19/42/18.
+ *
+ * Setting `utcInstant` keeps the two halves aligned: the ephemeris moves, sect
+ * stays on `dateTime`, and both agree.
+ *
+ * @param useTrueInstant query the sky at `birth.utcInstant`/`trueInstant`
+ *                       (NEW) rather than at the wall clock (CONTROL)
+ */
+async function deriveConstitution(
+  birth: BirthData,
+  trueInstant: Date | null,
+): Promise<{ esms: [number, number, number, number]; archetype: string; diurnal: boolean }> {
+  const chart = await calculateNatalChart({
+    ...birth,
+    // NEW: the true instant. CONTROL: undefined, so calculateNatalChart falls
+    // back to `dateTime` and reproduces exactly what prod computed before.
+    utcInstant: trueInstant ? trueInstant.toISOString() : undefined,
+  });
+  const shares = toEsmsShares(chart.alchemicalProperties);
+  // Sect from the WALL CLOCK, matching what calculateNatalChart used internally.
+  const diurnal = isSectDiurnal(new Date(birth.dateTime));
+  const { baseArchetype } = selectArchetype(shares, diurnal);
+  return {
+    esms: [
+      Math.round(shares.spirit),
+      Math.round(shares.essence),
+      Math.round(shares.matter),
+      Math.round(shares.substance),
+    ],
+    archetype: baseArchetype,
+    diurnal,
+  };
+}
+
+// ─────────────────────────────── the write ───────────────────────────────
+
+/**
+ * Mirrors `userDatabase.updateUserProfile`'s dual-write, plus the new columns,
+ * in ONE transaction. `dateTime` is left ALONE: it remains the wall clock, which
+ * is what every existing reader already assumes. The true instant is ADDED as
+ * `utcInstant`. Renaming `dateTime` would be a silent semantic swap under every
+ * consumer that reads it.
+ */
+async function writeRow(client: pg.PoolClient, plan: Plan): Promise<void> {
+  const { row, birth, zone, wallClock, trueInstant } = plan;
+  if (!birth || !zone?.zone || !wallClock || !trueInstant) {
+    throw new Error("writeRow called on an unresolved plan");
+  }
+
+  const nextBirth: BirthData = {
+    ...birth,
+    // unchanged — still the wall clock, still labelled Z, still what sect reads
+    dateTime: birth.dateTime,
+    // added
+    utcInstant: trueInstant.toISOString(),
+    timezone: zone.zone,
+    timezoneBasis: zone.basis,
+    ...(zone.storedTimezone && zone.storedTimezone !== zone.zone
+      ? { timezoneStoredBefore: zone.storedTimezone }
+      : {}),
+  };
+
+  const mergedProfile = {
+    ...(row.users_profile ?? {}),
+    birthData: nextBirth,
+  };
+
+  await client.query("BEGIN");
+  try {
+    await client.query(
+      `UPDATE users SET profile = $2, updated_at = CURRENT_TIMESTAMP WHERE id = $1::uuid`,
+      [row.user_id, JSON.stringify(mergedProfile)],
+    );
+
+    await client.query(
+      `INSERT INTO user_profiles (
+         user_id, birth_data,
+         birth_local_wall_time, birth_true_utc_instant,
+         birth_timezone, birth_timezone_basis, birth_instant_migrated_at)
+       VALUES ($1::uuid, $2::jsonb, $3::timestamp, $4::timestamptz, $5, $6, NOW())
+       ON CONFLICT (user_id) DO UPDATE SET
+         birth_data                = EXCLUDED.birth_data,
+         birth_local_wall_time     = EXCLUDED.birth_local_wall_time,
+         birth_true_utc_instant    = EXCLUDED.birth_true_utc_instant,
+         birth_timezone            = EXCLUDED.birth_timezone,
+         birth_timezone_basis      = EXCLUDED.birth_timezone_basis,
+         birth_instant_migrated_at = NOW(),
+         updated_at                = CURRENT_TIMESTAMP`,
+      [
+        row.user_id,
+        JSON.stringify(nextBirth),
+        // wall clock as a naive timestamp: strip the bogus Z, keep the reading
+        wallClock.toISOString().slice(0, 19),
+        trueInstant.toISOString(),
+        zone.zone,
+        zone.basis,
+      ],
+    );
+
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  }
+}
+
+// ──────────────────────────────── main ────────────────────────────────
+
+async function main(): Promise<void> {
+  if (!ZONES_ONLY) {
+    assertUtc();
+    if (!process.env.ALCHM_MCP_BACKEND_URL?.trim()) {
+      console.error(
+        "FATAL: set ALCHM_MCP_BACKEND_URL=https://alchm.kitchen so the archetype\n" +
+          "sizing reaches the real astrologize backend. Use --zones-only to run the\n" +
+          "zone normalization without any chart calls.",
+      );
+      process.exit(1);
+    }
+  }
+
+  const pool = new pg.Pool({
+    connectionString: resolveConnectionString(),
+    ssl: { rejectUnauthorized: false },
+    max: 2,
+  });
+  const client = await pool.connect();
+
+  try {
+    // PREFLIGHT: migration 76 must be applied before --apply can write.
+    //
+    // Learned the hard way — the first `--apply` ran the whole scope + archetype
+    // sizing, then died on row 1 with `42703: column "birth_local_wall_time"
+    // does not exist`. The per-row transaction rolled that back cleanly, so
+    // nothing was corrupted, but a run that does all its thinking and then
+    // discovers the schema is missing is a run that should have refused at the
+    // top. Checked for every mode, not just --apply, so a dry run also tells you
+    // the target is not ready.
+    const REQUIRED_COLUMNS = [
+      "birth_local_wall_time",
+      "birth_true_utc_instant",
+      "birth_timezone",
+      "birth_timezone_basis",
+      "birth_instant_migrated_at",
+    ];
+    const { rows: present } = await client.query<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'user_profiles' AND column_name = ANY($1::text[])`,
+      [REQUIRED_COLUMNS],
+    );
+    const missing = REQUIRED_COLUMNS.filter(
+      (c) => !present.some((r) => r.column_name === c),
+    );
+    if (missing.length > 0) {
+      console.error(
+        `\nFATAL: migration 76 is not applied to this database.\n` +
+          `  missing column(s): ${missing.join(", ")}\n\n` +
+          "Apply it first:\n" +
+          "  bun run scripts/run-sql-migration.ts database/init/76-birth-instant-dual-storage.sql\n",
+      );
+      process.exit(1);
+    }
+
+    const { rows } = await client.query<Row>(`
+      SELECT
+        u.id::text                        AS user_id,
+        u.email,
+        u.is_agent,
+        u.profile -> 'birthData'          AS jsonb_birth,
+        u.profile                         AS users_profile,
+        up.birth_data                     AS up_birth,
+        ac.base_archetype,
+        (ac.user_id IS NOT NULL)          AS has_constitution,
+        CASE WHEN ac.user_id IS NOT NULL
+             THEN ARRAY[ac.spirit_balance, ac.essence_balance,
+                        ac.matter_balance, ac.substance_balance]
+        END                               AS stored_esms
+      FROM users u
+      LEFT JOIN user_profiles up            ON up.user_id = u.id
+      LEFT JOIN alchemical_constitutions ac ON ac.user_id = u.id
+      WHERE u.profile -> 'birthData' ? 'dateTime'
+      ORDER BY u.is_agent, u.profile->'birthData'->>'dateTime'
+    `);
+
+    const plans = rows.map(planRow);
+    const byDisposition = new Map<Disposition, Plan[]>();
+    for (const p of plans) {
+      const list = byDisposition.get(p.disposition) ?? [];
+      list.push(p);
+      byDisposition.set(p.disposition, list);
+    }
+
+    console.log(`\n━━━ SCOPE (${rows.length} rows with birthData) ━━━`);
+    for (const d of [
+      "MIGRATABLE",
+      "SKIP_AGENT_SENTINEL",
+      "REFUSE_FABRICATED_PIN",
+      "REFUSE_NO_ZONE",
+      "REFUSE_UNUSABLE_BIRTHDATA",
+    ] as Disposition[]) {
+      const n = byDisposition.get(d)?.length ?? 0;
+      if (n > 0) console.log(`  ${d.padEnd(26)} ${n}`);
+    }
+
+    // ── zone normalization report ──────────────────────────────────────
+    console.log(`\n━━━ ZONE NORMALIZATION ━━━`);
+    const migratable = byDisposition.get("MIGRATABLE") ?? [];
+    for (const p of migratable) {
+      const z = p.zone!;
+      const flags: string[] = [];
+      if (z.storedIsRawOffset) flags.push("raw-offset → IANA");
+      if (z.storedDisagrees) flags.push("STORED ZONE DISAGREES WITH PIN");
+      if (p.resolution !== "UNIQUE") flags.push(`DST ${p.resolution}`);
+      console.log(
+        `  ${p.row.user_id.slice(0, 8)}  ${(p.row.email ?? "—").padEnd(32)}` +
+          `${(z.storedTimezone ?? "<none>").padEnd(18)} → ${z.zone}` +
+          `  (${(p.offsetMinutes! / 60).toFixed(2).padStart(6)}h)` +
+          (flags.length ? `  ⚠ ${flags.join("; ")}` : ""),
+      );
+      console.log(
+        `            wall ${p.wallClock!.toISOString()}  →  instant ${p.trueInstant!.toISOString()}` +
+          `  (shift ${((p.trueInstant!.getTime() - p.wallClock!.getTime()) / 3600000).toFixed(2)}h)`,
+      );
+    }
+
+    for (const d of [
+      "REFUSE_FABRICATED_PIN",
+      "REFUSE_NO_ZONE",
+      "REFUSE_UNUSABLE_BIRTHDATA",
+    ] as Disposition[]) {
+      for (const p of byDisposition.get(d) ?? []) {
+        console.log(`  ${p.row.user_id.slice(0, 8)}  ${p.row.email ?? "—"}  ${d}\n            ${p.reason}`);
+      }
+    }
+    const skipped = byDisposition.get("SKIP_AGENT_SENTINEL") ?? [];
+    if (skipped.length) {
+      console.log(
+        `  …and ${skipped.length} agent placeholder(s) at ${AGENT_SENTINEL_DATETIME} left untouched ` +
+          "(--include-agents to override).",
+      );
+    }
+
+    if (ZONES_ONLY) {
+      console.log("\n--zones-only: stopping before any chart call.\n");
+      return;
+    }
+
+    // ── archetype impact sizing ────────────────────────────────────────
+    console.log(`\n━━━ ARCHETYPE IMPACT (STORED / CONTROL / NEW) ━━━`);
+    console.log(
+      "  STORED  = the constitution row as it stands (older engine)\n" +
+        "  CONTROL = today's engine on today's instant  → isolates engine drift\n" +
+        "  NEW     = today's engine on the TRUE instant → the migration's own effect\n" +
+        "  Only CONTROL → NEW is attributable to this migration.\n",
+    );
+
+    let flips = 0;
+    let flipsWithConstitution = 0;
+    let controlMatchesStored = 0;
+    let storedComparable = 0;
+    let naiveFlips = 0;
+    /**
+     * STORED -> NEW. Distinct from CONTROL -> NEW and answering a different
+     * question: this is what a user would SEE change on their profile, because
+     * STORED is the label the table serves today. It can be smaller than the
+     * attributable flip count — engine drift and the temporal shift can move the
+     * archetype away and back, landing on the original label by two wrongs.
+     */
+    let userVisibleFlips = 0;
+
+    for (const p of migratable) {
+      const { birth, wallClock, trueInstant, row } = p;
+      let control: Awaited<ReturnType<typeof deriveConstitution>>;
+      let next: Awaited<ReturnType<typeof deriveConstitution>>;
+      try {
+        // sect reads the WALL CLOCK in both — only the ephemeris instant moves.
+        control = await deriveConstitution(birth!, null);
+        next = await deriveConstitution(birth!, trueInstant!);
+      } catch (err) {
+        console.log(`  ${row.user_id.slice(0, 8)}  FAILED to derive: ${(err as Error).message}`);
+        continue;
+      }
+
+      const flipped = control.archetype !== next.archetype;
+      if (flipped) {
+        flips += 1;
+        if (row.has_constitution) flipsWithConstitution += 1;
+      }
+      if (row.has_constitution && row.base_archetype) {
+        storedComparable += 1;
+        if (row.base_archetype === control.archetype) controlMatchesStored += 1;
+        if (row.base_archetype !== next.archetype) userVisibleFlips += 1;
+      }
+
+      console.log(
+        `  ${row.user_id.slice(0, 8)}  ${(row.email ?? "—").padEnd(32)}` +
+          `${row.has_constitution ? "" : "(no constitution row) "}`,
+      );
+      console.log(
+        `      STORED  ${(row.base_archetype ?? "—").padEnd(18)} ${row.stored_esms?.join("/") ?? "—"}`,
+      );
+      console.log(`      CONTROL ${control.archetype.padEnd(18)} ${control.esms.join("/")}`);
+      console.log(
+        `      NEW     ${next.archetype.padEnd(18)} ${next.esms.join("/")}` +
+          (flipped ? "   ← ARCHETYPE FLIPS" : ""),
+      );
+
+      if (SHOW_TRAP) {
+        const naiveDiurnal = isSectDiurnal(trueInstant!);
+        if (naiveDiurnal !== control.diurnal) {
+          naiveFlips += 1;
+          console.log(
+            `      ⚠ TRAP: sourcing sect from the true instant would flip ` +
+              `${control.diurnal ? "diurnal→nocturnal" : "nocturnal→diurnal"} here. Not done.`,
+          );
+        }
+      }
+    }
+
+    console.log(`\n━━━ SUMMARY ━━━`);
+    console.log(`  migratable rows                     : ${migratable.length}`);
+    console.log(`  archetypes that flip (CONTROL → NEW): ${flips}`);
+    console.log(`  …of which have a constitution row   : ${flipsWithConstitution}`);
+    console.log(
+      `  control gate (CONTROL == STORED)    : ${controlMatchesStored}/${storedComparable}` +
+        (storedComparable === 0
+          ? "  — no comparable rows"
+          : controlMatchesStored === storedComparable
+            ? "  ✔ engine reproduces stored archetypes; the flip count above is this migration's alone"
+            : "  ⚠ engine drift present; STORED → NEW would ALSO include changes this migration did not cause"),
+    );
+    console.log(
+      `  archetypes a USER would see change     : ${userVisibleFlips}/${storedComparable}` +
+        "  (STORED → NEW, i.e. the label served today vs the one that would be written)",
+    );
+    if (SHOW_TRAP) {
+      console.log(`  sect flips avoided by reading the wall clock: ${naiveFlips}`);
+    }
+
+    console.log(
+      "\n  ⚠ THIS SCRIPT DOES NOT WRITE THE CHART OR THE CONSTITUTION.\n" +
+        "    --apply persists birth_data + the three new columns only. The stored\n" +
+        "    natal_chart and alchemical_constitutions rows still hold geometry\n" +
+        "    computed from the OLD instant, so applying this alone leaves the two\n" +
+        "    inconsistent. Run `healConstitutionGeometry.ts --recompute-all` after\n" +
+        "    it to bring the charts and constitutions onto the migrated instant.",
+    );
+
+    // ── write ──────────────────────────────────────────────────────────
+    console.log(`\n━━━ ${APPLY ? "APPLY" : "DRY RUN"} ━━━`);
+    if (!APPLY) {
+      console.log(`  ${migratable.length} row(s) would be written. No changes made.`);
+      console.log("  Re-run with --apply to commit.\n");
+      return;
+    }
+
+    for (const p of migratable) {
+      await writeRow(client, p);
+      console.log(
+        `  ✔ ${p.row.user_id.slice(0, 8)} committed (users.profile + user_profiles + columns)`,
+      );
+    }
+    console.log(`\n  ${migratable.length} row(s) migrated.\n`);
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+await main();

--- a/scripts/healConstitutionGeometry.ts
+++ b/scripts/healConstitutionGeometry.ts
@@ -96,6 +96,35 @@ const WITH_DISTANCE = ARGV.has("--with-distance");
  * would matter.
  */
 const RECOMPUTE_ALL = ARGV.has("--recompute-all");
+/**
+ * Also refresh profiles that hold a natal chart but NO constitution row.
+ *
+ * This script's main query is `FROM alchemical_constitutions`, so such rows are
+ * structurally invisible to it — and after the temporal migration they are
+ * exactly the rows left holding a chart computed from the old wall-clock
+ * instant, with nothing to ever bring them forward. MEASURED 2026-08-04: 2 of
+ * the 6 migrated profiles are in this state.
+ *
+ * Only the chart is rewritten; there is no constitution row to update.
+ */
+const ORPHAN_CHARTS = ARGV.has("--orphan-charts");
+/**
+ * Run the CONTROL pass at the WALL CLOCK instead of the row's true instant.
+ *
+ * The control gate's job is to reproduce what prod actually stored. Which
+ * instant that was depends on where a row sits in the temporal migration:
+ *
+ *   - BEFORE the charts were recomputed, prod's stored charts came from the wall
+ *     clock, so the control had to strip `utcInstant` to match them. Without
+ *     this the gate failed on every migrated row — correctly, but for a reason
+ *     that was the migration's whole point rather than a harness fault.
+ *   - AFTER `--recompute-all` has run, prod's stored charts ARE true-instant
+ *     charts, and the control must use the birth data as-is (the default).
+ *
+ * Kept as a flag rather than deleted because it is the only way to re-verify the
+ * pre-migration geometry against a row that has since been recomputed.
+ */
+const CONTROL_WALL_CLOCK = ARGV.has("--control-wall-clock");
 
 // ─────────────────────────────── guardrails ───────────────────────────────
 
@@ -138,7 +167,14 @@ function resolveConnectionString(): string {
 // ──────────────────────────────── types ────────────────────────────────
 
 interface BirthData {
+  /** The birth WALL CLOCK, labelled `Z`. Drives sect. */
   dateTime: string;
+  /**
+   * The true UTC instant, written by `scripts/backfillBirthInstant.ts`. Drives
+   * the ephemeris. Absent on rows that predate the temporal migration and on
+   * rows where no defensible instant exists — never fabricated.
+   */
+  utcInstant?: string;
   latitude: number;
   longitude: number;
   timezone?: string;
@@ -197,11 +233,25 @@ function geocentricDistanceAu(planet: string, instant: Date): number | null {
  * the constitution with the canonical engine. This is the same sequence
  * `/api/agent-forge/ignite` runs, minus auth, geocoding and recipe generation.
  */
-async function reignite(birthData: BirthData) {
-  const chart: any = await calculateNatalChart(birthData);
+async function reignite(birthData: BirthData, opts: { useWallClock?: boolean } = {}) {
+  // `calculateNatalChart` queries the ephemeris at `utcInstant` when the temporal
+  // migration has supplied one, falling back to `dateTime` (the wall clock).
+  //
+  // The CONTROL pass must reproduce what prod actually stored, and prod stored
+  // charts computed from the wall clock. So the control strips `utcInstant` and
+  // re-runs on `dateTime`; the healing pass leaves it in place and gets the true
+  // sky. Without this split the control gate would fail on every migrated row —
+  // correctly, since the geometry genuinely changed — and refuse to apply,
+  // reporting the migration's whole point as a harness fault.
+  const source: BirthData = opts.useWallClock
+    ? { ...birthData, utcInstant: undefined }
+    : birthData;
+
+  const chart: any = await calculateNatalChart(source);
 
   if (WITH_DISTANCE) {
-    const instant = new Date(birthData.dateTime);
+    // The distance must come from the same instant the sky did.
+    const instant = new Date(source.utcInstant ?? source.dateTime);
     for (const planet of chart.planets ?? []) {
       const d = geocentricDistanceAu(planet.name, instant);
       if (d !== null) planet.distance = d;
@@ -275,7 +325,12 @@ async function runControl(healthy: CandidateRow[]): Promise<boolean> {
       continue;
     }
 
-    const { chart: control, esms } = await reignite(birth);
+    // Reproduce prod's own stored geometry. Post-migration that means using the
+    // birth data as-is (true instant); --control-wall-clock re-checks against
+    // the pre-migration sky. See CONTROL_WALL_CLOCK's docs.
+    const { chart: control, esms } = await reignite(birth, {
+      useWallClock: CONTROL_WALL_CLOCK,
+    });
     const storedPlanets: any[] = row.stored_chart?.planets ?? [];
     const controlPlanets: any[] = control.planets ?? [];
 
@@ -396,6 +451,45 @@ async function healRow(
   }
 }
 
+/**
+ * Rewrite a profile's stored chart on both surfaces, without touching any
+ * constitution row (these profiles have none — that is why they are here).
+ */
+async function refreshChartOnly(
+  client: pg.PoolClient,
+  row: CandidateRow,
+  birth: BirthData,
+  rebuilt: Awaited<ReturnType<typeof reignite>>,
+): Promise<void> {
+  const mergedProfile = {
+    ...(row.users_profile ?? {}),
+    userId: row.user_id,
+    birthData: birth,
+    natalChart: rebuilt.chart,
+  };
+
+  await client.query("BEGIN");
+  try {
+    await client.query(
+      `UPDATE users SET profile = $2, updated_at = CURRENT_TIMESTAMP WHERE id = $1::uuid`,
+      [row.user_id, JSON.stringify(mergedProfile)],
+    );
+    const res = await client.query(
+      `UPDATE user_profiles
+          SET natal_chart = $2::jsonb, updated_at = CURRENT_TIMESTAMP
+        WHERE user_id = $1::uuid`,
+      [row.user_id, JSON.stringify(rebuilt.chart)],
+    );
+    if (res.rowCount !== 1) {
+      throw new Error(`expected to update exactly 1 profile row, got ${res.rowCount}`);
+    }
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  }
+}
+
 // ──────────────────────────────── main ────────────────────────────────
 
 async function main(): Promise<void> {
@@ -460,8 +554,10 @@ async function main(): Promise<void> {
     console.log(`\n━━━ ${APPLY ? "APPLY" : "DRY RUN"} ━━━`);
     const targets = RECOMPUTE_ALL ? [...broken, ...healthy] : broken;
     if (targets.length === 0) {
-      console.log("  Nothing to heal.");
-      return;
+      // Deliberately NOT an early return: the orphan-chart pass below is
+      // independent of the constitution scope, and "no constitution needs
+      // healing" is the normal state in which orphans still do.
+      console.log("  No constitution row needs healing.");
     }
     if (RECOMPUTE_ALL) {
       console.log(`  --recompute-all: ${broken.length} broken + ${healthy.length} healthy rows`);
@@ -513,6 +609,94 @@ async function main(): Promise<void> {
 
       await healRow(client, row, birth, rebuilt);
       console.log("    ✔ committed (users.profile + user_profiles + constitution)");
+    }
+
+    // ── orphan charts: a stored chart with no constitution row ──────────
+    if (!ORPHAN_CHARTS) {
+      const { rows: orphanCount } = await client.query<{ n: string }>(`
+        SELECT count(*) AS n
+          FROM user_profiles up
+          LEFT JOIN alchemical_constitutions ac ON ac.user_id = up.user_id
+         WHERE ac.user_id IS NULL
+           -- CASE, not AND: SQL's AND is not short-circuiting, so a bare
+           -- jsonb_array_length beside the typeof guard still errors on the
+           -- 71 rows whose planets key is not an array.
+           AND CASE WHEN jsonb_typeof(up.natal_chart->'planets') = 'array'
+                    THEN jsonb_array_length(up.natal_chart->'planets')
+                    ELSE 0 END > 0
+      `);
+      if (Number(orphanCount[0]?.n ?? 0) > 0) {
+        console.log(
+          `\n  NOTE: ${orphanCount[0].n} profile(s) hold a natal chart but no constitution row,` +
+            "\n  so this script's constitution-scoped query cannot see them. After the\n" +
+            "  temporal migration those charts are stale. Pass --orphan-charts to include them.",
+        );
+      }
+      return;
+    }
+
+    console.log(`\n━━━ ORPHAN CHARTS (chart present, no constitution row) ━━━`);
+    const { rows: orphans } = await client.query<CandidateRow>(`
+      SELECT
+        up.user_id::text                       AS user_id,
+        u.email                                AS email,
+        NULL::text                             AS base_archetype,
+        ARRAY[0,0,0,0]                         AS stored_esms,
+        -- CASE-guarded, not COALESCE-guarded: 71 profile rows store the chart's
+        -- planets key as something other than an array, and jsonb_array_length
+        -- errors on those. The WHERE clause filters them out but does not
+        -- constrain when this select expression is evaluated.
+        CASE WHEN jsonb_typeof(up.natal_chart->'planets') = 'array'
+             THEN jsonb_array_length(up.natal_chart->'planets')
+             ELSE 0 END                        AS profile_planet_count,
+        up.birth_data                          AS profile_birth_data,
+        u.profile -> 'birthData'               AS jsonb_birth_data,
+        u.profile                              AS users_profile,
+        up.natal_chart                         AS stored_chart
+      FROM user_profiles up
+      LEFT JOIN users u                     ON u.id = up.user_id
+      LEFT JOIN alchemical_constitutions ac ON ac.user_id = up.user_id
+      WHERE ac.user_id IS NULL
+        AND CASE WHEN jsonb_typeof(up.natal_chart->'planets') = 'array'
+                 THEN jsonb_array_length(up.natal_chart->'planets')
+                 ELSE 0 END > 0
+      ORDER BY up.updated_at
+    `);
+
+    if (orphans.length === 0) {
+      console.log("  None.");
+      return;
+    }
+
+    for (const row of orphans) {
+      const birth = isUsableBirthData(row.profile_birth_data)
+        ? row.profile_birth_data
+        : row.jsonb_birth_data;
+      if (!isUsableBirthData(birth)) {
+        console.log(`  ${row.user_id}  SKIP — no usable birth data`);
+        continue;
+      }
+
+      let rebuilt: Awaited<ReturnType<typeof reignite>>;
+      try {
+        rebuilt = await reignite(birth);
+      } catch (err) {
+        console.log(`  ${row.user_id}  FAILED to re-ignite: ${(err as Error).message}`);
+        continue;
+      }
+
+      console.log(`\n  ${row.user_id}  (${row.email ?? "no email"})`);
+      console.log(
+        `    ephemeris    : ${birth.utcInstant ?? birth.dateTime}` +
+          `${birth.utcInstant ? "  (true instant)" : "  (wall clock — unmigrated)"}`,
+      );
+      console.log(`    chart        : ${rebuilt.chart.planets?.length ?? 0} planets`);
+      if (!APPLY) {
+        console.log("    (dry run — no write)");
+        continue;
+      }
+      await refreshChartOnly(client, row, birth, rebuilt);
+      console.log("    ✔ committed (users.profile + user_profiles.natal_chart)");
     }
   } finally {
     client.release();

--- a/src/__tests__/utils/birthTimezone.test.ts
+++ b/src/__tests__/utils/birthTimezone.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Guards the wall-clock ↔ absolute-instant boundary for birth data.
+ *
+ * Two things are pinned here, and they fail for different reasons:
+ *
+ *   RESOLUTION — the zone a birth record resolves to, and the exact historical
+ *     offset at that instant. This is what makes the two prod `UTC-5` rows come
+ *     out at −4 (they are EDT births), and what catches the row whose IANA
+ *     string names a different continent than its coordinates.
+ *
+ *   HOST INDEPENDENCE — none of it may read the runner's clock. The suite forces
+ *     TZ=Pacific/Auckland before importing, plus a meta-assertion that the runner
+ *     honoured it, because a TZ-keyed guard that silently goes blind is worse
+ *     than no guard: it passes on a UTC CI box while the bug ships.
+ *
+ * Every fixture below is a MEASURED prod row (2026-08-04) or a documented tzdata
+ * transition, never an invented convenience value.
+ */
+
+// Must precede the import under test: Date's local getters bind at construction.
+process.env.TZ = "Pacific/Auckland";
+
+import {
+  isIanaZone,
+  parseRawOffsetMinutes,
+  resolveBirthZone,
+  zoneOffsetMinutes,
+  wallClockToInstant,
+  instantToWallClock,
+} from "@/utils/astrology/birthTimezone";
+
+/** The 8 human birth records in prod, measured 2026-08-04. */
+const PROD_ROWS = [
+  {
+    id: "57672a00",
+    stored: "1958-10-01T16:00:00.000Z",
+    stz: "America/New_York",
+    lat: 40.75,
+    lon: -73.798,
+    zone: "America/New_York",
+    offset: -240,
+    instant: "1958-10-01T20:00:00.000Z",
+  },
+  {
+    id: "5f40a6e5",
+    stored: "1984-01-04T05:05:00.000Z",
+    stz: "America/New_York",
+    lat: 2.8208478,
+    lon: -60.6719582,
+    zone: "America/Boa_Vista", // ← coordinates are Brazil; the stored string is not
+    offset: -240,
+    instant: "1984-01-04T09:05:00.000Z",
+  },
+  {
+    id: "9726fa59",
+    stored: "1990-04-20T04:20:00.000Z",
+    stz: "America/New_York",
+    lat: 40.75,
+    lon: -73.798,
+    zone: "America/New_York",
+    offset: -240,
+    instant: "1990-04-20T08:20:00.000Z",
+  },
+  {
+    id: "2ee5eb05",
+    stored: "1991-06-23T14:24:00.000Z",
+    stz: "America/New_York",
+    lat: 40.6526006,
+    lon: -73.9497211,
+    zone: "America/New_York",
+    offset: -240,
+    instant: "1991-06-23T18:24:00.000Z",
+  },
+  {
+    id: "3de96e89",
+    stored: "1996-10-21T10:28:00.000Z",
+    stz: "UTC-5", // ← raw offset, and wrong: this is an EDT date
+    lat: 40.7956894,
+    lon: -73.6989103,
+    zone: "America/New_York",
+    offset: -240,
+    instant: "1996-10-21T14:28:00.000Z",
+  },
+  {
+    id: "5e813bbf",
+    stored: "2021-10-10T10:21:00.000Z",
+    stz: "UTC-5",
+    lat: 40.7135078,
+    lon: -73.8283132,
+    zone: "America/New_York",
+    offset: -240,
+    instant: "2021-10-10T14:21:00.000Z",
+  },
+] as const;
+
+describe("birth timezone resolution", () => {
+  it("runs under a non-UTC host, or the host-independence claims below are vacuous", () => {
+    // Meta-assertion. If the runner ignored process.env.TZ this suite would
+    // still pass every other case while proving nothing about host independence.
+    expect(new Date("2021-07-01T00:00:00Z").getTimezoneOffset()).not.toBe(0);
+  });
+
+  it.each(PROD_ROWS)(
+    "resolves $id from coordinates, not from its stored string",
+    ({ stz, lat, lon, zone }) => {
+      const r = resolveBirthZone({ latitude: lat, longitude: lon, timezone: stz });
+      expect(r.zone).toBe(zone);
+      expect(r.basis).toBe("DERIVED_FROM_COORDINATES");
+    },
+  );
+
+  it.each(PROD_ROWS)(
+    "converts $id's wall clock to the true instant at the real historical offset",
+    ({ stored, stz, lat, lon, zone, offset, instant }) => {
+      const r = resolveBirthZone({ latitude: lat, longitude: lon, timezone: stz });
+      const res = wallClockToInstant(new Date(stored), r.zone as string);
+      expect(res.resolution).toBe("UNIQUE");
+      expect(res.offsetMinutes).toBe(offset);
+      expect(res.instant.toISOString()).toBe(instant);
+      expect(zoneOffsetMinutes(zone, res.instant)).toBe(offset);
+    },
+  );
+
+  it("flags the row whose IANA string names a different continent than its pin", () => {
+    const boaVista = PROD_ROWS.find((r) => r.id === "5f40a6e5")!;
+    const r = resolveBirthZone({
+      latitude: boaVista.lat,
+      longitude: boaVista.lon,
+      timezone: boaVista.stz,
+    });
+    expect(r.zone).toBe("America/Boa_Vista");
+    expect(r.storedTimezone).toBe("America/New_York");
+    expect(r.storedDisagrees).toBe(true);
+    expect(r.storedIsRawOffset).toBe(false);
+  });
+
+  it("prices the two UTC-5 rows at −4, because both are EDT births", () => {
+    // This is the whole point of resolving through tzdata rather than the
+    // literal string: taking `UTC-5` at face value is an hour wrong on both.
+    for (const id of ["3de96e89", "5e813bbf"] as const) {
+      const row = PROD_ROWS.find((r) => r.id === id)!;
+      const r = resolveBirthZone({ latitude: row.lat, longitude: row.lon, timezone: row.stz });
+      expect(r.storedIsRawOffset).toBe(true);
+      expect(parseRawOffsetMinutes(row.stz)).toBe(-300); // what the string claims
+      expect(wallClockToInstant(new Date(row.stored), r.zone as string).offsetMinutes).toBe(-240);
+    }
+  });
+});
+
+describe("IANA validation", () => {
+  it("rejects the shapes the retired estimateTimezone emitted", () => {
+    expect(isIanaZone("UTC-5")).toBe(false);
+    expect(isIanaZone("UTC+13")).toBe(false);
+    expect(isIanaZone("")).toBe(false);
+    expect(isIanaZone(undefined)).toBe(false);
+    expect(isIanaZone("Not/AZone")).toBe(false);
+  });
+
+  it("accepts real IANA names, including the fixed-offset Etc/* family", () => {
+    expect(isIanaZone("America/New_York")).toBe(true);
+    expect(isIanaZone("America/Boa_Vista")).toBe(true);
+    expect(isIanaZone("Etc/GMT+5")).toBe(true);
+    expect(isIanaZone("UTC")).toBe(true);
+  });
+
+  it("parses raw offsets for reporting without ever accepting them as zones", () => {
+    expect(parseRawOffsetMinutes("UTC-5")).toBe(-300);
+    expect(parseRawOffsetMinutes("UTC+13")).toBe(780);
+    expect(parseRawOffsetMinutes("GMT+5:30")).toBe(330);
+    expect(parseRawOffsetMinutes("America/New_York")).toBeNull();
+    expect(parseRawOffsetMinutes("UTC+99")).toBeNull();
+  });
+
+  it("refuses to substitute a raw offset for a zone when coordinates are absent", () => {
+    const r = resolveBirthZone({ latitude: null, longitude: null, timezone: "UTC-5" });
+    expect(r.zone).toBeNull();
+    expect(r.basis).toBe("ABSENT");
+    expect(r.storedIsRawOffset).toBe(true);
+  });
+
+  it("falls back to a stored IANA name only when coordinates are unusable", () => {
+    const r = resolveBirthZone({ latitude: null, longitude: null, timezone: "America/New_York" });
+    expect(r.zone).toBe("America/New_York");
+    expect(r.basis).toBe("STORED_IANA_STRING");
+  });
+});
+
+describe("DST edges are detected, not papered over", () => {
+  // US DST 2021: forward 2021-03-14 02:00 → 03:00, back 2021-11-07 02:00 → 01:00.
+  it("reports the spring-forward gap as NONEXISTENT", () => {
+    const res = wallClockToInstant(new Date("2021-03-14T02:30:00.000Z"), "America/New_York");
+    expect(res.resolution).toBe("NONEXISTENT");
+  });
+
+  it("reports the fall-back overlap as AMBIGUOUS and returns the earlier pass", () => {
+    const res = wallClockToInstant(new Date("2021-11-07T01:30:00.000Z"), "America/New_York");
+    expect(res.resolution).toBe("AMBIGUOUS");
+    expect(res.offsetMinutes).toBe(-240); // EDT — the first of the two 01:30s
+    expect(res.instant.toISOString()).toBe("2021-11-07T05:30:00.000Z");
+  });
+
+  it("treats an ordinary wall clock either side of a transition as UNIQUE", () => {
+    for (const w of ["2021-03-14T04:30:00.000Z", "2021-11-07T03:30:00.000Z"]) {
+      expect(wallClockToInstant(new Date(w), "America/New_York").resolution).toBe("UNIQUE");
+    }
+  });
+});
+
+describe("round-trip", () => {
+  it("recovers the stored wall clock from the true instant", () => {
+    for (const row of PROD_ROWS) {
+      const r = resolveBirthZone({ latitude: row.lat, longitude: row.lon, timezone: row.stz });
+      const { instant } = wallClockToInstant(new Date(row.stored), r.zone as string);
+      // This is the invariant the dual-storage model rests on: local_wall_time is
+      // recoverable from true_utc_instant + zone, so nothing is lost by storing both.
+      expect(instantToWallClock(instant, r.zone as string).toISOString()).toBe(row.stored);
+    }
+  });
+
+  it("is unaffected by the host zone", () => {
+    // Same inputs, evaluated while the process sits in Pacific/Auckland (UTC+12).
+    // Any local getter anywhere in the chain would show up here as a 12h error.
+    const row = PROD_ROWS.find((r) => r.id === "2ee5eb05")!;
+    const res = wallClockToInstant(new Date(row.stored), "America/New_York");
+    expect(res.instant.toISOString()).toBe("1991-06-23T18:24:00.000Z");
+    expect(zoneOffsetMinutes("Pacific/Auckland", new Date("1991-06-23T18:24:00Z"))).toBe(720);
+  });
+});

--- a/src/app/api/agent-forge/__tests__/ignite.route.test.ts
+++ b/src/app/api/agent-forge/__tests__/ignite.route.test.ts
@@ -114,10 +114,14 @@ describe("POST /api/agent-forge/ignite", () => {
     jest.spyOn(console, "warn").mockImplementation(() => {});
     errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
 
+    // `timezone`, not the retired `estimatedTimezone`. Note this mock was always
+    // fictional under the old name: production's `estimatedTimezone` held
+    // `Math.round(lon / 15)` rendered as `UTC±N` and could never have produced
+    // "America/New_York". The field now genuinely carries an IANA name.
     mockGeocode.mockResolvedValue({
       latitude: 40.7,
       longitude: -74,
-      estimatedTimezone: "America/New_York",
+      timezone: "America/New_York",
     });
     mockCalcChart.mockResolvedValue(MOCK_CHART);
     mockExecuteQuery.mockResolvedValue({ rows: [] });
@@ -193,6 +197,27 @@ describe("POST /api/agent-forge/ignite", () => {
     const res = await POST(makeRequest({ city: "New York" }));
 
     expect(res.status).toBe(400);
+    expect(mockUpdateProfile).not.toHaveBeenCalled();
+  });
+
+  it("refuses a failed geocode instead of stamping the Fallback NY pin", async () => {
+    // Regression guard. This route used to do:
+    //   const latitude  = geocoded?.latitude  ?? 40.7498; // Fallback NY
+    //   const longitude = geocoded?.longitude ?? -73.7976;
+    //   const timezone  = geocoded?.estimatedTimezone ?? "UTC";
+    // MEASURED 2026-08-04, 2 of the 8 human birth records in prod carry that pin
+    // bit-for-bit — their birthplace was never geocoded, and nothing downstream
+    // could tell, because a fabricated pin passes every finiteness check there is.
+    mockAuth.mockResolvedValue({
+      user: { id: "user-123", email: "test@example.com" },
+    });
+    mockGeocode.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ dob: "1990-05-15T10:30", city: "Nowhere-at-all" }));
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({ error: "geocode_failed" });
+    expect(mockCalcChart).not.toHaveBeenCalled();
     expect(mockUpdateProfile).not.toHaveBeenCalled();
   });
 

--- a/src/app/api/agent-forge/ignite/route.ts
+++ b/src/app/api/agent-forge/ignite/route.ts
@@ -75,17 +75,37 @@ export async function POST(req: Request) {
     const { dob, city } = body;
 
     // 3. Geocode location to coordinates
+    //
+    // A failed geocode used to fall back to `40.7498, -73.7976` ("Fallback NY")
+    // with a timezone of `"UTC"`. That is not a degraded chart, it is a
+    // confidently wrong one: the pin satisfies every downstream finiteness check
+    // and reads as a real birthplace forever after. MEASURED 2026-08-04, 2 of
+    // the 8 human birth records in prod carry that exact pin bit-for-bit, so
+    // their stored birthplace — and the `America/New_York` zone derived from it —
+    // was never anything the user said.
+    //
+    // Refuse instead. A chart cannot be invented for a place we could not find.
     const geocoded = await geocodeLocationSingle(city);
-    const latitude = geocoded?.latitude ?? 40.7498; // Fallback NY
-    const longitude = geocoded?.longitude ?? -73.7976;
-    const timezone = geocoded?.estimatedTimezone ?? "UTC";
+    if (!geocoded || !Number.isFinite(geocoded.latitude) || !Number.isFinite(geocoded.longitude)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "geocode_failed",
+          message: `Could not resolve "${city}" to a birthplace. A natal chart cannot be computed without real coordinates.`,
+        },
+        { status: 422 },
+      );
+    }
+    const { latitude, longitude } = geocoded;
 
     // 4. Temporal Analysis (retrieves the natal chart)
     const birthData = {
       dateTime: new Date(dob).toISOString(),
       latitude,
       longitude,
-      timezone,
+      // IANA, resolved from the pin. Null rather than "UTC" when unresolvable —
+      // a fabricated "UTC" silently re-dates the birth by the true offset.
+      timezone: geocoded.timezone ?? undefined,
     };
 
     console.log(`[ignite] Calculating natal chart for user ${userId} at ${dob} in ${city}...`);

--- a/src/components/auth/OnboardingWizard.tsx
+++ b/src/components/auth/OnboardingWizard.tsx
@@ -7,6 +7,9 @@ import React, { useState } from "react";
 import { useForm } from "react-hook-form"; // For form management
 import { z } from "zod"; // For validation
 import { OnboardingRequestSchema } from "@/lib/validation/apiSchemas";
+// From `ianaZone`, not `birthTimezone`: this is a client component, and the
+// latter pulls tz-lookup's ~150KB boundary raster into the browser bundle.
+import { isIanaZone } from "@/utils/astrology/ianaZone";
 
 // Zod schemas for validation
 const IdentitySchema = z
@@ -34,7 +37,19 @@ const WizardBirthDataSchema = z.object({
     .number()
     .min(-180)
     .max(180, "Longitude must be between -180 and 180"),
-  timezone: z.string().min(1, "Timezone is required"),
+  // IANA-validated, not just non-empty. `z.string().min(1)` accepted anything
+  // typed here, which is how free-text zones entered the same key-space as the
+  // geocoder's `UTC±N` output. A bare `UTC-5` is NOT an IANA zone and is
+  // rejected; `Etc/GMT+5` is one, and is accepted.
+  timezone: z
+    .string()
+    .min(1, "Timezone is required")
+    .refine(isIanaZone, {
+      message:
+        "Enter an IANA timezone name such as America/New_York. Offsets like " +
+        "UTC-5 are not accepted: they cannot express daylight saving, so they " +
+        "date a birth chart an hour wrong for much of the year.",
+    }),
 });
 
 const KitchenPreferencesSchema = z.object({

--- a/src/components/onboarding/LocationSearch.tsx
+++ b/src/components/onboarding/LocationSearch.tsx
@@ -22,18 +22,23 @@ interface LocationSearchProps {
   placeholder?: string;
 }
 
-/**
- * Estimate IANA timezone from longitude (rough but useful fallback).
- * For birth chart calculations, the exact timezone matters less than
- * the UTC offset at the time of birth, which the backend derives from coords.
+/*
+ * `estimateTimezone` used to live here: `Math.round(longitude / 15)` rendered as
+ * `UTC±N`. It was removed rather than fixed, for three reasons —
+ *
+ *   1. Despite the name and its docstring, it never returned an IANA zone. It is
+ *      where every `UTC-5` in prod came from.
+ *   2. Being a fixed offset it was DST-blind, so it was an hour wrong for any
+ *      birth inside daylight saving — both `UTC-5` rows in prod are EDT births.
+ *   3. Its docstring justified the imprecision with "the UTC offset at the time
+ *      of birth, which the backend derives from coords". No such derivation
+ *      exists: `fetchPlanetaryPositions` sends the raw UTC components and lat/lon
+ *      and the route rebuilds the instant with `Date.UTC`.
+ *
+ * The zone now arrives already resolved on the geocoding result (`result.timezone`,
+ * DERIVED from the tz boundary data server-side). Resolving it here instead would
+ * pull ~150KB of boundary raster into the client bundle for no benefit.
  */
-function estimateTimezone(latitude: number, longitude: number): string {
-  // Simple longitude-based UTC offset estimation
-  const offsetHours = Math.round(longitude / 15);
-  const absOffset = Math.abs(offsetHours);
-  const sign = offsetHours >= 0 ? "+" : "-";
-  return `UTC${sign}${absOffset}`;
-}
 
 /**
  * Format a location display name to be more readable.
@@ -139,12 +144,13 @@ export function LocationSearch({
   }, [query, performSearch, selectedLocation]);
 
   const handleSelectLocation = (result: GeocodingResult) => {
-    const timezone = estimateTimezone(result.latitude, result.longitude);
     const locationData: LocationData = {
       displayName: result.displayName,
       latitude: result.latitude,
       longitude: result.longitude,
-      timezone,
+      // Server-resolved IANA name, or undefined when the pin resolves to no
+      // zone. Never substitute a guess: downstream this dates the birth chart.
+      timezone: result.timezone ?? undefined,
     };
 
     setQuery(result.displayName);

--- a/src/services/geocodingService.ts
+++ b/src/services/geocodingService.ts
@@ -5,6 +5,7 @@
  */
 
 import { _logger } from "@/lib/logger";
+import { resolveBirthZone } from "@/utils/astrology/birthTimezone";
 
 export interface GeocodingResult {
   displayName: string;
@@ -12,8 +13,16 @@ export interface GeocodingResult {
   longitude: number;
   type: string; // city, town, village, etc.
   country: string;
-  /** Estimated UTC offset string, e.g. "UTC+5" */
-  estimatedTimezone?: string;
+  /**
+   * IANA zone name for these coordinates, e.g. "America/New_York", or null when
+   * the pin resolves to no zone. Basis: DERIVED — tz boundary data at lat/lon.
+   *
+   * Renamed from `estimatedTimezone`, which held a `UTC±N` longitude estimate.
+   * The rename is deliberate: the old field's values are not valid inputs to the
+   * new one, so any reader still expecting the old shape must fail to compile
+   * rather than silently receive an IANA name where it wanted an offset.
+   */
+  timezone: string | null;
 }
 
 interface NominatimResult {
@@ -84,9 +93,6 @@ export async function geocodeLocation(
         
         const lat = parseFloat(result.lat);
         const lon = parseFloat(result.lon);
-        const offsetHours = Math.round(lon / 15);
-        const absOffset = Math.abs(offsetHours);
-        const sign = offsetHours >= 0 ? "+" : "-";
 
         uniqueResults.push({
           displayName: result.display_name,
@@ -94,7 +100,12 @@ export async function geocodeLocation(
           longitude: lon,
           type: result.type,
           country: result.address.country,
-          estimatedTimezone: `UTC${sign}${absOffset}`,
+          // Resolved from the tz boundary data, NOT from `Math.round(lon / 15)`.
+          // The longitude estimate this replaces was DST-blind and never emitted
+          // an IANA name at all, so it could not be used to date a birth chart —
+          // see `resolveBirthZone`'s docs for the two classes of error it caused
+          // in prod. `null` when the pin resolves to no zone; never fabricated.
+          timezone: resolveBirthZone({ latitude: lat, longitude: lon }).zone,
         });
 
         if (uniqueResults.length >= 5) break; // Limit to 5 unique results

--- a/src/services/natalChartService.ts
+++ b/src/services/natalChartService.ts
@@ -199,10 +199,32 @@ async function fetchPlanetaryPositions(
   birthData: BirthData,
 ): Promise<Record<Planet, PositionWithLongitude>> {
   try {
-    const date = new Date(birthData.dateTime);
+    // The EPHEMERIS is queried at the true instant when the temporal migration
+    // has supplied one, and falls back to the wall clock otherwise.
+    //
+    // `dateTime` is a wall clock labelled `Z` (see BirthData's docs): a Brooklyn
+    // birth at 14:24 is stored `1991-06-23T14:24:00.000Z` when the real instant
+    // is 18:24Z. Querying the sky at the wall clock is wrong by exactly the
+    // birthplace's UTC offset — four hours here, which is ~2.2 deg of Moon and
+    // ~60 deg (two whole signs) of Ascendant.
+    //
+    // `utcInstant` is written by `scripts/backfillBirthInstant.ts` and is absent
+    // on unmigrated rows and on rows where no defensible instant exists. It is
+    // never fabricated, so `undefined` really does mean "unknown" and the
+    // fallback below preserves exactly the pre-migration behaviour for them.
+    //
+    // ⚠️ SECT DOES NOT MOVE WITH THIS. `isSectDiurnal` is a 06:00-18:00 LOCAL
+    // window; it must keep reading `dateTime`. MEASURED 2026-08-04: sourcing it
+    // from the true instant instead flips day<->night on 6 of the 8 human rows
+    // in prod (14:24 local is diurnal; 18:24Z is nocturnal because `18 < 18` is
+    // false), swinging the profile ~32/49/9/9 -> ~14/16/47/22 and rewriting the
+    // archetype — a flip manufactured by the migration rather than found by it.
+    const ephemerisSource = birthData.utcInstant ?? birthData.dateTime;
+    const date = new Date(ephemerisSource);
     if (Number.isNaN(date.getTime())) {
       throw new Error(
-        `Unparseable birthData.dateTime: ${JSON.stringify(birthData.dateTime)}. ` +
+        `Unparseable birth instant: ${JSON.stringify(ephemerisSource)} ` +
+          `(from birthData.${birthData.utcInstant ? "utcInstant" : "dateTime"}). ` +
           "Refusing to compute a chart from an invalid instant.",
       );
     }
@@ -223,15 +245,23 @@ async function fetchPlanetaryPositions(
     // UTC branch; these getters make that the behaviour everywhere instead of an
     // accident of deployment.
     //
-    // NOTE: `birthData.timezone` is still not applied, and that is deliberate,
-    // not an oversight. `dateTime` is built from a `datetime-local` input via
-    // `new Date(dob).toISOString()`, so it holds the user's WALL-CLOCK birth
-    // time labelled UTC, not the true UTC instant of their birth. Interpreting
-    // it through `timezone` would be more astronomically correct but would
-    // re-date every chart already stored (5 hours for a New York birth) and the
-    // stored zone strings are not uniformly IANA ("America/New_York" alongside
-    // "UTC-5"). That is a physics ruling with a migration attached, not a
-    // boundary fix -- see the session notes accompanying this change.
+    // NOTE (superseded 2026-08-04): this used to read "`birthData.timezone` is
+    // still not applied, and that is deliberate" — parked because applying it
+    // would re-date every stored chart and because the stored zone strings were
+    // not uniformly IANA. Both halves are now resolved and the zone IS applied,
+    // via `utcInstant` above rather than here:
+    //
+    //   * the mixed key-space was RULED — the zone is DERIVED from the birth
+    //     coordinates, never from the stored string, which was wrong on 3 of the
+    //     6 migratable rows (2x `UTC-5` on EDT births, 1x `America/New_York` on
+    //     Brazilian coordinates). See `utils/astrology/birthTimezone.ts`.
+    //   * the re-dating is the point, and was sized before it was done:
+    //     `scripts/backfillBirthInstant.ts` reports it as a three-column
+    //     STORED/CONTROL/NEW diff so engine drift cannot be mistaken for it.
+    //
+    // These getters remain UTC-only regardless: `/api/astrologize` rebuilds the
+    // instant with `Date.UTC(...)`, so getUTC* -> Date.UTC is the exact
+    // round-trip and the caller's zone stays out of the physics.
     const payload = {
       year: date.getUTCFullYear(),
       month: date.getUTCMonth() + 1, // 1-indexed

--- a/src/types/natalChart.ts
+++ b/src/types/natalChart.ts
@@ -26,10 +26,38 @@ export type {
  * Birth data required to generate a natal chart
  */
 export interface BirthData {
+  /**
+   * The birth WALL CLOCK, labelled `Z` but not a UTC instant.
+   *
+   * Produced by `new Date(<datetime-local value>).toISOString()`, so a Brooklyn
+   * birth at 14:24 is stored `1991-06-23T14:24:00.000Z`. The true instant is
+   * 18:24Z — see {@link BirthData.utcInstant}.
+   *
+   * Deliberately NOT renamed or corrected in place: this is the field every
+   * existing reader already treats as a wall clock, and it is the field SECT
+   * must read (`isSectDiurnal` is a 06:00–18:00 LOCAL window; sourcing it from
+   * the true instant flips day↔night on 6 of the 8 measured prod rows).
+   */
   dateTime: string; // ISO 8601 format
+  /**
+   * The absolute UTC instant of birth = {@link BirthData.dateTime} interpreted
+   * as local time in {@link BirthData.timezone}. Written by
+   * `scripts/backfillBirthInstant.ts`.
+   *
+   * This is what the EPHEMERIS must be queried at. Absent on rows that predate
+   * the temporal migration, and absent by design on rows where no defensible
+   * instant exists (agent sentinels, fabricated pins) — never fabricated, so
+   * `undefined` genuinely means "unknown" and callers fall back to `dateTime`.
+   */
+  utcInstant?: string;
   latitude: number;
   longitude: number;
+  /** IANA zone name. Never a raw `UTC±N` offset — those cannot express DST. */
   timezone?: string;
+  /** How `timezone` was decided. See `ZoneBasis` in `utils/astrology/birthTimezone`. */
+  timezoneBasis?: "DERIVED_FROM_COORDINATES" | "STORED_IANA_STRING" | "ABSENT";
+  /** The pre-migration `timezone` string, kept for audit when it was replaced. */
+  timezoneStoredBefore?: string;
   location?: {
     latitude: number;
     longitude: number;

--- a/src/types/tz-lookup.d.ts
+++ b/src/types/tz-lookup.d.ts
@@ -1,0 +1,17 @@
+/**
+ * `tz-lookup` ships no types (CC0, zero deps, a rasterized form of the official
+ * tz boundary shapefile). Declared here rather than pulled from DefinitelyTyped
+ * so the contract we rely on is stated in-repo.
+ *
+ * Throws a RangeError on out-of-range coordinates rather than returning null,
+ * which is why `resolveBirthZone` wraps the call in a try/catch.
+ */
+declare module "tz-lookup" {
+  /**
+   * @param latitude  degrees, −90…90
+   * @param longitude degrees, −180…180
+   * @returns the IANA zone name covering that point, e.g. "America/New_York".
+   *          Every land and sea point resolves; the function does not return null.
+   */
+  export default function tzLookup(latitude: number, longitude: number): string;
+}

--- a/src/utils/astrology/birthTimezone.ts
+++ b/src/utils/astrology/birthTimezone.ts
@@ -1,0 +1,187 @@
+/**
+ * Birth-instant timezone resolution — the wall-clock ↔ absolute-instant boundary.
+ *
+ * ── THE DEBT THIS EXISTS TO PAY ─────────────────────────────────────────────
+ *
+ * `birthData.dateTime` holds the user's WALL-CLOCK birth time labelled `Z`. It is
+ * built by `new Date(<datetime-local value>).toISOString()`, so "born 14:24 in
+ * Brooklyn" is stored as `1991-06-23T14:24:00.000Z` — a string that claims to be
+ * a UTC instant and is not one. The true instant is 18:24Z. Every stored chart
+ * was therefore computed for a sky up to a full day-part away from the real one.
+ *
+ * `birthData.timezone` was supposed to carry the missing information but never
+ * could, because the writers that produced it disagreed on format and none
+ * validated:
+ *
+ *   - `geocodingService` emitted `Math.round(longitude / 15)` as `UTC±N` — not an
+ *     IANA name at all, and DST-blind by construction.
+ *   - `OnboardingWizard` took free text behind `z.string().min(1)`.
+ *   - `/api/agent-forge/ignite` fell back to `"UTC"` (with a hardcoded NY pin)
+ *     whenever geocoding failed.
+ *
+ * MEASURED against prod 2026-08-04, the whole population is 8 human rows (the
+ * other 52 `birthData` rows are agent placeholders stamped
+ * `1900-01-01T12:00:00.000Z`, which is a sentinel and not a birth):
+ *
+ *     America/New_York  ×6      UTC-5  ×2
+ *
+ * and BOTH spellings are wrong on rows that carry them:
+ *
+ *   - the 2 `UTC-5` rows are NY-metro coordinates born 1996-10-21 and
+ *     2021-10-10 — both inside EDT, where the true offset is −4, not −5;
+ *   - 1 of the 6 `America/New_York` rows carries coordinates 2.82, −60.67 —
+ *     Boa Vista, Roraima, Brazil. A syntactically perfect IANA string on the
+ *     wrong continent;
+ *   - 2 more carry `40.7498, −73.7976` bit-exact, which is the `ignite` route's
+ *     "Fallback NY" literal. Their birthplace was never geocoded at all, so
+ *     their zone is not a user statement and they are NOT migratable.
+ *
+ * That leaves 6 rows with a defensible birthplace.
+ *
+ * ── THE RULING ──────────────────────────────────────────────────────────────
+ *
+ * RULED 2026-08-04: **coordinates win.** The zone is resolved from lat/lon via
+ * `tz-lookup` (a raster of the official tz boundary shapefile), and the stored
+ * string is demoted to a cross-check that is REPORTED, never applied. This is
+ * the only basis that is right on all the rows that have a real pin; a
+ * string→string mapping table would faithfully preserve both errors above.
+ *
+ * Basis: DERIVED — IANA zone from tz-lookup at the birth coordinates, then the
+ * exact historical UTC offset from that zone's tzdata rules at the birth instant
+ * via `Intl.DateTimeFormat.formatToParts`. No fixed-offset approximation is used
+ * anywhere, which is what makes the EDT rows come out at −4.
+ *
+ * ⚠️ SECT DOES NOT MOVE WITH THE GEOMETRY. `isSectDiurnal` is a 06:00–18:00
+ * window, i.e. a LOCAL-clock quantity. Feeding it the true UTC instant inverts
+ * it: MEASURED, 6 of the 8 rows flip day↔night that way, which per
+ * `isSectDiurnalForBirth`'s own docs swings the profile from ~32/49/9/9 to
+ * ~14/16/47/22 and rewrites the archetype. Sect must keep reading the LOCAL WALL
+ * CLOCK. Only the ephemeris query moves to the true instant.
+ */
+
+import tzLookup from "tz-lookup";
+import { isIanaZone, parseRawOffsetMinutes } from "./ianaZone";
+
+// Re-exported so server-side callers have a single import for the whole
+// boundary. The primitives themselves live in `ianaZone.ts` because they need
+// only `Intl`, and client components must be able to validate a zone without
+// pulling tz-lookup's boundary raster into the browser bundle.
+export {
+  isIanaZone,
+  parseRawOffsetMinutes,
+  zoneOffsetMinutes,
+  wallClockToInstant,
+  instantToWallClock,
+} from "./ianaZone";
+export type { WallClockResolution, InstantResolution } from "./ianaZone";
+
+/** How a zone was arrived at. Never fabricated — an unresolvable zone is `null`. */
+export type ZoneBasis =
+  /** DERIVED from birth coordinates via the tz boundary data. The normal path. */
+  | "DERIVED_FROM_COORDINATES"
+  /** The stored string, used only when coordinates are absent or unusable. */
+  | "STORED_IANA_STRING"
+  /** Nothing usable. Callers must degrade, not guess. */
+  | "ABSENT";
+
+export interface ResolvedZone {
+  /** IANA zone name, or null when nothing defensible could be resolved. */
+  zone: string | null;
+  basis: ZoneBasis;
+  /**
+   * The raw stored `birthData.timezone`, preserved verbatim for auditing.
+   * Never used to compute an offset when coordinates are available.
+   */
+  storedTimezone?: string;
+  /**
+   * True when `storedTimezone` is a valid IANA name that names a DIFFERENT zone
+   * than the coordinates resolved to. The signal that a row's two fields
+   * disagree about where the birth happened (e.g. the Boa Vista row).
+   */
+  storedDisagrees: boolean;
+  /** True when `storedTimezone` is a `UTC±N` offset rather than an IANA name. */
+  storedIsRawOffset: boolean;
+}
+
+/**
+ * Resolve the IANA zone for a birth record.
+ *
+ * Coordinates win over the stored string — see the RULING above. The stored
+ * string is still parsed and compared so that disagreements surface in the
+ * migration report instead of being silently overwritten.
+ */
+export function resolveBirthZone(input: {
+  latitude?: number | null;
+  longitude?: number | null;
+  timezone?: string | null;
+}): ResolvedZone {
+  const stored = typeof input.timezone === "string" ? input.timezone.trim() : "";
+  const storedIsRawOffset = stored !== "" && parseRawOffsetMinutes(stored) !== null;
+  const storedIsIana = stored !== "" && !storedIsRawOffset && isIanaZone(stored);
+
+  const lat = input.latitude;
+  const lon = input.longitude;
+  const hasCoords =
+    typeof lat === "number" &&
+    Number.isFinite(lat) &&
+    typeof lon === "number" &&
+    Number.isFinite(lon) &&
+    Math.abs(lat) <= 90 &&
+    Math.abs(lon) <= 180;
+
+  if (hasCoords) {
+    let zone: string | null = null;
+    try {
+      zone = tzLookup(lat, lon);
+    } catch {
+      zone = null; // tz-lookup throws on out-of-range input; treated as unresolvable.
+    }
+    if (zone && isIanaZone(zone)) {
+      return {
+        zone,
+        basis: "DERIVED_FROM_COORDINATES",
+        storedTimezone: stored || undefined,
+        storedDisagrees: storedIsIana && stored !== zone,
+        storedIsRawOffset,
+      };
+    }
+  }
+
+  // No usable coordinates. A stored IANA name is better than nothing; a raw
+  // `UTC±N` is NOT accepted as a substitute, because it is exactly the
+  // DST-blind approximation this module exists to retire.
+  if (storedIsIana) {
+    return {
+      zone: stored,
+      basis: "STORED_IANA_STRING",
+      storedTimezone: stored,
+      storedDisagrees: false,
+      storedIsRawOffset: false,
+    };
+  }
+
+  return {
+    zone: null,
+    basis: "ABSENT",
+    storedTimezone: stored || undefined,
+    storedDisagrees: false,
+    storedIsRawOffset,
+  };
+}
+
+/**
+ * The `ignite` route's retired "Fallback NY" pin. Rows carrying it bit-exact
+ * never had their birthplace geocoded, so their coordinates — and every zone
+ * derived from them — are fabrications rather than anything the user supplied.
+ *
+ * Kept as a named constant so the migration can refuse those rows explicitly
+ * instead of confidently re-dating a chart from a literal.
+ */
+export const IGNITE_FALLBACK_PIN = { latitude: 40.7498, longitude: -73.7976 } as const;
+
+/** True when this pin is the retired `ignite` fallback rather than a real place. */
+export function isFabricatedFallbackPin(latitude: number, longitude: number): boolean {
+  return (
+    latitude === IGNITE_FALLBACK_PIN.latitude && longitude === IGNITE_FALLBACK_PIN.longitude
+  );
+}

--- a/src/utils/astrology/ianaZone.ts
+++ b/src/utils/astrology/ianaZone.ts
@@ -1,0 +1,159 @@
+/**
+ * IANA zone primitives — validation and the wall-clock ↔ instant conversion.
+ *
+ * Split out from `birthTimezone.ts` for one reason: everything here runs on
+ * `Intl` alone, with no dependencies, so client components (the onboarding
+ * wizard's timezone field) can validate a zone without pulling the ~150KB
+ * tz boundary raster that `resolveBirthZone` needs into the browser bundle.
+ *
+ * `birthTimezone.ts` re-exports all of it, so server callers have one import.
+ */
+
+/**
+ * Does the runtime accept this as an IANA zone? The only honest validator —
+ * hand-maintained allowlists go stale every time tzdata splits a zone.
+ *
+ * Note `Etc/GMT+5` IS valid IANA (and, confusingly, means UTC−5), while a bare
+ * `UTC-5` is not. That distinction is the whole point: `UTC±N` is the shape the
+ * retired `estimateTimezone` emitted, and it must not validate.
+ */
+export function isIanaZone(value: unknown): value is string {
+  if (typeof value !== "string" || value.trim() === "") return false;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: value });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Matches the `UTC±N` / `GMT±N` shapes the old `estimateTimezone` emitted. */
+const RAW_OFFSET_RE = /^(?:UTC|GMT)\s*([+-])\s*(\d{1,2})(?::?(\d{2}))?$/i;
+
+/**
+ * Minutes east of UTC for a raw `UTC±N` string, or null if it is not one.
+ *
+ * Exists to REPORT what a legacy string claimed, never to act on it — see the
+ * ruling in `birthTimezone.ts`. Both prod rows spelled `UTC-5` are EDT births
+ * whose true offset is −240, so acting on the parsed −300 would bake in the bug.
+ */
+export function parseRawOffsetMinutes(value: string): number | null {
+  const m = RAW_OFFSET_RE.exec(value.trim());
+  if (!m) return null;
+  const sign = m[1] === "-" ? -1 : 1;
+  const hours = Number(m[2]);
+  const minutes = m[3] ? Number(m[3]) : 0;
+  if (hours > 14 || minutes > 59) return null;
+  return sign * (hours * 60 + minutes);
+}
+
+/**
+ * Offset of `zone` at absolute instant `at`, in minutes east of UTC.
+ *
+ * Reads the zone's real tzdata rules, so it returns −240 for New York in July
+ * and −300 in January. This is why the two `UTC-5` rows resolve to −4.
+ */
+export function zoneOffsetMinutes(zone: string, at: Date): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: zone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(at);
+
+  const p: Record<string, string> = {};
+  for (const part of parts) p[part.type] = part.value;
+
+  const asIfUtc = Date.UTC(
+    Number(p.year),
+    Number(p.month) - 1,
+    Number(p.day),
+    Number(p.hour),
+    Number(p.minute),
+    Number(p.second),
+  );
+  return Math.round((asIfUtc - at.getTime()) / 60_000);
+}
+
+/** The wall clock in `zone` at `at`, expressed as UTC-labelled milliseconds. */
+function wallClockMsAt(zone: string, at: Date): number {
+  return at.getTime() + zoneOffsetMinutes(zone, at) * 60_000;
+}
+
+export type WallClockResolution =
+  /** Exactly one instant maps to this wall clock. */
+  | "UNIQUE"
+  /** DST fall-back overlap: two instants match. The EARLIER is returned. */
+  | "AMBIGUOUS"
+  /** DST spring-forward gap: this wall clock never happened. */
+  | "NONEXISTENT";
+
+export interface InstantResolution {
+  instant: Date;
+  resolution: WallClockResolution;
+  offsetMinutes: number;
+}
+
+/**
+ * Interpret a UTC-LABELLED wall clock as local time in `zone` and return the
+ * absolute instant.
+ *
+ * `wallLabelledUtc` is the value as stored: `1991-06-23T14:24:00.000Z` meaning
+ * "14:24 on the wall", not "14:24 UTC". Returns 1991-06-23T18:24:00Z.
+ *
+ * DST edges are DETECTED, not papered over, because a silent pick is how an hour
+ * goes missing without any check failing:
+ *
+ *   - AMBIGUOUS (clocks went back; the wall time occurred twice) — the earlier
+ *     instant is returned, matching the usual civil reading of the first pass.
+ *   - NONEXISTENT (clocks sprang forward; the wall time never occurred) — the
+ *     instant is resolved with the post-transition offset, landing just past the
+ *     gap. The caller is told, so it can refuse or flag the row.
+ */
+export function wallClockToInstant(wallLabelledUtc: Date, zone: string): InstantResolution {
+  const wallMs = wallLabelledUtc.getTime();
+
+  // Bracket the wall clock by ±24h and take the offset in force at each end. Any
+  // single tzdata transition lies between them, so this yields BOTH candidate
+  // offsets — the pre- and post-transition ones. (Iterating from the naive guess
+  // instead cannot do this: on a fall-back both probes converge on the first
+  // pass, and the second 01:30 is never generated at all.)
+  const offsetBefore = zoneOffsetMinutes(zone, new Date(wallMs - 86_400_000));
+  const offsetAfter = zoneOffsetMinutes(zone, new Date(wallMs + 86_400_000));
+
+  // Keep only candidates that actually round-trip back to the requested wall
+  // clock. This is what separates the three cases: 2 survivors means the wall
+  // clock happened twice, 0 means it never happened.
+  const candidates = Array.from(
+    new Set([wallMs - offsetBefore * 60_000, wallMs - offsetAfter * 60_000]),
+  )
+    .filter((ms) => wallClockMsAt(zone, new Date(ms)) === wallMs)
+    .sort((a, b) => a - b);
+
+  if (candidates.length === 1) {
+    const instant = new Date(candidates[0]);
+    return { instant, resolution: "UNIQUE", offsetMinutes: zoneOffsetMinutes(zone, instant) };
+  }
+
+  if (candidates.length > 1) {
+    const instant = new Date(candidates[0]); // earlier of the two passes
+    return { instant, resolution: "AMBIGUOUS", offsetMinutes: zoneOffsetMinutes(zone, instant) };
+  }
+
+  // Nothing round-tripped: the wall clock falls inside a spring-forward gap.
+  // Resolve with the post-transition offset, which lands just past the gap.
+  const instant = new Date(wallMs - offsetAfter * 60_000);
+  return { instant, resolution: "NONEXISTENT", offsetMinutes: zoneOffsetMinutes(zone, instant) };
+}
+
+/**
+ * Inverse of {@link wallClockToInstant}: the local wall clock at `instant`,
+ * returned UTC-labelled so it round-trips through the existing storage shape.
+ */
+export function instantToWallClock(instant: Date, zone: string): Date {
+  return new Date(wallClockMsAt(zone, instant));
+}

--- a/src/utils/planetaryAlchemyMapping.ts
+++ b/src/utils/planetaryAlchemyMapping.ts
@@ -404,34 +404,31 @@ export function isSectDiurnal(date?: Date): boolean {
 /**
  * Determine the sect of a *birth* moment.
  *
- * Birth times arrive as timezone-less wall-clock strings ("1990-05-15T14:30")
- * and so are parsed in whatever zone the host runs in. The astrologize payload
- * reads that Date back with the local getters, so the wall clock round-trips and
- * the chart itself is host-independent — but {@link isSectDiurnal} reads
- * getUTCHours(), which is not. On a UTC host (Vercel) the two agree; on any other
- * host the same birth flips day/night, which swings the whole ESMS profile
- * (day ~32/49/9/9 vs night ~14/16/47/22).
+ * ⚠️ Pass `birthData.dateTime` — the WALL CLOCK — never `birthData.utcInstant`.
  *
- * Re-projecting the wall clock into UTC keeps sect on the same hour the chart was
- * computed from, on every host. This is a no-op in production.
+ * Sect is a local-clock predicate: "was the sun up where they were born". A
+ * 14:24 Brooklyn birth is diurnal, and stays diurnal no matter that its true
+ * instant is 18:24Z. MEASURED 2026-08-04, feeding the true instant here instead
+ * flips day↔night on 6 of the 8 human rows in prod (18:24Z reads nocturnal,
+ * because `18 < 18` is false), swinging the profile from ~32/49/9/9 to
+ * ~14/16/47/22 and rewriting the archetype. `dateTime` is already the wall clock
+ * labelled `Z`, so {@link isSectDiurnal}'s getUTCHours() reads it correctly.
+ *
+ * This function previously re-projected through the host's LOCAL getters
+ * (`getFullYear`/`getHours`/…), to match `fetchPlanetaryPositions`, which then
+ * also used local getters. That premise died when the chart path moved to
+ * getUTC* (#725) and this call site was missed — leaving the chart host-
+ * independent while sect, which decides the archetype, was not. A no-op on
+ * prod's UTC infrastructure and wrong by the operator's offset anywhere else.
  *
  * Note: like isSectDiurnal, this is still a 06:00–18:00 local-clock approximation
  * of "sun above the horizon", not a true altitude calculation.
  *
- * @param birth - the birth instant, as parsed from a wall-clock string
+ * @param birth - the birth WALL CLOCK, UTC-labelled (i.e. `birthData.dateTime`)
  * @returns true if diurnal (day), false if nocturnal (night)
  */
 export function isSectDiurnalForBirth(birth: Date): boolean {
-  const wallClock = new Date(
-    Date.UTC(
-      birth.getFullYear(),
-      birth.getMonth(),
-      birth.getDate(),
-      birth.getHours(),
-      birth.getMinutes(),
-    ),
-  );
-  return isSectDiurnal(wallClock);
+  return isSectDiurnal(birth);
 }
 
 /**


### PR DESCRIPTION
Closes the temporal debt parked in #725 as *"a physics ruling with a migration attached"*.

`birthData.dateTime` is `new Date(<datetime-local>).toISOString()`, so a Brooklyn birth at 14:24 was stored `1991-06-23T14:24:00.000Z` — **a wall clock wearing a `Z`**. The true instant is 18:24Z. Every stored natal chart was computed for a sky four hours early: ~2.2° of Moon, and ~60° of Ascendant — two whole signs.

> [!IMPORTANT]
> **The data migration has already been applied to production** (2026-08-04). Migration 76 is applied, 6 profiles are on true instants, and all charts + constitutions have been recomputed and verified. Merging this PR ships the **code** that keeps prod correct — the readers, the writers, and the scripts. It is not a "merge then run" PR.

---

## 1. Schema migration, and the deliberate `utcInstant` / `dateTime` split

`database/init/76-birth-instant-dual-storage.sql` adds five nullable columns to `user_profiles`. The central design decision is that **the wall clock and the instant are two different physical quantities, and the engine needs both**:

| field | is | drives |
|---|---|---|
| `dateTime` / `birth_local_wall_time` | the clock reading at the birthplace | **sect** |
| `utcInstant` / `birth_true_utc_instant` | the absolute moment | **the ephemeris** |

`dateTime` is deliberately **not** renamed or corrected in place. It is already what every existing reader treats it as, and it is the field sect must read. `utcInstant` is *added* alongside it. `fetchPlanetaryPositions` now queries at `birthData.utcInstant ?? birthData.dateTime`, so unmigrated rows keep exactly their previous behaviour.

**Why the split is load-bearing, not stylistic.** `isSectDiurnal` is a `06:00–18:00` window — a *local*-clock predicate. Source it from the true instant and it silently inverts: **6 of the 8 human rows flip day↔night**, because 18:24Z reads nocturnal (`18 < 18` is false) where 14:24 local is plainly diurnal. Per `isSectDiurnalForBirth`'s own docs that swings the profile from ~32/49/9/9 to ~14/16/47/22 and rewrites the archetype — **a flip manufactured by the migration rather than discovered by it**.

I walked into this trap myself one level down and it is worth flagging for review. `calculateNatalChart` derives sect *internally* from `birthData.dateTime` (`natalChartService.ts:407`). The sizing script first supplied the ephemeris instant by **overwriting `dateTime`**, which flipped the chart's own internal sect to nocturnal while `selectArchetype` was still handed `diurnal` — an internally half-day/half-night constitution. It mis-reported 2 of 4 rows (`2ee5eb05`: `20/19/42/18` vs the correct `37/33/19/10`) and was caught only because a second, independent script disagreed. **Always pass the instant via `utcInstant`; never by overwriting `dateTime`.**

**Zone resolution — RULED: coordinates win.** The zone is DERIVED from lat/lon via `tz-lookup`; the stored string is a cross-check that is *reported*, never applied. A string→string mapping table was refused because both stored spellings are wrong on rows that carry them:
- 2 rows spelled `UTC-5` are NY-metro pins born inside **EDT**, where the true offset is −4. Taking the literal at face value is an hour wrong on both.
- 1 row spells a syntactically perfect `America/New_York` over coordinates `2.82, −60.67` — **Boa Vista, Roraima, Brazil**.

Migration 76 was validated against real Postgres inside a **rolled-back transaction**, with both `CHECK` constraints proven to reject bad rows, before being applied for real.

## 2. Third instance of the local-getter defect: `isSectDiurnalForBirth`

#725 sealed the timezone boundary in `fetchPlanetaryPositions` and `calculateApproximateAscendant` by moving them to `getUTC*`. **This call site was missed**, and it is the one that decides the archetype.

Its docstring justified the local getters with an explicit premise:

> *"The astrologize payload reads that Date back with the local getters, so the wall clock round-trips…"*

That premise **died in #725** when the chart path moved to `getUTC*`. The result was a chart that was host-independent while sect — feeding the entire ESMS profile — was not. A no-op on prod's UTC infrastructure, and wrong by the operator's own offset anywhere else, which is exactly the class of bug that passes CI and corrupts a local backfill. It now reads the wall clock directly, with the dead premise replaced by a note on why sect must never move with the geometry.

## 3. Verified containment of the archetype shift: exactly 1 of 4

Sized with a three-column **STORED / CONTROL / NEW** diff, so a year of unrelated engine drift could not be credited to this change:

| measure | result |
|---|---|
| `CONTROL → NEW` — attributable to this migration | 6 / 6 |
| `STORED → NEW` — **what a user actually sees change** | **1 / 4** |

The single user-visible change is **`lyndsaygoldfarb21`: Solar Forager → Lunar Adept**. The other three land on their existing label (`Root Alchemist`, `Wind Whisperer`, `Solar Forager`), with only their underlying ESMS refined.

Verified end state in prod:
- 6 profiles on true instants, **both** write surfaces agreeing (`users.profile` JSONB *and* `user_profiles` columns)
- 4 constitutions, control gate **bit-exact** with **ESMS unchanged** — fully converged, no drift left
- **0** rows remaining at the degenerate `25/25/25/25`
- 2 profiles held a chart but *no* constitution row, making them structurally invisible to `healConstitutionGeometry`'s `FROM alchemical_constitutions` query and stranding them on the old instant — covered by the new `--orphan-charts` flag

## 4. Git LFS hooks — restored on purpose, so they are *absent* from this diff

Adding `tz-lookup` triggered `husky install`, which **overwrote the repo's Git LFS hooks** (`.husky/_/post-checkout`, `post-commit`, `post-merge`, `pre-push`), replacing the `git lfs` delegation with husky's own shim.

**I reverted them, so there is intentionally no `.husky/` change in this diff.** Flagging it explicitly because the correct outcome here is an *absence*: if you see `.husky/_/*` modifications in a future PR that installs a dependency, that is the same collateral damage and should be reverted, not committed. Worth knowing before the next `bun add`.

---

## Writers fixed — all four fabrication sites

The migration would be re-polluted by the next signup without these:

- **`geocodingService`** — `Math.round(lon / 15)` rendered as `UTC±N` → real IANA from `tz-lookup`. Field renamed `estimatedTimezone` → `timezone` **deliberately**, so any stale reader fails to compile rather than silently taking an IANA name where it wanted an offset.
- **`LocationSearch.estimateTimezone`** — deleted. Despite its name it never returned an IANA zone, and its docstring justified the imprecision with a backend coordinate-derivation **that does not exist**.
- **`OnboardingWizard`** — `z.string().min(1)` → IANA-validated `.refine()`. Resolution stays server-side so `tz-lookup`'s ~150KB raster never enters the client bundle (hence the `ianaZone.ts` / `birthTimezone.ts` split).
- **`/api/agent-forge/ignite`** — `?? 40.7498 / ?? -73.7976 / ?? "UTC"` → **422 refusal**. This one had already done damage: **2 of the 8 human birth records carry that pin bit-for-bit**, meaning their birthplace was never geocoded and their `America/New_York` was never a user statement. A fabricated pin passes every finiteness check downstream and reads as a real birthplace forever after. Those 2 rows are refused by the backfill as unmigratable rather than confidently re-dated.

## Measured scope

The canonical surface is **`users.profile->'birthData'` (60 rows)**, *not* `user_profiles.birth_data` (4). A migration scoped to the normalized column would have touched 4 of 60.

```
60 rows with birthData
├── 52 agent placeholders @ 1900-01-01T12:00:00.000Z ... SKIPPED (a sentinel, not a birth)
└──  8 human
     ├── 2 @ 40.7498,-73.7976 bit-exact ............... REFUSED (ignite's "Fallback NY" literal)
     └──  6 migratable ............................... all shift exactly +4.00h
```

## Verification

- `birthTimezone.test.ts` — 25 cases, forces `TZ=Pacific/Auckland` before import **plus a meta-assertion that the runner honoured it**, so the suite cannot go quietly blind on a UTC CI box. **Mutation-verified:** inverting the ruling so the stored string wins fails 6/25.
- DST edges pinned against real tzdata transitions. The fall-back overlap initially returned `UNIQUE` because iterating from the naive guess can never generate the second pass of a repeated hour; bracketing ±24h finds both. The test caught that bug in my own implementation.
- `SQL AND does not short-circuit` — `jsonb_typeof(x)='array' AND jsonb_array_length(x)>0` still errors on the 71 rows whose `planets` key is not an array. Uses a `CASE`.
- Migration 76 dry-applied and rolled back against real Postgres before the real apply.
- **Full suite: 205 files, 2052 passed, 9 skipped, 0 failures.** Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
