### PR TITLE
fix(db): honor sslmode=disable so PgBouncer is reachable

### DIFF
--- a/src/lib/database/__tests__/resolveSslOption.test.ts
+++ b/src/lib/database/__tests__/resolveSslOption.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regression test for the PgBouncer SSL trap.
+ *
+ * getDatabaseConfig() in rawPool.ts destructures the connection URL into
+ * discrete pg fields, which drops the query string — so `?sslmode=disable` was
+ * read by nothing and every remote host got forced TLS. Railway's PgBouncer
+ * refuses TLS, so the app could never route through the pooler; setting
+ * DATABASE_URL to the pooler would fail the handshake and take the database
+ * offline on the next rebuild.
+ *
+ * The load-bearing case is "remote host + sslmode=disable". Under the previous
+ * behaviour that returned `{ rejectUnauthorized: false }`; it must now be
+ * `false`. The other cases pin the behaviour that must NOT change, so a future
+ * edit can't quietly drop TLS for ordinary connections.
+ */
+
+import { resolveSslOption } from "@/lib/database/config";
+
+const PGBOUNCER = "postgresql://u:p@zephyr.proxy.rlwy.net:40200/railway";
+const DIRECT = "postgresql://u:p@tramway.proxy.rlwy.net:35670/railway";
+
+describe("resolveSslOption", () => {
+  it("disables TLS for a remote host when sslmode=disable is present", () => {
+    // The whole point: this is what makes PgBouncer reachable.
+    expect(resolveSslOption(new URL(`${PGBOUNCER}?sslmode=disable`))).toBe(
+      false,
+    );
+  });
+
+  it("still forces TLS for a remote host with no sslmode", () => {
+    expect(resolveSslOption(new URL(DIRECT))).toEqual({
+      rejectUnauthorized: false,
+    });
+  });
+
+  it("does not disable TLS for other sslmode values", () => {
+    for (const mode of ["require", "verify-ca", "verify-full", "prefer"]) {
+      expect(resolveSslOption(new URL(`${DIRECT}?sslmode=${mode}`))).toEqual({
+        rejectUnauthorized: false,
+      });
+    }
+  });
+
+  it("finds sslmode alongside other query parameters", () => {
+    expect(
+      resolveSslOption(
+        new URL(`${PGBOUNCER}?application_name=alchm&sslmode=disable&foo=1`),
+      ),
+    ).toBe(false);
+  });
+
+  it("leaves local connections unencrypted", () => {
+    expect(resolveSslOption(new URL("postgresql://u:p@localhost:5432/db"))).toBe(
+      false,
+    );
+    expect(resolveSslOption(new URL("postgresql://u:p@127.0.0.1:5432/db"))).toBe(
+      false,
+    );
+  });
+});

--- a/src/lib/database/config.ts
+++ b/src/lib/database/config.ts
@@ -168,4 +168,30 @@ void logger.info("Database configuration loaded", {
 });
 */
 
+/**
+ * Resolve the `pg` `ssl` option for a parsed connection URL.
+ *
+ * getDatabaseConfig() in rawPool.ts destructures the connection URL into
+ * discrete pg fields (host/port/database/user/password), which drops the query
+ * string. That made libpq's `sslmode` parameter unreadable, so every non-local
+ * host got forced TLS. Railway's PgBouncer refuses TLS ("the server does not
+ * support SSL connections"), which made routing through the pooler impossible
+ * no matter what the connection string said — the pooler flip could not work
+ * on an env change alone.
+ *
+ * Only `sslmode=disable` is special-cased. Every other libpq mode (`require`,
+ * `verify-ca`, `verify-full`, …) wants TLS, which the default already provides.
+ * We can't pin a CA we don't control (Railway rotates it), so remote hosts get
+ * `rejectUnauthorized: false` — see the SSL note in rawPool.ts.
+ */
+export function resolveSslOption(
+  url: URL,
+): false | { rejectUnauthorized: boolean } {
+  if (url.searchParams.get("sslmode") === "disable") {
+    return false;
+  }
+  const isLocal = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+  return isLocal ? false : { rejectUnauthorized: false };
+}
+
 export default databaseConfig;

--- a/src/lib/database/rawPool.ts
+++ b/src/lib/database/rawPool.ts
@@ -1,6 +1,10 @@
 import pkg from 'pg';
 import { logger } from "../logger";
-import { databaseConfig, assertRuntimeDatabaseConfig } from "./config";
+import {
+  databaseConfig,
+  assertRuntimeDatabaseConfig,
+  resolveSslOption,
+} from "./config";
 import type { Pool, PoolClient } from "pg";
 
 /**
@@ -101,10 +105,12 @@ function getDatabaseConfig(): DatabaseConfig {
       database: url.pathname.slice(1),
       user: url.username,
       password: url.password,
-      // Enable SSL for any remote connection (non-localhost)
-      ssl: url.hostname !== "localhost" && url.hostname !== "127.0.0.1"
-        ? remoteSsl
-        : false,
+      // Enable SSL for any remote connection (non-localhost), unless the URL
+      // explicitly opts out with `?sslmode=disable`. The opt-out is required
+      // for PgBouncer, which refuses TLS — and because this function drops the
+      // query string when it destructures the URL, `sslmode` is invisible
+      // unless it is read here. See resolveSslOption in ./config.
+      ssl: resolveSslOption(url),
       max: maxConnections,
       idleTimeoutMillis: idleTimeout,
       connectionTimeoutMillis: connectionTimeout,


### PR DESCRIPTION
## Problem

Routing production through PgBouncer is impossible on the current code, and attempting it via env vars alone is an **outage waiting for the next rebuild**.

`getDatabaseConfig()` in `src/lib/database/rawPool.ts` does not pass `connectionString` to `pg`. It parses the URL and destructures it into discrete fields:

```ts
const url = new URL(databaseUrl);
return {
  host: url.hostname, port: parseInt(url.port, 10) || 5432,
  database: url.pathname.slice(1), user: url.username, password: url.password,
  ssl: url.hostname !== "localhost" && url.hostname !== "127.0.0.1" ? remoteSsl : false,
```

**The query string is discarded**, so libpq's `sslmode` is read by nothing — `sslmode` appears nowhere in the pool path. Every non-localhost host then gets forced TLS (`{ rejectUnauthorized: false }`).

Railway's PgBouncer **refuses TLS** (`the server does not support SSL connections`). So `DATABASE_URL=…zephyr.proxy.rlwy.net:40200/railway?sslmode=disable` cannot connect — the `?sslmode=disable` that makes it work with a plain `pg.Client` is invisible here.

### How this was found

Setting that env var in production looked harmless — the site stayed healthy — because `vercel redeploy` reuses the original build **and its env snapshot**, so the change never took effect. Verified by dual witness: across 1,500 requests Postgres `xact_commit` rose +20 while PgBouncer's `railway` pool `total_query_count` stayed pinned at 9 (`SHOW POOLS` → `cl_active=0`; `SHOW SERVERS` → empty). The first ordinary push to master would have triggered a real rebuild, picked up the pooler URL, forced TLS against a pooler that refuses it, and taken the production database offline. The env var has since been rolled back to the direct proxy.

## Fix

Read `sslmode` from the parsed URL before falling back to the forced-TLS default. Extracted as `resolveSslOption(url)` in `config.ts` — a zero-dependency module, so it is unit-testable without pulling in `pg` or the logger.

Only `disable` is special-cased. `require` / `verify-ca` / `verify-full` / `prefer` all still want TLS, which the default already provides. Behaviour for every existing connection string is **unchanged** — the direct proxy URL carries no `sslmode`, so it keeps forced TLS exactly as before.

## Tests

`src/lib/database/__tests__/resolveSslOption.test.ts` — 5 cases. The load-bearing one is *remote host + `sslmode=disable` → `false`*; the rest pin the behaviour that must **not** change, so a later edit can't quietly drop TLS for ordinary connections.

Mutation-checked: reverting `resolveSslOption` to the old logic makes the load-bearing assertion fail (old code returns `{rejectUnauthorized:false}` where `false` is required), so the test is not vacuous.

> Note: authored via the GitHub API — the working copy was locked by macOS TCC (`EPERM` on `~/Desktop`, surviving even a sandbox override), so `bun run test` and the linter could not be run locally. **Relying on CI for validation.** The pure function's logic was verified standalone in Node across all 9 assertions plus the mutation check.

## Deploy sequence — order matters

1. Merge this PR, let the production build finish, confirm healthy (still on the direct proxy).
2. **Then** set `DATABASE_URL` to `postgresql://…@zephyr.proxy.rlwy.net:40200/railway?sslmode=disable`.
3. Trigger a real rebuild — `vercel redeploy` will **not** pick up the new env var.
4. Verify with authenticated load (the synthetic probe JWT). Anonymous requests generate zero Postgres transactions — every public route is static or edge-cached, and `/api/health` memoizes its DB check (300 requests → 3 transactions), so anonymous load tests produce a false "pooling works" reading.

Reversing steps 1 and 2 is the outage.

Context: `DB_POOLER_MODE=session` is already set in production and is inert until then (session mode takes the same `statement_timeout` startup-param path as direct). Caps Postgres backends at the pool size instead of 5 conns × N Vercel instances against `max_connections=100`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
