### PR TITLE
fix(economy): bind sync-debit birth-data flag as a boolean

### DIFF
--- a/src/__tests__/economy/syncDebitBooleanParams.test.ts
+++ b/src/__tests__/economy/syncDebitBooleanParams.test.ts
@@ -1,0 +1,145 @@
+/**
+ * @jest-environment node
+ *
+ * Regression test for the sync-debit boolean binding.
+ *
+ * The UPDATE on user_profiles binds three flags to `$n::boolean`:
+ *   natal_chart     = CASE WHEN $3::boolean ...
+ *   natal_positions = CASE WHEN $5::boolean ...
+ *   birth_data      = CASE WHEN $9::boolean ...
+ *
+ * `$9` was computed as `ap.birthDate || ap.birthTime || ap.birthLocation`,
+ * which returns the *operand* rather than a boolean — so Postgres received the
+ * birth date itself and rejected it:
+ *
+ *   invalid input syntax for type boolean: "1756-01-27"   (SQLSTATE 22P02)
+ *
+ * That threw before the debit executed, so every call carrying birth data
+ * returned 500 and no agent operation was ever charged (1,349 calls / 24h,
+ * 100% failure; the agents_operation ledger has been empty since 2026-05-15).
+ *
+ * These assert the TYPE of the bound parameter, not a reimplementation of the
+ * predicate — a test that recomputed the expression would pass against the
+ * broken code. The route is allowed to fail after the statement we care about;
+ * the parameters are captured either way.
+ */
+
+const executeQuery = jest.fn();
+
+jest.mock("@/lib/database", () => ({
+  executeQuery: (...args: unknown[]) => executeQuery(...args),
+}));
+jest.mock("@/utils/agentMonicaResolver", () => ({
+  agentMonicaWithMethod: () => null,
+}));
+jest.mock("@/utils/fullChartMonica", () => ({
+  normaliseNatalPositions: (v: unknown) => (Array.isArray(v) ? v : []),
+}));
+
+const USER_ID = "11111111-2222-3333-4444-555555555555";
+const SECRET = "test-sync-secret";
+
+let keySeq = 0;
+
+/** Params bound to the `UPDATE user_profiles SET ...` statement. Throws if absent. */
+async function captureProfileUpdate(
+  agentProfile: Record<string, unknown>,
+): Promise<unknown[]> {
+  const calls: Array<{ sql: string; params: unknown[] }> = [];
+  executeQuery.mockImplementation(async (sql: string, params: unknown[] = []) => {
+    calls.push({ sql, params });
+    // Only the identity lookup must succeed for control flow to reach the
+    // statement under test. Everything after it may fail harmlessly.
+    if (/SELECT\s+u\.id/i.test(sql)) {
+      return { rows: [{ id: USER_ID, profile_name: "Ada Lovelace" }] };
+    }
+    return { rows: [] };
+  });
+
+  const { POST } = require("@/app/api/economy/sync-debit/route");
+  const req = new Request("https://alchm.kitchen/api/economy/sync-debit", {
+    method: "POST",
+    headers: { "content-type": "application/json", "X-Sync-Secret": SECRET },
+    body: JSON.stringify({
+      userEmail: "ada@agents.alchm.kitchen",
+      amounts: { spirit: 1, essence: 1, matter: 1, substance: 1 },
+      idempotencyKey: `test-key-${(keySeq += 1)}`,
+      metadata: { agentProfile },
+    }),
+  });
+
+  // The route may 500 further down on the deliberately-thin mocks; irrelevant.
+  await POST(req as never).catch(() => undefined);
+
+  const hit = calls.find((c) => /UPDATE\s+user_profiles\s+SET/i.test(c.sql));
+  if (!hit) throw new Error("UPDATE user_profiles was never executed — control flow did not reach the statement under test");
+  return hit.params;
+}
+
+describe("sync-debit — boolean parameters for user_profiles", () => {
+  const original = process.env.ALCHM_KITCHEN_SYNC_SECRET;
+
+  beforeEach(() => {
+    process.env.ALCHM_KITCHEN_SYNC_SECRET = SECRET;
+    executeQuery.mockReset();
+    jest.resetModules();
+  });
+
+  afterAll(() => {
+    if (original === undefined) delete process.env.ALCHM_KITCHEN_SYNC_SECRET;
+    else process.env.ALCHM_KITCHEN_SYNC_SECRET = original;
+  });
+
+  it("binds $9 as a boolean when a birth date is present", async () => {
+    const params = await captureProfileUpdate({
+      name: "Ada Lovelace",
+      birthDate: "1756-01-27",
+    });
+    // $9 is index 8. Under the bug this was the string "1756-01-27", which
+    // Postgres rejects with 22P02.
+    expect(typeof params[8]).toBe("boolean");
+    expect(params[8]).toBe(true);
+  });
+
+  it("binds $9 as a boolean for birthTime or birthLocation alone", async () => {
+    for (const ap of [
+      { name: "A", birthTime: "14:30" },
+      { name: "B", birthLocation: "Brooklyn, NY" },
+    ]) {
+      const params = await captureProfileUpdate(ap);
+      expect(typeof params[8]).toBe("boolean");
+      expect(params[8]).toBe(true);
+    }
+  });
+
+  it("binds $9 as false — not null — when no birth field is present", async () => {
+    const params = await captureProfileUpdate({ name: "No Birth Data" });
+    expect(params[8]).toBe(false);
+  });
+
+  it("binds $3 and $5 as booleans too", async () => {
+    const params = await captureProfileUpdate({
+      name: "Ada Lovelace",
+      birthDate: "1756-01-27",
+      natalChart: { sun: "Aquarius" },
+      natalPositions: [{ planet: "Sun", sign: "Aquarius" }],
+    });
+    expect(typeof params[2]).toBe("boolean"); // $3 natal_chart
+    expect(typeof params[4]).toBe("boolean"); // $5 natal_positions
+    expect(params[2]).toBe(true);
+    expect(params[4]).toBe(true);
+  });
+
+  it("still passes the birth payload itself through $10 as JSON", async () => {
+    const params = await captureProfileUpdate({
+      name: "Ada Lovelace",
+      birthDate: "1756-01-27",
+      birthLocation: "London",
+    });
+    expect(JSON.parse(params[9] as string)).toEqual({
+      date: "1756-01-27",
+      time: null,
+      location: "London",
+    });
+  });
+});

--- a/src/app/api/economy/sync-debit/route.ts
+++ b/src/app/api/economy/sync-debit/route.ts
@@ -223,14 +223,25 @@ export async function POST(req: NextRequest) {
         (typeof ap.name === "string" ? agentMonicaWithMethod(ap.name, onUnclassifiedPhase) : null);
       const resolvedMonica = resolved?.monica ?? null;
       const monicaCandidate = resolvedMonica?.combined ?? null;
-      const hasNatalChart =
-        ap.natalChart && typeof ap.natalChart === "object" && Object.keys(ap.natalChart).length > 0;
+      // Every one of these three is bound to a `$n::boolean` in the UPDATE
+      // below, so each MUST be a real boolean. `||` and `&&` return the
+      // *operand*, not a boolean — `ap.birthDate || ap.birthTime || ...`
+      // evaluated to the birth date itself, and Postgres rejected it with
+      // `invalid input syntax for type boolean: "1756-01-27"` (22P02). That
+      // threw before the debit ran, so EVERY call carrying birth data 500'd and
+      // no agent operation was charged. Boolean() is the whole fix; keep it on
+      // all three so the next field added here can't reintroduce it.
+      const hasNatalChart = Boolean(
+        ap.natalChart && typeof ap.natalChart === "object" && Object.keys(ap.natalChart).length > 0,
+      );
       // Strip the fabricated `longitude: 0` on the way in — see
       // normaliseNatalPositions. This endpoint is a live ingest path, so
       // cleaning stored rows without cleaning here would let the key return.
       const natalPositions = normaliseNatalPositions(ap.natalPositions);
-      const hasNatalPositions = Array.isArray(natalPositions) && (natalPositions as unknown[]).length > 0;
-      const hasBirthData = ap.birthDate || ap.birthTime || ap.birthLocation;
+      const hasNatalPositions = Boolean(
+        Array.isArray(natalPositions) && (natalPositions as unknown[]).length > 0,
+      );
+      const hasBirthData = Boolean(ap.birthDate || ap.birthTime || ap.birthLocation);
 
       // COALESCE so a null/empty field in this fire never wipes a previously
       // written value — every tick keeps the row fresh without regression.


### PR DESCRIPTION
## The bug

`$9` in the `user_profiles` UPDATE is cast to boolean:

```sql
birth_data = CASE WHEN $9::boolean THEN $10::jsonb ELSE birth_data END,
```

but it was computed as a truthy chain, which returns the **operand** rather than a boolean:

```ts
const hasBirthData = ap.birthDate || ap.birthTime || ap.birthLocation;
```

So Postgres received the birth date itself:

```
invalid input syntax for type boolean: "1756-01-27"   (SQLSTATE 22P02)
where: "unnamed portal parameter $9 = '...'"
```

The parameter order was never misaligned — the array maps cleanly to `$1..$13`. The value itself was simply the wrong type.

**Not date-specific.** Reproduced against production Postgres with the exact `CASE WHEN $1::boolean` shape:

| input | broken → `$9` | result |
|---|---|---|
| `birthDate: "1756-01-27"` | `"1756-01-27"` | ❌ 22P02 |
| `birthDate: "0001-01-01"` | `"0001-01-01"` | ❌ 22P02 |
| `birthTime: "14:30"` | `"14:30"` | ❌ 22P02 |
| `birthLocation: "Brooklyn, NY"` | `"Brooklyn, NY"` | ❌ 22P02 |
| none of the three | `null` | ✅ skipped |

Only the all-null case survived, because the chain yielded `null` and `CASE WHEN NULL` falls through to `ELSE`.

## Impact

- **1,349 calls in 24h, 100% HTTP 500, zero successes.** Every caller sends birth data.
- The **`agents_operation` ledger has been empty since 2026-05-15** — 317 transactions across 2026-05-14/15, then nothing. That is the day this line landed in `6b463194`. Agent operations have gone uncharged for ~12 weeks.
- **`user_profiles.birth_data` is NULL on all 5,663 agent rows** — that branch has never once executed.
- There is **no transaction wrapper** (every call is a separate autocommit `executeQuery`), so the preceding provisioning statements committed while the enrichment UPDATE and the debit did not. Agents were provisioned but never enriched or charged.

No double-charge risk: the throw precedes both the idempotency check and the debit, so nothing was written twice.

## The fix

`Boolean(...)` on all three flags bound to `$n::boolean`, not just the broken one — so a field added here later can't reintroduce it. `NULL` and `false` are equivalent under `CASE WHEN`, so the two already-working flags are behaviourally unchanged.

## Tests

`src/__tests__/economy/syncDebitBooleanParams.test.ts` — 5 cases asserting the **type of the bound parameter**, captured from a mocked `executeQuery`. Deliberately not a reimplementation of the predicate: a test that recomputed `a || b || c` would pass against the broken code and prove nothing. The route is allowed to 500 further down on thin mocks; the parameters are captured regardless.

> Authored via the GitHub API — the working copy is EPERM-locked by macOS TCC on `~/Desktop`, so `bun run test` could not run locally. **Relying on CI.** The SQL-level behaviour in the table above was verified directly against production Postgres.

## Not addressed here

The ~12 weeks of uncharged agent operations are **not** reconstructed. The requests failed before writing anything, so what those operations were isn't recoverable from this database — balances are simply higher than they should be. That's an economy decision, not a bug fix, and wants its own call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
