### PR TITLE
feat(observability): alarm when agents are active but no debits land

### DIFF
--- a/src/services/__tests__/agentDebitPathHealth.test.ts
+++ b/src/services/__tests__/agentDebitPathHealth.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment node
+ *
+ * The check that would have caught the twelve-week sync-debit outage.
+ *
+ * `/api/economy/sync-debit` 500'd on 100% of calls from 2026-05-15 to
+ * 2026-08-07 while every dashboard stayed green. These pin the three
+ * behaviours that make the check work, each of which a naive version got wrong:
+ *
+ *   1. traffic + no debits  -> INCIDENT   (the bug)
+ *   2. no traffic           -> IDLE       (not an alarm; alarming on silence
+ *                                          alone flagged 9 of 13 ledger sources)
+ *   3. query failed         -> UNKNOWN    (never green from missing data)
+ */
+
+import {
+  classifyDebitPath,
+  type DebitPathSignals,
+} from "@/services/agentDebitPathHealth";
+
+const base: DebitPathSignals = {
+  agentTraffic24h: 0,
+  debits24h: 0,
+  lastDebitAgeMs: null,
+  live: true,
+};
+const DAY = 24 * 60 * 60 * 1000;
+
+describe("classifyDebitPath", () => {
+  it("raises INCIDENT when agents are active but no debits land", () => {
+    const r = classifyDebitPath({
+      ...base,
+      agentTraffic24h: 307,
+      debits24h: 0,
+      lastDebitAgeMs: 84 * DAY,
+    });
+    expect(r.verdict).toBe("INCIDENT");
+    expect(r.summary).toMatch(/ZERO debits/);
+    expect(r.summary).toMatch(/84d ago/);
+  });
+
+  it("stays IDLE when there is no agent traffic — silence is not breakage", () => {
+    // The failure mode of every staleness-only alarm: a naturally quiet path
+    // is not a broken one, and crying wolf here makes the alarm worthless.
+    expect(classifyDebitPath({ ...base, agentTraffic24h: 0, debits24h: 0 }).verdict).toBe("IDLE");
+  });
+
+  it("reports OK once debits are landing again", () => {
+    // Live production values measured immediately after the fix deployed.
+    const r = classifyDebitPath({
+      ...base,
+      agentTraffic24h: 410,
+      debits24h: 143,
+      lastDebitAgeMs: 60_000,
+    });
+    expect(r.verdict).toBe("OK");
+    expect(r.summary).toMatch(/143 debits/);
+  });
+
+  it("reports UNKNOWN rather than green when the query failed", () => {
+    const r = classifyDebitPath({ ...base, agentTraffic24h: 307, live: false });
+    expect(r.verdict).toBe("UNKNOWN");
+    expect(r.summary).toMatch(/No source/);
+  });
+
+  it("says 'never' when the ledger has no debit at all", () => {
+    const r = classifyDebitPath({
+      ...base,
+      agentTraffic24h: 12,
+      debits24h: 0,
+      lastDebitAgeMs: null,
+    });
+    expect(r.verdict).toBe("INCIDENT");
+    expect(r.summary).toMatch(/never/);
+  });
+
+  it("treats a single debit as landing — the boundary is zero, not a threshold", () => {
+    expect(
+      classifyDebitPath({ ...base, agentTraffic24h: 500, debits24h: 1 }).verdict,
+    ).toBe("OK");
+  });
+
+  describe("replay of the real 2026 history", () => {
+    // (day, agent feed events 24h, agents_operation rows 24h) measured from
+    // production. The regression landed 2026-05-15.
+    const HISTORY: Array<[string, number, number]> = [
+      ["2026-05-10", 0, 0],
+      ["2026-05-13", 0, 0],
+      ["2026-05-16", 48, 210],
+      ["2026-05-19", 0, 0],
+      ["2026-05-22", 1, 0],
+      ["2026-06-03", 316, 0],
+      ["2026-07-21", 357, 0],
+      ["2026-08-05", 350, 0],
+    ];
+
+    const verdicts = HISTORY.map(([day, traffic, debits]) => ({
+      day,
+      verdict: classifyDebitPath({
+        ...base,
+        agentTraffic24h: traffic,
+        debits24h: debits,
+        lastDebitAgeMs: debits > 0 ? 60_000 : 30 * DAY,
+      }).verdict,
+    }));
+
+    it("fires on 2026-05-22, seven days in rather than eighty-four", () => {
+      expect(verdicts.find((v) => v.day === "2026-05-22")?.verdict).toBe("INCIDENT");
+    });
+
+    it("stays quiet on the genuinely idle days", () => {
+      for (const day of ["2026-05-10", "2026-05-13", "2026-05-19"]) {
+        expect(verdicts.find((v) => v.day === day)?.verdict).toBe("IDLE");
+      }
+    });
+
+    it("is OK on 2026-05-16, the one healthy sample before the break", () => {
+      expect(verdicts.find((v) => v.day === "2026-05-16")?.verdict).toBe("OK");
+    });
+
+    it("never returns OK on any day of the outage", () => {
+      const outage = verdicts.filter((v) => v.day >= "2026-05-22");
+      expect(outage).toHaveLength(4);
+      expect(outage.every((v) => v.verdict === "INCIDENT")).toBe(true);
+    });
+  });
+});

--- a/src/services/agentDebitPathHealth.ts
+++ b/src/services/agentDebitPathHealth.ts
@@ -1,0 +1,120 @@
+/**
+ * Debit-path liveness for the Planetary Agents flow.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `/api/economy/sync-debit` returned HTTP 500 on 100% of calls for twelve weeks
+ * (2026-05-15 → 2026-08-07, ~1,349 calls/day) and nothing noticed. The
+ * `agents_operation` ledger simply stopped — 317 rows, then silence, forever —
+ * while every dashboard stayed green, because no check asked whether a path
+ * that *should* be writing still *was*.
+ *
+ * WHY LEDGER SILENCE ALONE IS NOT THE SIGNAL
+ * ------------------------------------------
+ * Silence cannot distinguish "the path is broken" from "nobody called it".
+ * Alarming on silence alone flags every naturally-sporadic path; alarming only
+ * on paths with an established cadence misses exactly this bug, because
+ * sync-debit launched on 05-14 and broke on 05-15 — it never lived long enough
+ * to establish one. Both variants were tried against the real history: the
+ * first flagged 9 of 13 sources, the second flagged nothing at all.
+ *
+ * The discriminator is the CONJUNCTION: agent traffic arriving (the producer is
+ * alive and calling) while zero debits land (nothing is succeeding). Neither
+ * half is meaningful alone.
+ *
+ * Back-tested over 2026-05-10 → 2026-08-08 in 3-day steps: fires from
+ * 2026-05-22 — seven days after the regression, not eighty-four — stays silent
+ * on all three genuinely-idle days, and returns OK on live post-fix data.
+ */
+
+import { executeQuery } from "@/lib/database/connection";
+import { _logger } from "@/lib/logger";
+
+/** OK = debits landing · IDLE = no traffic, nothing expected · INCIDENT = traffic without debits. */
+export type DebitPathVerdict = "OK" | "IDLE" | "INCIDENT" | "UNKNOWN";
+
+export interface DebitPathSignals {
+  /** Agent-authored feed events in the last 24h — evidence the producer is alive. */
+  agentTraffic24h: number;
+  /** `agents_operation` ledger rows in the last 24h — evidence debits are landing. */
+  debits24h: number;
+  /** Age of the most recent debit, ms. Null when the ledger has never been written. */
+  lastDebitAgeMs: number | null;
+  /** False when the query failed — never fabricate a verdict from missing data. */
+  live: boolean;
+}
+
+export interface DebitPathHealth {
+  verdict: DebitPathVerdict;
+  summary: string;
+}
+
+/**
+ * Pure classifier. Kept free of database imports so it can be tested directly.
+ */
+export function classifyDebitPath(signals: DebitPathSignals): DebitPathHealth {
+  const { agentTraffic24h, debits24h, lastDebitAgeMs, live } = signals;
+
+  if (!live) {
+    return { verdict: "UNKNOWN", summary: "No source — debit-path query failed" };
+  }
+
+  // No producer traffic means no debit is owed. Silence here is not evidence of
+  // breakage, and treating it as such is what makes staleness alarms useless.
+  if (agentTraffic24h <= 0) {
+    return { verdict: "IDLE", summary: "No agent traffic in 24h — no debits expected" };
+  }
+
+  if (debits24h <= 0) {
+    const age =
+      lastDebitAgeMs === null
+        ? "never"
+        : `${Math.floor(lastDebitAgeMs / (24 * 60 * 60 * 1000))}d ago`;
+    return {
+      verdict: "INCIDENT",
+      summary:
+        `${agentTraffic24h} agent events in 24h but ZERO debits landed ` +
+        `(last debit ${age}) — sync-debit is failing silently`,
+    };
+  }
+
+  return { verdict: "OK", summary: `${debits24h} debits · ${agentTraffic24h} agent events 24h` };
+}
+
+/**
+ * Reads the two signals. Degrades to `live: false` rather than throwing, so the
+ * Planetary Agents flow reports an honest "no source" instead of going green.
+ */
+export async function fetchDebitPathSignals(): Promise<DebitPathSignals> {
+  try {
+    const result = await executeQuery<{
+      traffic_24h: number;
+      debits_24h: number;
+      last_debit_age_ms: number | null;
+    }>(
+      `SELECT
+         (SELECT COUNT(*)::int
+            FROM feed_events f
+            JOIN users u ON f.actor_id = u.id
+           WHERE u.is_agent = true
+             AND f.created_at > NOW() - INTERVAL '24 hours') AS traffic_24h,
+         (SELECT COUNT(*)::int
+            FROM token_transactions
+           WHERE source_type = 'agents_operation'
+             AND created_at > NOW() - INTERVAL '24 hours') AS debits_24h,
+         (SELECT (EXTRACT(EPOCH FROM (NOW() - MAX(created_at))) * 1000)::float8
+            FROM token_transactions
+           WHERE source_type = 'agents_operation') AS last_debit_age_ms`,
+    );
+    const row = result.rows[0];
+    return {
+      agentTraffic24h: row?.traffic_24h ?? 0,
+      debits24h: row?.debits_24h ?? 0,
+      lastDebitAgeMs: row?.last_debit_age_ms ?? null,
+      live: true,
+    };
+  } catch (err) {
+    _logger.warn("[systemStatus] debit-path liveness query failed:", err);
+    return { agentTraffic24h: 0, debits24h: 0, lastDebitAgeMs: null, live: false };
+  }
+}

--- a/src/services/systemStatusService.ts
+++ b/src/services/systemStatusService.ts
@@ -26,6 +26,10 @@ import {
 } from "@/lib/observability/requestLog";
 import { summarizeSlowQueries } from "@/lib/observability/slowQueryLog";
 import { getServiceUrlSafe } from "@/lib/serviceUrls";
+import {
+  classifyDebitPath,
+  fetchDebitPathSignals,
+} from "@/services/agentDebitPathHealth";
 import { getEventCounts } from "@/services/authEventsService";
 import { feedEmitTracker } from "@/services/feedEmitTracker";
 import { getMcpNetworkSummary } from "@/services/mcpNetworkService";
@@ -851,6 +855,14 @@ async function probeAgents(): Promise<FlowHealth> {
     live = false;
   }
 
+  // Is the debit path actually landing writes? Feed ingest can look perfectly
+  // healthy while sync-debit 500s on every call — that is exactly how the
+  // agents_operation ledger stayed empty for twelve weeks. See
+  // agentDebitPathHealth for why traffic-AND-no-writes is the only signal that
+  // separates "broken" from "nobody called".
+  const debitSignals = await fetchDebitPathSignals();
+  const debitHealth = classifyDebitPath(debitSignals);
+
   const lastEmitAgeMs = lastEmit
     ? Date.now() - new Date(lastEmit.timestamp).getTime()
     : null;
@@ -863,11 +875,20 @@ async function probeAgents(): Promise<FlowHealth> {
 
   let status: FlowStatus;
   if (!live && feedPathStatus === "UNKNOWN") status = "UNKNOWN";
-  else if (feedPathStatus === "INCIDENT") status = "INCIDENT";
+  // A dead debit path is a revenue outage, not a warning — rank it with the
+  // other INCIDENT conditions rather than letting a green feed mask it.
+  else if (feedPathStatus === "INCIDENT" || debitHealth.verdict === "INCIDENT") status = "INCIDENT";
   else if (feedPathStatus === "DEGRADED" || stale) status = "DEGRADED";
   else status = "OK";
 
   const issues: FlowIssue[] = [];
+  if (debitHealth.verdict === "INCIDENT") {
+    issues.push({
+      at: new Date().toISOString(),
+      message: debitHealth.summary,
+      severity: "error",
+    });
+  }
   if (stale && lastEmit) {
     issues.push({
       at: lastEmit.timestamp,
@@ -892,7 +913,9 @@ async function probeAgents(): Promise<FlowHealth> {
             ? "Webhook silent — PA may have stopped emitting"
             : "Feed-ingest errors detected"
           : status === "INCIDENT"
-            ? `Feed ingest failing (${formatPct(feedPath.errorRate)})`
+            ? debitHealth.verdict === "INCIDENT"
+              ? debitHealth.summary
+              : `Feed ingest failing (${formatPct(feedPath.errorRate)})`
             : "Awaiting signals",
     metrics: [
       { label: "Agents", value: `${agentCount}`, raw: agentCount },
@@ -906,6 +929,11 @@ async function probeAgents(): Promise<FlowHealth> {
         label: "Feed p95",
         value: formatLatency(feedPath.p95LatencyMs),
         raw: feedPath.p95LatencyMs,
+      },
+      {
+        label: "Debits · 24h",
+        value: debitSignals.live ? `${debitSignals.debits24h}` : "no source",
+        raw: debitSignals.debits24h,
       },
     ],
     issues: issues.slice(0, 3),


### PR DESCRIPTION
Follow-up to #733. That PR fixed the bug; this one makes sure the *class* of bug can't hide for twelve weeks again.

## What went undetected

`/api/economy/sync-debit` returned HTTP 500 on **100% of calls for twelve weeks** (~1,349/day). The `agents_operation` ledger stopped at 317 rows on 2026-05-15 and never moved. Every dashboard stayed green throughout, because nothing asked whether a path that *should* be writing still *was*.

The existing `/api/admin/observability` request log is **in-memory** — per-lambda and ephemeral on Vercel, so it resets constantly and can't see a trend. `request_log_entries` is persisted but instruments only 4 paths, none of them sync-debit. Neither could have caught this.

## Why ledger silence alone is not the signal

Silence can't distinguish *"the path is broken"* from *"nobody called it"*. I built and back-tested two obvious versions against the real history before discarding both:

| approach | result on real data |
|---|---|
| alarm on staleness vs. self-calibrated cadence | flagged **9 of 13** ledger sources — cries wolf |
| restrict to paths with an established cadence | flagged **nothing** — sync-debit launched 05-14, broke 05-15, and never lived long enough to establish one |

The discriminator is the **conjunction**: agent traffic arriving (producer alive) while **zero** debits land (nothing succeeding). Neither half means anything alone.

## Back-test

2026-05-10 → 2026-08-08 in 3-day steps, against production data:

```
2026-05-13    traffic=0     debits=0     · idle (no alarm)
2026-05-16    traffic=48    debits=210   ok
2026-05-19    traffic=0     debits=0     · idle (no alarm)
2026-05-22    traffic=1     debits=0     🚨 INCIDENT   <- first alarm
2026-06-03    traffic=316   debits=0     🚨 INCIDENT
2026-07-21    traffic=357   debits=0     🚨 INCIDENT
```

**First alarm 2026-05-22 — seven days after the regression, not eighty-four.** Silent on all three genuinely idle days. Evaluated live against post-fix production (410 agent events / 143 debits in 24h) it returns `OK`.

## Shape

- `classifyDebitPath()` is pure and dependency-free, so it's unit-testable without `pg`.
- `fetchDebitPathSignals()` degrades to `live: false` rather than throwing — per the admin-surface rule, never fabricate; report "no source".
- An INCIDENT ranks with the other incident conditions rather than being masked by a healthy feed, and the summary reports the debit cause instead of misattributing it to feed ingest.

## Tests

10 cases, including a replay of the real 2026 history asserting it fires on 05-22, stays IDLE on the quiet days, is OK on the one healthy pre-break sample, and never returns OK on any outage day.

Mutation-checked: removing the traffic guard turns an idle day into INCIDENT, so the "stays IDLE" test fails without it — the guard is load-bearing, not decorative.

> Authored via the GitHub API — the working copy is EPERM-locked by macOS TCC on `~/Desktop`, so `bun run test` could not run locally. **Relying on CI.** All classifier cases and the mutation check were verified standalone in Node, and every number above is measured from production, not assumed.

## Known limits

Traffic is proxied by agent-authored `feed_events`, not by sync-debit request count (which isn't persisted). So if PA keeps posting feed events but stops calling sync-debit entirely, this reads as an INCIDENT. That's the honest reading — "agents active, no debits landing" is worth surfacing either way — but it's a proxy, not the request count itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
