### PR TITLE
feat(observability): watch the connection ceiling that actually binds now

### DIFF
--- a/src/services/__tests__/poolerSaturationHealth.test.ts
+++ b/src/services/__tests__/poolerSaturationHealth.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment node
+ *
+ * The check that watches the connection ceiling nobody is watching.
+ *
+ * Production moved onto PgBouncer, which capped Postgres backends at exactly 20
+ * (`default_pool_size`) — so `max_connections = 100`, the number everyone used
+ * to watch, is now permanently and misleadingly healthy. The real wall is
+ * PgBouncer's `max_client_conn` (120), past which it REFUSES new client
+ * connections. The queueing signal that precedes it lives only inside the
+ * pooler; `pg_stat_activity` cannot see it at all.
+ */
+
+import {
+  classifyPoolerSaturation,
+  aggregatePools,
+  resolveAdminDsn,
+  MAXWAIT_INCIDENT_SECONDS,
+  type PoolerSaturationSignals,
+} from "@/services/poolerSaturationHealth";
+
+const healthy: PoolerSaturationSignals = {
+  clientsActive: 2,
+  clientsWaiting: 0,
+  serversActive: 1,
+  maxWaitSeconds: 0,
+  maxClientConn: 120,
+  poolSize: 20,
+  live: true,
+};
+
+describe("classifyPoolerSaturation", () => {
+  it("reports OK with headroom", () => {
+    const r = classifyPoolerSaturation(healthy);
+    expect(r.verdict).toBe("OK");
+    expect(r.summary).toMatch(/2\/120 clients/);
+  });
+
+  it("raises INCIDENT as the client ceiling approaches", () => {
+    // Past max_client_conn PgBouncer refuses connections outright — the app
+    // sees connection errors, not slow queries, so this must fire BEFORE it.
+    const r = classifyPoolerSaturation({ ...healthy, clientsActive: 108 });
+    expect(r.verdict).toBe("INCIDENT");
+    expect(r.summary).toMatch(/refuses/);
+  });
+
+  it("goes DEGRADED while filling up, before the ceiling", () => {
+    const r = classifyPoolerSaturation({ ...healthy, clientsActive: 84 });
+    expect(r.verdict).toBe("DEGRADED");
+    expect(r.clientUtilisation).toBeCloseTo(0.7, 5);
+  });
+
+  it("raises INCIDENT when clients starve waiting for a server connection", () => {
+    // All 20 servers busy and clients queued for 5s+: throughput has collapsed
+    // even though the client count is nowhere near the ceiling.
+    const r = classifyPoolerSaturation({
+      ...healthy, clientsActive: 20, clientsWaiting: 8,
+      serversActive: 20, maxWaitSeconds: MAXWAIT_INCIDENT_SECONDS,
+    });
+    expect(r.verdict).toBe("INCIDENT");
+    expect(r.summary).toMatch(/queued/);
+  });
+
+  describe("a momentary queue is not an incident", () => {
+    it("stays OK when clients are waiting but nobody has waited yet", () => {
+      // cl_waiting flickers above zero under perfectly healthy burst load.
+      // Alarming on it alone is how a saturation check becomes noise nobody
+      // reads — the same failure the debit-path detector had to design around.
+      const r = classifyPoolerSaturation({
+        ...healthy, clientsWaiting: 4, serversActive: 20, maxWaitSeconds: 0,
+      });
+      expect(r.verdict).toBe("OK");
+    });
+
+    it("goes DEGRADED once the wait persists a full second", () => {
+      const r = classifyPoolerSaturation({
+        ...healthy, clientsWaiting: 4, serversActive: 20, maxWaitSeconds: 1,
+      });
+      expect(r.verdict).toBe("DEGRADED");
+    });
+  });
+
+  it("reports UNKNOWN rather than green when there is no source", () => {
+    const r = classifyPoolerSaturation({ ...healthy, live: false });
+    expect(r.verdict).toBe("UNKNOWN");
+    expect(r.summary).toMatch(/No source/);
+  });
+
+  it("does not divide by zero when max_client_conn is unlimited", () => {
+    // PgBouncer reports 0 for "unlimited"; dividing by it would give Infinity
+    // and pin the panel to a permanent false INCIDENT.
+    const r = classifyPoolerSaturation({ ...healthy, clientsActive: 500, maxClientConn: 0 });
+    expect(r.clientUtilisation).toBe(0);
+    expect(r.verdict).toBe("OK");
+  });
+});
+
+describe("aggregatePools", () => {
+  // Captured verbatim from the live Railway pooler — including the columns that
+  // do NOT exist, which is the point of using a real fixture.
+  const LIVE_ROWS = [
+    {
+      database: "pgbouncer", user: "pgbouncer", cl_active: 1, cl_waiting: 0,
+      sv_active: 0, sv_idle: 0, maxwait: 0, maxwait_us: 0, pool_mode: "statement",
+    },
+    {
+      database: "railway", user: "postgres", cl_active: 1, cl_waiting: 0,
+      sv_active: 1, sv_idle: 0, sv_used: 3, maxwait: 0, maxwait_us: 0, pool_mode: "session",
+    },
+  ];
+
+  it("excludes the admin pool so the probe does not count itself", () => {
+    // The connection running SHOW POOLS appears in the `pgbouncer` pool. Counting
+    // it would mean the check always observes at least one client of its own.
+    const agg = aggregatePools(LIVE_ROWS);
+    expect(agg.clientsActive).toBe(1); // the railway pool only, not 2
+  });
+
+  it("sums across application pools and takes the worst wait", () => {
+    const agg = aggregatePools([
+      { database: "railway", cl_active: 3, cl_waiting: 1, sv_active: 4, maxwait: 2 },
+      { database: "railway", cl_active: 5, cl_waiting: 2, sv_active: 6, maxwait: 9 },
+    ]);
+    expect(agg.clientsActive).toBe(8);
+    expect(agg.clientsWaiting).toBe(3);
+    expect(agg.serversActive).toBe(10);
+    expect(agg.maxWaitSeconds).toBe(9); // worst, not sum
+  });
+
+  it("never reports pool_size from SHOW POOLS, which does not have it", () => {
+    // SHOW POOLS carries no pool_size column (that is SHOW DATABASES). Reading
+    // it here would silently yield 0 and make the servers-busy denominator a
+    // lie. It comes from default_pool_size in SHOW CONFIG instead.
+    expect(aggregatePools(LIVE_ROWS)).not.toHaveProperty("poolSize");
+  });
+
+  it("survives string-valued counters", () => {
+    const agg = aggregatePools([
+      { database: "railway", cl_active: "7", cl_waiting: "2", sv_active: "3", maxwait: "4" },
+    ]);
+    expect(agg.clientsActive).toBe(7);
+    expect(agg.maxWaitSeconds).toBe(4);
+  });
+});
+
+describe("resolveAdminDsn", () => {
+  const URL_POOLED = "postgresql://postgres:sec%40ret@pgbouncer.railway.internal:6432/railway?sslmode=disable";
+
+  it("points at the pgbouncer virtual database, not the app database", () => {
+    const dsn = resolveAdminDsn(URL_POOLED, "session");
+    expect(dsn?.database).toBe("pgbouncer");
+    expect(dsn?.host).toBe("pgbouncer.railway.internal");
+    expect(dsn?.port).toBe(6432);
+  });
+
+  it("honours sslmode=disable — PgBouncer refuses TLS", () => {
+    // Forcing TLS here would fail every probe and report a permanent UNKNOWN,
+    // which is exactly how the pooler flip failed the first time.
+    expect(resolveAdminDsn(URL_POOLED, "session")?.ssl).toBe(false);
+  });
+
+  it("decodes percent-escapes in the password", () => {
+    expect(resolveAdminDsn(URL_POOLED, "session")?.password).toBe("sec@ret");
+  });
+
+  it("returns null in a direct topology — there is no pooler to ask", () => {
+    // Otherwise every poll logs a confusing connection error against a database
+    // that does not exist.
+    expect(resolveAdminDsn(URL_POOLED, "direct")).toBeNull();
+  });
+
+  it("returns null rather than throwing on an unparseable URL", () => {
+    expect(resolveAdminDsn("not-a-url", "session")).toBeNull();
+  });
+});

--- a/src/services/poolerSaturationHealth.ts
+++ b/src/services/poolerSaturationHealth.ts
@@ -1,0 +1,230 @@
+/**
+ * PgBouncer saturation for the Database flow.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The connection ceiling moved when production flipped onto PgBouncer, and
+ * nothing watches the new one. Postgres backends are now capped at exactly 20 by
+ * `default_pool_size`, comfortably under `max_connections = 100` — so the metric
+ * everyone used to watch is permanently, misleadingly healthy. The wall is now
+ * PgBouncer's own `max_client_conn` (120): past it, PgBouncer REFUSES new client
+ * connections outright, and the app sees connection errors rather than slow
+ * queries.
+ *
+ * WHY IT NEEDS THE ADMIN CONSOLE
+ * ------------------------------
+ * The load-bearing signal is `cl_waiting` / `maxwait` — clients queued waiting
+ * for one of the 20 server connections. That exists only inside PgBouncer.
+ * `pg_stat_activity` cannot see it: from Postgres's side a saturated pooler and
+ * an idle one look identical, because both show at most 20 backends. Railway's
+ * service metrics cannot see it either.
+ *
+ * So this opens a short-lived connection to the pooler's own `pgbouncer` admin
+ * database. When that is not possible — direct topology, no admin rights, pooler
+ * unreachable — it reports `live: false` rather than inventing a verdict, per
+ * the admin-surface rule that a panel must degrade to an honest "no source".
+ */
+
+import pkg from "pg";
+import { databaseConfig, resolveSslOption } from "@/lib/database/config";
+import { _logger } from "@/lib/logger";
+
+const { Client } = pkg as unknown as { Client: new (config: unknown) => any };
+
+/** OK = headroom · DEGRADED = queueing or filling up · INCIDENT = refusals imminent or clients starving. */
+export type PoolerVerdict = "OK" | "DEGRADED" | "INCIDENT" | "UNKNOWN";
+
+export interface PoolerSaturationSignals {
+  /** Client connections currently attached to a server connection. */
+  clientsActive: number;
+  /** Clients queued waiting for a server connection — invisible from Postgres. */
+  clientsWaiting: number;
+  /** Server connections in use, bounded by default_pool_size. */
+  serversActive: number;
+  /** Seconds the longest-waiting client has been queued. 0 when nobody waits. */
+  maxWaitSeconds: number;
+  /** Hard ceiling: past this PgBouncer refuses new client connections. */
+  maxClientConn: number;
+  /** Server connections available per (database, user) pair. */
+  poolSize: number;
+  /** False when there is no source — never fabricate a verdict from missing data. */
+  live: boolean;
+}
+
+export interface PoolerSaturationHealth {
+  verdict: PoolerVerdict;
+  summary: string;
+  /** Clients in use as a fraction of max_client_conn, 0-1. */
+  clientUtilisation: number;
+}
+
+/**
+ * Queueing is normal in a burst; queueing that LASTS is starvation. maxwait is
+ * therefore the discriminator rather than cl_waiting, which flickers above zero
+ * under perfectly healthy load and would make this alarm cry wolf — the same
+ * mistake the debit-path detector had to design around.
+ */
+export const MAXWAIT_DEGRADED_SECONDS = 1;
+export const MAXWAIT_INCIDENT_SECONDS = 5;
+export const CLIENT_UTILISATION_DEGRADED = 0.7;
+export const CLIENT_UTILISATION_INCIDENT = 0.9;
+
+/** Pure classifier. Free of database imports so it can be tested directly. */
+export function classifyPoolerSaturation(
+  signals: PoolerSaturationSignals,
+): PoolerSaturationHealth {
+  const {
+    clientsActive, clientsWaiting, serversActive,
+    maxWaitSeconds, maxClientConn, poolSize, live,
+  } = signals;
+
+  if (!live) {
+    return {
+      verdict: "UNKNOWN",
+      summary: "No source — PgBouncer admin console unreachable",
+      clientUtilisation: 0,
+    };
+  }
+
+  const clients = clientsActive + clientsWaiting;
+  // Guard the divisor: a pooler reporting max_client_conn = 0 means unlimited,
+  // and dividing by it would produce Infinity and a permanent false INCIDENT.
+  const utilisation = maxClientConn > 0 ? clients / maxClientConn : 0;
+
+  if (utilisation >= CLIENT_UTILISATION_INCIDENT) {
+    return {
+      verdict: "INCIDENT",
+      summary:
+        `${clients}/${maxClientConn} client connections — PgBouncer refuses ` +
+        `new connections at the ceiling`,
+      clientUtilisation: utilisation,
+    };
+  }
+  if (maxWaitSeconds >= MAXWAIT_INCIDENT_SECONDS) {
+    return {
+      verdict: "INCIDENT",
+      summary:
+        `${clientsWaiting} clients queued, longest waiting ${maxWaitSeconds}s ` +
+        `for one of ${poolSize} server connections`,
+      clientUtilisation: utilisation,
+    };
+  }
+  if (utilisation >= CLIENT_UTILISATION_DEGRADED) {
+    return {
+      verdict: "DEGRADED",
+      summary: `${clients}/${maxClientConn} client connections — approaching the ceiling`,
+      clientUtilisation: utilisation,
+    };
+  }
+  if (clientsWaiting > 0 && maxWaitSeconds >= MAXWAIT_DEGRADED_SECONDS) {
+    return {
+      verdict: "DEGRADED",
+      summary: `${clientsWaiting} clients queued ${maxWaitSeconds}s for a server connection`,
+      clientUtilisation: utilisation,
+    };
+  }
+
+  return {
+    verdict: "OK",
+    summary: `${clients}/${maxClientConn} clients · ${serversActive}/${poolSize} servers busy`,
+    clientUtilisation: utilisation,
+  };
+}
+
+/**
+ * The pooler's admin DSN: the app's own connection string, pointed at the
+ * `pgbouncer` virtual database instead of the application one.
+ *
+ * Returns null in a direct topology — there is no pooler to ask, and probing
+ * would just log a confusing connection error every poll.
+ */
+export function resolveAdminDsn(
+  databaseUrl: string,
+  poolerMode: string,
+): { host: string; port: number; user: string; password: string; database: string; ssl: false | { rejectUnauthorized: boolean } } | null {
+  if (poolerMode === "direct") return null;
+  try {
+    const url = new URL(databaseUrl);
+    return {
+      host: url.hostname,
+      port: parseInt(url.port, 10) || 6432,
+      user: decodeURIComponent(url.username),
+      password: decodeURIComponent(url.password),
+      // PgBouncer's own admin console lives in a virtual database of this name.
+      database: "pgbouncer",
+      // Reuse the app's TLS decision: PgBouncer refuses TLS, and the URL says so
+      // with ?sslmode=disable. Forcing TLS here would fail every probe.
+      ssl: resolveSslOption(url),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sum the per-pool rows PgBouncer reports, ignoring its own admin pool.
+ *
+ * Note `pool_size` is deliberately NOT read here: `SHOW POOLS` does not carry
+ * it (that column belongs to `SHOW DATABASES`), so reading it would silently
+ * yield 0 and make the "servers busy" denominator a lie. It comes from
+ * `default_pool_size` in `SHOW CONFIG` instead.
+ */
+export function aggregatePools(
+  rows: Array<Record<string, unknown>>,
+): Pick<PoolerSaturationSignals, "clientsActive" | "clientsWaiting" | "serversActive" | "maxWaitSeconds"> {
+  const n = (v: unknown) => {
+    const parsed = typeof v === "number" ? v : parseInt(String(v ?? 0), 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+  };
+  // The `pgbouncer` pool is the admin console itself — including it would count
+  // this very probe as application load.
+  const app = rows.filter((r) => String(r.database) !== "pgbouncer");
+  return {
+    clientsActive: app.reduce((s, r) => s + n(r.cl_active), 0),
+    clientsWaiting: app.reduce((s, r) => s + n(r.cl_waiting), 0),
+    serversActive: app.reduce((s, r) => s + n(r.sv_active), 0),
+    maxWaitSeconds: app.reduce((m, r) => Math.max(m, n(r.maxwait)), 0),
+  };
+}
+
+const UNAVAILABLE: PoolerSaturationSignals = {
+  clientsActive: 0, clientsWaiting: 0, serversActive: 0,
+  maxWaitSeconds: 0, maxClientConn: 0, poolSize: 0, live: false,
+};
+
+/**
+ * Reads SHOW POOLS + SHOW CONFIG from the pooler. Degrades to `live: false`
+ * rather than throwing, so the Database flow reports an honest "no source".
+ */
+export async function fetchPoolerSaturationSignals(): Promise<PoolerSaturationSignals> {
+  const dsn = resolveAdminDsn(databaseConfig.databaseUrl, databaseConfig.poolerMode);
+  if (!dsn) return UNAVAILABLE;
+
+  // Short fuses on purpose: the admin database has a pool_size of 2, and this
+  // is a health probe. It must never become the thing that holds a slot.
+  const client = new Client({ ...dsn, connectionTimeoutMillis: 2000, query_timeout: 2000 });
+  try {
+    await client.connect();
+    const pools = await client.query("SHOW POOLS");
+    const config = await client.query("SHOW CONFIG");
+
+    const setting = (key: string) =>
+      parseInt(
+        (config.rows as Array<{ key: string; value: string }>).find((r) => r.key === key)?.value ??
+          "0",
+        10,
+      ) || 0;
+
+    return {
+      ...aggregatePools(pools.rows as Array<Record<string, unknown>>),
+      maxClientConn: setting("max_client_conn"),
+      poolSize: setting("default_pool_size"),
+      live: true,
+    };
+  } catch (err) {
+    _logger.warn("[systemStatus] PgBouncer saturation probe failed:", err);
+    return UNAVAILABLE;
+  } finally {
+    await client.end().catch(() => undefined);
+  }
+}

--- a/src/services/systemStatusService.ts
+++ b/src/services/systemStatusService.ts
@@ -33,6 +33,10 @@ import {
 import { getEventCounts } from "@/services/authEventsService";
 import { feedEmitTracker } from "@/services/feedEmitTracker";
 import { getMcpNetworkSummary } from "@/services/mcpNetworkService";
+import {
+  classifyPoolerSaturation,
+  fetchPoolerSaturationSignals,
+} from "@/services/poolerSaturationHealth";
 import { getSubscriptionRevenueBreakdown } from "@/services/subscriptionRevenueService";
 import {
   getLatestProbeResults,
@@ -1087,10 +1091,19 @@ async function probeDatabase(): Promise<FlowHealth> {
 
   const slowQueries = summarizeSlowQueries(FIVE_MIN);
 
+  // Connection-pool saturation. Since the PgBouncer flip the old ceiling
+  // (max_connections = 100) is permanently healthy — backends are capped at 20
+  // by default_pool_size — while the real wall is the pooler's max_client_conn.
+  // See poolerSaturationHealth for why only the admin console can see it.
+  const poolerSignals = await fetchPoolerSaturationSignals();
+  const pooler = classifyPoolerSaturation(poolerSignals);
+
   let status: FlowStatus;
   if (!healthy) status = "INCIDENT";
+  else if (pooler.verdict === "INCIDENT") status = "INCIDENT";
   else if ((latency ?? 0) > 200 || slowQueries.count >= 20) status = "DEGRADED";
   else if (slowQueries.count >= 5) status = "DEGRADED";
+  else if (pooler.verdict === "DEGRADED") status = "DEGRADED";
   else status = "OK";
 
   const issues: FlowIssue[] = [];
@@ -1099,6 +1112,13 @@ async function probeDatabase(): Promise<FlowHealth> {
       at: checkedAt,
       message: `Database unreachable: ${dbError}`,
       severity: "error",
+    });
+  }
+  if (pooler.verdict === "INCIDENT" || pooler.verdict === "DEGRADED") {
+    issues.push({
+      at: checkedAt,
+      message: `Connection pool: ${pooler.summary}`,
+      severity: pooler.verdict === "INCIDENT" ? "error" : "warn",
     });
   }
   if (slowQueries.count >= 5) {
@@ -1118,14 +1138,37 @@ async function probeDatabase(): Promise<FlowHealth> {
     summary:
       status === "OK"
         ? `Healthy · ${formatLatency(latency ?? 0)} ping · ${slowQueries.count} slow queries 5m`
-        : status === "DEGRADED"
-          ? `${slowQueries.count} slow queries in 5m`
-          : "Database unreachable",
+        : // Name the pooler when it is the cause. Reporting "N slow queries"
+          // during a connection-pool incident points the reader at the wrong
+          // layer — queries are not slow, they are waiting to start.
+          status === "INCIDENT" && healthy && pooler.verdict === "INCIDENT"
+          ? pooler.summary
+          : status === "DEGRADED"
+            ? pooler.verdict === "DEGRADED" && slowQueries.count < 5
+              ? pooler.summary
+              : `${slowQueries.count} slow queries in 5m`
+            : "Database unreachable",
     metrics: [
       {
         label: "Health ping",
         value: formatLatency(latency ?? 0),
         raw: latency ?? 0,
+      },
+      {
+        label: "Pooler clients",
+        // An honest dash beats a fabricated 0/0 when the admin console is
+        // unreachable — the panel must never imply it measured something.
+        value: poolerSignals.live
+          ? `${poolerSignals.clientsActive + poolerSignals.clientsWaiting}/${poolerSignals.maxClientConn}`
+          : "—",
+        raw: poolerSignals.live ? poolerSignals.clientsActive + poolerSignals.clientsWaiting : 0,
+      },
+      {
+        label: "Pooler servers",
+        value: poolerSignals.live
+          ? `${poolerSignals.serversActive}/${poolerSignals.poolSize}`
+          : "—",
+        raw: poolerSignals.live ? poolerSignals.serversActive : 0,
       },
       {
         label: "Slow queries · 5m",


### PR DESCRIPTION
The PgBouncer flip moved the connection ceiling, and no check followed it.

## The number everyone watches is now permanently healthy

Postgres backends are capped at exactly **20** by `default_pool_size` — comfortably under `max_connections = 100`. So the metric that used to mean something can never move again, no matter how badly saturated the pooler is.

The real wall is PgBouncer's own **`max_client_conn` (120)**. Past it PgBouncer *refuses* new client connections outright, and the app sees connection errors rather than slow queries.

## Only the admin console can see the warning sign

The signal that precedes refusal is `cl_waiting` / `maxwait` — clients queued waiting for one of the 20 server connections. That exists **only inside PgBouncer**:

- `pg_stat_activity` can't see it. From Postgres's side a saturated pooler and an idle one look identical, because both show at most 20 backends.
- Railway's service metrics can't see it either — they observe container health, not pool internals.

So this opens a short-lived connection to the pooler's `pgbouncer` virtual database. Fuses are 2s on purpose: that pool has a size of **2**, and a health probe must never become the thing holding a slot.

## Thresholds, and why they aren't `cl_waiting > 0`

`cl_waiting` flickers above zero under perfectly healthy burst load. Alarming on it alone is how a saturation check becomes noise nobody reads — the same failure mode the debit-path detector (#734) had to design around. **`maxwait` is the discriminator: queueing is normal, queueing that *lasts* is starvation.**

| Verdict | Condition |
|---|---|
| `INCIDENT` | clients ≥ 90% of `max_client_conn`, **or** `maxwait` ≥ 5s |
| `DEGRADED` | clients ≥ 70%, **or** a queue that has persisted ≥ 1s |
| `OK` | otherwise — including a momentary queue with `maxwait = 0` |
| `UNKNOWN` | no source; never a fabricated verdict |

The Database flow **names the pooler when it's the cause**. Reporting "N slow queries" during a pool incident points the reader at the wrong layer — the queries aren't slow, they're waiting to start. And the metrics render an em dash rather than a fabricated `0/0` when the admin console is unreachable, per the admin-surface rule that a panel degrades to an honest "no source".

## Verified against the live pooler, not just in unit tests

```
signals : {"clientsActive":0,"clientsWaiting":0,"serversActive":0,
           "maxWaitSeconds":0,"maxClientConn":120,"poolSize":20,"live":true}
verdict : {"verdict":"OK","summary":"0/120 clients · 0/20 servers busy"}
```

**That run caught a real bug the unit tests would have missed.** `SHOW POOLS` has no `pool_size` column — it belongs to `SHOW DATABASES` — so the first implementation silently reported a servers-busy denominator of `0`. It now reads `default_pool_size` from `SHOW CONFIG`, and a test pins the absence so it can't creep back:

```
✓ never reports pool_size from SHOW POOLS, which does not have it
```

17 tests, with the `SHOW POOLS` fixture rows captured verbatim from the live pooler — including the columns that don't exist, which is the point of using a real fixture rather than an invented one.

## Limits

The probe reads a live source or reports nothing, but it is **pull-based**: it evaluates when the Database flow is polled. A pool that saturates and recovers between polls is invisible. Making this push-based is the same open question as the debit-path alarm, and belongs with it rather than duplicated here.

Under a transaction-mode pooler the thresholds still apply, but the client/server ratio means very different things — this is tuned for the session mode production actually runs, confirmed on the running daemon rather than read off the declared variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
