### PR TITLE
feat(observability): measure the debit path directly, and watch the yield cron

### DIFF
--- a/src/__tests__/economy/syncDebitInstrumentation.test.ts
+++ b/src/__tests__/economy/syncDebitInstrumentation.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @jest-environment node
+ *
+ * sync-debit must leave a DURABLE record that it was called.
+ *
+ * The liveness check for this endpoint asks "are agents calling while nothing
+ * is landing?". The calling half used to be proxied by agent-authored
+ * feed_events, because sync-debit requests were persisted nowhere — so the
+ * check could not tell "sync-debit is broken" apart from "the producer stopped
+ * calling sync-debit but kept posting feed events".
+ *
+ * Recording STATUS is what makes the outage legible: 1,349 calls/day at 100%
+ * HTTP 500 is unmistakable in request_log_entries, and was invisible without
+ * it. `/api/admin/observability` could not have shown it either — that ring is
+ * in-memory and resets on every Vercel cold start.
+ */
+
+const recordRequest = jest.fn();
+const executeQuery = jest.fn();
+
+jest.mock("@/lib/observability/requestLog", () => ({
+  recordRequest: (...args: unknown[]) => recordRequest(...args),
+}));
+jest.mock("@/lib/database", () => ({
+  executeQuery: (sql: string, params: unknown[] = [], options = {}) =>
+    executeQuery(sql, params, options),
+  withTransaction: (op: (c: unknown) => Promise<unknown>) =>
+    op({ query: (sql: string, params: unknown[]) => executeQuery(sql, params, {}) }),
+}));
+jest.mock("@/utils/agentMonicaResolver", () => ({ agentMonicaWithMethod: () => null }));
+jest.mock("@/utils/fullChartMonica", () => ({
+  normaliseNatalPositions: (v: unknown) => (Array.isArray(v) ? v : []),
+}));
+
+const USER_ID = "11111111-2222-3333-4444-555555555555";
+const SECRET = "test-sync-secret";
+let keySeq = 0;
+
+function wireHappyPath() {
+  executeQuery.mockImplementation(async (sql: string) => {
+    if (/SELECT\s+u\.id/i.test(sql)) return { rows: [{ id: USER_ID, profile_name: "Ada" }] };
+    if (/FROM token_transactions WHERE idempotency_key/i.test(sql)) return { rows: [] };
+    if (/SELECT spirit::text/i.test(sql)) {
+      return { rows: [{ spirit: "100", essence: "100", matter: "100", substance: "100" }] };
+    }
+    if (/UPDATE token_balances/i.test(sql)) {
+      return { rows: [{ spirit: "99", essence: "99", matter: "99", substance: "99" }] };
+    }
+    return { rows: [] };
+  });
+}
+
+async function post(headers: Record<string, string> = {}) {
+  const { POST } = require("@/app/api/economy/sync-debit/route");
+  const req = new Request("https://alchm.kitchen/api/economy/sync-debit", {
+    method: "POST",
+    headers: { "content-type": "application/json", "X-Sync-Secret": SECRET, ...headers },
+    body: JSON.stringify({
+      userEmail: "ada@agents.alchm.kitchen",
+      amounts: { spirit: 1, essence: 1, matter: 1, substance: 1 },
+      idempotencyKey: `instr-${(keySeq += 1)}`,
+    }),
+  });
+  return POST(req as never);
+}
+
+describe("sync-debit — durable call instrumentation", () => {
+  const original = process.env.ALCHM_KITCHEN_SYNC_SECRET;
+
+  beforeEach(() => {
+    process.env.ALCHM_KITCHEN_SYNC_SECRET = SECRET;
+    recordRequest.mockReset();
+    executeQuery.mockReset();
+    jest.resetModules();
+  });
+
+  afterAll(() => {
+    if (original === undefined) delete process.env.ALCHM_KITCHEN_SYNC_SECRET;
+    else process.env.ALCHM_KITCHEN_SYNC_SECRET = original;
+  });
+
+  it("records the call under a stable route name", async () => {
+    wireHappyPath();
+    const res = await post();
+    expect(res.status).toBe(200);
+
+    // Recording is fire-and-forget off the hot path; let the microtask run.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(recordRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "/api/economy/sync-debit", method: "POST", status: 200 }),
+    );
+  });
+
+  it("records the STATUS, so a route that only ever 500s is visible", async () => {
+    // The whole point. A path returning 1,349×500 and zero 200s is a dead
+    // endpoint, and this table is where that becomes greppable.
+    executeQuery.mockImplementation(async () => {
+      throw new Error("invalid input syntax for type boolean");
+    });
+    const res = await post();
+    expect(res.status).toBe(500);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(recordRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "/api/economy/sync-debit", status: 500 }),
+    );
+  });
+
+  it("records rejected calls too — auth failures are traffic", async () => {
+    // An authentication regression on the producer side looks like silence in
+    // the ledger. It must not also look like silence in the traffic signal.
+    wireHappyPath();
+    const res = await post({ "X-Sync-Secret": "wrong" });
+    expect(res.status).toBeGreaterThanOrEqual(400);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(recordRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "/api/economy/sync-debit" }),
+    );
+  });
+
+  it("does not attempt user resolution on a machine-to-machine call", async () => {
+    // skipUserResolution avoids a database round-trip per call that could only
+    // ever return null — there is no session cookie, only X-Sync-Secret.
+    wireHappyPath();
+    await post();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(recordRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: null }),
+    );
+  });
+});

--- a/src/app/api/economy/sync-debit/route.ts
+++ b/src/app/api/economy/sync-debit/route.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import { NextResponse, type NextRequest } from "next/server";
 import { executeQuery, withTransaction } from "@/lib/database";
+import { withObservability } from "@/lib/observability/withObservability";
 import { agentMonicaWithMethod } from "@/utils/agentMonicaResolver";
 import { normaliseNatalPositions } from "@/utils/fullChartMonica";
 
@@ -57,7 +58,7 @@ interface SyncDebitBody {
   metadata?: Record<string, unknown>;
 }
 
-export async function POST(req: NextRequest) {
+async function handlePost(req: NextRequest) {
   const authHeader = req.headers.get("X-Sync-Secret");
   const syncSecret = process.env.ALCHM_KITCHEN_SYNC_SECRET;
   if (!syncSecret || authHeader !== syncSecret) {
@@ -507,3 +508,27 @@ export async function POST(req: NextRequest) {
     );
   }
 }
+
+/**
+ * Instrumented so the debit path has a DURABLE record of being called.
+ *
+ * The liveness check for this endpoint (agentDebitPathHealth) has to answer
+ * "are agents calling while nothing is landing?". Until now the calling half
+ * was proxied by agent-authored feed_events, because sync-debit requests were
+ * persisted nowhere — so the check could not distinguish "sync-debit is broken"
+ * from "the producer stopped calling sync-debit but kept posting feed events".
+ * request_log_entries makes the traffic signal measure the thing it is about.
+ *
+ * It also matters that STATUS is recorded: the outage was 1,349 calls/day at
+ * 100% HTTP 500, which is unmistakable in this table and was invisible without
+ * it. `/api/admin/observability` could not have shown it either — that ring is
+ * in-memory and resets on every Vercel cold start.
+ *
+ * skipUserResolution: this is a machine-to-machine endpoint authenticated by
+ * X-Sync-Secret, with no session cookie to resolve. Attempting resolution would
+ * spend a database round-trip per call to always return null.
+ */
+export const POST = withObservability(
+  { routeName: "/api/economy/sync-debit", skipUserResolution: true },
+  handlePost,
+);

--- a/src/lib/observability/withObservability.ts
+++ b/src/lib/observability/withObservability.ts
@@ -21,7 +21,6 @@
  */
 
 import { NextResponse, type NextRequest } from "next/server";
-import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
 import { extractClientIp, hashIp } from "./hashIp";
 import { recordRequest } from "./requestLog";
 
@@ -125,6 +124,12 @@ async function resolveAndRecord(opts: ResolveAndRecordOpts): Promise<void> {
   let ipHashed: string | null = null;
   try {
     if (!opts.skipUserResolution) {
+      // Imported lazily so routes that skip user resolution never load the
+      // auth chain at all. `validateRequest` pulls in `jose`, which is
+      // ESM-only — a static import drags it into every instrumented route,
+      // including machine-to-machine endpoints that authenticate by shared
+      // secret and can never have a user to resolve.
+      const { getUserIdFromRequest } = await import("@/lib/auth/validateRequest");
       userId = await getUserIdFromRequest(opts.request);
     }
     const ip = extractClientIp(opts.request.headers);

--- a/src/services/__tests__/cronLedgerHealth.test.ts
+++ b/src/services/__tests__/cronLedgerHealth.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment node
+ *
+ * Liveness for the daily agents_yield cron.
+ *
+ * The interesting claim is not that a threshold works — it is that the OBVIOUS
+ * check cannot work here. `agents_yield` has two writers: the daily cron and a
+ * scattered ad-hoc writer that lands 8-20 times a day. So "hours since the last
+ * yield row" never goes stale, and a staleness alarm would sit green through a
+ * completely dead cron.
+ */
+
+import {
+  classifyCronLedgerPath,
+  MIN_CRON_BATCH,
+  type CronLedgerSignals,
+} from "@/services/cronLedgerHealth";
+
+const healthy: CronLedgerSignals = {
+  biggestBatch24h: 29,
+  eligibleProducers: 30,
+  live: true,
+};
+
+describe("classifyCronLedgerPath", () => {
+  it("reports OK when the daily batch landed", () => {
+    const r = classifyCronLedgerPath(healthy);
+    expect(r.verdict).toBe("OK");
+    expect(r.summary).toMatch(/29 agents/);
+  });
+
+  it("raises INCIDENT when only the ad-hoc writer is active", () => {
+    // The exact shape of a dead cron: yield rows still arrive, but never as a
+    // batch. This is what a staleness check cannot see.
+    const r = classifyCronLedgerPath({ ...healthy, biggestBatch24h: 2 });
+    expect(r.verdict).toBe("INCIDENT");
+    expect(r.summary).toMatch(/has not run/);
+  });
+
+  it("raises INCIDENT when nothing was written at all", () => {
+    expect(classifyCronLedgerPath({ ...healthy, biggestBatch24h: 0 }).verdict).toBe("INCIDENT");
+  });
+
+  it("stays IDLE when no agent is eligible — silence is not breakage", () => {
+    expect(
+      classifyCronLedgerPath({ ...healthy, eligibleProducers: 0, biggestBatch24h: 0 }).verdict,
+    ).toBe("IDLE");
+  });
+
+  it("reports UNKNOWN rather than green when the query failed", () => {
+    const r = classifyCronLedgerPath({ ...healthy, live: false });
+    expect(r.verdict).toBe("UNKNOWN");
+    expect(r.summary).toMatch(/No source/);
+  });
+
+  describe("back-test against 21 days of real history", () => {
+    // (day, largest single-minute batch) measured from production. The ad-hoc
+    // writer contributed 8-20 separate write instants on every one of these
+    // days, never exceeding 2 agents each.
+    const HISTORY: Array<[string, number]> = [
+      ["2026-08-08", 29], ["2026-08-07", 29], ["2026-08-06", 29], ["2026-08-05", 29],
+      ["2026-08-04", 29], ["2026-08-03", 29], ["2026-08-02", 29], ["2026-08-01", 29],
+      ["2026-07-31", 29], ["2026-07-30", 29], ["2026-07-29", 29], ["2026-07-28", 29],
+      ["2026-07-27", 29], ["2026-07-26", 29], ["2026-07-25", 29], ["2026-07-24", 29],
+      ["2026-07-23", 29], ["2026-07-22", 30], ["2026-07-21", 30], ["2026-07-20", 30],
+      ["2026-07-19", 56],
+    ];
+
+    it("is silent on every one of the 21 healthy days", () => {
+      const verdicts = HISTORY.map(([, batch]) =>
+        classifyCronLedgerPath({ ...healthy, biggestBatch24h: batch }).verdict,
+      );
+      expect(verdicts).toHaveLength(21);
+      expect(verdicts.every((v) => v === "OK")).toBe(true);
+    });
+
+    it("keeps a wide margin — the threshold is a gap, not a tuned edge", () => {
+      // Healthy floor 29, ad-hoc ceiling 2. A threshold anywhere between is
+      // correct, which is what makes this robust rather than calibrated.
+      const healthyFloor = Math.min(...HISTORY.map(([, b]) => b));
+      const adHocCeiling = 2;
+      expect(MIN_CRON_BATCH).toBeGreaterThan(adHocCeiling);
+      expect(MIN_CRON_BATCH).toBeLessThan(healthyFloor);
+      expect(healthyFloor / adHocCeiling).toBeGreaterThan(10);
+    });
+
+    it("would fire the day the cron stopped, with the ad-hoc writer still active", () => {
+      // Simulated dead cron on an otherwise normal day.
+      expect(classifyCronLedgerPath({ ...healthy, biggestBatch24h: 2 }).verdict).toBe("INCIDENT");
+    });
+  });
+});

--- a/src/services/__tests__/debitPathTrafficSource.test.ts
+++ b/src/services/__tests__/debitPathTrafficSource.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment node
+ *
+ * Which measurement the debit-path check uses for "the producer is alive".
+ *
+ * The real signal is the sync-debit call count in request_log_entries. The
+ * older feed-event proxy is retained as a FALLBACK, and that fallback is
+ * load-bearing rather than defensive: request_log_entries began covering this
+ * route only when instrumentation shipped, and keeps 7 days. A hard switch
+ * would report zero traffic on a perfectly healthy system, drop the check to
+ * IDLE, and stop alarming — a regression indistinguishable from success, which
+ * is the exact failure this whole check exists to prevent.
+ */
+
+const executeQuery = jest.fn();
+
+jest.mock("@/lib/database/connection", () => ({
+  executeQuery: (...args: unknown[]) => executeQuery(...args),
+}));
+jest.mock("@/lib/logger", () => ({ _logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn() } }));
+
+import {
+  fetchDebitPathSignals,
+  classifyDebitPath,
+} from "@/services/agentDebitPathHealth";
+
+function rowsFrom(calls: number, feed: number, debits: number) {
+  executeQuery.mockResolvedValue({
+    rows: [{ calls_24h: calls, traffic_24h: feed, debits_24h: debits, last_debit_age_ms: 60_000 }],
+  });
+}
+
+describe("debit-path traffic source", () => {
+  beforeEach(() => executeQuery.mockReset());
+
+  it("uses the real call count once the request log has data", async () => {
+    rowsFrom(1349, 412, 143);
+    const s = await fetchDebitPathSignals();
+    expect(s.trafficSource).toBe("sync-debit-calls");
+    expect(s.agentTraffic24h).toBe(1349);
+  });
+
+  it("falls back to feed events when the route has no call history yet", async () => {
+    // The state immediately after deploy. Reporting 0 here would read as IDLE
+    // on a live system and silence the alarm.
+    rowsFrom(0, 412, 143);
+    const s = await fetchDebitPathSignals();
+    expect(s.trafficSource).toBe("agent-feed-events");
+    expect(s.agentTraffic24h).toBe(412);
+  });
+
+  it("does not go IDLE just because the call count is empty", async () => {
+    // The regression the fallback exists to prevent, stated as a verdict.
+    rowsFrom(0, 307, 0);
+    const s = await fetchDebitPathSignals();
+    expect(classifyDebitPath(s).verdict).toBe("INCIDENT");
+  });
+
+  it("still reports IDLE when BOTH signals are quiet", async () => {
+    rowsFrom(0, 0, 0);
+    const s = await fetchDebitPathSignals();
+    expect(classifyDebitPath(s).verdict).toBe("IDLE");
+  });
+
+  it("reports no source rather than a verdict when the query fails", async () => {
+    executeQuery.mockRejectedValue(new Error("relation does not exist"));
+    const s = await fetchDebitPathSignals();
+    expect(s.live).toBe(false);
+    expect(classifyDebitPath(s).verdict).toBe("UNKNOWN");
+  });
+
+  describe("the summary names the measurement it used", () => {
+    it("says 'sync-debit calls' when that is what was counted", () => {
+      const r = classifyDebitPath({
+        agentTraffic24h: 1349, trafficSource: "sync-debit-calls",
+        debits24h: 0, lastDebitAgeMs: null, live: true,
+      });
+      expect(r.summary).toMatch(/1349 sync-debit calls/);
+    });
+
+    it("says 'agent events' when falling back", () => {
+      // The two can legitimately disagree; naming the wrong one sends the next
+      // reader to the wrong table.
+      const r = classifyDebitPath({
+        agentTraffic24h: 412, trafficSource: "agent-feed-events",
+        debits24h: 0, lastDebitAgeMs: null, live: true,
+      });
+      expect(r.summary).toMatch(/412 agent events/);
+    });
+  });
+});

--- a/src/services/agentDebitPathHealth.ts
+++ b/src/services/agentDebitPathHealth.ts
@@ -33,9 +33,23 @@ import { _logger } from "@/lib/logger";
 /** OK = debits landing · IDLE = no traffic, nothing expected · INCIDENT = traffic without debits. */
 export type DebitPathVerdict = "OK" | "IDLE" | "INCIDENT" | "UNKNOWN";
 
+/**
+ * Where the "producer is alive" half came from.
+ *
+ * `sync-debit-calls` is the real thing: durable, per-request, status-bearing.
+ * `agent-feed-events` is the proxy this check launched with, kept as a fallback
+ * because request_log_entries only began covering this route when instrumentation
+ * shipped, and its retention is 7 days. Switching outright would make the check
+ * read zero traffic on a healthy system and silently downgrade itself to IDLE —
+ * a regression that looks exactly like success.
+ */
+export type TrafficSource = "sync-debit-calls" | "agent-feed-events";
+
 export interface DebitPathSignals {
-  /** Agent-authored feed events in the last 24h — evidence the producer is alive. */
+  /** Calls (or agent feed events — see trafficSource) in 24h; the producer-alive half. */
   agentTraffic24h: number;
+  /** Which measurement the traffic figure came from. */
+  trafficSource?: TrafficSource;
   /** `agents_operation` ledger rows in the last 24h — evidence debits are landing. */
   debits24h: number;
   /** Age of the most recent debit, ms. Null when the ledger has never been written. */
@@ -65,6 +79,12 @@ export function classifyDebitPath(signals: DebitPathSignals): DebitPathHealth {
     return { verdict: "IDLE", summary: "No agent traffic in 24h — no debits expected" };
   }
 
+  // Name the measurement in the summary. Reading "412 agent events" when the
+  // figure is actually sync-debit calls would send the next reader to the wrong
+  // table, and the two can legitimately disagree.
+  const unit =
+    signals.trafficSource === "sync-debit-calls" ? "sync-debit calls" : "agent events";
+
   if (debits24h <= 0) {
     const age =
       lastDebitAgeMs === null
@@ -73,12 +93,12 @@ export function classifyDebitPath(signals: DebitPathSignals): DebitPathHealth {
     return {
       verdict: "INCIDENT",
       summary:
-        `${agentTraffic24h} agent events in 24h but ZERO debits landed ` +
+        `${agentTraffic24h} ${unit} in 24h but ZERO debits landed ` +
         `(last debit ${age}) — sync-debit is failing silently`,
     };
   }
 
-  return { verdict: "OK", summary: `${debits24h} debits · ${agentTraffic24h} agent events 24h` };
+  return { verdict: "OK", summary: `${debits24h} debits · ${agentTraffic24h} ${unit} 24h` };
 }
 
 /**
@@ -88,11 +108,16 @@ export function classifyDebitPath(signals: DebitPathSignals): DebitPathHealth {
 export async function fetchDebitPathSignals(): Promise<DebitPathSignals> {
   try {
     const result = await executeQuery<{
+      calls_24h: number;
       traffic_24h: number;
       debits_24h: number;
       last_debit_age_ms: number | null;
     }>(
       `SELECT
+         (SELECT COUNT(*)::int
+            FROM request_log_entries
+           WHERE path = '/api/economy/sync-debit'
+             AND at > NOW() - INTERVAL '24 hours') AS calls_24h,
          (SELECT COUNT(*)::int
             FROM feed_events f
             JOIN users u ON f.actor_id = u.id
@@ -107,14 +132,28 @@ export async function fetchDebitPathSignals(): Promise<DebitPathSignals> {
            WHERE source_type = 'agents_operation') AS last_debit_age_ms`,
     );
     const row = result.rows[0];
+    // Prefer the real call count; fall back to the feed-event proxy while the
+    // request log has nothing for this route. The fallback is not belt-and-
+    // braces — request_log_entries began covering sync-debit only when
+    // instrumentation shipped and keeps 7 days, so a hard switch would report
+    // zero traffic on a perfectly healthy system and quietly go IDLE.
+    const calls = row?.calls_24h ?? 0;
+    const useCalls = calls > 0;
     return {
-      agentTraffic24h: row?.traffic_24h ?? 0,
+      agentTraffic24h: useCalls ? calls : (row?.traffic_24h ?? 0),
+      trafficSource: useCalls ? "sync-debit-calls" : "agent-feed-events",
       debits24h: row?.debits_24h ?? 0,
       lastDebitAgeMs: row?.last_debit_age_ms ?? null,
       live: true,
     };
   } catch (err) {
     _logger.warn("[systemStatus] debit-path liveness query failed:", err);
-    return { agentTraffic24h: 0, debits24h: 0, lastDebitAgeMs: null, live: false };
+    return {
+      agentTraffic24h: 0,
+      trafficSource: "agent-feed-events",
+      debits24h: 0,
+      lastDebitAgeMs: null,
+      live: false,
+    };
   }
 }

--- a/src/services/cronLedgerHealth.ts
+++ b/src/services/cronLedgerHealth.ts
@@ -1,0 +1,129 @@
+/**
+ * Liveness for ledger sources written by a SCHEDULED job.
+ *
+ * WHY ONLY ONE SOURCE IS COVERED HERE
+ * -----------------------------------
+ * `token_transactions` has 13 `source_type` values. Most cannot be watched
+ * honestly, and pretending otherwise is how a monitor becomes noise:
+ *
+ *   agents_operation   already covered — agentDebitPathHealth
+ *   agents_yield       COVERED HERE — daily cron with a DECLARED schedule
+ *   initial_grant,
+ *   signup_grant       producer is human signups: 14 in six months, and 0 in
+ *                      some months. Silence is indistinguishable from "nobody
+ *                      signed up", so no threshold can be meaningful.
+ *   premium_purchase   one paying user; same sparsity problem
+ *   daily_yield,
+ *   practice_reward    user-action driven with no independent liveness signal
+ *   admin              manual by definition
+ *   quest_reward       dormant by design — there is no quest UI
+ *   onchain_claim,
+ *   transit_attunement testnet / feature-flagged, dormant
+ *   test,
+ *   planetary_agents_test  fixtures
+ *
+ * A source qualifies only when something OTHER than the ledger itself says a
+ * write was owed. For a cron that is its declared schedule — known a priori
+ * from vercel.json, not inferred from the table's own history. That distinction
+ * matters: inferring cadence from history is precisely the design that flagged
+ * 9 of 13 sources when this approach was first tried.
+ *
+ * WHY A BATCH, NOT A TIMESTAMP
+ * ----------------------------
+ * `agents_yield` has TWO writers: the daily cron (`30 0 * * *`, one large batch)
+ * and scattered ad-hoc writes. Measured over 21 days, the ad-hoc writes land
+ * 8-20 times a day at 1-2 agents each — so "hours since the last yield row"
+ * NEVER goes stale, and a staleness check could not detect a dead cron at all.
+ *
+ * The batch is what must be observed. Back-test over 21 days: the largest
+ * single-minute batch was 29-30 agents every single day (56 once), while ad-hoc
+ * writes never exceeded 2. A threshold of 10 sits in that gap with a wide
+ * margin and needs no calibration.
+ */
+
+import { executeQuery } from "@/lib/database/connection";
+import { _logger } from "@/lib/logger";
+
+export type CronLedgerVerdict = "OK" | "IDLE" | "INCIDENT" | "UNKNOWN";
+
+export interface CronLedgerSignals {
+  /** Largest number of distinct users credited within one minute in 24h. */
+  biggestBatch24h: number;
+  /** Users who could have been credited. Zero means nothing was owed. */
+  eligibleProducers: number;
+  /** False when the query failed — never fabricate a verdict from missing data. */
+  live: boolean;
+}
+
+export interface CronLedgerHealth {
+  verdict: CronLedgerVerdict;
+  summary: string;
+}
+
+/**
+ * Minimum distinct users in one minute to count as a cron batch.
+ *
+ * Measured: healthy runs credit 29-30 agents; the ad-hoc writer never exceeds
+ * 2. Anywhere in between works — this is a gap, not a tuned edge.
+ */
+export const MIN_CRON_BATCH = 10;
+
+/** Pure classifier, free of database imports so it can be tested directly. */
+export function classifyCronLedgerPath(signals: CronLedgerSignals): CronLedgerHealth {
+  const { biggestBatch24h, eligibleProducers, live } = signals;
+
+  if (!live) {
+    return { verdict: "UNKNOWN", summary: "No source — yield-path query failed" };
+  }
+  if (eligibleProducers <= 0) {
+    return { verdict: "IDLE", summary: "No agents eligible for yield — none expected" };
+  }
+  if (biggestBatch24h < MIN_CRON_BATCH) {
+    return {
+      verdict: "INCIDENT",
+      summary:
+        `${eligibleProducers} agents eligible but the largest yield batch in 24h ` +
+        `credited only ${biggestBatch24h} — the daily yield cron has not run`,
+    };
+  }
+  return {
+    verdict: "OK",
+    summary: `daily yield batch credited ${biggestBatch24h} agents · ${eligibleProducers} eligible`,
+  };
+}
+
+/**
+ * Reads the batch signal. Degrades to `live: false` rather than throwing.
+ */
+export async function fetchCronLedgerSignals(): Promise<CronLedgerSignals> {
+  try {
+    const result = await executeQuery<{
+      biggest_batch: number;
+      eligible: number;
+    }>(
+      `SELECT
+         COALESCE((
+           SELECT MAX(agents) FROM (
+             SELECT COUNT(DISTINCT user_id)::int AS agents
+               FROM token_transactions
+              WHERE source_type = 'agents_yield'
+                AND created_at > NOW() - INTERVAL '24 hours'
+              GROUP BY date_trunc('minute', created_at)
+           ) runs
+         ), 0)::int AS biggest_batch,
+         (SELECT COUNT(DISTINCT user_id)::int
+            FROM token_transactions
+           WHERE source_type = 'agents_yield'
+             AND created_at > NOW() - INTERVAL '7 days') AS eligible`,
+    );
+    const row = result.rows[0];
+    return {
+      biggestBatch24h: row?.biggest_batch ?? 0,
+      eligibleProducers: row?.eligible ?? 0,
+      live: true,
+    };
+  } catch (err) {
+    _logger.warn("[systemStatus] cron-ledger liveness query failed:", err);
+    return { biggestBatch24h: 0, eligibleProducers: 0, live: false };
+  }
+}

--- a/src/services/systemStatusService.ts
+++ b/src/services/systemStatusService.ts
@@ -31,6 +31,10 @@ import {
   fetchDebitPathSignals,
 } from "@/services/agentDebitPathHealth";
 import { getEventCounts } from "@/services/authEventsService";
+import {
+  classifyCronLedgerPath,
+  fetchCronLedgerSignals,
+} from "@/services/cronLedgerHealth";
 import { feedEmitTracker } from "@/services/feedEmitTracker";
 import { getMcpNetworkSummary } from "@/services/mcpNetworkService";
 import {
@@ -684,6 +688,13 @@ async function probeTokenEconomy(): Promise<FlowHealth> {
     live = false;
   }
 
+  // Daily yield cron liveness. `txns24h` above cannot see this: agents_yield
+  // has a second, ad-hoc writer that lands 8-20 times a day, so the ledger
+  // never looks stale even when the cron is completely dead. Only the BATCH
+  // shape distinguishes them — see cronLedgerHealth.
+  const yieldSignals = await fetchCronLedgerSignals();
+  const yieldHealth = classifyCronLedgerPath(yieldSignals);
+
   const pathStatus = statusFromPathHealth(economy, {
     warnErrorRate: 0.1,
     warnP95Ms: 1000,
@@ -692,13 +703,16 @@ async function probeTokenEconomy(): Promise<FlowHealth> {
 
   let status: FlowStatus;
   if (!live && pathStatus === "UNKNOWN") status = "UNKNOWN";
-  else if (pathStatus === "INCIDENT") status = "INCIDENT";
+  else if (pathStatus === "INCIDENT" || yieldHealth.verdict === "INCIDENT") status = "INCIDENT";
   else if (pathStatus === "DEGRADED") status = "DEGRADED";
   else status = "OK";
 
   const issues: FlowIssue[] = [];
   const econIssue = issueFromFailure(economy, "economy");
   if (econIssue) issues.push(econIssue);
+  if (yieldHealth.verdict === "INCIDENT") {
+    issues.push({ at: checkedAt, message: yieldHealth.summary, severity: "error" });
+  }
 
   return {
     id: "economy",
@@ -712,10 +726,21 @@ async function probeTokenEconomy(): Promise<FlowHealth> {
         : status === "DEGRADED"
           ? `Economy endpoints slow or partially failing`
           : status === "INCIDENT"
-            ? `/api/economy failing (${formatPct(economy.errorRate)})`
+            ? // Name the yield cron when it is the cause. Reporting an
+              // /api/economy error rate during a dead-cron incident points the
+              // reader at a healthy endpoint.
+              yieldHealth.verdict === "INCIDENT" && pathStatus !== "INCIDENT"
+              ? yieldHealth.summary
+              : `/api/economy failing (${formatPct(economy.errorRate)})`
             : "Awaiting signals",
     metrics: [
       { label: "Txns · 24h", value: `${txns24h}`, raw: txns24h },
+      {
+        label: "Yield batch · 24h",
+        // An em dash rather than a fabricated 0 when there is no source.
+        value: yieldSignals.live ? `${yieldSignals.biggestBatch24h}` : "—",
+        raw: yieldSignals.live ? yieldSignals.biggestBatch24h : 0,
+      },
       {
         label: "In circulation",
         value: inCirculation.toLocaleString(undefined, { maximumFractionDigits: 0 }),


### PR DESCRIPTION
Two follow-ons to #734, both about measuring the thing instead of a proxy.

## 1 · sync-debit calls are now persisted

The debit-path check asks *"are agents calling while nothing is landing?"* — but the **calling** half was proxied by agent-authored `feed_events`, because sync-debit requests were persisted nowhere. That proxy can't tell "sync-debit is broken" apart from "the producer stopped calling sync-debit but kept posting feed events".

The route is now wrapped in `withObservability`, so calls land in `request_log_entries` **with their status**. `1,349/day at 100% HTTP 500` is unmistakable in that table, and was invisible without it. (`/api/admin/observability` couldn't have shown it either — that ring is in-memory and resets on every cold start.)

**The fallback is load-bearing, not defensive.** `request_log_entries` began covering this route only when this ships, and retention is 7 days. A hard switch would read zero traffic on a perfectly healthy system, drop the check to `IDLE`, and stop alarming — a regression indistinguishable from success, which is the exact failure this check exists to prevent. So the check prefers the real call count and falls back to feed events, and a test pins it:

```
✓ uses the real call count once the request log has data
✓ falls back to feed events when the route has no call history yet
✓ does not go IDLE just because the call count is empty
✓ still reports IDLE when BOTH signals are quiet
```

The summary also names which measurement it used — the two can legitimately disagree, and naming the wrong one sends the next reader to the wrong table.

Incidentally: `withObservability` now imports the auth chain lazily. It pulls in `jose` (ESM-only), and routes passing `skipUserResolution` never call it — a static import dragged a heavy dependency into every machine-to-machine endpoint that authenticates by shared secret and can never have a user to resolve.

## 2 · The daily yield cron is now watched

Of 13 ledger `source_type` values, **only `agents_yield` qualified**. A source is watchable only when something *other than the ledger* says a write was owed. For a cron that's its **declared schedule**, known a priori from `vercel.json` — not inferred from the table's own history. That distinction is the whole point: inferring cadence is what flagged 9 of 13 sources when this approach was first tried.

Every exclusion is documented in the module with its reason. The notable ones:

| Source | Why not |
|---|---|
| `initial_grant`, `signup_grant` | producer is human signups — **14 in six months**, zero in some months. Silence is indistinguishable from nobody signing up. |
| `premium_purchase` | one paying user |
| `quest_reward` | dormant by design — there is no quest UI |
| `onchain_claim`, `transit_attunement` | testnet / feature-flagged |

**The obvious check would not have worked.** `agents_yield` has *two* writers — the daily cron and an ad-hoc writer landing 8–20 times a day — so "hours since the last yield row" never goes stale and would sit green through a completely dead cron. The **batch** is the only usable signal.

Back-tested over 21 days:

| | |
|---|---|
| Largest single-minute batch, every day | **29–30** (56 once) |
| Ad-hoc writes | 1–2 agents each, 8–20 times daily |

A threshold of 10 sits in that gap. It's a gap, not a tuned edge — a test asserts the healthy floor is >10× the ad-hoc ceiling, so this can't silently become fragile.

## Verified live before wiring

```
yield : {"biggestBatch24h":29,"eligibleProducers":73,"live":true}
        -> OK  "daily yield batch credited 29 agents · 73 eligible"
```

Matches the back-test exactly. Both flows name the real cause in their summary rather than misattributing — a dead cron should not read as `/api/economy failing`, which is a healthy endpoint.

## Also found, not fixed here

**6 of the 14 human signups in the last six months received no grant** (most recently 2026-08-05), despite all having balance rows. That's a real defect in `TokenEconomyService.grantSignupTokens`, but at 14 users over six months it's far too sparse to alarm on — which is why it's reported here rather than built into a detector. Worth a separate look.

19 new tests · 38 suites / 309 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
