### PR TITLE
feat(admin): add quantum operations control plane

### DIFF
--- a/src/app/admin/_dashboard/Dashboard.tsx
+++ b/src/app/admin/_dashboard/Dashboard.tsx
@@ -3,7 +3,12 @@
 import React from "react";
 import { AgentFeedControlRoom } from "./agents";
 import "./dashboard.css";
-import { PALETTES, type AdminDashboardData, type Density, type PaletteKey } from "./data";
+import {
+  PALETTES,
+  type AdminDashboardData,
+  type Density,
+  type PaletteKey,
+} from "./data";
 import {
   SubdomainMatrix,
   APIHeatmap,
@@ -15,6 +20,7 @@ import {
   DatabaseStorage,
 } from "./extras";
 import { KPIStrip, MasterLineHero } from "./hero";
+import { OperationsControlPlane } from "./OperationsControlPlane";
 import {
   ServiceMatrix,
   LiveEventStream,
@@ -87,11 +93,31 @@ export function Dashboard({ data }: DashboardProps) {
   const cohortFunnel = data.practitionerCohorts.funnel;
   const funnelTop = cohortFunnel.signup || 1;
   const realFunnel = [
-    { stage: "Signup · Google", count: cohortFunnel.signup, pct: cohortFunnel.signup / funnelTop },
-    { stage: "Onboarding · complete", count: cohortFunnel.onboarded, pct: cohortFunnel.onboarded / funnelTop },
-    { stage: "Active · 24h", count: cohortFunnel.active, pct: cohortFunnel.active / funnelTop },
-    { stage: "First cook log", count: cohortFunnel.firstCook, pct: cohortFunnel.firstCook / funnelTop },
-    { stage: "Paid · Pro", count: cohortFunnel.paidPro, pct: cohortFunnel.paidPro / funnelTop },
+    {
+      stage: "Signup · Google",
+      count: cohortFunnel.signup,
+      pct: cohortFunnel.signup / funnelTop,
+    },
+    {
+      stage: "Onboarding · complete",
+      count: cohortFunnel.onboarded,
+      pct: cohortFunnel.onboarded / funnelTop,
+    },
+    {
+      stage: "Active · 24h",
+      count: cohortFunnel.active,
+      pct: cohortFunnel.active / funnelTop,
+    },
+    {
+      stage: "First cook log",
+      count: cohortFunnel.firstCook,
+      pct: cohortFunnel.firstCook / funnelTop,
+    },
+    {
+      stage: "Paid · Pro",
+      count: cohortFunnel.paidPro,
+      pct: cohortFunnel.paidPro / funnelTop,
+    },
   ];
 
   return (
@@ -112,15 +138,25 @@ export function Dashboard({ data }: DashboardProps) {
         `}
       </style>
 
-      <AdminShell density={density} showGrid={showGrid} user={data.user} pulse={data.pulse} data={data}>
-        <MasterLineHero
-          greeting={`Good ${data.skyConditions.planetaryHour.planet} hour, ${data.user.name.split(" ")[0]}`}
-          data={data}
-        />
+      <AdminShell
+        density={density}
+        showGrid={showGrid}
+        user={data.user}
+        pulse={data.pulse}
+        data={data}
+      >
+        <section id="overview" style={{ scrollMarginTop: 70 }}>
+          <MasterLineHero
+            greeting={`Good ${data.skyConditions.planetaryHour.planet} hour, ${data.user.name.split(" ")[0]}`}
+            data={data}
+          />
+        </section>
         <KPIStrip data={data} />
+        <OperationsControlPlane data={data} />
         <SkyConditions data={data.skyConditions} />
 
         <div
+          id="platform-telemetry"
           className="dash-stack"
           style={{
             display: "grid",
@@ -134,9 +170,19 @@ export function Dashboard({ data }: DashboardProps) {
           <LiveEventStream liveActivity={data.liveActivity} />
         </div>
 
-        <AgentFeedControlRoom />
+        <section id="agents" style={{ scrollMarginTop: 70 }}>
+          <AgentFeedControlRoom />
+        </section>
 
-        <div className="dash-stack" style={{ display: "grid", gridTemplateColumns: "1.2fr 1fr", gap: 12, marginBottom: 12 }}>
+        <div
+          className="dash-stack"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1.2fr 1fr",
+            gap: 12,
+            marginBottom: 12,
+          }}
+        >
           <SEMSDistribution />
           <AstronomicalEngine
             live={data.skyConditions.live}
@@ -154,47 +200,85 @@ export function Dashboard({ data }: DashboardProps) {
           }}
         >
           <ElementalTraffic cohorts={data.practitionerCohorts} />
-          <PractitionersCohort realFunnel={realFunnel} retention={data.cohortRetention} />
+          <PractitionersCohort
+            realFunnel={realFunnel}
+            retention={data.cohortRetention}
+          />
           <IncidentsPanel recentAlerts={data.recentAlerts} />
         </div>
 
-        <div className="dash-stack" style={{ display: "grid", gridTemplateColumns: "1fr 1.3fr", gap: 12, marginBottom: 12 }}>
+        <div
+          className="dash-stack"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1.3fr",
+            gap: 12,
+            marginBottom: 12,
+          }}
+        >
           <SubdomainMatrix pageTelemetry={data.pageTelemetry} />
           <APIHeatmap db={data.dbObservability} />
         </div>
 
-        <div className="dash-stack" style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, marginBottom: 12 }}>
-          <EngineHealth enginePerformance={data.enginePerformance} />
+        <div
+          className="dash-stack"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: 12,
+            marginBottom: 12,
+          }}
+        >
+          <section id="engine" style={{ scrollMarginTop: 70 }}>
+            <EngineHealth enginePerformance={data.enginePerformance} />
+          </section>
           <RecipeQualityInspector trending={data.catalogTrending} />
         </div>
 
         <div
+          id="commerce"
           className="dash-stack"
           style={{
             display: "grid",
             gridTemplateColumns: "1fr 0.9fr 1fr",
             gap: 12,
             marginBottom: 12,
+            scrollMarginTop: 70,
           }}
         >
-          <CatalogState realCards={catalogCards} trending={data.catalogTrending} />
+          <CatalogState
+            realCards={catalogCards}
+            trending={data.catalogTrending}
+          />
           <CommensalPulse pageTelemetry={data.pageTelemetry} />
           <CommercePanel commerceSummary={data.commerce} />
           <LivingEconomyPanel data={data.livingEconomy} />
         </div>
 
-        <div className="dash-stack" style={{ display: "grid", gridTemplateColumns: "1.4fr 1fr", gap: 12, marginBottom: 12 }}>
+        <div
+          id="economy"
+          className="dash-stack"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1.4fr 1fr",
+            gap: 12,
+            marginBottom: 12,
+            scrollMarginTop: 70,
+          }}
+        >
           <CosmicYieldEconomy data={data.cosmicYield} />
           <PractitionerGeo data={data.practitionerGeo} />
         </div>
 
         <div
+          id="infrastructure"
           className="dash-stack"
           style={{
             display: "grid",
             gridTemplateColumns: "1.2fr 1fr 1fr",
             gap: 12,
             marginBottom: 12,
+            scrollMarginTop: 70,
           }}
         >
           <DatabaseStorage data={data.dbObservability} />
@@ -202,12 +286,32 @@ export function Dashboard({ data }: DashboardProps) {
           <ResourceUsage data={data.resourceUsage} />
         </div>
 
-        <div className="dash-stack" style={{ display: "grid", gridTemplateColumns: "1.2fr 1fr", gap: 12, marginBottom: 12 }}>
+        <div
+          id="trust"
+          className="dash-stack"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1.2fr 1fr",
+            gap: 12,
+            marginBottom: 12,
+            scrollMarginTop: 70,
+          }}
+        >
           <ModerationQueue />
           <SecurityPanel security={data.security} />
         </div>
 
-        <div className="dash-stack" style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 12, marginBottom: 12 }}>
+        <div
+          id="delivery"
+          className="dash-stack"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr 1fr",
+            gap: 12,
+            marginBottom: 12,
+            scrollMarginTop: 70,
+          }}
+        >
           <DeploysPanel data={data.deploys} />
           <FeatureFlagsPanel data={data.featureFlags} />
           <AuditLogPanel data={data.auditEvents} />
@@ -227,17 +331,29 @@ export function Dashboard({ data }: DashboardProps) {
           }}
         >
           <div style={{ display: "flex", gap: 18, flexWrap: "wrap" }}>
-            <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>
+            <span
+              className="t-mono"
+              style={{ fontSize: 9.5, color: "var(--fg-mute)" }}
+            >
               alchm.kitchen · admin · agentic.alchm.kitchen
             </span>
-            <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>
+            <span
+              className="t-mono"
+              style={{ fontSize: 9.5, color: "var(--fg-mute)" }}
+            >
               region · {process.env.NEXT_PUBLIC_VERCEL_REGION ?? "—"}
             </span>
-            <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>
+            <span
+              className="t-mono"
+              style={{ fontSize: 9.5, color: "var(--fg-mute)" }}
+            >
               build · #{shortSha()}
             </span>
             {data.meta.mockedFields.length > 0 && (
-              <span className="t-mono" style={{ fontSize: 9.5, color: "var(--el-fire)" }}>
+              <span
+                className="t-mono"
+                style={{ fontSize: 9.5, color: "var(--el-fire)" }}
+              >
                 mocked: {data.meta.mockedFields.join(", ")}
               </span>
             )}
@@ -247,7 +363,9 @@ export function Dashboard({ data }: DashboardProps) {
               className="t-mono"
               style={{
                 fontSize: 9.5,
-                color: data.skyConditions.planetaryHour.live ? "var(--accent)" : "var(--fg-mute)",
+                color: data.skyConditions.planetaryHour.live
+                  ? "var(--accent)"
+                  : "var(--fg-mute)",
               }}
             >
               ● {data.skyConditions.planetaryHour.planet.toLowerCase()} hour
@@ -263,10 +381,14 @@ export function Dashboard({ data }: DashboardProps) {
               className="t-mono"
               style={{
                 fontSize: 9.5,
-                color: data.skyConditions.live ? "var(--el-earth)" : "var(--fg-mute)",
+                color: data.skyConditions.live
+                  ? "var(--el-earth)"
+                  : "var(--fg-mute)",
               }}
             >
-              {data.skyConditions.live ? "● ephemeris · live" : "○ ephemeris · degraded"}
+              {data.skyConditions.live
+                ? "● ephemeris · live"
+                : "○ ephemeris · degraded"}
             </span>
             <span
               className="t-mono"
@@ -313,7 +435,16 @@ interface TweaksBarProps {
   onGrid: (v: boolean) => void;
 }
 
-function TweaksBar({ palette, density, motion, showGrid, onPalette, onDensity, onMotion, onGrid }: TweaksBarProps) {
+function TweaksBar({
+  palette,
+  density,
+  motion,
+  showGrid,
+  onPalette,
+  onDensity,
+  onMotion,
+  onGrid,
+}: TweaksBarProps) {
   const [open, setOpen] = React.useState(false);
   return (
     <div
@@ -340,7 +471,9 @@ function TweaksBar({ palette, density, motion, showGrid, onPalette, onDensity, o
           }}
         >
           <div>
-            <div className="t-tag" style={{ marginBottom: 6 }}>PALETTE</div>
+            <div className="t-tag" style={{ marginBottom: 6 }}>
+              PALETTE
+            </div>
             <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
               {(Object.keys(PALETTES) as PaletteKey[]).map((k) => (
                 <button
@@ -356,7 +489,9 @@ function TweaksBar({ palette, density, motion, showGrid, onPalette, onDensity, o
             </div>
           </div>
           <div>
-            <div className="t-tag" style={{ marginBottom: 6 }}>DENSITY</div>
+            <div className="t-tag" style={{ marginBottom: 6 }}>
+              DENSITY
+            </div>
             <div style={{ display: "flex", gap: 4 }}>
               <button
                 type="button"
@@ -377,7 +512,9 @@ function TweaksBar({ palette, density, motion, showGrid, onPalette, onDensity, o
             </div>
           </div>
           <div>
-            <div className="t-tag" style={{ marginBottom: 6 }}>DISPLAY</div>
+            <div className="t-tag" style={{ marginBottom: 6 }}>
+              DISPLAY
+            </div>
             <div style={{ display: "flex", gap: 4 }}>
               <button
                 type="button"

--- a/src/app/admin/_dashboard/OperationsControlPlane.tsx
+++ b/src/app/admin/_dashboard/OperationsControlPlane.tsx
@@ -1,0 +1,1045 @@
+"use client";
+
+import Link from "next/link";
+import React from "react";
+import type { OperationsStatus } from "@/services/operationsControlPlaneService";
+import { Glyph } from "./atoms";
+import type { AdminDashboardData } from "./data";
+
+interface Props {
+  data: AdminDashboardData;
+}
+
+const STATUS_COLOR: Record<OperationsStatus, string> = {
+  HEALTHY: "var(--el-earth)",
+  WATCH: "var(--accent-2)",
+  CRITICAL: "#FF5252",
+  BLIND: "var(--fg-mute)",
+};
+
+const PRIORITY_COLOR = {
+  P0: "#FF5252",
+  P1: "var(--accent-2)",
+  P2: "var(--el-water)",
+} as const;
+
+const MAINTENANCE_COLOR = {
+  CLEAR: "var(--el-earth)",
+  WATCH: "var(--accent-2)",
+  DUE: "#FF5252",
+} as const;
+
+function statusColor(status: OperationsStatus): string {
+  return STATUS_COLOR[status];
+}
+
+function QuickRoute({
+  href,
+  label,
+  badge,
+}: {
+  href: string;
+  label: string;
+  badge?: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="btn btn-ghost"
+      style={{ padding: "7px 10px", fontSize: 8.5, textDecoration: "none" }}
+    >
+      {label}
+      {badge && (
+        <span
+          className="t-mono"
+          style={{
+            padding: "1px 5px",
+            borderRadius: 999,
+            color: "var(--accent-2)",
+            background: "rgba(255,255,255,0.05)",
+          }}
+        >
+          {badge}
+        </span>
+      )}
+    </Link>
+  );
+}
+
+function HeadlineMetric({
+  label,
+  value,
+  detail,
+  color = "var(--fg)",
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  color?: string;
+}) {
+  return (
+    <div
+      style={{
+        padding: "11px 12px",
+        borderRight: "1px solid var(--line)",
+        minWidth: 0,
+      }}
+    >
+      <div className="t-tag" style={{ fontSize: 8, marginBottom: 5 }}>
+        {label}
+      </div>
+      <div className="t-num" style={{ fontSize: 19, color, lineHeight: 1.1 }}>
+        {value}
+      </div>
+      <div
+        style={{
+          color: "var(--fg-mute)",
+          fontSize: 9.5,
+          marginTop: 4,
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        }}
+        title={detail}
+      >
+        {detail}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The synthesis layer for the dashboard: independent telemetry becomes an
+ * ordered work queue, domain coverage matrix, maintenance board, and operator
+ * routes. This is intentionally first in the dashboard's long-form body.
+ */
+export function OperationsControlPlane({ data }: Props) {
+  const {
+    operations,
+    onboardingHealth,
+    launchReadiness,
+    planetaryIntegration,
+  } = data;
+  const stateColor =
+    operations.state === "NOMINAL"
+      ? "var(--el-earth)"
+      : operations.state === "ATTENTION"
+        ? "var(--accent-2)"
+        : "#FF5252";
+  const p0 = operations.priorities.filter(
+    (item) => item.severity === "P0",
+  ).length;
+  const due = operations.maintenance.filter(
+    (item) => item.status === "DUE",
+  ).length;
+  const maxFunnel = Math.max(
+    1,
+    ...onboardingHealth.funnel.map((stage) => stage.count),
+  );
+  const rolloutNeedsWork = launchReadiness.subsystems.filter(
+    (subsystem) => subsystem.status !== "READY",
+  );
+  const warming = operations.domains.length === 0;
+
+  return (
+    <section
+      id="operations"
+      className="panel-glow quantum-control-plane"
+      style={{ marginBottom: 12, overflow: "hidden", scrollMarginTop: 70 }}
+    >
+      <div
+        style={{
+          padding: "16px 18px 14px",
+          borderBottom: "1px solid var(--line)",
+          background:
+            "radial-gradient(650px 180px at 0% 0%, var(--accent-glow), transparent 70%), rgba(255,255,255,0.008)",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "flex-start",
+            gap: 16,
+            flexWrap: "wrap",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 14,
+              minWidth: 260,
+            }}
+          >
+            <div
+              aria-label={`Operational readiness ${operations.readinessScore} percent`}
+              style={{
+                width: 68,
+                height: 68,
+                borderRadius: "50%",
+                padding: 5,
+                background: `conic-gradient(${stateColor} ${operations.readinessScore}%, rgba(255,255,255,0.06) 0)`,
+                boxShadow: `0 0 28px color-mix(in oklch, ${stateColor}, transparent 75%)`,
+                flexShrink: 0,
+              }}
+            >
+              <div
+                style={{
+                  width: "100%",
+                  height: "100%",
+                  borderRadius: "50%",
+                  background: "var(--bg)",
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <span
+                  className="t-num"
+                  style={{ fontSize: 20, color: stateColor, lineHeight: 1 }}
+                >
+                  {operations.readinessScore}
+                </span>
+                <span
+                  className="t-mono"
+                  style={{ fontSize: 7, color: "var(--fg-mute)" }}
+                >
+                  READINESS
+                </span>
+              </div>
+            </div>
+            <div>
+              <div
+                className="t-tag"
+                style={{ color: stateColor, marginBottom: 3 }}
+              >
+                QUANTUM CONTROL PLANE · {operations.state}
+              </div>
+              <h2
+                className="t-display"
+                style={{ fontSize: 25, margin: 0, lineHeight: 1.1 }}
+              >
+                The work that matters, in order
+              </h2>
+              <p
+                style={{
+                  margin: "5px 0 0",
+                  color: "var(--fg-dim)",
+                  fontSize: 11.5,
+                }}
+              >
+                {operations.summary}
+              </p>
+            </div>
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              gap: 6,
+              flexWrap: "wrap",
+              justifyContent: "flex-end",
+              maxWidth: 760,
+            }}
+          >
+            <QuickRoute
+              href="/admin/users"
+              label="Users"
+              badge={String(data.stats.totalUsers)}
+            />
+            <QuickRoute
+              href="/admin/onboarding"
+              label="Onboarding"
+              badge={
+                onboardingHealth.stuckUsers.length > 0
+                  ? `${onboardingHealth.stuckUsers.length} stuck`
+                  : "clear"
+              }
+            />
+            <QuickRoute href="#economy" label="Token economy" />
+            <QuickRoute
+              href="#agents"
+              label="Agent mesh"
+              badge={String(planetaryIntegration.agentCount)}
+            />
+            <QuickRoute href="/admin/mcp" label="MCP" />
+            <QuickRoute
+              href="/admin/settlements"
+              label="Settlements"
+              badge={String(launchReadiness.settlement.pending)}
+            />
+            <QuickRoute href="/admin/chat-reports" label="Moderation" />
+            <QuickRoute href="/admin/settings" label="Settings" />
+          </div>
+        </div>
+      </div>
+
+      <div
+        className="quantum-headline-grid"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(6, minmax(0, 1fr))",
+          borderBottom: "1px solid var(--line)",
+        }}
+      >
+        <HeadlineMetric
+          label="Signal coverage"
+          value={`${operations.coverage.percent}%`}
+          detail={`${operations.coverage.live}/${operations.coverage.total} sources live`}
+          color={
+            operations.coverage.percent === 100
+              ? "var(--el-earth)"
+              : "var(--accent-2)"
+          }
+        />
+        <HeadlineMetric
+          label="Priority work"
+          value={String(operations.priorities.length)}
+          detail={`${p0} immediate · ${operations.priorities.length - p0} queued`}
+          color={
+            p0 > 0
+              ? "#FF5252"
+              : operations.priorities.length > 0
+                ? "var(--accent-2)"
+                : "var(--el-earth)"
+          }
+        />
+        <HeadlineMetric
+          label="Maintenance"
+          value={String(due)}
+          detail={`${operations.maintenance.length} registered routines`}
+          color={due > 0 ? "var(--accent-2)" : "var(--el-earth)"}
+        />
+        <HeadlineMetric
+          label="Rollout readiness"
+          value={`${operations.rollout.ready}/${operations.rollout.total}`}
+          detail={`${operations.rollout.partial} partial · ${operations.rollout.off} gated`}
+        />
+        <HeadlineMetric
+          label="Onboarding API"
+          value={
+            onboardingHealth.apiHealth.observed
+              ? `${(onboardingHealth.apiHealth.successRate * 100).toFixed(0)}%`
+              : "—"
+          }
+          detail={`${onboardingHealth.apiHealth.count} calls · p95 ${onboardingHealth.apiHealth.p95LatencyMs}ms`}
+          color={
+            onboardingHealth.overall === "OK"
+              ? "var(--el-earth)"
+              : "var(--accent-2)"
+          }
+        />
+        <HeadlineMetric
+          label="Planetary backend"
+          value={planetaryIntegration.health.toUpperCase()}
+          detail={`${planetaryIntegration.agentCount} agents · ${planetaryIntegration.telemetry?.mcpInvocationRate.value ?? "MCP blind"}`}
+          color={
+            operations.domains.find((item) => item.id === "planetary-agents")
+              ? statusColor(
+                  operations.domains.find(
+                    (item) => item.id === "planetary-agents",
+                  )!.status,
+                )
+              : "var(--fg-mute)"
+          }
+        />
+      </div>
+
+      <div
+        className="dash-stack quantum-primary-grid"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "0.92fr 1.55fr",
+          gap: 0,
+        }}
+      >
+        <div
+          style={{
+            padding: 16,
+            borderRight: "1px solid var(--line)",
+            minWidth: 0,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              marginBottom: 10,
+            }}
+          >
+            <div>
+              <div className="t-tag">PRIORITY QUEUE</div>
+              <div
+                style={{ fontSize: 11, color: "var(--fg-mute)", marginTop: 3 }}
+              >
+                Live failures, blind spots, and unfinished rollout work
+              </div>
+            </div>
+            <span className="chip" style={{ fontSize: 8 }}>
+              {operations.priorities.length} OPEN
+            </span>
+          </div>
+
+          {operations.priorities.length === 0 ? (
+            <div
+              style={{
+                border:
+                  "1px dashed color-mix(in oklch, var(--el-earth), transparent 55%)",
+                borderRadius: 10,
+                padding: "28px 14px",
+                textAlign: "center",
+                color: "var(--el-earth)",
+                background:
+                  "color-mix(in oklch, var(--el-earth), transparent 94%)",
+              }}
+            >
+              <Glyph name="check" size={22} />
+              <div
+                className="t-mono"
+                style={{ fontSize: 10, letterSpacing: "0.12em", marginTop: 8 }}
+              >
+                {warming
+                  ? "CONTROL PLANE · SYNTHESIZING"
+                  : "NO ACTIONABLE WEAK POINTS"}
+              </div>
+            </div>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              {operations.priorities.slice(0, 8).map((item) => {
+                const color = PRIORITY_COLOR[item.severity];
+                return (
+                  <Link
+                    key={item.id}
+                    href={item.href}
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "38px 1fr auto",
+                      gap: 10,
+                      alignItems: "center",
+                      padding: "9px 10px",
+                      border: "1px solid var(--line)",
+                      borderLeft: `2px solid ${color}`,
+                      borderRadius: 8,
+                      color: "inherit",
+                      textDecoration: "none",
+                      background: "rgba(255,255,255,0.012)",
+                    }}
+                  >
+                    <span
+                      className="t-mono"
+                      style={{ color, fontSize: 10, fontWeight: 700 }}
+                    >
+                      {item.severity}
+                    </span>
+                    <span style={{ minWidth: 0 }}>
+                      <span
+                        style={{
+                          display: "block",
+                          fontSize: 11.5,
+                          color: "var(--fg)",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {item.title}
+                      </span>
+                      <span
+                        style={{
+                          display: "block",
+                          fontSize: 9.5,
+                          color: "var(--fg-mute)",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                          marginTop: 2,
+                        }}
+                        title={item.detail}
+                      >
+                        {item.category} · {item.detail}
+                      </span>
+                    </span>
+                    <Glyph
+                      name="chevron"
+                      size={11}
+                      style={{ color: "var(--fg-mute)" }}
+                    />
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div style={{ padding: 16, minWidth: 0 }}>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              marginBottom: 10,
+            }}
+          >
+            <div>
+              <div className="t-tag">DOMAIN PULSE · ENTIRE SITE</div>
+              <div
+                style={{ fontSize: 11, color: "var(--fg-mute)", marginTop: 3 }}
+              >
+                Business health and observability are scored independently
+              </div>
+            </div>
+            <span
+              className="t-mono"
+              style={{ fontSize: 9, color: "var(--fg-mute)" }}
+            >
+              {
+                operations.domains.filter((item) => item.status === "HEALTHY")
+                  .length
+              }
+              /{operations.domains.length} GREEN
+            </span>
+          </div>
+          <div
+            className="quantum-domain-grid"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+              gap: 7,
+            }}
+          >
+            {operations.domains.map((item) => {
+              const color = statusColor(item.status);
+              return (
+                <Link
+                  key={item.id}
+                  href={item.href}
+                  style={{
+                    padding: "10px 11px",
+                    border: "1px solid var(--line)",
+                    borderRadius: 9,
+                    background: "rgba(255,255,255,0.012)",
+                    color: "inherit",
+                    textDecoration: "none",
+                    minWidth: 0,
+                  }}
+                >
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                      gap: 8,
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 7,
+                        minWidth: 0,
+                      }}
+                    >
+                      <span
+                        style={{
+                          width: 7,
+                          height: 7,
+                          borderRadius: 999,
+                          background: color,
+                          boxShadow: `0 0 8px ${color}`,
+                          flexShrink: 0,
+                        }}
+                      />
+                      <span
+                        style={{
+                          fontSize: 11.5,
+                          color: "var(--fg)",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {item.label}
+                      </span>
+                    </div>
+                    <span className="t-mono" style={{ fontSize: 7.5, color }}>
+                      {item.status}
+                    </span>
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 9.5,
+                      color: "var(--fg-mute)",
+                      margin: "5px 0 8px",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                    title={item.summary}
+                  >
+                    {item.summary}
+                  </div>
+                  <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+                    {item.metrics.map((metric) => (
+                      <span
+                        key={metric.label}
+                        className="t-mono"
+                        style={{ fontSize: 8.5, color: "var(--fg-dim)" }}
+                      >
+                        <span style={{ color: "var(--fg-mute)" }}>
+                          {metric.label}
+                        </span>{" "}
+                        {metric.value}
+                      </span>
+                    ))}
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <div
+        className="dash-stack quantum-secondary-grid"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1.05fr 1fr 0.9fr",
+          borderTop: "1px solid var(--line)",
+        }}
+      >
+        <div
+          style={{
+            padding: 16,
+            borderRight: "1px solid var(--line)",
+            minWidth: 0,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              marginBottom: 11,
+            }}
+          >
+            <div>
+              <div className="t-tag">ONBOARDING ROUTE</div>
+              <div
+                style={{ fontSize: 10, color: "var(--fg-mute)", marginTop: 3 }}
+              >
+                {onboardingHealth.headline}
+              </div>
+            </div>
+            <Link
+              href="/admin/onboarding"
+              className="btn btn-ghost"
+              style={{
+                padding: "5px 8px",
+                fontSize: 8,
+                textDecoration: "none",
+              }}
+            >
+              OPEN OPS
+            </Link>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {onboardingHealth.funnel.map((stage, index) => (
+              <div key={stage.id}>
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    marginBottom: 3,
+                  }}
+                >
+                  <span style={{ fontSize: 9.5, color: "var(--fg-dim)" }}>
+                    {stage.label}
+                  </span>
+                  <span
+                    className="t-mono"
+                    style={{ fontSize: 9.5, color: "var(--fg)" }}
+                  >
+                    {stage.count}
+                    {index > 0 && stage.dropOff > 0 && (
+                      <span style={{ color: "var(--accent-2)", marginLeft: 6 }}>
+                        −{Math.round(stage.dropOff * 100)}%
+                      </span>
+                    )}
+                  </span>
+                </div>
+                <div
+                  style={{
+                    height: 5,
+                    borderRadius: 99,
+                    background: "rgba(255,255,255,0.05)",
+                    overflow: "hidden",
+                  }}
+                >
+                  <div
+                    style={{
+                      height: "100%",
+                      width: `${Math.max(stage.count > 0 ? 4 : 0, (stage.count / maxFunnel) * 100)}%`,
+                      background:
+                        index === onboardingHealth.funnel.length - 1
+                          ? "var(--el-earth)"
+                          : "var(--accent)",
+                      borderRadius: 99,
+                    }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+          {onboardingHealth.stuckUsers.length > 0 && (
+            <div
+              style={{
+                marginTop: 12,
+                paddingTop: 10,
+                borderTop: "1px solid var(--line)",
+              }}
+            >
+              <div
+                className="t-tag"
+                style={{ color: "var(--accent-2)", marginBottom: 6 }}
+              >
+                RESCUE QUEUE · {onboardingHealth.stuckUsers.length}
+              </div>
+              {onboardingHealth.stuckUsers.slice(0, 3).map((user) => (
+                <Link
+                  key={user.userId}
+                  href={`/admin/users/${user.userId}`}
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    gap: 8,
+                    padding: "5px 0",
+                    color: "inherit",
+                    textDecoration: "none",
+                    borderBottom: "1px dashed var(--line)",
+                  }}
+                >
+                  <span
+                    style={{
+                      minWidth: 0,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                      fontSize: 9.5,
+                      color: "var(--fg-dim)",
+                    }}
+                  >
+                    {user.email}
+                  </span>
+                  <span
+                    className="t-mono"
+                    style={{
+                      fontSize: 8.5,
+                      color: "var(--accent-2)",
+                      flexShrink: 0,
+                    }}
+                  >
+                    {user.ageHours}h · {user.missing}
+                  </span>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div
+          style={{
+            padding: 16,
+            borderRight: "1px solid var(--line)",
+            minWidth: 0,
+          }}
+        >
+          <div className="t-tag" style={{ marginBottom: 10 }}>
+            MAINTENANCE BOARD
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {operations.maintenance.map((item) => {
+              const color = MAINTENANCE_COLOR[item.status];
+              return (
+                <Link
+                  key={item.id}
+                  href={item.href}
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "8px 1fr auto",
+                    gap: 8,
+                    alignItems: "center",
+                    color: "inherit",
+                    textDecoration: "none",
+                    padding: "7px 8px",
+                    border: "1px solid var(--line)",
+                    borderRadius: 7,
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 6,
+                      height: 6,
+                      borderRadius: 99,
+                      background: color,
+                    }}
+                  />
+                  <span style={{ minWidth: 0 }}>
+                    <span
+                      style={{
+                        display: "block",
+                        fontSize: 10.5,
+                        color: "var(--fg)",
+                      }}
+                    >
+                      {item.label}
+                    </span>
+                    <span
+                      style={{
+                        display: "block",
+                        fontSize: 8.5,
+                        color: "var(--fg-mute)",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                      title={item.detail}
+                    >
+                      {item.detail}
+                    </span>
+                  </span>
+                  <span className="t-mono" style={{ fontSize: 8, color }}>
+                    {item.status}
+                    {item.count > 0 ? ` · ${item.count}` : ""}
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+
+        <div style={{ padding: 16, minWidth: 0 }}>
+          <div className="t-tag" style={{ marginBottom: 10 }}>
+            ROLLOUT & BLIND SPOTS
+          </div>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(3, 1fr)",
+              gap: 5,
+              marginBottom: 10,
+            }}
+          >
+            {(["READY", "PARTIAL", "OFF"] as const).map((status) => {
+              const count = launchReadiness.subsystems.filter(
+                (item) => item.status === status,
+              ).length;
+              const color =
+                status === "READY"
+                  ? "var(--el-earth)"
+                  : status === "PARTIAL"
+                    ? "var(--accent-2)"
+                    : "var(--fg-mute)";
+              return (
+                <div
+                  key={status}
+                  style={{
+                    border: "1px solid var(--line)",
+                    borderRadius: 7,
+                    padding: "7px 5px",
+                    textAlign: "center",
+                  }}
+                >
+                  <div className="t-num" style={{ color, fontSize: 15 }}>
+                    {count}
+                  </div>
+                  <div
+                    className="t-mono"
+                    style={{ color: "var(--fg-mute)", fontSize: 7 }}
+                  >
+                    {status}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          {rolloutNeedsWork.slice(0, 4).map((subsystem) => (
+            <Link
+              key={subsystem.key}
+              href="/admin/settings"
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                gap: 8,
+                padding: "5px 0",
+                borderBottom: "1px dashed var(--line)",
+                color: "inherit",
+                textDecoration: "none",
+              }}
+            >
+              <span
+                style={{
+                  fontSize: 9,
+                  color: "var(--fg-dim)",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {subsystem.label}
+              </span>
+              <span
+                className="t-mono"
+                style={{
+                  fontSize: 8,
+                  color:
+                    subsystem.status === "PARTIAL"
+                      ? "var(--accent-2)"
+                      : "var(--fg-mute)",
+                  flexShrink: 0,
+                }}
+              >
+                {subsystem.configured}/{subsystem.total}
+              </span>
+            </Link>
+          ))}
+
+          <div className="t-tag" style={{ margin: "13px 0 7px" }}>
+            OBSERVABILITY GAPS · {operations.coverage.blindSpots.length}
+          </div>
+          {operations.coverage.total === 0 ? (
+            <div
+              className="t-mono"
+              style={{ color: "var(--fg-mute)", fontSize: 9 }}
+            >
+              ○ SOURCE REGISTRY WARMING
+            </div>
+          ) : operations.coverage.blindSpots.length === 0 ? (
+            <div
+              className="t-mono"
+              style={{ color: "var(--el-earth)", fontSize: 9 }}
+            >
+              ● ALL REGISTERED SOURCES LIVE
+            </div>
+          ) : (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+              {operations.coverage.blindSpots.slice(0, 8).map((label) => (
+                <span
+                  key={label}
+                  className="chip"
+                  style={{
+                    padding: "2px 6px",
+                    fontSize: 7.5,
+                    color: "var(--accent-2)",
+                  }}
+                >
+                  {label}
+                </span>
+              ))}
+            </div>
+          )}
+
+          <div className="t-tag" style={{ margin: "13px 0 7px" }}>
+            KNOWN CODEBASE GAPS · {operations.codebase.knownGaps.length}
+          </div>
+          {operations.codebase.knownGaps.length === 0 ? (
+            <div
+              className="t-mono"
+              style={{ color: "var(--el-earth)", fontSize: 9 }}
+            >
+              ● NO REGISTERED IMPLEMENTATION DEBT
+            </div>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column" }}>
+              {operations.codebase.knownGaps.slice(0, 5).map((gap) => (
+                <Link
+                  key={gap.id}
+                  href={gap.href}
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    gap: 8,
+                    padding: "5px 0",
+                    borderBottom: "1px dashed var(--line)",
+                    color: "inherit",
+                    textDecoration: "none",
+                  }}
+                  title={gap.detail}
+                >
+                  <span
+                    style={{
+                      fontSize: 9,
+                      color: "var(--fg-dim)",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {gap.label}
+                  </span>
+                  <span
+                    className="t-mono"
+                    style={{
+                      fontSize: 8,
+                      color:
+                        gap.severity === "P1"
+                          ? "var(--accent-2)"
+                          : "var(--el-water)",
+                      flexShrink: 0,
+                    }}
+                  >
+                    {gap.severity}
+                  </span>
+                </Link>
+              ))}
+            </div>
+          )}
+
+          <div
+            style={{ display: "flex", gap: 5, marginTop: 12, flexWrap: "wrap" }}
+          >
+            {planetaryIntegration.endpoints.paUi && (
+              <a
+                href={planetaryIntegration.endpoints.paUi}
+                target="_blank"
+                rel="noreferrer"
+                className="btn btn-ghost"
+                style={{
+                  padding: "5px 7px",
+                  fontSize: 7.5,
+                  textDecoration: "none",
+                }}
+              >
+                PA CONSOLE ↗
+              </a>
+            )}
+            <Link
+              href="/admin/mcp"
+              className="btn btn-ghost"
+              style={{
+                padding: "5px 7px",
+                fontSize: 7.5,
+                textDecoration: "none",
+              }}
+            >
+              MCP NETWORK
+            </Link>
+            <Link
+              href="/admin/settings"
+              className="btn btn-ghost"
+              style={{
+                padding: "5px 7px",
+                fontSize: 7.5,
+                textDecoration: "none",
+              }}
+            >
+              CONFIG REGISTRY
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/admin/_dashboard/__tests__/OperationsControlPlane.test.tsx
+++ b/src/app/admin/_dashboard/__tests__/OperationsControlPlane.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from "@testing-library/react";
+import { OperationsControlPlane } from "@/app/admin/_dashboard/OperationsControlPlane";
+import {
+  FALLBACK_DATA,
+  type AdminDashboardData,
+} from "@/app/admin/_dashboard/data";
+
+function makeDashboard(): AdminDashboardData {
+  return {
+    ...FALLBACK_DATA,
+    stats: {
+      ...FALLBACK_DATA.stats,
+      totalUsers: 12,
+      activeUsers: 9,
+      completedOnboarding: 8,
+    },
+    onboardingHealth: {
+      ...FALLBACK_DATA.onboardingHealth,
+      overall: "DEGRADED",
+      headline: "1 user is stuck mid-onboarding",
+      live: true,
+      stuckUsers: [
+        {
+          userId: "user-123",
+          email: "stuck@example.com",
+          name: "Stuck User",
+          createdAt: "2026-08-09T08:00:00.000Z",
+          ageHours: 4,
+          missing: "no-natal-chart",
+        },
+      ],
+    },
+    launchReadiness: {
+      generatedAt: "2026-08-09T12:00:00.000Z",
+      readyCount: 0,
+      settlement: { pending: 1, live: true },
+      subsystems: [
+        {
+          key: "stripe-pro",
+          label: "Stripe Pro",
+          description: "Subscription billing",
+          status: "PARTIAL",
+          configured: 2,
+          total: 4,
+          checks: [],
+        },
+      ],
+    },
+    planetaryIntegration: {
+      ...FALLBACK_DATA.planetaryIntegration,
+      health: "unhealthy",
+      agentCount: 24,
+    },
+    operations: {
+      generatedAt: "2026-08-09T12:00:00.000Z",
+      state: "ATTENTION",
+      readinessScore: 72,
+      summary: "2 domains need attention · 1 blind spot",
+      coverage: {
+        live: 11,
+        total: 12,
+        percent: 92,
+        blindSpots: ["Token ledger"],
+      },
+      rollout: { ready: 0, total: 1, partial: 1, off: 0 },
+      codebase: {
+        highPriority: 1,
+        knownGaps: [
+          {
+            id: "api-heatmap",
+            label: "API heatmap is seeded",
+            category: "PLACEHOLDER_DATA",
+            severity: "P1",
+            detail: "Hourly request telemetry is missing.",
+            href: "#infrastructure",
+          },
+        ],
+      },
+      domains: [
+        {
+          id: "token-economy",
+          label: "Token Economy",
+          status: "BLIND",
+          summary: "Ledger rollup unavailable",
+          href: "#economy",
+          metrics: [{ label: "Circulation", value: "—" }],
+        },
+        {
+          id: "planetary-agents",
+          label: "Planetary Agents",
+          status: "WATCH",
+          summary: "24 agents · backend unhealthy",
+          href: "#agents",
+          metrics: [{ label: "Agents", value: "24" }],
+        },
+      ],
+      priorities: [
+        {
+          id: "settlement-backlog",
+          severity: "P0",
+          category: "Commerce",
+          title: "1 settlement is unresolved",
+          detail: "Tokens were debited but transfer is unconfirmed.",
+          href: "/admin/settlements",
+        },
+      ],
+      maintenance: [
+        {
+          id: "onboarding-review",
+          label: "Onboarding rescue",
+          status: "DUE",
+          count: 1,
+          detail: "Inspect the incomplete journey.",
+          href: "/admin/onboarding",
+        },
+      ],
+    },
+  };
+}
+
+describe("OperationsControlPlane", () => {
+  it("renders actionable priorities, domain health, codebase gaps, and admin routes", () => {
+    render(<OperationsControlPlane data={makeDashboard()} />);
+
+    expect(
+      screen.getByRole("heading", { name: "The work that matters, in order" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("1 settlement is unresolved")).toBeInTheDocument();
+    expect(screen.getByText("Token Economy")).toBeInTheDocument();
+    expect(screen.getByText("API heatmap is seeded")).toBeInTheDocument();
+    expect(screen.getByText("stuck@example.com")).toBeInTheDocument();
+
+    expect(screen.getByRole("link", { name: /Users 12/ })).toHaveAttribute(
+      "href",
+      "/admin/users",
+    );
+    expect(
+      screen.getByRole("link", { name: /Onboarding 1 stuck/ }),
+    ).toHaveAttribute("href", "/admin/onboarding");
+    expect(
+      screen.getByRole("link", { name: /1 settlement is unresolved/ }),
+    ).toHaveAttribute("href", "/admin/settlements");
+    expect(
+      screen.getByRole("link", { name: /stuck@example.com/ }),
+    ).toHaveAttribute("href", "/admin/users/user-123");
+  });
+});

--- a/src/app/admin/_dashboard/__tests__/TelemetryTruthfulness.test.tsx
+++ b/src/app/admin/_dashboard/__tests__/TelemetryTruthfulness.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import {
+  APIHeatmap,
+  CosmicYieldEconomy,
+  RecipeQualityInspector,
+} from "@/app/admin/_dashboard/extras";
+import { FALLBACK_DATA } from "@/app/admin/_dashboard/data";
+
+describe("admin telemetry truthfulness", () => {
+  it("marks missing route-volume and database telemetry instead of inventing traffic", () => {
+    render(<APIHeatmap db={FALLBACK_DATA.dbObservability} />);
+
+    expect(screen.getByText("◌ NOT INSTRUMENTED")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Database slow-query telemetry is unavailable/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/1\.3M requests/)).not.toBeInTheDocument();
+  });
+
+  it("uses ledger aggregates while disclosing absent token time-series and Gini data", () => {
+    render(
+      <CosmicYieldEconomy
+        data={{
+          inCirculation: 1_000,
+          minted30d: 300,
+          burned30d: 100,
+          netFlow30d: 200,
+          sinks24h: [],
+          topHolders: [{ handle: "@holder", balance: 250 }],
+          live: true,
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText("Daily time-series telemetry is not yet persisted."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("25.0%")).toBeInTheDocument();
+    expect(
+      screen.getByText(/A true Gini coefficient requires/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("0.42")).not.toBeInTheDocument();
+  });
+
+  it("shows an honest empty state when no live recipe-quality data exists", () => {
+    render(<RecipeQualityInspector trending={{ recipes: [], live: false }} />);
+
+    expect(screen.getByText("○ NO SOURCE")).toBeInTheDocument();
+    expect(screen.getByText(/No live recipe-quality rows/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Braised cheek · pomegranate/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/app/admin/_dashboard/dashboard.css
+++ b/src/app/admin/_dashboard/dashboard.css
@@ -14,23 +14,23 @@
   width: 100%;
   min-height: 100vh;
   background: #050409;
-  color: #F2EDFF;
+  color: #f2edff;
 }
 
 /* Scope tokens to the dashboard root so the rest of the
    app (Tailwind, marketing pages) is untouched. */
 .dashboard-root {
-  --bg: #07060B;
-  --bg-elev: #0E0C16;
-  --bg-elev-2: #15121F;
+  --bg: #07060b;
+  --bg-elev: #0e0c16;
+  --bg-elev-2: #15121f;
   --surface: rgba(255, 255, 255, 0.03);
   --surface-hi: rgba(255, 255, 255, 0.055);
   --line: rgba(255, 255, 255, 0.08);
   --line-hi: rgba(255, 255, 255, 0.14);
-  --fg: #F2EDFF;
-  --fg-dim: #B5ADCC;
-  --fg-mute: #6E6884;
-  --fg-faint: #3F3A52;
+  --fg: #f2edff;
+  --fg-dim: #b5adcc;
+  --fg-mute: #6e6884;
+  --fg-faint: #3f3a52;
 
   --accent: oklch(0.72 0.18 305);
   --accent-2: oklch(0.78 0.14 65);
@@ -53,8 +53,16 @@
   -webkit-font-smoothing: antialiased;
 
   background:
-    radial-gradient(1200px 800px at 20% 10%, rgba(120, 90, 255, 0.06), transparent 60%),
-    radial-gradient(900px 700px at 90% 90%, rgba(255, 160, 80, 0.04), transparent 60%),
+    radial-gradient(
+      1200px 800px at 20% 10%,
+      rgba(120, 90, 255, 0.06),
+      transparent 60%
+    ),
+    radial-gradient(
+      900px 700px at 90% 90%,
+      rgba(255, 160, 80, 0.04),
+      transparent 60%
+    ),
     #050409;
 }
 
@@ -70,12 +78,12 @@
   --accent-2: oklch(0.78 0.14 65);
 }
 .dashboard-root[data-palette="bio"] {
-  --accent: oklch(0.82 0.20 165);
+  --accent: oklch(0.82 0.2 165);
   --accent-2: oklch(0.78 0.14 90);
 }
 .dashboard-root[data-palette="copper"] {
   --accent: oklch(0.78 0.16 60);
-  --accent-2: oklch(0.70 0.18 25);
+  --accent-2: oklch(0.7 0.18 25);
 }
 .dashboard-root[data-palette="prism"] {
   --accent: oklch(0.74 0.22 330);
@@ -94,9 +102,17 @@
   width: 100%;
   height: 100%;
   background:
-    radial-gradient(1000px 700px at 15% 0%, rgba(140, 100, 255, 0.10), transparent 60%),
-    radial-gradient(700px 600px at 100% 100%, rgba(255, 170, 90, 0.06), transparent 60%),
-    linear-gradient(180deg, #0A0712 0%, #07060B 100%);
+    radial-gradient(
+      1000px 700px at 15% 0%,
+      rgba(140, 100, 255, 0.1),
+      transparent 60%
+    ),
+    radial-gradient(
+      700px 600px at 100% 100%,
+      rgba(255, 170, 90, 0.06),
+      transparent 60%
+    ),
+    linear-gradient(180deg, #0a0712 0%, #07060b 100%);
   color: var(--fg);
   overflow: hidden;
   font-family: var(--f-body);
@@ -110,7 +126,11 @@
     linear-gradient(to right, rgba(255, 255, 255, 0.025) 1px, transparent 1px),
     linear-gradient(to bottom, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
   background-size: 64px 64px;
-  mask-image: radial-gradient(ellipse 80% 70% at 50% 40%, black 30%, transparent 95%);
+  mask-image: radial-gradient(
+    ellipse 80% 70% at 50% 40%,
+    black 30%,
+    transparent 95%
+  );
   pointer-events: none;
 }
 
@@ -174,7 +194,11 @@
    ========================================================= */
 .panel {
   position: relative;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.025), rgba(255, 255, 255, 0.005));
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.025),
+    rgba(255, 255, 255, 0.005)
+  );
   border: 1px solid var(--line);
   border-radius: var(--radius);
   backdrop-filter: blur(12px);
@@ -186,7 +210,11 @@
 }
 .panel-glow {
   position: relative;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.005));
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.03),
+    rgba(255, 255, 255, 0.005)
+  );
   border: 1px solid var(--line-hi);
   border-radius: var(--radius);
   box-shadow:
@@ -262,7 +290,11 @@
   border-color: rgba(255, 255, 255, 0.22);
 }
 .dashboard-root .btn-primary {
-  background: linear-gradient(180deg, color-mix(in oklch, var(--accent), transparent 60%), color-mix(in oklch, var(--accent), transparent 80%));
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--accent), transparent 60%),
+    color-mix(in oklch, var(--accent), transparent 80%)
+  );
   border-color: color-mix(in oklch, var(--accent), transparent 40%);
   color: var(--fg);
   box-shadow:
@@ -270,7 +302,11 @@
     0 12px 40px -10px var(--accent-soft);
 }
 .dashboard-root .btn-primary:hover {
-  background: linear-gradient(180deg, color-mix(in oklch, var(--accent), transparent 40%), color-mix(in oklch, var(--accent), transparent 70%));
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--accent), transparent 40%),
+    color-mix(in oklch, var(--accent), transparent 70%)
+  );
 }
 .dashboard-root .btn-ghost {
   background: transparent;
@@ -383,6 +419,50 @@
 
 .dashboard-root.motion-off [data-motion] {
   animation: none !important;
+}
+
+/* Quantum control-plane interaction + dense widescreen layout. */
+.quantum-control-plane a {
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    transform 160ms ease;
+}
+.quantum-control-plane a:hover {
+  background-color: rgba(255, 255, 255, 0.035) !important;
+  border-color: var(--line-hi) !important;
+}
+.quantum-domain-grid > a:hover {
+  transform: translateY(-1px);
+}
+
+@media (max-width: 1380px) {
+  .quantum-headline-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+  }
+  .quantum-headline-grid > div:nth-child(3n) {
+    border-right: none !important;
+  }
+  .quantum-headline-grid > div:nth-child(-n + 3) {
+    border-bottom: 1px solid var(--line);
+  }
+  .quantum-secondary-grid {
+    grid-template-columns: 1fr 1fr !important;
+  }
+  .quantum-secondary-grid > div:last-child {
+    grid-column: 1 / -1;
+    border-top: 1px solid var(--line);
+  }
+}
+
+@media (max-width: 1160px) {
+  .quantum-primary-grid {
+    grid-template-columns: 1fr !important;
+  }
+  .quantum-primary-grid > div:first-child {
+    border-right: none !important;
+    border-bottom: 1px solid var(--line);
+  }
 }
 
 /* =========================================================
@@ -519,6 +599,7 @@
   }
   .admin-shell main[data-shell-main] {
     padding: 12px 12px 96px !important;
+    overflow-x: hidden !important;
   }
 
   /* stack helpers — applied to inline-styled grids in Dashboard.tsx */
@@ -546,6 +627,17 @@
   .dash-kpi-grid > div:nth-child(-n + 10) {
     border-bottom: 1px solid var(--line) !important;
   }
+  .quantum-secondary-grid {
+    grid-template-columns: 1fr !important;
+  }
+  .quantum-secondary-grid > div {
+    grid-column: auto !important;
+    border-right: none !important;
+    border-bottom: 1px solid var(--line);
+  }
+  .quantum-domain-grid {
+    grid-template-columns: 1fr !important;
+  }
 
   /* tighten panel internals */
   .dashboard-root .panel,
@@ -565,6 +657,21 @@
 }
 
 @media (max-width: 600px) {
+  .admin-shell [data-shell-actions] {
+    display: none !important;
+  }
+  .admin-shell header[data-shell-topbar] {
+    grid-template-columns: 1fr !important;
+  }
+  .quantum-headline-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+  .quantum-headline-grid > div {
+    border-bottom: 1px solid var(--line);
+  }
+  .quantum-headline-grid > div:nth-child(2n) {
+    border-right: none !important;
+  }
   .dash-kpi-grid {
     grid-template-columns: 1fr !important;
   }

--- a/src/app/admin/_dashboard/data.ts
+++ b/src/app/admin/_dashboard/data.ts
@@ -1,11 +1,9 @@
 /**
  * data.ts — admin dashboard data contract.
  *
- * The prototype baked deterministic mock data into the component
- * tree. Here we extract the same data into a typed contract that
- * the page fetches from `/api/admin/dashboard`. Anything the API
- * doesn't yet provide is filled with the same seeded mock the
- * prototype used, so the visual output matches one-for-one.
+ * Typed contract consumed by the admin dashboard. The API fills this from
+ * operational sources; FALLBACK_DATA is an explicit loading/error state and
+ * must not impersonate live telemetry.
  */
 
 import type {
@@ -27,22 +25,15 @@ import type {
   PractitionerGeoData,
   CohortRetentionData,
 } from "@/services/dashboardPanelsService";
+import type { LaunchReadinessReport } from "@/services/launchReadinessService";
 import type { ActivityEvent } from "@/services/liveActivityService";
+import type { OnboardingHealthPayload } from "@/services/onboardingHealthService";
+import type {
+  OperationsControlPlane,
+  PlanetaryIntegrationSnapshot,
+} from "@/services/operationsControlPlaneService";
 import type { SkyConditionsData } from "@/services/skyConditionsService";
 import type { SystemStatusPayload } from "@/services/systemStatusService";
-
-// ============================================================
-// DETERMINISTIC PSEUDO-RANDOM — used for sparkline / heatmap fill
-// ============================================================
-export function seeded(seed: number, n: number, lo = 0.2, hi = 0.95): number[] {
-  const out: number[] = [];
-  let s = seed;
-  for (let i = 0; i < n; i++) {
-    s = (s * 9301 + 49297) % 233280;
-    out.push(lo + (s / 233280) * (hi - lo));
-  }
-  return out;
-}
 
 // ============================================================
 // PALETTE
@@ -144,6 +135,14 @@ export interface AdminDashboardData {
   pageTelemetry: PageTelemetryData;
   /** Per-flow + dependency health from systemStatusService. */
   systemStatus: SystemStatusPayload;
+  /** Dedicated 24h onboarding funnel, stuck-user queue, and API health. */
+  onboardingHealth: OnboardingHealthPayload;
+  /** Presence-only rollout configuration and settlement backlog. */
+  launchReadiness: LaunchReadinessReport;
+  /** Synthesized operator priorities, domain coverage, and maintenance queue. */
+  operations: OperationsControlPlane;
+  /** Cross-project Planetary Agents reachability and live telemetry. */
+  planetaryIntegration: PlanetaryIntegrationSnapshot;
   /** Recent merged activity feed (auth + recipe + token + agent events). */
   liveActivity: { entries: ActivityEvent[]; live: boolean };
   /** Recent alert_events rows for the IncidentsPanel. */
@@ -166,30 +165,79 @@ export interface AdminDashboardData {
   cohortRetention: CohortRetentionData;
   /**
    * Generation metadata. `mockedFields` lists any panels still served
-   * from seeded fixtures rather than a live source — currently empty.
+   * from explicitly-labelled illustrative values rather than a live source.
    */
   meta: {
     generatedAt: string;
-    /** Which fields are still served from seeded fixtures. */
+    /** Which panels still contain explicitly-labelled illustrative values. */
     mockedFields: string[];
   };
 }
 
 // ============================================================
-// FALLBACK / SEED — used during loading and as the API mock
+// FALLBACK / LOADING — deliberately neutral when the API is unavailable
 // ============================================================
 const SKY_SEED: SkyConditionsData = {
   headline: "Awaiting ephemeris",
   live: false,
   generatedAt: new Date(0).toISOString(),
   planets: [
-    { symbol: "☉", name: "Sun", position: "—", speed: "—", retrograde: false, stationing: false },
-    { symbol: "☽", name: "Moon", position: "—", speed: "—", retrograde: false, stationing: false },
-    { symbol: "☿", name: "Mercury", position: "—", speed: "—", retrograde: false, stationing: false },
-    { symbol: "♀", name: "Venus", position: "—", speed: "—", retrograde: false, stationing: false },
-    { symbol: "♂", name: "Mars", position: "—", speed: "—", retrograde: false, stationing: false },
-    { symbol: "♃", name: "Jupiter", position: "—", speed: "—", retrograde: false, stationing: false },
-    { symbol: "♄", name: "Saturn", position: "—", speed: "—", retrograde: false, stationing: false },
+    {
+      symbol: "☉",
+      name: "Sun",
+      position: "—",
+      speed: "—",
+      retrograde: false,
+      stationing: false,
+    },
+    {
+      symbol: "☽",
+      name: "Moon",
+      position: "—",
+      speed: "—",
+      retrograde: false,
+      stationing: false,
+    },
+    {
+      symbol: "☿",
+      name: "Mercury",
+      position: "—",
+      speed: "—",
+      retrograde: false,
+      stationing: false,
+    },
+    {
+      symbol: "♀",
+      name: "Venus",
+      position: "—",
+      speed: "—",
+      retrograde: false,
+      stationing: false,
+    },
+    {
+      symbol: "♂",
+      name: "Mars",
+      position: "—",
+      speed: "—",
+      retrograde: false,
+      stationing: false,
+    },
+    {
+      symbol: "♃",
+      name: "Jupiter",
+      position: "—",
+      speed: "—",
+      retrograde: false,
+      stationing: false,
+    },
+    {
+      symbol: "♄",
+      name: "Saturn",
+      position: "—",
+      speed: "—",
+      retrograde: false,
+      stationing: false,
+    },
   ],
   aspects: [],
   planetaryHour: {
@@ -257,9 +305,21 @@ export const FALLBACK_DATA: AdminDashboardData = {
   },
   catalogTrending: { recipes: [], live: false },
   auditEvents: { events: [], live: false },
-  enginePerformance: { clickToCookRate: 0, totalCalculations: 0, averageLatencyMs: 0, live: false },
+  enginePerformance: {
+    clickToCookRate: 0,
+    totalCalculations: 0,
+    averageLatencyMs: 0,
+    live: false,
+  },
   practitionerCohorts: {
-    funnel: { landing: 0, signup: 0, onboarded: 0, active: 0, firstCook: 0, paidPro: 0 },
+    funnel: {
+      landing: 0,
+      signup: 0,
+      onboarded: 0,
+      active: 0,
+      firstCook: 0,
+      paidPro: 0,
+    },
     elementalBreakdown: [],
     live: false,
   },
@@ -270,16 +330,88 @@ export const FALLBACK_DATA: AdminDashboardData = {
     recentOrders: [],
     live: false,
   },
-  pageTelemetry: { foodDiary: 0, customRecipes: 0, restaurants: 0, commensals: 0, mealPlans: 0, live: false },
+  pageTelemetry: {
+    foodDiary: 0,
+    customRecipes: 0,
+    restaurants: 0,
+    commensals: 0,
+    mealPlans: 0,
+    live: false,
+  },
   systemStatus: {
     generatedAt: new Date(0).toISOString(),
     overall: "UNKNOWN",
     flows: [],
     dependencies: [],
   },
+  onboardingHealth: {
+    generatedAt: new Date(0).toISOString(),
+    overall: "UNKNOWN",
+    headline: "Awaiting onboarding signals",
+    funnel: [
+      { id: "signup", label: "Signed up", count: 0, dropOff: 0 },
+      { id: "birth-data", label: "Submitted birth data", count: 0, dropOff: 0 },
+      {
+        id: "natal-chart",
+        label: "Natal chart computed",
+        count: 0,
+        dropOff: 0,
+      },
+      { id: "onboarded", label: "Onboarding complete", count: 0, dropOff: 0 },
+    ],
+    stuckUsers: [],
+    recentSuccesses: [],
+    apiHealth: {
+      observed: false,
+      count: 0,
+      successRate: 0,
+      errors4xx: 0,
+      errors5xx: 0,
+      p50LatencyMs: 0,
+      p95LatencyMs: 0,
+      recentErrors: [],
+    },
+    skipRate: 0,
+    live: false,
+  },
+  launchReadiness: {
+    subsystems: [],
+    settlement: { pending: 0, live: false },
+    readyCount: 0,
+    generatedAt: new Date(0).toISOString(),
+  },
+  operations: {
+    generatedAt: new Date(0).toISOString(),
+    state: "ATTENTION",
+    readinessScore: 0,
+    summary: "Awaiting control-plane signals",
+    coverage: { live: 0, total: 0, percent: 0, blindSpots: [] },
+    rollout: { ready: 0, total: 0, partial: 0, off: 0 },
+    codebase: { knownGaps: [], highPriority: 0 },
+    domains: [],
+    priorities: [],
+    maintenance: [],
+  },
+  planetaryIntegration: {
+    endpoints: {
+      alchmNextApp: "https://alchm.kitchen",
+      paUi: "",
+      paBackend: "",
+      wtenLegacyBackend: "",
+    },
+    health: "unknown",
+    agentCount: 0,
+    lastFeedEmit: null,
+    telemetry: null,
+  },
   liveActivity: { entries: [], live: false },
   recentAlerts: { entries: [], live: false },
-  livingEconomy: { affiliateClicksWeek: 0, cookedPostsWeek: 0, feedDauToday: 0, live: false },
+  livingEconomy: {
+    affiliateClicksWeek: 0,
+    cookedPostsWeek: 0,
+    feedDauToday: 0,
+    live: false,
+  },
   errorGroups: { groups: [], windowMinutes: 60, live: false },
   security: {
     signinSuccess24h: 0,
@@ -291,7 +423,12 @@ export const FALLBACK_DATA: AdminDashboardData = {
   },
   deploys: { entries: [], live: false },
   featureFlags: { flags: [], live: false },
-  resourceUsage: { items: [], provider: "Railway", periodLabel: "", live: false },
+  resourceUsage: {
+    items: [],
+    provider: "Railway",
+    periodLabel: "",
+    live: false,
+  },
   practitionerGeo: { regions: [], live: false },
   cohortRetention: { cohorts: [], live: false },
   meta: {

--- a/src/app/admin/_dashboard/extras.tsx
+++ b/src/app/admin/_dashboard/extras.tsx
@@ -11,7 +11,6 @@ import type {
   PractitionerGeoData,
 } from "@/services/dashboardPanelsService";
 import { Glyph } from "./atoms";
-import { seeded } from "./data";
 import { Card } from "./hero";
 
 // ============================================================
@@ -38,8 +37,6 @@ export function SubdomainMatrix({ pageTelemetry }: SubdomainMatrixProps) {
       component: "<FoodDiary />",
       table: "food_diary_entries",
       rows: tele.foodDiary,
-      latency: "44ms",
-      err: 0.01,
       color: "var(--accent)",
     },
     {
@@ -48,8 +45,6 @@ export function SubdomainMatrix({ pageTelemetry }: SubdomainMatrixProps) {
       component: "<MealPlanner />",
       table: "user_meal_plans",
       rows: tele.mealPlans,
-      latency: "62ms",
-      err: 0.0,
       color: "var(--accent-2)",
     },
     {
@@ -58,8 +53,6 @@ export function SubdomainMatrix({ pageTelemetry }: SubdomainMatrixProps) {
       component: "<RestaurantDiscovery />",
       table: "restaurants",
       rows: tele.restaurants,
-      latency: "120ms",
-      err: 0.02,
       color: "var(--el-fire)",
     },
     {
@@ -68,8 +61,6 @@ export function SubdomainMatrix({ pageTelemetry }: SubdomainMatrixProps) {
       component: "<CommensalPortal />",
       table: "manual_companion_charts",
       rows: tele.commensals,
-      latency: "96ms",
-      err: 0.03,
       color: "var(--el-water)",
     },
     {
@@ -78,15 +69,22 @@ export function SubdomainMatrix({ pageTelemetry }: SubdomainMatrixProps) {
       component: "<RecipeComposer />",
       table: "recipes",
       rows: tele.customRecipes,
-      latency: "32ms",
-      err: 0.0,
       color: "var(--el-earth)",
     },
   ];
 
   return (
-    <Card title="Canonical Route Telemetry" subtitle="core pages · route resolution, component binding, underlying table, and live row counts">
-      <div style={{ border: "1px solid var(--line)", borderRadius: 8, overflow: "hidden" }}>
+    <Card
+      title="Canonical Route Telemetry"
+      subtitle="core pages · bindings and row counts; route performance is not instrumented"
+    >
+      <div
+        style={{
+          border: "1px solid var(--line)",
+          borderRadius: 8,
+          overflow: "hidden",
+        }}
+      >
         <div
           style={{
             display: "grid",
@@ -96,7 +94,15 @@ export function SubdomainMatrix({ pageTelemetry }: SubdomainMatrixProps) {
             background: "rgba(255,255,255,0.02)",
           }}
         >
-          {["Route", "Purpose", "Component", "Db Table", "Live Rows", "Latency", "Err%"].map((h, i) => (
+          {[
+            "Route",
+            "Purpose",
+            "Component",
+            "Db Table",
+            "Live Rows",
+            "Latency",
+            "Err%",
+          ].map((h, i) => (
             <span
               key={h}
               className="t-tag"
@@ -114,27 +120,50 @@ export function SubdomainMatrix({ pageTelemetry }: SubdomainMatrixProps) {
               gridTemplateColumns: "1.2fr 1.3fr 1.1fr 1.3fr 0.7fr 0.5fr 0.5fr",
               padding: "10px 10px",
               alignItems: "center",
-              borderBottom: i === routes.length - 1 ? "none" : "1px solid var(--line)",
+              borderBottom:
+                i === routes.length - 1 ? "none" : "1px solid var(--line)",
               fontFamily: "var(--f-mono)",
               fontSize: 11,
             }}
           >
             <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
-              <span className="el-dot" style={{ background: r.color, boxShadow: `0 0 8px ${r.color}` }} />
+              <span
+                className="el-dot"
+                style={{ background: r.color, boxShadow: `0 0 8px ${r.color}` }}
+              />
               <span style={{ color: "var(--fg)" }}>{r.route}</span>
             </span>
-            <span style={{ color: "var(--fg-dim)", fontSize: 10 }}>{r.purpose}</span>
-            <span style={{ color: "var(--accent-2)", fontSize: 10.5 }}>{r.component}</span>
-            <span style={{ color: "var(--fg-dim)", fontSize: 10 }}>{r.table}</span>
+            <span style={{ color: "var(--fg-dim)", fontSize: 10 }}>
+              {r.purpose}
+            </span>
+            <span style={{ color: "var(--accent-2)", fontSize: 10.5 }}>
+              {r.component}
+            </span>
+            <span style={{ color: "var(--fg-dim)", fontSize: 10 }}>
+              {r.table}
+            </span>
             <span style={{ textAlign: "right", color: "var(--fg)" }}>
               {r.rows.toLocaleString()}{" "}
-              <span style={{ fontSize: 8, color: tele.live ? "var(--el-earth)" : "var(--fg-mute)" }}>
+              <span
+                style={{
+                  fontSize: 8,
+                  color: tele.live ? "var(--el-earth)" : "var(--fg-mute)",
+                }}
+              >
                 {tele.live ? "live" : "mock"}
               </span>
             </span>
-            <span style={{ textAlign: "right", color: "var(--fg-dim)" }}>{r.latency}</span>
-            <span style={{ textAlign: "right", color: r.err > 0.02 ? "var(--el-fire)" : "var(--fg-dim)" }}>
-              {r.err.toFixed(2)}
+            <span
+              style={{ textAlign: "right", color: "var(--fg-mute)" }}
+              title="Latency telemetry is not captured for this route."
+            >
+              —
+            </span>
+            <span
+              style={{ textAlign: "right", color: "var(--fg-mute)" }}
+              title="Per-route error telemetry is not captured here."
+            >
+              —
             </span>
           </div>
         ))}
@@ -151,116 +180,37 @@ interface APIHeatmapProps {
 }
 
 export function APIHeatmap({ db }: APIHeatmapProps) {
-  const endpoints = [
-    "GET  /api/recommendations",
-    "POST /api/recipe/compose",
-    "GET  /api/ingredients/:id",
-    "GET  /api/transit",
-    "GET  /api/natal",
-    "POST /api/cart/bundle",
-    "GET  /api/recipes/:id",
-    "POST /api/feedback",
-    "GET  /api/pantry",
-    "POST /api/dossier/export",
-    "GET  /api/cuisines",
-    "POST /api/commensal/dispatch",
-  ];
-  const rows = endpoints.map((_, ri) => seeded(ri * 13 + 7, 24, 0.05, 1.0));
-  const max = 1.0;
   return (
     <Card
       title="API Endpoint Heatmap"
-      subtitle="last 24h · request volume × hour"
+      subtitle="per-route request volume × hour"
       right={
-        <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>12 endpoints · 1.3M requests</span>
+        <span
+          className="t-mono"
+          style={{ fontSize: 9, color: "var(--accent-2)" }}
+        >
+          ◌ NOT INSTRUMENTED
+        </span>
       }
     >
-      <div style={{ display: "grid", gridTemplateColumns: "220px 1fr 80px", gap: 8 }}>
-        <div />
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(24, 1fr)" }}>
-          {Array.from({ length: 24 }, (_, h) => (
-            <span
-              key={h}
-              className="t-mono"
-              style={{ fontSize: 8, color: "var(--fg-mute)", textAlign: "center", padding: "0 1px" }}
-            >
-              {h % 4 === 0 ? String(h).padStart(2, "0") : ""}
-            </span>
-          ))}
+      <div
+        style={{
+          padding: "18px 16px",
+          border: "1px dashed var(--line-hi)",
+          borderRadius: 8,
+          background: "rgba(255,255,255,0.012)",
+        }}
+      >
+        <div style={{ color: "var(--fg)", fontSize: 11, marginBottom: 4 }}>
+          Hourly route-volume telemetry is not being captured.
         </div>
-        <span className="t-tag" style={{ fontSize: 8.5, textAlign: "right" }}>RPS · P95</span>
-
-        {endpoints.map((e, ri) => {
-          const peak = Math.max(...rows[ri]);
-          const peakIdx = rows[ri].indexOf(peak);
-          const rps = Math.round(peak * 1240);
-          const p95 = 60 + (ri * 17) % 240;
-          return (
-            <React.Fragment key={e}>
-              <span
-                className="t-mono"
-                style={{
-                  fontSize: 10,
-                  color: "var(--fg-dim)",
-                  whiteSpace: "nowrap",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                }}
-              >
-                {e}
-              </span>
-              <div style={{ display: "grid", gridTemplateColumns: "repeat(24, 1fr)", gap: 1.5 }}>
-                {rows[ri].map((v, hi) => (
-                  <div
-                    key={hi}
-                    style={{
-                      height: 16,
-                      background: `color-mix(in oklch, var(--accent), transparent ${(1 - v / max) * 92}%)`,
-                      border: "1px solid var(--line)",
-                      borderRadius: 2,
-                      position: "relative",
-                    }}
-                  >
-                    {hi === peakIdx && v > 0.6 && (
-                      <div
-                        style={{
-                          position: "absolute",
-                          inset: -1,
-                          border: "1px solid var(--accent-2)",
-                          borderRadius: 2,
-                        }}
-                      />
-                    )}
-                  </div>
-                ))}
-              </div>
-              <span className="t-mono" style={{ fontSize: 10, color: "var(--fg)", textAlign: "right" }}>
-                {rps} ·{" "}
-                <span style={{ color: p95 > 200 ? "var(--el-fire)" : "var(--fg-mute)" }}>{p95}ms</span>
-              </span>
-            </React.Fragment>
-          );
-        })}
-      </div>
-      <div style={{ display: "flex", justifyContent: "space-between", marginTop: 10, alignItems: "center" }}>
-        <span className="t-mono" style={{ fontSize: 8.5, color: "var(--fg-mute)" }}>
-          PEAK · 21:30 UTC · /api/recommendations · 1,182 rps
-        </span>
-        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-          <span className="t-mono" style={{ fontSize: 8.5, color: "var(--fg-mute)" }}>low</span>
-          {[0.1, 0.3, 0.5, 0.7, 0.9].map((v) => (
-            <div
-              key={v}
-              style={{
-                width: 14,
-                height: 10,
-                background: `color-mix(in oklch, var(--accent), transparent ${(1 - v) * 92}%)`,
-                border: "1px solid var(--line)",
-                borderRadius: 2,
-              }}
-            />
-          ))}
-          <span className="t-mono" style={{ fontSize: 8.5, color: "var(--fg-mute)" }}>high</span>
+        <div
+          className="t-mono"
+          style={{ color: "var(--fg-mute)", fontSize: 9.5, lineHeight: 1.6 }}
+        >
+          Persist route, status, latency, and hourly request counts before this
+          panel is used for capacity or reliability decisions. The codebase gap
+          is tracked in the control-plane work queue above.
         </div>
       </div>
 
@@ -275,14 +225,42 @@ export function APIHeatmap({ db }: APIHeatmapProps) {
           gap: 6,
         }}
       >
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
-          <span className="t-tag" style={{ color: "var(--accent)" }}>SLOW QUERY TELEMETRY (THRESHOLD: {db?.slowQueryThresholdMs ?? 200}ms)</span>
-          <span className="t-mono" style={{ fontSize: 8.5, color: db?.live ? "var(--el-earth)" : "var(--fg-mute)" }}>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "baseline",
+          }}
+        >
+          <span className="t-tag" style={{ color: "var(--accent)" }}>
+            SLOW QUERY TELEMETRY (THRESHOLD: {db?.slowQueryThresholdMs ?? 200}
+            ms)
+          </span>
+          <span
+            className="t-mono"
+            style={{
+              fontSize: 8.5,
+              color: db?.live ? "var(--el-earth)" : "var(--fg-mute)",
+            }}
+          >
             {db?.live ? "● Live stats" : "○ Local cache fallback"}
           </span>
         </div>
-        
-        {db?.slowQueries && db.slowQueries.length > 0 ? (
+
+        {!db?.live ? (
+          <div
+            className="t-mono"
+            style={{
+              fontSize: 9.5,
+              color: "var(--fg-mute)",
+              fontStyle: "italic",
+              padding: "4px 0",
+            }}
+          >
+            Database slow-query telemetry is unavailable; no health claim can be
+            made from this panel.
+          </div>
+        ) : db.slowQueries.length > 0 ? (
           <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
             {db.slowQueries.slice(0, 3).map((sq, i) => (
               <div
@@ -310,15 +288,31 @@ export function APIHeatmap({ db }: APIHeatmapProps) {
                 >
                   {sq.query}
                 </span>
-                <span style={{ color: sq.durationMs > 500 ? "var(--el-fire)" : "var(--accent-2)" }}>
+                <span
+                  style={{
+                    color:
+                      sq.durationMs > 500
+                        ? "var(--el-fire)"
+                        : "var(--accent-2)",
+                  }}
+                >
                   {sq.durationMs}ms
                 </span>
               </div>
             ))}
           </div>
         ) : (
-          <div className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)", fontStyle: "italic", padding: "4px 0" }}>
-            No slow queries detected in the past 24 hours. Database performance is nominal.
+          <div
+            className="t-mono"
+            style={{
+              fontSize: 9.5,
+              color: "var(--fg-mute)",
+              fontStyle: "italic",
+              padding: "4px 0",
+            }}
+          >
+            No queries exceeded the configured threshold in the observed 24-hour
+            window.
           </div>
         )}
       </div>
@@ -333,110 +327,41 @@ interface RecipeQualityInspectorProps {
   trending?: CatalogTrendingData;
 }
 
-export function RecipeQualityInspector({ trending }: RecipeQualityInspectorProps) {
+export function RecipeQualityInspector({
+  trending,
+}: RecipeQualityInspectorProps) {
   const liveRecipes = trending?.recipes || [];
-  
-  const items = liveRecipes.length > 0
-    ? liveRecipes.slice(0, 6).map((r, i) => {
-        const rating = r.rating || 5.0;
-        const state = rating >= 4.7 ? "GREEN" : rating >= 4.0 ? "REVIEW" : "FLAG";
-        
-        // Generate beautiful deterministic SEMS elements
-        const semsBase = seeded(i * 12 + 5, 4, 0.4, 0.95);
-        
-        // Generate issue tags if low popularity or low reviews
-        const issues: string[] = [];
-        if (r.ratingCount === 0) {
-          issues.push("No registered user reviews");
-        } else if (r.ratingCount < 3) {
-          issues.push("Low sample size");
-        }
-        
-        if (r.popularity < 0.2) {
-          issues.push("Low recommendation affinity");
-        }
-        
-        return {
-          id: `RC-LN${String(i).padStart(3, "0")}`,
-          name: r.name,
-          author: `Cuisine: ${r.cuisine}`,
-          state,
-          sems: { 
-            s: semsBase[0] ?? 0.6, 
-            e: semsBase[1] ?? 0.7, 
-            m: semsBase[2] ?? 0.5, 
-            sub: semsBase[3] ?? 0.5 
-          },
-          issues,
-          score: r.popularity * 100, // Show popularity as a scale
-          eta: r.rating >= 4.7 ? "high harmony" : "rising",
-        };
-      })
-    : [
-        {
-          id: "RC-c8f1ad",
-          name: "Braised cheek · pomegranate · sumac",
-          author: "engine-v17",
-          state: "GREEN",
-          sems: { s: 0.62, e: 0.71, m: 0.48, sub: 0.55 },
-          issues: [] as string[],
-          score: 94,
-          eta: "approved",
-        },
-        {
-          id: "RC-84a210",
-          name: "Molecular caviar · tangerine pearl",
-          author: "engine-v17",
-          state: "REVIEW",
-          sems: { s: 0.84, e: 0.42, m: 0.18, sub: 0.22 },
-          issues: ["Substance too low · 22%", "Matter outside band", "no allergen tag"],
-          score: 62,
-          eta: "needs you",
-        },
-        {
-          id: "RC-192bb7",
-          name: "Burnt cabbage · brown butter · capers",
-          author: "engine-v17",
-          state: "GREEN",
-          sems: { s: 0.41, e: 0.68, m: 0.62, sub: 0.51 },
-          issues: [] as string[],
-          score: 91,
-          eta: "approved",
-        },
-        {
-          id: "RC-7c3091",
-          name: "Kheer · saffron · cardamom",
-          author: "@isobel.r → enhanced",
-          state: "GREEN",
-          sems: { s: 0.58, e: 0.55, m: 0.49, sub: 0.42 },
-          issues: [] as string[],
-          score: 88,
-          eta: "approved",
-        },
-        {
-          id: "RC-412de8",
-          name: "Squid ink risotto · sea urchin",
-          author: "engine-v17",
-          state: "FLAG",
-          sems: { s: 0.72, e: 0.81, m: 0.61, sub: 0.74 },
-          issues: [
-            "High allergen · shellfish + cephalopod",
-            "Sourcing limited to coastal regions",
-          ],
-          score: 74,
-          eta: "tag · gate",
-        },
-        {
-          id: "RC-ee920f",
-          name: "Pho gà · star anise · rice paper",
-          author: "engine-v17",
-          state: "GREEN",
-          sems: { s: 0.52, e: 0.74, m: 0.51, sub: 0.41 },
-          issues: [] as string[],
-          score: 92,
-          eta: "approved",
-        },
-      ];
+  const items = liveRecipes.slice(0, 6).map((recipe, index) => {
+    const issues: string[] = [];
+    if (recipe.ratingCount === 0) {
+      issues.push("No registered user reviews");
+    } else if (recipe.ratingCount < 3) {
+      issues.push("Low review sample");
+    }
+    if (recipe.popularity < 0.2) {
+      issues.push("Low recommendation affinity");
+    }
+
+    const state =
+      recipe.ratingCount === 0
+        ? "REVIEW"
+        : recipe.rating < 4
+          ? "FLAG"
+          : issues.length > 0
+            ? "REVIEW"
+            : "GREEN";
+
+    return {
+      id: `RC-LN${String(index).padStart(3, "0")}`,
+      name: recipe.name,
+      author: `Cuisine: ${recipe.cuisine}`,
+      state,
+      issues,
+      rating: recipe.rating,
+      ratingCount: recipe.ratingCount,
+      popularity: recipe.popularity,
+    };
+  });
 
   const stateColor: Record<string, string> = {
     GREEN: "var(--el-earth)",
@@ -446,20 +371,42 @@ export function RecipeQualityInspector({ trending }: RecipeQualityInspectorProps
   return (
     <Card
       title="Recipe Quality Inspector"
-      subtitle="auto-generated recipes · SEMS + allergen + sourcing"
+      subtitle="live catalog rating, review volume, and recommendation affinity"
       right={
-        <button className="btn btn-primary" style={{ padding: "5px 10px", fontSize: 9 }} type="button">
-          BATCH REVIEW
-        </button>
+        <span
+          className="t-mono"
+          style={{
+            fontSize: 9,
+            color: trending?.live ? "var(--el-earth)" : "var(--fg-mute)",
+          }}
+        >
+          {trending?.live ? "● LIVE CATALOG" : "○ NO SOURCE"}
+        </span>
       }
     >
       <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {items.length === 0 && (
+          <div
+            className="t-mono"
+            style={{
+              padding: "28px 14px",
+              textAlign: "center",
+              color: "var(--fg-mute)",
+              border: "1px dashed var(--line)",
+              borderRadius: 8,
+              fontSize: 9.5,
+            }}
+          >
+            No live recipe-quality rows are available. SEMS and allergen scoring
+            remain registered codebase gaps in the control plane.
+          </div>
+        )}
         {items.map((r) => (
           <div
             key={r.id}
             style={{
               display: "grid",
-              gridTemplateColumns: "1fr 110px 100px 100px",
+              gridTemplateColumns: "1fr 110px 100px",
               gap: 10,
               alignItems: "center",
               padding: "8px 10px",
@@ -481,62 +428,47 @@ export function RecipeQualityInspector({ trending }: RecipeQualityInspectorProps
           >
             <div>
               <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
-                <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>{r.id}</span>
-                <span style={{ fontSize: 12, color: "var(--fg)", fontWeight: "500" }}>{r.name}</span>
+                <span
+                  className="t-mono"
+                  style={{ fontSize: 9, color: "var(--fg-mute)" }}
+                >
+                  {r.id}
+                </span>
+                <span
+                  style={{
+                    fontSize: 12,
+                    color: "var(--fg)",
+                    fontWeight: "500",
+                  }}
+                >
+                  {r.name}
+                </span>
               </div>
               <div style={{ display: "flex", gap: 8, marginTop: 2 }}>
-                <span className="t-mono" style={{ fontSize: 9, color: "var(--accent-2)" }}>{r.author}</span>
+                <span
+                  className="t-mono"
+                  style={{ fontSize: 9, color: "var(--accent-2)" }}
+                >
+                  {r.author}
+                </span>
                 {r.issues.length > 0 && (
-                  <span className="t-mono" style={{ fontSize: 9, color: "var(--el-fire)" }}>
+                  <span
+                    className="t-mono"
+                    style={{ fontSize: 9, color: "var(--el-fire)" }}
+                  >
                     {r.issues.map((i) => `· ${i}`).join("   ")}
                   </span>
                 )}
               </div>
             </div>
 
-            <div style={{ display: "flex", gap: 2 }}>
-              {[
-                { v: r.sems.s, c: "S", col: "var(--el-fire)" },
-                { v: r.sems.e, c: "E", col: "var(--accent)" },
-                { v: r.sems.m, c: "M", col: "var(--el-earth)" },
-                { v: r.sems.sub, c: "Sb", col: "var(--el-water)" },
-              ].map((b) => (
-                <div
-                  key={b.c}
-                  style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center" }}
-                >
-                  <div
-                    style={{
-                      width: "100%",
-                      height: 26,
-                      background: "rgba(255,255,255,0.04)",
-                      borderRadius: 3,
-                      position: "relative",
-                      overflow: "hidden",
-                    }}
-                  >
-                    <div
-                      style={{
-                        position: "absolute",
-                        left: 0,
-                        right: 0,
-                        bottom: 0,
-                        height: `${b.v * 100}%`,
-                        background: b.col,
-                        opacity: 0.85,
-                      }}
-                    />
-                  </div>
-                  <span
-                    className="t-mono"
-                    style={{ fontSize: 7.5, color: "var(--fg-mute)", marginTop: 1, letterSpacing: "0.1em" }}
-                  >
-                    {b.c}
-                  </span>
-                </div>
-              ))}
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+              }}
+            >
               <span
                 style={{
                   padding: "2px 10px",
@@ -551,25 +483,25 @@ export function RecipeQualityInspector({ trending }: RecipeQualityInspectorProps
               >
                 {r.state}
               </span>
-              <span className="t-num" style={{ fontSize: 13, color: "var(--fg)", marginTop: 2 }}>
-                {r.score.toFixed(0)}%
+              <span
+                className="t-num"
+                style={{ fontSize: 13, color: "var(--fg)", marginTop: 2 }}
+              >
+                {r.rating.toFixed(1)} ★
               </span>
             </div>
             <span
               className="t-mono"
               style={{
                 fontSize: 9,
-                color:
-                  r.eta === "needs edit"
-                    ? "var(--el-fire)"
-                    : r.eta === "approved"
-                      ? "var(--el-earth)"
-                      : "var(--accent)",
+                color: "var(--fg-dim)",
                 textAlign: "right",
                 letterSpacing: "0.14em",
               }}
             >
-              {r.eta.toUpperCase()}
+              {r.ratingCount} REVIEWS
+              <br />
+              {(r.popularity * 100).toFixed(0)}% AFFINITY
             </span>
           </div>
         ))}
@@ -582,9 +514,12 @@ export function RecipeQualityInspector({ trending }: RecipeQualityInspectorProps
 // COSMIC YIELD ECONOMY
 // ============================================================
 export function CosmicYieldEconomy({ data }: { data: CosmicYieldData }) {
-  const burndata = seeded(51, 30, 0.4, 0.85);
-  const mintdata = seeded(53, 30, 0.45, 0.9);
   const maxSink = Math.max(1, ...data.sinks24h.map((s) => s.amount));
+  const maxFlow = Math.max(1, data.minted30d, data.burned30d);
+  const topHolderShare =
+    data.inCirculation > 0 && data.topHolders.length > 0
+      ? (data.topHolders[0].balance / data.inCirculation) * 100
+      : null;
   const sinks = data.sinks24h.map((s) => ({
     k: s.source.replace(/_/g, " "),
     v: Math.round(s.amount),
@@ -593,16 +528,31 @@ export function CosmicYieldEconomy({ data }: { data: CosmicYieldData }) {
   return (
     <Card
       title="Cosmic Yield · internal economy"
-      subtitle={`${Math.round(data.inCirculation).toLocaleString()} CY in circulation · ${data.live ? "live ledger" : "cached"}`}
+      subtitle={`${Math.round(data.inCirculation).toLocaleString()} ESMS in circulation · ${data.live ? "live ledger" : "ledger unavailable"}`}
       right={
-        <button className="btn btn-ghost" style={{ padding: "4px 10px", fontSize: 9 }} type="button">
-          OPEN LEDGER
-        </button>
+        <span
+          className="t-mono"
+          style={{
+            fontSize: 9,
+            color: data.live ? "var(--el-earth)" : "var(--fg-mute)",
+          }}
+        >
+          {data.live ? "● LIVE LEDGER" : "○ NO SOURCE"}
+        </span>
       }
     >
-      <div style={{ display: "grid", gridTemplateColumns: "1.1fr 1fr", gap: 14 }}>
+      <div
+        style={{ display: "grid", gridTemplateColumns: "1.1fr 1fr", gap: 14 }}
+      >
         <div>
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginBottom: 10 }}>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gap: 8,
+              marginBottom: 10,
+            }}
+          >
             <Stat2
               k="Minted · 30d"
               v={Math.round(data.minted30d).toLocaleString()}
@@ -621,50 +571,83 @@ export function CosmicYieldEconomy({ data }: { data: CosmicYieldData }) {
             <Stat2
               k="Net flow · 30d"
               v={`${data.netFlow30d >= 0 ? "+" : ""}${Math.round(data.netFlow30d).toLocaleString()}`}
-              d={data.netFlow30d >= 0 ? "inflationary tilt" : "deflationary tilt"}
+              d={
+                data.netFlow30d >= 0 ? "inflationary tilt" : "deflationary tilt"
+              }
               accent
             />
           </div>
           <div
             style={{
-              position: "relative",
-              height: 76,
               border: "1px solid var(--line)",
               borderRadius: 8,
-              padding: 6,
+              padding: "9px 10px",
               background: "rgba(0,0,0,0.2)",
             }}
           >
-            <div className="t-tag" style={{ fontSize: 8, position: "absolute", top: 4, left: 8 }}>
-              MINT vs BURN · 30D
+            <div className="t-tag" style={{ fontSize: 8, marginBottom: 7 }}>
+              MINT vs BURN · 30D AGGREGATE
             </div>
-            <svg viewBox="0 0 280 60" width="100%" height="60" style={{ marginTop: 12 }}>
-              <path
-                d={mintdata
-                  .map((v, i) => `${i === 0 ? "M" : "L"}${(i / 29) * 280} ${60 - v * 50}`)
-                  .join(" ")}
-                fill="none"
-                stroke="var(--el-earth)"
-                strokeWidth="1.2"
-              />
-              <path
-                d={burndata
-                  .map((v, i) => `${i === 0 ? "M" : "L"}${(i / 29) * 280} ${60 - v * 50}`)
-                  .join(" ")}
-                fill="none"
-                stroke="var(--el-fire)"
-                strokeWidth="1.2"
-              />
-            </svg>
-            <div style={{ position: "absolute", bottom: 4, right: 8, display: "flex", gap: 8 }}>
-              <span className="t-mono" style={{ fontSize: 8.5, color: "var(--el-earth)" }}>━ mint</span>
-              <span className="t-mono" style={{ fontSize: 8.5, color: "var(--el-fire)" }}>━ burn</span>
+            {[
+              {
+                label: "Minted",
+                value: data.minted30d,
+                color: "var(--el-earth)",
+              },
+              {
+                label: "Burned",
+                value: data.burned30d,
+                color: "var(--el-fire)",
+              },
+            ].map((flow) => (
+              <div key={flow.label} style={{ marginTop: 5 }}>
+                <div
+                  className="t-mono"
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    color: "var(--fg-dim)",
+                    fontSize: 8.5,
+                  }}
+                >
+                  <span>{flow.label}</span>
+                  <span>{Math.round(flow.value).toLocaleString()} ESMS</span>
+                </div>
+                <div
+                  style={{
+                    height: 5,
+                    marginTop: 2,
+                    background: "rgba(255,255,255,0.04)",
+                    borderRadius: 999,
+                    overflow: "hidden",
+                  }}
+                >
+                  <div
+                    style={{
+                      width: `${(flow.value / maxFlow) * 100}%`,
+                      height: "100%",
+                      background: flow.color,
+                    }}
+                  />
+                </div>
+              </div>
+            ))}
+            <div
+              className="t-mono"
+              style={{ color: "var(--fg-mute)", fontSize: 8, marginTop: 7 }}
+            >
+              Daily time-series telemetry is not yet persisted.
             </div>
           </div>
-          <div className="t-tag" style={{ marginTop: 10, marginBottom: 4 }}>SINKS · LAST 24H</div>
+          <div className="t-tag" style={{ marginTop: 10, marginBottom: 4 }}>
+            SINKS · LAST 24H
+          </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
             {sinks.length === 0 && (
-              <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>
+              <span
+                className="t-mono"
+                style={{ fontSize: 9, color: "var(--fg-mute)" }}
+              >
                 no debits in last 24h
               </span>
             )}
@@ -680,9 +663,13 @@ export function CosmicYieldEconomy({ data }: { data: CosmicYieldData }) {
                 }}
               >
                 <div>
-                  <div style={{ display: "flex", justifyContent: "space-between" }}>
+                  <div
+                    style={{ display: "flex", justifyContent: "space-between" }}
+                  >
                     <span style={{ color: "var(--fg-dim)" }}>{s.k}</span>
-                    <span className="t-num" style={{ color: "var(--fg)" }}>{s.v.toLocaleString()}</span>
+                    <span className="t-num" style={{ color: "var(--fg)" }}>
+                      {s.v.toLocaleString()}
+                    </span>
                   </div>
                   <div
                     style={{
@@ -704,17 +691,37 @@ export function CosmicYieldEconomy({ data }: { data: CosmicYieldData }) {
                     />
                   </div>
                 </div>
-                <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)", textAlign: "right" }}>CY</span>
+                <span
+                  className="t-mono"
+                  style={{
+                    fontSize: 9,
+                    color: "var(--fg-mute)",
+                    textAlign: "right",
+                  }}
+                >
+                  ESMS
+                </span>
               </div>
             ))}
           </div>
         </div>
         <div>
-          <div className="t-tag" style={{ marginBottom: 6 }}>TOP HOLDERS · BY BALANCE</div>
-          <div style={{ border: "1px solid var(--line)", borderRadius: 8, overflow: "hidden" }}>
+          <div className="t-tag" style={{ marginBottom: 6 }}>
+            TOP HOLDERS · BY BALANCE
+          </div>
+          <div
+            style={{
+              border: "1px solid var(--line)",
+              borderRadius: 8,
+              overflow: "hidden",
+            }}
+          >
             {data.topHolders.length === 0 && (
               <div style={{ padding: "10px 12px", textAlign: "center" }}>
-                <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>
+                <span
+                  className="t-mono"
+                  style={{ fontSize: 9, color: "var(--fg-mute)" }}
+                >
                   no token holders yet
                 </span>
               </div>
@@ -729,10 +736,15 @@ export function CosmicYieldEconomy({ data }: { data: CosmicYieldData }) {
                   alignItems: "center",
                   gap: 6,
                   borderBottom:
-                    i === data.topHolders.length - 1 ? "none" : "1px solid var(--line)",
+                    i === data.topHolders.length - 1
+                      ? "none"
+                      : "1px solid var(--line)",
                 }}
               >
-                <span className="t-num" style={{ fontSize: 10, color: "var(--fg-mute)" }}>
+                <span
+                  className="t-num"
+                  style={{ fontSize: 10, color: "var(--fg-mute)" }}
+                >
                   {i + 1}
                 </span>
                 <span
@@ -746,35 +758,57 @@ export function CosmicYieldEconomy({ data }: { data: CosmicYieldData }) {
                 >
                   {t.handle}
                 </span>
-                <span className="t-num" style={{ fontSize: 11, color: "var(--fg)", textAlign: "right" }}>
-                  {Math.round(t.balance).toLocaleString()} CY
+                <span
+                  className="t-num"
+                  style={{
+                    fontSize: 11,
+                    color: "var(--fg)",
+                    textAlign: "right",
+                  }}
+                >
+                  {Math.round(t.balance).toLocaleString()} ESMS
                 </span>
               </div>
             ))}
           </div>
-          <div style={{ marginTop: 8, padding: "8px 10px", border: "1px dashed var(--line)", borderRadius: 8 }}>
-            <div className="t-tag" style={{ fontSize: 8 }}>DISTRIBUTION · GINI</div>
-            <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between" }}>
-              <span className="t-num" style={{ fontSize: 16 }}>0.42</span>
-              <span className="t-mono" style={{ fontSize: 9, color: "var(--el-earth)" }}>healthy · &lt; 0.5</span>
+          <div
+            style={{
+              marginTop: 8,
+              padding: "8px 10px",
+              border: "1px dashed var(--line)",
+              borderRadius: 8,
+            }}
+          >
+            <div className="t-tag" style={{ fontSize: 8 }}>
+              CONCENTRATION · TOP OBSERVED HOLDER
             </div>
-            <div style={{ marginTop: 6, display: "grid", gridTemplateColumns: "repeat(10, 1fr)", gap: 1.5 }}>
-              {[0.1, 0.2, 0.3, 0.45, 0.55, 0.65, 0.72, 0.78, 0.88, 0.95].map((v, i) => (
-                <div
-                  key={i}
-                  style={{
-                    height: v * 28,
-                    alignSelf: "end",
-                    background: "var(--accent)",
-                    opacity: 0.8 - i * 0.05,
-                    borderRadius: 1,
-                  }}
-                />
-              ))}
+            <div
+              style={{
+                display: "flex",
+                alignItems: "baseline",
+                justifyContent: "space-between",
+              }}
+            >
+              <span className="t-num" style={{ fontSize: 16 }}>
+                {topHolderShare === null
+                  ? "—"
+                  : `${topHolderShare.toFixed(1)}%`}
+              </span>
+              <span
+                className="t-mono"
+                style={{ fontSize: 9, color: "var(--fg-mute)" }}
+              >
+                {topHolderShare === null
+                  ? "no live distribution"
+                  : "of circulation"}
+              </span>
             </div>
-            <div style={{ display: "flex", justifyContent: "space-between" }}>
-              <span className="t-mono" style={{ fontSize: 8, color: "var(--fg-mute)" }}>top 10%</span>
-              <span className="t-mono" style={{ fontSize: 8, color: "var(--fg-mute)" }}>bottom 10%</span>
+            <div
+              className="t-mono"
+              style={{ color: "var(--fg-mute)", fontSize: 8, marginTop: 5 }}
+            >
+              A true Gini coefficient requires the complete holder distribution
+              and is not currently computed.
             </div>
           </div>
         </div>
@@ -783,7 +817,17 @@ export function CosmicYieldEconomy({ data }: { data: CosmicYieldData }) {
   );
 }
 
-function Stat2({ k, v, d, accent }: { k: string; v: string; d: string; accent?: boolean }) {
+function Stat2({
+  k,
+  v,
+  d,
+  accent,
+}: {
+  k: string;
+  v: string;
+  d: string;
+  accent?: boolean;
+}) {
   return (
     <div
       style={{
@@ -793,9 +837,24 @@ function Stat2({ k, v, d, accent }: { k: string; v: string; d: string; accent?: 
         background: "rgba(255,255,255,0.02)",
       }}
     >
-      <div className="t-tag" style={{ fontSize: 8 }}>{k}</div>
-      <div className="t-num" style={{ fontSize: 16, color: accent ? "var(--accent)" : "var(--fg)" }}>{v}</div>
-      <div className="t-mono" style={{ fontSize: 8.5, color: "var(--fg-mute)", letterSpacing: "0.1em", marginTop: 1 }}>
+      <div className="t-tag" style={{ fontSize: 8 }}>
+        {k}
+      </div>
+      <div
+        className="t-num"
+        style={{ fontSize: 16, color: accent ? "var(--accent)" : "var(--fg)" }}
+      >
+        {v}
+      </div>
+      <div
+        className="t-mono"
+        style={{
+          fontSize: 8.5,
+          color: "var(--fg-mute)",
+          letterSpacing: "0.1em",
+          marginTop: 1,
+        }}
+      >
         {d}
       </div>
     </div>
@@ -816,11 +875,17 @@ export function PractitionerGeo({ data }: { data?: PractitionerGeoData }) {
   return (
     <Card
       title="Practitioner Geography"
-      subtitle={live ? `${regions.length} active regions` : "geo aggregation offline"}
+      subtitle={
+        live ? `${regions.length} active regions` : "geo aggregation offline"
+      }
       right={
         <span
           className="t-mono"
-          style={{ fontSize: 9, color: live ? "var(--el-earth)" : "var(--fg-mute)", letterSpacing: "0.14em" }}
+          style={{
+            fontSize: 9,
+            color: live ? "var(--el-earth)" : "var(--fg-mute)",
+            letterSpacing: "0.14em",
+          }}
         >
           {live ? "● LIVE" : "○ NO SOURCE"}
         </span>
@@ -837,11 +902,17 @@ export function PractitionerGeo({ data }: { data?: PractitionerGeoData }) {
               "radial-gradient(ellipse 80% 60% at 50% 50%, rgba(140,100,255,0.04), transparent 70%)",
           }}
         >
-          <div style={{ fontSize: 12, color: "var(--fg-dim)", marginBottom: 4 }}>
+          <div
+            style={{ fontSize: 12, color: "var(--fg-dim)", marginBottom: 4 }}
+          >
             No location aggregation yet
           </div>
-          <div className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>
-            birth charts store coordinates · roll up by city / region when we have a sample
+          <div
+            className="t-mono"
+            style={{ fontSize: 9, color: "var(--fg-mute)" }}
+          >
+            birth charts store coordinates · roll up by city / region when we
+            have a sample
           </div>
         </div>
       ) : (
@@ -861,13 +932,36 @@ export function PractitionerGeo({ data }: { data?: PractitionerGeoData }) {
               }}
             >
               <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                <Glyph name="diamond" size={12} style={{ color: "var(--accent)" }} />
-                <span style={{ fontSize: 11.5, color: "var(--fg)", fontWeight: "500" }}>{r.name}</span>
+                <Glyph
+                  name="diamond"
+                  size={12}
+                  style={{ color: "var(--accent)" }}
+                />
+                <span
+                  style={{
+                    fontSize: 11.5,
+                    color: "var(--fg)",
+                    fontWeight: "500",
+                  }}
+                >
+                  {r.name}
+                </span>
               </div>
-              <span className="t-mono" style={{ fontSize: 9.5, color: "var(--fg-mute)" }}>
-                {r.lat.toFixed(2)}°{r.lat >= 0 ? "N" : "S"} · {r.lng.toFixed(2)}°{r.lng >= 0 ? "E" : "W"}
+              <span
+                className="t-mono"
+                style={{ fontSize: 9.5, color: "var(--fg-mute)" }}
+              >
+                {r.lat.toFixed(2)}°{r.lat >= 0 ? "N" : "S"} · {r.lng.toFixed(2)}
+                °{r.lng >= 0 ? "E" : "W"}
               </span>
-              <span className="t-num" style={{ fontSize: 11.5, color: "var(--fg-dim)", textAlign: "right" }}>
+              <span
+                className="t-num"
+                style={{
+                  fontSize: 11.5,
+                  color: "var(--fg-dim)",
+                  textAlign: "right",
+                }}
+              >
                 {r.count} chart{r.count === 1 ? "" : "s"}
               </span>
             </div>
@@ -920,14 +1014,18 @@ export function ErrorGroups({ errorGroups }: { errorGroups: ErrorGroupsData }) {
     >
       {groups.length === 0 ? (
         <div style={{ padding: "16px 0", textAlign: "center" }}>
-          <span className="t-mono" style={{ fontSize: 10, color: "var(--fg-mute)" }}>
+          <span
+            className="t-mono"
+            style={{ fontSize: 10, color: "var(--fg-mute)" }}
+          >
             {errorGroups.live ? "all green" : "request_log_entries unavailable"}
           </span>
         </div>
       ) : (
         <div style={{ display: "flex", flexDirection: "column" }}>
           {groups.map((g, i) => {
-            const recent = Date.now() - new Date(g.lastSeenAt).getTime() < 5 * 60 * 1000;
+            const recent =
+              Date.now() - new Date(g.lastSeenAt).getTime() < 5 * 60 * 1000;
             const hot = g.fiveXxCount > 0;
             return (
               <div
@@ -938,7 +1036,8 @@ export function ErrorGroups({ errorGroups }: { errorGroups: ErrorGroupsData }) {
                   gap: 8,
                   alignItems: "center",
                   padding: "10px 0",
-                  borderBottom: i === groups.length - 1 ? "none" : "1px solid var(--line)",
+                  borderBottom:
+                    i === groups.length - 1 ? "none" : "1px solid var(--line)",
                 }}
               >
                 <span
@@ -946,8 +1045,16 @@ export function ErrorGroups({ errorGroups }: { errorGroups: ErrorGroupsData }) {
                     width: 5,
                     height: 32,
                     borderRadius: 999,
-                    background: hot ? "#FF5252" : recent ? "var(--el-fire)" : "var(--fg-faint)",
-                    boxShadow: hot ? "0 0 6px #FF5252" : recent ? "0 0 6px var(--el-fire)" : "none",
+                    background: hot
+                      ? "#FF5252"
+                      : recent
+                        ? "var(--el-fire)"
+                        : "var(--fg-faint)",
+                    boxShadow: hot
+                      ? "0 0 6px #FF5252"
+                      : recent
+                        ? "0 0 6px var(--el-fire)"
+                        : "none",
                   }}
                 />
                 <div style={{ minWidth: 0 }}>
@@ -964,7 +1071,10 @@ export function ErrorGroups({ errorGroups }: { errorGroups: ErrorGroupsData }) {
                   >
                     {g.path}
                   </span>
-                  <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>
+                  <span
+                    className="t-mono"
+                    style={{ fontSize: 9, color: "var(--fg-mute)" }}
+                  >
                     last · {formatRelativeShort(g.lastSeenAt)}
                   </span>
                 </div>
@@ -983,7 +1093,8 @@ export function ErrorGroups({ errorGroups }: { errorGroups: ErrorGroupsData }) {
                   className="t-num"
                   style={{
                     textAlign: "right",
-                    color: g.fourXxCount > 0 ? "var(--el-fire)" : "var(--fg-mute)",
+                    color:
+                      g.fourXxCount > 0 ? "var(--el-fire)" : "var(--fg-mute)",
                     fontSize: 11,
                   }}
                   title="4xx responses"
@@ -992,7 +1103,11 @@ export function ErrorGroups({ errorGroups }: { errorGroups: ErrorGroupsData }) {
                 </span>
                 <span
                   className="t-num"
-                  style={{ textAlign: "right", color: "var(--fg-dim)", fontSize: 11 }}
+                  style={{
+                    textAlign: "right",
+                    color: "var(--fg-dim)",
+                    fontSize: 11,
+                  }}
                   title="total in window"
                 >
                   {g.totalCount}
@@ -1010,9 +1125,15 @@ export function ErrorGroups({ errorGroups }: { errorGroups: ErrorGroupsData }) {
           >
             <span />
             <span />
-            <span className="t-tag" style={{ fontSize: 8, textAlign: "right" }}>5XX</span>
-            <span className="t-tag" style={{ fontSize: 8, textAlign: "right" }}>4XX</span>
-            <span className="t-tag" style={{ fontSize: 8, textAlign: "right" }}>TOTAL</span>
+            <span className="t-tag" style={{ fontSize: 8, textAlign: "right" }}>
+              5XX
+            </span>
+            <span className="t-tag" style={{ fontSize: 8, textAlign: "right" }}>
+              4XX
+            </span>
+            <span className="t-tag" style={{ fontSize: 8, textAlign: "right" }}>
+              TOTAL
+            </span>
           </div>
         </div>
       )}
@@ -1032,16 +1153,26 @@ function fmtUsage(n: number): string {
 }
 
 export function ResourceUsage({ data }: { data?: ResourceUsageData }) {
-  const { items = [], provider = "Railway", periodLabel = "", live = false } =
-    data || {};
+  const {
+    items = [],
+    provider = "Railway",
+    periodLabel = "",
+    live = false,
+  } = data || {};
   return (
     <Card
       title="Resource Usage · MTD"
-      subtitle={live ? `${provider} · ${periodLabel}` : "Railway usage not connected"}
+      subtitle={
+        live ? `${provider} · ${periodLabel}` : "Railway usage not connected"
+      }
       right={
         <span
           className="t-mono"
-          style={{ fontSize: 9, color: live ? "var(--el-earth)" : "var(--fg-mute)", letterSpacing: "0.14em" }}
+          style={{
+            fontSize: 9,
+            color: live ? "var(--el-earth)" : "var(--fg-mute)",
+            letterSpacing: "0.14em",
+          }}
         >
           {live ? "● LIVE" : "○ NO SOURCE"}
         </span>
@@ -1056,10 +1187,15 @@ export function ResourceUsage({ data }: { data?: ResourceUsageData }) {
             borderRadius: 8,
           }}
         >
-          <div style={{ fontSize: 11, color: "var(--fg-dim)", marginBottom: 4 }}>
+          <div
+            style={{ fontSize: 11, color: "var(--fg-dim)", marginBottom: 4 }}
+          >
             Railway usage not connected
           </div>
-          <div className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>
+          <div
+            className="t-mono"
+            style={{ fontSize: 9, color: "var(--fg-mute)" }}
+          >
             set RAILWAY_API_TOKEN to populate
           </div>
         </div>
@@ -1067,17 +1203,37 @@ export function ResourceUsage({ data }: { data?: ResourceUsageData }) {
         <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
           <div
             className="t-mono"
-            style={{ fontSize: 8, color: "var(--fg-mute)", letterSpacing: "0.08em" }}
+            style={{
+              fontSize: 8,
+              color: "var(--fg-mute)",
+              letterSpacing: "0.08em",
+            }}
           >
             METERED USAGE · MTD / PROJECTED MONTH-END (not billed $)
           </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
             {items.map((item) => (
-              <div key={item.measurement} style={{ border: "1px solid var(--line)", borderRadius: 8, padding: "8px 10px" }}>
-                <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4 }}>
-                  <span style={{ fontSize: 11, color: "var(--fg-dim)" }}>{item.resource}</span>
+              <div
+                key={item.measurement}
+                style={{
+                  border: "1px solid var(--line)",
+                  borderRadius: 8,
+                  padding: "8px 10px",
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    marginBottom: 4,
+                  }}
+                >
+                  <span style={{ fontSize: 11, color: "var(--fg-dim)" }}>
+                    {item.resource}
+                  </span>
                   <span className="t-num" style={{ fontSize: 11 }}>
-                    {fmtUsage(item.mtdValue)} / {fmtUsage(item.projectedValue)} {item.unit}
+                    {fmtUsage(item.mtdValue)} / {fmtUsage(item.projectedValue)}{" "}
+                    {item.unit}
                   </span>
                 </div>
                 <div
@@ -1093,13 +1249,23 @@ export function ResourceUsage({ data }: { data?: ResourceUsageData }) {
                     style={{
                       width: `${Math.min(100, item.pct * 100)}%`,
                       height: "100%",
-                      background: item.pct > 0.8 ? "var(--el-fire)" : "var(--accent)",
+                      background:
+                        item.pct > 0.8 ? "var(--el-fire)" : "var(--accent)",
                       boxShadow: `0 0 8px ${item.pct > 0.8 ? "var(--el-fire)" : "var(--accent)"}`,
                     }}
                   />
                 </div>
-                <span className="t-mono" style={{ fontSize: 8, color: "var(--fg-mute)", marginTop: 2, display: "block" }}>
-                  {Math.round(item.pct * 100)}% of projected · {item.measurement}
+                <span
+                  className="t-mono"
+                  style={{
+                    fontSize: 8,
+                    color: "var(--fg-mute)",
+                    marginTop: 2,
+                    display: "block",
+                  }}
+                >
+                  {Math.round(item.pct * 100)}% of projected ·{" "}
+                  {item.measurement}
                 </span>
               </div>
             ))}
@@ -1134,7 +1300,10 @@ export function DatabaseStorage({ data }: { data: DatabaseObservabilityData }) {
       right={
         <span
           className="t-mono"
-          style={{ fontSize: 9, color: live ? "var(--el-earth)" : "var(--fg-mute)" }}
+          style={{
+            fontSize: 9,
+            color: live ? "var(--el-earth)" : "var(--fg-mute)",
+          }}
         >
           {live ? "● LIVE" : "○ CACHED"}
         </span>
@@ -1161,15 +1330,29 @@ export function DatabaseStorage({ data }: { data: DatabaseObservabilityData }) {
           d="queued acquires"
           accent={pool.waiting > 0}
         />
-        <Stat2 k="DB size" v={formatBytes(data.dbSizeBytes)} d="current database" />
+        <Stat2
+          k="DB size"
+          v={formatBytes(data.dbSizeBytes)}
+          d="current database"
+        />
       </div>
 
       <div className="t-tag" style={{ marginBottom: 4 }}>
         SLOW QUERIES · LAST 24H &gt; {slowQueryThresholdMs}MS
       </div>
-      <div style={{ display: "flex", flexDirection: "column", gap: 3, marginBottom: 10 }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 3,
+          marginBottom: 10,
+        }}
+      >
         {slowQueries.length === 0 ? (
-          <span className="t-mono" style={{ fontSize: 9, color: "var(--el-earth)" }}>
+          <span
+            className="t-mono"
+            style={{ fontSize: 9, color: "var(--el-earth)" }}
+          >
             none — all logged queries under {slowQueryThresholdMs}ms
           </span>
         ) : (
@@ -1195,7 +1378,10 @@ export function DatabaseStorage({ data }: { data: DatabaseObservabilityData }) {
               >
                 {q.query}
               </span>
-              <span className="t-num" style={{ textAlign: "right", color: "var(--el-fire)" }}>
+              <span
+                className="t-num"
+                style={{ textAlign: "right", color: "var(--el-fire)" }}
+              >
                 {q.durationMs}ms
               </span>
             </div>
@@ -1203,10 +1389,15 @@ export function DatabaseStorage({ data }: { data: DatabaseObservabilityData }) {
         )}
       </div>
 
-      <div className="t-tag" style={{ marginBottom: 4 }}>LARGEST TABLES</div>
+      <div className="t-tag" style={{ marginBottom: 4 }}>
+        LARGEST TABLES
+      </div>
       <div style={{ display: "flex", flexDirection: "column" }}>
         {tables.length === 0 && (
-          <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>
+          <span
+            className="t-mono"
+            style={{ fontSize: 9, color: "var(--fg-mute)" }}
+          >
             table stats unavailable
           </span>
         )}
@@ -1219,21 +1410,34 @@ export function DatabaseStorage({ data }: { data: DatabaseObservabilityData }) {
               gap: 8,
               alignItems: "center",
               padding: "8px 0",
-              borderBottom: i === tables.length - 1 ? "none" : "1px solid var(--line)",
+              borderBottom:
+                i === tables.length - 1 ? "none" : "1px solid var(--line)",
               fontSize: 11,
             }}
           >
-            <Glyph name="diamond" size={12} style={{ color: "var(--el-earth)" }} />
+            <Glyph
+              name="diamond"
+              size={12}
+              style={{ color: "var(--el-earth)" }}
+            />
             <span style={{ color: "var(--fg)" }}>{t.name}</span>
             <span
               className="t-mono"
-              style={{ fontSize: 10, color: "var(--fg-dim)", textAlign: "right" }}
+              style={{
+                fontSize: 10,
+                color: "var(--fg-dim)",
+                textAlign: "right",
+              }}
             >
               {t.rows.toLocaleString()} rows
             </span>
             <span
               className="t-mono"
-              style={{ fontSize: 10, color: "var(--fg-dim)", textAlign: "right" }}
+              style={{
+                fontSize: 10,
+                color: "var(--fg-dim)",
+                textAlign: "right",
+              }}
             >
               {formatBytes(t.sizeBytes)}
             </span>

--- a/src/app/admin/_dashboard/shell.tsx
+++ b/src/app/admin/_dashboard/shell.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import React from "react";
 import { Glyph, LiveTimecode, ScanLine } from "./atoms";
 import type { AdminDashboardData, Density } from "./data";
@@ -54,12 +55,21 @@ export function AdminShell({
       />
       <div
         data-shell-body=""
-        style={{ display: "grid", gridTemplateColumns: "232px 1fr", minHeight: 0 }}
+        style={{
+          display: "grid",
+          gridTemplateColumns: "232px 1fr",
+          minHeight: 0,
+        }}
       >
-        <AdminSideRail data={data} />
+        <AdminSideRail data={data} onNavigate={() => setNavOpen(false)} />
         <main
           data-shell-main=""
-          style={{ minWidth: 0, minHeight: 0, overflow: "auto", padding: "16px 20px 24px" }}
+          style={{
+            minWidth: 0,
+            minHeight: 0,
+            overflow: "auto",
+            padding: "16px 20px 24px",
+          }}
           onClick={() => navOpen && setNavOpen(false)}
         >
           {children}
@@ -100,7 +110,8 @@ function AdminTopBar({
         gap: 24,
         padding: "0 20px",
         borderBottom: "1px solid var(--line)",
-        background: "linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0.005))",
+        background:
+          "linear-gradient(180deg, rgba(255,255,255,0.025), rgba(255,255,255,0.005))",
         backdropFilter: "blur(12px)",
         position: "relative",
         zIndex: 5,
@@ -117,12 +128,33 @@ function AdminTopBar({
           <Glyph name="crosshair" size={16} stroke={1.4} />
         </button>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          <Glyph name="orbital" size={20} stroke={1.4} style={{ color: "var(--accent)" }} />
-          <div style={{ display: "flex", flexDirection: "column", lineHeight: 1.0 }}>
-            <span className="t-display" style={{ fontSize: 17, letterSpacing: "0.02em" }}>
+          <Glyph
+            name="orbital"
+            size={20}
+            stroke={1.4}
+            style={{ color: "var(--accent)" }}
+          />
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              lineHeight: 1.0,
+            }}
+          >
+            <span
+              className="t-display"
+              style={{ fontSize: 17, letterSpacing: "0.02em" }}
+            >
               alchm
             </span>
-            <span className="t-mono" style={{ fontSize: 8, letterSpacing: "0.32em", color: "var(--fg-mute)" }}>
+            <span
+              className="t-mono"
+              style={{
+                fontSize: 8,
+                letterSpacing: "0.32em",
+                color: "var(--fg-mute)",
+              }}
+            >
               ADMIN
             </span>
           </div>
@@ -134,26 +166,46 @@ function AdminTopBar({
               width: 28,
               height: 28,
               borderRadius: "50%",
-              background: "linear-gradient(135deg, var(--accent), var(--accent-2))",
+              background:
+                "linear-gradient(135deg, var(--accent), var(--accent-2))",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
               fontFamily: "var(--f-display)",
               fontSize: 14,
               color: "#0A0712",
-              boxShadow: "0 0 0 1px var(--line-hi), 0 0 16px var(--accent-glow)",
+              boxShadow:
+                "0 0 0 1px var(--line-hi), 0 0 16px var(--accent-glow)",
             }}
           >
             {user.initial}
           </div>
-          <div style={{ display: "flex", flexDirection: "column", lineHeight: 1.15 }}>
-            <span style={{ fontSize: 12, color: "var(--fg)" }}>{user.name}</span>
-            <span className="t-mono" style={{ fontSize: 9, letterSpacing: "0.16em", color: "var(--accent-2)" }}>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              lineHeight: 1.15,
+            }}
+          >
+            <span style={{ fontSize: 12, color: "var(--fg)" }}>
+              {user.name}
+            </span>
+            <span
+              className="t-mono"
+              style={{
+                fontSize: 9,
+                letterSpacing: "0.16em",
+                color: "var(--accent-2)",
+              }}
+            >
               {user.badge} · {user.role}
             </span>
           </div>
           {user.onCall && (
-            <span className="chip chip-active" style={{ padding: "2px 8px", fontSize: 8 }}>
+            <span
+              className="chip chip-active"
+              style={{ padding: "2px 8px", fontSize: 8 }}
+            >
               <span
                 style={{
                   width: 5,
@@ -172,7 +224,12 @@ function AdminTopBar({
       {/* center — global heartbeat */}
       <div
         data-shell-topbar-metrics=""
-        style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 18 }}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 18,
+        }}
       >
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
           <span
@@ -186,10 +243,20 @@ function AdminTopBar({
             }}
             data-motion
           />
-          <span className="t-mono" style={{ fontSize: 11, letterSpacing: "0.18em", color: "var(--fg)" }}>
+          <span
+            className="t-mono"
+            style={{
+              fontSize: 11,
+              letterSpacing: "0.18em",
+              color: "var(--fg)",
+            }}
+          >
             ALL SYSTEMS · {pulse.state}
           </span>
-          <span className="t-mono" style={{ fontSize: 11, color: "var(--fg-mute)" }}>
+          <span
+            className="t-mono"
+            style={{ fontSize: 11, color: "var(--fg-mute)" }}
+          >
             · {pulse.score.toFixed(2)}
             <span style={{ color: "var(--fg-faint)" }}>%</span>
           </span>
@@ -198,25 +265,50 @@ function AdminTopBar({
         <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
           <TopMetric label="AVAIL" value={`${pulse.availability}%`} />
           <TopMetric label="P95" value={`${pulse.p95}ms`} />
-          <TopMetric label="ERR" value={`${pulse.errRate}%`} tone={pulse.errRate > 0.1 ? "warn" : "ok"} />
+          <TopMetric
+            label="ERR"
+            value={`${pulse.errRate}%`}
+            tone={pulse.errRate > 0.1 ? "warn" : "ok"}
+          />
           <TopMetric label="DEPLOY" value={pulse.deployFreshness} />
-          <TopMetric label="INC" value={pulse.activeIncidents} tone={pulse.activeIncidents ? "warn" : "ok"} />
+          <TopMetric
+            label="INC"
+            value={pulse.activeIncidents}
+            tone={pulse.activeIncidents ? "warn" : "ok"}
+          />
         </div>
       </div>
 
       {/* right — time, search, alerts, deploy */}
-      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+      <div
+        data-shell-actions=""
+        style={{ display: "flex", alignItems: "center", gap: 12 }}
+      >
         <div
           data-shell-time=""
-          style={{ display: "flex", flexDirection: "column", textAlign: "right", lineHeight: 1.1 }}
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            textAlign: "right",
+            lineHeight: 1.1,
+          }}
         >
           <LiveTimecode format="JD" />
           <LiveTimecode format="UTC" />
         </div>
-        <button className="btn btn-ghost" style={{ padding: "6px 10px", fontSize: 10, gap: 8 }} type="button">
-          <Glyph name="search" size={12} />⌘K
+        <button
+          className="btn btn-ghost"
+          style={{ padding: "6px 10px", fontSize: 10, gap: 8 }}
+          type="button"
+        >
+          <Glyph name="search" size={12} />
+          ⌘K
         </button>
-        <button className="btn btn-ghost" style={{ padding: "6px 10px", fontSize: 10, position: "relative" }} type="button">
+        <button
+          className="btn btn-ghost"
+          style={{ padding: "6px 10px", fontSize: 10, position: "relative" }}
+          type="button"
+        >
           <Glyph name="ring" size={12} />
           <span
             style={{
@@ -256,8 +348,15 @@ function TopMetric({
   const color = tone === "warn" ? "var(--el-fire)" : "var(--fg)";
   return (
     <div style={{ display: "flex", flexDirection: "column", lineHeight: 1.05 }}>
-      <span className="t-mono" style={{ fontSize: 8, letterSpacing: "0.2em", color: "var(--fg-mute)" }}>{label}</span>
-      <span className="t-num" style={{ fontSize: 12, color }}>{value}</span>
+      <span
+        className="t-mono"
+        style={{ fontSize: 8, letterSpacing: "0.2em", color: "var(--fg-mute)" }}
+      >
+        {label}
+      </span>
+      <span className="t-num" style={{ fontSize: 12, color }}>
+        {value}
+      </span>
     </div>
   );
 }
@@ -268,6 +367,7 @@ function TopMetric({
 interface ModuleEntry {
   id: string;
   label: string;
+  href: string;
   glyph:
     | "orbital"
     | "crosshair"
@@ -309,24 +409,42 @@ function formatBytes(bytes: number): string {
   return `${n.toFixed(n < 10 ? 1 : 0)} ${units[i]}`;
 }
 
-function AdminSideRail({ data }: { data: AdminDashboardData }) {
-  const flowsCount = data.systemStatus.flows.length + data.systemStatus.dependencies.length;
-  const activeAlerts = data.recentAlerts.entries.filter((a) => !a.suppressed && a.severity !== "info").length;
+function AdminSideRail({
+  data,
+  onNavigate,
+}: {
+  data: AdminDashboardData;
+  onNavigate: () => void;
+}) {
+  const flowsCount =
+    data.systemStatus.flows.length + data.systemStatus.dependencies.length;
+  const activeAlerts = data.recentAlerts.entries.filter(
+    (a) => !a.suppressed && a.severity !== "info",
+  ).length;
   const recipeCount = data.stats.totalRecipes;
   const ingredientCount = data.stats.totalIngredients;
   const commensals = data.pageTelemetry.commensals;
 
   const modules: ModuleEntry[] = [
-    { id: "overview", label: "Overview", glyph: "orbital", badge: null, active: true },
+    {
+      id: "overview",
+      label: "Overview",
+      href: "#overview",
+      glyph: "orbital",
+      badge: null,
+    },
     {
       id: "ops",
       label: "Operations",
+      href: "#operations",
       glyph: "crosshair",
       badge: flowsCount > 0 ? `${flowsCount} svc` : null,
+      active: true,
     },
     {
       id: "engine",
       label: "Recommendation",
+      href: "#engine",
       glyph: "atom",
       badge: data.enginePerformance.live
         ? `${data.enginePerformance.totalCalculations.toLocaleString()} calc`
@@ -335,18 +453,22 @@ function AdminSideRail({ data }: { data: AdminDashboardData }) {
     {
       id: "agents",
       label: "Agent Mesh",
+      href: "#agents",
       glyph: "ring",
       badge: null,
     },
     {
       id: "users",
       label: "Practitioners",
+      href: "/admin/users",
       glyph: "diamond",
-      badge: data.stats.totalUsers > 0 ? formatCount(data.stats.totalUsers) : null,
+      badge:
+        data.stats.totalUsers > 0 ? formatCount(data.stats.totalUsers) : null,
     },
     {
       id: "catalog",
       label: "Catalog",
+      href: "#engine",
       glyph: "bookmark",
       badge:
         recipeCount + ingredientCount > 0
@@ -356,27 +478,60 @@ function AdminSideRail({ data }: { data: AdminDashboardData }) {
     {
       id: "commensal",
       label: "Commensal",
+      href: "#platform-telemetry",
       glyph: "wave",
       badge: commensals > 0 ? String(commensals) : null,
     },
     {
       id: "commerce",
       label: "Commerce",
+      href: "#commerce",
       glyph: "triangle-up-bar",
       badge: data.commerce.live ? formatCurrencyShort(data.commerce.mrr) : null,
     },
     {
       id: "moderation",
       label: "Moderation",
+      href: "#trust",
       glyph: "flask",
       badge: activeAlerts > 0 ? String(activeAlerts) : null,
       warn: activeAlerts > 0,
     },
-    { id: "security", label: "Security", glyph: "spiral", badge: null },
-    { id: "experiments", label: "Experiments", glyph: "triangle-down-bar", badge: null },
-    { id: "deploys", label: "Deploys", glyph: "triangle-up", badge: null },
-    { id: "audit", label: "Audit Log", glyph: "bookmark", badge: null },
-    { id: "settings", label: "Settings", glyph: "settings", badge: null },
+    {
+      id: "security",
+      label: "Security",
+      href: "#trust",
+      glyph: "spiral",
+      badge: null,
+    },
+    {
+      id: "experiments",
+      label: "Experiments",
+      href: "#delivery",
+      glyph: "triangle-down-bar",
+      badge: null,
+    },
+    {
+      id: "deploys",
+      label: "Deploys",
+      href: "#delivery",
+      glyph: "triangle-up",
+      badge: null,
+    },
+    {
+      id: "audit",
+      label: "Audit Log",
+      href: "#delivery",
+      glyph: "bookmark",
+      badge: null,
+    },
+    {
+      id: "settings",
+      label: "Settings",
+      href: "/admin/settings",
+      glyph: "settings",
+      badge: null,
+    },
   ];
 
   const buildId =
@@ -396,20 +551,25 @@ function AdminSideRail({ data }: { data: AdminDashboardData }) {
       data-shell-rail=""
       style={{
         borderRight: "1px solid var(--line)",
-        background: "linear-gradient(180deg, rgba(255,255,255,0.012), rgba(255,255,255,0.002))",
+        background:
+          "linear-gradient(180deg, rgba(255,255,255,0.012), rgba(255,255,255,0.002))",
         display: "flex",
         flexDirection: "column",
         minHeight: 0,
       }}
     >
       <div style={{ padding: "12px 16px 6px" }}>
-        <div className="t-tag" style={{ fontSize: 9 }}>HIGH ALCHEMIST · CONTROL</div>
+        <div className="t-tag" style={{ fontSize: 9 }}>
+          HIGH ALCHEMIST · CONTROL
+        </div>
       </div>
 
       <nav style={{ flex: 1, overflow: "auto", padding: "4px 8px 10px" }}>
         {modules.map((m) => (
-          <div
+          <Link
             key={m.id}
+            href={m.href}
+            onClick={onNavigate}
             style={{
               display: "flex",
               alignItems: "center",
@@ -417,13 +577,16 @@ function AdminSideRail({ data }: { data: AdminDashboardData }) {
               padding: "9px 10px",
               borderRadius: 8,
               cursor: "pointer",
-              background: m.active ? "color-mix(in oklch, var(--accent), transparent 86%)" : "transparent",
+              background: m.active
+                ? "color-mix(in oklch, var(--accent), transparent 86%)"
+                : "transparent",
               border: m.active
                 ? "1px solid color-mix(in oklch, var(--accent), transparent 60%)"
                 : "1px solid transparent",
               color: m.active ? "var(--fg)" : "var(--fg-dim)",
               position: "relative",
               marginBottom: 2,
+              textDecoration: "none",
             }}
           >
             {m.active && (
@@ -467,12 +630,14 @@ function AdminSideRail({ data }: { data: AdminDashboardData }) {
                 {m.badge}
               </span>
             )}
-          </div>
+          </Link>
         ))}
       </nav>
 
       <div style={{ padding: 12, borderTop: "1px solid var(--line)" }}>
-        <div className="t-tag" style={{ fontSize: 9, marginBottom: 6 }}>ENVIRONMENT</div>
+        <div className="t-tag" style={{ fontSize: 9, marginBottom: 6 }}>
+          ENVIRONMENT
+        </div>
         <div style={{ display: "flex", gap: 6, marginBottom: 8 }}>
           <span
             className={`chip ${env === "production" || env === "prod" ? "chip-active" : ""}`}
@@ -514,7 +679,16 @@ function AdminSideRail({ data }: { data: AdminDashboardData }) {
 function SideKv({ k, v }: { k: string; v: string }) {
   return (
     <div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
-      <span className="t-mono" style={{ fontSize: 9, letterSpacing: "0.12em", color: "var(--fg-mute)" }}>{k}</span>
+      <span
+        className="t-mono"
+        style={{
+          fontSize: 9,
+          letterSpacing: "0.12em",
+          color: "var(--fg-mute)",
+        }}
+      >
+        {k}
+      </span>
       <span
         className="t-mono"
         style={{
@@ -560,15 +734,26 @@ export function ArchitectCard({
     info: "var(--fg-mute)",
   };
   return (
-    <div className="panel-glow" style={{ padding: 16, position: "relative", overflow: "hidden" }}>
+    <div
+      className="panel-glow"
+      style={{ padding: 16, position: "relative", overflow: "hidden" }}
+    >
       <ScanLine />
-      <div style={{ display: "flex", alignItems: "center", gap: 14, marginBottom: 14 }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 14,
+          marginBottom: 14,
+        }}
+      >
         <div
           style={{
             width: 56,
             height: 56,
             borderRadius: "50%",
-            background: "linear-gradient(135deg, var(--accent), var(--accent-2))",
+            background:
+              "linear-gradient(135deg, var(--accent), var(--accent-2))",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
@@ -594,8 +779,15 @@ export function ArchitectCard({
           />
         </div>
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div className="t-tag" style={{ fontSize: 8.5 }}>HIGH ALCHEMIST · {user.role}</div>
-          <div className="t-display" style={{ fontSize: 18, lineHeight: 1.1, marginTop: 2 }}>{user.name}</div>
+          <div className="t-tag" style={{ fontSize: 8.5 }}>
+            HIGH ALCHEMIST · {user.role}
+          </div>
+          <div
+            className="t-display"
+            style={{ fontSize: 18, lineHeight: 1.1, marginTop: 2 }}
+          >
+            {user.name}
+          </div>
           <div
             className="t-mono"
             style={{
@@ -613,12 +805,23 @@ export function ArchitectCard({
         </div>
       </div>
 
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6, marginBottom: 12 }}>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: 6,
+          marginBottom: 12,
+        }}
+      >
         <KvLine k="BADGE" v={user.badge} />
         <KvLine k="TIER" v={user.tier} accent />
         <KvLine k="JOINED" v={user.joined} />
         <KvLine k="REGION" v={process.env.NEXT_PUBLIC_VERCEL_REGION ?? "—"} />
-        <KvLine k="ON CALL" v={user.onCall ? "YES · primary" : "no"} accent={user.onCall} />
+        <KvLine
+          k="ON CALL"
+          v={user.onCall ? "YES · primary" : "no"}
+          accent={user.onCall}
+        />
         <KvLine k="2FA" v={user.onCall ? "hw key · ok" : "—"} />
       </div>
 
@@ -642,7 +845,9 @@ export function ArchitectCard({
               fontSize: 11,
             }}
           >
-            {recentAlerts.live ? "no alerts in window" : "alert_events unreachable"}
+            {recentAlerts.live
+              ? "no alerts in window"
+              : "alert_events unreachable"}
           </div>
         ) : (
           <div style={{ display: "flex", flexDirection: "column" }}>
@@ -655,7 +860,8 @@ export function ArchitectCard({
                   gap: 10,
                   alignItems: "center",
                   padding: "8px 4px",
-                  borderBottom: i === alerts.length - 1 ? "none" : "1px solid var(--line)",
+                  borderBottom:
+                    i === alerts.length - 1 ? "none" : "1px solid var(--line)",
                   opacity: a.suppressed ? 0.55 : 1,
                 }}
               >
@@ -685,7 +891,10 @@ export function ArchitectCard({
                 >
                   {a.title}
                 </span>
-                <span className="t-mono" style={{ fontSize: 9, color: "var(--fg-mute)" }}>
+                <span
+                  className="t-mono"
+                  style={{ fontSize: 9, color: "var(--fg-mute)" }}
+                >
                   {formatRelative(a.triggeredAt)}
                 </span>
               </div>
@@ -695,10 +904,18 @@ export function ArchitectCard({
       </div>
 
       <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
-        <button className="btn btn-primary" style={{ padding: "6px 12px", fontSize: 9, flex: 1 }} type="button">
+        <button
+          className="btn btn-primary"
+          style={{ padding: "6px 12px", fontSize: 9, flex: 1 }}
+          type="button"
+        >
           OPEN INBOX
         </button>
-        <button className="btn btn-ghost" style={{ padding: "6px 12px", fontSize: 9 }} type="button">
+        <button
+          className="btn btn-ghost"
+          style={{ padding: "6px 12px", fontSize: 9 }}
+          type="button"
+        >
           HAND OFF
         </button>
       </div>
@@ -718,7 +935,9 @@ function KvLine({ k, v, accent }: { k: string; v: string; accent?: boolean }) {
         minWidth: 0,
       }}
     >
-      <span className="t-tag" style={{ fontSize: 8.5 }}>{k}</span>
+      <span className="t-tag" style={{ fontSize: 8.5 }}>
+        {k}
+      </span>
       <span
         className="t-mono"
         style={{

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -67,9 +67,14 @@ export default function AdminLayout({
     { href: "/admin/dashboard", label: "Dashboard ✦", icon: "🔭" },
     { href: "/admin/mcp", label: "MCP Network ✦", icon: "🔌" },
     { href: "/admin/users", label: "Users", icon: "👥" },
+    { href: "/admin/onboarding", label: "Onboarding", icon: "🧭" },
     { href: "/admin/settlements", label: "Settlements", icon: "💳" },
     { href: "/admin/chat-reports", label: "Chat Reports", icon: "🚩" },
-    { href: "/admin/feed/comment-reports", label: "Comment Reports", icon: "💬" },
+    {
+      href: "/admin/feed/comment-reports",
+      label: "Comment Reports",
+      icon: "💬",
+    },
     { href: "/admin/settings", label: "Settings", icon: "⚙️" },
   ];
 

--- a/src/app/admin/onboarding/page.tsx
+++ b/src/app/admin/onboarding/page.tsx
@@ -1,0 +1,76 @@
+import Link from "next/link";
+import OnboardingFunnelPanel from "@/components/admin/OnboardingFunnelPanel";
+
+/** Dedicated operator route for the complete signup → calibrated-user journey. */
+export default function AdminOnboardingPage() {
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-purple-600">
+            Journey operations
+          </p>
+          <h1 className="mt-1 text-2xl font-bold text-gray-900 sm:text-3xl">
+            User onboarding
+          </h1>
+          <p className="mt-1 max-w-2xl text-sm text-gray-600 sm:text-base">
+            Monitor route health, funnel loss, recent completions, and users who
+            need hands-on recovery.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Link
+            href="/admin/users"
+            className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+          >
+            Human accounts
+          </Link>
+          <Link
+            href="/onboarding"
+            className="rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-purple-700"
+          >
+            Open public route ↗
+          </Link>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <RouteCard
+          route="/login"
+          title="Authentication entry"
+          detail="Session establishment and identity provider hand-off."
+        />
+        <RouteCard
+          route="/onboarding"
+          title="Birth-data calibration"
+          detail="Profile, location, natal chart, and completion transition."
+        />
+        <RouteCard
+          route="/admin/users/[userId]"
+          title="Operator recovery"
+          detail="Timeline and account-level inspection for a stuck user."
+        />
+      </div>
+
+      <OnboardingFunnelPanel />
+    </div>
+  );
+}
+
+function RouteCard({
+  route,
+  title,
+  detail,
+}: {
+  route: string;
+  title: string;
+  detail: string;
+}) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+      <div className="font-mono text-xs text-purple-700">{route}</div>
+      <div className="mt-2 text-sm font-semibold text-gray-900">{title}</div>
+      <p className="mt-1 text-xs leading-relaxed text-gray-500">{detail}</p>
+    </div>
+  );
+}

--- a/src/app/api/admin/dashboard/route.ts
+++ b/src/app/api/admin/dashboard/route.ts
@@ -8,7 +8,7 @@
  * Every telemetry panel is wired to a live source (user database, request
  * log, ephemeris, Postgres stat views, Planetary Agents backend); only the
  * admin identity card is static. `meta.mockedFields` lists any panels still
- * on seeded data — currently empty.
+ * on explicitly-labelled illustrative data.
  */
 
 import { NextResponse, type NextRequest } from "next/server";
@@ -38,7 +38,14 @@ import {
   getCohortRetention,
 } from "@/services/dashboardPanelsService";
 import { feedEmitTracker } from "@/services/feedEmitTracker";
+import { getLaunchReadiness } from "@/services/launchReadinessService";
 import { getLiveActivity } from "@/services/liveActivityService";
+import { getOnboardingHealth } from "@/services/onboardingHealthService";
+import {
+  buildOperationsControlPlane,
+  normalizePlanetaryHealth,
+  type CodebaseGap,
+} from "@/services/operationsControlPlaneService";
 import { getSkyConditions } from "@/services/skyConditionsService";
 import { getSubscriptionRevenueBreakdown } from "@/services/subscriptionRevenueService";
 import { getSystemStatus } from "@/services/systemStatusService";
@@ -51,10 +58,119 @@ export const runtime = "nodejs";
 // must render even when a dependency URL is unconfigured.
 const PA_BACKEND_URL = getServiceUrlSafe("planetaryAgentsApi");
 
+// Known implementation debt that is visible from the admin surface. Keeping
+// this registry beside the payload assembly makes unfinished work explicit in
+// production instead of hiding it behind a permanently-empty `mockedFields`.
+const KNOWN_CODEBASE_GAPS: CodebaseGap[] = [
+  {
+    id: "api-volume-heatmap",
+    label: "API volume heatmap is not instrumented",
+    category: "MISSING_INSTRUMENTATION",
+    severity: "P1",
+    detail:
+      "Persist per-route hourly request counts before enabling the heatmap for capacity decisions.",
+    href: "#infrastructure",
+  },
+  {
+    id: "canonical-route-performance",
+    label: "Canonical route latency and error rates are not captured",
+    category: "MISSING_INSTRUMENTATION",
+    severity: "P1",
+    detail:
+      "The route matrix has live row counts but no per-route request, latency, or error aggregation.",
+    href: "#infrastructure",
+  },
+  {
+    id: "recipe-quality-sems",
+    label: "Recipe-level SEMS quality scores are not captured",
+    category: "MISSING_INSTRUMENTATION",
+    severity: "P1",
+    detail:
+      "Recipe ingestion does not persist the per-axis quality scores rendered by the inspector.",
+    href: "#engine",
+  },
+  {
+    id: "token-flow-series",
+    label: "Token mint/burn trend lacks time-series telemetry",
+    category: "MISSING_INSTRUMENTATION",
+    severity: "P1",
+    detail:
+      "The ledger provides 30-day totals, but no dated daily aggregates are persisted.",
+    href: "#economy",
+  },
+  {
+    id: "sems-rollup",
+    label: "SEMS thermodynamic rollup is illustrative",
+    category: "PLACEHOLDER_DATA",
+    severity: "P2",
+    detail:
+      "Add a persisted per-recipe SEMS rollup before restoring this sample panel.",
+    href: "#engine",
+  },
+  {
+    id: "recommendation-evals",
+    label: "Recommendation eval and canary controls are not wired",
+    category: "MISSING_WORKFLOW",
+    severity: "P2",
+    detail:
+      "NDCG, MAP, canary promotion, and rollback have no operator workflow yet.",
+    href: "#engine",
+  },
+  {
+    id: "billing-analytics",
+    label: "Billing retention analytics are not wired",
+    category: "MISSING_INSTRUMENTATION",
+    severity: "P2",
+    detail:
+      "Subscription mix, churn, lifetime value, and free-to-pro conversion are absent.",
+    href: "#commerce",
+  },
+  {
+    id: "agent-reasoning-traces",
+    label: "Agent step-level traces are not instrumented",
+    category: "MISSING_INSTRUMENTATION",
+    severity: "P2",
+    detail:
+      "Only agent-chat decision previews exist; no structured trace event or table is emitted.",
+    href: "#agents",
+  },
+  {
+    id: "agent-topology-state",
+    label: "Agent topology node states are decorative",
+    category: "PLACEHOLDER_DATA",
+    severity: "P2",
+    detail:
+      "Role counts are live, but per-node healthy, warning, and idle states are not backed by agent heartbeat data.",
+    href: "#agents",
+  },
+  {
+    id: "dashboard-visual-traces",
+    label: "Dashboard pulse and KPI mini-traces are illustrative",
+    category: "PLACEHOLDER_DATA",
+    severity: "P2",
+    detail:
+      "Headline values are live, but the hero line and KPI sparkline shapes are synthesized because time-series samples are not stored.",
+    href: "#overview",
+  },
+  {
+    id: "sky-event-projections",
+    label: "Upcoming sky-event impact projections are illustrative",
+    category: "PLACEHOLDER_DATA",
+    severity: "P2",
+    detail:
+      "Future event timing and projected site impact are not backed by a forecast feed.",
+    href: "#engine",
+  },
+];
+
 /**
  * Helper to fetch external APIs safely with a timeout
  */
-async function fetchWithTimeout(url: string, options: RequestInit = {}, timeoutMs = 2000): Promise<Response> {
+async function fetchWithTimeout(
+  url: string,
+  options: RequestInit = {},
+  timeoutMs = 2000,
+): Promise<Response> {
   const controller = new AbortController();
   const id = setTimeout(() => controller.abort(), timeoutMs);
   try {
@@ -140,7 +256,8 @@ export async function GET(request: NextRequest) {
     const stats = {
       totalUsers: allUsers.length,
       activeUsers: allUsers.filter((u) => u.isActive).length,
-      newUsersToday: allUsers.filter((u) => new Date(u.createdAt) > oneDayAgo).length,
+      newUsersToday: allUsers.filter((u) => new Date(u.createdAt) > oneDayAgo)
+        .length,
       completedOnboarding: allUsers.filter(
         (u) => u.profile.birthData && u.profile.natalChart,
       ).length,
@@ -191,6 +308,9 @@ export async function GET(request: NextRequest) {
     const featureFlagsPromise = Promise.resolve(getFeatureFlags());
     const practitionerGeoPromise = getPractitionerGeo();
     const cohortRetentionPromise = getCohortRetention();
+    const onboardingHealthPromise = getOnboardingHealth();
+    const launchReadinessPromise = getLaunchReadiness();
+    const resourceUsagePromise = getResourceUsage();
 
     let paHealth = "offline";
     let paAgentCount = 0;
@@ -221,7 +341,9 @@ export async function GET(request: NextRequest) {
       }
 
       if (agentsRes.status === "fulfilled" && agentsRes.value.ok) {
-        paAgentCount = getAgentCount(await agentsRes.value.json().catch(() => []));
+        paAgentCount = getAgentCount(
+          await agentsRes.value.json().catch(() => []),
+        );
       }
     } catch (err) {
       console.error("Failed to query Planetary Agents backend metrics:", err);
@@ -248,14 +370,61 @@ export async function GET(request: NextRequest) {
     const featureFlags = await featureFlagsPromise;
     const practitionerGeo = await practitionerGeoPromise;
     const cohortRetention = await cohortRetentionPromise;
-    const resourceUsage = await getResourceUsage();
+    const onboardingHealth = await onboardingHealthPromise;
+    const launchReadiness = await launchReadinessPromise;
+    const resourceUsage = await resourceUsagePromise;
+
+    // Live metaphysical telemetry — feed-event rate + event-type entropy from
+    // the database, elemental harmony from the live ephemeris. Supersedes the
+    // former `meta.mockedTelemetry` seed fixture.
+    const telemetry = await telemetryPromise;
+
+    const planetaryIntegration = {
+      endpoints: {
+        alchmNextApp: "https://alchm.kitchen",
+        paUi: getServiceUrlSafe("agentsUi"),
+        paBackend: PA_BACKEND_URL,
+        wtenLegacyBackend: getServiceUrlSafe("wtenBackend"),
+      },
+      health: normalizePlanetaryHealth(paHealth),
+      agentCount: paAgentCount,
+      lastFeedEmit: feedEmitTracker.getLastEmit(),
+      telemetry,
+    };
+
+    const mockedFields = KNOWN_CODEBASE_GAPS.filter(
+      (gap) => gap.category === "PLACEHOLDER_DATA",
+    ).map((gap) => gap.label);
+    const operations = buildOperationsControlPlane({
+      systemStatus,
+      onboarding: onboardingHealth,
+      cosmicYield,
+      launchReadiness,
+      recentAlerts,
+      planetaryIntegration,
+      pulse: platformPulse,
+      stats,
+      observability: {
+        catalog: catalogTrending.live,
+        database: dbObservability.live,
+        engine: enginePerformance.live,
+        security: security.live,
+        commerce: commerce.live,
+        resources: resourceUsage.live,
+        deploys: deploys.live,
+        featureFlags: featureFlags.live,
+      },
+      mockedFields,
+      codebaseGaps: KNOWN_CODEBASE_GAPS,
+    });
 
     // Resolve the admin identity from the validated session rather than
     // hardcoding a single operator. Falls back to the session token payload
     // when the DB lookup fails so the panel always renders something.
     const adminEmail = authResult.user.email;
-    let adminDbUser: Awaited<ReturnType<typeof userDatabase.getUserById>> | null =
-      null;
+    let adminDbUser: Awaited<
+      ReturnType<typeof userDatabase.getUserById>
+    > | null = null;
     try {
       adminDbUser = await userDatabase.getUserById(authResult.user.userId);
     } catch (err) {
@@ -306,6 +475,10 @@ export async function GET(request: NextRequest) {
       commerce,
       pageTelemetry,
       systemStatus,
+      onboardingHealth,
+      launchReadiness,
+      operations,
+      planetaryIntegration,
       liveActivity: {
         entries: liveActivityResult.events,
         live: liveActivityResult.live,
@@ -321,26 +494,8 @@ export async function GET(request: NextRequest) {
       cohortRetention,
       meta: {
         generatedAt: now.toISOString(),
-        mockedFields: [],
+        mockedFields,
       },
-    };
-
-    // Live metaphysical telemetry — feed-event rate + event-type entropy from
-    // the database, elemental harmony from the live ephemeris. Supersedes the
-    // former `meta.mockedTelemetry` seed fixture.
-    const telemetry = await telemetryPromise;
-
-    const paIntegration = {
-      endpoints: {
-        alchmNextApp: "https://alchm.kitchen",
-        paUi: getServiceUrlSafe("agentsUi"),
-        paBackend: PA_BACKEND_URL,
-        wtenLegacyBackend: getServiceUrlSafe("wtenBackend"),
-      },
-      health: paHealth,
-      agentCount: paAgentCount,
-      lastFeedEmit: feedEmitTracker.getLastEmit(),
-      telemetry,
     };
 
     // Backwards-compatible response: legacy `/admin` reads `stats` and
@@ -351,7 +506,7 @@ export async function GET(request: NextRequest) {
       stats,
       recentUsers,
       data,
-      paIntegration,
+      paIntegration: planetaryIntegration,
     });
   } catch (error) {
     console.error("Admin dashboard error:", error);

--- a/src/components/admin/OnboardingFunnelPanel.tsx
+++ b/src/components/admin/OnboardingFunnelPanel.tsx
@@ -16,6 +16,7 @@
  * Polls /api/admin/onboarding-health every 30s with visibility-aware backoff.
  */
 
+import Link from "next/link";
 import React from "react";
 import { useHardenedPolling } from "@/hooks/useHardenedPolling";
 
@@ -80,7 +81,8 @@ const STATUS_STYLE: Record<
   { banner: string; dot: string; label: string; pill: string }
 > = {
   OK: {
-    banner: "bg-gradient-to-r from-emerald-50 to-emerald-100 border-emerald-200",
+    banner:
+      "bg-gradient-to-r from-emerald-50 to-emerald-100 border-emerald-200",
     dot: "bg-emerald-500 animate-pulse",
     label: "OK",
     pill: "bg-emerald-200 text-emerald-900",
@@ -142,7 +144,9 @@ export default function OnboardingFunnelPanel() {
         setError(`Failed to load onboarding health (HTTP ${res.status})`);
         return { ok: false };
       }
-      const json = (await res.json()) as { success: boolean } & OnboardingHealthPayload;
+      const json = (await res.json()) as {
+        success: boolean;
+      } & OnboardingHealthPayload;
       if (json.success) {
         setData(json);
         setError(null);
@@ -247,7 +251,9 @@ export default function OnboardingFunnelPanel() {
                           ? "bg-gradient-to-r from-emerald-400 to-emerald-500"
                           : "bg-gradient-to-r from-purple-400 to-purple-500"
                       }`}
-                      style={{ width: `${Math.max(widthPct, stage.count > 0 ? 4 : 0)}%` }}
+                      style={{
+                        width: `${Math.max(widthPct, stage.count > 0 ? 4 : 0)}%`,
+                      }}
                     />
                   </div>
                 </div>
@@ -256,8 +262,11 @@ export default function OnboardingFunnelPanel() {
           </div>
           {data.skipRate > 0 && (
             <p className="mt-4 text-xs text-gray-500">
-              <span className="font-semibold">{(data.skipRate * 100).toFixed(0)}%</span>{" "}
-              of completions used &ldquo;skip natal&rdquo; (no birth data submitted).
+              <span className="font-semibold">
+                {(data.skipRate * 100).toFixed(0)}%
+              </span>{" "}
+              of completions used &ldquo;skip natal&rdquo; (no birth data
+              submitted).
             </p>
           )}
         </div>
@@ -282,7 +291,10 @@ export default function OnboardingFunnelPanel() {
                         : "error"
                   }
                 />
-                <Stat label="p50 latency" value={`${data.apiHealth.p50LatencyMs}ms`} />
+                <Stat
+                  label="p50 latency"
+                  value={`${data.apiHealth.p50LatencyMs}ms`}
+                />
                 <Stat
                   label="p95 latency"
                   value={`${data.apiHealth.p95LatencyMs}ms`}
@@ -319,7 +331,9 @@ export default function OnboardingFunnelPanel() {
                         </span>
                         {err.method} {err.path} →{" "}
                         <span className="font-bold">{err.status}</span>{" "}
-                        <span className="text-gray-500">({err.latencyMs}ms)</span>
+                        <span className="text-gray-500">
+                          ({err.latencyMs}ms)
+                        </span>
                       </li>
                     ))}
                   </ul>
@@ -357,12 +371,17 @@ export default function OnboardingFunnelPanel() {
                     className="hover:bg-amber-100 border-t border-amber-200"
                   >
                     <td className="px-2 py-1.5">
-                      <div className="font-medium text-gray-800">
-                        {user.name || "No name"}
-                      </div>
-                      <div className="text-xs text-gray-600 font-mono">
-                        {user.email}
-                      </div>
+                      <Link
+                        href={`/admin/users/${user.userId}`}
+                        className="block hover:text-purple-700"
+                      >
+                        <div className="font-medium text-gray-800">
+                          {user.name || "No name"}
+                        </div>
+                        <div className="text-xs text-gray-600 font-mono">
+                          {user.email}
+                        </div>
+                      </Link>
                     </td>
                     <td className="px-2 py-1.5 text-xs font-mono text-amber-900">
                       {user.ageHours}h
@@ -386,7 +405,9 @@ export default function OnboardingFunnelPanel() {
           Recent successful onboardings
         </h3>
         {data.recentSuccesses.length === 0 ? (
-          <p className="text-sm text-gray-500 italic">No completed onboardings yet.</p>
+          <p className="text-sm text-gray-500 italic">
+            No completed onboardings yet.
+          </p>
         ) : (
           <ul className="space-y-2">
             {data.recentSuccesses.slice(0, 5).map((user) => (
@@ -399,9 +420,12 @@ export default function OnboardingFunnelPanel() {
                     ✓
                   </span>
                   <div className="min-w-0">
-                    <div className="font-medium text-gray-800 truncate">
+                    <Link
+                      href={`/admin/users/${user.userId}`}
+                      className="block font-medium text-gray-800 truncate hover:text-purple-700"
+                    >
                       {user.name || "No name"}
-                    </div>
+                    </Link>
                     <div className="text-xs text-gray-500 font-mono truncate">
                       {user.email}
                     </div>
@@ -418,7 +442,9 @@ export default function OnboardingFunnelPanel() {
                     </span>
                   )}
                   {!user.fullOnboarding && (
-                    <span className="text-[10px] text-gray-400 italic">skipped natal</span>
+                    <span className="text-[10px] text-gray-400 italic">
+                      skipped natal
+                    </span>
                   )}
                   <span className="text-xs text-gray-500 font-mono">
                     {formatRelative(user.completedAt)}

--- a/src/services/__tests__/operationsControlPlaneService.test.ts
+++ b/src/services/__tests__/operationsControlPlaneService.test.ts
@@ -1,0 +1,381 @@
+import {
+  buildOperationsControlPlane,
+  normalizePlanetaryHealth,
+  type OperationsControlPlaneInput,
+} from "@/services/operationsControlPlaneService";
+
+function makeInput(
+  overrides: Partial<OperationsControlPlaneInput> = {},
+): OperationsControlPlaneInput {
+  const checkedAt = "2026-08-09T12:00:00.000Z";
+  const flow = (id: string, label: string) => ({
+    id,
+    label,
+    description: `${label} flow`,
+    status: "OK" as const,
+    summary: `${label} healthy`,
+    metrics: [],
+    issues: [],
+    checkedAt,
+    live: true,
+  });
+
+  return {
+    systemStatus: {
+      generatedAt: checkedAt,
+      overall: "OK",
+      flows: [
+        flow("auth", "Authentication"),
+        flow("onboarding", "Onboarding"),
+        flow("recommendations", "Recommendations"),
+        flow("ai-generation", "AI Generation"),
+        flow("economy", "Token Economy"),
+        flow("payments", "Payments"),
+        flow("agents", "Planetary Agents"),
+        flow("mcp", "MCP"),
+        flow("database", "Database"),
+      ],
+      dependencies: [],
+    },
+    onboarding: {
+      generatedAt: checkedAt,
+      overall: "OK",
+      headline: "4/5 new users onboarded (80%)",
+      funnel: [
+        { id: "signup", label: "Signed up", count: 5, dropOff: 0 },
+        { id: "birth-data", label: "Birth data", count: 4, dropOff: 0.2 },
+        { id: "natal-chart", label: "Natal chart", count: 4, dropOff: 0 },
+        { id: "onboarded", label: "Complete", count: 4, dropOff: 0 },
+      ],
+      stuckUsers: [],
+      recentSuccesses: [],
+      apiHealth: {
+        observed: true,
+        count: 5,
+        successRate: 1,
+        errors4xx: 0,
+        errors5xx: 0,
+        p50LatencyMs: 80,
+        p95LatencyMs: 120,
+        recentErrors: [],
+      },
+      skipRate: 0,
+      live: true,
+    },
+    cosmicYield: {
+      inCirculation: 1200,
+      minted30d: 300,
+      burned30d: 100,
+      netFlow30d: 200,
+      sinks24h: [],
+      topHolders: [],
+      live: true,
+    },
+    launchReadiness: {
+      subsystems: [
+        {
+          key: "stripe-pro",
+          label: "Stripe Pro",
+          description: "Subscriptions",
+          status: "READY",
+          configured: 4,
+          total: 4,
+          checks: [],
+        },
+      ],
+      settlement: { pending: 0, live: true },
+      readyCount: 1,
+      generatedAt: checkedAt,
+    },
+    recentAlerts: { entries: [], live: true },
+    planetaryIntegration: {
+      endpoints: {
+        alchmNextApp: "https://alchm.kitchen",
+        paUi: "https://agents.alchm.kitchen",
+        paBackend: "https://api.agents.alchm.kitchen",
+        wtenLegacyBackend: "https://api.alchm.kitchen",
+      },
+      health: "healthy",
+      agentCount: 24,
+      lastFeedEmit: {
+        eventType: "recipe.created",
+        agentEmail: "agent@agentic.alchm.kitchen",
+        responseCode: 200,
+        timestamp: checkedAt,
+      },
+      telemetry: {
+        agentHarmony: {
+          value: "90%",
+          raw: 0.9,
+          live: true,
+          source: "ephemeris",
+        },
+        transmutationRate: {
+          value: "12 /hr",
+          raw: 12,
+          live: true,
+          source: "database",
+        },
+        spiritualEntropy: {
+          value: "0.75",
+          raw: 0.75,
+          live: true,
+          source: "database",
+        },
+        mcpInvocationRate: {
+          value: "8 /hr",
+          raw: 8,
+          live: true,
+          source: "database",
+        },
+        generatedAt: checkedAt,
+        allLive: true,
+      },
+    },
+    pulse: {
+      state: "NOMINAL",
+      score: 100,
+      availability: 100,
+      activeIncidents: 0,
+      p95: 120,
+      errRate: 0,
+      deployFreshness: "4h",
+    },
+    stats: {
+      totalUsers: 100,
+      activeUsers: 80,
+      newUsersToday: 5,
+      completedOnboarding: 70,
+      totalRecipes: 400,
+      totalIngredients: 900,
+      totalSubscriptions: 10,
+      totalTransactions: 5000,
+    },
+    observability: {
+      catalog: true,
+      database: true,
+      engine: true,
+      security: true,
+      commerce: true,
+      resources: true,
+      deploys: true,
+      featureFlags: true,
+    },
+    mockedFields: [],
+    codebaseGaps: [],
+    ...overrides,
+  };
+}
+
+describe("operationsControlPlaneService", () => {
+  it("normalizes backend-specific planetary health vocabulary", () => {
+    expect(normalizePlanetaryHealth("ready")).toBe("healthy");
+    expect(normalizePlanetaryHealth("degraded")).toBe("unhealthy");
+    expect(normalizePlanetaryHealth("offline")).toBe("offline");
+    expect(normalizePlanetaryHealth("something-new")).toBe("unknown");
+  });
+
+  it("reports a fully observed healthy platform as nominal", () => {
+    const result = buildOperationsControlPlane(makeInput());
+
+    expect(result.state).toBe("NOMINAL");
+    expect(result.readinessScore).toBe(100);
+    expect(result.priorities).toHaveLength(0);
+    expect(result.coverage.live).toBe(result.coverage.total);
+    expect(result.domains.every((domain) => domain.status === "HEALTHY")).toBe(
+      true,
+    );
+  });
+
+  it("promotes a broken planetary-agent path into a P0 control-plane incident", () => {
+    const input = makeInput();
+    input.systemStatus.flows = input.systemStatus.flows.map((flow) =>
+      flow.id === "agents"
+        ? {
+            ...flow,
+            status: "INCIDENT",
+            summary: "Agent traffic is arriving but no debits are landing",
+          }
+        : flow,
+    );
+    input.planetaryIntegration.health = "offline";
+
+    const result = buildOperationsControlPlane(input);
+    const agents = result.domains.find(
+      (domain) => domain.id === "planetary-agents",
+    );
+
+    expect(result.state).toBe("CRITICAL");
+    expect(agents?.status).toBe("CRITICAL");
+    expect(result.priorities[0]).toMatchObject({
+      severity: "P0",
+      category: "Planetary Agents",
+      href: "#agents",
+    });
+  });
+
+  it("turns stuck onboarding users into an actionable maintenance item", () => {
+    const input = makeInput();
+    input.onboarding.stuckUsers = [
+      {
+        userId: "user-123",
+        email: "stuck@example.com",
+        name: "Stuck User",
+        createdAt: "2026-08-09T08:00:00.000Z",
+        ageHours: 4,
+        missing: "no-natal-chart",
+      },
+    ];
+
+    const result = buildOperationsControlPlane(input);
+
+    expect(result.priorities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "onboarding-stuck",
+          href: "/admin/onboarding",
+        }),
+      ]),
+    );
+    expect(
+      result.maintenance.find((item) => item.id === "onboarding-review"),
+    ).toMatchObject({
+      status: "DUE",
+      count: 1,
+    });
+  });
+
+  it("does not count recovered alert transitions as active incidents", () => {
+    const input = makeInput();
+    input.recentAlerts.entries = [
+      {
+        id: 2,
+        triggeredAt: "2026-08-09T12:00:00.000Z",
+        component: "database",
+        previousStatus: "INCIDENT",
+        currentStatus: "OK",
+        severity: "info",
+        title: "Database recovered",
+        message: "Healthy again",
+        suppressed: false,
+      },
+      {
+        id: 1,
+        triggeredAt: "2026-08-09T11:00:00.000Z",
+        component: "database",
+        previousStatus: "OK",
+        currentStatus: "INCIDENT",
+        severity: "error",
+        title: "Database failed",
+        message: "Connection refused",
+        suppressed: false,
+      },
+    ];
+
+    const result = buildOperationsControlPlane(input);
+
+    expect(
+      result.domains.find((domain) => domain.id === "trust")?.metrics,
+    ).toEqual(expect.arrayContaining([{ label: "Open alerts", value: "0" }]));
+    expect(
+      result.maintenance.find((item) => item.id === "alert-triage")?.status,
+    ).toBe("CLEAR");
+  });
+
+  it("does not count a suppressed current alert as open work", () => {
+    const input = makeInput();
+    input.recentAlerts.entries = [
+      {
+        id: 3,
+        triggeredAt: "2026-08-09T12:00:00.000Z",
+        component: "recommendations",
+        previousStatus: "OK",
+        currentStatus: "DEGRADED",
+        severity: "warn",
+        title: "Expected canary degradation",
+        message: "Suppressed during a controlled rollout",
+        suppressed: true,
+      },
+    ];
+
+    const result = buildOperationsControlPlane(input);
+
+    expect(
+      result.domains.find((domain) => domain.id === "trust")?.metrics,
+    ).toEqual(expect.arrayContaining([{ label: "Open alerts", value: "0" }]));
+  });
+
+  it("registers known codebase debt as unfinished priority work", () => {
+    const result = buildOperationsControlPlane(
+      makeInput({
+        codebaseGaps: [
+          {
+            id: "api-heatmap",
+            label: "API heatmap is seeded",
+            category: "PLACEHOLDER_DATA",
+            severity: "P1",
+            detail: "Hourly route telemetry is missing.",
+            href: "#infrastructure",
+          },
+        ],
+      }),
+    );
+
+    expect(result.state).toBe("ATTENTION");
+    expect(result.readinessScore).toBe(97);
+    expect(result.codebase).toMatchObject({ highPriority: 1 });
+    expect(result.priorities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "codebase-api-heatmap", severity: "P1" }),
+      ]),
+    );
+  });
+
+  it("surfaces partial rollout configuration and telemetry blind spots", () => {
+    const input = makeInput({
+      cosmicYield: {
+        inCirculation: 0,
+        minted30d: 0,
+        burned30d: 0,
+        netFlow30d: 0,
+        sinks24h: [],
+        topHolders: [],
+        live: false,
+      },
+      mockedFields: ["catalogTrending"],
+      observability: {
+        catalog: false,
+        database: true,
+        engine: true,
+        security: true,
+        commerce: true,
+        resources: true,
+        deploys: true,
+        featureFlags: true,
+      },
+    });
+    input.launchReadiness.subsystems[0] = {
+      ...input.launchReadiness.subsystems[0],
+      status: "PARTIAL",
+      configured: 2,
+    };
+    input.launchReadiness.readyCount = 0;
+
+    const result = buildOperationsControlPlane(input);
+
+    expect(result.state).toBe("ATTENTION");
+    expect(result.coverage.blindSpots).toEqual(
+      expect.arrayContaining([
+        "Token ledger",
+        "Catalog telemetry",
+        "Mocked: catalogTrending",
+      ]),
+    );
+    expect(result.priorities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "config-stripe-pro", severity: "P2" }),
+        expect.objectContaining({ id: "blind-token-ledger", severity: "P1" }),
+      ]),
+    );
+  });
+});

--- a/src/services/operationsControlPlaneService.ts
+++ b/src/services/operationsControlPlaneService.ts
@@ -1,0 +1,761 @@
+/**
+ * Operations Control Plane
+ *
+ * The admin dashboard has dozens of live panels. This service turns those
+ * independent observations into an operator decision surface: what is broken,
+ * what is merely unobserved, what maintenance is due, and where to go next.
+ *
+ * The builder is deliberately pure. Collection remains in the existing
+ * telemetry services; synthesis lives here so priority and scoring behaviour
+ * can be tested without a database or network.
+ */
+
+import type { AgentNetworkTelemetry } from "@/services/agentTelemetryService";
+import type {
+  CosmicYieldData,
+  PlatformPulse,
+  RecentAlertsData,
+} from "@/services/dashboardPanelsService";
+import type { FeedEmitStatus } from "@/services/feedEmitTracker";
+import type { LaunchReadinessReport } from "@/services/launchReadinessService";
+import type { OnboardingHealthPayload } from "@/services/onboardingHealthService";
+import type {
+  FlowHealth,
+  FlowStatus,
+  SystemStatusPayload,
+} from "@/services/systemStatusService";
+
+export type OperationsStatus = "HEALTHY" | "WATCH" | "CRITICAL" | "BLIND";
+export type OperationsState = "NOMINAL" | "ATTENTION" | "CRITICAL";
+export type OperationsPrioritySeverity = "P0" | "P1" | "P2";
+export type PlanetaryIntegrationHealth =
+  | "healthy"
+  | "unhealthy"
+  | "offline"
+  | "unknown";
+
+export interface PlanetaryIntegrationSnapshot {
+  endpoints: {
+    alchmNextApp: string;
+    paUi: string;
+    paBackend: string;
+    wtenLegacyBackend: string;
+  };
+  health: PlanetaryIntegrationHealth;
+  agentCount: number;
+  lastFeedEmit: FeedEmitStatus | null;
+  telemetry: AgentNetworkTelemetry | null;
+}
+
+export interface OperationsDomain {
+  id: string;
+  label: string;
+  status: OperationsStatus;
+  summary: string;
+  href: string;
+  metrics: Array<{ label: string; value: string }>;
+}
+
+export interface OperationsPriority {
+  id: string;
+  severity: OperationsPrioritySeverity;
+  category: string;
+  title: string;
+  detail: string;
+  href: string;
+}
+
+export interface OperationsMaintenanceItem {
+  id: string;
+  label: string;
+  status: "CLEAR" | "WATCH" | "DUE";
+  count: number;
+  detail: string;
+  href: string;
+}
+
+export interface CodebaseGap {
+  id: string;
+  label: string;
+  category: "PLACEHOLDER_DATA" | "MISSING_INSTRUMENTATION" | "MISSING_WORKFLOW";
+  severity: "P1" | "P2";
+  detail: string;
+  href: string;
+}
+
+export interface OperationsControlPlane {
+  generatedAt: string;
+  state: OperationsState;
+  readinessScore: number;
+  summary: string;
+  coverage: {
+    live: number;
+    total: number;
+    percent: number;
+    blindSpots: string[];
+  };
+  rollout: {
+    ready: number;
+    total: number;
+    partial: number;
+    off: number;
+  };
+  codebase: {
+    knownGaps: CodebaseGap[];
+    highPriority: number;
+  };
+  domains: OperationsDomain[];
+  priorities: OperationsPriority[];
+  maintenance: OperationsMaintenanceItem[];
+}
+
+export interface OperationsControlPlaneInput {
+  systemStatus: SystemStatusPayload;
+  onboarding: OnboardingHealthPayload;
+  cosmicYield: CosmicYieldData;
+  launchReadiness: LaunchReadinessReport;
+  recentAlerts: RecentAlertsData;
+  planetaryIntegration: PlanetaryIntegrationSnapshot;
+  pulse: PlatformPulse;
+  stats: {
+    totalUsers: number;
+    activeUsers: number;
+    newUsersToday: number;
+    completedOnboarding: number;
+    totalRecipes: number;
+    totalIngredients: number;
+    totalSubscriptions: number;
+    totalTransactions: number;
+  };
+  observability: {
+    catalog: boolean;
+    database: boolean;
+    engine: boolean;
+    security: boolean;
+    commerce: boolean;
+    resources: boolean;
+    deploys: boolean;
+    featureFlags: boolean;
+  };
+  mockedFields: string[];
+  codebaseGaps: CodebaseGap[];
+}
+
+const FLOW_HREF: Record<string, string> = {
+  auth: "/admin/onboarding",
+  onboarding: "/admin/onboarding",
+  recommendations: "#engine",
+  "ai-generation": "#engine",
+  economy: "#economy",
+  payments: "#commerce",
+  agents: "#agents",
+  mcp: "#agents",
+  database: "#infrastructure",
+};
+
+const PRIORITY_RANK: Record<OperationsPrioritySeverity, number> = {
+  P0: 0,
+  P1: 1,
+  P2: 2,
+};
+
+function statusFromFlow(status: FlowStatus): OperationsStatus {
+  if (status === "INCIDENT") return "CRITICAL";
+  if (status === "DEGRADED") return "WATCH";
+  if (status === "UNKNOWN") return "BLIND";
+  return "HEALTHY";
+}
+
+function worstStatus(statuses: OperationsStatus[]): OperationsStatus {
+  if (statuses.includes("CRITICAL")) return "CRITICAL";
+  if (statuses.includes("WATCH")) return "WATCH";
+  if (statuses.includes("BLIND")) return "BLIND";
+  return "HEALTHY";
+}
+
+function findFlow(
+  systemStatus: SystemStatusPayload,
+  id: string,
+): FlowHealth | undefined {
+  return systemStatus.flows.find((flow) => flow.id === id);
+}
+
+function flowStatus(
+  systemStatus: SystemStatusPayload,
+  id: string,
+): OperationsStatus {
+  const flow = findFlow(systemStatus, id);
+  return flow ? statusFromFlow(flow.status) : "BLIND";
+}
+
+function observedStatus(live: boolean): OperationsStatus {
+  return live ? "HEALTHY" : "BLIND";
+}
+
+/** Collapse backend-specific health vocabulary at the API boundary. */
+export function normalizePlanetaryHealth(
+  health: string | null | undefined,
+): PlanetaryIntegrationHealth {
+  const normalized = health?.trim().toLowerCase();
+  if (["healthy", "online", "ok", "ready"].includes(normalized ?? "")) {
+    return "healthy";
+  }
+  if (["unhealthy", "degraded"].includes(normalized ?? "")) {
+    return "unhealthy";
+  }
+  if (normalized === "offline") return "offline";
+  return "unknown";
+}
+
+function isPlanetaryHealthy(health: PlanetaryIntegrationHealth): boolean {
+  return health === "healthy";
+}
+
+function isPlanetaryReachable(health: PlanetaryIntegrationHealth): boolean {
+  return health === "healthy" || health === "unhealthy";
+}
+
+function fmt(value: number): string {
+  return value.toLocaleString(undefined, { maximumFractionDigits: 0 });
+}
+
+function activeAlerts(recentAlerts: RecentAlertsData): number {
+  // alert_events is transition history, not an open-incident table. Only the
+  // newest transition for each component represents its current state; older
+  // failures must not remain "active" after a later OK recovery.
+  const latestByComponent = new Map<
+    string,
+    RecentAlertsData["entries"][number]
+  >();
+  for (const alert of recentAlerts.entries) {
+    if (!latestByComponent.has(alert.component)) {
+      latestByComponent.set(alert.component, alert);
+    }
+  }
+  return [...latestByComponent.values()].filter(
+    (alert) =>
+      !alert.suppressed &&
+      ["DEGRADED", "INCIDENT"].includes(alert.currentStatus.toUpperCase()),
+  ).length;
+}
+
+function priorityFromFlow(flow: FlowHealth): OperationsPriority | null {
+  if (flow.status === "OK") return null;
+  const severity: OperationsPrioritySeverity =
+    flow.status === "INCIDENT"
+      ? "P0"
+      : flow.status === "DEGRADED"
+        ? "P1"
+        : "P2";
+  return {
+    id: `flow-${flow.id}`,
+    severity,
+    category: flow.label,
+    title:
+      flow.status === "UNKNOWN"
+        ? `${flow.label} is not observable`
+        : `${flow.label} is ${flow.status.toLowerCase()}`,
+    detail: flow.summary,
+    href: FLOW_HREF[flow.id] ?? "#operations",
+  };
+}
+
+/** Build the scored, actionable view consumed by the quantum control panel. */
+export function buildOperationsControlPlane(
+  input: OperationsControlPlaneInput,
+): OperationsControlPlane {
+  const {
+    systemStatus,
+    onboarding,
+    cosmicYield,
+    launchReadiness,
+    recentAlerts,
+    planetaryIntegration,
+    pulse,
+    stats,
+    observability,
+    mockedFields,
+    codebaseGaps,
+  } = input;
+
+  const planetaryReachable = isPlanetaryReachable(planetaryIntegration.health);
+  const planetaryHealthy = isPlanetaryHealthy(planetaryIntegration.health);
+  const rollout = {
+    ready: launchReadiness.readyCount,
+    total: launchReadiness.subsystems.length,
+    partial: launchReadiness.subsystems.filter(
+      (item) => item.status === "PARTIAL",
+    ).length,
+    off: launchReadiness.subsystems.filter((item) => item.status === "OFF")
+      .length,
+  };
+  const alertCount = activeAlerts(recentAlerts);
+  const onboardingCompletion =
+    stats.totalUsers > 0
+      ? Math.round((stats.completedOnboarding / stats.totalUsers) * 100)
+      : 0;
+
+  const domains: OperationsDomain[] = [
+    {
+      id: "platform",
+      label: "Core Platform",
+      status: statusFromFlow(systemStatus.overall),
+      summary:
+        systemStatus.overall === "OK"
+          ? "Critical user journeys are operating normally."
+          : `${systemStatus.overall.toLowerCase()} platform signals require review.`,
+      href: "#operations",
+      metrics: [
+        { label: "Availability", value: `${pulse.availability}%` },
+        { label: "p95", value: `${pulse.p95}ms` },
+        { label: "Open alerts", value: String(alertCount) },
+      ],
+    },
+    {
+      id: "identity-onboarding",
+      label: "Identity & Onboarding",
+      status: worstStatus([
+        flowStatus(systemStatus, "auth"),
+        flowStatus(systemStatus, "onboarding"),
+        statusFromFlow(onboarding.overall),
+        observedStatus(onboarding.live),
+      ]),
+      summary: onboarding.headline,
+      href: "/admin/onboarding",
+      metrics: [
+        { label: "New · 24h", value: String(stats.newUsersToday) },
+        { label: "Stuck", value: String(onboarding.stuckUsers.length) },
+        { label: "All-time complete", value: `${onboardingCompletion}%` },
+      ],
+    },
+    {
+      id: "experience",
+      label: "Culinary Intelligence",
+      status: worstStatus([
+        flowStatus(systemStatus, "recommendations"),
+        flowStatus(systemStatus, "ai-generation"),
+        observedStatus(observability.engine),
+        observedStatus(observability.catalog),
+      ]),
+      summary: `${fmt(stats.totalRecipes)} recipes · ${fmt(stats.totalIngredients)} ingredients`,
+      href: "#engine",
+      metrics: [
+        { label: "Recipes", value: fmt(stats.totalRecipes) },
+        { label: "Ingredients", value: fmt(stats.totalIngredients) },
+      ],
+    },
+    {
+      id: "practitioners",
+      label: "Practitioners",
+      status: worstStatus([
+        observedStatus(onboarding.live),
+        flowStatus(systemStatus, "auth"),
+      ]),
+      summary: `${fmt(stats.activeUsers)} active of ${fmt(stats.totalUsers)} accounts`,
+      href: "/admin/users",
+      metrics: [
+        { label: "Total", value: fmt(stats.totalUsers) },
+        { label: "Active", value: fmt(stats.activeUsers) },
+        { label: "Onboarded", value: fmt(stats.completedOnboarding) },
+      ],
+    },
+    {
+      id: "token-economy",
+      label: "Token Economy",
+      status: worstStatus([
+        flowStatus(systemStatus, "economy"),
+        observedStatus(cosmicYield.live),
+      ]),
+      summary: cosmicYield.live
+        ? `${fmt(cosmicYield.inCirculation)} ESMS in circulation · ${cosmicYield.netFlow30d >= 0 ? "+" : ""}${fmt(cosmicYield.netFlow30d)} net 30d`
+        : "Ledger rollup is unavailable.",
+      href: "#economy",
+      metrics: [
+        { label: "Circulation", value: fmt(cosmicYield.inCirculation) },
+        { label: "Minted · 30d", value: fmt(cosmicYield.minted30d) },
+        { label: "Burned · 30d", value: fmt(cosmicYield.burned30d) },
+      ],
+    },
+    {
+      id: "planetary-agents",
+      label: "Planetary Agents",
+      status: worstStatus([
+        flowStatus(systemStatus, "agents"),
+        flowStatus(systemStatus, "mcp"),
+        planetaryHealthy
+          ? "HEALTHY"
+          : planetaryReachable
+            ? "WATCH"
+            : "CRITICAL",
+        observedStatus(Boolean(planetaryIntegration.telemetry?.allLive)),
+      ]),
+      summary: `${planetaryIntegration.agentCount} remote agents · backend ${planetaryIntegration.health || "unknown"}`,
+      href: "#agents",
+      metrics: [
+        { label: "Agents", value: String(planetaryIntegration.agentCount) },
+        {
+          label: "Feed · 1h",
+          value: planetaryIntegration.telemetry?.transmutationRate.value ?? "—",
+        },
+        {
+          label: "MCP · 1h",
+          value: planetaryIntegration.telemetry?.mcpInvocationRate.value ?? "—",
+        },
+      ],
+    },
+    {
+      id: "commerce",
+      label: "Commerce & Settlement",
+      status: worstStatus([
+        flowStatus(systemStatus, "payments"),
+        observedStatus(observability.commerce),
+        observedStatus(launchReadiness.settlement.live),
+        launchReadiness.settlement.pending > 0 ? "CRITICAL" : "HEALTHY",
+        rollout.partial > 0 ? "WATCH" : "HEALTHY",
+      ]),
+      summary:
+        launchReadiness.settlement.pending > 0
+          ? `${launchReadiness.settlement.pending} restaurant settlements require action.`
+          : "No unresolved restaurant settlement backlog.",
+      href: "/admin/settlements",
+      metrics: [
+        { label: "Paid subs", value: String(stats.totalSubscriptions) },
+        {
+          label: "Pending settlement",
+          value: String(launchReadiness.settlement.pending),
+        },
+        { label: "Rollouts ready", value: `${rollout.ready}/${rollout.total}` },
+      ],
+    },
+    {
+      id: "infrastructure",
+      label: "Data & Infrastructure",
+      status: worstStatus([
+        flowStatus(systemStatus, "database"),
+        observedStatus(observability.database),
+        observedStatus(observability.resources),
+      ]),
+      summary:
+        "Database, connection pool, storage, and hosting resource telemetry.",
+      href: "#infrastructure",
+      metrics: [
+        { label: "Ledger rows", value: fmt(stats.totalTransactions) },
+        {
+          label: "Resource meter",
+          value: observability.resources ? "live" : "blind",
+        },
+      ],
+    },
+    {
+      id: "trust",
+      label: "Trust & Governance",
+      status: worstStatus([
+        observedStatus(observability.security),
+        observedStatus(recentAlerts.live),
+        alertCount > 0 ? "WATCH" : "HEALTHY",
+      ]),
+      summary:
+        alertCount > 0
+          ? `${alertCount} unsuppressed alerts are awaiting operator review.`
+          : "No active trust or governance alerts.",
+      href: "#trust",
+      metrics: [
+        { label: "Open alerts", value: String(alertCount) },
+        { label: "Alert stream", value: recentAlerts.live ? "live" : "blind" },
+      ],
+    },
+    {
+      id: "delivery",
+      label: "Delivery & Change",
+      status: worstStatus([
+        observedStatus(observability.deploys),
+        observedStatus(observability.featureFlags),
+      ]),
+      summary: "Deploy history, feature gates, and audit trail coverage.",
+      href: "#delivery",
+      metrics: [
+        { label: "Deploy", value: pulse.deployFreshness },
+        {
+          label: "Flags",
+          value: observability.featureFlags ? "tracked" : "blind",
+        },
+      ],
+    },
+  ];
+
+  const blindSignals: Array<[string, boolean]> = [
+    ...systemStatus.flows.map((flow): [string, boolean] => [
+      `${flow.label} flow`,
+      flow.live,
+    ]),
+    ["Onboarding funnel", onboarding.live],
+    ["Token ledger", cosmicYield.live],
+    ["Alert history", recentAlerts.live],
+    ["Planetary backend", planetaryReachable],
+    ["Planetary telemetry", Boolean(planetaryIntegration.telemetry?.allLive)],
+    ["Catalog telemetry", observability.catalog],
+    ["Database telemetry", observability.database],
+    ["Recommendation telemetry", observability.engine],
+    ["Security telemetry", observability.security],
+    ["Commerce telemetry", observability.commerce],
+    ["Resource metering", observability.resources],
+    ["Deploy history", observability.deploys],
+    ["Feature flags", observability.featureFlags],
+    ["Settlement queue", launchReadiness.settlement.live],
+  ];
+  const blindSpots = blindSignals
+    .filter(([, live]) => !live)
+    .map(([label]) => label);
+  blindSpots.push(...mockedFields.map((field) => `Mocked: ${field}`));
+  const coverageLive = blindSignals.filter(([, live]) => live).length;
+  const coverageTotal = blindSignals.length + mockedFields.length;
+
+  const priorities: OperationsPriority[] = systemStatus.flows
+    .map(priorityFromFlow)
+    .filter((item): item is OperationsPriority => item !== null);
+
+  for (const dependency of systemStatus.dependencies) {
+    if (dependency.status !== "DEGRADED" && dependency.status !== "INCIDENT") {
+      continue;
+    }
+    priorities.push({
+      id: `dependency-${dependency.id}`,
+      severity: dependency.status === "INCIDENT" ? "P0" : "P1",
+      category: dependency.label,
+      title: `${dependency.label} dependency is ${dependency.status.toLowerCase()}`,
+      detail: dependency.summary,
+      href:
+        dependency.id === "planetary-agents"
+          ? "#agents"
+          : dependency.id === "stripe"
+            ? "#commerce"
+            : "#operations",
+    });
+  }
+
+  if (!planetaryHealthy) {
+    priorities.push({
+      id: "planetary-backend",
+      severity: planetaryReachable ? "P1" : "P0",
+      category: "Planetary Agents",
+      title: planetaryReachable
+        ? "Planetary Agents backend is degraded"
+        : "Planetary Agents backend is offline",
+      detail: `Remote health probe reports ${planetaryIntegration.health || "unknown"}; verify signed sync, feed emit, and MCP paths.`,
+      href: "#agents",
+    });
+  }
+
+  if (onboarding.stuckUsers.length > 0) {
+    priorities.push({
+      id: "onboarding-stuck",
+      severity: onboarding.stuckUsers.length >= 5 ? "P1" : "P2",
+      category: "Onboarding",
+      title: `${onboarding.stuckUsers.length} ${onboarding.stuckUsers.length === 1 ? "user is" : "users are"} stuck in onboarding`,
+      detail:
+        "Review incomplete birth-data, natal-chart, and completion-flag transitions.",
+      href: "/admin/onboarding",
+    });
+  }
+
+  if (launchReadiness.settlement.pending > 0) {
+    priorities.push({
+      id: "settlement-backlog",
+      severity: "P0",
+      category: "Commerce",
+      title: `${launchReadiness.settlement.pending} settlement ${launchReadiness.settlement.pending === 1 ? "is" : "are"} unresolved`,
+      detail:
+        "Tokens have been debited but restaurant transfers are not confirmed.",
+      href: "/admin/settlements",
+    });
+  }
+
+  for (const subsystem of launchReadiness.subsystems) {
+    if (subsystem.status !== "PARTIAL") continue;
+    priorities.push({
+      id: `config-${subsystem.key}`,
+      severity: "P2",
+      category: "Rollout Readiness",
+      title: `${subsystem.label} is only partially configured`,
+      detail: `${subsystem.configured}/${subsystem.total} required configuration checks pass.`,
+      href: "/admin/settings",
+    });
+  }
+
+  if (!cosmicYield.live) {
+    priorities.push({
+      id: "blind-token-ledger",
+      severity: "P1",
+      category: "Token Economy",
+      title: "Token ledger rollup is blind",
+      detail:
+        "Circulation, mint, burn, sink, and holder telemetry could not be verified.",
+      href: "#economy",
+    });
+  }
+
+  if (mockedFields.length > 0) {
+    priorities.push({
+      id: "mocked-dashboard-fields",
+      severity: "P2",
+      category: "Observability",
+      title: `${mockedFields.length} dashboard ${mockedFields.length === 1 ? "field is" : "fields are"} still mocked`,
+      detail: mockedFields.join(", "),
+      href: "#infrastructure",
+    });
+  }
+
+  for (const gap of codebaseGaps) {
+    priorities.push({
+      id: `codebase-${gap.id}`,
+      severity: gap.severity,
+      category: "Codebase Debt",
+      title: gap.label,
+      detail: gap.detail,
+      href: gap.href,
+    });
+  }
+
+  priorities.sort(
+    (a, b) => PRIORITY_RANK[a.severity] - PRIORITY_RANK[b.severity],
+  );
+
+  const maintenance: OperationsMaintenanceItem[] = [
+    {
+      id: "onboarding-review",
+      label: "Onboarding rescue",
+      status: onboarding.stuckUsers.length > 0 ? "DUE" : "CLEAR",
+      count: onboarding.stuckUsers.length,
+      detail:
+        onboarding.stuckUsers.length > 0
+          ? "Inspect incomplete journey state and contact or recover the account through the user admin route."
+          : "No users are stuck beyond the one-hour threshold.",
+      href: "/admin/onboarding",
+    },
+    {
+      id: "settlement-review",
+      label: "Settlement reconciliation",
+      status: !launchReadiness.settlement.live
+        ? "WATCH"
+        : launchReadiness.settlement.pending > 0
+          ? "DUE"
+          : "CLEAR",
+      count: launchReadiness.settlement.pending,
+      detail: launchReadiness.settlement.live
+        ? "Resolve retry-required restaurant transfers before fulfillment drifts."
+        : "Settlement queue cannot be observed.",
+      href: "/admin/settlements",
+    },
+    {
+      id: "alert-triage",
+      label: "Incident triage",
+      status: !recentAlerts.live ? "WATCH" : alertCount > 0 ? "DUE" : "CLEAR",
+      count: alertCount,
+      detail: recentAlerts.live
+        ? "Review unsuppressed operational alerts and recent transitions."
+        : "Alert history cannot be observed.",
+      href: "#trust",
+    },
+    {
+      id: "telemetry-repair",
+      label: "Observability repair",
+      status: blindSpots.length > 0 ? "DUE" : "CLEAR",
+      count: blindSpots.length,
+      detail:
+        blindSpots.length > 0
+          ? "Restore missing sources before treating green panels as proof."
+          : "Every registered control-plane signal is live.",
+      href: "#infrastructure",
+    },
+    {
+      id: "rollout-review",
+      label: "Rollout configuration",
+      status: rollout.partial > 0 ? "DUE" : rollout.off > 0 ? "WATCH" : "CLEAR",
+      count: rollout.partial,
+      detail:
+        rollout.partial > 0
+          ? "Finish partially configured subsystems or intentionally turn them off."
+          : rollout.off > 0
+            ? `${rollout.off} subsystem${rollout.off === 1 ? " is" : "s are"} feature-gated off.`
+            : "All registered rollout subsystems are ready.",
+      href: "/admin/settings",
+    },
+    {
+      id: "agent-network-review",
+      label: "Agent network continuity",
+      status: !planetaryHealthy
+        ? "DUE"
+        : planetaryIntegration.lastFeedEmit
+          ? "CLEAR"
+          : "WATCH",
+      count: planetaryHealthy ? 0 : 1,
+      detail: planetaryIntegration.lastFeedEmit
+        ? `Last feed emit: ${planetaryIntegration.lastFeedEmit.eventType} (${planetaryIntegration.lastFeedEmit.responseCode}).`
+        : "No in-process feed emit has been observed; confirm durable agent telemetry.",
+      href: "#agents",
+    },
+  ];
+
+  const criticalDomains = domains.filter(
+    (item) => item.status === "CRITICAL",
+  ).length;
+  const watchDomains = domains.filter((item) => item.status === "WATCH").length;
+  const blindDomains = domains.filter((item) => item.status === "BLIND").length;
+  const codebasePenalty = codebaseGaps.reduce(
+    (sum, gap) => sum + (gap.severity === "P1" ? 3 : 1),
+    0,
+  );
+  // This is an operator triage score, not a product KPI. Incidents consume a
+  // large fixed slice so one broken domain cannot hide behind many green ones;
+  // degraded and blind domains carry smaller penalties, and each individual
+  // missing source adds a final observability penalty. Registered codebase
+  // gaps are intentionally lighter than live incidents, but prevent a known
+  // placeholder-heavy dashboard from claiming 100% readiness. The weights are
+  // policy, deliberately centralized here and boundary-tested above.
+  const readinessScore = Math.max(
+    0,
+    Math.round(
+      100 -
+        criticalDomains * 15 -
+        watchDomains * 6 -
+        blindDomains * 4 -
+        blindSpots.length * 2 -
+        codebasePenalty,
+    ),
+  );
+  const state: OperationsState =
+    criticalDomains > 0 || priorities.some((item) => item.severity === "P0")
+      ? "CRITICAL"
+      : watchDomains > 0 || blindDomains > 0 || priorities.length > 0
+        ? "ATTENTION"
+        : "NOMINAL";
+
+  return {
+    generatedAt: new Date().toISOString(),
+    state,
+    readinessScore,
+    summary:
+      state === "CRITICAL"
+        ? `${criticalDomains} critical domain${criticalDomains === 1 ? "" : "s"} · immediate operator action required`
+        : state === "ATTENTION"
+          ? `${watchDomains + blindDomains} domain${watchDomains + blindDomains === 1 ? "" : "s"} need attention · ${blindSpots.length} blind spot${blindSpots.length === 1 ? "" : "s"}`
+          : "Every registered domain is healthy and observable.",
+    coverage: {
+      live: coverageLive,
+      total: coverageTotal,
+      percent:
+        coverageTotal > 0
+          ? Math.round((coverageLive / coverageTotal) * 100)
+          : 100,
+      blindSpots,
+    },
+    rollout,
+    codebase: {
+      knownGaps: codebaseGaps,
+      highPriority: codebaseGaps.filter((gap) => gap.severity === "P1").length,
+    },
+    domains,
+    priorities,
+    maintenance,
+  };
+}


### PR DESCRIPTION
## What changed

- adds a scored, site-wide admin operations control plane with domain health, P0–P2 priorities, observability coverage, rollout state, and maintenance work
- expands token-economy and Planetary Agents monitoring while replacing fabricated telemetry with honest aggregates or explicit instrumentation gaps
- adds a dedicated admin onboarding route with stuck-user recovery links and improves responsive admin navigation
- registers known implementation debt directly in the live dashboard

## Why

The existing dashboard exposed many independent panels but did not synthesize them into an operator-ready view of incidents, blind spots, unfinished work, onboarding, token health, or Planetary Agents integration.

## Validation

- TypeScript typecheck passed
- ESLint passed with no errors
- 224 Jest suites passed: 2,188 tests passed, 9 skipped
- Next.js production build passed
- desktop and mobile browser QA completed
