### PR TITLE
fix(nav): add a global sign-out, and stop advertising the abandoned premium tier

### DIFF
--- a/src/app/(alchm)/lab/page.tsx
+++ b/src/app/(alchm)/lab/page.tsx
@@ -99,7 +99,7 @@ function AwaitingBackend({
         }}
       >
         <div className="t-tag" style={{ color: "var(--accent)" }}>
-          {title} · AWAITING BACKEND
+          {title} · NOT YET AVAILABLE
         </div>
         <span
           className="t-mono"

--- a/src/app/(alchm)/profile/page.tsx
+++ b/src/app/(alchm)/profile/page.tsx
@@ -134,6 +134,7 @@ function PremiumDashboard({
               onClick={() => { void signOut({ callbackUrl: '/' }); }}
               className="p-2.5 rounded-full glass-base text-white/20 hover:text-white/60 border border-white/5 hover:border-white/10 transition-all"
               title="Sign out"
+              aria-label="Sign out"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
@@ -511,6 +512,7 @@ function FreeDashboard({
             onClick={() => { void signOut({ callbackUrl: '/' }); }}
             className="p-2.5 rounded-full glass-base text-white/20 hover:text-white/50 border border-white/5 transition-all"
             title="Sign out"
+            aria-label="Sign out"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -221,7 +221,7 @@ function LoginContent() {
           <div className="mt-12">
             <div className="relative flex items-center mb-6">
               <div className="flex-grow border-t border-white/10" />
-              <span className="flex-shrink-0 mx-4 text-xs font-semibold text-gray-500 uppercase tracking-widest">Premium Access</span>
+              <span className="flex-shrink-0 mx-4 text-xs font-semibold text-gray-500 uppercase tracking-widest">What you unlock</span>
               <div className="flex-grow border-t border-white/10" />
             </div>
             

--- a/src/components/nav/CommandPalette.tsx
+++ b/src/components/nav/CommandPalette.tsx
@@ -28,7 +28,7 @@ const QUICK_ACTIONS: PaletteItem[] = [
   { id: "action:compose", icon: "flask", label: "Compose tonight's menu", hint: "RECIPE BUILDER · ENTER", href: "/recipe-builder" },
   { id: "action:pantry", icon: "mortar", label: "Open the pantry", hint: "PANTRY · ENTER", href: "/pantry" },
   { id: "action:commensal", icon: "ring", label: "Plan a commensal gathering", hint: "COMMENSAL · ENTER", href: "/commensal" },
-  { id: "action:upgrade", icon: "diamond", label: "Upgrade to Alchemist", hint: "PREMIUM · ENTER", href: "/premium" },
+  { id: "action:vault", icon: "diamond", label: "Open the ESMS vault", hint: "TOKENS · ENTER", href: "/premium" },
   { id: "action:security", icon: "atom", label: "Account & sessions", hint: "SECURITY · ENTER", href: "/profile/security" },
 ];
 

--- a/src/components/nav/RedesignedFooter.tsx
+++ b/src/components/nav/RedesignedFooter.tsx
@@ -129,7 +129,7 @@ export function RedesignedFooter(): JSX.Element {
               <Link href="/profile/security" className="alchm-footer-link">Account & sessions</Link>
             </li>
             <li>
-              <Link href="/premium" className="alchm-footer-link">Premium</Link>
+              <Link href="/premium" className="alchm-footer-link">ESMS Vault</Link>
             </li>
           </ul>
           <div

--- a/src/components/nav/RedesignedHeader.tsx
+++ b/src/components/nav/RedesignedHeader.tsx
@@ -3,7 +3,7 @@
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useSession } from "next-auth/react";
+import { signOut, useSession } from "next-auth/react";
 import { useEffect, useRef, useState, type JSX } from "react";
 import { Glyph } from "@/components/ui/alchm/Glyph";
 import { PlanetaryChip } from "@/components/ui/alchm/PlanetaryChip";
@@ -67,7 +67,7 @@ const FEATURED_TILE: Record<PrimaryKey, {
     href: "/commensal",
   },
   lab: {
-    tag: "PREMIUM · PRACTITIONER",
+    tag: "PRACTITIONER · ENGINE",
     title: "Engine internals",
     sub: "Recommendation weights, planetary chart, standing chart, quantities.",
     cta: "Open lab",
@@ -94,9 +94,25 @@ const MENU_GROUPS: Partial<
   ],
   lab: [
     { label: "Engine", paths: ["/lab", "/quantities"] },
-    { label: "Charts & Premium", paths: ["/planetary-chart", "/current-chart", "/birth-chart", "/premium"] },
+    { label: "Charts & Vault", paths: ["/planetary-chart", "/current-chart", "/birth-chart", "/premium"] },
   ],
 };
+
+/**
+ * Account-menu destinations, shown above the sign-out control. Kept short on
+ * purpose — this menu exists so signing out is reachable from every route,
+ * not as a second home for the full profile IA.
+ */
+const ACCOUNT_LINKS: ReadonlyArray<{
+  href: string;
+  label: string;
+  glyph: "user" | "settings" | "diamond" | "shield";
+}> = [
+  { href: "/profile", label: "Profile", glyph: "user" },
+  { href: "/profile/preferences", label: "Preferences", glyph: "settings" },
+  { href: "/premium", label: "ESMS Vault", glyph: "diamond" },
+  { href: "/profile/security", label: "Account & sessions", glyph: "shield" },
+];
 
 export interface RedesignedHeaderProps {
   /** When provided, overrides the path-derived active key. */
@@ -116,8 +132,10 @@ export function RedesignedHeader({ active }: RedesignedHeaderProps = {}): JSX.El
   const resolved = active ?? activePrimaryFromPathname(pathname);
 
   const [openMenu, setOpenMenu] = useState<PrimaryKey | "none">("none");
+  const [accountOpen, setAccountOpen] = useState(false);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
+  const accountRef = useRef<HTMLDivElement>(null);
 
   // Generous 400ms delay so a slow cursor can bridge from the pill button to
   // the mega-menu without the panel snapping shut mid-transit. A taller hover
@@ -136,7 +154,34 @@ export function RedesignedHeader({ active }: RedesignedHeaderProps = {}): JSX.El
   // Close mega-menus on route change
   useEffect(() => {
     setOpenMenu("none");
+    setAccountOpen(false);
   }, [pathname]);
+
+  // The account menu is click-driven (not hover, like the mega-menus), so it
+  // owns its own Escape / click-outside listener scoped to the chip subtree.
+  // Focus returns to the trigger on Escape so keyboard users aren't stranded.
+  useEffect(() => {
+    if (!accountOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setAccountOpen(false);
+        accountRef.current?.querySelector("button")?.focus();
+      }
+    };
+    const onDocMouseDown = (e: MouseEvent) => {
+      const root = accountRef.current;
+      if (!root) return;
+      if (e.target instanceof Node && !root.contains(e.target)) {
+        setAccountOpen(false);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    document.addEventListener("mousedown", onDocMouseDown);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.removeEventListener("mousedown", onDocMouseDown);
+    };
+  }, [accountOpen]);
 
   // Close on Escape, and close on mousedown outside the header. The previous
   // implementation used a full-viewport overlay div (z-30) for click-outside,
@@ -277,6 +322,56 @@ export function RedesignedHeader({ active }: RedesignedHeaderProps = {}): JSX.El
         .alchm-header-planet { display: none; }
         @media (min-width: 1024px) {
           .alchm-header-planet { display: flex; }
+        }
+        .alchm-account-wrap { position: relative; }
+        .alchm-account-menu {
+          position: absolute;
+          top: calc(100% + 10px);
+          right: 0;
+          min-width: 224px;
+          padding: 6px;
+          background: var(--bg-elev, #12101d);
+          border: 1px solid var(--line);
+          border-radius: 12px;
+          box-shadow: 0 18px 44px rgba(0,0,0,0.55);
+          z-index: 70;
+        }
+        .alchm-account-head {
+          padding: 10px 12px 8px;
+          border-bottom: 1px solid var(--line);
+          margin-bottom: 6px;
+        }
+        .alchm-account-item {
+          display: flex; align-items: center; gap: 10px;
+          width: 100%;
+          padding: 9px 12px;
+          border: 0;
+          border-radius: 8px;
+          background: transparent;
+          color: var(--fg-mute);
+          font-family: var(--f-mono);
+          font-size: 11px;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          text-align: left;
+          text-decoration: none;
+          cursor: pointer;
+        }
+        .alchm-account-item:hover,
+        .alchm-account-item:focus-visible {
+          background: rgba(255,255,255,0.05);
+          color: var(--fg);
+          outline: none;
+        }
+        .alchm-account-sep {
+          height: 1px;
+          background: var(--line);
+          margin: 6px 4px;
+        }
+        .alchm-account-signout:hover,
+        .alchm-account-signout:focus-visible {
+          background: color-mix(in oklch, #ef4444, transparent 86%);
+          color: #fca5a5;
         }
       `}</style>
 
@@ -442,26 +537,82 @@ export function RedesignedHeader({ active }: RedesignedHeaderProps = {}): JSX.El
           {status === "authenticated" && <NotificationBell />}
 
           {status === "authenticated" ? (
-            <Link
-              href="/profile"
-              className="alchm-header-userchip"
-              aria-label="Your account"
-            >
-              <div className="alchm-header-userchip-text">
-                <div style={{ fontSize: 11, color: "var(--fg)" }}>{userName}</div>
-                <div
-                  className="t-mono"
-                  style={{
-                    fontSize: 9,
-                    color: "var(--fg-mute)",
-                    letterSpacing: "0.12em",
-                  }}
-                >
-                  {userId}
+            <div className="alchm-account-wrap" ref={accountRef}>
+              <button
+                type="button"
+                className="alchm-header-userchip"
+                aria-label="Your account"
+                aria-haspopup="menu"
+                aria-expanded={accountOpen}
+                onClick={() => setAccountOpen((v) => !v)}
+              >
+                <div className="alchm-header-userchip-text">
+                  <div style={{ fontSize: 11, color: "var(--fg)" }}>{userName}</div>
+                  <div
+                    className="t-mono"
+                    style={{
+                      fontSize: 9,
+                      color: "var(--fg-mute)",
+                      letterSpacing: "0.12em",
+                    }}
+                  >
+                    {userId}
+                  </div>
                 </div>
-              </div>
-              <div className="alchm-header-avatar">{userInitial}</div>
-            </Link>
+                <div className="alchm-header-avatar">{userInitial}</div>
+              </button>
+
+              {accountOpen && (
+                <div className="alchm-account-menu" role="menu" aria-label="Account">
+                  <div className="alchm-account-head">
+                    <div style={{ fontSize: 12, color: "var(--fg)" }}>{userName}</div>
+                    {session?.user?.email && (
+                      <div
+                        className="t-mono"
+                        style={{
+                          fontSize: 9,
+                          color: "var(--fg-faint)",
+                          letterSpacing: "0.06em",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {session.user.email}
+                      </div>
+                    )}
+                  </div>
+
+                  {ACCOUNT_LINKS.map((l) => (
+                    <Link
+                      key={l.href}
+                      href={l.href}
+                      role="menuitem"
+                      className="alchm-account-item"
+                      onClick={() => setAccountOpen(false)}
+                    >
+                      <Glyph name={l.glyph} size={13} stroke={1.4} />
+                      {l.label}
+                    </Link>
+                  ))}
+
+                  <div className="alchm-account-sep" />
+
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="alchm-account-item alchm-account-signout"
+                    onClick={() => {
+                      setAccountOpen(false);
+                      void signOut({ callbackUrl: "/" });
+                    }}
+                  >
+                    <Glyph name="logout" size={13} stroke={1.4} />
+                    Sign out
+                  </button>
+                </div>
+              )}
+            </div>
           ) : (
             <Link
               href="/login"

--- a/src/components/nav/__tests__/RedesignedHeader.account.test.tsx
+++ b/src/components/nav/__tests__/RedesignedHeader.account.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment jsdom
+ *
+ * RedesignedHeader — account menu. Regression guard for the live-site audit
+ * finding: an authenticated user had no way to sign out from the global nav.
+ * The user chip was a plain <Link href="/profile">, so signing out meant
+ * knowing to visit /profile and finding an icon-only button there.
+ *
+ * These assert the MECHANISM (chip opens a menu; the menu's sign-out control
+ * calls next-auth signOut), not merely that some element says "Sign out".
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { RedesignedHeader } from "../RedesignedHeader";
+
+const mockSignOut = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/",
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+// The header lazy-loads three unrelated widgets (messages, notifications,
+// cart). They pull their own data hooks and are not under test here, so
+// next/dynamic is stubbed to a no-op rather than mocking each one.
+jest.mock("next/dynamic", () => () => {
+  const Stub = () => null;
+  Stub.displayName = "DynamicStub";
+  return Stub;
+});
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({
+    status: "authenticated",
+    data: { user: { name: "Ada Lovelace", email: "ada@example.com", id: "abcd1234efgh" } },
+  }),
+  signOut: (...args: unknown[]) => mockSignOut(...args),
+}));
+
+describe("RedesignedHeader account menu", () => {
+  beforeEach(() => {
+    mockSignOut.mockClear();
+  });
+
+  const openMenu = () => {
+    const chip = screen.getByRole("button", { name: /your account/i });
+    fireEvent.click(chip);
+    return chip;
+  };
+
+  it("exposes the account chip as a menu trigger, collapsed by default", () => {
+    render(<RedesignedHeader />);
+    const chip = screen.getByRole("button", { name: /your account/i });
+    expect(chip).toHaveAttribute("aria-haspopup", "menu");
+    expect(chip).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("menu", { name: /account/i })).not.toBeInTheDocument();
+  });
+
+  it("opens a menu containing a visible, labelled Sign out control", () => {
+    render(<RedesignedHeader />);
+    const chip = openMenu();
+    expect(chip).toHaveAttribute("aria-expanded", "true");
+
+    const menu = screen.getByRole("menu", { name: /account/i });
+    expect(menu).toBeInTheDocument();
+
+    // A real accessible name, not a title-attribute tooltip.
+    const signOut = screen.getByRole("menuitem", { name: /^sign out$/i });
+    expect(signOut).toBeInTheDocument();
+  });
+
+  it("calls signOut and returns the user to the homepage", () => {
+    render(<RedesignedHeader />);
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /^sign out$/i }));
+
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+    expect(mockSignOut).toHaveBeenCalledWith({ callbackUrl: "/" });
+  });
+
+  it("closes on Escape without signing the user out", () => {
+    render(<RedesignedHeader />);
+    const chip = openMenu();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(chip).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("menu", { name: /account/i })).not.toBeInTheDocument();
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+
+  it("closes on an outside mousedown", () => {
+    render(<RedesignedHeader />);
+    const chip = openMenu();
+
+    fireEvent.mouseDown(document.body);
+
+    expect(chip).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("menu", { name: /account/i })).not.toBeInTheDocument();
+  });
+
+  it("still shows the account destinations alongside sign out", () => {
+    render(<RedesignedHeader />);
+    openMenu();
+    for (const label of [/^profile$/i, /^preferences$/i, /^esms vault$/i, /account & sessions/i]) {
+      expect(screen.getByRole("menuitem", { name: label })).toBeInTheDocument();
+    }
+  });
+});

--- a/src/components/ui/alchm/Glyph.tsx
+++ b/src/components/ui/alchm/Glyph.tsx
@@ -23,7 +23,10 @@ export type GlyphName =
   | "x"
   | "check"
   | "google"
-  | "settings";
+  | "settings"
+  | "user"
+  | "shield"
+  | "logout";
 
 export interface GlyphProps {
   name: GlyphName;
@@ -208,6 +211,28 @@ export function Glyph({
         <svg {...common}>
           <circle cx="12" cy="12" r="3" />
           <path d="M19 12a7 7 0 0 0-.1-1.3l2-1.5-2-3.4-2.3.9a7 7 0 0 0-2.3-1.3L13.7 3h-3.4l-.6 2.4a7 7 0 0 0-2.3 1.3l-2.3-.9-2 3.4 2 1.5A7 7 0 0 0 5 12c0 .4 0 .9.1 1.3l-2 1.5 2 3.4 2.3-.9a7 7 0 0 0 2.3 1.3l.6 2.4h3.4l.6-2.4a7 7 0 0 0 2.3-1.3l2.3.9 2-3.4-2-1.5c.1-.4.1-.9.1-1.3z" />
+        </svg>
+      );
+    case "user":
+      return (
+        <svg {...common}>
+          <circle cx="12" cy="8" r="3.6" />
+          <path d="M4.5 20a7.5 7.5 0 0 1 15 0" />
+        </svg>
+      );
+    case "shield":
+      return (
+        <svg {...common}>
+          <path d="M12 3l7 3v5.5c0 4.2-2.9 7.9-7 9.5-4.1-1.6-7-5.3-7-9.5V6l7-3z" />
+          <path d="M9.2 12.2l2 2 3.6-3.9" />
+        </svg>
+      );
+    case "logout":
+      return (
+        <svg {...common}>
+          <path d="M14 4.5h4a1.5 1.5 0 0 1 1.5 1.5v12a1.5 1.5 0 0 1-1.5 1.5h-4" />
+          <path d="M10 16l-4-4 4-4" />
+          <path d="M6 12h8.5" />
         </svg>
       );
     default:


### PR DESCRIPTION
Found during a live-site navigability audit ahead of handing out business cards. Scope is deliberately narrow: the sign-out gap and the copy that contradicts the shipped economy. Nothing here touches auth logic, routing, or the tier plumbing.

## Summary

**There was no way to sign out.** When authenticated, the header user chip was a plain `<Link href="/profile">`. The only sign-out control lived on `/profile` as an icon-only button whose meaning was carried by a `title` tooltip — which does not render on touch. On mobile there was effectively no logout at all.

The chip is now a menu: **Profile / Preferences / ESMS Vault / Account & sessions**, then **Sign out** below a separator. It has `aria-haspopup` + `aria-expanded`, closes on Escape (returning focus to the trigger) and on outside mousedown. It owns its own listener rather than reusing the mega-menu's, because it is click-driven where those are hover-driven. Adds the `user` / `shield` / `logout` glyphs, and real `aria-label`s to the two icon-only sign-outs on `/profile`.

**Copy that sells a product you cannot buy.** `ede69c41` abandoned the premium tier for pay-as-you-go ESMS and rewrote `/premium` into the ESMS Vault — but the labels pointing at it never followed:

| Surface | Before | After |
|---|---|---|
| `/login` | `Premium Access` | `What you unlock` |
| Footer | `Premium` | `ESMS Vault` |
| ⌘K palette | `Upgrade to Alchemist` | `Open the ESMS vault` |
| Mega-menu | `Charts & Premium` | `Charts & Vault` |
| Lab tile | `PREMIUM · PRACTITIONER` | `PRACTITIONER · ENGINE` |

The `/premium` route itself is unchanged — only what we call it.

**`AWAITING BACKEND` → `NOT YET AVAILABLE`** on `/lab` (one line, single source). Those eight panels behave correctly — they are natal-dependent or genuinely unbuilt — but the label is our vocabulary, not the reader's, and it reads as breakage on a page linked from the homepage tile grid.

## Test plan

- **6 new tests** in `RedesignedHeader.account.test.tsx`, asserting the mechanism rather than the wording: the chip is a menu trigger, the control invokes `signOut({callbackUrl: "/"})`, Escape closes without signing anyone out, outside-mousedown closes, and the account destinations render.
- **Mutation-checked, not just green.** Breaking the `callbackUrl` failed only the signOut test; disabling outside-click failed only the outside-click test. Both reverted and re-confirmed.
- `bun run verify` — exit **0** (20 warnings, all pre-existing; none in the changed files).
- Full suite — **207 suites, 2,066 passing, 9 skipped, 0 failures**.
- Menu rendering and interaction confirmed in a browser against the dev server.

**Not verified here:** a real Google sign-in click-through. Completing OAuth needs credentials, so the authenticated header was exercised via a minted local session and the test suite. Worth eyeballing once on the preview deploy.

## Out of scope (ticketed separately)

- **Mobile nav hierarchy** — `Discover` and `Tables` are both the social feature, and `/discover` greets new visitors with an empty state, so 40% of the persistent mobile nav points at a cold-start surface while the ingredient/cuisine library is reachable only via homepage tiles or the footer.
- **Vestigial tier plumbing** — only admins can resolve to `"premium"`, making `PremiumDashboard` near-dead, but removing it is auth-adjacent and deserves its own branch.
- **`/dev/tables-kit` soft-404** — returns HTTP 200 with 404 content; contained by `noindex`.

Two operational findings from the same audit are being handled outside this PR: prod bypasses PgBouncer (direct :5432, ceiling ~100 connections), and the synthetic probe has been out of ESMS since 2026-05-29, so authenticated probes have been dark for 68 days.

## Reflection

I initially flagged an unmerged local test fix and a stale `/lab` backend bug that both turned out to already be on master — I trusted my own prior notes instead of checking `origin/master` first. Verifying against the remote before reporting would have saved two false alarms. The mutation check was worth the extra minutes: it is the only reason I would claim these tests actually guard anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
