### PR TITLE
fix(cache): stop AstrologizeApiCache from touching localStorage on the server

### DIFF
--- a/src/services/AstrologizeApiCache.ts
+++ b/src/services/AstrologizeApiCache.ts
@@ -51,6 +51,23 @@ interface TransitPrediction {
   sources: string[]; // Which cached entries contributed to this prediction
 }
 
+/**
+ * This module ends with `export default new AstrologizeApiCache()`, so the
+ * constructor — and its `loadFromStorage()` call — runs the moment anything
+ * imports it, including server-only code. `localStorage` does not exist on the
+ * server, so importing this from an API route threw a ReferenceError on every
+ * cold start. It was caught and logged rather than fatal, which is why it
+ * survived: the Vercel build printed "Failed to load astrologize cache from
+ * localStorage: ReferenceError: localStorage is not defined" while collecting
+ * page data for /api/feed/share, and the build still passed.
+ *
+ * Checked at call time rather than construction time because jsdom-based tests
+ * install `localStorage` after module load.
+ */
+function hasLocalStorage(): boolean {
+  return typeof globalThis !== "undefined" && typeof globalThis.localStorage !== "undefined";
+}
+
 class AstrologizeApiCache {
   private cache: Map<string, CachedAstrologicalData> = new Map();
   private readonly maxCacheSize = 1000; // Store up to 1000 calculations
@@ -415,6 +432,7 @@ class AstrologizeApiCache {
   }
 
   private saveToStorage(): void {
+    if (!hasLocalStorage()) return;
     try {
       const data = Array.from(this.cache.entries());
       localStorage.setItem(this.STORAGE_KEY, JSON.stringify(data));
@@ -424,6 +442,7 @@ class AstrologizeApiCache {
   }
 
   private loadFromStorage(): void {
+    if (!hasLocalStorage()) return;
     try {
       const stored = localStorage.getItem(this.STORAGE_KEY);
       if (stored) {

--- a/src/services/__tests__/AstrologizeApiCache.browser.test.ts
+++ b/src/services/__tests__/AstrologizeApiCache.browser.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Companion to AstrologizeApiCache.ssr.test.ts. That file proves the server no
+ * longer throws on `localStorage`; this one proves the fix did not achieve
+ * that by simply disabling persistence everywhere. jsdom provides a real
+ * localStorage, so the guard must fall through and the cache must still
+ * round-trip.
+ */
+
+const LAT = 40.7128;
+const LNG = -74.006;
+const WHEN = new Date("2026-08-06T12:00:00Z");
+const STORAGE_KEY = "astrologize_cache";
+
+const importFresh = async () => {
+  jest.resetModules();
+  return (await import("../AstrologizeApiCache")).default;
+};
+
+/** Minimal shapes matching what store()/calculateElementalValues() read. */
+const seed = (cache: Awaited<ReturnType<typeof importFresh>>) =>
+  cache.store(
+    LAT,
+    LNG,
+    WHEN,
+    { sunSign: "leo" } as never,
+    { elementalBalance: { Fire: 0.4, Water: 0.2, Earth: 0.3, Air: 0.1 } } as never,
+    { Sun: { sign: "leo", degree: 14 } } as never,
+  );
+
+describe("AstrologizeApiCache in the browser (localStorage present)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("has a real localStorage in this environment (control)", () => {
+    // Mirrors the ssr suite's control. If this fails, the guard would be
+    // short-circuiting for the wrong reason and the round-trip proves nothing.
+    expect(typeof globalThis.localStorage).toBe("object");
+    expect(typeof globalThis.localStorage.getItem).toBe("function");
+  });
+
+  it("still writes the cache to localStorage", async () => {
+    const cache = await importFresh();
+    seed(cache);
+
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw as string).length).toBeGreaterThan(0);
+  });
+
+  it("rehydrates a previously persisted cache on construction", async () => {
+    const first = await importFresh();
+    seed(first);
+    expect(first.getCacheStats().size).toBe(1);
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+
+    // Fresh module instance — its constructor must read storage back.
+    const second = await importFresh();
+    expect(second.getCacheStats().size).toBe(1);
+  });
+
+  it("starts empty when storage holds nothing (control)", async () => {
+    localStorage.clear();
+    const cache = await importFresh();
+    expect(cache.getCacheStats().size).toBe(0);
+  });
+});

--- a/src/services/__tests__/AstrologizeApiCache.ssr.test.ts
+++ b/src/services/__tests__/AstrologizeApiCache.ssr.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment node
+ *
+ * The `node` environment is the point of this file — it has no `localStorage`,
+ * exactly like the Vercel server runtime. Under jsdom these assertions would
+ * pass trivially whether or not the guard exists.
+ *
+ * Regression guard for the build-log error:
+ *   "Failed to load astrologize cache from localStorage:
+ *    ReferenceError: localStorage is not defined
+ *      at g.loadFromStorage (.next/server/app/api/feed/share/route.js)"
+ *
+ * The module ends in `export default new AstrologizeApiCache()`, so importing
+ * it from any server route ran the constructor → loadFromStorage() → boom. The
+ * throw was swallowed by a try/catch, so the build stayed green while the
+ * error fired on every cold start of that route.
+ *
+ * NOTE: the spy is created inside each test, not at describe scope. This
+ * project sets `restoreMocks: true`, which restores a describe-scoped spy
+ * after the FIRST test — leaving later tests asserting against a dead spy
+ * whose `mock.calls` is always empty, i.e. passing no matter what the code
+ * does. The `captures console.warn at all` control below fails loudly if that
+ * ever silently regresses.
+ */
+
+const importFresh = async () => {
+  jest.resetModules();
+  return import("../AstrologizeApiCache");
+};
+
+const localStorageWarnings = (spy: jest.SpyInstance) =>
+  spy.mock.calls.filter((args) =>
+    args.some((a) => typeof a === "string" && a.includes("localStorage")),
+  );
+
+describe("AstrologizeApiCache on the server (no localStorage)", () => {
+  it("has no localStorage in this environment (control)", () => {
+    // If this fails, the file is running under jsdom and proves nothing.
+    expect(typeof (globalThis as { localStorage?: unknown }).localStorage).toBe(
+      "undefined",
+    );
+  });
+
+  it("captures console.warn at all (control for restoreMocks)", () => {
+    const spy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    console.warn("probe localStorage sentinel");
+    expect(localStorageWarnings(spy)).toHaveLength(1);
+    spy.mockRestore();
+  });
+
+  it("imports without throwing, even though construction is a side effect", async () => {
+    await expect(importFresh()).resolves.toBeDefined();
+  });
+
+  it("does not log a localStorage failure on import", async () => {
+    const spy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    await importFresh();
+    expect(localStorageWarnings(spy)).toEqual([]);
+    spy.mockRestore();
+  });
+
+  it("still exposes a usable cache instance server-side", async () => {
+    const spy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const mod = await importFresh();
+    expect(mod.default).toBeDefined();
+    // Constructed fine; it just starts empty rather than rehydrating from a
+    // storage API that does not exist here.
+    expect(typeof mod.default).toBe("object");
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
Fixes an error visible in the production build log for `b63dc855`, spotted while reviewing that deploy.

## The bug

```
Failed to load astrologize cache from localStorage:
ReferenceError: localStorage is not defined
    at g.loadFromStorage (.next/server/app/api/feed/share/route.js)
```

`AstrologizeApiCache.ts` ends in `export default new AstrologizeApiCache()`. The constructor calls `loadFromStorage()`, so importing the module from **any** server route runs a browser API on the server.

It survived because it was already wrapped in a try/catch — the throw became a `console.warn` and the build stayed green. The real cost was quieter than a crash: **server-side the cache never rehydrated at all**, so every request started cold while the log made it look like a transient storage problem.

## The fix

Both storage methods check for `localStorage` before touching it. The check runs at call time rather than construction time, because jsdom installs `localStorage` after module load.

## Test plan

Two suites, because this guard has an obvious wrong fix — disabling persistence everywhere — that a single-environment test would happily pass:

| Suite | Environment | Asserts |
|---|---|---|
| `ssr.test.ts` | `node` (no localStorage, like Vercel) | importing neither throws nor warns |
| `browser.test.ts` | `jsdom` (real localStorage) | cache still writes, and still rehydrates on construction |

Each carries an environment control (`localStorage` absent / present) so neither can pass for the wrong reason.

**Mutation-checked:** removing the `loadFromStorage` guard fails exactly the ssr "does not log a localStorage failure" test, and nothing else.

- `bun run verify` — exit **0** (20 warnings, all pre-existing; none in the changed file)
- `bun run test` — **209 suites, 2,080 passing, 0 failures**

Note: `bun test` is not a valid gate on this repo — Bun's native runner ignores the `@jest-environment` docblock and fails passing tests on unmodified code. Both suites here depend on that docblock, so they must run under jest.

## Reflection

My first version of the ssr test **passed with the guard removed**. This project sets `restoreMocks: true`, which restored a describe-scoped `console.warn` spy after the first test, leaving the later assertion reading a dead spy whose `mock.calls` is permanently empty — green regardless of the code. The spy is now created per-test, and a "captures console.warn at all" control fails loudly if that regresses. Second time this session a mutation check caught a test asserting less than its name claimed; I'd rather find these here than trust them later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
