### PR TITLE
fix(security): a userId argument is a claim, not identity

### DIFF
--- a/src/__tests__/actions/foodDiaryAuthorization.test.ts
+++ b/src/__tests__/actions/foodDiaryAuthorization.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @jest-environment node
+ *
+ * Authorization on the food-diary Server Actions.
+ *
+ * Server Actions are PUBLIC endpoints — their action ids ship in the client
+ * bundle because `useFoodDiary` imports them — so a `userId` parameter is a
+ * claim from the caller, not identity. Before the guard, every one of these
+ * read and wrote an arbitrary account's diary: `getEntries` turns the argument
+ * straight into `WHERE user_id = $1`, and delete/update accepted it too. It
+ * also routed around `/api/food-diary`, which authenticates properly.
+ *
+ * These tests poison the session getter rather than relying on ambient auth
+ * state, and assert on whether the SERVICE was reached — a thrown error that
+ * still queried the database would be no protection at all.
+ */
+
+// Stable delegates: jest `resetModules` re-runs mock factories per test, so the
+// factories forward to these single instances.
+const mockAuth = jest.fn();
+const mockGetDayEntries = jest.fn();
+const mockDeleteEntry = jest.fn();
+const mockGetQuickFoodPresets = jest.fn();
+const mockSearchFoods = jest.fn();
+
+jest.mock("@/lib/auth/auth", () => ({
+  auth: (...args: unknown[]) => mockAuth(...args),
+}));
+
+jest.mock("@/services/FoodDiaryService", () => ({
+  foodDiaryService: {
+    getDayEntries: (...args: unknown[]) => mockGetDayEntries(...args),
+    deleteEntry: (...args: unknown[]) => mockDeleteEntry(...args),
+    getQuickFoodPresets: (...args: unknown[]) => mockGetQuickFoodPresets(...args),
+    searchFoods: (...args: unknown[]) => mockSearchFoods(...args),
+  },
+}));
+
+jest.mock("@/services/questEventReporter", () => ({
+  reportQuestEventBestEffort: jest.fn(),
+}));
+
+import {
+  getServerDayEntries,
+  deleteServerEntry,
+  searchServerFoods,
+  getServerQuickFoodPresets,
+} from "@/actions/foodDiary";
+
+const OWNER = "11111111-1111-1111-1111-111111111111";
+const VICTIM = "22222222-2222-2222-2222-222222222222";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetDayEntries.mockResolvedValue([{ id: "entry-1" }]);
+  mockDeleteEntry.mockResolvedValue(true);
+  mockGetQuickFoodPresets.mockResolvedValue([{ id: "preset-1" }]);
+  mockSearchFoods.mockResolvedValue([]);
+});
+
+describe("food-diary Server Actions — caller-supplied userId is not identity", () => {
+  it("rejects reading another user's diary, and never reaches the service", async () => {
+    mockAuth.mockResolvedValue({ user: { id: OWNER } });
+
+    await expect(getServerDayEntries(VICTIM, new Date())).rejects.toThrow(
+      /not authorized/i,
+    );
+
+    // The assertion that matters: no query was issued for the victim.
+    expect(mockGetDayEntries).not.toHaveBeenCalled();
+  });
+
+  it("rejects DELETING another user's entry, and never reaches the service", async () => {
+    mockAuth.mockResolvedValue({ user: { id: OWNER } });
+
+    await expect(deleteServerEntry(VICTIM, "entry-1")).rejects.toThrow(
+      /not authorized/i,
+    );
+    expect(mockDeleteEntry).not.toHaveBeenCalled();
+  });
+
+  it("rejects a real user id when there is no session at all", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    await expect(getServerDayEntries(VICTIM, new Date())).rejects.toThrow(
+      /not authorized/i,
+    );
+    expect(mockGetDayEntries).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the session exists but carries no user id", async () => {
+    mockAuth.mockResolvedValue({ user: {} });
+
+    await expect(getServerDayEntries(VICTIM, new Date())).rejects.toThrow(
+      /not authorized/i,
+    );
+    expect(mockGetDayEntries).not.toHaveBeenCalled();
+  });
+
+  it("does not leak whether the target id exists — same message either way", async () => {
+    mockAuth.mockResolvedValue({ user: { id: OWNER } });
+    const a = await getServerDayEntries(VICTIM, new Date()).catch(
+      (e: Error) => e.message,
+    );
+    const b = await getServerDayEntries("no-such-user", new Date()).catch(
+      (e: Error) => e.message,
+    );
+    // Assert they REJECTED before comparing. Comparing the two results alone
+    // passes vacuously if neither throws (both become undefined) — which is
+    // exactly the state this test exists to catch.
+    expect(typeof a).toBe("string");
+    expect(typeof b).toBe("string");
+    expect(a).toBe(b);
+  });
+});
+
+describe("the paths that must keep working", () => {
+  it("allows a user to read their OWN diary", async () => {
+    mockAuth.mockResolvedValue({ user: { id: OWNER } });
+
+    await expect(getServerDayEntries(OWNER, new Date())).resolves.toEqual([
+      { id: "entry-1" },
+    ]);
+    expect(mockGetDayEntries).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows guest mode with no session — signed-out visitors still track food", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    await expect(searchServerFoods("guest", "apple")).resolves.toEqual([]);
+    expect(mockSearchFoods).toHaveBeenCalledWith("guest", "apple");
+    // Guest mode must not even consult the session; it is the signed-out path.
+    expect(mockAuth).not.toHaveBeenCalled();
+  });
+
+  it("leaves the shared preset catalogue unguarded — it is not user data", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    await expect(getServerQuickFoodPresets()).resolves.toEqual([
+      { id: "preset-1" },
+    ]);
+    expect(mockAuth).not.toHaveBeenCalled();
+  });
+});
+
+describe("control — the mocks are actually wired", () => {
+  it("proves the service mock is reachable, so 'not called' means blocked", async () => {
+    // Without this, every `not.toHaveBeenCalled()` above would pass just as
+    // happily against a mock nothing ever imports.
+    mockAuth.mockResolvedValue({ user: { id: OWNER } });
+    await getServerDayEntries(OWNER, new Date());
+    expect(mockGetDayEntries).toHaveBeenCalledTimes(1);
+  });
+
+  it("proves the auth mock is reachable, so session poisoning is real", async () => {
+    mockAuth.mockResolvedValue({ user: { id: OWNER } });
+    await getServerDayEntries(OWNER, new Date());
+    expect(mockAuth).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/actions/foodDiary.ts
+++ b/src/actions/foodDiary.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { auth } from "@/lib/auth/auth";
 import { foodDiaryService } from "@/services/FoodDiaryService";
 import { reportQuestEventBestEffort } from "@/services/questEventReporter";
 import type {
@@ -16,27 +17,68 @@ import {
   type LogFromPlanInput,
 } from "@/utils/foodDiary/logMealFromPlan";
 
+/** The id `useFoodDiary` passes for signed-out visitors. */
+const GUEST_USER_ID = "guest";
+
+/**
+ * Server Actions are public endpoints. Their action ids ship inside the client
+ * bundle (`useFoodDiary` imports these), so anyone who loads the site can invoke
+ * them with arguments of their own choosing. A `userId` PARAMETER is therefore
+ * untrusted input — it is a claim, never identity.
+ *
+ * Without this check these actions read and write an arbitrary account's diary:
+ * `getEntries` turns the argument straight into `WHERE user_id = $1`, and the
+ * write actions (create/update/delete/rate) accept it just as readily. That also
+ * bypasses `/api/food-diary`, which authenticates properly via
+ * `getUserIdFromRequest` — leaving the actions as the way around the front door.
+ *
+ * Guest mode is deliberate and stays open: `useFoodDiary` passes "guest" for
+ * signed-out visitors, and only authenticated users are routed to the REST API
+ * (see the branch at useFoodDiary.ts:142). Anything that is NOT the guest id has
+ * to match the caller's own session.
+ */
+async function requireOwnUserId(userId: string): Promise<string> {
+  if (userId === GUEST_USER_ID) return GUEST_USER_ID;
+
+  const session = await auth();
+  const sessionUserId =
+    typeof session?.user?.id === "string" ? session.user.id : "";
+
+  if (!sessionUserId || sessionUserId !== userId) {
+    // Deliberately does not distinguish "signed out" from "wrong user" — that
+    // difference tells a caller whether a given id exists.
+    throw new Error("Not authorized for this food diary");
+  }
+  return userId;
+}
+
 export async function getServerDayEntries(userId: string, date: Date) {
+  await requireOwnUserId(userId);
   return typeof date === "string" ? foodDiaryService.getDayEntries(userId, new Date(date)) : foodDiaryService.getDayEntries(userId, date);
 }
 
 export async function getServerDailySummary(userId: string, date: Date) {
+  await requireOwnUserId(userId);
   return typeof date === "string" ? foodDiaryService.getDailySummary(userId, new Date(date)) : foodDiaryService.getDailySummary(userId, date);
 }
 
 export async function getServerWeeklySummary(userId: string, date: Date) {
+  await requireOwnUserId(userId);
   return typeof date === "string" ? foodDiaryService.getWeeklySummary(userId, new Date(date)) : foodDiaryService.getWeeklySummary(userId, date);
 }
 
 export async function getServerStats(userId: string) {
+  await requireOwnUserId(userId);
   return foodDiaryService.getStats(userId);
 }
 
 export async function getServerFavorites(userId: string) {
+  await requireOwnUserId(userId);
   return foodDiaryService.getFavorites(userId);
 }
 
 export async function createServerEntry(userId: string, input: CreateFoodDiaryEntryInput) {
+  await requireOwnUserId(userId);
   // Convert date if it became a string during Next.js serialization
   const parsedInput = { ...input };
   if (typeof parsedInput.date === "string") {
@@ -46,17 +88,21 @@ export async function createServerEntry(userId: string, input: CreateFoodDiaryEn
 }
 
 export async function updateServerEntry(userId: string, input: UpdateFoodDiaryEntryInput) {
+  await requireOwnUserId(userId);
   return foodDiaryService.updateEntry(userId, input);
 }
 
 export async function deleteServerEntry(userId: string, entryId: string) {
+  await requireOwnUserId(userId);
   return foodDiaryService.deleteEntry(userId, entryId);
 }
 
 export async function rateServerEntry(userId: string, entryId: string, rating: FoodRating, moodTags?: MoodTag[]) {
+  await requireOwnUserId(userId);
   return foodDiaryService.rateEntry(userId, entryId, rating, moodTags);
 }
 
+// Quick-food presets are a shared catalogue, not user data — no owner to check.
 export async function getServerQuickFoodPreset(presetId: string) {
   return foodDiaryService.getQuickFoodPreset(presetId);
 }
@@ -66,10 +112,12 @@ export async function getServerQuickFoodPresets(category?: QuickFoodCategory) {
 }
 
 export async function searchServerFoods(userId: string, query: string) {
+  await requireOwnUserId(userId);
   return foodDiaryService.searchFoods(userId, query);
 }
 
 export async function addServerToFavorites(userId: string, entryId: string) {
+  await requireOwnUserId(userId);
   return foodDiaryService.addToFavorites(userId, entryId);
 }
 
@@ -77,10 +125,12 @@ export async function removeServerFavorite(
   userId: string,
   favoriteIdOrName: string,
 ) {
+  await requireOwnUserId(userId);
   return foodDiaryService.removeFavorite(userId, favoriteIdOrName);
 }
 
 export async function generateServerInsights(userId: string) {
+  await requireOwnUserId(userId);
   return foodDiaryService.generateInsights(userId);
 }
 
@@ -101,6 +151,7 @@ export async function logServerMealFromPlan(
     notes?: string;
   },
 ) {
+  await requireOwnUserId(userId);
   let payload: LogFromPlanInput;
   if (input.mealSlot) {
     payload = {

--- a/src/app/api/food-diary/search/route.ts
+++ b/src/app/api/food-diary/search/route.ts
@@ -7,6 +7,7 @@
  */
 
 import { NextResponse } from "next/server";
+import { getUserIdFromRequest } from "@/lib/auth/validateRequest";
 import { foodDiaryService } from "@/services/FoodDiaryService";
 import type { QuickFoodCategory } from "@/types/foodDiary";
 import type { NextRequest } from "next/server";
@@ -20,7 +21,7 @@ export const runtime = "nodejs";
  *
  * Query params:
  * - q: string (required, search query)
- * - userId: string (optional, for personalized results)
+ *   (identity is taken from the session — a `userId` query param is ignored)
  * - limit: number (optional, default 20)
  * - category: string (optional, filter by category)
  */
@@ -28,7 +29,11 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const query = searchParams.get("q");
-    const userId = searchParams.get("userId") || "guest";
+    // Identity comes from the session, never the query string. searchFoods()
+    // reads the user's own saved favourites, so a caller-supplied `userId`
+    // returned someone else's. Signed-out callers still search the shared
+    // preset catalogue as "guest" — that half was never user-scoped.
+    const userId = (await getUserIdFromRequest(request)) ?? "guest";
     const limit = parseInt(searchParams.get("limit") || "20", 10);
     const category = searchParams.get("category") as QuickFoodCategory | null;
 

--- a/src/lib/auth/validateRequest.ts
+++ b/src/lib/auth/validateRequest.ts
@@ -276,7 +276,14 @@ export async function validateAdminRequest(
 }
 
 /**
- * Helper to get userId from request (from NextAuth session, token, or query param)
+ * Helper to get userId from request: NextAuth session, then bearer token, then
+ * the agents bridge. Returns null if none identify a user.
+ *
+ * There is deliberately NO query-param fallback. One existed until #632 and was
+ * a live production auth bypass — `?userId=<uuid>` returned that account's data
+ * with no cookie and no header. Do not reintroduce it: `getDatabaseUserFromRequest`
+ * guards the spend paths by calling this function, so a fallback here silently
+ * becomes a fallback for money.
  */
 export async function getUserIdFromRequest(
   request: NextRequest,


### PR DESCRIPTION
You asked me to check `food-diary/search` for cross-user exposure before fixing it. The check found something bigger one layer up.

## The finding

`src/actions/foodDiary.ts` exported **16 Server Actions; 12 took `userId` as their first parameter and did no authorization at all.**

Server Actions are **public endpoints** — their action ids ship in the client bundle, because `useFoodDiary` imports them — so that parameter is caller-controlled input, not identity. `getEntries` turns it straight into `WHERE user_id = $1`.

It was not read-only:

| Action | Effect with an arbitrary `userId` |
|---|---|
| `getServerDayEntries` / `DailySummary` / `WeeklySummary` / `Stats` | read another account's diary |
| `createServerEntry` | **write** into another account |
| `updateServerEntry` / `rateServerEntry` | **modify** another account's entries |
| `deleteServerEntry` | **delete** another account's entries |

It also routed around `/api/food-diary`, which authenticates correctly via `getUserIdFromRequest` — so the actions were the way past the front door.

## What was actually at risk: nothing yet

```
food_diary_entries → 0 rows, 0 distinct users
```

This is a hole closed **before the feature has its first user**, not an incident. Worth saying plainly.

## Scope was measured, not assumed

Only three `"use server"` files exist. `recipes.ts` takes no `userId` (catalogue reads) and `types/indexedRecipe.ts` exports no actions — so `foodDiary.ts` was the entire surface.

I'd also better correct something from my own first pass: I initially reported `recipes.ts` as having an auth call, from a `grep -c "auth"` that was matching the word "**auth**oritative" in a comment. It has none either. The re-run used a precise pattern.

## The fix

`requireOwnUserId()` resolves the session and requires it to match.

- **Guest mode stays open, deliberately.** `useFoodDiary` passes `"guest"` for signed-out visitors and only routes authenticated users to the REST API ([useFoodDiary.ts:142](src/hooks/useFoodDiary.ts:142)). `"guest"` short-circuits before the session is even consulted, so signed-out food tracking is untouched.
- **The shared preset catalogue stays unguarded** — it isn't user data.
- **The error message doesn't distinguish "signed out" from "wrong user"**, since that difference tells a caller whether an id exists.

Smaller, same pattern: `/api/food-diary/search` read `searchParams.get("userId") || "guest"` and handed it to `searchFoods()`, which returns the user's own saved favourites. Identity now comes from the session.

And the doc comment on `getUserIdFromRequest` still advertised *"or query param"* — describing the exact bypass removed in #632. A stale comment documenting a removed security hole is an invitation to restore it, so it now states why there is no fallback and what breaks if one is added.

## Tests: mutation-verified

Removing the guard from a **single** action fails **5 of 10**.

```
✓ rejects reading another user's diary, and never reaches the service
✓ rejects DELETING another user's entry, and never reaches the service
✓ rejects a real user id when there is no session at all
✓ rejects when the session exists but carries no user id
✓ does not leak whether the target id exists — same message either way
✓ allows a user to read their OWN diary
✓ allows guest mode with no session — signed-out visitors still track food
✓ leaves the shared preset catalogue unguarded — it is not user data
✓ control: the service mock is reachable, so 'not called' means blocked
✓ control: the auth mock is reachable, so session poisoning is real
```

They assert **the service was never reached**, not merely that an error was thrown — a rejection that still queried the database is no protection.

One test initially passed *under mutation*: it compared two error messages, and with no throw both were `undefined` and compared equal. Strengthened to assert rejection first, which is what took the mutation score from 4 to 5.

**221 suites / 2,176 tests green. Typecheck clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
