### PR TITLE
perf(probes): stop scanning 40k rows to return 7, and make the probe JWT expiry self-checking

### DIFF
--- a/src/services/__tests__/syntheticProbeTokenExpiry.test.ts
+++ b/src/services/__tests__/syntheticProbeTokenExpiry.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @jest-environment node
+ *
+ * The synthetic probes all authenticate with one long-lived JWT
+ * (`SYNTHETIC_PROBE_TOKEN`). When it expires, all seven probes start failing at
+ * the same moment and the dashboard reports a platform-wide incident that is
+ * really one expired credential.
+ *
+ * The variable is marked Sensitive in Vercel, so the expiry cannot be read back
+ * to re-derive it — which is exactly how a recorded date rots into one nobody
+ * has checked since it was written. Two things stop that: the tripwire below,
+ * which turns this suite red 60 days out, and `warnIfProbeTokenNearExpiry`,
+ * which re-derives the real `exp` in production where the token actually lives.
+ */
+
+jest.mock("@/lib/database/connection", () => ({
+  executeQuery: jest.fn().mockResolvedValue({ rows: [] }),
+}));
+
+const mockWarn = jest.fn();
+jest.mock("@/lib/logger", () => ({
+  _logger: { warn: mockWarn, error: jest.fn(), info: jest.fn() },
+  logger: { warn: mockWarn, error: jest.fn(), info: jest.fn() },
+}));
+
+import {
+  daysUntilProbeTokenExpiry,
+  decodeJwtExpiry,
+  warnIfProbeTokenNearExpiry,
+  PROBE_TOKEN_EXPIRY_WARNING_DAYS,
+  SYNTHETIC_PROBE_TOKEN_EXPIRES_AT,
+} from "@/services/syntheticProbeService";
+
+/** Build an unsigned JWT whose `exp` is `days` from `from`. */
+function tokenExpiringIn(days: number, from = new Date()): string {
+  const exp = Math.floor((from.getTime() + days * 86_400_000) / 1000);
+  const b64 = (o: unknown) =>
+    Buffer.from(JSON.stringify(o)).toString("base64url");
+  return `${b64({ alg: "HS256" })}.${b64({ sub: "probe", exp })}.signature`;
+}
+
+describe("the recorded expiry is still far enough away", () => {
+  it("has not come within the warning window", () => {
+    // THIS IS THE TRIPWIRE. When it fails, nothing is broken yet — mint a new
+    // SYNTHETIC_PROBE_TOKEN, set it in Vercel, and move
+    // SYNTHETIC_PROBE_TOKEN_EXPIRES_AT to the new `exp`. Do not widen the
+    // window to make it pass.
+    const days = daysUntilProbeTokenExpiry(new Date());
+    expect(days).toBeGreaterThan(PROBE_TOKEN_EXPIRY_WARNING_DAYS);
+  });
+
+  it("is a parseable instant, not a date-shaped string", () => {
+    expect(Number.isFinite(Date.parse(SYNTHETIC_PROBE_TOKEN_EXPIRES_AT))).toBe(true);
+  });
+});
+
+describe("daysUntilProbeTokenExpiry", () => {
+  it("counts down toward the recorded date", () => {
+    const expiry = new Date(SYNTHETIC_PROBE_TOKEN_EXPIRES_AT);
+    const tenDaysBefore = new Date(expiry.getTime() - 10 * 86_400_000);
+    expect(daysUntilProbeTokenExpiry(tenDaysBefore)).toBe(10);
+  });
+
+  it("goes negative once the date has passed", () => {
+    const after = new Date(Date.parse(SYNTHETIC_PROBE_TOKEN_EXPIRES_AT) + 5 * 86_400_000);
+    expect(daysUntilProbeTokenExpiry(after)).toBeLessThan(0);
+  });
+});
+
+describe("decodeJwtExpiry", () => {
+  it("reads the exp claim", () => {
+    const now = new Date("2026-08-11T00:00:00.000Z");
+    const exp = decodeJwtExpiry(tokenExpiringIn(30, now));
+    expect(exp).not.toBeNull();
+    expect(Math.round((exp!.getTime() - now.getTime()) / 86_400_000)).toBe(30);
+  });
+
+  // An unreadable token is a reason to stay quiet, never to break the probe
+  // that is about to use it — so every one of these returns null, not throws.
+  it.each([
+    ["undefined", undefined],
+    ["empty", ""],
+    ["not a JWT", "just-a-plain-string"],
+    ["wrong segment count", "a.b"],
+    ["undecodable payload", "aaa.!!!!.ccc"],
+    ["payload with no exp", `x.${Buffer.from('{"sub":"p"}').toString("base64url")}.y`],
+    ["non-numeric exp", `x.${Buffer.from('{"exp":"soon"}').toString("base64url")}.y`],
+  ])("returns null for %s", (_label, token) => {
+    expect(decodeJwtExpiry(token as string | undefined)).toBeNull();
+  });
+});
+
+describe("warnIfProbeTokenNearExpiry", () => {
+  const saved = process.env.SYNTHETIC_PROBE_TOKEN;
+  const recordedExpiry = new Date(SYNTHETIC_PROBE_TOKEN_EXPIRES_AT);
+
+  beforeEach(() => mockWarn.mockClear());
+  afterEach(() => {
+    if (saved === undefined) delete process.env.SYNTHETIC_PROBE_TOKEN;
+    else process.env.SYNTHETIC_PROBE_TOKEN = saved;
+  });
+
+  it("says nothing while the token is comfortably valid", () => {
+    // The token must expire when the constant says it does, or this would test
+    // the disagreement branch instead of the proximity one.
+    const now = new Date(recordedExpiry.getTime() - 400 * 86_400_000);
+    process.env.SYNTHETIC_PROBE_TOKEN = tokenExpiringIn(400, now);
+    warnIfProbeTokenNearExpiry(now);
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+
+  it("warns once the real token is inside the window", () => {
+    const now = new Date(recordedExpiry.getTime() - 30 * 86_400_000);
+    process.env.SYNTHETIC_PROBE_TOKEN = tokenExpiringIn(30, now);
+    warnIfProbeTokenNearExpiry(now);
+    expect(mockWarn).toHaveBeenCalledWith(expect.stringMatching(/expires in 30d/));
+  });
+
+  it("reports the recorded date disagreeing with the token in use", () => {
+    // The half that keeps the constant honest: production holds the real token,
+    // so production is where a wrong constant gets caught.
+    const now = new Date(recordedExpiry.getTime() - 300 * 86_400_000);
+    process.env.SYNTHETIC_PROBE_TOKEN = tokenExpiringIn(5, now);
+    warnIfProbeTokenNearExpiry(now);
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.stringMatching(/disagrees with the token in use/),
+      expect.objectContaining({ recorded: SYNTHETIC_PROBE_TOKEN_EXPIRES_AT }),
+    );
+  });
+
+  it("falls back to the recorded date when the token cannot be decoded", () => {
+    // The Sensitive-variable case: no token in this context, so the constant is
+    // all there is — and it still has to be able to raise the alarm.
+    delete process.env.SYNTHETIC_PROBE_TOKEN;
+    warnIfProbeTokenNearExpiry(new Date(recordedExpiry.getTime() - 10 * 86_400_000));
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.stringMatching(/expires in 10d.*recorded — token not decodable here/),
+    );
+  });
+
+  it("stays quiet with no token when the recorded date is far off", () => {
+    delete process.env.SYNTHETIC_PROBE_TOKEN;
+    warnIfProbeTokenNearExpiry(new Date(recordedExpiry.getTime() - 500 * 86_400_000));
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/syntheticProbeService.ts
+++ b/src/services/syntheticProbeService.ts
@@ -40,6 +40,95 @@ import { invokeTool } from "@/lib/mcp/tools";
 
 const PROBE_TIMEOUT_MS = 10_000;
 
+/**
+ * When the long-lived `SYNTHETIC_PROBE_TOKEN` JWT stops being accepted.
+ *
+ * BASIS: recorded, not re-derived. The variable is marked Sensitive in Vercel,
+ * so its value cannot be read back to decode the `exp` claim — this date is
+ * carried forward from when it could be. `assertProbeTokenExpiryIsNotImminent`
+ * (see its test) turns that into a tripwire that goes red 60 days out, and
+ * `warnIfProbeTokenNearExpiry` re-derives the true `exp` at runtime wherever
+ * the token actually is, so a wrong date here corrects itself in the logs
+ * rather than sitting undetected until every probe starts failing at once.
+ */
+export const SYNTHETIC_PROBE_TOKEN_EXPIRES_AT = "2027-05-25T00:00:00.000Z";
+
+/** Lead time on the tripwire — long enough to rotate without urgency. */
+export const PROBE_TOKEN_EXPIRY_WARNING_DAYS = 60;
+
+/**
+ * Days until the recorded expiry. Negative once it has passed. Pure.
+ */
+export function daysUntilProbeTokenExpiry(now: Date): number {
+  const expiresAt = Date.parse(SYNTHETIC_PROBE_TOKEN_EXPIRES_AT);
+  return Math.floor((expiresAt - now.getTime()) / 86_400_000);
+}
+
+/**
+ * Read the `exp` claim from the configured token, or null if it has none.
+ *
+ * Decodes only — no signature check, which would need the signing secret and
+ * is not the question being asked. Returns null rather than throwing on
+ * anything unexpected: an unreadable token is a reason to stay quiet here, not
+ * to break the probe that is about to use it.
+ */
+export function decodeJwtExpiry(token: string | undefined): Date | null {
+  if (!token) return null;
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const claims = JSON.parse(
+      Buffer.from(parts[1], "base64url").toString("utf8"),
+    ) as { exp?: unknown };
+    if (typeof claims.exp !== "number" || !Number.isFinite(claims.exp)) {
+      return null;
+    }
+    return new Date(claims.exp * 1000);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Cross-check the recorded expiry against the token actually in use, and warn
+ * when either says rotation is due. Called once per probe batch.
+ *
+ * This is what keeps SYNTHETIC_PROBE_TOKEN_EXPIRES_AT from rotting into a date
+ * nobody has verified since it was written: production holds the real token,
+ * so production is where the constant gets checked.
+ */
+export function warnIfProbeTokenNearExpiry(now: Date = new Date()): void {
+  const recordedDays = daysUntilProbeTokenExpiry(now);
+  const actual = decodeJwtExpiry(process.env.SYNTHETIC_PROBE_TOKEN);
+
+  if (actual) {
+    const actualDays = Math.floor((actual.getTime() - now.getTime()) / 86_400_000);
+    if (Math.abs(actualDays - recordedDays) > 1) {
+      _logger.warn(
+        "[syntheticProbe] SYNTHETIC_PROBE_TOKEN_EXPIRES_AT disagrees with the token in use",
+        {
+          recorded: SYNTHETIC_PROBE_TOKEN_EXPIRES_AT,
+          actual: actual.toISOString(),
+        },
+      );
+    }
+    if (actualDays <= PROBE_TOKEN_EXPIRY_WARNING_DAYS) {
+      _logger.warn(
+        `[syntheticProbe] SYNTHETIC_PROBE_TOKEN expires in ${actualDays}d ` +
+          `(${actual.toISOString()}) — every probe fails at once when it does`,
+      );
+    }
+    return;
+  }
+
+  if (recordedDays <= PROBE_TOKEN_EXPIRY_WARNING_DAYS) {
+    _logger.warn(
+      `[syntheticProbe] SYNTHETIC_PROBE_TOKEN expires in ${recordedDays}d ` +
+        `(${SYNTHETIC_PROBE_TOKEN_EXPIRES_AT}, recorded — token not decodable here)`,
+    );
+  }
+}
+
 export type ProbeStatus = "success" | "failure" | "timeout";
 
 export interface ProbeResult {
@@ -63,6 +152,10 @@ export interface LatestProbeRow {
 }
 
 async function recordProbeResult(result: ProbeResult): Promise<void> {
+  // Every probe funnels through here, and this runs in the cron context where
+  // SYNTHETIC_PROBE_TOKEN actually exists — the only place the recorded expiry
+  // can be checked against the real token. Silent until rotation is due.
+  warnIfProbeTokenNearExpiry();
   try {
     await executeQuery(
       `INSERT INTO synthetic_probe_results
@@ -764,10 +857,41 @@ export async function getLatestProbeResults(): Promise<LatestProbeRow[]> {
       http_status: number | null;
       error_message: string | null;
     }>(
-      `SELECT DISTINCT ON (probe_name)
-         probe_name, started_at, status, latency_ms, http_status, error_message
-       FROM synthetic_probe_results
-       ORDER BY probe_name, started_at DESC`,
+      // Emulated loose index scan. The obvious spelling —
+      //   SELECT DISTINCT ON (probe_name) ... ORDER BY probe_name, started_at DESC
+      // — does use idx_synthetic_probe_results_name_started, but `DISTINCT ON`
+      // cannot skip: it walks EVERY index entry in order and discards the
+      // duplicates. Measured against production at 40,301 rows it read all of
+      // them, 6,356 buffers, to return 7 — and pg_stat_user_indexes showed
+      // 44.7M tuples read across 1,580 scans of this one query. Nothing prunes
+      // this table, so that cost grows forever.
+      //
+      // The recursive term instead descends the index once per DISTINCT
+      // probe_name (7 of them), then takes one LIMIT 1 per probe. Measured:
+      // 8.688ms → 0.161ms, 6,356 → 65 buffers, and the cost is now O(probes)
+      // rather than O(rows). Verified to return byte-identical rows.
+      `WITH RECURSIVE names AS (
+           (SELECT probe_name FROM synthetic_probe_results
+             ORDER BY probe_name LIMIT 1)
+           UNION ALL
+           SELECT (SELECT s.probe_name FROM synthetic_probe_results s
+                    WHERE s.probe_name > n.probe_name
+                    ORDER BY s.probe_name LIMIT 1)
+             FROM names n WHERE n.probe_name IS NOT NULL
+         )
+         SELECT r.probe_name, r.started_at, r.status, r.latency_ms,
+                r.http_status, r.error_message
+           FROM names n
+           CROSS JOIN LATERAL (
+             SELECT s.probe_name, s.started_at, s.status, s.latency_ms,
+                    s.http_status, s.error_message
+               FROM synthetic_probe_results s
+              WHERE s.probe_name = n.probe_name
+              ORDER BY s.started_at DESC
+              LIMIT 1
+           ) r
+          WHERE n.probe_name IS NOT NULL
+          ORDER BY r.probe_name`,
     );
     return result.rows.map((row) => ({
       probeName: row.probe_name,


### PR DESCRIPTION
Closes #23.

## The index #23 asks for already exists

Measured against production before writing anything:

```
indexname                                   | indexdef
--------------------------------------------+-----------------------------------------------------------
idx_synthetic_probe_results_name_started    | btree (probe_name, started_at DESC)
idx_synthetic_probe_results_status_started  | btree (status, started_at DESC)
synthetic_probe_results_pkey                | btree (id)
```

`(probe_name, started_at DESC)` is exactly the index I would have added, and the planner already picks it. So no migration — **the cost is the query, not a missing index.**

## What is actually expensive

`getLatestProbeResults()` is polled by the admin dashboard. `DISTINCT ON` cannot skip: it walks every index entry in order and throws away the duplicates.

```
Unique  (actual time=0.011..13.975 rows=7)
  Buffers: shared hit=6356
  ->  Index Scan using idx_synthetic_probe_results_name_started  (actual rows=40301)
        Buffers: shared hit=6356
```

40,301 index entries read to return **7 rows**. `pg_stat_user_indexes` gives the lifetime figure: **44,696,241 tuples read across 1,580 scans** of this one query. Nothing prunes this table — you asked for no pruning — so that grows linearly and forever.

Replaced with an emulated loose index scan: a recursive CTE walks the DISTINCT `probe_name` values (one index descent each, 7 of them), then one `LIMIT 1` per probe.

| shape | best of 5 | buffers |
|---|---|---|
| `DISTINCT ON` (current) | 8.688 ms | 6,356 |
| **recursive CTE + lateral** | **0.161 ms** | **65** |
| `SELECT DISTINCT` + lateral | 6.419 ms | 853 |

54× faster, and the point is not the constant: cost is now **O(distinct probes) rather than O(rows)**, so it stops growing. Correctness was checked before speed — both candidates were confirmed to return byte-identical rows to the query they replace, because a faster query that answers a different question is not a fix.

I left `idx_synthetic_probe_results_status_started` alone. It has only 12 lifetime scans, but 12 is not 0 and removing it is not this PR.

## The probe JWT

All seven probes share one long-lived `SYNTHETIC_PROBE_TOKEN`. When it expires they fail *simultaneously*, and the dashboard reports a platform-wide incident that is really one expired credential.

`SYNTHETIC_PROBE_TOKEN` is marked **Sensitive** in Vercel, so I could not read it back to decode `exp` and re-derive the date. The recorded `2027-05-25` is therefore carried forward, and the constant says so — its BASIS is *recorded*, not *measured*. A bare comment with an unverifiable date in it is exactly the kind of thing that rots, so two mechanisms check it:

1. **A tripwire test** that fails 60 days before the recorded expiry. Nothing is broken when it goes red — it is the signal to rotate. Its comment says explicitly not to widen the window to make it pass.
2. **`warnIfProbeTokenNearExpiry()`**, called from `recordProbeResult()` — the one function every probe passes through, and one that runs in the cron context where the real token exists. It decodes the live `exp` and logs when the constant disagrees with it, so a wrong date corrects itself in production rather than sitting undetected until every probe fails at once.

Decoding is deliberately signature-free (that would need the signing secret and is not the question being asked), and returns `null` on anything unexpected — an unreadable token is a reason to stay quiet, never to break the probe about to use it. Seven malformed-input cases are pinned.

## Verification

230 suites / 2282 tests pass; typecheck, lint and build clean.

The shipped SQL was **extracted from the source file rather than retyped**, then `PREPARE`d against the production schema — CI's SQL gate covers only the economy builders, and a mocked `executeQuery` will happily "pass" invalid SQL:

```
Extracted from source, first line: WITH RECURSIVE names AS (
PREPARE: ok
CONTROL: ok — column s.startd_at does not exist
Identical rows to the DISTINCT ON it replaces: yes
Plan: 0.335 ms, 65 buffers, 7 rows
```

The control is there because a `PREPARE` that succeeds proves nothing unless a deliberately broken variant fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)