### PR TITLE
docs(ops): capture the credential rotation, including what went wrong

### DIFF
--- a/docs/runbooks/rotate-database-credential.md
+++ b/docs/runbooks/rotate-database-credential.md
@@ -1,0 +1,204 @@
+# Runbook — rotating the production Postgres credential
+
+Last executed: **2026-08-08** (successful). This runbook is written from that
+run, including the two things that went wrong.
+
+The database is Railway Postgres, fronted by PgBouncer, consumed by Vercel
+(the Next.js app), three Railway services, and GitHub Actions. The password is
+copied **literally** into most of those places — only Postgres's own
+`PGPASSWORD` / `DATABASE_URL` / `DATABASE_PUBLIC_URL` are `${{...}}` references
+off `POSTGRES_PASSWORD`. So there is no single place to change.
+
+---
+
+## The one rule that matters
+
+**Capture the current password to a file before you touch anything.**
+
+`ALTER USER` needs the *old* password to authenticate. On 2026-08-08 the new
+value was staged into all six Railway variables first — and those variables were
+the only readable copy of the old one. The rotation was locked out of itself.
+
+Production never went down (nothing had redeployed, so running containers still
+held the old value), and recovery only worked because Vercel happened to store
+`POSTGRESQL_PASSWORD` as non-sensitive plaintext. That was luck. `railway ssh`
+needs a registered SSH key, and Postgres stores only a non-reversible SCRAM
+verifier — there is no other way back.
+
+```bash
+railway variables -s Postgres --kv | grep '^POSTGRES_PASSWORD=' | cut -d= -f2- > /tmp/old_pw
+chmod 600 /tmp/old_pw
+```
+
+Use a **file**, not `CUR="$(...)"` — a shell variable evaporates with the shell,
+and this is a multi-step process across several invocations.
+
+Order is always: **capture old → change the role → propagate copies → rebuild.**
+
+---
+
+## 1. Enumerate the surface by value
+
+Never work from a list of services you remember. On 2026-08-08 the guessed list
+was wrong twice.
+
+```bash
+./scripts/find-secret-copies.sh --file /tmp/old_pw
+```
+
+Expected shape of the answer (2026-08-08): **9 Railway variables across 4
+services**, plus whatever is local.
+
+| Service | Variables holding the literal password |
+|---|---|
+| `Postgres` | `POSTGRES_PASSWORD`, `PGPASSWORD`, `DATABASE_URL`, `DATABASE_PUBLIC_URL` |
+| `PgBouncer` | `POSTGRESQL_PASSWORD`, `DATABASE_URL`, `DATABASE_PUBLIC_URL` |
+| `WhatToEatNext` | `DATABASE_URL` |
+| `device-sessions-cleanup` | `DATABASE_URL` |
+
+`device-sessions-cleanup` was on nobody's list. It was found **only** by
+scanning every service's variables for the literal value. `daily-digest-cron`
+and `Redis` are clean — but that is a measured result, not an assumption.
+
+### Two surfaces the scan cannot see
+
+The script reports these as blind spots rather than implying completeness.
+Resolve both by hand.
+
+- **GitHub Actions secrets are write-only.** They cannot be read back, so a
+  by-value scan is impossible. This is the surface that was missed on
+  2026-08-08: `DATABASE_PUBLIC_URL` still held the old password, CI went red on
+  the next push, and the 06:45 and 07:15 scheduled workflows would have failed
+  too. Check `gh secret list` by name against what you rotated.
+- **Vercel "Sensitive" variables pull as `[SENSITIVE]`.** Since 2026-08-08 the
+  password vars are marked Sensitive — better security, but it means a future
+  by-value scan is blind to them. Handle Vercel by **name**.
+
+---
+
+## 2. Change the role
+
+Generate a password with no shell-hostile or URL-hostile characters (`@ : / ? #`
+break DSN parsing):
+
+```bash
+openssl rand -hex 24
+```
+
+Authenticate with the **old** credential and change the role:
+
+```sql
+ALTER USER postgres WITH PASSWORD '<new>';
+```
+
+Verify both directions before going further — new accepted, old rejected:
+
+```
+new password → connects
+old password → 28P01 invalid_password
+```
+
+If the old one still works, the change did not apply. Stop.
+
+---
+
+## 3. Propagate
+
+Stage every copy found in step 1 **without** triggering redeploys, so the
+rotation isn't half-applied across a fleet mid-flight:
+
+```bash
+railway variable set --stdin --skip-deploys --service <svc>
+```
+
+Then Vercel, by name — `DATABASE_URL`, `DATABASE_PUBLIC_URL`,
+`POSTGRES_PASSWORD`, `POSTGRESQL_PASSWORD`.
+
+> **Vercel Sensitive vars are one-way.** `DATABASE_URL` was already Sensitive and
+> therefore unreadable, so overwriting it destroys a value you cannot restore.
+> Reconstruct the DSN from evidence — check which host production's backends
+> actually arrive from — before writing.
+
+Then GitHub:
+
+```bash
+gh secret set DATABASE_PUBLIC_URL
+```
+
+---
+
+## 4. Rebuild — do not use `vercel redeploy`
+
+**Vercel binds environment variables at build time.** `vercel redeploy` reuses
+the *existing build's* env snapshot, so it will happily redeploy the old
+credential and look successful.
+
+Trigger a **git-based** rebuild instead. A no-op commit is enough:
+
+```bash
+git commit --allow-empty -m "chore(deploy): rebuild to pick up the rotated database credential"
+git push origin master
+```
+
+Then redeploy the Railway services (`railway redeploy -s <svc>`), PgBouncer
+last — it is the path everything else depends on.
+
+---
+
+## 5. Verify
+
+```bash
+curl -s https://alchm.kitchen/api/health | jq '.database'
+```
+
+Must read `"healthy"`. `/api/health` memoizes, so also confirm with a route that
+does real database work.
+
+Then re-run the enumeration against the **new** value — it should find the new
+password everywhere the old one was:
+
+```bash
+./scripts/find-secret-copies.sh --file /tmp/new_pw
+```
+
+And confirm CI, which is the step that was missed:
+
+```bash
+gh run list --limit 5
+```
+
+**A zero-result scan is a claim, not a result.** Before trusting one, plant a
+canary and prove the scan can see anything at all:
+
+```bash
+printf 'canary %s\n' "$(cat /tmp/new_pw)" > ./.credcanary.tmp
+./scripts/find-secret-copies.sh --file /tmp/new_pw   # must report it
+rm -f ./.credcanary.tmp
+```
+
+A broken scan and a clean one look identical.
+
+---
+
+## Rollback
+
+If health returns anything other than `"database":"healthy"`, reconstruct the
+direct (non-pooled) DSN, set it as `DATABASE_URL` on Vercel, and trigger a
+git-based rebuild. This bypasses PgBouncer, which is the most likely failure
+point — its `auth_file` userlist is static and does not follow an `ALTER USER`
+automatically.
+
+---
+
+## Where the credential lives now
+
+`.env` at the repo root holds `DATABASE_PUBLIC_URL`. It is gitignored
+(`.gitignore:34` → `.env*`), untracked, and `chmod 600`.
+
+It is deliberately **not** named `DATABASE_URL`: `src/lib/database/config.ts`
+reads `process.env.DATABASE_URL`, so that name would silently point `bun run dev`
+at production.
+
+It exists so the live credential has a readable copy **outside** the variables a
+rotation overwrites — which is exactly what step 0 above needs, and exactly what
+was missing on 2026-08-08.

--- a/scripts/find-secret-copies.sh
+++ b/scripts/find-secret-copies.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# find-secret-copies.sh — enumerate every copy of a secret BY VALUE.
+#
+# Why this exists
+# ---------------
+# On 2026-08-08 the production Postgres password was rotated. The service list
+# you would guess was wrong twice:
+#
+#   * `device-sessions-cleanup` held its own literal copy of the password. It was
+#     on nobody's list and was found ONLY by scanning every service's variables
+#     for the literal value.
+#   * The GitHub Actions secret DATABASE_PUBLIC_URL also held it. That one was
+#     missed, and CI went red on the next push — along with two scheduled
+#     workflows that would have failed silently at 06:45 and 07:15.
+#
+# Railway variables are copied LITERALLY between services far more often than
+# they are referenced with ${{...}}. So enumerate by value, never by memory.
+#
+# Usage
+# -----
+#   ./scripts/find-secret-copies.sh --stdin        # paste/pipe the secret
+#   ./scripts/find-secret-copies.sh --file <path>  # read it from a file
+#
+# The secret is NEVER accepted as an argument: argv is visible to every other
+# process on the machine via `ps`.
+#
+set -uo pipefail
+
+RAILWAY_CALLER="${RAILWAY_CALLER:-script:find-secret-copies}"
+export RAILWAY_CALLER
+
+die() { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+hdr() { printf '\n\033[1m%s\033[0m\n' "$*"; }
+
+SECRET=""
+case "${1:-}" in
+  --stdin)
+    printf 'Paste the secret, then press Enter: ' >&2
+    IFS= read -r SECRET
+    ;;
+  --file)
+    [ -n "${2:-}" ] || die "--file needs a path"
+    [ -f "$2" ] || die "no such file: $2"
+    SECRET="$(cat "$2")"
+    ;;
+  *)
+    die "usage: $0 --stdin | --file <path>   (never pass the secret as an argument)"
+    ;;
+esac
+
+SECRET="${SECRET%$'\n'}"
+[ -n "$SECRET" ] || die "empty secret"
+[ "${#SECRET}" -ge 8 ] || die "refusing to scan for a value under 8 chars — too many false positives"
+
+printf 'Scanning for a %d-character secret (…%s)\n' "${#SECRET}" "${SECRET: -4}"
+
+FOUND=0
+BLIND=0
+
+# ---------------------------------------------------------------------------
+# 1. Railway — every service in the linked project, read by value.
+# ---------------------------------------------------------------------------
+hdr "1. Railway (all services in the linked project)"
+if ! command -v railway >/dev/null 2>&1; then
+  printf '  \033[33mSKIPPED\033[0m — railway CLI not installed. THIS IS A BLIND SPOT.\n'
+  BLIND=$((BLIND + 1))
+else
+  # "serviceName" is the precise key. Do NOT use "name" — that also matches
+  # volumes, environments and the workspace, so you scan phantoms and miss the
+  # point that this list must be COMPLETE.
+  SERVICES="$(railway status --json 2>/dev/null \
+    | grep -oE '"serviceName"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    | sed -E 's/.*:[[:space:]]*"([^"]*)"/\1/' \
+    | sort -u)"
+
+  printf '  services discovered: %s\n' "$(printf '%s' "$SERVICES" | tr '\n' ' ')"
+
+  if [ -z "$SERVICES" ]; then
+    printf '  \033[33mNo services resolved\033[0m — is the project linked? BLIND SPOT.\n'
+    BLIND=$((BLIND + 1))
+  else
+    while IFS= read -r svc; do
+      [ -n "$svc" ] || continue
+      KV="$(railway variables -s "$svc" --kv 2>/dev/null)" || continue
+      [ -n "$KV" ] || continue
+      HITS="$(printf '%s\n' "$KV" | grep -F -- "$SECRET" | cut -d= -f1)"
+      if [ -n "$HITS" ]; then
+        while IFS= read -r k; do
+          printf '  \033[31mFOUND\033[0m  railway/%s  %s\n' "$svc" "$k"
+          FOUND=$((FOUND + 1))
+        done <<< "$HITS"
+      fi
+    done <<< "$SERVICES"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Vercel — readable vars only. "Sensitive" ones pull as [SENSITIVE].
+# ---------------------------------------------------------------------------
+hdr "2. Vercel (production)"
+if ! command -v vercel >/dev/null 2>&1; then
+  printf '  \033[33mSKIPPED\033[0m — vercel CLI not installed. THIS IS A BLIND SPOT.\n'
+  BLIND=$((BLIND + 1))
+else
+  # -u: reserve a NAME without creating the file. `vercel env pull` prompts to
+  # overwrite an existing path and --yes does not answer that prompt, so a plain
+  # mktemp makes this hang forever with no output.
+  TMP="$(mktemp -u -t vercelenv)"
+  trap 'rm -f "$TMP"' EXIT
+  if vercel env pull "$TMP" --environment=production --yes >/dev/null 2>&1; then
+    HITS="$(grep -F -- "$SECRET" "$TMP" 2>/dev/null | cut -d= -f1)"
+    if [ -n "$HITS" ]; then
+      while IFS= read -r k; do
+        printf '  \033[31mFOUND\033[0m  vercel/production  %s\n' "$k"
+        FOUND=$((FOUND + 1))
+      done <<< "$HITS"
+    fi
+    # The blind spot that matters: anything marked Sensitive is write-only.
+    SENS="$(grep -c '\[SENSITIVE\]' "$TMP" 2>/dev/null || echo 0)"
+    if [ "$SENS" -gt 0 ]; then
+      printf '  \033[33m%s Vercel var(s) are Sensitive and pull as [SENSITIVE].\033[0m\n' "$SENS"
+      printf '  A by-value scan CANNOT see inside them. Names to check by hand:\n'
+      grep '\[SENSITIVE\]' "$TMP" | cut -d= -f1 | sed 's/^/      /'
+      BLIND=$((BLIND + 1))
+    fi
+  else
+    printf '  \033[33mvercel env pull failed\033[0m — BLIND SPOT.\n'
+    BLIND=$((BLIND + 1))
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. GitHub Actions — values are WRITE-ONLY. By-value scanning is impossible.
+#    This is the surface that broke CI on 2026-08-08.
+# ---------------------------------------------------------------------------
+hdr "3. GitHub Actions secrets"
+printf '  \033[33mGitHub secret values cannot be read back — by-value scanning is\n'
+printf '  IMPOSSIBLE here. This is the surface that was missed on 2026-08-08.\033[0m\n\n'
+if command -v gh >/dev/null 2>&1; then
+  printf '  Repo secrets (check each by NAME against what you just rotated):\n'
+  gh secret list 2>/dev/null | sed 's/^/      /' || printf '      (could not list)\n'
+  printf '\n  Workflows that consume secrets:\n'
+  grep -rl 'secrets\.' .github/workflows 2>/dev/null | sed 's/^/      /' || printf '      (none found)\n'
+else
+  printf '  gh CLI not installed — cannot even list names.\n'
+fi
+BLIND=$((BLIND + 1))
+
+# ---------------------------------------------------------------------------
+# 4. Local working tree — tracked and untracked.
+# ---------------------------------------------------------------------------
+hdr "4. Local repo (tracked + untracked)"
+# Driven by git rather than a recursive walk: `grep -r` over this repo takes
+# minutes (.next is 4.4G, node_modules 3.8G), while git already knows every file
+# that could plausibly be committed. The explicit .env* names are added because
+# those are gitignored — invisible to both ls-files modes — and are exactly
+# where a credential is most likely to sit.
+LOCAL="$( { git ls-files -z 2>/dev/null
+            git ls-files -z --others --exclude-standard 2>/dev/null
+            printf '%s\0' .env .env.local .env.production .env.production.local
+          } | sort -z -u | xargs -0 grep -l -I -F -- "$SECRET" 2>/dev/null )"
+if [ -n "$LOCAL" ]; then
+  while IFS= read -r f; do
+    if git check-ignore -q "$f" 2>/dev/null; then
+      printf '  \033[33mFOUND\033[0m  %s (gitignored)\n' "$f"
+    else
+      printf '  \033[31mFOUND — NOT IGNORED, would reach git!\033[0m  %s\n' "$f"
+    fi
+    FOUND=$((FOUND + 1))
+  done <<< "$LOCAL"
+else
+  printf '  none\n'
+fi
+
+# ---------------------------------------------------------------------------
+# Verdict — an unproven zero is not a zero.
+# ---------------------------------------------------------------------------
+hdr "Verdict"
+printf '  copies found : %d\n' "$FOUND"
+printf '  blind spots  : %d\n' "$BLIND"
+if [ "$FOUND" -eq 0 ]; then
+  cat <<'EOS'
+
+  Zero hits is a CLAIM, not a result. Before trusting it, prove the scan can
+  see anything at all — plant the value somewhere it must be found and re-run:
+
+      printf 'canary %s\n' "$SECRET" > ./.credcanary.tmp
+      ./scripts/find-secret-copies.sh --file <secret-file>   # must report it
+      rm -f ./.credcanary.tmp
+
+  A scan that finds nothing because it is broken looks exactly like a clean one.
+EOS
+fi
+if [ "$BLIND" -gt 0 ]; then
+  printf '\n  \033[33mThis scan was NOT exhaustive. Resolve the blind spots above by hand.\033[0m\n'
+fi


### PR DESCRIPTION
The 2026-08-08 credential rotation worked, but two steps failed first. Both are the kind that repeat, so this writes them down and automates the part that can be automated. **No application code is touched.**

## 1 · Enumerate by value, not by memory

The password is copied **literally** between services — only Postgres's own `PGPASSWORD` / `DATABASE_URL` / `DATABASE_PUBLIC_URL` are `${{…}}` references. So the service list you'd guess is incomplete, and it was wrong twice:

- `device-sessions-cleanup` held its own copy. It was on nobody's list, and was found **only** by scanning every service's variables for the literal value.
- The GitHub Actions secret `DATABASE_PUBLIC_URL` was missed entirely. CI went red on the next push, and two scheduled workflows were set up to fail at 06:45 and 07:15.

`scripts/find-secret-copies.sh` scans Railway (every service in the linked project), Vercel, GitHub and the local repo. **16s end to end.** Verified against the live credential:

```
1. Railway — services discovered: PgBouncer Postgres Redis WhatToEatNext daily-digest-cron device-sessions-cleanup
   FOUND  railway/PgBouncer               DATABASE_PUBLIC_URL, DATABASE_URL, POSTGRESQL_PASSWORD
   FOUND  railway/Postgres                DATABASE_PUBLIC_URL, DATABASE_URL, PGPASSWORD, POSTGRES_PASSWORD
   FOUND  railway/WhatToEatNext           DATABASE_URL
   FOUND  railway/device-sessions-cleanup DATABASE_URL
4. Local repo
   FOUND  .env (gitignored)

   copies found : 10      blind spots : 2
```

Nine Railway variables across four services — matching the rotation surface exactly. `daily-digest-cron` and `Redis` are clean, which is now a *measured* result rather than an assumption.

The secret is never accepted as an argument (argv is world-readable via `ps`) — stdin or a file only.

### It reports what it cannot see

Two surfaces can't be scanned by value **at all**:

| Surface | Why | Handle by |
|---|---|---|
| GitHub Actions secrets | values are write-only, never readable | name |
| Vercel "Sensitive" vars | pull as `[SENSITIVE]` | name |

So the script prints them as **blind spots** and says the scan was not exhaustive, rather than printing a tidy total that implies coverage it doesn't have. A scan that silently can't see half the surface is worse than no scan — it manufactures confidence.

There's a wrinkle worth flagging: marking the Vercel password vars Sensitive during this rotation was a security improvement, but it traded away future scannability. That's the right trade, and it's why the runbook says Vercel is a by-name surface now.

### Zero is a claim, not a result

On a zero result the script prints a canary recipe, because a broken scan and a clean one produce identical output — and the zero is the answer you most want to trust. That wasn't hypothetical here: the first repo scan in this session returned zero **and so did its control**, which meant it had proven nothing. Planting the value and re-running is what made the clean result trustworthy.

The local stage is driven by `git ls-files` rather than `grep -r`: a recursive walk of this repo takes minutes (`.next` is 4.4G, `node_modules` 3.8G), while git already knows every file that could plausibly be committed. Gitignored `.env*` names are added explicitly — invisible to both `ls-files` modes, and exactly where a credential is most likely to sit.

## 2 · Capture the old secret *before* staging the new one

`ALTER USER` needs the old password to authenticate. Staging the new value into all six Railway variables first destroyed the only readable copy of the old one, and locked the rotation out of itself.

Production was never at risk — nothing had redeployed, so running containers still held the old value. But recovery only worked because Vercel happened to store the password as **non-sensitive plaintext**. That was luck, not design: `railway ssh` needs a registered key, and Postgres stores only a non-reversible SCRAM verifier.

The runbook leads with the ordering rule: **capture old → change the role → propagate copies → rebuild.** Capture to a *file*; `CUR="$(…)"` evaporates with the shell, and this spans many invocations.

## 3 · The rebuild trap

Vercel binds environment variables at **build time**, so `vercel redeploy` reuses the old build's snapshot — it will redeploy the stale credential and report success. The rebuild has to be git-based.

## Where the credential lives now

`.env` at the repo root, holding `DATABASE_PUBLIC_URL` — gitignored (`.gitignore:34` → `.env*`, verified rather than assumed), untracked, `chmod 600`, and confirmed to authenticate against production.

Deliberately **not** named `DATABASE_URL`: `src/lib/database/config.ts` reads `process.env.DATABASE_URL`, so that name would silently point `bun run dev` at production.

It exists so the live credential has a readable copy **outside** the variables a rotation overwrites — which is exactly what step 0 needs, and exactly what was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
