### PR TITLE
fix(economy): make the sync-debit charge atomic and unblockable

### DIFF
--- a/docs/adr/010-uncharged-agent-operations-writeoff.md
+++ b/docs/adr/010-uncharged-agent-operations-writeoff.md
@@ -1,0 +1,143 @@
+# ADR-010: Write off the uncharged agent operations of 2026-05-15 → 2026-08-08
+
+**Status:** Accepted (ruled 2026-08-08)
+**Date:** 2026-08-08
+**Related:** #733 (the fix), #734 (the detector), ADR-003 (token economy throttle)
+
+## Context
+
+`POST /api/economy/sync-debit` is the only path that charges agents for
+operations. From 2026-05-15 it returned HTTP 500 on **100% of calls** — measured
+at the time as `1,349 calls / 24h, zero successes` — because a JS truthy chain
+was bound to a `$n::boolean` parameter and Postgres rejected the value:
+
+```
+invalid input syntax for type boolean: "1756-01-27"   (SQLSTATE 22P02)
+```
+
+The throw landed before the debit, so no agent operation was charged for the
+duration. Fixed in #733.
+
+### The hole, measured
+
+`token_transactions WHERE source_type = 'agents_operation'`, by month:
+
+| Month | Rows | Agents | Tokens charged |
+|---|---|---|---|
+| 2026-05 | 317 | 52 | 475.00 |
+| *2026-06* | **0** | — | — |
+| *2026-07* | **0** | — | — |
+| 2026-08 | 1,132 | 71 | 1,766.00 |
+
+The gap is exact, and contains nothing at all:
+
+| | |
+|---|---|
+| Last row before the outage | `2026-05-15T02:05:30.696Z` |
+| First row after the fix | `2026-08-08T02:01:38.410Z` |
+| Rows in between | **0** |
+| Elapsed | **85 days** |
+
+Agent activity did not stop while charging did. Agent-authored `feed_events`
+during the window — a proxy for volume, not a record of what was owed:
+
+| Month | Agent feed events | Distinct agents |
+|---|---|---|
+| 2026-05 (part) | 65 | 49 |
+| 2026-06 | 4,088 | 1,078 |
+| 2026-07 | 8,588 | 2,044 |
+| 2026-08 (part) | 2,066 | 800 |
+
+### The ledger is consistent, not corrupt
+
+This matters more than the size of the hole. Comparing every account's held
+balance against the sum of its ledger rows:
+
+```
+real       (no offset)  : 0 accounts disagree
+control (+0.5 injected) : 14868 accounts disagree
+```
+
+Zero disagreement across 3,717 balance rows and 11,239 ledger rows. The control
+— the same query with a deliberate +0.5 offset — reports 14,868, so the
+comparison is capable of detecting disagreement and the real zero is a
+measurement rather than an artifact of a query that matched nothing.
+
+The failing requests wrote **nothing at all**: they threw before both the
+balance update and the ledger insert. So this is *under-charging*, not
+corruption. Balances are uniformly higher than they should be, and every balance
+is still exactly explained by its ledger.
+
+## Decision
+
+**Write off the uncharged operations. Balances stay as they are. No
+reconstructed or estimated ledger rows will be written.**
+
+## Rationale
+
+**The amounts are not recoverable.** A charge is derived from the request
+payload, and the failing requests persisted no trace of themselves — not the
+operation type, not the amounts, not the agent. Nothing in the database records
+what any individual call would have cost.
+
+**Any estimate spans an order of magnitude, which makes it arbitrary.** The
+observed charge rate was ~346 rows/day immediately before the outage (52 agents)
+and ~3,019 rows/day immediately after (71 agents), against an agent population
+that grew throughout the window. Extrapolating across 85 days gives anywhere
+from ~29,000 to ~257,000 rows — roughly 44,000 to 385,000 tokens at the observed
+~1.5 tokens/row. Picking a number inside that band would be a guess wearing the
+costume of an accounting entry, and it would land in the same ledger that
+currently reconciles perfectly.
+
+**Synthetic rows would destroy the property that makes the ledger useful.**
+Right now every balance is explained by its transactions. Writing estimated
+debits would break that invariant deliberately, in a system whose reconciliation
+check is one of the few things that has reliably caught real problems.
+
+This is consistent with the repo's standing rule that every value must name its
+basis and be reproducible: an estimated debit has no basis anyone could
+reproduce.
+
+## Consequences
+
+- Agents that operated between 2026-05-15 and 2026-08-08 kept tokens they would
+  otherwise have spent. The benefit is unevenly distributed — it favours the
+  agents that were most active during the window — and is not corrected.
+- Any future audit that finds the 85-day hole should find this ADR rather than
+  re-open the question.
+- Economy metrics spanning the window are not comparable across it. Charts of
+  `agents_operation` volume should treat 2026-05-15 → 2026-08-08 as missing
+  data, not as zero demand.
+- The ledger/balance reconciliation invariant is preserved and remains a
+  trustworthy signal.
+
+## Alternatives rejected
+
+**Estimate and post one reconciling debit per agent.** Rejected: the estimate
+band spans an order of magnitude (above), so the number would be arbitrary, and
+it would knowingly introduce unexplainable rows into a ledger that currently
+reconciles exactly.
+
+**Reconstruct per operation from `feed_events`.** Rejected: `feed_events`
+records that an agent did something publishable, not that it performed a
+chargeable operation or which one. The mapping from feed event to charge does
+not exist and would have to be invented, which is fabrication regardless of how
+carefully it is done.
+
+**Leave it undecided.** Rejected: an unrecorded hole is exactly what turns into
+a fire drill the first time someone reconciles the year.
+
+## Guarding against a repeat
+
+The bug itself is fixed and pinned by a regression test that asserts the *bound
+parameter's type*, not a re-computation of the predicate. Two structural changes
+matter more than that one binding:
+
+- **Detection** (#734): the debit path is now watched by the conjunction of
+  agent traffic arriving *and* zero debits landing. Back-tested against this
+  incident, it fires on 2026-05-22 — seven days in, not eighty-five — and stays
+  silent on genuinely idle days.
+- **Blast radius**: profile enrichment can no longer block a charge, and the
+  debit and its ledger rows now commit in a single transaction. An enrichment
+  bug of the kind that caused this now degrades to a stale profile instead of
+  to lost revenue.

--- a/src/__tests__/economy/syncDebitBooleanParams.test.ts
+++ b/src/__tests__/economy/syncDebitBooleanParams.test.ts
@@ -28,6 +28,11 @@ const executeQuery = jest.fn();
 
 jest.mock("@/lib/database", () => ({
   executeQuery: (...args: unknown[]) => executeQuery(...args),
+  // Steps 2-5 run inside a transaction now. Hand the operation a client whose
+  // query() routes back through the same spy, so statements issued with
+  // `{ client }` are captured exactly like the unpooled ones.
+  withTransaction: (op: (client: unknown) => Promise<unknown>) =>
+    op({ query: (...args: unknown[]) => executeQuery(...args) }),
 }));
 jest.mock("@/utils/agentMonicaResolver", () => ({
   agentMonicaWithMethod: () => null,

--- a/src/__tests__/economy/syncDebitTransaction.test.ts
+++ b/src/__tests__/economy/syncDebitTransaction.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @jest-environment node
+ *
+ * Two properties of /api/economy/sync-debit that the twelve-week outage argued for.
+ *
+ * 1. THE DEBIT AND ITS LEDGER ROWS COMMIT TOGETHER.
+ *    Every statement used to autocommit on its own, so a failure between the
+ *    balance UPDATE and the token_transactions INSERTs would leave a user
+ *    charged with nothing accounting for it — permanent, undetectable drift in
+ *    the ledger that exists to reconcile. It stayed clean during the outage
+ *    only because the throw landed before the debit, which was luck.
+ *
+ * 2. PROFILE ENRICHMENT CANNOT BLOCK THE DEBIT.
+ *    That is precisely how the outage happened: one bad parameter binding threw
+ *    during enrichment, before the debit, and 1,349 calls a day returned 500
+ *    with nothing charged for twelve weeks. Enrichment is a nice-to-have;
+ *    charging for the operation is the point of the endpoint.
+ *
+ * These assert the wiring — which statements ran, and on which connection —
+ * rather than restating the route's logic.
+ */
+
+const executeQuery = jest.fn();
+/** Statements issued on the transaction client, in order. */
+const inTransaction: string[] = [];
+/** Statements issued outside any transaction (straight to the pool). */
+const outsideTransaction: string[] = [];
+let transactionRejected: Error | null = null;
+
+jest.mock("@/lib/database", () => ({
+  executeQuery: (sql: string, params: unknown[] = [], options: { client?: unknown } = {}) => {
+    (options.client ? inTransaction : outsideTransaction).push(sql);
+    return executeQuery(sql, params, options);
+  },
+  withTransaction: async (op: (client: unknown) => Promise<unknown>) => {
+    // A real withTransaction issues BEGIN/COMMIT and rolls back on throw. What
+    // matters here is that the operation receives a client and that a throw
+    // propagates instead of leaving partial work committed.
+    try {
+      return await op({ query: (sql: string, params: unknown[]) => executeQuery(sql, params, {}) });
+    } catch (err) {
+      transactionRejected = err as Error;
+      throw err;
+    }
+  },
+}));
+jest.mock("@/utils/agentMonicaResolver", () => ({ agentMonicaWithMethod: () => null }));
+jest.mock("@/utils/fullChartMonica", () => ({
+  normaliseNatalPositions: (v: unknown) => (Array.isArray(v) ? v : []),
+}));
+
+const USER_ID = "11111111-2222-3333-4444-555555555555";
+const SECRET = "test-sync-secret";
+let keySeq = 0;
+
+/** Default happy-path responses; `overrides` can make one statement throw. */
+function wireDatabase(overrides: (sql: string) => unknown | undefined = () => undefined) {
+  executeQuery.mockImplementation(async (sql: string) => {
+    const override = overrides(sql);
+    if (override instanceof Error) throw override;
+
+    if (/SELECT\s+u\.id/i.test(sql)) {
+      return { rows: [{ id: USER_ID, profile_name: "Ada Lovelace" }] };
+    }
+    if (/FROM token_transactions WHERE idempotency_key/i.test(sql)) {
+      return { rows: [] }; // not a duplicate
+    }
+    if (/SELECT spirit::text/i.test(sql)) {
+      return { rows: [{ spirit: "100", essence: "100", matter: "100", substance: "100" }] };
+    }
+    if (/UPDATE token_balances/i.test(sql)) {
+      return { rows: [{ spirit: "99", essence: "99", matter: "99", substance: "99" }] };
+    }
+    return { rows: [] };
+  });
+}
+
+async function post(body: Record<string, unknown>) {
+  const { POST } = require("@/app/api/economy/sync-debit/route");
+  const req = new Request("https://alchm.kitchen/api/economy/sync-debit", {
+    method: "POST",
+    headers: { "content-type": "application/json", "X-Sync-Secret": SECRET },
+    body: JSON.stringify({
+      userEmail: "ada@agents.alchm.kitchen",
+      amounts: { spirit: 1, essence: 1, matter: 1, substance: 1 },
+      idempotencyKey: `txn-test-${(keySeq += 1)}`,
+      ...body,
+    }),
+  });
+  return POST(req as never);
+}
+
+describe("sync-debit — transactional integrity", () => {
+  const original = process.env.ALCHM_KITCHEN_SYNC_SECRET;
+
+  beforeEach(() => {
+    process.env.ALCHM_KITCHEN_SYNC_SECRET = SECRET;
+    executeQuery.mockReset();
+    inTransaction.length = 0;
+    outsideTransaction.length = 0;
+    transactionRejected = null;
+    jest.resetModules();
+  });
+
+  afterAll(() => {
+    if (original === undefined) delete process.env.ALCHM_KITCHEN_SYNC_SECRET;
+    else process.env.ALCHM_KITCHEN_SYNC_SECRET = original;
+  });
+
+  it("runs the debit and its ledger rows on the SAME transaction client", async () => {
+    wireDatabase();
+    const res = await post({});
+    expect(res.status).toBe(200);
+
+    const debit = inTransaction.filter((s) => /UPDATE token_balances/i.test(s));
+    const ledger = inTransaction.filter((s) => /INSERT INTO token_transactions/i.test(s));
+
+    // Four token types were debited, so four ledger rows — all inside.
+    expect(debit).toHaveLength(1);
+    expect(ledger).toHaveLength(4);
+    // ...and none of them leaked onto an autocommitting pool connection.
+    expect(outsideTransaction.some((s) => /UPDATE token_balances/i.test(s))).toBe(false);
+    expect(outsideTransaction.some((s) => /INSERT INTO token_transactions/i.test(s))).toBe(false);
+  });
+
+  it("propagates a ledger-write failure so the debit rolls back with it", async () => {
+    // The drift scenario: balance reduced, ledger row missing. The write must
+    // not be allowed to half-commit.
+    wireDatabase((sql) =>
+      /INSERT INTO token_transactions/i.test(sql) ? new Error("ledger write failed") : undefined,
+    );
+
+    const res = await post({});
+    expect(res.status).toBe(500);
+    // The transaction saw the error — a real withTransaction issues ROLLBACK here.
+    expect(transactionRejected).toBeInstanceOf(Error);
+    expect(transactionRejected?.message).toBe("ledger write failed");
+  });
+
+  it("keeps provisioning OUTSIDE the transaction so a refused debit does not undo it", async () => {
+    // Identity provisioning is idempotent and worth keeping even when the debit
+    // is refused; folding it in would let an enrichment failure roll back a
+    // completed charge.
+    wireDatabase();
+    await post({ metadata: { agentProfile: { name: "Ada Lovelace", birthDate: "1756-01-27" } } });
+
+    expect(outsideTransaction.some((s) => /UPDATE user_profiles SET/i.test(s))).toBe(true);
+    expect(inTransaction.some((s) => /UPDATE user_profiles SET/i.test(s))).toBe(false);
+  });
+
+  describe("profile enrichment cannot block the debit", () => {
+    it("still charges when the enrichment UPDATE throws", async () => {
+      // This is the outage, reproduced: enrichment fails, and the debit must
+      // still happen. Before this guard the route returned 500 and charged
+      // nothing — for twelve weeks.
+      wireDatabase((sql) =>
+        /UPDATE user_profiles SET/i.test(sql)
+          ? new Error('invalid input syntax for type boolean: "1756-01-27"')
+          : undefined,
+      );
+
+      const res = await post({
+        metadata: { agentProfile: { name: "Ada Lovelace", birthDate: "1756-01-27" } },
+      });
+
+      expect(res.status).toBe(200);
+      expect(inTransaction.filter((s) => /INSERT INTO token_transactions/i.test(s))).toHaveLength(4);
+    });
+
+    it("logs the enrichment failure rather than swallowing it", async () => {
+      // Non-fatal must not mean invisible: a persistent enrichment failure is a
+      // real defect, just not one worth losing revenue over.
+      const spy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+      wireDatabase((sql) =>
+        /UPDATE user_profiles SET/i.test(sql) ? new Error("constraint violation") : undefined,
+      );
+
+      await post({ metadata: { agentProfile: { name: "Ada Lovelace", birthDate: "1756-01-27" } } });
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining("PROFILE_ENRICHMENT_FAILED"),
+        expect.objectContaining({ userId: USER_ID }),
+      );
+      spy.mockRestore();
+    });
+  });
+});

--- a/src/app/api/economy/sync-debit/route.ts
+++ b/src/app/api/economy/sync-debit/route.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "crypto";
 import { NextResponse, type NextRequest } from "next/server";
-import { executeQuery } from "@/lib/database";
+import { executeQuery, withTransaction } from "@/lib/database";
 import { agentMonicaWithMethod } from "@/utils/agentMonicaResolver";
 import { normaliseNatalPositions } from "@/utils/fullChartMonica";
 
@@ -160,6 +160,20 @@ export async function POST(req: NextRequest) {
     // Treat the payload as Record<string, unknown> — the planetary-agents
     // engine ships untyped JSON so we can't lean on the route's own interface.
     const agentProfileRaw = metadata?.agentProfile;
+    // ── Enrichment is deliberately NON-FATAL ──────────────────────────────
+    //
+    // This block used to be able to kill the debit, and did: a single bad
+    // parameter binding threw here, before step 4, so every call carrying birth
+    // data returned 500 and NOTHING was charged for twelve weeks (#733).
+    // Profile enrichment is a nice-to-have; charging for the operation is the
+    // point of the endpoint. A failure here must degrade to "the profile is
+    // stale" and never to "no revenue".
+    //
+    // The four §18o CHECK constraints below make this a live risk rather than a
+    // hypothetical — any of them can reject a write on data we do not control,
+    // since the payload comes from another repo's engine. Logged at error level
+    // with a greppable marker so it degrades loudly rather than silently.
+    try {
     if (agentProfileRaw && typeof agentProfileRaw === "object") {
       const ap = agentProfileRaw as Record<string, unknown>;
 
@@ -317,56 +331,74 @@ export async function POST(req: NextRequest) {
         ]
       );
     }
-
-    // 2. Idempotency check
-    const dup = await executeQuery(
-      `SELECT 1 FROM token_transactions WHERE idempotency_key LIKE $1 LIMIT 1`,
-      [`${idempotencyKey}:%`],
-    );
-    if (dup.rows.length > 0) {
-      // Even on idempotency hit, return userId so the caller can persist the
-      // alchm.kitchen UUID for downstream profile linking.
-      return NextResponse.json(
-        { ok: false, reason: "already_applied", userId },
-        { status: 409 },
+    } catch (enrichmentError) {
+      // Never rethrow: the debit below is the reason this endpoint exists.
+      console.error(
+        "[sync-debit] PROFILE_ENRICHMENT_FAILED — continuing to the debit.",
+        { userId, name: storedName, error: enrichmentError },
       );
     }
 
-    // 3. Ensure balance row, read current balances
-    await executeQuery(
-      `INSERT INTO token_balances (user_id) VALUES ($1) ON CONFLICT (user_id) DO NOTHING`,
-      [userId],
-    );
-    const balRow = await executeQuery<{
-      spirit: string; essence: string; matter: string; substance: string;
-    }>(
-      `SELECT spirit::text, essence::text, matter::text, substance::text FROM token_balances WHERE user_id = $1`,
-      [userId],
-    );
-    const bal = balRow.rows[0] ?? { spirit: "0", essence: "0", matter: "0", substance: "0" };
-    const curSpirit = parseFloat(bal.spirit) || 0;
-    const curEssence = parseFloat(bal.essence) || 0;
-    const curMatter = parseFloat(bal.matter) || 0;
-    const curSubstance = parseFloat(bal.substance) || 0;
+    // ── Steps 2-5 are ONE transaction ─────────────────────────────────────
+    //
+    // Every statement here used to autocommit independently, so a failure
+    // between the debit and the ledger writes would leave the balance reduced
+    // with no transaction rows to account for it — a user charged with no
+    // record, and permanent drift in a ledger whose whole purpose is to
+    // reconcile. Nothing detects that after the fact; the sums simply disagree
+    // forever. The twelve-week outage happened to be clean only because the
+    // throw landed before step 4, which was luck, not design.
+    //
+    // Provisioning and enrichment stay OUTSIDE deliberately: they are
+    // idempotent (ON CONFLICT) and worth keeping even when the debit is
+    // refused, and folding them in would mean an enrichment failure could roll
+    // back a completed charge.
+    //
+    // Early returns inside commit, which is correct — none of them has written
+    // anything that should be undone. Only a throw rolls back.
+    const outcome = await withTransaction(async (client) => {
+      // 2. Idempotency check
+      const dup = await executeQuery(
+        `SELECT 1 FROM token_transactions WHERE idempotency_key LIKE $1 LIMIT 1`,
+        [`${idempotencyKey}:%`],
+        { client },
+      );
+      if (dup.rows.length > 0) {
+        return { kind: "already_applied" as const };
+      }
 
-    if (curSpirit < spirit || curEssence < essence || curMatter < matter || curSubstance < substance) {
-      return NextResponse.json(
-        {
-          ok: false,
-          reason: "insufficient_funds",
-          userId,
+      // 3. Ensure balance row, read current balances
+      await executeQuery(
+        `INSERT INTO token_balances (user_id) VALUES ($1) ON CONFLICT (user_id) DO NOTHING`,
+        [userId],
+        { client },
+      );
+      const balRow = await executeQuery<{
+        spirit: string; essence: string; matter: string; substance: string;
+      }>(
+        `SELECT spirit::text, essence::text, matter::text, substance::text FROM token_balances WHERE user_id = $1`,
+        [userId],
+        { client },
+      );
+      const bal = balRow.rows[0] ?? { spirit: "0", essence: "0", matter: "0", substance: "0" };
+      const curSpirit = parseFloat(bal.spirit) || 0;
+      const curEssence = parseFloat(bal.essence) || 0;
+      const curMatter = parseFloat(bal.matter) || 0;
+      const curSubstance = parseFloat(bal.substance) || 0;
+
+      if (curSpirit < spirit || curEssence < essence || curMatter < matter || curSubstance < substance) {
+        return {
+          kind: "insufficient_funds" as const,
           balances: { spirit: curSpirit, essence: curEssence, matter: curMatter, substance: curSubstance },
-        },
-        { status: 402 },
-      );
-    }
+        };
+      }
 
-    // 4. Atomic debit — UPDATE using text-cast params to avoid operator ambiguity.
-    //    The amounts are passed as fixed-point strings (e.g. "2.0000"), which
-    //    Postgres coerces to DECIMAL without ambiguity.
-    const groupId = randomUUID();
-    const updateRes = await executeQuery<{ spirit: string; essence: string; matter: string; substance: string }>(
-      `UPDATE token_balances
+      // 4. Atomic debit — UPDATE using text-cast params to avoid operator ambiguity.
+      //    The amounts are passed as fixed-point strings (e.g. "2.0000"), which
+      //    Postgres coerces to DECIMAL without ambiguity.
+      const groupId = randomUUID();
+      const updateRes = await executeQuery<{ spirit: string; essence: string; matter: string; substance: string }>(
+        `UPDATE token_balances
        SET spirit    = spirit    - $2::decimal,
            essence   = essence   - $3::decimal,
            matter    = matter    - $4::decimal,
@@ -378,68 +410,90 @@ export async function POST(req: NextRequest) {
          AND matter    >= $4::decimal
          AND substance >= $5::decimal
        RETURNING spirit::text, essence::text, matter::text, substance::text`,
-      [userId, sSpirit, sEssence, sMatter, sSubstance],
-    );
-
-    if (updateRes.rows.length === 0) {
-      // Race condition lost — re-read and return 402
-      const cur2 = await executeQuery<{ spirit: string; essence: string; matter: string; substance: string }>(
-        `SELECT spirit::text, essence::text, matter::text, substance::text FROM token_balances WHERE user_id = $1`,
-        [userId],
+        [userId, sSpirit, sEssence, sMatter, sSubstance],
+        { client },
       );
-      const b2 = cur2.rows[0] ?? { spirit: "0", essence: "0", matter: "0", substance: "0" };
-      return NextResponse.json(
-        {
-          ok: false,
-          reason: "insufficient_funds",
-          userId,
+
+      if (updateRes.rows.length === 0) {
+        // Race condition lost — re-read and return 402
+        const cur2 = await executeQuery<{ spirit: string; essence: string; matter: string; substance: string }>(
+          `SELECT spirit::text, essence::text, matter::text, substance::text FROM token_balances WHERE user_id = $1`,
+          [userId],
+          { client },
+        );
+        const b2 = cur2.rows[0] ?? { spirit: "0", essence: "0", matter: "0", substance: "0" };
+        return {
+          kind: "insufficient_funds" as const,
           balances: {
             spirit: parseFloat(b2.spirit) || 0,
             essence: parseFloat(b2.essence) || 0,
             matter: parseFloat(b2.matter) || 0,
             substance: parseFloat(b2.substance) || 0,
           },
+        };
+      }
+
+      // 5. Write ledger rows — per non-zero token type, with child idempotency keys.
+      //    These share the transaction with the debit above: the balance change
+      //    and the rows that account for it commit together or not at all.
+      const tokenEntries: Array<{ type: string; amount: string }> = [
+        { type: "Spirit", amount: sSpirit },
+        { type: "Essence", amount: sEssence },
+        { type: "Matter", amount: sMatter },
+        { type: "Substance", amount: sSubstance },
+      ].filter((e) => parseFloat(e.amount) > 0);
+
+      for (const entry of tokenEntries) {
+        await executeQuery(
+          `INSERT INTO token_transactions
+           (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
+         VALUES ($1, $2, $3, -$4::decimal, 'agents_operation', $5, $6, $7)`,
+          [
+            groupId,
+            userId,
+            entry.type,
+            entry.amount,
+            operationType ?? null,
+            description,
+            `${idempotencyKey}:${entry.type}`,
+          ],
+          { client },
+        );
+      }
+
+      const final = updateRes.rows[0];
+      return {
+        kind: "ok" as const,
+        groupId,
+        balances: {
+          spirit: parseFloat(final.spirit) || 0,
+          essence: parseFloat(final.essence) || 0,
+          matter: parseFloat(final.matter) || 0,
+          substance: parseFloat(final.substance) || 0,
         },
+      };
+    });
+
+    if (outcome.kind === "already_applied") {
+      // Even on idempotency hit, return userId so the caller can persist the
+      // alchm.kitchen UUID for downstream profile linking.
+      return NextResponse.json(
+        { ok: false, reason: "already_applied", userId },
+        { status: 409 },
+      );
+    }
+    if (outcome.kind === "insufficient_funds") {
+      return NextResponse.json(
+        { ok: false, reason: "insufficient_funds", userId, balances: outcome.balances },
         { status: 402 },
       );
     }
 
-    // 5. Write ledger rows — per non-zero token type, with child idempotency keys
-    const tokenEntries: Array<{ type: string; amount: string }> = [
-      { type: "Spirit", amount: sSpirit },
-      { type: "Essence", amount: sEssence },
-      { type: "Matter", amount: sMatter },
-      { type: "Substance", amount: sSubstance },
-    ].filter((e) => parseFloat(e.amount) > 0);
-
-    for (const entry of tokenEntries) {
-      await executeQuery(
-        `INSERT INTO token_transactions
-           (transaction_group_id, user_id, token_type, amount, source_type, source_id, description, idempotency_key)
-         VALUES ($1, $2, $3, -$4::decimal, 'agents_operation', $5, $6, $7)`,
-        [
-          groupId,
-          userId,
-          entry.type,
-          entry.amount,
-          operationType ?? null,
-          description,
-          `${idempotencyKey}:${entry.type}`,
-        ],
-      );
-    }
-
-    const final = updateRes.rows[0];
     return NextResponse.json({
       ok: true,
       userId,
-      transactionGroupId: groupId,
-      balances: {
-        spirit: parseFloat(final.spirit) || 0,
-        essence: parseFloat(final.essence) || 0,
-        matter: parseFloat(final.matter) || 0,
-        substance: parseFloat(final.substance) || 0,
-      },
+      transactionGroupId: outcome.groupId,
+      balances: outcome.balances,
     });
   } catch (error) {
     // Unique-violation on idempotency_key (race condition) → 409

--- a/src/lib/database/connection.ts
+++ b/src/lib/database/connection.ts
@@ -94,6 +94,18 @@ export async function executeQuery<_T extends any = any>(
   options: {
     logQuery?: boolean;
     timeout?: number;
+    /**
+     * Run on an existing transaction client instead of checking a fresh
+     * connection out of the pool.
+     *
+     * Without this, every call lands on whatever connection the pool hands
+     * over, so a caller inside {@link withTransaction} would silently execute
+     * OUTSIDE its own transaction — the statements would autocommit and a
+     * rollback would not undo them. Passing the client keeps the statement in
+     * the transaction while retaining the slow-query instrumentation and error
+     * handling below, which raw `client.query` would bypass.
+     */
+    client?: PoolClient;
   } = {},
 ): Promise<QueryResult<any>> {
   const { logQuery = databaseConfig.logQueries, timeout: _timeout = 30000 } = options;
@@ -105,7 +117,7 @@ export async function executeQuery<_T extends any = any>(
         paramCount: params.length,
       });
     }
-    const result = await getDatabasePool().query(query, params);
+    const result = await (options.client ?? getDatabasePool()).query(query, params);
     const executionTime = Date.now() - startTime;
     // Push to the in-memory slow-query ring (threshold defaults to 200ms).
     // The admin observability endpoint reads this; production traffic should


### PR DESCRIPTION
#733 fixed the parameter binding that caused the twelve-week outage. It did not change the two structural properties that let one bad binding become a total revenue outage, and that would have left the ledger inconsistent had the throw landed a few lines later.

## 1. The debit and its ledger rows could half-commit

Every statement ran in autocommit. A failure between the balance `UPDATE` and the `token_transactions` `INSERT`s would leave a user **charged with nothing accounting for it** — permanent drift in the ledger whose whole purpose is to reconcile, and nothing detects it after the fact.

It stayed clean during the outage only because the throw landed before step 4. That was luck, not design.

Steps 2–5 now run inside one `withTransaction`. Provisioning and enrichment stay **outside** deliberately — they're idempotent (`ON CONFLICT`) and worth keeping when a debit is refused, and folding them in would let an enrichment failure roll back a completed charge. The early returns inside commit, which is correct: none of them has written anything that should be undone. Only a throw rolls back.

`executeQuery` gains an optional `client`. Without it, a caller inside `withTransaction` would silently execute **outside** its own transaction — the statements would autocommit and a rollback would not undo them. Threading the client keeps each statement in the transaction while retaining the slow-query instrumentation and error handling that raw `client.query` bypasses.

## 2. Profile enrichment could still kill the charge

This is exactly how the outage happened: one bad binding threw during enrichment, *before* the debit, and 1,349 calls a day returned 500 with nothing charged for twelve weeks. Fixing that one binding left the shape intact — any future enrichment error does it again.

That's a live risk, not a hypothetical: four §18o `CHECK` constraints police those columns, and the payload comes from another repo's engine.

Enrichment is now non-fatal. It degrades to a stale profile, never to lost revenue, and logs at error level with a greppable `PROFILE_ENRICHMENT_FAILED` marker so it fails loudly rather than silently.

## Mutation-checked both ways

Dropping `{ client }` from just the ledger insert:

```
✕ runs the debit and its ledger rows on the SAME transaction client
✓ propagates a ledger-write failure so the debit rolls back with it
✓ keeps provisioning OUTSIDE the transaction so a refused debit does not undo it
✕ still charges when the enrichment UPDATE throws
✓ logs the enrichment failure rather than swallowing it
```

Making enrichment fatal again — reintroducing the outage verbatim:

```
✓ runs the debit and its ledger rows on the SAME transaction client
✓ propagates a ledger-write failure so the debit rolls back with it
✓ keeps provisioning OUTSIDE the transaction so a refused debit does not undo it
✕ still charges when the enrichment UPDATE throws
✓ logs the enrichment failure rather than swallowing it
```

Each mutation fails exactly the cases written for it.

## ADR-010: writing off the gap

Also records the decision on the ~85 days of uncharged operations, with the measurement behind it.

| Month | Rows | Agents | Tokens |
|---|---|---|---|
| 2026-05 | 317 | 52 | 475.00 |
| *2026-06* | **0** | — | — |
| *2026-07* | **0** | — | — |
| 2026-08 | 1,132 | 71 | 1,766.00 |

Gap boundaries are exact: last row `2026-05-15T02:05:30.696Z`, first row after the fix `2026-08-08T02:01:38.410Z`, **zero rows in between** — 85 days. Agent `feed_events` kept flowing throughout (4,088 in June, 8,588 in July), so this was under-charging, not idleness.

**The ledger is consistent, not corrupt.** Comparing every account's balance against the sum of its ledger rows across 3,717 balance rows and 11,239 ledger rows:

```
real       (no offset)  : 0 accounts disagree
control (+0.5 injected) : 14868 accounts disagree
```

The control matters — an empty result set looks identical whether nothing disagrees or the query never compared anything. Injecting a deliberate offset produces 14,868 disagreements, so the comparison can detect drift and the real zero is a measurement.

The failing requests wrote *nothing*, so what was owed isn't reconstructible, and the observed charge rate ranged from ~346 rows/day before to ~3,019 rows/day after — extrapolating across 85 days spans ~29,000 to ~257,000 rows. Any "reconciling adjustment" would be a guess dressed as an accounting entry, landing in a ledger that currently reconciles exactly. Hence: write off, record it, change nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
