### PR TITLE
fix(payments): settle crypto orders, and watch what Stripe actually sends

### DIFF
--- a/docs/payments/STRIPE_DASHBOARD_ACTIONS.md
+++ b/docs/payments/STRIPE_DASHBOARD_ACTIONS.md
@@ -1,0 +1,148 @@
+# Stripe — required Dashboard and Vercel actions
+
+Everything in the **codebase** is done. This is the half that lives in Stripe's
+Dashboard and Vercel's settings, which no PR can change.
+
+Findings below are measured against the live platform account (US,
+`charges_enabled: true`, `payouts_enabled: true`,
+`capabilities.crypto_payments: **active**`) on 2026-08-10, read-only via
+`webhookEndpoints.list()`.
+
+**Do these in order.** Action 4 turns on a money path, and it is only safe after
+action 1.
+
+---
+
+## 1 · Add three missing webhook events ← the one that matters
+
+Endpoint `https://alchm.kitchen/api/stripe/webhook` is `enabled` with **5 events**.
+Three events the code handles are **not among them**:
+
+| Event | What silently breaks today |
+|---|---|
+| `checkout.session.async_payment_succeeded` | **The only signal that a crypto order was paid.** Customer is charged, the Connect transfer to the restaurant never runs, fulfilment never fires. |
+| `checkout.session.async_payment_failed` | A failed crypto order is never marked terminal. |
+| `account.updated` | **Connect onboarding state has never synced.** A restaurant that finished onboarding still reads `pending` locally and cannot be paid out. |
+
+`account.updated` deserves emphasis: the handler has existed all along. Stripe
+was simply never sending the event, so it has never once run. That is the
+characteristic failure of webhooks — the missing half raises no error anywhere,
+because from the application's point of view the event never happened.
+
+**Do:** Stripe Dashboard → Developers → Webhooks → that endpoint → *Update
+details* → add the three events above.
+
+---
+
+## 2 · Align the endpoint's API version
+
+| | |
+|---|---|
+| Endpoint sends | `2026-02-25.clover` |
+| SDK + code expect | `2026-04-22.dahlia` |
+
+The endpoint serialises event payloads at the **older** version, so payload
+shapes can differ from what the types promise. The code currently defends itself
+— `getSubscriptionPeriod` and `getInvoiceSubscriptionId` read fields defensively
+with fallbacks, which is almost certainly a scar from this exact skew — but
+relying on that indefinitely means every future field move is a live incident.
+
+**Do:** set the endpoint's API version to `2026-04-22.dahlia`, then re-run the
+verification in §6. Keep this in step with `apiVersion` in
+[src/lib/stripe/stripe.ts](../../src/lib/stripe/stripe.ts) whenever the SDK is upgraded.
+
+---
+
+## 3 · Mark the Stripe secrets Sensitive in Vercel
+
+```
+STRIPE_SECRET_KEY      Non-sensitive   ← live-mode key, readable in plaintext
+STRIPE_WEBHOOK_SECRET  Non-sensitive   ← readable in plaintext
+```
+
+Both currently pull as **plaintext** for anyone who can run `vercel env pull`.
+`STRIPE_SECRET_KEY` is a **live-mode** key (`sk_live_…`) with full account
+access. This is the same exposure class as the database password found on
+2026-08-08, and the same fix.
+
+**Do:** Vercel → Settings → Environment Variables → edit each → mark
+**Sensitive**.
+
+> Once Sensitive they can no longer be read back, so a by-value scan cannot see
+> them — they become a by-NAME surface for any future rotation. See
+> [rotate-database-credential.md](../runbooks/rotate-database-credential.md).
+
+Worth deciding separately: whether to rotate `STRIPE_SECRET_KEY` outright. It has
+been readable plaintext for an unknown period. Rotating is a Dashboard action
+(*Developers → API keys → roll*), followed by updating Vercel and a **git-based**
+rebuild — `vercel redeploy` reuses the old build's env snapshot.
+
+---
+
+## 4 · Only then: enable crypto restaurant payments
+
+`NEXT_PUBLIC_STRIPE_RESTAURANT_CRYPTO_ENABLED` is **not set** in Vercel
+production, so `restaurantCryptoPaymentsEnabled()` returns false and the crypto
+option is hidden.
+
+**That flag is the only thing that has prevented stranded paid orders.** The
+platform account already has `crypto_payments: active`, and until this PR the
+code could not settle an async payment. Setting it before action 1 would take
+real customer money into a state nothing advances.
+
+**Do (after §1 is confirmed):** add
+`NEXT_PUBLIC_STRIPE_RESTAURANT_CRYPTO_ENABLED=true`, then redeploy — it is
+`NEXT_PUBLIC_`, so it is inlined at **build** time and a redeploy of the existing
+build will not pick it up.
+
+---
+
+## 5 · Housekeeping
+
+- `NEXT_PUBLIC_STRIPE_PREMIUM_PRICE_ID` is set in Vercel and checked by
+  `launchReadinessService`, but **read by no code**. It becomes fully dead with
+  the premium removal; remove it then, not before, to keep the diffs separate.
+- `STRIPE_RESTAURANT_ORDER_PRICE_ID` and `STRIPE_RESTAURANT_SPLIT_MODE` are unset
+  and that is **fine** — the split mode falls back to
+  `separate_charges_and_transfers`, which is the intended default. Listed here
+  only so their absence is not mistaken for a gap.
+
+---
+
+## 6 · Verify (no guessing)
+
+The check is now in the code and on the admin board, so this is not a trust
+exercise. **Admin → System Status → Payments · Stripe** shows a
+**"Webhook events"** metric:
+
+- `all covered` — every handled event is enabled
+- `N missing` — with an issue naming the exact events, and the flow escalated to
+  **INCIDENT** if any missing event is one that costs money or fulfilment
+- `no source` — Stripe was unreachable; deliberately *not* reported as healthy
+
+The declared event list lives in
+[src/lib/stripe/handledEvents.ts](../../src/lib/stripe/handledEvents.ts), and a unit test
+parses the webhook's `switch` to guarantee the list cannot drift from what the
+route actually handles.
+
+### Expected state once §1 and §2 are done
+
+```
+Webhook events : all covered
+Payments flow  : OK
+endpoint       : https://alchm.kitchen/api/stripe/webhook   enabled
+api_version    : 2026-04-22.dahlia
+```
+
+### End-to-end, in test mode
+
+An event-coverage check proves Stripe *will send* the event; it does not prove
+the handler works. For that:
+
+```bash
+stripe listen --forward-to localhost:3000/api/stripe/webhook
+stripe trigger checkout.session.async_payment_succeeded
+```
+
+The order should move to `paid`, a transfer should be created with idempotency
+key `restaurant_order_transfer_<orderId>`, and fulfilment should fire once.

--- a/src/app/api/stripe/restaurant-order/route.ts
+++ b/src/app/api/stripe/restaurant-order/route.ts
@@ -19,6 +19,7 @@ import {
   quoteEsmsBasket,
 } from "@/lib/payments/restaurantEsms";
 import {
+  RESTAURANT_ORDER_PURPOSE,
   normalizeRestaurantPaymentPreference,
   restaurantCryptoPaymentsEnabled,
   stripePaymentMethodTypes,
@@ -865,7 +866,7 @@ export async function POST(request: Request) {
       }
     }
     const commonMetadata = {
-      purpose: "restaurant_order",
+      purpose: RESTAURANT_ORDER_PURPOSE,
       source: "cuisine_restaurant_discovery",
       orderId: metadataValue(orderId),
       userId: effectiveUser?.id ?? "",

--- a/src/app/api/stripe/webhook/__tests__/asyncPaymentSettlement.test.ts
+++ b/src/app/api/stripe/webhook/__tests__/asyncPaymentSettlement.test.ts
@@ -1,0 +1,228 @@
+/**
+ * @jest-environment node
+ *
+ * Delayed-settlement (crypto) restaurant orders.
+ *
+ * Card payments settle during the Checkout redirect, so `checkout.session.
+ * completed` already carries `payment_status: "paid"`. Crypto does NOT: Stripe
+ * finishes the session as UNPAID and reports the real outcome minutes-to-hours
+ * later on `checkout.session.async_payment_succeeded` / `…_failed`.
+ *
+ * Handling only `completed` left paid crypto orders written as
+ * `payment_pending` / `waiting_for_paid_status` — a state NOTHING in the
+ * codebase read. Terminal: the customer was charged, the Connect transfer to
+ * the restaurant never ran, and fulfillment never fired because
+ * `claimOrderForFulfillment` only claims rows at `status = 'paid'`.
+ *
+ * These tests drive the real route handler with synthetic Stripe events.
+ */
+
+const mockConstructEvent = jest.fn();
+const mockTransfersCreate = jest.fn();
+const mockPaymentIntentsRetrieve = jest.fn();
+const mockExecuteQuery = jest.fn();
+const mockTriggerOrderFulfillment = jest.fn();
+
+jest.mock("@/lib/stripe/stripe", () => ({
+  getStripe: () => ({
+    webhooks: { constructEvent: (...a: unknown[]) => mockConstructEvent(...a) },
+    transfers: { create: (...a: unknown[]) => mockTransfersCreate(...a) },
+    paymentIntents: {
+      retrieve: (...a: unknown[]) => mockPaymentIntentsRetrieve(...a),
+    },
+  }),
+}));
+
+jest.mock("@/lib/database/connection", () => ({
+  executeQuery: (...a: unknown[]) => mockExecuteQuery(...a),
+}));
+
+jest.mock("@/lib/orders/fulfillment", () => ({
+  triggerOrderFulfillment: (...a: unknown[]) => mockTriggerOrderFulfillment(...a),
+}));
+
+jest.mock("@/services/subscriptionService", () => ({
+  subscriptionService: {},
+}));
+
+import { POST } from "@/app/api/stripe/webhook/route";
+
+const ORDER_ID = "order_abc123";
+const CONNECTED_ACCOUNT = "acct_restaurant_1";
+
+function cryptoSession(paymentStatus: string) {
+  return {
+    id: "cs_test_crypto_1",
+    mode: "payment",
+    status: "complete",
+    payment_status: paymentStatus,
+    payment_intent: "pi_crypto_1",
+    metadata: {
+      purpose: "restaurant_order",
+      orderId: ORDER_ID,
+      splitMode: "separate_charges_and_transfers",
+      stripeConnectedAccountId: CONNECTED_ACCOUNT,
+      transferAmountCents: "4200",
+      transferGroup: `restaurant_order_${ORDER_ID}`,
+      restaurantName: "Test Kitchen",
+      provider: "test",
+    },
+  };
+}
+
+function request() {
+  return new Request("https://alchm.kitchen/api/stripe/webhook", {
+    method: "POST",
+    headers: { "stripe-signature": "sig_test" },
+    body: "{}",
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+  mockExecuteQuery.mockResolvedValue({ rows: [] });
+  mockTriggerOrderFulfillment.mockResolvedValue(undefined);
+  mockTransfersCreate.mockResolvedValue({ id: "tr_1" });
+  mockPaymentIntentsRetrieve.mockResolvedValue({
+    id: "pi_crypto_1",
+    currency: "usd",
+    latest_charge: { id: "ch_1", payment_method_details: { type: "crypto" } },
+  });
+});
+
+/** The UPDATE statement's bound parameters, for the single order write. */
+function orderUpdateParams(): unknown[] | null {
+  const call = mockExecuteQuery.mock.calls.find(
+    (c) => typeof c[0] === "string" && c[0].includes("restaurant_order_intents"),
+  );
+  return call ? (call[1] as unknown[]) : null;
+}
+
+describe("checkout.session.async_payment_succeeded — the event that was missing", () => {
+  beforeEach(() => {
+    mockConstructEvent.mockReturnValue({
+      type: "checkout.session.async_payment_succeeded",
+      data: { object: cryptoSession("paid") },
+    });
+  });
+
+  // NB: this asserts only that the handler does not error. It does NOT prove
+  // the event is handled — the `default` branch also returns 200, so this test
+  // passes even with the async case deleted. The three below are the ones that
+  // actually pin the behaviour.
+  it("does not error — returns 2xx so Stripe stops retrying", async () => {
+    const res = await POST(request());
+    expect(res.status).toBe(200);
+  });
+
+  it("advances the order to paid instead of leaving it pending", async () => {
+    await POST(request());
+    const params = orderUpdateParams();
+    expect(params).not.toBeNull();
+    expect(params?.[1]).toBe("paid");
+    // The state the old code wrote and nothing ever read.
+    expect(params?.[1]).not.toBe("payment_pending");
+  });
+
+  it("pays the restaurant — creates the Connect transfer", async () => {
+    await POST(request());
+    expect(mockTransfersCreate).toHaveBeenCalledTimes(1);
+    const [body, options] = mockTransfersCreate.mock.calls[0];
+    expect(body).toMatchObject({
+      amount: 4200,
+      destination: CONNECTED_ACCOUNT,
+      source_transaction: "ch_1",
+    });
+    // Redelivery is safe: Stripe delivers at least once.
+    expect(options).toEqual({
+      idempotencyKey: `restaurant_order_transfer_${ORDER_ID}`,
+    });
+  });
+
+  it("triggers fulfillment, which the pending state never reached", async () => {
+    await POST(request());
+    expect(mockTriggerOrderFulfillment).toHaveBeenCalledWith(ORDER_ID);
+  });
+});
+
+describe("checkout.session.async_payment_failed", () => {
+  beforeEach(() => {
+    mockConstructEvent.mockReturnValue({
+      type: "checkout.session.async_payment_failed",
+      data: { object: cryptoSession("unpaid") },
+    });
+  });
+
+  it("marks the order failed rather than leaving it mid-flight", async () => {
+    const res = await POST(request());
+    expect(res.status).toBe(200);
+    expect(orderUpdateParams()?.[1]).toBe("payment_failed");
+  });
+
+  it("moves no money and fulfils nothing", async () => {
+    await POST(request());
+    expect(mockTransfersCreate).not.toHaveBeenCalled();
+    expect(mockTriggerOrderFulfillment).not.toHaveBeenCalled();
+  });
+});
+
+describe("checkout.session.completed still behaves correctly", () => {
+  it("a crypto session that has NOT settled yet stays pending, moving no money", async () => {
+    mockConstructEvent.mockReturnValue({
+      type: "checkout.session.completed",
+      data: { object: cryptoSession("unpaid") },
+    });
+
+    await POST(request());
+    expect(orderUpdateParams()?.[1]).toBe("payment_pending");
+    expect(mockTransfersCreate).not.toHaveBeenCalled();
+    expect(mockTriggerOrderFulfillment).not.toHaveBeenCalled();
+  });
+
+  it("a card session that HAS settled pays out inline, exactly as before", async () => {
+    mockConstructEvent.mockReturnValue({
+      type: "checkout.session.completed",
+      data: { object: cryptoSession("paid") },
+    });
+
+    await POST(request());
+    expect(orderUpdateParams()?.[1]).toBe("paid");
+    expect(mockTransfersCreate).toHaveBeenCalledTimes(1);
+    expect(mockTriggerOrderFulfillment).toHaveBeenCalledWith(ORDER_ID);
+  });
+});
+
+describe("signature handling", () => {
+  it("rejects a request with no stripe-signature header", async () => {
+    const res = await POST(
+      new Request("https://alchm.kitchen/api/stripe/webhook", {
+        method: "POST",
+        body: "{}",
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockConstructEvent).not.toHaveBeenCalled();
+  });
+
+  it("returns non-2xx when the signature does not verify, so Stripe retries", async () => {
+    mockConstructEvent.mockImplementation(() => {
+      throw new Error("No signatures found matching the expected signature");
+    });
+    const res = await POST(request());
+    expect(res.status).not.toBe(200);
+    expect(mockExecuteQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe("control — the mocks are wired, so 'not called' means blocked", () => {
+  it("proves executeQuery and constructEvent are reachable", async () => {
+    mockConstructEvent.mockReturnValue({
+      type: "checkout.session.completed",
+      data: { object: cryptoSession("paid") },
+    });
+    await POST(request());
+    expect(mockConstructEvent).toHaveBeenCalledTimes(1);
+    expect(mockExecuteQuery).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,18 +1,34 @@
 /**
  * Stripe Webhook Handler
  *
- * Processes Stripe events to keep subscription state in sync.
- * Handles: checkout.session.completed, invoice.paid, invoice.payment_failed,
- * customer.subscription.updated, customer.subscription.deleted
+ * Processes Stripe events for all three money paths: restaurant orders
+ * (Connect), MCP top-ups, and subscriptions.
+ *
+ * Handles:
+ *   checkout.session.completed                 all three purposes
+ *   checkout.session.async_payment_succeeded   delayed methods (crypto)
+ *   checkout.session.async_payment_failed      delayed methods (crypto)
+ *   account.updated                            Connect onboarding state
+ *   customer.subscription.updated / .deleted
+ *   invoice.payment_succeeded / .payment_failed
+ *
+ * DUPLICATE DELIVERY IS SAFE, by construction rather than by a dedup table:
+ * Stripe delivers at least once, so every write here is either naturally
+ * idempotent (the subscription updates re-write the same values) or explicitly
+ * guarded — the Connect transfer carries an idempotency key, and fulfillment is
+ * claimed with a conditional UPDATE that only matches an unfulfilled paid row.
+ *
+ * FAILURES DELIBERATELY RETURN NON-2XX so Stripe retries. A swallowed database
+ * error would report success for an order that real money already moved for.
  *
  * @file src/app/api/stripe/webhook/route.ts
  */
 
-import { headers } from "next/headers";
 import { NextResponse } from "next/server";
 import { handleMcpTopUpCheckout } from "@/lib/billing/handleMcpTopUpCheckout";
 import { MCP_TOP_UP_PURPOSE } from "@/lib/billing/mcpTopUp";
 import { triggerOrderFulfillment } from "@/lib/orders/fulfillment";
+import { RESTAURANT_ORDER_PURPOSE } from "@/lib/payments/restaurantPayments";
 import type { SubscriptionTier, SubscriptionStatus } from "@/types/subscription";
 // Bundler/ESM resolution (Next.js, scripts/tsconfig.json) sees the
 // `stripe` default export as the actual class with merged namespace —
@@ -21,6 +37,13 @@ import type { SubscriptionTier, SubscriptionStatus } from "@/types/subscription"
 // wrapper instead; we align the scripts tsconfig to bundler resolution
 // to avoid that mismatch.
 import type Stripe from "stripe";
+
+// This route verifies a Stripe signature with Node crypto and writes to
+// Postgres. Declared explicitly so it can never be hoisted to the Edge runtime,
+// where `constructEvent` and the `pg` driver do not work, and so Next cannot
+// treat a webhook as statically cacheable.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 /**
  * Extract current_period_start/end from a Stripe Subscription.
@@ -331,10 +354,99 @@ async function handleRestaurantOrderCheckout(
   }
 }
 
+/**
+ * A restaurant order whose asynchronous payment ultimately failed.
+ *
+ * Terminal: Stripe will not retry the customer's payment, so the order must
+ * stop looking like it is still on its way to being paid. Nothing is
+ * transferred and nothing is fulfilled — `claimOrderForFulfillment` only claims
+ * rows at `status = 'paid'`, so leaving this un-handled would be safe but
+ * silent; the point of writing it down is that support can see what happened.
+ */
+async function handleRestaurantOrderPaymentFailed(
+  session: Stripe.Checkout.Session,
+) {
+  const orderId = session.metadata?.orderId;
+  if (!orderId) {
+    console.warn(
+      `[webhook] Restaurant order session ${session.id} missing orderId on async_payment_failed`,
+    );
+    return;
+  }
+
+  await updateRestaurantOrderIntent({
+    orderId,
+    status: "payment_failed",
+    stripeCheckoutSessionId: session.id,
+    paymentStatus: session.payment_status,
+    transferStatus: "not_transferred",
+    metadata: {
+      checkoutStatus: session.status,
+      paymentStatus: session.payment_status,
+      failureReason: "async_payment_failed",
+    },
+  });
+
+  console.log(
+    `[webhook] Restaurant order payment FAILED: order=${orderId} session=${session.id}`,
+  );
+}
+
+/**
+ * Dispatch a non-subscription Checkout Session to its purpose handler.
+ *
+ * Shared by `checkout.session.completed` AND
+ * `checkout.session.async_payment_succeeded`, because those are the same event
+ * for our purposes — "this session reached a settled state" — and which one
+ * fires depends only on the customer's payment method.
+ *
+ * Crypto (see DELAYED_SETTLEMENT_PAYMENT_METHODS) does not settle during the
+ * redirect: `completed` arrives with `payment_status: "unpaid"` and the real
+ * outcome lands minutes-to-hours later on the async event. Handling only
+ * `completed` is what left paid crypto orders parked at `payment_pending`
+ * forever — customer charged, restaurant never transferred to, order never
+ * fulfilled.
+ *
+ * Re-entry is safe: the transfer carries an idempotency key and fulfillment is
+ * claimed with a conditional UPDATE, so a redelivered event cannot double-pay
+ * or double-fulfil.
+ */
+async function dispatchSettledCheckoutSession(
+  stripe: Stripe,
+  session: Stripe.Checkout.Session,
+  eventType: string,
+) {
+  const purpose = session.metadata?.purpose;
+
+  if (purpose === RESTAURANT_ORDER_PURPOSE) {
+    await handleRestaurantOrderCheckout(stripe, session);
+    return;
+  }
+
+  if (purpose === MCP_TOP_UP_PURPOSE) {
+    const result = await handleMcpTopUpCheckout({
+      id: session.id,
+      payment_status: session.payment_status,
+      metadata: session.metadata,
+    });
+    console.log(
+      `[webhook] MCP top-up ${result.outcome}: session=${session.id} user=${result.userId ?? "—"} sku=${result.sku ?? "—"}`,
+    );
+    return;
+  }
+
+  console.warn(
+    `[webhook] ${eventType} for session ${session.id} with unrecognised purpose=${purpose ?? "—"} — no handler ran`,
+  );
+}
+
 export async function POST(request: Request) {
   const body = await request.text();
-  const headersList = await headers();
-  const signature = headersList.get("stripe-signature");
+  // Read the signature off the Request rather than next/headers: it is the same
+  // header, but next/headers needs an async request scope, which couples a pure
+  // request→response handler to Next's rendering context and makes it
+  // unreachable from tests.
+  const signature = request.headers.get("stripe-signature");
 
   if (!signature) {
     return NextResponse.json({ error: "Missing signature" }, { status: 400 });
@@ -365,21 +477,26 @@ export async function POST(request: Request) {
     console.log(`[webhook] Processing event: ${event.type}`);
 
     switch (event.type) {
+      // Both of these mean "this Checkout Session reached a settled state".
+      // Which one fires is decided by the customer's payment method, not by us:
+      // card settles inline and emits `completed` already paid, while crypto
+      // emits `completed` as UNPAID and reports the real outcome later on
+      // `async_payment_succeeded`. Handling only the first is what stranded paid
+      // crypto orders at `payment_pending`.
+      case "checkout.session.async_payment_succeeded": {
+        await dispatchSettledCheckoutSession(stripe, event.data.object, event.type);
+        break;
+      }
+
+      case "checkout.session.async_payment_failed": {
+        await handleRestaurantOrderPaymentFailed(event.data.object);
+        break;
+      }
+
       case "checkout.session.completed": {
         const session = event.data.object;
         if (session.mode !== "subscription") {
-          if (session.metadata?.purpose === "restaurant_order") {
-            await handleRestaurantOrderCheckout(stripe, session);
-          } else if (session.metadata?.purpose === MCP_TOP_UP_PURPOSE) {
-            const result = await handleMcpTopUpCheckout({
-              id: session.id,
-              payment_status: session.payment_status,
-              metadata: session.metadata,
-            });
-            console.log(
-              `[webhook] MCP top-up ${result.outcome}: session=${session.id} user=${result.userId ?? "—"} sku=${result.sku ?? "—"}`,
-            );
-          }
+          await dispatchSettledCheckoutSession(stripe, session, event.type);
           break;
         }
 

--- a/src/lib/payments/restaurantPayments.ts
+++ b/src/lib/payments/restaurantPayments.ts
@@ -4,6 +4,26 @@ export type RestaurantPaymentPreference =
   | "crypto"
   | "esms";
 
+/**
+ * `metadata.purpose` stamped on restaurant-order Checkout Sessions.
+ *
+ * Shared so the writer (the checkout route) and the reader (the webhook) cannot
+ * drift: a typo on either side silently routes a PAID order to no handler at
+ * all, which looks identical to a customer who never checked out. The MCP
+ * top-up path already does this via `MCP_TOP_UP_PURPOSE`.
+ */
+export const RESTAURANT_ORDER_PURPOSE = "restaurant_order" as const;
+
+/**
+ * Payment methods that do NOT settle during the Checkout redirect.
+ *
+ * Stripe finishes such a session with `payment_status: "unpaid"` and only later
+ * emits `checkout.session.async_payment_succeeded` (or `…_failed`). Anything
+ * listed here therefore REQUIRES those two events to be handled — without them
+ * the order is written as pending and never advances.
+ */
+export const DELAYED_SETTLEMENT_PAYMENT_METHODS: readonly string[] = ["crypto"];
+
 export function restaurantCryptoPaymentsEnabled(): boolean {
   return process.env.NEXT_PUBLIC_STRIPE_RESTAURANT_CRYPTO_ENABLED === "true";
 }

--- a/src/lib/stripe/handledEvents.ts
+++ b/src/lib/stripe/handledEvents.ts
@@ -1,0 +1,83 @@
+/**
+ * The Stripe events this codebase actually handles.
+ *
+ * This is the single source of truth for what the Dashboard endpoint must be
+ * subscribed to. It exists because the two halves of a webhook integration live
+ * in different systems: the `switch` in `src/app/api/stripe/webhook/route.ts`
+ * decides what we CAN process, and the Stripe Dashboard decides what we ever
+ * RECEIVE. Neither one can see the other.
+ *
+ * A mismatch is silent in the worst direction. If the Dashboard is not sending
+ * `checkout.session.async_payment_succeeded`, no error is raised anywhere — the
+ * customer is charged, the code that would pay the restaurant simply never runs,
+ * and the order sits in `payment_pending` looking like an abandoned checkout.
+ *
+ * `stripeWebhookCoverageService` diffs this list against the live endpoint so
+ * that gap shows up on the admin board instead of in a support ticket. A unit
+ * test keeps this list and the route's `switch` in step.
+ *
+ * @file src/lib/stripe/handledEvents.ts
+ */
+
+export interface HandledStripeEvent {
+  /** The Stripe event type, exactly as it appears in the Dashboard. */
+  readonly type: string;
+  /** Which money path breaks if this event is not delivered. */
+  readonly why: string;
+  /**
+   * Whether losing this event costs money or fulfilment, as opposed to leaving
+   * a record slightly stale. Drives INCIDENT vs DEGRADED on the admin board.
+   */
+  readonly critical: boolean;
+}
+
+export const HANDLED_STRIPE_EVENTS: readonly HandledStripeEvent[] = [
+  {
+    type: "checkout.session.completed",
+    why: "Settles card restaurant orders, MCP top-ups and subscription starts.",
+    critical: true,
+  },
+  {
+    type: "checkout.session.async_payment_succeeded",
+    why: "The ONLY signal that a crypto order was paid. Without it the customer is charged, the restaurant is never transferred to, and fulfilment never runs.",
+    critical: true,
+  },
+  {
+    type: "checkout.session.async_payment_failed",
+    why: "Marks a failed crypto order terminal instead of leaving it mid-flight.",
+    critical: true,
+  },
+  {
+    type: "account.updated",
+    why: "Connect onboarding state — charges_enabled/payouts_enabled. Without it a restaurant that finished onboarding still reads as pending and cannot be paid out.",
+    critical: true,
+  },
+  {
+    type: "customer.subscription.updated",
+    why: "Keeps local subscription status and period in sync.",
+    critical: false,
+  },
+  {
+    type: "customer.subscription.deleted",
+    why: "Downgrades a cancelled subscriber to free.",
+    critical: false,
+  },
+  {
+    type: "invoice.payment_succeeded",
+    why: "Extends the paid period on renewal.",
+    critical: false,
+  },
+  {
+    type: "invoice.payment_failed",
+    why: "Marks a subscriber past_due.",
+    critical: false,
+  },
+] as const;
+
+/** Event type strings only — convenient for set arithmetic. */
+export const HANDLED_STRIPE_EVENT_TYPES: readonly string[] =
+  HANDLED_STRIPE_EVENTS.map((e) => e.type);
+
+/** The subset whose absence costs money or fulfilment. */
+export const CRITICAL_STRIPE_EVENT_TYPES: readonly string[] =
+  HANDLED_STRIPE_EVENTS.filter((e) => e.critical).map((e) => e.type);

--- a/src/services/__tests__/stripeWebhookCoverage.test.ts
+++ b/src/services/__tests__/stripeWebhookCoverage.test.ts
@@ -1,0 +1,174 @@
+/**
+ * @jest-environment node
+ *
+ * Stripe webhook coverage: the declared list vs the route, and the route vs the
+ * Dashboard.
+ *
+ * A webhook integration has two halves that cannot see each other — the
+ * `switch` decides what we CAN process, the Stripe Dashboard decides what we
+ * ever RECEIVE — and a mismatch raises no error anywhere. The declared list in
+ * `handledEvents.ts` is what bridges them, so it is only useful if it cannot
+ * drift from the route.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import {
+  CRITICAL_STRIPE_EVENT_TYPES,
+  HANDLED_STRIPE_EVENTS,
+  HANDLED_STRIPE_EVENT_TYPES,
+} from "@/lib/stripe/handledEvents";
+import {
+  classifyWebhookCoverage,
+  selectOurEndpoint,
+} from "@/services/stripeWebhookCoverageService";
+
+const ROUTE_PATH = path.join(
+  process.cwd(),
+  "src/app/api/stripe/webhook/route.ts",
+);
+
+/** Every `case "<event>":` in the webhook's switch. */
+function routeCaseEvents(): string[] {
+  const source = fs.readFileSync(ROUTE_PATH, "utf8");
+  const matches = source.matchAll(/case\s+"([a-z_]+(?:\.[a-z_]+)+)":/g);
+  return [...matches].map((m) => m[1]).sort();
+}
+
+describe("the declared list cannot drift from the route", () => {
+  it("finds the route's cases at all (control — a zero here would pass everything)", () => {
+    expect(routeCaseEvents().length).toBeGreaterThan(0);
+  });
+
+  it("declares every event the route handles", () => {
+    const inRoute = routeCaseEvents();
+    const undeclared = inRoute.filter(
+      (e) => !HANDLED_STRIPE_EVENT_TYPES.includes(e),
+    );
+    // A handled event missing from the list would never be checked against the
+    // Dashboard, so nobody would notice Stripe wasn't sending it.
+    expect(undeclared).toEqual([]);
+  });
+
+  it("does not declare events the route cannot actually process", () => {
+    const inRoute = routeCaseEvents();
+    const phantom = HANDLED_STRIPE_EVENT_TYPES.filter(
+      (e) => !inRoute.includes(e),
+    );
+    // A phantom entry makes the admin board demand a Dashboard event that would
+    // hit `default` — busywork that erodes trust in the check.
+    expect(phantom).toEqual([]);
+  });
+
+  it("still handles the async events the 2026-08 crypto gap was about", () => {
+    const inRoute = routeCaseEvents();
+    expect(inRoute).toContain("checkout.session.async_payment_succeeded");
+    expect(inRoute).toContain("checkout.session.async_payment_failed");
+    expect(CRITICAL_STRIPE_EVENT_TYPES).toContain(
+      "checkout.session.async_payment_succeeded",
+    );
+  });
+});
+
+describe("classifyWebhookCoverage", () => {
+  const allEnabled = [...HANDLED_STRIPE_EVENT_TYPES];
+
+  it("is ok when every handled event is enabled", () => {
+    const r = classifyWebhookCoverage({ enabledEvents: allEnabled });
+    expect(r.status).toBe("ok");
+    expect(r.missingEvents).toEqual([]);
+  });
+
+  it("is ok for a wildcard endpoint", () => {
+    const r = classifyWebhookCoverage({ enabledEvents: ["*"] });
+    expect(r.status).toBe("ok");
+    expect(r.missingEvents).toEqual([]);
+  });
+
+  it("is an INCIDENT when a critical event is not enabled", () => {
+    const r = classifyWebhookCoverage({
+      enabledEvents: allEnabled.filter(
+        (e) => e !== "checkout.session.async_payment_succeeded",
+      ),
+    });
+    expect(r.status).toBe("incident");
+    expect(r.missingCriticalEvents).toEqual([
+      "checkout.session.async_payment_succeeded",
+    ]);
+    // The summary must name the real cause, not a generic failure.
+    expect(r.summary).toMatch(/async_payment_succeeded/);
+  });
+
+  it("is only DEGRADED when a non-critical event is missing", () => {
+    const r = classifyWebhookCoverage({
+      enabledEvents: allEnabled.filter((e) => e !== "invoice.payment_failed"),
+    });
+    expect(r.status).toBe("degraded");
+    expect(r.missingCriticalEvents).toEqual([]);
+  });
+
+  it("is an INCIDENT when the endpoint is disabled, whatever it subscribes to", () => {
+    const r = classifyWebhookCoverage({
+      enabledEvents: allEnabled,
+      endpointStatus: "disabled",
+    });
+    expect(r.status).toBe("incident");
+    expect(r.summary).toMatch(/disabled/);
+  });
+
+  it("reports unknown — never ok — when no endpoint matches", () => {
+    const r = classifyWebhookCoverage({ enabledEvents: null });
+    expect(r.status).toBe("unknown");
+    expect(r.status).not.toBe("ok");
+  });
+
+  it("flags extra subscribed events as noise, not danger", () => {
+    const r = classifyWebhookCoverage({
+      enabledEvents: [...allEnabled, "radar.early_fraud_warning.created"],
+    });
+    expect(r.status).toBe("ok");
+    expect(r.unhandledEvents).toEqual(["radar.early_fraud_warning.created"]);
+  });
+});
+
+describe("selectOurEndpoint — the Stripe account is shared across projects", () => {
+  it("picks by path, so a sibling project's endpoint is not mistaken for ours", () => {
+    const chosen = selectOurEndpoint([
+      { url: "https://other-project.com/api/stripe/webhook-v1", status: "enabled" },
+      { url: "https://alchm.kitchen/api/stripe/webhook", status: "enabled" },
+    ]);
+    expect(chosen?.url).toBe("https://alchm.kitchen/api/stripe/webhook");
+  });
+
+  it("prefers the enabled endpoint when several share our path", () => {
+    const chosen = selectOurEndpoint([
+      { url: "https://preview.alchm.kitchen/api/stripe/webhook", status: "disabled" },
+      { url: "https://alchm.kitchen/api/stripe/webhook", status: "enabled" },
+    ]);
+    expect(chosen?.status).toBe("enabled");
+  });
+
+  it("returns null rather than guessing among unrelated endpoints", () => {
+    const chosen = selectOurEndpoint([
+      { url: "https://a.com/hooks/one", status: "enabled" },
+      { url: "https://b.com/hooks/two", status: "enabled" },
+    ]);
+    expect(chosen).toBeNull();
+  });
+
+  it("accepts a lone endpoint even on an unexpected path", () => {
+    const chosen = selectOurEndpoint([
+      { url: "https://alchm.kitchen/api/stripe/webhook-legacy", status: "enabled" },
+    ]);
+    expect(chosen).not.toBeNull();
+  });
+});
+
+describe("every declared event explains what breaks without it", () => {
+  it.each(HANDLED_STRIPE_EVENTS.map((e) => [e.type, e.why]))(
+    "%s has a non-trivial rationale",
+    (_type, why) => {
+      expect(why.length).toBeGreaterThan(20);
+    },
+  );
+});

--- a/src/services/stripeWebhookCoverageService.ts
+++ b/src/services/stripeWebhookCoverageService.ts
@@ -1,0 +1,217 @@
+/**
+ * Is the live Stripe webhook endpoint subscribed to everything we handle?
+ *
+ * Webhook integrations fail in a direction that produces no error: if the
+ * Dashboard endpoint is not sending an event, the handler simply never runs.
+ * Nothing throws, nothing retries, no log line appears — because from the app's
+ * point of view the event never happened. The 2026-08 finding that paid crypto
+ * restaurant orders were stranded at `payment_pending` had exactly this shape,
+ * and the code half of it is fixed; this module watches the Dashboard half.
+ *
+ * Read-only: it lists endpoints and compares `enabled_events`. It never mutates
+ * Stripe configuration — flipping events on is a deliberate human action.
+ *
+ * @file src/services/stripeWebhookCoverageService.ts
+ */
+
+import {
+  CRITICAL_STRIPE_EVENT_TYPES,
+  HANDLED_STRIPE_EVENTS,
+  HANDLED_STRIPE_EVENT_TYPES,
+} from "@/lib/stripe/handledEvents";
+
+export type CoverageStatus = "ok" | "degraded" | "incident" | "unknown";
+
+export interface StripeWebhookCoverage {
+  status: CoverageStatus;
+  /** Human-readable one-liner naming the real cause. */
+  summary: string;
+  /** True when we actually reached Stripe. False means this is a "no source" state. */
+  live: boolean;
+  /** The endpoint URL we matched, if any. */
+  endpointUrl?: string;
+  /** Handled by us, NOT enabled in Stripe — these events never arrive. */
+  missingEvents: string[];
+  /** Of the above, the ones that cost money or fulfilment. */
+  missingCriticalEvents: string[];
+  /** Enabled in Stripe but hitting our `default` branch — noise, not danger. */
+  unhandledEvents: string[];
+  /** Endpoint status as Stripe reports it (`enabled` / `disabled`). */
+  endpointStatus?: string;
+}
+
+/**
+ * A Stripe endpoint subscribed to `["*"]` receives everything, so nothing can
+ * be missing. Stripe uses this literal in `enabled_events`.
+ */
+const WILDCARD = "*";
+
+function describeMissing(missingCritical: string[], missing: string[]): string {
+  if (missingCritical.length > 0) {
+    return `Stripe is not sending ${missingCritical.length} critical event(s): ${missingCritical.join(", ")} — the matching handler can never run`;
+  }
+  return `Stripe is not sending ${missing.length} handled event(s): ${missing.join(", ")}`;
+}
+
+/**
+ * Compare a set of enabled events against what the code handles.
+ *
+ * Pure, so the classification is testable without touching Stripe.
+ */
+export function classifyWebhookCoverage(input: {
+  enabledEvents: string[] | null;
+  endpointUrl?: string;
+  endpointStatus?: string;
+}): StripeWebhookCoverage {
+  const { enabledEvents, endpointUrl, endpointStatus } = input;
+
+  if (enabledEvents === null) {
+    return {
+      status: "unknown",
+      summary: "No Stripe webhook endpoint matched this deployment's URL",
+      live: true,
+      missingEvents: [],
+      missingCriticalEvents: [],
+      unhandledEvents: [],
+    };
+  }
+
+  // A disabled endpoint receives nothing at all, whatever it is subscribed to.
+  if (endpointStatus && endpointStatus !== "enabled") {
+    return {
+      status: "incident",
+      summary: `Stripe webhook endpoint is ${endpointStatus} — no events are being delivered at all`,
+      live: true,
+      endpointUrl,
+      endpointStatus,
+      missingEvents: [...HANDLED_STRIPE_EVENT_TYPES],
+      missingCriticalEvents: [...CRITICAL_STRIPE_EVENT_TYPES],
+      unhandledEvents: [],
+    };
+  }
+
+  const enabled = new Set(enabledEvents);
+  const receivesEverything = enabled.has(WILDCARD);
+
+  const missingEvents = receivesEverything
+    ? []
+    : HANDLED_STRIPE_EVENT_TYPES.filter((t) => !enabled.has(t));
+  const missingCriticalEvents = missingEvents.filter((t) =>
+    CRITICAL_STRIPE_EVENT_TYPES.includes(t),
+  );
+  const unhandledEvents = receivesEverything
+    ? []
+    : enabledEvents.filter((t) => !HANDLED_STRIPE_EVENT_TYPES.includes(t));
+
+  if (missingCriticalEvents.length > 0) {
+    return {
+      status: "incident",
+      summary: describeMissing(missingCriticalEvents, missingEvents),
+      live: true,
+      endpointUrl,
+      endpointStatus,
+      missingEvents,
+      missingCriticalEvents,
+      unhandledEvents,
+    };
+  }
+
+  if (missingEvents.length > 0) {
+    return {
+      status: "degraded",
+      summary: describeMissing(missingCriticalEvents, missingEvents),
+      live: true,
+      endpointUrl,
+      endpointStatus,
+      missingEvents,
+      missingCriticalEvents,
+      unhandledEvents,
+    };
+  }
+
+  return {
+    status: "ok",
+    summary: receivesEverything
+      ? `Endpoint receives all events (${WILDCARD}); all ${HANDLED_STRIPE_EVENTS.length} handled events covered`
+      : `All ${HANDLED_STRIPE_EVENTS.length} handled events are enabled in Stripe`,
+    live: true,
+    endpointUrl,
+    endpointStatus,
+    missingEvents: [],
+    missingCriticalEvents: [],
+    unhandledEvents,
+  };
+}
+
+/**
+ * Pick the endpoint belonging to this deployment.
+ *
+ * Matched on path rather than full URL: the same Stripe account is shared with
+ * two sibling projects, so several endpoints exist and the host differs between
+ * production and preview. Falls back to the sole endpoint when exactly one is
+ * configured, since that cannot be ambiguous.
+ */
+export function selectOurEndpoint<T extends { url: string; status?: string }>(
+  endpoints: T[],
+  expectedPath = "/api/stripe/webhook",
+): T | null {
+  const byPath = endpoints.filter((e) => {
+    try {
+      return new URL(e.url).pathname === expectedPath;
+    } catch {
+      return false;
+    }
+  });
+
+  if (byPath.length === 1) return byPath[0];
+  if (byPath.length > 1) {
+    // Prefer an enabled one; otherwise the first, so we still report something.
+    return byPath.find((e) => e.status === "enabled") ?? byPath[0];
+  }
+  return endpoints.length === 1 ? endpoints[0] : null;
+}
+
+/**
+ * Ask Stripe what our endpoint is subscribed to.
+ *
+ * Degrades to an honest `live: false` rather than inventing a verdict — an
+ * unreachable Stripe must not read as "correctly configured".
+ */
+export async function fetchStripeWebhookCoverage(): Promise<StripeWebhookCoverage> {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    return {
+      status: "unknown",
+      summary: "STRIPE_SECRET_KEY not configured — cannot read webhook config",
+      live: false,
+      missingEvents: [],
+      missingCriticalEvents: [],
+      unhandledEvents: [],
+    };
+  }
+
+  try {
+    const { getStripe } = await import("@/lib/stripe/stripe");
+    const stripe = getStripe();
+    const { data } = await stripe.webhookEndpoints.list({ limit: 100 });
+
+    const ours = selectOurEndpoint(data);
+    if (!ours) {
+      return classifyWebhookCoverage({ enabledEvents: null });
+    }
+
+    return classifyWebhookCoverage({
+      enabledEvents: [...ours.enabled_events],
+      endpointUrl: ours.url,
+      endpointStatus: ours.status,
+    });
+  } catch (error) {
+    return {
+      status: "unknown",
+      summary: `Could not read Stripe webhook config: ${error instanceof Error ? error.message : "unknown error"}`,
+      live: false,
+      missingEvents: [],
+      missingCriticalEvents: [],
+      unhandledEvents: [],
+    };
+  }
+}

--- a/src/services/systemStatusService.ts
+++ b/src/services/systemStatusService.ts
@@ -790,15 +790,44 @@ async function probePayments(latest: LatestProbeRow[]): Promise<FlowHealth> {
     STALE_15MIN,
   );
 
+  // Is Stripe actually SENDING the events we handle? Every other signal here
+  // measures requests that arrived. An event the Dashboard is not subscribed to
+  // produces no request, no error and no log line — the handler simply never
+  // runs, which is indistinguishable from "nothing happened". That is precisely
+  // how paid crypto restaurant orders sat in `payment_pending`.
+  const { fetchStripeWebhookCoverage } = await import(
+    "@/services/stripeWebhookCoverageService"
+  );
+  const coverage = await fetchStripeWebhookCoverage();
+
   let status: FlowStatus;
   if (!live && !observed && synthetic.missing) status = "UNKNOWN";
-  else if (errorRate >= 0.3 || synthetic.freshFailure) status = "INCIDENT";
+  else if (
+    errorRate >= 0.3 ||
+    synthetic.freshFailure ||
+    coverage.status === "incident"
+  )
+    status = "INCIDENT";
   else if (errorRate >= 0.05) status = "DEGRADED";
-  else if (webhook.errors5xx > 0 || synthetic.stale) status = "DEGRADED";
+  else if (
+    webhook.errors5xx > 0 ||
+    synthetic.stale ||
+    coverage.status === "degraded"
+  )
+    status = "DEGRADED";
   else status = "OK";
 
   const issues: FlowIssue[] = [];
   if (synthetic.issue) issues.push(synthetic.issue);
+  if (coverage.status === "incident" || coverage.status === "degraded") {
+    issues.push({
+      at: checkedAt,
+      // Names the Dashboard as the thing to change — a missing subscription is
+      // not fixed by touching this codebase.
+      message: `${coverage.summary}. Enable it on the Stripe Dashboard webhook endpoint.`,
+      severity: coverage.status === "incident" ? "error" : "warn",
+    });
+  }
   if (webhook.errors5xx > 0 && webhook.lastFailure) {
     issues.push({
       at: webhook.lastFailure.at,
@@ -824,9 +853,11 @@ async function probePayments(latest: LatestProbeRow[]): Promise<FlowHealth> {
             ? "Synthetic stripe-webhook probe stale"
             : `Webhook or checkout errors detected`
           : status === "INCIDENT"
-            ? synthetic.freshFailure
-              ? "Synthetic stripe-webhook probe failing"
-              : `Stripe endpoints failing (${formatPct(errorRate)})`
+            ? coverage.status === "incident"
+              ? coverage.summary
+              : synthetic.freshFailure
+                ? "Synthetic stripe-webhook probe failing"
+                : `Stripe endpoints failing (${formatPct(errorRate)})`
             : "No payment traffic in window",
     metrics: [
       { label: "Paid subs", value: `${paidSubs}`, raw: paidSubs },
@@ -846,10 +877,21 @@ async function probePayments(latest: LatestProbeRow[]): Promise<FlowHealth> {
         value: synthetic.metricValue,
         raw: synthetic.metricRaw,
       },
+      {
+        label: "Webhook events",
+        value: coverage.live
+          ? coverage.missingEvents.length === 0
+            ? "all covered"
+            : `${coverage.missingEvents.length} missing`
+          : "no source",
+        raw: coverage.missingEvents.length,
+      },
     ],
     issues: issues.slice(0, 3),
     checkedAt,
-    live,
+    // An unreachable Stripe must not read as "verified"; fold it into liveness
+    // rather than letting a silent failure look like a clean board.
+    live: live && coverage.live,
   };
 }
 


### PR DESCRIPTION
## The finding

**A restaurant order paid in crypto was written as `payment_pending` and never advanced.** Customer charged, restaurant never transferred to, order never fulfilled.

Card payments settle during the Checkout redirect, so `checkout.session.completed` already carries `payment_status: "paid"`. **Crypto does not** — Stripe finishes that session UNPAID and reports the real outcome minutes-to-hours later on `checkout.session.async_payment_succeeded`. Only `completed` was handled.

That state was terminal, not merely slow:

```
payment_pending / waiting_for_paid_status
  → appear ONLY in the webhook that writes them
  → no cron, no admin route, no reconciliation ever reads either
```

`claimOrderForFulfillment` only claims rows at `status = 'paid'`, so fulfilment could never fire either.

## The Dashboard half was also wrong — and no PR can fix that part

Read live from the account (read-only, `webhookEndpoints.list()`): the endpoint is `enabled` with **5 events**, and is missing **three** we handle.

| Missing event | Consequence |
|---|---|
| `checkout.session.async_payment_succeeded` | the only signal a crypto order was paid |
| `checkout.session.async_payment_failed` | failed crypto orders never marked terminal |
| `account.updated` | **Connect onboarding state has never synced** |

`account.updated` is the sharp one. **That handler has existed all along and has therefore never once run.** A restaurant that completes onboarding still reads `pending` locally and cannot be paid out.

This is the characteristic way webhooks fail: the missing half raises no error, produces no request and writes no log line — because from the application's point of view the event never happened.

## So coverage is now checked, not assumed

- `handledEvents.ts` declares what we process **and what breaks without each event**.
- `stripeWebhookCoverageService` diffs that against the live endpoint.
- It surfaces on **Admin → System Status → Payments** as a `Webhook events` metric: `all covered` / `N missing` / `no source`. A missing *critical* event escalates the flow to **INCIDENT**; an unreachable Stripe reports `no source` rather than letting silence look like a clean board.
- A unit test **parses the route's `switch`** so the declared list cannot drift from what the code actually handles — in both directions.

## Also found, deliberately not changed here

Full write-up and ordering in [`docs/payments/STRIPE_DASHBOARD_ACTIONS.md`](docs/payments/STRIPE_DASHBOARD_ACTIONS.md).

- **The endpoint's API version is older than the code's.** It serialises at `2026-02-25.clover`; the SDK and `stripe.ts` pin `2026-04-22.dahlia`. The defensive field-reading in `getSubscriptionPeriod` / `getInvoiceSubscriptionId` looks like a scar from exactly this skew.
- **`STRIPE_SECRET_KEY` (live-mode) and `STRIPE_WEBHOOK_SECRET` are `Non-sensitive` in Vercel** — readable plaintext by anyone who can run `vercel env pull`. Same exposure class as the database password on 2026-08-08.
- **`NEXT_PUBLIC_STRIPE_RESTAURANT_CRYPTO_ENABLED` is unset — and that flag is the only reason nothing has been stranded yet.** The platform account already has `crypto_payments: active`. It must not be turned on before the two async events are subscribed, which is why the doc orders the actions.

## Smaller, in passing

- Signature now read from the `Request` rather than `next/headers`, which required an async request scope and made the handler untestable.
- `runtime = "nodejs"` / `dynamic = "force-dynamic"` declared explicitly — this route verifies a signature with Node crypto and writes to Postgres.
- `metadata.purpose` uses a shared `RESTAURANT_ORDER_PURPOSE` constant, matching `MCP_TOP_UP_PURPOSE`. A typo on either side silently routed a **paid** order to no handler.
- Removed untracked Finder duplicates from `src/lib/payments/`. `restaurantPayments 2.ts` looked *better* (it used Stripe's own type) but actually references `SessionCreateParams`, which does not exist in this SDK — I checked before trusting it. `node_modules/stripe` has the same duplication (`VERSION 4`, `cjs 4`), which suggests a clean reinstall is worth doing.

## What I checked rather than assumed

- **`'crypto'` is a valid Checkout `PaymentMethodType`** in this API version — confirmed by reading the SDK's union directly. My first two attempts to verify this returned zero *including the control*, so they proved nothing and were redone.
- **API version pinning was already correct** (SDK 22.1.1 declares `2026-04-22.dahlia`; we pin exactly that) and is left alone.
- **Duplicate delivery was already safe** — the transfer carries an idempotency key and fulfilment uses a conditional-UPDATE claim. No dedup table was added because none is needed; that is now documented at the top of the route instead.

## Tests

**34 new, mutation-verified.** Deleting the `async_payment_succeeded` case fails 3 of the settlement tests.

```
✓ advances the order to paid instead of leaving it pending
✓ pays the restaurant — creates the Connect transfer (with idempotency key)
✓ triggers fulfillment, which the pending state never reached
✓ marks a failed async payment terminal, moving no money
✓ a crypto session that has NOT settled yet stays pending
✓ a card session that HAS settled pays out inline, exactly as before
✓ the declared event list cannot drift from the route's switch (both directions)
✓ INCIDENT when a critical event is missing · DEGRADED when non-critical
✓ unknown — never ok — when no endpoint matches
```

One test's name overclaimed (`is handled at all`) because the `default` branch also returns 200, so it passed under mutation. Renamed to what it actually proves, with a comment pointing at the three that do the real work.

**226 suites / 2,222 tests green. Typecheck clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
