### PR TITLE
fix(db): omit statement_timeout startup param when pooled

### DIFF
--- a/src/lib/database/__tests__/resolveServerStatementCap.test.ts
+++ b/src/lib/database/__tests__/resolveServerStatementCap.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression test for the PgBouncer startup-parameter gate.
+ *
+ * node-postgres sends `statement_timeout` in the connection startup packet.
+ * PgBouncer refuses any startup parameter missing from
+ * `ignore_startup_parameters` — at client login, in EVERY pool mode. The live
+ * Railway pooler allows only `extra_float_digits`, so the app's real config was
+ * rejected with `unsupported startup parameter: statement_timeout` and
+ * connected the moment that key was dropped.
+ *
+ * The load-bearing case is therefore "session omits the startup param". Under
+ * the previous logic (`poolerMode === "transaction" ? {} : {...}`) session
+ * returned the timeout and the pool could not connect at all.
+ */
+
+import { resolveServerStatementCap } from "@/lib/database/config";
+
+describe("resolveServerStatementCap", () => {
+  // The last case mutates DB_POOLER_MODE, and process.env is shared across
+  // every file in a jest worker — restore it so nothing downstream inherits it.
+  const originalPoolerMode = process.env.DB_POOLER_MODE;
+
+  afterEach(() => {
+    if (originalPoolerMode === undefined) delete process.env.DB_POOLER_MODE;
+    else process.env.DB_POOLER_MODE = originalPoolerMode;
+    jest.resetModules();
+  });
+
+  it("omits statement_timeout in session mode (PgBouncer rejects it)", () => {
+    expect(resolveServerStatementCap("session", 5000)).toEqual({});
+  });
+
+  it("omits statement_timeout in transaction mode", () => {
+    expect(resolveServerStatementCap("transaction", 5000)).toEqual({});
+  });
+
+  it("sends statement_timeout on a direct connection", () => {
+    expect(resolveServerStatementCap("direct", 5000)).toEqual({
+      statement_timeout: 5000,
+    });
+  });
+
+  it("passes the configured timeout through unchanged", () => {
+    expect(resolveServerStatementCap("direct", 1234)).toEqual({
+      statement_timeout: 1234,
+    });
+  });
+
+  it("fails safe on an unrecognised pooler mode", () => {
+    // Anything not explicitly direct must omit the param — sending it to an
+    // unknown topology risks wedging the pool shut on every connection.
+    for (const mode of ["", "pgbouncer", "SESSION", "unknown"]) {
+      expect(resolveServerStatementCap(mode, 5000)).toEqual({});
+    }
+  });
+
+  it("defaults to direct, so an unset DB_POOLER_MODE still gets the cap", () => {
+    delete process.env.DB_POOLER_MODE;
+    jest.resetModules();
+    const { databaseConfig, resolveServerStatementCap: fn } = require("@/lib/database/config");
+    expect(databaseConfig.poolerMode).toBe("direct");
+    expect(fn(databaseConfig.poolerMode, 5000)).toEqual({
+      statement_timeout: 5000,
+    });
+  });
+});

--- a/src/lib/database/config.ts
+++ b/src/lib/database/config.ts
@@ -194,4 +194,34 @@ export function resolveSslOption(
   return isLocal ? false : { rejectUnauthorized: false };
 }
 
+/**
+ * Decide whether `statement_timeout` may ride the connection startup packet.
+ *
+ * node-postgres sends `statement_timeout` as a startup parameter. PgBouncer
+ * rejects any startup parameter absent from `ignore_startup_parameters` with
+ * `unsupported startup parameter: statement_timeout`, and **that check runs at
+ * client login regardless of pool mode** — it is not specific to transaction
+ * mode, as previously assumed. Verified against the live Railway pooler, whose
+ * `ignore_startup_parameters` is `extra_float_digits` only: the app's exact
+ * config was refused, and succeeded as soon as `statement_timeout` was removed.
+ *
+ * So the startup param is only safe on a genuinely direct connection. Anything
+ * pooled (session or transaction) must omit it, or the pool cannot connect at
+ * all.
+ *
+ * ⚠ Trade-off: when pooled, the server-side cap from docs/adr/007 is NOT in
+ * force. `query_timeout` still bounds the request client-side, but it only
+ * aborts the client read — it does not cancel the backend query. Restore the
+ * server-side floor with a PgBouncer `connect_query` (`SET statement_timeout`)
+ * or `SET LOCAL` inside withTransaction.
+ */
+export function resolveServerStatementCap(
+  poolerMode: string,
+  statementTimeoutMs: number,
+): { statement_timeout?: number } {
+  // Fail safe: only the explicitly-direct topology gets the startup param, so
+  // an unrecognised value can never wedge the pool shut.
+  return poolerMode === "direct" ? { statement_timeout: statementTimeoutMs } : {};
+}
+
 export default databaseConfig;

--- a/src/lib/database/rawPool.ts
+++ b/src/lib/database/rawPool.ts
@@ -4,6 +4,7 @@ import {
   databaseConfig,
   assertRuntimeDatabaseConfig,
   resolveSslOption,
+  resolveServerStatementCap,
 } from "./config";
 import type { Pool, PoolClient } from "pg";
 
@@ -78,16 +79,18 @@ function getDatabaseConfig(): DatabaseConfig {
     poolerMode,
   } = databaseConfig;
 
-  // Under transaction-mode PgBouncer, `statement_timeout` cannot ride the
-  // connection startup packet: PgBouncer rejects non-allow-listed startup
-  // params, and even when ignored it has no effect because server connections
-  // are shared across clients. Omit it there and deliver the server-side cap
-  // via a PgBouncer `connect_query` (+ `SET LOCAL` in withTransaction) instead.
-  // In direct/session mode the per-connection startup param is the right floor.
-  const serverStatementCap =
-    poolerMode === "transaction"
-      ? {}
-      : { statement_timeout: statementTimeoutMs };
+  // `statement_timeout` may only ride the connection startup packet on a
+  // genuinely direct connection. PgBouncer refuses any startup parameter that
+  // is not in `ignore_startup_parameters`, and that check runs at client login
+  // in EVERY pool mode — the previous note here claimed session mode took "the
+  // same startup-param path as direct", which is wrong and made the pooler
+  // unreachable. Deliver the server-side cap when pooled via a PgBouncer
+  // `connect_query` (+ `SET LOCAL` in withTransaction) instead. See
+  // resolveServerStatementCap in ./config and docs/adr/007.
+  const serverStatementCap = resolveServerStatementCap(
+    poolerMode,
+    statementTimeoutMs,
+  );
 
   // SSL: Railway fronts Postgres/PgBouncer with a self-signed cert, and the
   // internal `*.railway.internal` traffic never leaves Railway's private


### PR DESCRIPTION
Follow-up to #731. That PR was **necessary but not sufficient** — with it merged, pointing `DATABASE_URL` at PgBouncer would still have taken the production database offline, with a different error.

## Problem

node-postgres sends `statement_timeout` in the connection **startup packet**. PgBouncer refuses any startup parameter absent from `ignore_startup_parameters`, and **that check runs at client login in every pool mode**. The comment in `rawPool.ts` asserting that session mode "uses the same startup-param path as direct" was wrong, and it is what made this look safe.

Live Railway pooler: `ignore_startup_parameters = "extra_float_digits"`, no `connect_query`, `pool_mode=session`, `default_pool_size=20`, `max_client_conn=120`.

Tested against it with the **exact config object** `getDatabaseConfig()` builds — discrete fields, not a connection string, which is what an earlier preflight got wrong:

```
❌ full app config (ssl:false + statement_timeout) → unsupported startup parameter: statement_timeout
✅ same, statement_timeout REMOVED                 → connects, users=5732
❌ same, ssl:{rejectUnauthorized:false}            → server does not support SSL   (why #731 was needed)
✅ control: direct proxy + statement_timeout       → connects
```

The infrastructure-side alternative (allowlisting `statement_timeout` on the pooler plus a `connect_query` to re-apply the cap) was attempted first and could not be made to take effect — across a restart and a redeploy the running process never cycled, with `SHOW STATS.total_query_count` pinned and `ignore_startup_parameters` unmoved.

## Fix

Only an explicitly `direct` topology gets the startup parameter. Anything pooled omits it, and an unrecognised mode **fails safe** by omitting — sending it to an unknown topology risks wedging every connection shut.

`direct` and `transaction` behaviour are unchanged; only `session` moves. Extracted as `resolveServerStatementCap()` in `config.ts` — zero-dependency, so it is unit-testable without importing `pg` or the logger.

## ⚠ Trade-off, explicitly

When pooled, the ADR-007 server-side cap is **not in force**. `query_timeout` still bounds the request client-side, but it only aborts the client read — it does **not** cancel the backend query, so a runaway query still burns a backend. Restore the floor with a PgBouncer `connect_query` (`SET statement_timeout=5000`) or `SET LOCAL` inside `withTransaction`. Worth doing before this pooling path carries sustained production traffic.

## Tests

`src/lib/database/__tests__/resolveServerStatementCap.test.ts` — 6 cases. The load-bearing one is *session omits the param*; under the old logic (`poolerMode === "transaction" ? {} : {...}`) session returned the timeout, so that assertion fails against the unfixed code. The rest pin what must not change, including that an unset `DB_POOLER_MODE` still defaults to `direct` and keeps its cap.

> Authored via the GitHub API — the working copy is locked by macOS TCC (`EPERM` on `~/Desktop`, surviving a sandbox override), so `bun run test` and the linter could not run locally. **Relying on CI.** The pure function was verified standalone in Node across all 8 assertions plus the mutation check, confirming `direct`/`transaction` outputs are byte-identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
