### PR TITLE
fix(economy): grant the welcome balance when the user is created, not when they sign in

### DIFF
--- a/scripts/backfillSignupGrants.ts
+++ b/scripts/backfillSignupGrants.ts
@@ -1,0 +1,149 @@
+/**
+ * Backfill the welcome grant for human users who never received one.
+ *
+ * ── Why this exists ─────────────────────────────────────────────────────────
+ *
+ * `[MEASURED 2026-08-10]` against production: 6 of 14 human signups held a zero
+ * ESMS balance. `grantSignupBonus` was reachable from exactly ONE call site —
+ * the NextAuth `signIn` callback — while THREE code paths create a user. The two
+ * JIT paths (the `jwt` callback fallback, and the heal in
+ * `getDatabaseUserFromRequest`) created the row, seeded an empty
+ * `token_balances`, and granted nothing.
+ *
+ * All 6 had `login_count = 0`, no `accounts` row, and no `auth_events` months
+ * after signing up, so the "self-heals on the next sign-in" retry could never
+ * reach them: it lives in the callback that had never completed for them.
+ *
+ * The leak is fixed at the source — `createUser` now writes the grant inside the
+ * same transaction as the user row — so this script only repairs the users who
+ * predate that. Run it AFTER the fix is deployed, or the next signup during a DB
+ * blip rejoins the backlog.
+ *
+ * ── Design ──────────────────────────────────────────────────────────────────
+ *
+ * Selects by PREDICATE, never a hardcoded list of ids: "human with no grant
+ * row". That makes it re-runnable, self-limiting, and correct if the set has
+ * changed since the diagnosis.
+ *
+ * Calls `tokenEconomy.grantSignupBonus` — the real production writer, with its
+ * retries and its idempotency key — rather than hand-rolled INSERTs, so a
+ * backfilled user is indistinguishable from a correctly-granted one. The
+ * per-axis `ON CONFLICT (idempotency_key) DO NOTHING` means running this twice
+ * cannot double-credit.
+ *
+ * Usage (dry run prints the plan and changes nothing):
+ *   DATABASE_URL="$PROD_URL" bun run scripts/backfillSignupGrants.ts
+ *   DATABASE_URL="$PROD_URL" bun run scripts/backfillSignupGrants.ts --execute
+ */
+
+import { executeQuery } from "@/lib/database";
+import { tokenEconomy } from "@/services/TokenEconomyService";
+import { SIGNUP_GRANT_PER_TOKEN } from "@/services/tokenEconomyQueries";
+
+const EXECUTE = process.argv.includes("--execute");
+
+interface TargetRow {
+  id: string;
+  email: string;
+  created_at: string;
+  login_count: number | null;
+  total_esms: string;
+}
+
+/** Humans with no welcome grant on the ledger. Both grant sources count:
+ *  `initial_grant` is the retired predecessor of `signup_grant`, and a user who
+ *  got one is not owed the other. */
+const SELECT_TARGETS = `
+  SELECT u.id::text            AS id,
+         u.email,
+         u.created_at::text    AS created_at,
+         u.login_count,
+         (COALESCE(b.spirit,0) + COALESCE(b.essence,0)
+          + COALESCE(b.matter,0) + COALESCE(b.substance,0))::text AS total_esms
+  FROM users u
+  LEFT JOIN token_balances b ON b.user_id = u.id
+  WHERE u.is_agent = false
+    AND NOT EXISTS (
+      SELECT 1 FROM token_transactions t
+      WHERE t.user_id = u.id
+        AND t.source_type IN ('signup_grant', 'initial_grant')
+    )
+  ORDER BY u.created_at
+`;
+
+const mask = (email: string) => {
+  const [local, domain] = email.split("@");
+  const head = local.slice(0, 2);
+  return `${head}${"*".repeat(Math.max(1, local.length - 2))}@${domain}`;
+};
+
+async function main(): Promise<void> {
+  if (!process.env.DATABASE_URL) {
+    console.error("refusing to run: no DATABASE_URL in the environment");
+    process.exit(1);
+  }
+
+  const targets = (await executeQuery(SELECT_TARGETS, [])).rows as TargetRow[];
+
+  if (targets.length === 0) {
+    console.log("Nothing to do: every human user already holds a welcome grant.");
+    return;
+  }
+
+  console.log(
+    `${targets.length} human user(s) owed a welcome grant ` +
+      `(${SIGNUP_GRANT_PER_TOKEN} per axis = ${SIGNUP_GRANT_PER_TOKEN * 4} ESMS each):\n`,
+  );
+  for (const t of targets) {
+    console.log(
+      `  ${t.id.slice(0, 8)}  ${mask(t.email).padEnd(28)}  ` +
+        `signed up ${t.created_at.slice(0, 10)}  ` +
+        `login_count=${t.login_count ?? 0}  balance=${t.total_esms}`,
+    );
+  }
+
+  if (!EXECUTE) {
+    console.log("\nDRY RUN — nothing written. Re-run with --execute to apply.");
+    return;
+  }
+
+  console.log("\nApplying…\n");
+  let granted = 0;
+  const failed: string[] = [];
+
+  for (const t of targets) {
+    const ok = await tokenEconomy.grantSignupBonus(t.id);
+    if (ok) {
+      granted += 1;
+      console.log(`  ✓ ${t.id.slice(0, 8)}  granted`);
+    } else {
+      failed.push(t.id);
+      console.log(`  ✗ ${t.id.slice(0, 8)}  FAILED — grantSignupBonus exhausted its retries`);
+    }
+  }
+
+  // Re-run the selection rather than trusting the return values: the ledger is
+  // the authority on whether the grant landed, and a `true` from a writer is
+  // not the same claim as a row being present.
+  const remaining = (await executeQuery(SELECT_TARGETS, [])).rows as TargetRow[];
+  console.log(
+    `\nGranted ${granted}/${targets.length}. ` +
+      `Users still owed a grant, re-read from the ledger: ${remaining.length}.`,
+  );
+  if (failed.length > 0) {
+    console.log(`Failed ids: ${failed.join(", ")}`);
+  }
+  if (remaining.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error("backfill failed:", err);
+    process.exit(1);
+  })
+  .finally(() => {
+    // The pg pool keeps the event loop alive; this is a one-shot script.
+    setTimeout(() => process.exit(process.exitCode ?? 0), 250);
+  });

--- a/scripts/checkEconomySqlParses.ts
+++ b/scripts/checkEconomySqlParses.ts
@@ -84,13 +84,10 @@ const COLUMNS: readonly AxisColumn[] = [
 ];
 
 // The credit/debit builders derive their column from the token type, so they
-// are driven by the token names rather than the column names.
-const TOKEN_TYPES: readonly TokenTypeName[] = [
-  "Spirit",
-  "Essence",
-  "Matter",
-  "Substance",
-];
+// are driven by the token names rather than the column names. Taken from the
+// module under test rather than re-listed here: a gate that hand-maintains its
+// own copy of the axes stops covering a fifth one the day it is added.
+const TOKEN_TYPES: readonly TokenTypeName[] = queries.TOKEN_TYPES;
 
 /** Placeholder bind values. PREPARE only performs type analysis, so these are
  *  never sent to the server — they exist because the builders return their
@@ -314,7 +311,16 @@ try {
   // PREPARE. Listed explicitly rather than filtered by a name pattern: adding
   // an export then has to be a conscious decision here, instead of silently
   // slipping past a `endsWith("Sql")` test.
-  const NON_BUILDER_EXPORTS = new Set(["columnFor"]);
+  // `signupGrantIdempotencyKey` returns the ON CONFLICT key for one axis of the
+  // welcome grant, not SQL. It lives in this module because TWO producers now
+  // write those rows — `createUser`'s transaction and `grantSignupBonus` — and
+  // a key they spell independently is a double-credit waiting to happen.
+  // Covered by userDatabaseService.signupGrant.test.ts, which asserts the two
+  // agree; there is nothing here for PREPARE to analyse.
+  const NON_BUILDER_EXPORTS = new Set([
+    "columnFor",
+    "signupGrantIdempotencyKey",
+  ]);
 
   const exportedBuilders = Object.entries(queries)
     .filter(([k, v]) => typeof v === "function" && !NON_BUILDER_EXPORTS.has(k))

--- a/src/services/TokenEconomyService.ts
+++ b/src/services/TokenEconomyService.ts
@@ -12,6 +12,8 @@ import { _logger } from "@/lib/logger";
 import {
   columnFor,
   creditTokensSql,
+  SIGNUP_GRANT_PER_TOKEN,
+  TOKEN_TYPES,
   dailyClaimTimestampSql,
   debitAllTokensSql,
   debitTokensSql,
@@ -495,16 +497,32 @@ class TokenEconomyService {
   // SIGNUP GRANT
   // ═══════════════════════════════════════════════════════════════════
 
-  /** Welcome grant: every new user starts with this even ESMS balance. */
-  static readonly SIGNUP_GRANT_PER_TOKEN = 15;
+  /** Welcome grant: every new user starts with this even ESMS balance.
+   *  Defined in `tokenEconomyQueries` so `createUser` — which now seeds the
+   *  grant in the same transaction as the user row — cannot drift from it. */
+  static readonly SIGNUP_GRANT_PER_TOKEN = SIGNUP_GRANT_PER_TOKEN;
 
   /**
-   * Grant (or heal) a new user's one-time welcome balance.
+   * Heal a user's one-time welcome balance.
+   *
+   * NOT the primary producer any more. `userDatabase.createUser` seeds the
+   * grant in the same transaction as the user row, so a user cannot be created
+   * without one. This remains the repair path for users created before that —
+   * and for any future path that manages to insert a user row some other way.
+   *
+   * `[MEASURED 2026-08-10]` why the primary moved: this method is reachable
+   * from exactly one call site, the NextAuth `signIn` callback. Two OTHER code
+   * paths create users (the JIT fallback in the `jwt` callback, and the JIT
+   * heal in `getDatabaseUserFromRequest`), and neither granted. 6 of 14 human
+   * signups were created by those paths and held nothing. The "self-heals on
+   * every sign-in" promise below could never rescue them, because the sign-in
+   * callback it lives in is the one that never completed for them — all 6 had
+   * `login_count = 0` and no `accounts` row, months later.
    *
    * Idempotent via the per-user key `signup_grant:<userId>` (per-token under
-   * the hood), so it is safe to call on every sign-in: an already-granted user
-   * is a cheap no-op, and a user whose grant failed once is healed the next
-   * time they sign in.
+   * the hood, see `signupGrantIdempotencyKey`), so it is safe to call on every
+   * sign-in and safe to run alongside the `createUser` seed: whichever writes
+   * first wins and the other hits `ON CONFLICT DO NOTHING`.
    *
    * Resilient by design. `creditMultipleTokens` swallows DB errors and returns
    * `null` rather than throwing, so the previous caller's try/catch was dead
@@ -519,9 +537,10 @@ class TokenEconomyService {
    */
   async grantSignupBonus(userId: string): Promise<boolean> {
     const amount = TokenEconomyService.SIGNUP_GRANT_PER_TOKEN;
-    const credits = (
-      ["Spirit", "Essence", "Matter", "Substance"] as TokenType[]
-    ).map((tokenType) => ({ tokenType, amount }));
+    const credits = (TOKEN_TYPES as readonly TokenType[]).map((tokenType) => ({
+      tokenType,
+      amount,
+    }));
     const backoffsMs = [0, 250, 750];
 
     for (let attempt = 0; attempt < backoffsMs.length; attempt++) {

--- a/src/services/__tests__/userDatabaseService.signupGrant.test.ts
+++ b/src/services/__tests__/userDatabaseService.signupGrant.test.ts
@@ -1,0 +1,168 @@
+/**
+ * @jest-environment node
+ *
+ * The welcome grant is part of CREATING a user, not part of signing in.
+ *
+ * `[MEASURED 2026-08-10]` against production: 6 of 14 human signups held a zero
+ * balance. `grantSignupBonus` had exactly one call site — the NextAuth `signIn`
+ * callback — while THREE code paths create a user. The two JIT paths (the `jwt`
+ * callback fallback and the heal in `getDatabaseUserFromRequest`) created the
+ * row, seeded an empty `token_balances`, and granted nothing. All 6 affected
+ * users had `login_count = 0` and no `accounts` row months later, so the
+ * "self-heals on the next sign-in" retry could never reach them.
+ *
+ * These tests pin the structural fix: the grant is written inside `createUser`'s
+ * own transaction, so it cannot be skipped by whichever caller got there. Delete
+ * the loop in `createUser` and the first test fails.
+ */
+
+// The holder is deliberate. `createUser` reaches the database through a lazy
+// `await import("@/lib/database")`, which resolves to a DIFFERENT instance of
+// the mocked module than a top-level `import * as database` in this file — so
+// an implementation attached to the latter never applies to the former, the
+// transaction callback never runs, and every assertion below passes vacuously
+// on zero captured statements. Routing both through one `mock`-prefixed
+// function (the prefix is what lets babel-jest hoist it) removes the question.
+const mockWithTransaction = jest.fn();
+jest.mock("@/lib/database", () => ({
+  withTransaction: (...args: unknown[]) => mockWithTransaction(...args),
+  executeQuery: jest.fn(),
+}));
+
+import { tokenEconomy } from "@/services/TokenEconomyService";
+import {
+  SIGNUP_GRANT_PER_TOKEN,
+  TOKEN_TYPES,
+  signupGrantIdempotencyKey,
+} from "@/services/tokenEconomyQueries";
+import { userDatabase } from "@/services/userDatabaseService";
+import type { TokenBalances } from "@/types/economy";
+
+/** `creditTokensSql` positional parameters, in build order. */
+const P_USER = 0;
+const P_TOKEN_TYPE = 1;
+const P_AMOUNT = 2;
+const P_SOURCE_TYPE = 3;
+const P_GROUP = 6;
+const P_IDEMPOTENCY = 7;
+
+type Seen = { sql: string; values: unknown[] };
+
+/** Drive createUser through a fake transaction and capture every statement. */
+async function createUserCapturingSql(email: string): Promise<Seen[]> {
+  const seen: Seen[] = [];
+  const client = {
+    query: jest.fn(async (sql: string, values: unknown[] = []) => {
+      seen.push({ sql, values });
+      // Non-zero rowCount on the users INSERT => not an email conflict, so
+      // createUser proceeds through the rest of the transaction.
+      return { rowCount: 1, rows: [{ id: "row" }] };
+    }),
+  };
+  mockWithTransaction.mockImplementation(
+    async (fn: (c: unknown) => Promise<unknown>) => fn(client),
+  );
+
+  await userDatabase.createUser({ email, name: "Test Human" });
+  return seen;
+}
+
+const grantsIn = (seen: Seen[]) =>
+  seen.filter((s) => s.values[P_SOURCE_TYPE] === "signup_grant");
+
+describe("createUser seeds the welcome grant in its own transaction", () => {
+  const OLD_DB_URL = process.env.DATABASE_URL;
+
+  beforeAll(() => {
+    // Set explicitly rather than relying on the ambient environment:
+    // `getDbModule` no-ops without it, which would make every assertion below
+    // vacuously pass on a machine that happens not to export DATABASE_URL.
+    process.env.DATABASE_URL = "postgres://test-only/not-a-real-db";
+  });
+  afterAll(() => {
+    if (OLD_DB_URL === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = OLD_DB_URL;
+  });
+  afterEach(() => jest.clearAllMocks());
+
+  it("writes one signup_grant credit per ESMS axis", async () => {
+    const grants = grantsIn(await createUserCapturingSql("grant@example.com"));
+
+    expect(grants).toHaveLength(4);
+    expect(grants.map((g) => g.values[P_TOKEN_TYPE]).sort()).toEqual(
+      [...TOKEN_TYPES].sort(),
+    );
+    for (const g of grants) {
+      expect(g.values[P_AMOUNT]).toBe(SIGNUP_GRANT_PER_TOKEN);
+    }
+  });
+
+  it("keys each credit exactly as grantSignupBonus would, so the two producers cannot double-credit", async () => {
+    const grants = grantsIn(await createUserCapturingSql("idem@example.com"));
+    const userId = grants[0].values[P_USER] as string;
+
+    for (const g of grants) {
+      expect(g.values[P_IDEMPOTENCY]).toBe(
+        signupGrantIdempotencyKey(userId, g.values[P_TOKEN_TYPE] as never),
+      );
+    }
+  });
+
+  it("groups all four credits under one transaction_group_id", async () => {
+    const grants = grantsIn(await createUserCapturingSql("group@example.com"));
+    const groups = new Set(grants.map((g) => g.values[P_GROUP]));
+
+    expect(groups.size).toBe(1);
+    expect([...groups][0]).toEqual(expect.any(String));
+  });
+
+  it("grants nothing when the email already exists (ON CONFLICT no-op)", async () => {
+    const seen: Seen[] = [];
+    const client = {
+      // rowCount 0 on the users INSERT => the email was taken; createUser must
+      // return before seeding anything, or a re-sign-in would re-grant.
+      query: jest.fn(async (sql: string, values: unknown[] = []) => {
+        seen.push({ sql, values });
+        return { rowCount: 0, rows: [] };
+      }),
+    };
+    mockWithTransaction.mockImplementation(
+      async (fn: (c: unknown) => Promise<unknown>) => fn(client),
+    );
+    jest
+      .spyOn(userDatabase, "getUserByEmail")
+      .mockResolvedValue({ id: "existing" } as never);
+
+    await userDatabase.createUser({
+      email: "taken@example.com",
+      name: "Already Here",
+    });
+
+    // Prove the transaction actually ran before trusting the zero: "no grants"
+    // and "nothing executed at all" look identical otherwise, and this suite
+    // has already been fooled once by exactly that.
+    expect(seen.some((s) => s.sql.includes("INSERT INTO users"))).toBe(true);
+    expect(grantsIn(seen)).toHaveLength(0);
+  });
+});
+
+describe("grantSignupBonus stays key-compatible with the createUser seed", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it("derives the same per-axis key the transaction seed writes", async () => {
+    const USER = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    const credit = jest
+      .spyOn(tokenEconomy, "creditMultipleTokens")
+      .mockResolvedValue({} as TokenBalances);
+
+    await tokenEconomy.grantSignupBonus(USER);
+
+    // creditMultipleTokens appends `:<TokenType>` to the base key it is given.
+    const baseKey = credit.mock.calls[0][3]?.idempotencyKey as string;
+    for (const tokenType of TOKEN_TYPES) {
+      expect(`${baseKey}:${tokenType}`).toBe(
+        signupGrantIdempotencyKey(USER, tokenType),
+      );
+    }
+  });
+});

--- a/src/services/tokenEconomyQueries.ts
+++ b/src/services/tokenEconomyQueries.ts
@@ -46,6 +46,36 @@ export type TokenTypeName = "Spirit" | "Essence" | "Matter" | "Substance";
 export const columnFor = (tokenType: TokenTypeName): AxisColumn =>
   tokenType.toLowerCase() as AxisColumn;
 
+/** The four axes in the order every multi-axis grant writes them. */
+export const TOKEN_TYPES: readonly TokenTypeName[] = [
+  "Spirit",
+  "Essence",
+  "Matter",
+  "Substance",
+];
+
+/** Welcome grant: what every new user starts with, on each axis. */
+export const SIGNUP_GRANT_PER_TOKEN = 15;
+
+/**
+ * The idempotency key for one axis of a user's welcome grant.
+ *
+ * `[MEASURED 2026-08-10]` 6 of 14 human signups held no grant, because the
+ * grant lived in exactly one of the THREE code paths that create a user. The
+ * fix seeds it inside `createUser` itself, which means two independent
+ * producers now write these rows: `createUser` (in the same transaction as the
+ * user) and `grantSignupBonus` (the self-heal for users who predate that).
+ *
+ * Two producers agreeing on a key by writing the same string literal twice is
+ * exactly how a double-credit ships — the `ON CONFLICT (idempotency_key) DO
+ * NOTHING` that makes the grant replay-safe only works if both sides spell the
+ * key identically. So both derive it from here, and a test asserts they agree.
+ */
+export const signupGrantIdempotencyKey = (
+  userId: string,
+  tokenType: TokenTypeName,
+): string => `signup_grant:${userId}:${tokenType}`;
+
 /** Amounts across all four axes, for the multi-axis statements. */
 export interface AxisAmounts {
   spirit: number;

--- a/src/services/userDatabaseService.ts
+++ b/src/services/userDatabaseService.ts
@@ -8,6 +8,12 @@ import { randomUUID } from "crypto";
 import type { UserProfile } from "@/contexts/UserContext";
 import type { User, UserRole } from "@/lib/auth/jwt-auth";
 import { _logger } from "@/lib/logger";
+import {
+  creditTokensSql,
+  signupGrantIdempotencyKey,
+  SIGNUP_GRANT_PER_TOKEN,
+  TOKEN_TYPES,
+} from "@/services/tokenEconomyQueries";
 import { agentMonicaWithMethod } from "@/utils/agentMonicaResolver";
 import { safeJsonParse } from "@/utils/typeGuards";
 
@@ -224,6 +230,44 @@ class UserDatabaseService {
             `INSERT INTO user_streaks (user_id) VALUES ($1) ON CONFLICT (user_id) DO NOTHING`,
             [userId]
           );
+
+          // ── Welcome grant, in the SAME transaction as the user row ────────
+          //
+          // `[MEASURED 2026-08-10]` 6 of 14 human signups held a zero balance
+          // because the grant was not part of creating a user — it hung off ONE
+          // of the three call sites that create one. `signIn` granted; the JIT
+          // fallback in the `jwt` callback and the JIT heal in
+          // `getDatabaseUserFromRequest` did not. Users who arrived by either
+          // of those got the balance row seeded four lines above and nothing in
+          // it, permanently: the "self-heals on the next sign-in" retry also
+          // lives only in `signIn`, which had never completed for any of them.
+          //
+          // Seeding it here makes a user without a grant unconstructible rather
+          // than merely unlikely, and it costs no round trip a caller can time
+          // out on — two callers race `createUser` against an 8s timeout, so
+          // this deliberately stays inside the open transaction instead of
+          // awaiting the retry loop in `grantSignupBonus`.
+          //
+          // Reuses `creditTokensSql` rather than hand-writing the INSERTs: it
+          // is the statement CI already PREPAREs against a real PostgreSQL, and
+          // it upserts `token_balances` itself, so it is correct whether or not
+          // the seed above won. Same idempotency key as `grantSignupBonus`, so
+          // the two producers can never double-credit.
+          const grantGroupId = randomUUID();
+          for (const tokenType of TOKEN_TYPES) {
+            const grant = creditTokensSql({
+              userId,
+              tokenType,
+              amount: SIGNUP_GRANT_PER_TOKEN,
+              sourceType: "signup_grant",
+              sourceId: null,
+              description:
+                "Welcome to Alchm.kitchen — starter cosmic balance",
+              transactionGroupId: grantGroupId,
+              idempotencyKey: signupGrantIdempotencyKey(userId, tokenType),
+            });
+            await client.query(grant.sql, grant.values);
+          }
         });
 
         if (!conflictOccurred) {


### PR DESCRIPTION
## The finding

`[MEASURED 2026-08-10]` against production: **6 of 14 human signups held a zero ESMS balance**, most recently 2026-08-05.

`grantSignupBonus` was reachable from exactly **one** call site — the NextAuth `signIn` callback — while **three** code paths create a user:

| Path | Grants? |
|---|---|
| `auth.ts:184` — `signIn` callback | ✅ |
| `auth.ts:621` — JIT fallback inside the `jwt` callback | ❌ |
| `validateRequest.ts:411` — JIT heal, fires from **any** API route | ❌ |

`createUser` seeds an empty `token_balances` row, so a user made by either JIT path ends up with a balance row containing nothing — exactly what the 6 look like.

## Evidence they never went through the granting path

| Signal | 8 granted | 6 ungranted |
|---|---|---|
| `accounts` row | 1 each | **0 — all six** |
| `sessions` / `device_sessions` | present | **0** |
| `auth_events` | 118 rows / 7 users | **0** |
| `login_count` / `last_login_at` | ≥1 / set | **0 / NULL** |

`auth_events` spans 2026-05-21→08-06, covering every one of those signup dates, so the absence is real rather than a logging gap.

**The #551 retry could never rescue them.** It is idempotent and re-runs "on every sign-in" — but that re-run lives in the same callback that has never completed for this population; `login_count` is still 0 months later. One of them (signed up 05-30) earned a `practice_reward` on **07-19** while still holding no grant, so these are active users, not stubs.

## The fix

Move the grant into `createUser`'s own transaction, where all three paths converge — a user without a grant becomes *unconstructible* rather than merely unlikely.

It deliberately does **not** call `grantSignupBonus` there. Two callers race `createUser` against an 8s timeout, so awaiting that retry loop would convert a missing grant into a **failed sign-in**. Instead it reuses `creditTokensSql` — the statement CI already PREPAREs against a real PostgreSQL, and which upserts `token_balances` itself — inside the already-open transaction.

Two producers now write these rows, so the grant amount and idempotency key move to `tokenEconomyQueries` and both sides derive them from one place. A key spelled independently on each side is a double-credit waiting to happen; a test asserts they agree. `grantSignupBonus` stays as the repair path for users predating this, and is a cheap no-op for everyone else.

Also fixed: the SQL gate hand-maintained its own copy of the four axes, which would stop covering a fifth the day one is added — it now reads the canonical list. The new non-builder export is registered in `NON_BUILDER_EXPORTS`, as that gate's completeness control requires.

## Backfill

`scripts/backfillSignupGrants.ts` repairs the existing 6. It selects **by predicate**, not a hardcoded id list, calls the real production writer, is idempotent, and re-reads the ledger afterwards rather than trusting the writer's return value. Dry run confirmed exactly the 6 diagnosed users.

**It must run only after this deploys** — otherwise the next signup during a DB blip rejoins the backlog.

## Verification

- `bun run verify` (typecheck + lint) — 0 errors; **227 suites / 2227 tests** pass.
- The economy SQL gate PREPAREs all **37** statements against production PostgreSQL, both controls green.
- The new tests are **mutation-checked**: deleting the grant loop from `createUser` fails three of them. The "no grant on email conflict" test additionally asserts the transaction actually ran, so it cannot pass vacuously on zero captured statements — it did exactly that during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
