### PR TITLE
fix(db): validate the database config at pool creation, and make the validator real

### DIFF
--- a/src/lib/database/__tests__/configValidation.test.ts
+++ b/src/lib/database/__tests__/configValidation.test.ts
@@ -1,0 +1,225 @@
+/**
+ * @jest-environment node
+ *
+ * validateDatabaseConfig() had no callers, so nothing ever exercised it and two
+ * defects sat in it unnoticed:
+ *
+ *   1. it rejected `postgres://`, a scheme `pg` accepts and that Railway, Neon,
+ *      Supabase and Heroku all hand out;
+ *   2. a malformed numeric env var resolved to NaN, and every range check is a
+ *      comparison against NaN — all of which are `false`. The most broken
+ *      configuration was the one it was blindest to.
+ *
+ * Both matter now that initializeDatabase() throws on the result: (1) would
+ * abort the pool on a working connection string, and (2) would let it through.
+ *
+ * These drive the real initializeDatabase() against a fake pg, so what is under
+ * test is the wiring, not a restatement of the validator.
+ */
+
+const mockPools: Array<{ config: Record<string, unknown> }> = [];
+
+jest.mock("pg", () => {
+  class FakePool {
+    config: Record<string, unknown>;
+    constructor(config: Record<string, unknown>) {
+      this.config = config;
+      mockPools.push(this);
+    }
+    on() {
+      return this;
+    }
+  }
+  return {
+    __esModule: true,
+    default: {
+      Pool: FakePool,
+      types: {
+        setTypeParser: () => undefined,
+        builtins: { NUMERIC: 1700, INT8: 20 },
+      },
+    },
+  };
+});
+
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+const DB_ENV_KEYS = [
+  "DATABASE_URL",
+  "DB_POOLER_MODE",
+  "DB_MAX_CONNECTIONS",
+  "DB_IDLE_TIMEOUT",
+  "DB_CONNECTION_TIMEOUT",
+  "DB_STATEMENT_TIMEOUT_MS",
+  "NODE_ENV",
+] as const;
+
+/** A configuration that is valid in every respect, as the baseline to perturb. */
+const GOOD_ENV: Record<string, string> = {
+  DATABASE_URL: "postgresql://u:p@pgbouncer.railway.internal:6432/railway?sslmode=disable",
+  DB_POOLER_MODE: "session",
+};
+
+/** Apply `overrides` on top of GOOD_ENV and re-import the config-reading modules. */
+function withEnv(overrides: Record<string, string | undefined>) {
+  jest.resetModules();
+  mockPools.length = 0;
+  for (const key of DB_ENV_KEYS) delete process.env[key];
+  for (const [k, v] of Object.entries({ ...GOOD_ENV, ...overrides })) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require("@/lib/database/rawPool") as {
+    initializeDatabase: () => unknown;
+  };
+}
+
+describe("validateDatabaseConfig is wired into initializeDatabase", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeAll(() => {
+    for (const key of DB_ENV_KEYS) saved[key] = process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of DB_ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+    jest.resetModules();
+  });
+
+  it("builds the pool when the configuration is valid", () => {
+    const { initializeDatabase } = withEnv({});
+    expect(() => initializeDatabase()).not.toThrow();
+    expect(mockPools).toHaveLength(1);
+  });
+
+  it("refuses to build a pool from an invalid configuration", () => {
+    const { initializeDatabase } = withEnv({ DB_POOLER_MODE: "sesion" });
+    expect(() => initializeDatabase()).toThrow(/DB_POOLER_MODE/);
+    // The load-bearing half: it must throw BEFORE `new Pool()`, or the bad
+    // config is already live and the throw is only cosmetic.
+    expect(mockPools).toHaveLength(0);
+  });
+
+  it("names every offending value in one error, not just the first", () => {
+    // Order is the validator's, not the caller's, so assert on membership: a
+    // deploy blocked by two bad variables should not need two round trips.
+    const { initializeDatabase } = withEnv({
+      DB_POOLER_MODE: "nope",
+      DB_MAX_CONNECTIONS: "500",
+    });
+    expect(() => initializeDatabase()).toThrow(/DB_POOLER_MODE/);
+    expect(() => initializeDatabase()).toThrow(/DB_MAX_CONNECTIONS/);
+  });
+});
+
+describe("connection URL scheme", () => {
+  const savedUrl = process.env.DATABASE_URL;
+  const savedMode = process.env.DB_POOLER_MODE;
+
+  afterEach(() => {
+    if (savedUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = savedUrl;
+    if (savedMode === undefined) delete process.env.DB_POOLER_MODE;
+    else process.env.DB_POOLER_MODE = savedMode;
+    jest.resetModules();
+  });
+
+  // `postgres://` is the regression that motivated the fix: Railway, Neon,
+  // Supabase and Heroku hand out this spelling, and the old check rejected it.
+  it.each([
+    ["postgresql://u:p@h:5432/d", true],
+    ["postgres://u:p@h:5432/d", true],
+    ["mysql://u:p@h:3306/d", false],
+    ["not a url at all", false],
+  ])("accepts %s: %s", (url, shouldBeValid) => {
+    const { initializeDatabase } = withEnv({ DATABASE_URL: url });
+    if (shouldBeValid) {
+      expect(() => initializeDatabase()).not.toThrow();
+    } else {
+      expect(() => initializeDatabase()).toThrow(/DATABASE_URL/);
+    }
+  });
+});
+
+describe("malformed numeric knobs", () => {
+  afterEach(() => {
+    for (const key of DB_ENV_KEYS) delete process.env[key];
+    jest.resetModules();
+  });
+
+  // Each of these used to resolve to NaN (or to a plausible partial parse) and
+  // sail through validation into `new Pool()`.
+  it.each([
+    ["DB_MAX_CONNECTIONS", "abc"],
+    ["DB_MAX_CONNECTIONS", "5s"],
+    ["DB_MAX_CONNECTIONS", "5.5"],
+    ["DB_IDLE_TIMEOUT", "ten thousand"],
+    ["DB_CONNECTION_TIMEOUT", "5_000"],
+    ["DB_STATEMENT_TIMEOUT_MS", "5s"],
+  ])("rejects %s=%s", (key, value) => {
+    const { initializeDatabase } = withEnv({ [key]: value });
+    expect(() => initializeDatabase()).toThrow(new RegExp(key));
+  });
+
+  it("still accepts every knob at its documented default", () => {
+    const { initializeDatabase } = withEnv({
+      DB_MAX_CONNECTIONS: undefined,
+      DB_IDLE_TIMEOUT: undefined,
+      DB_CONNECTION_TIMEOUT: undefined,
+      DB_STATEMENT_TIMEOUT_MS: undefined,
+    });
+    expect(() => initializeDatabase()).not.toThrow();
+  });
+
+  it("treats an empty string as unset rather than as zero", () => {
+    // Vercel and Railway both surface a cleared variable as "", and `Number("")`
+    // is 0 — which would fail the range check on a variable nobody had set.
+    const { initializeDatabase } = withEnv({ DB_MAX_CONNECTIONS: "" });
+    expect(() => initializeDatabase()).not.toThrow();
+  });
+});
+
+describe("the summary logged before validation", () => {
+  afterEach(() => {
+    for (const key of DB_ENV_KEYS) delete process.env[key];
+    jest.resetModules();
+  });
+
+  it("reports the resolved topology and carries no credentials", () => {
+    const { initializeDatabase } = withEnv({});
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { logger } = require("@/lib/logger");
+    initializeDatabase();
+
+    const call = (logger.info as jest.Mock).mock.calls.find(
+      ([msg]: [string]) => msg === "Database configuration resolved",
+    );
+    expect(call).toBeDefined();
+    const summary = call[1] as Record<string, unknown>;
+    expect(summary.poolerMode).toBe("session");
+    expect(summary.hasDatabaseUrl).toBe(true);
+
+    // The URL holds the password, so nothing derived from it may be serialised.
+    expect(JSON.stringify(summary)).not.toMatch(/u:p@|railway\.internal|:p\b/);
+  });
+
+  it("is emitted even when validation then rejects the config", () => {
+    // Otherwise a refused deployment leaves no record of WHAT was refused
+    // beyond the exception, and the resolved values stay unobservable.
+    const { initializeDatabase } = withEnv({ DB_POOLER_MODE: "sesion" });
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { logger } = require("@/lib/logger");
+    expect(() => initializeDatabase()).toThrow();
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "Database configuration resolved",
+      expect.objectContaining({ poolerMode: "sesion" }),
+    );
+  });
+});

--- a/src/lib/database/config.ts
+++ b/src/lib/database/config.ts
@@ -7,16 +7,45 @@
  */
 
 
+/**
+ * Read an integer env var, yielding NaN for anything that is not cleanly one.
+ *
+ * `parseInt` stops at the first non-digit, so it turns a malformed value into a
+ * plausible one: `DB_MAX_CONNECTIONS="5s"` silently resolves to 5, and `="abc"`
+ * resolves to NaN — which then passes every range check in
+ * {@link validateDatabaseConfig}, because *every* comparison against NaN is
+ * false. `Number` refuses the partial parse instead, collapsing both cases into
+ * one detectable NaN that the validator's `Number.isInteger` guard rejects.
+ *
+ * Empty-string is treated as unset, matching the `||` fallback this replaced.
+ */
+function intFromEnv(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === "") return fallback;
+  return Number(raw);
+}
+
+/**
+ * Connection-URL schemes `pg` accepts. BOTH are valid libpq URLs, and Railway,
+ * Neon, Supabase and Heroku all hand out the `postgres://` spelling. The
+ * validator used to accept only `postgresql:`, which was harmless while nothing
+ * called it — and would have aborted the pool on a perfectly working connection
+ * string the moment initializeDatabase() started throwing on it.
+ */
+const VALID_DB_PROTOCOLS = ["postgresql:", "postgres:"];
+
 // Environment variable validation and defaults
 export const databaseConfig = {
   // Database connection
   databaseUrl:
     process.env.DATABASE_URL ||
     "postgresql://user:pass@localhost:5432/alchm_kitchen",
-  
-  // Individual connection parameters (fallback if DATABASE_URL not provided)
+
+  // Individual connection parameters (fallback if DATABASE_URL not provided).
+  // Note these are effectively unreachable: `databaseUrl` above always resolves
+  // to a truthy default, and getDatabaseConfig() branches on `if (databaseUrl)`.
+  // They are left in place because removing them is a separate change.
   host: process.env.DB_HOST || "localhost",
-  port: parseInt(process.env.DB_PORT || "5432", 10),
+  port: intFromEnv(process.env.DB_PORT, 5432),
   database: process.env.DB_NAME || "alchm_kitchen",
   user: process.env.DB_USER || "user",
   password: process.env.DB_PASSWORD || "pass",
@@ -24,9 +53,9 @@ export const databaseConfig = {
 
   // Connection pool settings — kept small for serverless (each Vercel invocation
   // owns its own pool; 50 concurrent connections per instance would exhaust Railway).
-  maxConnections: parseInt(process.env.DB_MAX_CONNECTIONS || "5", 10),
-  idleTimeout: parseInt(process.env.DB_IDLE_TIMEOUT || "10000", 10),
-  connectionTimeout: parseInt(process.env.DB_CONNECTION_TIMEOUT || "5000", 10),
+  maxConnections: intFromEnv(process.env.DB_MAX_CONNECTIONS, 5),
+  idleTimeout: intFromEnv(process.env.DB_IDLE_TIMEOUT, 10000),
+  connectionTimeout: intFromEnv(process.env.DB_CONNECTION_TIMEOUT, 5000),
 
   // Per-statement cap. Pool-acquisition storms (cold start + cron storms) used
   // to surface as 1737s queries on trivial SELECTs because the SQL never started
@@ -35,13 +64,16 @@ export const databaseConfig = {
   // fails fast instead of holding a function instance for 29 minutes. Pair
   // with a proper pooler (PgBouncer/Supavisor) for the root-cause fix; this is
   // the floor that should always be on.
-  statementTimeoutMs: parseInt(process.env.DB_STATEMENT_TIMEOUT_MS || "5000", 10),
+  statementTimeoutMs: intFromEnv(process.env.DB_STATEMENT_TIMEOUT_MS, 5000),
 
   // Pooler topology in front of Postgres. Governs how the per-statement cap is
   // delivered (see getDatabaseConfig in connection.ts):
-  //   "direct"      — app talks straight to Postgres (or a session-mode pooler).
-  //                   `statement_timeout` is sent as a connection startup param.
-  //   "session"     — session-mode PgBouncer; same startup-param path as direct.
+  //   "direct"      — app talks straight to Postgres. `statement_timeout` is
+  //                   sent as a connection startup param.
+  //   "session"     — session-mode PgBouncer. NOT the same path as direct: the
+  //                   startup param is refused at login in every pool mode (see
+  //                   resolveServerStatementCap), so the cap is delivered by a
+  //                   post-connect `SET`, which session mode makes stick.
   //   "transaction" — transaction-mode PgBouncer. Startup params other than the
   //                   allow-listed few are REJECTED, and `SET`s don't persist
   //                   across the shared server connections, so we must NOT send
@@ -61,7 +93,36 @@ export const databaseConfig = {
   redisUrl: process.env.REDIS_URL || "redis://localhost:6379",
 };
 
-// Validate configuration on import
+/**
+ * Range-check one integer knob.
+ *
+ * The `Number.isInteger` guard is the load-bearing half. Before it existed a
+ * malformed env var produced NaN, and `NaN < min || NaN > max` is `false` — so
+ * the *most* broken configuration was the one the validator was blindest to.
+ */
+function checkIntegerRange(
+  errors: string[],
+  name: string,
+  value: number,
+  min: number,
+  max: number,
+  unit = "",
+): void {
+  if (!Number.isInteger(value)) {
+    errors.push(`${name} must be an integer (got ${JSON.stringify(value)})`);
+    return;
+  }
+  if (value < min || value > max) {
+    errors.push(
+      `${name} must be between ${min}${unit} and ${max}${unit} (got ${value}${unit})`,
+    );
+  }
+}
+
+/**
+ * Pure check of the resolved {@link databaseConfig}. Returns errors rather than
+ * throwing so callers choose the consequence; initializeDatabase() throws.
+ */
 export function validateDatabaseConfig(): { valid: boolean; errors: string[] } {
   const errors: string[] = [];
 
@@ -69,8 +130,10 @@ export function validateDatabaseConfig(): { valid: boolean; errors: string[] } {
   if (databaseConfig.databaseUrl) {
     try {
       const url = new URL(databaseConfig.databaseUrl);
-      if (url.protocol !== "postgresql:") {
-        errors.push("DATABASE_URL must use postgresql:// protocol");
+      if (!VALID_DB_PROTOCOLS.includes(url.protocol)) {
+        errors.push(
+          `DATABASE_URL must use postgresql:// or postgres:// (got ${url.protocol}//)`,
+        );
       }
     } catch {
       errors.push("DATABASE_URL is not a valid URL");
@@ -85,35 +148,30 @@ export function validateDatabaseConfig(): { valid: boolean; errors: string[] } {
       errors.push("DB_NAME is required when DATABASE_URL is not provided");
     if (!databaseConfig.user)
       errors.push("DB_USER is required when DATABASE_URL is not provided");
-    if (databaseConfig.port <= 0 || databaseConfig.port > 65535) {
-      errors.push("DB_PORT must be a valid port number (1-65535)");
-    }
+    checkIntegerRange(errors, "DB_PORT", databaseConfig.port, 1, 65535);
   }
 
-  // Check connection pool settings
-  if (
-    databaseConfig.maxConnections < 1 ||
-    databaseConfig.maxConnections > 100
-  ) {
-    errors.push("DB_MAX_CONNECTIONS must be between 1 and 100");
-  }
-  if (databaseConfig.idleTimeout < 1000) {
-    errors.push("DB_IDLE_TIMEOUT must be at least 1000ms");
-  }
-  if (databaseConfig.connectionTimeout < 100) {
-    errors.push("DB_CONNECTION_TIMEOUT must be at least 100ms");
-  }
-  if (
-    databaseConfig.statementTimeoutMs < 100 ||
-    databaseConfig.statementTimeoutMs > 60000
-  ) {
-    errors.push(
-      "DB_STATEMENT_TIMEOUT_MS must be between 100ms and 60000ms",
-    );
-  }
+  // Check connection pool settings. Upper bounds are the blast radius, not a
+  // preference: the pool is per-serverless-instance, so a large `max` multiplied
+  // by concurrent instances is what exhausts PgBouncer's max_client_conn.
+  checkIntegerRange(errors, "DB_MAX_CONNECTIONS", databaseConfig.maxConnections, 1, 100);
+  checkIntegerRange(
+    errors, "DB_IDLE_TIMEOUT", databaseConfig.idleTimeout, 1000, 600_000, "ms",
+  );
+  checkIntegerRange(
+    errors, "DB_CONNECTION_TIMEOUT", databaseConfig.connectionTimeout, 100, 60_000, "ms",
+  );
+  checkIntegerRange(
+    errors, "DB_STATEMENT_TIMEOUT_MS", databaseConfig.statementTimeoutMs, 100, 60_000, "ms",
+  );
+  // An unrecognised pooler mode is not cosmetic: resolveServerStatementCap and
+  // resolvePooledStatementTimeoutSql both compare against exact strings, so a
+  // typo silently disables the docs/adr/007 statement floor on every connection
+  // while the pool still appears to work.
   if (!["direct", "session", "transaction"].includes(databaseConfig.poolerMode)) {
     errors.push(
-      'DB_POOLER_MODE must be one of "direct", "session", or "transaction"',
+      `DB_POOLER_MODE must be one of "direct", "session", or "transaction" ` +
+        `(got ${JSON.stringify(databaseConfig.poolerMode)})`,
     );
   }
 
@@ -140,33 +198,29 @@ export function assertRuntimeDatabaseConfig(): void {
   }
 }
 
-// Initialize configuration and log warnings
-// DISABLED: Module-level logging causes Next.js build to hang during module scanning
-// These validations and logs should be called at runtime, not during import
-/*
-const validation = validateDatabaseConfig();
-if (!validation.valid) {
-  void logger.error("Database configuration validation failed", {
-    errors: validation.errors,
-  });
-  throw new Error(
-    `Invalid database configuration: ${validation.errors.join(", ")}`,
-  );
+/**
+ * Loggable summary of the resolved config — no credentials.
+ *
+ * The connection URL carries the password, so nothing derived from it is
+ * reported beyond presence. `host`/`database` mirror what initializeDatabase()
+ * already logs on pool creation, and `poolerMode` is a topology enum rather
+ * than a secret; it is included because a wrong value silently disables the
+ * statement floor and was otherwise unobservable in production.
+ */
+export function databaseConfigSummary(): Record<string, unknown> {
+  return {
+    environment: databaseConfig.environment,
+    hasDatabaseUrl: !!process.env.DATABASE_URL,
+    port: databaseConfig.port,
+    poolerMode: databaseConfig.poolerMode,
+    maxConnections: databaseConfig.maxConnections,
+    idleTimeout: databaseConfig.idleTimeout,
+    connectionTimeout: databaseConfig.connectionTimeout,
+    statementTimeoutMs: databaseConfig.statementTimeoutMs,
+    logQueries: databaseConfig.logQueries,
+    autoMigrate: databaseConfig.autoMigrate,
+  };
 }
-
-// Log configuration summary (without sensitive data)
-void logger.info("Database configuration loaded", {
-  environment: databaseConfig.environment,
-  hasDatabaseUrl: !!databaseConfig.databaseUrl,
-  host: databaseConfig.databaseUrl ? "[hidden]" : databaseConfig.host,
-  port: databaseConfig.port,
-  database: databaseConfig.database,
-  maxConnections: databaseConfig.maxConnections,
-  ssl: databaseConfig.ssl,
-  logQueries: databaseConfig.logQueries,
-  autoMigrate: databaseConfig.autoMigrate,
-});
-*/
 
 /**
  * Resolve the `pg` `ssl` option for a parsed connection URL.

--- a/src/lib/database/rawPool.ts
+++ b/src/lib/database/rawPool.ts
@@ -3,6 +3,8 @@ import { logger } from "../logger";
 import {
   databaseConfig,
   assertRuntimeDatabaseConfig,
+  validateDatabaseConfig,
+  databaseConfigSummary,
   resolveSslOption,
   resolveServerStatementCap,
   resolvePooledStatementTimeoutSql,
@@ -151,6 +153,26 @@ export function initializeDatabase(): Pool {
   // Fail fast in production if DATABASE_URL is unset (would silently fall back
   // to the localhost default and "succeed" until the first query times out).
   assertRuntimeDatabaseConfig();
+
+  // The resolved config, before it can throw — so a rejected configuration is
+  // still legible in the runtime logs rather than only in the exception.
+  void logger.info("Database configuration resolved", databaseConfigSummary());
+
+  // This validation used to run at module scope and was commented out because
+  // module-level work hung the Next build. Pool creation is the right place: it
+  // is lazy (first query after a cold start), it runs in the environment being
+  // validated rather than at build time, and a bad value is refused before it
+  // reaches `new Pool()` — where NaN and out-of-range knobs otherwise produce a
+  // pool that connects and then misbehaves under load.
+  const validation = validateDatabaseConfig();
+  if (!validation.valid) {
+    void logger.error("Database configuration validation failed", {
+      errors: validation.errors,
+    });
+    throw new Error(
+      `Invalid database configuration: ${validation.errors.join("; ")}`,
+    );
+  }
 
   const config = getDatabaseConfig();
 


### PR DESCRIPTION
Closes #25.

`validateDatabaseConfig()` has been commented out at module scope since it hung the Next build (`src/lib/database/config.ts`, the old lines 146–169). Nothing called it. Per the decision on #25 it now runs from `initializeDatabase()` and throws.

## Two defects had to be fixed first

Enabling a throw on an unexercised validator is only safe once the validator is right. Both of these were measured, not inferred:

| case | before | after |
|---|---|---|
| `DATABASE_URL=postgres://…` | **FAIL** — "must use postgresql:// protocol" | accepted |
| `DB_MAX_CONNECTIONS=abc` | **pass** (resolves to NaN) | rejected |
| `DB_MAX_CONNECTIONS=5s` | **pass** (silently resolves to 5) | rejected |
| `DB_MAX_CONNECTIONS=500` | rejected | rejected |

1. **`postgres://` was rejected.** It is a valid libpq scheme that `pg` accepts, and Railway, Neon, Supabase and Heroku all hand it out. `getDatabaseConfig()` handles it fine — it only reads hostname/port/pathname/username/password. Arming the throw without this would have aborted the pool on a *working* connection string.

2. **Every numeric range check was blind to a malformed value.** `parseInt` fails two ways: it stops at the first non-digit (`"5s"` → `5`), and it yields `NaN` for `"abc"` — and `NaN < 1 || NaN > 100` is `false`. The most broken configuration was the one the validator was blindest to. Reading through `Number` collapses both into a NaN that a `Number.isInteger` guard rejects.

## Where the call went, and why

`initializeDatabase()`, alongside the `assertRuntimeDatabaseConfig()` that already throws there:

- **lazy** — first query after a cold start, so it runs in the environment being validated rather than at build time (the original hang);
- **ahead of `new Pool()`** — a bad value is refused rather than producing a pool that connects and then misbehaves under load;
- **same blast radius as the existing throw** — DB routes 500, static pages unaffected, and Vercel rollback is one click.

The config summary is logged *before* validation, so a refused deployment still records what was refused rather than only surfacing an exception. It reports `poolerMode` — a topology enum, not a credential — because a typo there silently disables the docs/adr/007 statement floor and is otherwise unobservable in production. Nothing derived from the connection URL is serialised beyond presence.

Also corrected a stale comment claiming session mode "takes the same startup-param path as direct". `resolveServerStatementCap` documents the measured opposite, and that exact misconception is what made the pooler unreachable before #732.

## Verification

228 suites / 2244 tests pass; `bun run typecheck`, `bun run lint` and `bun run build` all clean.

New tests drive the real `initializeDatabase()` against a fake `pg`, so the wiring is under test rather than a restatement of the validator — including that it throws **before** `new Pool()` is constructed, which is the load-bearing property.

All four guards were mutation-tested, with the sources restored byte-identically afterwards (`diff`-verified):

| mutation | tests failed |
|---|---|
| remove the throw from `initializeDatabase()` | 11 |
| protocol list back to `["postgresql:"]` | 1 |
| drop the `Number.isInteger` guard | 6 |
| `intFromEnv` back to `parseInt` | 2 |

## One residual, stated plainly

`DB_POOLER_MODE` is marked **Sensitive** in Vercel, so its live value cannot be read back — not by me and not from the dashboard. What is known: it is set (4 days ago, with the PgBouncer flip); it is not `"direct"`, because direct mode sends `statement_timeout` in the startup packet and PgBouncer refuses that at login in every pool mode, so the pool could not connect at all; and PgBouncer's own `PGBOUNCER_POOL_MODE` is `"session"`. Both `"session"` and `"transaction"` pass validation — only a typo would fail, and a typo would connect too, so it is not excluded by that reasoning.

I tried to settle it from the production slow-query log and the witness turned out to measure the wrong interval — `executeQuery` starts its timer before pool checkout, so those durations are acquisition wait plus execution, which `statement_timeout` never bounds. Reporting that as evidence either way would have been wrong. I will check production health immediately after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)