### PR TITLE
perf(observability): record pool gauges so a slow query says WHICH failure it was

### DIFF
--- a/database/init/78-slow-query-pool-gauges.sql
+++ b/database/init/78-slow-query-pool-gauges.sql
@@ -1,0 +1,48 @@
+-- Slow-query log: record the pool's state at the moment the query was recorded.
+--
+-- WHY
+-- ---
+-- `executeQuery` starts its timer BEFORE `pool.query()`, which does checkout
+-- AND execution, so a recorded `ms` conflates two unrelated failure modes:
+-- a genuinely slow statement, and a request that never got a connection.
+--
+-- On 2026-08-11 that ambiguity cost a whole investigation. `slow_query_log_entries`
+-- showed durations up to 1,185,182 ms (19.7 minutes) and the obvious reading —
+-- "the pool is starving" — was wrong. Every entry over 60s was a fire-and-forget
+-- observability write (`void recordInvocation(...)`, `void persistRequestEntry(...)`),
+-- 11 of 12 had ZERO other slow queries within ±2 minutes, and Postgres was sitting
+-- at 5 backends against a ceiling of 100. Nothing was starving; the wall clock was
+-- spanning a suspended serverless instance.
+--
+-- `waiting` is the column that settles it. node-postgres exposes
+-- `pool.waitingCount` — the number of callers queued for a connection. A slow
+-- entry recorded with `waiting = 0` cannot be checkout starvation, whatever the
+-- duration says. `total`/`idle` give the saturation picture alongside it.
+--
+-- These are gauges read synchronously off the pool object, not a second timer,
+-- so nothing about connection acquisition or release changes. Splitting the
+-- timer would have meant replacing `pool.query()` with manual
+-- connect/query/release on the hottest path in the app — where a missed release
+-- leaks a connection and manufactures the very starvation being measured.
+--
+-- Nullable with no default: existing rows keep NULL, meaning "recorded before
+-- this column existed", which must stay distinguishable from a measured 0.
+-- ADD COLUMN without a default is a catalog-only change, so this does not
+-- rewrite the table.
+
+ALTER TABLE slow_query_log_entries
+  ADD COLUMN IF NOT EXISTS pool_waiting INTEGER,
+  ADD COLUMN IF NOT EXISTS pool_total   INTEGER,
+  ADD COLUMN IF NOT EXISTS pool_idle    INTEGER;
+
+COMMENT ON COLUMN slow_query_log_entries.pool_waiting IS
+  'pg.Pool.waitingCount when the entry was recorded. 0 rules out checkout starvation as the cause of `ms`; NULL means the row predates this column.';
+COMMENT ON COLUMN slow_query_log_entries.pool_total IS
+  'pg.Pool.totalCount (open connections held by this serverless instance).';
+COMMENT ON COLUMN slow_query_log_entries.pool_idle IS
+  'pg.Pool.idleCount. total - idle - waiting is roughly the in-flight count.';
+
+-- Find the starved entries, if there ever are any:
+--   SELECT at, ms, pool_waiting, pool_total, left(preview,60)
+--     FROM slow_query_log_entries
+--    WHERE pool_waiting > 0 ORDER BY ms DESC;

--- a/scripts/checkAgentMonicaDrift.ts
+++ b/scripts/checkAgentMonicaDrift.ts
@@ -150,6 +150,24 @@ for (const r of rows) {
     const fc = fullChartMonica(r.natal_positions);
     if (!fc) {
       notAPlacementNoChart++;
+      // The failure message below tells the operator "the names are printed
+      // above" — but this branch used to increment and `continue` without
+      // recording anything, so the one name you actually need was the one name
+      // never shown. Finding it meant re-implementing this classification by
+      // hand against production. Record it here, with the chart shape, since
+      // "unparseable name" and "empty chart" want different fixes.
+      if (examples.length < 15) {
+        const positions = r.natal_positions;
+        const shape = Array.isArray(positions)
+          ? `array[${positions.length}]`
+          : positions == null
+            ? "null"
+            : `object{${Object.keys(positions).length}}`;
+        examples.push(
+          `NO-CHART ${r.name}: name does not parse as a placement and ` +
+            `natal_positions is ${shape}`,
+        );
+      }
       continue;
     }
     const t = tally.fullChart;

--- a/src/lib/database/connection.ts
+++ b/src/lib/database/connection.ts
@@ -1,5 +1,5 @@
 import { logger } from "../logger";
-import { recordSlowQuery } from "../observability/slowQueryLog";
+import { recordSlowQuery, type PoolGauges } from "../observability/slowQueryLog";
 import { databaseConfig } from "./config";
 import { getDatabasePool, initializeDatabase, closeDatabase } from "./rawPool";
 import type { PoolClient, QueryResult } from "pg";
@@ -26,6 +26,39 @@ export type { DatabaseConfig } from "./rawPool";
 // instance.
 let _lastSlowQueryMetricAt = 0;
 const SLOW_QUERY_METRIC_MIN_INTERVAL_MS = 2000;
+
+/**
+ * Read the pool's counters, or undefined if the pool cannot be reached.
+ *
+ * `getDatabasePool()` constructs the pool on first call and now throws on an
+ * invalid config, so this must never be the thing that surfaces that — it runs
+ * on the slow-query path, after a query has already succeeded, which means the
+ * pool provably exists. The guard is for the shapes where it does not: a
+ * caller-supplied client with no pool of its own, or a mocked pool in tests.
+ */
+export function readPoolGauges(): PoolGauges | undefined {
+  try {
+    const pool = getDatabasePool() as unknown as {
+      waitingCount?: number;
+      totalCount?: number;
+      idleCount?: number;
+    };
+    if (
+      typeof pool?.waitingCount !== "number" ||
+      typeof pool?.totalCount !== "number" ||
+      typeof pool?.idleCount !== "number"
+    ) {
+      return undefined;
+    }
+    return {
+      waiting: pool.waitingCount,
+      total: pool.totalCount,
+      idle: pool.idleCount,
+    };
+  } catch {
+    return undefined;
+  }
+}
 
 // Health check function
 export async function checkDatabaseHealth(): Promise<{
@@ -122,7 +155,15 @@ export async function executeQuery<_T extends any = any>(
     // Push to the in-memory slow-query ring (threshold defaults to 200ms).
     // The admin observability endpoint reads this; production traffic should
     // surface gradual regressions here long before they trip the >1s warn.
-    recordSlowQuery(executionTime, query, result.rowCount);
+    //
+    // `executionTime` spans BOTH checkout and execution, because `pool.query()`
+    // does both — so on its own it cannot say whether a slow entry means slow
+    // SQL or no connection. The gauges answer that: `waiting` is how many
+    // callers were queued for a connection, so an entry recorded with
+    // `waiting === 0` was not waiting on the pool. Read AFTER the query so it
+    // reflects the state the query actually left behind rather than a guess
+    // made before dispatch.
+    recordSlowQuery(executionTime, query, result.rowCount, readPoolGauges());
 
     // Persist slow queries to system_metrics (sampled — see throttle note at top).
     const nowMs = Date.now();

--- a/src/lib/observability/__tests__/slowQueryPoolGauges.test.ts
+++ b/src/lib/observability/__tests__/slowQueryPoolGauges.test.ts
@@ -1,0 +1,205 @@
+/**
+ * @jest-environment node
+ *
+ * A slow-query entry's `ms` conflates two unrelated failures, because
+ * executeQuery starts its timer before `pool.query()` and that call does
+ * checkout AND execution. On 2026-08-11 that ambiguity sent a whole
+ * investigation down the wrong path: production showed durations up to
+ * 1,185,182 ms and the obvious reading — "the pool is starving" — was wrong.
+ *
+ * `pool_waiting` is what settles it. An entry recorded with `waiting === 0` was
+ * not queued for a connection, whatever the duration says.
+ *
+ * The property these tests exist to protect is therefore narrow and specific:
+ * **a measured 0 must never be stored as NULL.** NULL means "this row predates
+ * the column"; 0 means "measured, and nothing was waiting". Collapsing them
+ * would delete exactly the signal the column was added for — and `?? null` on a
+ * zero is an easy way to do it by accident.
+ */
+
+const mockQuery = jest.fn().mockResolvedValue({ rows: [] });
+const mockPool = {
+  query: mockQuery,
+  waitingCount: 0,
+  totalCount: 0,
+  idleCount: 0,
+};
+
+jest.mock("@/lib/database/rawPool", () => ({
+  getDatabasePool: () => mockPool,
+}));
+
+import {
+  recordSlowQuery,
+  setSlowQueryThresholdMs,
+  type PoolGauges,
+} from "@/lib/observability/slowQueryLog";
+
+/**
+ * The parameter array of the persisted INSERT, once it has been flushed.
+ *
+ * persistSlowQueryEntry is void-ed AND does a dynamic `await import(...)`, so a
+ * couple of microtask ticks is not enough to see it — poll the macrotask queue
+ * instead. Returning null after the budget is a real "it never wrote", which is
+ * what several tests below assert.
+ */
+async function persistedParams(): Promise<unknown[] | null> {
+  for (let i = 0; i < 20; i++) {
+    const call = mockQuery.mock.calls.find(([sql]: [string]) =>
+      String(sql).includes("INSERT INTO slow_query_log_entries"),
+    );
+    if (call) return call[1] as unknown[];
+    await new Promise((r) => setImmediate(r));
+  }
+  return null;
+}
+
+const PARAM = { waiting: 4, total: 5, idle: 6 } as const;
+
+describe("pool gauges on the slow-query log", () => {
+  const savedUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    mockQuery.mockClear();
+    process.env.DATABASE_URL = "postgresql://u:p@h:5432/d";
+    setSlowQueryThresholdMs(200);
+  });
+
+  afterEach(() => {
+    if (savedUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = savedUrl;
+  });
+
+  it("persists the gauges alongside the duration", async () => {
+    recordSlowQuery(500, "SELECT 1", 1, {
+      waiting: PARAM.waiting,
+      total: PARAM.total,
+      idle: PARAM.idle,
+    });
+    const params = await persistedParams();
+    expect(params).not.toBeNull();
+    // (at, ms, preview, row_count, pool_waiting, pool_total, pool_idle)
+    expect(params!.slice(4)).toEqual([PARAM.waiting, PARAM.total, PARAM.idle]);
+  });
+
+  it("stores a measured ZERO as 0, not NULL", async () => {
+    // THE LOAD-BEARING CASE. `waiting: 0` is the finding — it is what proves an
+    // entry was not starved. `?? null` on a zero would erase it and make the
+    // column useless for the one question it was added to answer.
+    recordSlowQuery(500, "SELECT 1", 1, { waiting: 0, total: 3, idle: 3 });
+    const params = await persistedParams();
+    expect(params!.slice(4)).toEqual([0, 3, 3]);
+    expect(params![4]).not.toBeNull();
+  });
+
+  it("stores NULL when the gauges were not available", async () => {
+    // Distinct from the case above: nothing was measured, so nothing may be
+    // claimed. A row from before this column exists reads the same way.
+    recordSlowQuery(500, "SELECT 1", 1, undefined);
+    const params = await persistedParams();
+    expect(params!.slice(4)).toEqual([null, null, null]);
+  });
+
+  it("still skips its own writes, so the log cannot feed itself", async () => {
+    recordSlowQuery(500, "INSERT INTO slow_query_log_entries (at) VALUES ($1)", 1, {
+      waiting: 0,
+      total: 1,
+      idle: 1,
+    });
+    expect(await persistedParams()).toBeNull();
+  });
+
+  it("respects the threshold — gauges do not make a fast query loggable", async () => {
+    recordSlowQuery(10, "SELECT 1", 1, { waiting: 9, total: 9, idle: 0 });
+    expect(await persistedParams()).toBeNull();
+  });
+});
+
+describe("executeQuery actually passes the gauges through", () => {
+  // Without this, dropping the `readPoolGauges()` argument at the single call
+  // site in connection.ts leaves every test above passing while every row in
+  // production silently records NULL — the column would be dead and nothing
+  // would say so. Mutation-checked: removing that argument fails this test and
+  // only this test.
+  const savedUrl = process.env.DATABASE_URL;
+
+  // The threshold MUST be set through `require`, not through the ESM import at
+  // the top of this file: they resolve to different module instances here (the
+  // ESM one read 0 while connection.ts's read 200), so setting it the obvious
+  // way leaves executeQuery's copy at 200, the sub-millisecond mock query falls
+  // under it, nothing is recorded — and the assertion below would fail for a
+  // reason that has nothing to do with the code under test.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const live = () => require("@/lib/observability/slowQueryLog");
+
+  beforeEach(() => {
+    mockQuery.mockClear();
+    process.env.DATABASE_URL = "postgresql://u:p@h:5432/d";
+    live().setSlowQueryThresholdMs(0); // record every query, however fast
+  });
+
+  afterEach(() => {
+    live().setSlowQueryThresholdMs(200);
+    if (savedUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = savedUrl;
+  });
+
+  it("records the live pool state for a real executeQuery call", async () => {
+    mockPool.waitingCount = 2;
+    mockPool.totalCount = 5;
+    mockPool.idleCount = 1;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { executeQuery } = require("@/lib/database/connection");
+
+    await executeQuery("SELECT 1 FROM users", []);
+
+    // Anti-vacuity: prove the query actually ran before trusting what was or
+    // was not persisted alongside it.
+    expect(mockQuery).toHaveBeenCalledWith("SELECT 1 FROM users", []);
+
+    const params = await persistedParams();
+    expect(params).not.toBeNull();
+    expect(params!.slice(4)).toEqual([2, 5, 1]);
+  });
+});
+
+describe("readPoolGauges", () => {
+  // The real function, not a restatement of it: it runs on the hot query path,
+  // so "never throws" is the property that matters and it can only be shown by
+  // calling it.
+  afterEach(() => {
+    mockPool.waitingCount = 0;
+    mockPool.totalCount = 0;
+    mockPool.idleCount = 0;
+    delete (mockPool as { throwOnAccess?: boolean }).throwOnAccess;
+  });
+
+  it("reads the live counters off the pool", () => {
+    mockPool.waitingCount = 7;
+    mockPool.totalCount = 5;
+    mockPool.idleCount = 1;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { readPoolGauges } = require("@/lib/database/connection");
+    expect(readPoolGauges()).toEqual({ waiting: 7, total: 5, idle: 1 });
+  });
+
+  it("reports zero as zero, not as 'unavailable'", () => {
+    mockPool.waitingCount = 0;
+    mockPool.totalCount = 2;
+    mockPool.idleCount = 2;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { readPoolGauges } = require("@/lib/database/connection");
+    const g: PoolGauges | undefined = readPoolGauges();
+    expect(g).toEqual({ waiting: 0, total: 2, idle: 2 });
+  });
+
+  it("returns undefined when the pool has no counters", () => {
+    // A mocked or non-pg pool. Degrade to "not measured" rather than inventing
+    // a number that would read as a measurement.
+    delete (mockPool as { waitingCount?: number }).waitingCount;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { readPoolGauges } = require("@/lib/database/connection");
+    expect(readPoolGauges()).toBeUndefined();
+    mockPool.waitingCount = 0;
+  });
+});

--- a/src/lib/observability/slowQueryLog.ts
+++ b/src/lib/observability/slowQueryLog.ts
@@ -15,12 +15,35 @@
  * @file src/lib/observability/slowQueryLog.ts
  */
 
+/**
+ * The pool's state at the instant an entry was recorded.
+ *
+ * `ms` conflates two unrelated failure modes, because executeQuery starts its
+ * timer before `pool.query()` and that call does checkout AND execution. These
+ * gauges separate them: `waiting` is how many callers were queued for a
+ * connection, so **a slow entry with `waiting === 0` cannot be checkout
+ * starvation**, whatever the duration says.
+ *
+ * Gauges rather than a second timer on purpose. Timing checkout separately
+ * would mean replacing `pool.query()` with manual connect/query/release on the
+ * hottest path in the app, where one missed release leaks a connection and
+ * manufactures the starvation being measured. Reading three counters off the
+ * pool object changes nothing about acquisition.
+ */
+export interface PoolGauges {
+  waiting: number;
+  total: number;
+  idle: number;
+}
+
 export interface SlowQueryEntry {
   id: number;
   at: string;
   ms: number;
   preview: string;
   rowCount: number | null;
+  /** Absent when the caller could not reach the pool (e.g. a passed-in client). */
+  pool?: PoolGauges;
 }
 
 const RING_SIZE = 200;
@@ -43,6 +66,7 @@ export function recordSlowQuery(
   ms: number,
   query: string,
   rowCount: number | null,
+  pool?: PoolGauges,
 ): void {
   if (ms < threshold) return;
   const entry: SlowQueryEntry = {
@@ -51,6 +75,7 @@ export function recordSlowQuery(
     ms: Math.round(ms),
     preview: query.length > 200 ? `${query.slice(0, 200)}…` : query,
     rowCount,
+    pool,
   };
   ring.push(entry);
   if (ring.length > RING_SIZE) ring.shift();
@@ -69,9 +94,21 @@ async function persistSlowQueryEntry(entry: SlowQueryEntry): Promise<void> {
     // there is no import cycle with connection.ts.
     const { getDatabasePool } = await import("@/lib/database/rawPool");
     await getDatabasePool().query(
-      `INSERT INTO slow_query_log_entries (at, ms, preview, row_count)
-       VALUES ($1, $2, $3, $4)`,
-      [entry.at, entry.ms, entry.preview, entry.rowCount],
+      `INSERT INTO slow_query_log_entries
+         (at, ms, preview, row_count, pool_waiting, pool_total, pool_idle)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      [
+        entry.at,
+        entry.ms,
+        entry.preview,
+        entry.rowCount,
+        // NULL, not 0, when the gauges were unavailable — "not measured" has to
+        // stay distinguishable from "measured as zero", which is the whole
+        // point of the column.
+        entry.pool?.waiting ?? null,
+        entry.pool?.total ?? null,
+        entry.pool?.idle ?? null,
+      ],
     );
   } catch {
     // Observability writes never crash the query path.


### PR DESCRIPTION
## The starvation report was wrong, and the instrumentation is why

`executeQuery` starts its timer **before** `pool.query()` ([connection.ts:112/120](src/lib/database/connection.ts#L112)), and that call does checkout *and* execution. So `ms` cannot distinguish slow SQL from a request that never got a connection — and reading it as the latter sent an investigation down the wrong path.

The premise was: 8,171 slow entries after the PgBouncer flip vs 163 before, max 19.7 minutes → the pool is starving. **Every part of that is refuted.**

**The windows weren't comparable.** `prune_observability_logs` keeps 7 days and runs daily at 03:00, so the "before" bucket was the truncated tail of the retention window, not a period.

**The step change isn't at the flip.** It's at 08-09/08-10, and it's traffic:

| day | requests | slow entries | p50 | p90 | p99 |
|---|---|---|---|---|---|
| 08-06 | 84 | 44 | 664 | 10,086 | 227,008 |
| 08-07 | 54 | 41 | 1,853 | 4,595 | 658,282 |
| 08-09 | 1,735 | 429 | 312 | 2,687 | 11,786 |
| 08-10 | 1,597 | 4,343 | 246 | **411** | **4,918** |
| 08-11 | 1,304 | 3,185 | 239 | **418** | **5,478** |

Traffic rose ~20× and **every latency percentile improved by an order of magnitude** — p90 from 4.6–10s to ~415ms, p99 from 658,282ms to ~5,000ms. That is a pool getting healthier under load, not starving.

**The giants are an artifact.** Splitting by call shape:

| kind | n | p50 | p95 | max | >60s |
|---|---|---|---|---|---|
| awaited (request path) | 7,940 | 244 | 912 | 639,584 | **1** |
| fire-and-forget observability write | 419 | 1,024 | 16,874 | 1,185,182 | **11** |

5% of the volume, 92% of the giants. All of them are `void`-ed writes issued as the handler returns — `void recordInvocation(...)` ([tools.ts:370/433](src/lib/mcp/tools.ts#L433)) and `void persistRequestEntry(...)` ([requestLog.ts:57](src/lib/observability/requestLog.ts#L57)).

**The discriminating test:** for 11 of 12 entries over 60s there were **zero other slow queries within ±2 minutes** (the twelfth's worst neighbour was 3,533ms — three orders of magnitude smaller). A starved pool cannot be selectively slow for one statement. Meanwhile Postgres sat at **5 backends against a ceiling of 100**, which answers Q3: nothing is near `PGBOUNCER_DEFAULT_POOL_SIZE=20`, let alone `MAX_CLIENT_CONN=120`.

The timers on those entries all start on `:00`/`:30` cron boundaries — they are the synthetic MCP probe's own writes, on a path that runs ~90×/day. The wall clock is spanning a suspended serverless instance. I could not pin the exact resume trigger: I predicted they would complete at the next invocation and **that was wrong** — they finish 9–29 minutes before it. `pg_stat_statements` is not installed, so DB-side time isn't recoverable retrospectively.

## What this adds

`pool_waiting` settles it going forward. node-postgres exposes `pool.waitingCount` — callers queued for a connection — so **an entry recorded with `waiting = 0` was not starved**, whatever its duration says. `pool_total`/`pool_idle` give the saturation picture alongside.

Gauges rather than the literal checkout/execution split, deliberately: splitting the timer means replacing `pool.query()` with manual connect/query/release on the hottest path in the app, where one missed release leaks a connection and **manufactures the very starvation being measured**. Three counters read off the pool object change nothing about acquisition.

Nullable, no default: existing rows stay NULL = "predates this column", which must stay distinguishable from a measured `0`. That distinction is the entire point, so it is what the tests defend — `?? null`, never `|| null`.

## Verification

231 suites / 2291 tests pass; typecheck, lint, build clean. Mutation-tested:

| mutation | result |
|---|---|
| `?? null` → `\|\| null` (erases a measured zero) | fails 1 |
| `readPoolGauges` invents `{0,0,0}` instead of `undefined` | fails 1 |
| drop `readPoolGauges()` at executeQuery's call site | **initially passed — gap closed** |

That third one is the useful one: the first pass had no coverage of the wiring, so removing the argument would have left every test green while every production row silently recorded NULL. A test that drives the real `executeQuery` now fails on it. (Writing it surfaced the dual-module-instance trap again — the ESM import and `require()` resolve to different instances here, so the threshold has to be set through `require` or the query falls under it and the assertion fails for an unrelated reason.)

## Also

`checkAgentMonicaDrift` says *"The names are printed above"*, but the `notAPlacementNoChart` branch incremented a counter and `continue`d without recording anything — the one name you need was the one never shown. Finding `Chiron` meant re-implementing the classification by hand against production. It now prints:

```
NO-CHART Chiron: name does not parse as a placement and natal_positions is array[0]
```

with the chart shape, since an unparseable name and an empty chart want different fixes. (That file's own comment notes two rows once sat in this bucket unobserved for two months — same blind spot.)

## ⚠️ Deploy order

**Migration `database/init/78-slow-query-pool-gauges.sql` must be applied BEFORE this merges.** The persist is inside a swallowing try/catch, so against the old schema the slow-query log would go silently dark rather than error. The migration is additive, nullable, no default — catalog-only, no table rewrite — and `ADD COLUMN IF NOT EXISTS`, so it is safe to apply ahead of time and safe to re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)