### PR TITLE
fix(astro): sect is the Sun's altitude, not a clock hour

### DIFF
--- a/database/init/77-attested-region-basis.sql
+++ b/database/init/77-attested-region-basis.sql
@@ -1,0 +1,40 @@
+-- Admit a fourth zone basis: ATTESTED_REGION_DEFAULT_PIN.
+--
+-- Migration 76 refused two rows outright. Both carry `40.7498, -73.7976`
+-- bit-exact — the retired `ignite` route's "Fallback NY" literal — so their
+-- coordinates were a fabrication and no birth instant could be derived from
+-- them. That was the right call on the evidence available at the time.
+--
+-- The operator has since confirmed that both users were in fact born in New
+-- York. That changes what is known, but it does NOT promote the pin to a
+-- measurement, and the two halves must not be conflated:
+--
+--   ZONE      — now defensible. Every pin in the New York metro resolves to
+--               America/New_York, so the birth INSTANT follows correctly and
+--               is no better or worse than any other NYC-born row.
+--
+--   POSITION  — still a city-level default, NOT the user's birthplace. NYC
+--               spans ~0.55 deg of longitude, i.e. ~2.2 minutes of sidereal
+--               time, i.e. up to ~0.55 deg of Ascendant. That is invisible
+--               except within about half a degree of a sign cusp, where it can
+--               move the rising sign outright.
+--
+-- Hence a distinct basis rather than reusing DERIVED_FROM_COORDINATES. A reader
+-- must always be able to tell "we know where they were born" from "we know
+-- which region they were born in, and defaulted the rest". Collapsing the two
+-- would relabel a default as a measurement, which is the exact failure that
+-- produced these rows in the first place.
+
+ALTER TABLE user_profiles
+  DROP CONSTRAINT IF EXISTS user_profiles_birth_timezone_basis_check;
+
+ALTER TABLE user_profiles
+  ADD CONSTRAINT user_profiles_birth_timezone_basis_check
+  CHECK (birth_timezone_basis IS NULL
+         OR birth_timezone_basis IN ('DERIVED_FROM_COORDINATES',
+                                     'STORED_IANA_STRING',
+                                     'ATTESTED_REGION_DEFAULT_PIN',
+                                     'ABSENT'));
+
+COMMENT ON COLUMN user_profiles.birth_timezone_basis IS
+  'How birth_timezone was decided: DERIVED_FROM_COORDINATES (normal — a real geocoded pin), ATTESTED_REGION_DEFAULT_PIN (region confirmed by the operator, coordinates are a city-level default — the instant is sound, the Ascendant is approximate), STORED_IANA_STRING (no usable pin), or ABSENT. Recorded so an inferred zone can never be mistaken for a user statement.';

--- a/scripts/backfillBirthInstant.ts
+++ b/scripts/backfillBirthInstant.ts
@@ -96,6 +96,20 @@ const SHOW_TRAP = ARGV.has("--show-trap");
  * produces a more precise fiction, not a more accurate birth.
  */
 const INCLUDE_AGENTS = ARGV.has("--include-agents");
+/**
+ * Admit the rows carrying the retired `ignite` "Fallback NY" pin, on the
+ * operator's attestation that those users were in fact born in New York.
+ *
+ * This resolves the ZONE (every NYC-metro pin is America/New_York, so the birth
+ * instant follows correctly) WITHOUT pretending the coordinates are theirs. The
+ * pin stays a city-level default, which is why these rows are written with
+ * basis ATTESTED_REGION_DEFAULT_PIN rather than DERIVED_FROM_COORDINATES: the
+ * instant is sound, the Ascendant is approximate to within ~0.55 deg, and a
+ * reader must be able to tell the two apart.
+ *
+ * Opt-in, because it encodes a human claim that is not in the data.
+ */
+const ATTEST_FALLBACK_PIN = ARGV.has("--attest-fallback-pin");
 
 /** The sentinel every agent placeholder carries. */
 const AGENT_SENTINEL_DATETIME = "1900-01-01T12:00:00.000Z";
@@ -213,7 +227,7 @@ function planRow(row: Row): Plan {
     };
   }
 
-  if (isFabricatedFallbackPin(birth.latitude, birth.longitude)) {
+  if (isFabricatedFallbackPin(birth.latitude, birth.longitude) && !ATTEST_FALLBACK_PIN) {
     return {
       row,
       disposition: "REFUSE_FABRICATED_PIN",
@@ -225,6 +239,15 @@ function planRow(row: Row): Plan {
   }
 
   const zone = resolveBirthZone(birth);
+  // An attested row resolves its zone from a default pin, so it must NOT claim
+  // DERIVED_FROM_COORDINATES — that label means "we know where they were born".
+  if (
+    ATTEST_FALLBACK_PIN &&
+    isFabricatedFallbackPin(birth.latitude, birth.longitude) &&
+    zone.zone
+  ) {
+    zone.basis = "ATTESTED_REGION_DEFAULT_PIN";
+  }
   if (!zone.zone) {
     return {
       row,

--- a/scripts/healConstitutionGeometry.ts
+++ b/scripts/healConstitutionGeometry.ts
@@ -264,7 +264,9 @@ async function reignite(birthData: BirthData, opts: { useWallClock?: boolean } =
   }
 
   const shares = toEsmsShares(chart.alchemicalProperties);
-  const diurnal = isSectDiurnalForBirth(new Date(birthData.dateTime));
+  // Whole birthData: sect is the Sun's altitude at the birthplace, so it
+  // needs the true instant AND the coordinates.
+  const diurnal = isSectDiurnalForBirth(source);
   const { baseArchetype } = selectArchetype(shares, diurnal);
 
   return {
@@ -618,12 +620,7 @@ async function main(): Promise<void> {
           FROM user_profiles up
           LEFT JOIN alchemical_constitutions ac ON ac.user_id = up.user_id
          WHERE ac.user_id IS NULL
-           -- CASE, not AND: SQL's AND is not short-circuiting, so a bare
-           -- jsonb_array_length beside the typeof guard still errors on the
-           -- 71 rows whose planets key is not an array.
-           AND CASE WHEN jsonb_typeof(up.natal_chart->'planets') = 'array'
-                    THEN jsonb_array_length(up.natal_chart->'planets')
-                    ELSE 0 END > 0
+           AND up.birth_true_utc_instant IS NOT NULL
       `);
       if (Number(orphanCount[0]?.n ?? 0) > 0) {
         console.log(
@@ -635,7 +632,7 @@ async function main(): Promise<void> {
       return;
     }
 
-    console.log(`\n━━━ ORPHAN CHARTS (chart present, no constitution row) ━━━`);
+    console.log(`\n━━━ ORPHAN CHARTS (migrated profile, no constitution row) ━━━`);
     const { rows: orphans } = await client.query<CandidateRow>(`
       SELECT
         up.user_id::text                       AS user_id,
@@ -656,10 +653,12 @@ async function main(): Promise<void> {
       FROM user_profiles up
       LEFT JOIN users u                     ON u.id = up.user_id
       LEFT JOIN alchemical_constitutions ac ON ac.user_id = up.user_id
+      -- Any MIGRATED profile the constitution-scoped pass cannot reach, whether
+      -- it holds a stale chart or none at all. Requiring planets > 0 here (the
+      -- first version of this query) silently skipped the rows whose chart had
+      -- never reached the profile table -- exactly the rows most in need of one.
       WHERE ac.user_id IS NULL
-        AND CASE WHEN jsonb_typeof(up.natal_chart->'planets') = 'array'
-                 THEN jsonb_array_length(up.natal_chart->'planets')
-                 ELSE 0 END > 0
+        AND up.birth_true_utc_instant IS NOT NULL
       ORDER BY up.updated_at
     `);
 

--- a/src/__tests__/utils/birthTimezone.test.ts
+++ b/src/__tests__/utils/birthTimezone.test.ts
@@ -8,17 +8,32 @@
  *     out at −4 (they are EDT births), and what catches the row whose IANA
  *     string names a different continent than its coordinates.
  *
- *   HOST INDEPENDENCE — none of it may read the runner's clock. The suite forces
- *     TZ=Pacific/Auckland before importing, plus a meta-assertion that the runner
- *     honoured it, because a TZ-keyed guard that silently goes blind is worse
- *     than no guard: it passes on a UTC CI box while the bug ships.
+ *   HOST INDEPENDENCE — none of it may read the runner's clock.
+ *
+ * ── WHY THIS DOES NOT SET process.env.TZ ────────────────────────────────────
+ *
+ * The first version of this suite did exactly that: `process.env.TZ =
+ * "Pacific/Auckland"` before the import, plus a meta-assertion that the offset
+ * was non-zero. It shipped broken and CI caught it.
+ *
+ * Setting `process.env.TZ` inside a test module does not reliably relatch
+ * Node's zone — jest's setup files have already constructed Dates by then. On a
+ * developer machine that is invisible, because the ambient zone is non-UTC
+ * anyway, so the meta-assertion passes for the WRONG REASON: it was measuring
+ * my laptop, not Auckland. On the UTC CI runner the offset is 0 and the whole
+ * host-independence section was vacuous.
+ *
+ * `natalChartTimezoneBoundary.test.ts` had already documented this exact trap
+ * and solved it. Same solution here: the zone is not the lever at all. The
+ * LOCAL getters are POISONED, so any read of `getFullYear`/`getMonth`/`getDate`/
+ * `getHours`/`getMinutes`/`getTimezoneOffset` returns a value that cannot occur
+ * in a correct result. Correct code never touches them and is unaffected; a
+ * regression reads poison and fails. That holds in EVERY zone — including UTC,
+ * which is precisely where the TZ-based version went blind.
  *
  * Every fixture below is a MEASURED prod row (2026-08-04) or a documented tzdata
  * transition, never an invented convenience value.
  */
-
-// Must precede the import under test: Date's local getters bind at construction.
-process.env.TZ = "Pacific/Auckland";
 
 import {
   isIanaZone,
@@ -28,6 +43,34 @@ import {
   wallClockToInstant,
   instantToWallClock,
 } from "@/utils/astrology/birthTimezone";
+
+/**
+ * Local-getter sentinels — deliberately impossible for the instants under test,
+ * so a poisoned read is unmistakable rather than plausible.
+ */
+const POISON = {
+  getFullYear: 1888,
+  getMonth: 10,
+  getDate: 28,
+  getHours: 7,
+  getMinutes: 55,
+  getTimezoneOffset: 999,
+} as const;
+
+/**
+ * Run `fn` with every local-time getter poisoned. Scoped as tightly as possible
+ * and always restored, since Date.prototype is global and jest itself uses it.
+ */
+function withPoisonedLocalGetters<T>(fn: () => T): T {
+  const spies = (Object.keys(POISON) as Array<keyof typeof POISON>).map((name) =>
+    jest.spyOn(Date.prototype, name as never).mockReturnValue(POISON[name] as never),
+  );
+  try {
+    return fn();
+  } finally {
+    for (const s of spies) s.mockRestore();
+  }
+}
 
 /** The 8 human birth records in prod, measured 2026-08-04. */
 const PROD_ROWS = [
@@ -94,12 +137,6 @@ const PROD_ROWS = [
 ] as const;
 
 describe("birth timezone resolution", () => {
-  it("runs under a non-UTC host, or the host-independence claims below are vacuous", () => {
-    // Meta-assertion. If the runner ignored process.env.TZ this suite would
-    // still pass every other case while proving nothing about host independence.
-    expect(new Date("2021-07-01T00:00:00Z").getTimezoneOffset()).not.toBe(0);
-  });
-
   it.each(PROD_ROWS)(
     "resolves $id from coordinates, not from its stored string",
     ({ stz, lat, lon, zone }) => {
@@ -217,12 +254,29 @@ describe("round-trip", () => {
     }
   });
 
-  it("is unaffected by the host zone", () => {
-    // Same inputs, evaluated while the process sits in Pacific/Auckland (UTC+12).
-    // Any local getter anywhere in the chain would show up here as a 12h error.
+  it("never reads a local getter — verified by poisoning all of them", () => {
+    // The mechanism, not the ambient. Poisoned local getters return values that
+    // cannot occur in any correct result, so this fails in EVERY zone if the
+    // module reaches for one — including on a UTC runner, where a
+    // TZ-substitution test proves nothing because local and UTC agree.
     const row = PROD_ROWS.find((r) => r.id === "2ee5eb05")!;
-    const res = wallClockToInstant(new Date(row.stored), "America/New_York");
-    expect(res.instant.toISOString()).toBe("1991-06-23T18:24:00.000Z");
-    expect(zoneOffsetMinutes("Pacific/Auckland", new Date("1991-06-23T18:24:00Z"))).toBe(720);
+
+    const before = wallClockToInstant(new Date(row.stored), "America/New_York");
+    expect(before.instant.toISOString()).toBe("1991-06-23T18:24:00.000Z");
+
+    const poisoned = withPoisonedLocalGetters(() => ({
+      resolved: resolveBirthZone({ latitude: row.lat, longitude: row.lon, timezone: row.stz }),
+      resolution: wallClockToInstant(new Date(row.stored), "America/New_York"),
+      offset: zoneOffsetMinutes("America/New_York", new Date("1991-06-23T18:24:00Z")),
+      roundTrip: instantToWallClock(before.instant, "America/New_York"),
+    }));
+
+    // Byte-identical to the un-poisoned answers.
+    expect(poisoned.resolved.zone).toBe("America/New_York");
+    expect(poisoned.resolution.instant.toISOString()).toBe("1991-06-23T18:24:00.000Z");
+    expect(poisoned.resolution.instant.getTime()).toBe(before.instant.getTime());
+    expect(poisoned.resolution.offsetMinutes).toBe(-240);
+    expect(poisoned.offset).toBe(-240);
+    expect(poisoned.roundTrip.toISOString()).toBe(row.stored);
   });
 });

--- a/src/__tests__/utils/sectSolarAltitude.test.ts
+++ b/src/__tests__/utils/sectSolarAltitude.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Sect = the Sun's real altitude above the birthplace horizon.
+ *
+ * The 06:00–18:00 UTC window this replaces was never a definition of sect — it
+ * was a proxy for "the Sun is up", and one phrased in clock hours with no
+ * horizon anywhere in it. These cases pin the places the proxy and the sky
+ * actually disagree, because on the current production population they agree
+ * everywhere (VERIFIED: 0 of 6 migrated rows change sect), so a suite built only
+ * from prod data would pass with the proxy still in place and prove nothing.
+ *
+ * Altitudes below are astronomy-engine's, computed at the stated instant and
+ * place; the `> 0` horizon crossing is the sect boundary.
+ */
+
+import {
+  isSectDiurnal,
+  isSectDiurnalForBirth,
+} from "@/utils/planetaryAlchemyMapping";
+
+const BROOKLYN = { latitude: 40.6526006, longitude: -73.9497211 };
+const TROMSO = { latitude: 69.6496, longitude: 18.956 }; // inside the Arctic Circle
+
+describe("sect from true solar altitude", () => {
+  it("agrees with the retired clock proxy on every migrated production row", () => {
+    // MEASURED 2026-08-04 against prod. Listed as {wall clock, true instant}
+    // pairs so the fixture stays honest about which field drives which half.
+    const PROD = [
+      { utcInstant: "1991-06-23T18:24:00.000Z", ...BROOKLYN, expected: true }, // alt +65.05°
+      { utcInstant: "1996-10-21T14:28:00.000Z", latitude: 40.7956894, longitude: -73.6989103, expected: true }, // +30.07°
+      { utcInstant: "2021-10-10T14:21:00.000Z", latitude: 40.7135078, longitude: -73.8283132, expected: true }, // +32.44°
+      { utcInstant: "1984-01-04T09:05:00.000Z", latitude: 2.8208478, longitude: -60.6719582, expected: false }, // −14.91°
+    ];
+    for (const row of PROD) {
+      expect(
+        isSectDiurnalForBirth({ dateTime: row.utcInstant, ...row }),
+      ).toBe(row.expected);
+    }
+  });
+
+  it("reads an evening birth as diurnal while the Sun is still up", () => {
+    // 19:00 local in Brooklyn in late June — Sun at +14.70°, plainly daylight.
+    // The proxy called this NOCTURNAL because 23:00 UTC falls outside 06:00–18:00.
+    const birth = { dateTime: "1991-06-23T23:00:00.000Z", utcInstant: "1991-06-23T23:00:00.000Z", ...BROOKLYN };
+    expect(isSectDiurnalForBirth(birth)).toBe(true);
+    expect(isSectDiurnal(new Date(birth.utcInstant))).toBe(false); // the old answer
+  });
+
+  it("handles the midnight sun — 02:00 local inside the Arctic Circle in June", () => {
+    // Sun at +4.22°: above the horizon at 2am. Sect is diurnal, and no
+    // clock-hour rule can ever produce that answer.
+    const birth = { dateTime: "2021-06-21T00:00:00.000Z", utcInstant: "2021-06-21T00:00:00.000Z", ...TROMSO };
+    expect(isSectDiurnalForBirth(birth)).toBe(true);
+    expect(isSectDiurnal(new Date(birth.utcInstant))).toBe(false);
+  });
+
+  it("handles the polar night — noon local inside the Arctic Circle in December", () => {
+    // Sun at −2.51°: below the horizon at midday. Sect is nocturnal.
+    const birth = { dateTime: "2021-12-21T11:00:00.000Z", utcInstant: "2021-12-21T11:00:00.000Z", ...TROMSO };
+    expect(isSectDiurnalForBirth(birth)).toBe(false);
+    expect(isSectDiurnal(new Date(birth.utcInstant))).toBe(true);
+  });
+
+  it("resolves the horizon crossing itself, not a rounded hour", () => {
+    // Sunrise in Brooklyn on 1991-06-23 is ~09:25Z. Ten minutes either side of
+    // it must land on opposite sides of the boundary — a granularity no
+    // whole-hour window can express.
+    const before = { dateTime: "1991-06-23T09:15:00.000Z", utcInstant: "1991-06-23T09:15:00.000Z", ...BROOKLYN };
+    const after = { dateTime: "1991-06-23T09:35:00.000Z", utcInstant: "1991-06-23T09:35:00.000Z", ...BROOKLYN };
+    expect(isSectDiurnalForBirth(before)).toBe(false);
+    expect(isSectDiurnalForBirth(after)).toBe(true);
+  });
+});
+
+describe("documented degradation, never silent", () => {
+  it("falls back to the clock proxy when the row has no true instant", () => {
+    // Unmigrated row: `dateTime` is a wall clock, which is not an instant, so
+    // computing an altitude from it would be an altitude for the wrong moment.
+    // Previous behaviour is preserved deliberately.
+    const unmigrated = { dateTime: "1991-06-23T14:24:00.000Z", ...BROOKLYN };
+    expect(isSectDiurnalForBirth(unmigrated)).toBe(isSectDiurnal(new Date("1991-06-23T14:24:00.000Z")));
+  });
+
+  it("falls back to the clock proxy when the row has no coordinates", () => {
+    const noPlace = { dateTime: "1991-06-23T18:24:00.000Z", utcInstant: "1991-06-23T18:24:00.000Z" };
+    expect(isSectDiurnalForBirth(noPlace)).toBe(false); // 18:24Z is outside 06:00–18:00
+  });
+
+  it("still accepts a bare Date for legacy callers", () => {
+    expect(isSectDiurnalForBirth(new Date("1991-06-23T14:24:00.000Z"))).toBe(true);
+    expect(isSectDiurnalForBirth(new Date("1991-06-23T23:00:00.000Z"))).toBe(false);
+  });
+
+  it("ignores a malformed instant rather than throwing", () => {
+    const bad = { dateTime: "1991-06-23T14:24:00.000Z", utcInstant: "not-a-date", ...BROOKLYN };
+    expect(isSectDiurnalForBirth(bad)).toBe(true); // falls through to the wall clock
+  });
+});

--- a/src/app/(alchm)/birth-chart/page.tsx
+++ b/src/app/(alchm)/birth-chart/page.tsx
@@ -36,12 +36,14 @@ function buildNatalFBDs(natalChart: NatalChart): PlanetFBD[] | null {
   }
   if (Object.keys(fbdPositions).length < 2) return null;
 
-  const birthDate = natalChart.birthData?.dateTime
-    ? new Date(natalChart.birthData.dateTime)
+  // Whole birthData when we have it: sect is the Sun's altitude at the
+  // birthplace, and a bare Date falls back to the location-less clock proxy.
+  const sectInput = natalChart.birthData?.dateTime
+    ? natalChart.birthData
     : new Date(natalChart.calculatedAt);
   return buildFreeBodyDiagrams({
     positions: fbdPositions,
-    diurnal: isSectDiurnalForBirth(birthDate),
+    diurnal: isSectDiurnalForBirth(sectInput),
   }).cards;
 }
 

--- a/src/app/(alchm)/profile/day-night-effects/page.tsx
+++ b/src/app/(alchm)/profile/day-night-effects/page.tsx
@@ -47,8 +47,10 @@ export default function DayNightEffectsPage() {
   const natalChart = profileData.natalChart;
 
   // Calculate user's natal sect using the birth time if available
-  const birthDate = natalChart.birthData?.dateTime ? new Date(natalChart.birthData.dateTime) : new Date();
-  const _isNatalDiurnal = isSectDiurnalForBirth(birthDate);
+  // Whole birthData: sect needs the birthplace, not just the moment.
+  const _isNatalDiurnal = isSectDiurnalForBirth(
+    natalChart.birthData?.dateTime ? natalChart.birthData : new Date(),
+  );
 
   // Get alchemical properties for the toggled view. Aspects (Layer 3) come from
   // the chart's own planet longitudes and don't depend on the day/night toggle.

--- a/src/app/api/agent-forge/ignite/route.ts
+++ b/src/app/api/agent-forge/ignite/route.ts
@@ -131,7 +131,9 @@ export async function POST(req: Request) {
     // ESMS_BASELINE for why the raw maximum is not usable here. Uses the same
     // birth instant and the same sect helper as `calculateNatalChart`, so the
     // archetype can never disagree with the quantities it is scoring.
-    const diurnal = isSectDiurnalForBirth(new Date(birthData.dateTime));
+    // Whole birthData, not a bare Date — sect needs the birthplace to have a
+    // horizon to measure the Sun against.
+    const diurnal = isSectDiurnalForBirth(birthData);
     const { dominantToken, baseArchetype } = selectArchetype(shares, diurnal);
 
     console.log(`[ignite] Dominant token: ${dominantToken}, Archetype: ${baseArchetype}`);

--- a/src/app/api/group-recommendations/route.ts
+++ b/src/app/api/group-recommendations/route.ts
@@ -140,7 +140,7 @@ export async function POST(request: NextRequest) {
         Air: 0.25,
       }) as any;
       const diurnal = ownerChart.birthData?.dateTime
-        ? isSectDiurnalForBirth(new Date(ownerChart.birthData.dateTime))
+        ? isSectDiurnalForBirth(ownerChart.birthData)
         : true;
       const alch = (ownerChart.alchemicalProperties ??
         calculateAlchemicalFromPlanets(
@@ -182,7 +182,7 @@ export async function POST(request: NextRequest) {
           Air: 0.25,
         }) as any;
         const diurnal = chart.birthData?.dateTime
-          ? isSectDiurnalForBirth(new Date(chart.birthData.dateTime))
+          ? isSectDiurnalForBirth(chart.birthData)
           : true;
         const alch = (chart.alchemicalProperties ??
           calculateAlchemicalFromPlanets(
@@ -209,7 +209,7 @@ export async function POST(request: NextRequest) {
             Air: 0.25,
           }) as any;
           const diurnal = chart.birthData?.dateTime
-            ? isSectDiurnalForBirth(new Date(chart.birthData.dateTime))
+            ? isSectDiurnalForBirth(chart.birthData)
             : true;
           const alch = (chart.alchemicalProperties ??
             calculateAlchemicalFromPlanets(

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -238,7 +238,8 @@ export async function POST(request: NextRequest) {
       // dignity and aspects cannot drift from the stored natal calculation.
       alchemicalProperties: calculateAlchemicalFromPlanets(
         rawPositions,
-        isSectDiurnalForBirth(birthDate),
+        // Whole birthData — sect is the Sun's altitude at the birthplace.
+        isSectDiurnalForBirth(birthData),
       ),
       calculatedAt: new Date().toISOString(),
     };

--- a/src/app/api/personalized-recommendations/route.ts
+++ b/src/app/api/personalized-recommendations/route.ts
@@ -134,7 +134,7 @@ async function handlePost(request: NextRequest) {
       };
     } | null = null;
     if (includeChartAnalysis && Object.keys(natalPositions).length > 0) {
-      const natalDiurnal = natalChart?.birthData?.dateTime ? isSectDiurnalForBirth(new Date(natalChart.birthData.dateTime)) : true;
+      const natalDiurnal = natalChart?.birthData?.dateTime ? isSectDiurnalForBirth(natalChart.birthData) : true;
       const currentDiurnal = isCurrentSkyDiurnal(new Date());
 
       const natalAlch = calculateAlchemicalFromPlanets(

--- a/src/app/api/user/charts/route.ts
+++ b/src/app/api/user/charts/route.ts
@@ -263,7 +263,8 @@ export async function POST(request: NextRequest) {
   }
   const { positions, planets } = bodies;
 
-  const diurnal = isSectDiurnalForBirth(birthDate);
+  // Whole birthData — sect is the Sun's altitude at the birthplace.
+  const diurnal = isSectDiurnalForBirth(birthData);
 
   const natalChart: NatalChart = {
     birthData: { dateTime: birthData.dateTime, latitude: birthData.latitude, longitude: birthData.longitude, timezone: birthData.timezone },

--- a/src/services/natalChartService.ts
+++ b/src/services/natalChartService.ts
@@ -405,7 +405,10 @@ export async function calculateNatalChart(
 
     // Validate birth chart positions against astronomical estimates
     const birthDate = new Date(birthData.dateTime);
-    const diurnal = isSectDiurnalForBirth(birthDate);
+    // Pass the whole birthData: sect is the Sun's real altitude at the
+    // birthplace, so it needs the true instant AND the coordinates. A bare Date
+    // would silently fall back to the location-less 06:00–18:00 clock proxy.
+    const diurnal = isSectDiurnalForBirth(birthData);
 
     if (detectStaticFallback(signPositions)) {
       _logger.error(

--- a/src/utils/astrology/birthTimezone.ts
+++ b/src/utils/astrology/birthTimezone.ts
@@ -81,6 +81,17 @@ export type ZoneBasis =
   | "DERIVED_FROM_COORDINATES"
   /** The stored string, used only when coordinates are absent or unusable. */
   | "STORED_IANA_STRING"
+  /**
+   * The REGION is confirmed (operator attestation), but the coordinates are a
+   * city-level default rather than the user's actual birthplace.
+   *
+   * The zone — and therefore the birth INSTANT — is as sound as any other row.
+   * The Ascendant is not: a default pin can be off by up to ~0.55 deg of rising
+   * degree across a city the size of New York, which matters only within about
+   * half a degree of a sign cusp. Kept distinct from
+   * DERIVED_FROM_COORDINATES so a default can never be read as a measurement.
+   */
+  | "ATTESTED_REGION_DEFAULT_PIN"
   /** Nothing usable. Callers must degrade, not guess. */
   | "ABSENT";
 

--- a/src/utils/astrology/natalAlchemy.ts
+++ b/src/utils/astrology/natalAlchemy.ts
@@ -127,10 +127,11 @@ function resolveNatalQuantities(
     return { Spirit: 0, Essence: 0, Matter: 0, Substance: 0 };
   }
 
-  const birthDate = chart.birthData?.dateTime
-    ? new Date(chart.birthData.dateTime)
-    : null;
-  const diurnal = birthDate ? isSectDiurnalForBirth(birthDate) : true;
+  // Whole birthData: sect is the Sun's altitude at the birthplace, so the
+  // coordinates matter as much as the instant.
+  const diurnal = chart.birthData?.dateTime
+    ? isSectDiurnalForBirth(chart.birthData)
+    : true;
 
   return calculateAlchemicalFromPlanets(positions, diurnal);
 }

--- a/src/utils/planetaryAlchemyMapping.ts
+++ b/src/utils/planetaryAlchemyMapping.ts
@@ -29,6 +29,10 @@ import type { DignityType, ElementalProperties } from "@/types/alchemy";
 import type { AlchemicalProperties } from "@/types/celestial";
 import { buildAspectsWithStrength } from "./aspectCalculator";
 import { calculateAspectESMSModifications } from "./aspectESMSEffects";
+// The real sect primitive: the Sun's altitude above a given observer's horizon.
+// `positions` imports only astronomy-engine, the logger and types, so this
+// direction introduces no cycle.
+import { isDiurnalAt } from "./astrology/positions";
 
 export type { AlchemicalProperties };
 
@@ -385,12 +389,17 @@ export function calculatePositionalAscendantVessel(sign: string, degree: number 
 }
 
 /**
- * Determine whether the current moment is diurnal (day) or nocturnal (night).
+ * Location-less sect fallback: 06:00–18:00 UTC → diurnal.
  *
- * A fully precise answer requires the observer's geographic coordinates and the
- * local sidereal time to compute the Sun's altitude above the horizon. Without
- * location data this function uses UTC hour as a reasonable approximation:
- * 06:00–18:00 UTC → diurnal, otherwise → nocturnal.
+ * ⚠️ PREFER {@link isSectDiurnalForBirth} (natal) or `isCurrentSkyDiurnal`
+ * (live sky). Both compute the Sun's REAL altitude above a real horizon. This
+ * function cannot: with no coordinates there is no horizon to be above, so it
+ * substitutes the UTC clock for the sky.
+ *
+ * The substitution is wrong by the observer's offset from Greenwich — a little
+ * over 5 hours for New York, where it reads US afternoons as "night". It
+ * survives only as the degraded path for callers that genuinely have no
+ * location, and as the catch-branch when astronomy-engine throws.
  *
  * @param date - Optional date/time to evaluate (defaults to now)
  * @returns true if diurnal (day), false if nocturnal (night)
@@ -402,33 +411,81 @@ export function isSectDiurnal(date?: Date): boolean {
 }
 
 /**
- * Determine the sect of a *birth* moment.
+ * The inputs sect actually needs: an instant, and a place to stand.
+ * A `BirthData` satisfies this directly — every natal call site already has one.
+ */
+export interface BirthSectInput {
+  /** Wall clock, UTC-labelled. The fallback when `utcInstant` is absent. */
+  dateTime: string;
+  /**
+   * The true UTC instant. PREFERRED, because solar altitude is a physical fact
+   * about an absolute moment — a wall clock is not a moment until a zone is
+   * applied to it. Written by `scripts/backfillBirthInstant.ts`.
+   */
+  utcInstant?: string;
+  latitude?: number;
+  longitude?: number;
+}
+
+/**
+ * Determine the sect of a *birth* moment — was the Sun above the horizon at the
+ * birthplace.
  *
- * ⚠️ Pass `birthData.dateTime` — the WALL CLOCK — never `birthData.utcInstant`.
+ * ⚠️ PASS THE WHOLE `birthData`, not a bare `Date`. Sect drives the entire
+ * day/night ESMS split (day → Spirit/Essence, night → Matter/Substance), so
+ * getting it wrong rewrites the chart and the archetype with it.
  *
- * Sect is a local-clock predicate: "was the sun up where they were born". A
- * 14:24 Brooklyn birth is diurnal, and stays diurnal no matter that its true
- * instant is 18:24Z. MEASURED 2026-08-04, feeding the true instant here instead
- * flips day↔night on 6 of the 8 human rows in prod (18:24Z reads nocturnal,
- * because `18 < 18` is false), swinging the profile from ~32/49/9/9 to
- * ~14/16/47/22 and rewriting the archetype. `dateTime` is already the wall clock
- * labelled `Z`, so {@link isSectDiurnal}'s getUTCHours() reads it correctly.
+ * ── WHY THIS TAKES THE TRUE INSTANT WHERE THE OLD ONE TOOK THE WALL CLOCK ──
  *
- * This function previously re-projected through the host's LOCAL getters
- * (`getFullYear`/`getHours`/…), to match `fetchPlanetaryPositions`, which then
- * also used local getters. That premise died when the chart path moved to
- * getUTC* (#725) and this call site was missed — leaving the chart host-
- * independent while sect, which decides the archetype, was not. A no-op on
- * prod's UTC infrastructure and wrong by the operator's offset anywhere else.
+ * This function used to insist on `birthData.dateTime` and explicitly forbid
+ * `utcInstant`. That was correct FOR THE OLD IMPLEMENTATION, and is wrong for
+ * this one, so the reversal is deliberate rather than a regression:
  *
- * Note: like isSectDiurnal, this is still a 06:00–18:00 local-clock approximation
- * of "sun above the horizon", not a true altitude calculation.
+ *   The 06:00–18:00 rule was never a definition of sect. It was a PROXY for
+ *   "the Sun is up", phrased in local clock hours. Feeding a true instant into
+ *   a local-clock proxy mixes two frames: 18:24Z reads nocturnal (`18 < 18` is
+ *   false) for a Brooklyn birth that was plainly 2:24pm in broad daylight.
+ *   Hence the old rule, which managed the hazard rather than removing it.
  *
- * @param birth - the birth WALL CLOCK, UTC-labelled (i.e. `birthData.dateTime`)
+ *   {@link isDiurnalAt} is not a proxy — it computes the Sun's real altitude,
+ *   and altitude is a fact about an ABSOLUTE moment at a REAL place. So the
+ *   correct inputs flip to `utcInstant` + coordinates, and the wall-clock
+ *   hazard dissolves instead of needing to be remembered.
+ *
+ * MEASURED: both readings agree on all 6 migrated prod rows. The difference is
+ * that this one keeps agreeing near dawn, near dusk, and at high latitude,
+ * where a 06:00–18:00 window is simply not what the sky is doing.
+ *
+ * Degrades in documented steps, never silently — no `utcInstant` or no
+ * coordinates falls back to the clock proxy on the wall clock, i.e. exactly the
+ * previous behaviour, preserved on purpose for unmigrated rows.
+ *
+ * @param birth - the full birth data, or (legacy, degraded) a bare wall-clock Date
  * @returns true if diurnal (day), false if nocturnal (night)
  */
-export function isSectDiurnalForBirth(birth: Date): boolean {
-  return isSectDiurnal(birth);
+export function isSectDiurnalForBirth(birth: Date | BirthSectInput): boolean {
+  // Legacy shape: a bare Date carries no horizon, so the proxy is all there is.
+  if (birth instanceof Date) return isSectDiurnal(birth);
+
+  const { dateTime, utcInstant, latitude, longitude } = birth;
+
+  const hasPlace =
+    typeof latitude === "number" &&
+    Number.isFinite(latitude) &&
+    typeof longitude === "number" &&
+    Number.isFinite(longitude);
+
+  if (hasPlace && utcInstant) {
+    const instant = new Date(utcInstant);
+    if (!Number.isNaN(instant.getTime())) {
+      return isDiurnalAt(instant, latitude, longitude);
+    }
+  }
+
+  // The wall clock is not an instant, so use the clock proxy it was designed
+  // for rather than computing an altitude for demonstrably the wrong moment.
+  const wall = new Date(dateTime);
+  return isSectDiurnal(Number.isNaN(wall.getTime()) ? undefined : wall);
 }
 
 /**


### PR DESCRIPTION
Follow-up to #726. Two things: sect becomes a real astronomical calculation, and the two "Fallback NY" rows that #726 refused are admitted on your attestation — under a basis that keeps a default distinguishable from a measurement.

> [!IMPORTANT]
> **Already applied to production.** Migration 77 is applied, 8 profiles are migrated (6 derived + 2 attested), and all charts/constitutions are recomputed. Merging ships the code.

## 1. Sect is the Sun's altitude, not a clock hour

`isSectDiurnal` answered *"is the Sun up?"* with `06:00 <= getUTCHours() < 18`. That was never a definition of sect — it was a **proxy**, phrased in clock hours, with no horizon anywhere in it. It is wrong by the observer's offset from Greenwich (a little over 5h for New York, where it reads US afternoons as "night"), and it cannot represent dawn, dusk, or a polar sky at all.

**The correct primitive already existed.** `isDiurnalAt` in `utils/astrology/positions.ts` computes the Sun's true altitude, and its own docstring already told natal callers to use it *"with the birth moment AND the birthplace"*. `isSectDiurnalForBirth` simply never did. This routes it there and updates every natal call site to pass the whole `birthData` rather than a bare `Date` — a bare `Date` carries no horizon, so it silently degrades to the proxy.

### The wall-clock rule from #726 reverses, on purpose

#726 established that sect must read `dateTime` and **never** `utcInstant`. That was correct *for the proxy* and is wrong for this, so the reversal is deliberate rather than a regression:

- Feeding a true instant into a **local-clock rule** mixes two frames — `18:24Z` reads nocturnal (`18 < 18` is false) for a Brooklyn birth that was plainly 2:24pm in daylight. Hence the old rule, which *managed* the hazard.
- **Altitude is a physical fact about an absolute moment at a real place.** A wall clock is not a moment until a zone is applied to it. So the correct inputs flip to `utcInstant` + coordinates, and the hazard *dissolves* rather than needing to be remembered.

### Containment

**MEASURED: 0 of 6 migrated production rows change sect**, so no archetype moves — the constitutions were recomputed and came back byte-identical. The two rules part company exactly where the proxy could never follow:

| case | Sun altitude | proxy said | truth |
|---|---|---|---|
| Brooklyn 19:00 local, June | **+14.70°** | nocturnal | diurnal |
| Tromsø 02:00 local, June (midnight sun) | **+4.22°** | nocturnal | diurnal |
| Tromsø 12:00 local, Dec (polar night) | **−2.51°** | diurnal | nocturnal |

`sectSolarAltitude.test.ts` is built deliberately from **those** cases rather than from prod data: on the current population both rules agree everywhere, so a prod-only suite would pass with the proxy still in place and prove nothing. It also pins the horizon crossing itself (±10 min around sunrise), which no whole-hour window can express. **Mutation-verified: reverting to the proxy fails 5/9.**

Degradation is documented, never silent — no `utcInstant` or no coordinates falls back to the proxy on the wall clock, i.e. exactly the previous behaviour, preserved on purpose for unmigrated rows.

## 2. The two Fallback NY rows — attested, not laundered

#726 refused 2 rows carrying `40.7498,-73.7976` bit-exact, on the grounds that a fabricated pin cannot yield a birth instant. You've since confirmed both users were born in New York. That changes what is known, but the two halves must not be conflated:

- **Zone → now defensible.** Every NYC-metro pin resolves to `America/New_York`, so the birth **instant** follows correctly and is no worse than any other NYC-born row.
- **Position → still a city-level default.** NYC spans ~0.55° of longitude ≈ 2.2 minutes of sidereal time ≈ up to ~0.55° of Ascendant. Invisible except within about half a degree of a sign cusp, where it can move the rising sign outright.

So they migrate under a **distinct** basis — `ATTESTED_REGION_DEFAULT_PIN` (migration 77), behind an explicit `--attest-fallback-pin` flag, because it encodes a human claim that is not in the data. Collapsing them into `DERIVED_FROM_COORDINATES` would relabel a default as a measurement, which is the exact failure that produced these rows in the first place. A reader must always be able to tell *"we know where they were born"* from *"we know which region, and defaulted the rest"*.

## 3. `--orphan-charts` was still too narrow

It required `planets > 0`, which silently skipped rows whose chart had never reached `user_profiles` — **precisely the rows most in need of one**, including both attested rows. Now scoped to any migrated profile with no constitution row, chart or not.

## Verified end state

| | |
|---|---|
| migrated profiles | **8** (6 `DERIVED`, 2 `ATTESTED_REGION_DEFAULT_PIN`) |
| chartless | **0** |
| degenerate `25/25/25/25` | **0** |
| sect changes on prod | **0** — no archetype moved |
| full suite | **206 files, 2061 passed, 0 failures** |

## Not addressed here (pre-existing, flagged for the record)

Two build-log lines predate this work and are unrelated to it — the build completes:
- `Can't resolve '@farcaster/mini-app-solana'` — an optional sub-export of `@privy-io/react-auth`.
- `localStorage is not defined` in `AstrologizeApiCache.ts` — an SSR guard gap, last touched 2026-05-19.

Happy to take either in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
