### PR TITLE
feat(alerts): keep announcing an incident that never ends

### DIFF
--- a/src/lib/observability/alertLog.ts
+++ b/src/lib/observability/alertLog.ts
@@ -15,6 +15,19 @@ import type { FlowStatus } from "@/services/systemStatusService";
 
 export type AlertSeverity = "info" | "warn" | "error";
 
+/**
+ * Component id of the sustained-incident digest alertService emits (see
+ * `collectSustainedReminder`). It is a re-announcement of components that are
+ * already alerting, not a component of its own, so readers that count open
+ * incidents must skip it.
+ *
+ * It lives in this leaf rather than in alertService because
+ * operationsControlPlaneService is deliberately pure, and importing
+ * alertService there would drag the database, Slack and email clients into it.
+ * Two matching string literals would drift; one constant cannot.
+ */
+export const SUSTAINED_COMPONENT = "sustained";
+
 export interface AlertLogEntry {
   id: number;
   at: string;

--- a/src/services/__tests__/alertServiceSustained.test.ts
+++ b/src/services/__tests__/alertServiceSustained.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Sustained-incident re-alerting.
+ *
+ * Every rule in alertService keys off CHANGE, which meant a component that went
+ * INCIDENT and stayed there alerted exactly once, ever. Measured in production
+ * on 2026-08-11: `payments` had been INCIDENT for 35 consecutive hourly
+ * snapshots on the strength of one email sent 35 hours earlier.
+ *
+ * The two properties that matter pull against each other, so both are pinned
+ * here: a long outage must keep announcing itself, and it must not turn the
+ * hourly cron into an hourly mailing list.
+ */
+
+const mockExecuteQuery = jest.fn();
+jest.mock("@/lib/database/connection", () => ({
+  executeQuery: (...args: unknown[]) => mockExecuteQuery(...args),
+}));
+
+import {
+  buildSustainedReminder,
+  collectSustainedReminder,
+  getReminderIntervalMs,
+  selectIncidentComponents,
+  type SustainedIncident,
+} from "@/services/alertService";
+import { SUSTAINED_COMPONENT } from "@/lib/observability/alertLog";
+import type {
+  DependencyHealth,
+  FlowHealth,
+  FlowStatus,
+  SystemStatusPayload,
+} from "@/services/systemStatusService";
+
+const NOW = new Date("2026-08-11T18:00:00.000Z");
+const HOUR = 3_600_000;
+
+function makeFlow(id: string, status: FlowStatus): FlowHealth {
+  return {
+    id,
+    label: `${id} label`,
+    description: `${id} flow`,
+    status,
+    summary: `${id} is ${status}`,
+    metrics: [],
+    issues: [],
+    checkedAt: NOW.toISOString(),
+    live: true,
+  };
+}
+
+function makeDep(id: string, status: FlowStatus): DependencyHealth {
+  return {
+    id,
+    label: `${id} label`,
+    status,
+    summary: `${id} is ${status}`,
+    latencyMs: 50,
+    checkedAt: NOW.toISOString(),
+  };
+}
+
+function makePayload(
+  overall: FlowStatus,
+  flows: FlowHealth[],
+  deps: DependencyHealth[] = [],
+): SystemStatusPayload {
+  return {
+    generatedAt: NOW.toISOString(),
+    overall,
+    flows,
+    dependencies: deps,
+  };
+}
+
+function hoursAgo(h: number): string {
+  return new Date(NOW.getTime() - h * HOUR).toISOString();
+}
+
+describe("selectIncidentComponents", () => {
+  it("picks up INCIDENT flows and dependencies, and nothing else", () => {
+    const payload = makePayload(
+      "INCIDENT",
+      [
+        makeFlow("payments", "INCIDENT"),
+        makeFlow("economy", "DEGRADED"),
+        makeFlow("auth", "OK"),
+        makeFlow("mcp", "UNKNOWN"),
+      ],
+      [makeDep("stripe", "INCIDENT"), makeDep("planetary-agents", "OK")],
+    );
+    expect(selectIncidentComponents(payload).map((c) => c.component)).toEqual([
+      "payments",
+      "stripe",
+    ]);
+  });
+
+  it("does not report `overall` as its own component", () => {
+    // It is derived from the flows below it, so including it would announce
+    // the same outage twice in one digest.
+    const payload = makePayload("INCIDENT", [makeFlow("payments", "INCIDENT")]);
+    expect(selectIncidentComponents(payload)).toHaveLength(1);
+  });
+});
+
+describe("buildSustainedReminder", () => {
+  const reminderMs = 24 * HOUR;
+
+  const incident = (
+    component: string,
+    since: string | null,
+  ): SustainedIncident => ({
+    component,
+    componentLabel: `${component} label`,
+    summary: `${component} is broken`,
+    since,
+  });
+
+  it("reminds about an incident older than one interval", () => {
+    const c = buildSustainedReminder([incident("payments", hoursAgo(35))], NOW, reminderMs);
+    expect(c).not.toBeNull();
+    expect(c!.component).toBe(SUSTAINED_COMPONENT);
+    expect(c!.severity).toBe("error");
+    expect(c!.title).toMatch(/still down/);
+    expect(c!.message).toMatch(/35h/);
+  });
+
+  it("stays silent about an incident that only just started", () => {
+    // Otherwise the reminder arrives in the same cron cycle as the transition
+    // alert that announced it — two emails for one event.
+    expect(
+      buildSustainedReminder([incident("economy", hoursAgo(1))], NOW, reminderMs),
+    ).toBeNull();
+  });
+
+  it("reminds about an incident with no recorded start", () => {
+    // A component that is red with no transition on file is one whose outage
+    // predates the alert history — precisely the case this exists for.
+    const c = buildSustainedReminder([incident("payments", null)], NOW, reminderMs);
+    expect(c).not.toBeNull();
+    expect(c!.message).toMatch(/duration unrecorded/);
+  });
+
+  it("digests many components into ONE alert", () => {
+    const c = buildSustainedReminder(
+      [
+        incident("payments", hoursAgo(35)),
+        incident("economy", hoursAgo(50)),
+        incident("mcp", hoursAgo(200)),
+      ],
+      NOW,
+      reminderMs,
+    );
+    expect(c!.title).toBe("3 components still down");
+    // One alert, every component named — when something goes broadly red,
+    // per-component reminders would multiply the noise the cooldown prevents.
+    for (const name of ["payments label", "economy label", "mcp label"]) {
+      expect(c!.message).toContain(name);
+    }
+  });
+
+  it("drops only the components that are too young, keeping the rest", () => {
+    const c = buildSustainedReminder(
+      [incident("payments", hoursAgo(35)), incident("economy", hoursAgo(2))],
+      NOW,
+      reminderMs,
+    );
+    expect(c!.title).toMatch(/payments label still down/);
+    expect(c!.message).not.toContain("economy label");
+  });
+
+  it("declares INCIDENT → INCIDENT, so its own rows never reset the clock", () => {
+    // getIncidentStartTimes filters on `previous_status <> 'INCIDENT'`. If a
+    // reminder recorded a transition INTO incident, every reminder would reset
+    // the age it is measuring and the digest would never mature again.
+    const c = buildSustainedReminder([incident("payments", hoursAgo(35))], NOW, reminderMs);
+    expect(c!.previous).toBe("INCIDENT");
+    expect(c!.current).toBe("INCIDENT");
+  });
+
+  it("formats a multi-day outage in days, not three-digit hours", () => {
+    const c = buildSustainedReminder([incident("payments", hoursAgo(85 * 24 + 3))], NOW, reminderMs);
+    expect(c!.title).toMatch(/85d 3h/);
+  });
+
+  it("returns nothing when reminders are disabled", () => {
+    expect(
+      buildSustainedReminder([incident("payments", hoursAgo(500))], NOW, 0),
+    ).toBeNull();
+  });
+
+  it("returns nothing when nothing is in incident", () => {
+    expect(buildSustainedReminder([], NOW, reminderMs)).toBeNull();
+  });
+});
+
+describe("getReminderIntervalMs", () => {
+  const saved = process.env.ALERT_REMINDER_HOURS;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.ALERT_REMINDER_HOURS;
+    else process.env.ALERT_REMINDER_HOURS = saved;
+  });
+
+  it("defaults to 24h", () => {
+    delete process.env.ALERT_REMINDER_HOURS;
+    expect(getReminderIntervalMs()).toBe(24 * HOUR);
+  });
+
+  it("honours an explicit value", () => {
+    process.env.ALERT_REMINDER_HOURS = "6";
+    expect(getReminderIntervalMs()).toBe(6 * HOUR);
+  });
+
+  it("treats 0 as 'disabled' rather than as 'remind constantly'", () => {
+    process.env.ALERT_REMINDER_HOURS = "0";
+    expect(getReminderIntervalMs()).toBe(0);
+  });
+
+  it("falls back to the default on garbage rather than to NaN", () => {
+    process.env.ALERT_REMINDER_HOURS = "sometimes";
+    expect(getReminderIntervalMs()).toBe(24 * HOUR);
+  });
+});
+
+describe("collectSustainedReminder — the dedup gate", () => {
+  beforeEach(() => {
+    mockExecuteQuery.mockReset();
+    delete process.env.ALERT_REMINDER_HOURS;
+  });
+
+  const payload = makePayload("INCIDENT", [
+    makeFlow("payments", "INCIDENT"),
+    makeFlow("auth", "OK"),
+  ]);
+
+  /** First query = incident start times; second = last reminder dispatch. */
+  function stubQueries(starts: unknown[], lastReminder: unknown[]) {
+    mockExecuteQuery
+      .mockResolvedValueOnce({ rows: starts })
+      .mockResolvedValueOnce({ rows: lastReminder });
+  }
+
+  it("emits a reminder when none has gone out within the interval", async () => {
+    stubQueries(
+      [{ component: "payments", triggered_at: new Date(hoursAgo(35)) }],
+      [],
+    );
+    const c = await collectSustainedReminder(payload, NOW);
+    expect(c).not.toBeNull();
+    expect(c!.component).toBe(SUSTAINED_COMPONENT);
+  });
+
+  it("suppresses a second reminder inside the same interval", async () => {
+    // The load-bearing half. The cron runs hourly; without this a 35-hour
+    // outage would produce 35 emails instead of one per day.
+    stubQueries(
+      [{ component: "payments", triggered_at: new Date(hoursAgo(35)) }],
+      [{ triggered_at: new Date(hoursAgo(3)) }],
+    );
+    expect(await collectSustainedReminder(payload, NOW)).toBeNull();
+  });
+
+  it("does no DB work at all when nothing is in incident", async () => {
+    const healthy = makePayload("OK", [makeFlow("payments", "OK")]);
+    expect(await collectSustainedReminder(healthy, NOW)).toBeNull();
+    expect(mockExecuteQuery).not.toHaveBeenCalled();
+  });
+
+  it("does no DB work when reminders are disabled", async () => {
+    process.env.ALERT_REMINDER_HOURS = "0";
+    expect(await collectSustainedReminder(payload, NOW)).toBeNull();
+    expect(mockExecuteQuery).not.toHaveBeenCalled();
+  });
+
+  it("still reminds when the start-time lookup fails", async () => {
+    // Fail open: an unknown start date should make an incident eligible, not
+    // invisible. A monitoring failure must not silence an outage.
+    mockExecuteQuery
+      .mockRejectedValueOnce(new Error("connection terminated"))
+      .mockResolvedValueOnce({ rows: [] });
+    const c = await collectSustainedReminder(payload, NOW);
+    expect(c).not.toBeNull();
+    expect(c!.message).toMatch(/duration unrecorded/);
+  });
+
+  it("asks for start times only for components that are actually red", async () => {
+    stubQueries([], []);
+    await collectSustainedReminder(payload, NOW);
+    const [, params] = mockExecuteQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[0]).toEqual(["payments"]);
+  });
+});

--- a/src/services/alertService.ts
+++ b/src/services/alertService.ts
@@ -22,6 +22,12 @@
  *     event to DB but skips Slack + email. Prevents flapping from
  *     spamming operators while preserving the audit trail.
  *
+ * Those rules are all about CHANGE, which left a hole: a component that
+ * goes INCIDENT and stays there produces exactly one alert, ever. Measured
+ * 2026-08-11 in production, `payments` had been INCIDENT for 35 consecutive
+ * hourly snapshots on the strength of a single email sent 35 hours earlier.
+ * `collectSustainedReminder` closes that — see the block comment above it.
+ *
  * Each sink (DB, Slack, email) dispatches independently with try/catch
  * — a broken webhook URL doesn't block the email and vice versa.
  *
@@ -35,6 +41,7 @@ import { renderAlertEmail } from "@/lib/notifications/alertEmail";
 import { sendSlackAlert } from "@/lib/notifications/slackNotifier";
 import {
   recordAlert,
+  SUSTAINED_COMPONENT,
   type AlertDispatchSummary,
   type AlertLogEntry,
   type AlertSeverity,
@@ -249,6 +256,199 @@ export function diffPayloadsForAlerts(
   return candidates;
 }
 
+// ─── Sustained incidents ────────────────────────────────────────────────
+//
+// Everything above alerts on TRANSITIONS, so silence means either "nothing is
+// wrong" or "everything has been wrong for so long that nothing changed". Those
+// are indistinguishable to an operator, and the second one is the emergency.
+//
+// The reminder is one digest per interval covering every component still in
+// INCIDENT, rather than one alert per component: when something goes broadly
+// red, per-component reminders would multiply the very noise the cooldown
+// exists to prevent. It carries its own synthetic component id so it dedups on
+// its own clock and never collides with a real component's transition history.
+
+const DEFAULT_REMINDER_HOURS = 24;
+
+/** Re-alert interval in ms. `ALERT_REMINDER_HOURS=0` disables reminders. */
+export function getReminderIntervalMs(): number {
+  const raw = process.env.ALERT_REMINDER_HOURS;
+  if (!raw) return DEFAULT_REMINDER_HOURS * 3_600_000;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_REMINDER_HOURS * 3_600_000;
+  }
+  return parsed * 3_600_000;
+}
+
+export interface SustainedIncident {
+  component: string;
+  componentLabel: string;
+  summary: string;
+  /** When the component last entered INCIDENT; null when unrecorded. */
+  since: string | null;
+}
+
+/**
+ * Every flow and dependency currently in INCIDENT. Pure — exported for tests.
+ *
+ * `overall` is deliberately excluded: it is derived from these, so including it
+ * would report the same outage twice in one digest.
+ */
+export function selectIncidentComponents(
+  payload: SystemStatusPayload,
+): Array<{ component: string; componentLabel: string; summary: string }> {
+  const out: Array<{
+    component: string;
+    componentLabel: string;
+    summary: string;
+  }> = [];
+  for (const flow of payload.flows) {
+    if (flow.status === "INCIDENT") {
+      out.push({
+        component: flow.id,
+        componentLabel: flow.label,
+        summary: flow.summary,
+      });
+    }
+  }
+  for (const dep of payload.dependencies) {
+    if (dep.status === "INCIDENT") {
+      out.push({
+        component: dep.id,
+        componentLabel: dep.label,
+        summary: dep.summary,
+      });
+    }
+  }
+  return out;
+}
+
+function formatDuration(fromIso: string | null, now: Date): string {
+  if (!fromIso) return "duration unrecorded";
+  const ms = now.getTime() - Date.parse(fromIso);
+  if (!Number.isFinite(ms) || ms < 0) return "duration unrecorded";
+  const hours = Math.floor(ms / 3_600_000);
+  if (hours < 48) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d ${hours % 24}h`;
+}
+
+/**
+ * Build the digest for incidents that have outlasted one reminder interval.
+ * Pure — exported for tests.
+ *
+ * The age filter is what keeps a reminder from arriving alongside the very
+ * transition alert that announced the incident: something that broke ten
+ * minutes ago is news, not a reminder. An incident with no recorded start is
+ * INCLUDED — a component that is red with no transition on file is one whose
+ * outage predates our records, which is precisely the case this exists for.
+ */
+export function buildSustainedReminder(
+  incidents: SustainedIncident[],
+  now: Date,
+  reminderMs: number,
+): AlertCandidate | null {
+  if (reminderMs <= 0) return null;
+  const due = incidents.filter((i) => {
+    if (!i.since) return true;
+    const started = Date.parse(i.since);
+    if (!Number.isFinite(started)) return true;
+    return now.getTime() - started >= reminderMs;
+  });
+  if (due.length === 0) return null;
+
+  const lines = due.map(
+    (i) => `• ${i.componentLabel} (${formatDuration(i.since, now)}) — ${i.summary}`,
+  );
+  const hours = Math.round(reminderMs / 3_600_000);
+  return {
+    component: SUSTAINED_COMPONENT,
+    componentLabel: "Sustained incident",
+    // Honest about the shape of the event: nothing changed, and that is the
+    // point. It also keeps these rows out of getIncidentStartTimes, so a
+    // reminder can never reset the clock it is measuring.
+    previous: "INCIDENT",
+    current: "INCIDENT",
+    severity: "error",
+    title:
+      due.length === 1
+        ? `${due[0].componentLabel} still down (${formatDuration(due[0].since, now)})`
+        : `${due.length} components still down`,
+    message:
+      `Still in INCIDENT with no change since the last alert. ` +
+      `Repeats every ${hours}h until resolved.\n\n${lines.join("\n")}`,
+  };
+}
+
+/**
+ * When each component last ENTERED incident, from the transition history.
+ *
+ * `previous_status <> 'INCIDENT'` is load-bearing twice: it skips the
+ * INCIDENT→INCIDENT reminder rows this service writes (which would otherwise
+ * reset each component's clock every interval), and it picks the start of the
+ * current run rather than any point inside it.
+ */
+async function getIncidentStartTimes(
+  components: string[],
+): Promise<Map<string, string>> {
+  const starts = new Map<string, string>();
+  if (components.length === 0) return starts;
+  try {
+    const result = await executeQuery<{ component: string; triggered_at: Date }>(
+      `SELECT DISTINCT ON (component) component, triggered_at
+         FROM alert_events
+        WHERE current_status = 'INCIDENT'
+          AND previous_status <> 'INCIDENT'
+          AND component = ANY($1::text[])
+        ORDER BY component, triggered_at DESC`,
+      [components],
+    );
+    for (const row of result.rows) {
+      starts.set(row.component, new Date(row.triggered_at).toISOString());
+    }
+  } catch (err) {
+    // Fail open: an unknown start date makes an incident eligible rather than
+    // invisible, which is the safer direction for an outage reminder.
+    _logger.warn("[alertService] incident-start lookup failed:", err);
+  }
+  return starts;
+}
+
+/**
+ * The reminder due this cycle, or null. Applies the dedup gate: a reminder
+ * that already went out within the interval suppresses the next one.
+ */
+export async function collectSustainedReminder(
+  current: SystemStatusPayload,
+  now: Date = new Date(),
+): Promise<AlertCandidate | null> {
+  const reminderMs = getReminderIntervalMs();
+  if (reminderMs <= 0) return null;
+
+  const bad = selectIncidentComponents(current);
+  if (bad.length === 0) return null;
+
+  const starts = await getIncidentStartTimes(bad.map((b) => b.component));
+  const incidents: SustainedIncident[] = bad.map((b) => ({
+    ...b,
+    since: starts.get(b.component) ?? null,
+  }));
+
+  const candidate = buildSustainedReminder(incidents, now, reminderMs);
+  if (!candidate) return null;
+
+  // Dedup on the digest's own component, so one reminder per interval no matter
+  // how many components are red or how often the cron runs.
+  const lastReminderAt = await getLastNonSuppressedDispatchAt(
+    SUSTAINED_COMPONENT,
+    "INCIDENT",
+    reminderMs,
+  );
+  if (lastReminderAt) return null;
+
+  return candidate;
+}
+
 /**
  * Dispatch a single alert candidate to all enabled sinks. Logs the
  * outcome to `alert_events` + in-memory ring. Returns the dispatched
@@ -397,20 +597,36 @@ async function persistAlertEvent(args: {
 
 /**
  * Top-level helper used by the snapshot cron: compute transitions
- * between two payloads and dispatch each. Returns the dispatched alerts
- * in the order they were emitted.
+ * between two payloads and dispatch each, then the sustained-incident
+ * reminder if one is due. Returns the dispatched alerts in the order they
+ * were emitted.
+ *
+ * Transitions run FIRST so this cycle's own OK→INCIDENT rows are already on
+ * `alert_events` when the reminder reads incident start times — otherwise a
+ * brand-new incident would look undated and be reminded about immediately.
+ *
+ * A missing `previous` skips transitions (there is nothing to diff against)
+ * but NOT the reminder: the first snapshot after a cold start is exactly when
+ * a long-running outage most needs to be re-announced.
  */
 export async function dispatchTransitions(
   previous: SystemStatusPayload | null,
   current: SystemStatusPayload,
   options: { snapshotId?: number | null } = {},
 ): Promise<DispatchedAlert[]> {
-  if (!previous) return [];
-  const candidates = diffPayloadsForAlerts(previous, current);
   const dispatched: DispatchedAlert[] = [];
-  for (const c of candidates) {
-    dispatched.push(await dispatchAlert(c, options));
+
+  if (previous) {
+    for (const c of diffPayloadsForAlerts(previous, current)) {
+      dispatched.push(await dispatchAlert(c, options));
+    }
   }
+
+  const reminder = await collectSustainedReminder(current);
+  if (reminder) {
+    dispatched.push(await dispatchAlert(reminder, options));
+  }
+
   return dispatched;
 }
 

--- a/src/services/operationsControlPlaneService.ts
+++ b/src/services/operationsControlPlaneService.ts
@@ -10,6 +10,7 @@
  * can be tested without a database or network.
  */
 
+import { SUSTAINED_COMPONENT } from "@/lib/observability/alertLog";
 import type { AgentNetworkTelemetry } from "@/services/agentTelemetryService";
 import type {
   CosmicYieldData,
@@ -228,6 +229,10 @@ function activeAlerts(recentAlerts: RecentAlertsData): number {
     RecentAlertsData["entries"][number]
   >();
   for (const alert of recentAlerts.entries) {
+    // The sustained-incident digest is a re-announcement of components already
+    // counted here, not a component of its own. Counting it would inflate this
+    // number by one for the entire life of any outage.
+    if (alert.component === SUSTAINED_COMPONENT) continue;
     if (!latestByComponent.has(alert.component)) {
       latestByComponent.set(alert.component, alert);
     }


### PR DESCRIPTION
Closes #24.

Every rule in `alertService` keys off **change**. `classifyTransition` opens with `if (previous === current) return null;`, so a component that goes INCIDENT and stays there alerts exactly once, ever. Silence then means either "nothing is wrong" or "everything has been wrong so long that nothing changed" — and the second one is the emergency.

## The bug, measured in production

`payments` has been INCIDENT for **35 consecutive hourly snapshots** (since 2026-08-10T07:00Z, Stripe not sending 3 critical events). `alert_events` holds exactly one row for it:

| component | previous → current | events | last fired |
|---|---|---|---|
| `payments` | OK → INCIDENT | **1** | 2026-08-10T07:00:19Z |

The hourly snapshot cron has run 35 times since and had nothing to say, because nothing changed. That is the whole failure.

## What this adds

One digest alert per interval covering every component still in INCIDENT, dispatched from the same cron:

- **One alert, not N.** When something goes broadly red, per-component reminders would multiply the very noise the cooldown exists to prevent.
- **Dedup on its own synthetic component id** (`sustained`), so it keys off its own clock and never collides with a real component's transition history. `ALERT_REMINDER_HOURS`, default 24; `0` disables.
- **Only incidents that outlasted a full interval qualify.** Otherwise the reminder arrives in the same cron cycle as the transition alert that announced it — two emails for one event. Verified against live data: `payments` (35h) is due; `economy`, which re-entered INCIDENT minutes before I ran the probe, is correctly excluded.
- **It declares INCIDENT → INCIDENT.** Honest, and load-bearing: `getIncidentStartTimes` filters `previous_status <> 'INCIDENT'`, so a reminder can never reset the clock it is measuring.
- **Fails open.** An unrecorded start date makes an incident *eligible* rather than invisible — a component that is red with no transition on file is one whose outage predates the alert history, which is exactly the case this exists for.

Transitions dispatch **before** the reminder, so this cycle's own rows are already on `alert_events` when start times are read. A missing `previous` snapshot skips transitions but not the reminder: the first cycle after a cold start is precisely when a long outage most needs re-announcing.

## Two things I had to not break

`SUSTAINED_COMPONENT` lives in the `alertLog` leaf, not in `alertService`. `operationsControlPlaneService` is documented as "deliberately pure", and importing `alertService` there would drag the database, Slack and email clients into it. Two matching string literals would drift; one constant cannot.

That service's `activeAlerts()` now skips the digest. It is a re-announcement of components already counted, so without the skip it would have inflated the open-incident count by one for the entire life of any outage.

## Verification

229 suites / 2265 tests pass; typecheck, lint and build clean. 21 new tests cover both directions — that a long outage keeps announcing itself, **and** that it does not turn the hourly cron into an hourly mailing list.

The new query was `PREPARE`d against the production schema, since CI's SQL gate covers only the economy builders and a mocked `executeQuery` will happily "pass" invalid SQL:

```
PREPARE: ok — Postgres planned the statement
CONTROL: ok — misspelled column rejected (column "triggerd_at" does not exist)
```

The control is there because a `PREPARE` that succeeds proves nothing unless a deliberately broken variant fails.

## What happens on deploy

The next hourly cron will send **one** email: `payments label still down (35h)`, then repeat daily until the flow recovers. That flow is red because of the Stripe Dashboard webhook events in §2 of the handoff — the reminder will keep arriving until those are added, which is the intended behaviour but worth knowing in advance. `ALERT_REMINDER_HOURS` tunes or silences it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)